### PR TITLE
fix(analysis): carry json and xml overlay attributes through intersect

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -290,36 +290,11 @@ def _validate_intersect_columns(source, overlay) -> None:
                 "choose a different layer."
             ),
         )
-    # fix(#1097 review): the OVERLAY's columns, and only the overlay's.
-    #
-    # render_intersect_pairs groups by `_src.gid, _mp._mask_gid` plus every
-    # carried overlay column. The source's columns need no grouping — gid is a
-    # real table's primary key, so PostgreSQL licenses them by functional
-    # dependency — but `_mask_pieces` is a CTE with no key, so each overlay
-    # column it carries has to be named in the GROUP BY explicitly. json and
-    # xml have no equality operator, so grouping on one fails the CTAS with
-    # SQLSTATE 42883, and it fails there rather than in the preview: the
-    # preview carries gid and source_gid only, so it succeeds and the operation
-    # dies after the queue wait with an error naming a generated alias the user
-    # never wrote.
-    #
-    # Refused at enqueue instead, which is what NON_GROUPABLE_COLUMN_TYPES already
-    # does for dissolve's by_field. Refusing rather than silently dropping the
-    # column is the same choice the sibling guards above make: an overlay whose
-    # output columns depend on which of them happened to be groupable is worse
-    # for anyone scripting against the result than one that says no.
-    #
-    # Carrying these through an overlay is a real gap and is worth doing — it
-    # needs the aggregate to group by the two gids alone and join the overlay's
-    # attributes back afterwards, which is a change to this query's shape
-    # rather than a guard. Tracked separately.
     # fix(#1097 review): a carried column may not sit in the alias namespace.
-    # Both layers, because an overlay carries columns from both and the inner
-    # aggregate names them in one select list alongside _gl_src_type; the
-    # overlay's are additionally re-listed inside _mask_pieces beside
-    # _gl_mask_gid and _gl_g. Checked against the PREFIX rather than the three
-    # alias names, so an alias added to that query later is covered without a
-    # second place to update.
+    # Both layers, because an overlay carries columns from both and they share
+    # the statement with _gl_src_type and _gl_mask_gid. Checked against the
+    # PREFIX rather than the alias names, so an alias added to that query later
+    # is covered without a second place to update.
     reserved = sorted(
         name
         for name in (_column_names(source) | _column_names(overlay))
@@ -334,27 +309,14 @@ def _validate_intersect_columns(source, overlay) -> None:
                 "columns. Rename it, or choose a different layer."
             ),
         )
-    # fix(#1097 review): SCALAR json/xml only. The snapshot stores an array
-    # column's type as 'ARRAY' with no element type, so json[]/xml[] are
-    # invisible here by construction; the worker's live-schema recheck
-    # (_ungroupable_type_name reads udt_name) is their sole guard, and the
-    # same applies to dissolve's by_field check above.
-    ungroupable = sorted(
-        (col.get("name"), str(col.get("type") or "").lower())
-        for col in (overlay.column_info or [])
-        if col and str(col.get("type") or "").lower() in NON_GROUPABLE_COLUMN_TYPES
-    )
-    if ungroupable:
-        name, col_type = ungroupable[0]
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=(
-                f"The overlay layer's column {name!r} has type {col_type!r}, "
-                "which cannot be grouped, and an overlay carries every overlay "
-                "column onto its output. Choose a different layer, or remove "
-                "that column from it."
-            ),
-        )
+    # fix(#1099): no ungroupable-type branch here any more. The overlay's
+    # attributes used to ride through `_mask_pieces` and get named in the
+    # aggregate's GROUP BY, which meant json and xml — the types nested GeoJSON
+    # properties routinely land as — took an overlay layer out of service
+    # entirely. render_intersect_pairs groups by the two gids alone now and
+    # joins the overlay table back afterwards, where no grouping applies, so the
+    # column type stops mattering. Dissolve's by_field guard above stays: that
+    # one really does group by a user-chosen column.
 
 
 @router.post("/{dataset_id}/analysis/preview/", response_model=AnalysisPreviewResponse)

--- a/backend/app/platform/analysis_sql.py
+++ b/backend/app/platform/analysis_sql.py
@@ -667,9 +667,13 @@ INTERNAL_ALIAS_PREFIX = "_gl_"
 # Column types PostgreSQL cannot group by, because they have no equality
 # operator. Grouping on one fails with SQLSTATE 42883.
 #
-# Here rather than in either caller: dissolve's by_field guard (the router) and
-# intersect's overlay guards (the router at enqueue, the worker again after the
-# queue wait) all need it, and the worker must not import from the API layer.
+# Here rather than in either caller: dissolve's by_field guard needs it at
+# enqueue (the router) and again after the queue wait (the worker), and the
+# worker must not import from the API layer. Intersect used to be the other
+# caller — it grouped by every carried overlay column, so it inherited the same
+# limit. fix(#1099) moved those attributes out of the GROUP BY and the intersect
+# guards came out with them; only the operation that really groups by a
+# user-chosen column is left.
 NON_GROUPABLE_COLUMN_TYPES = frozenset({"json", "xml"})
 
 
@@ -706,10 +710,27 @@ def render_intersect_pairs(
       it runs once per source row rather than once per candidate pair. Inlined,
       it is #953's 28.4s-vs-0.2s trap, and worse here: this shape probes every
       piece of every overlapping mask feature.
-    - ``GROUP BY _src.gid`` alone licenses the ungrouped ``_src.*`` references
-      (PostgreSQL recognizes functional dependency on a real table's primary
-      key). ``_mp`` is a CTE and has no key, so every ``_mp`` column that is
-      selected has to be grouped explicitly.
+    - The aggregate groups by the two gids and NOTHING else (fix(#1099)).
+      ``_src.gid`` is a real table's primary key, so PostgreSQL licenses the
+      other ``_src`` columns by functional dependency; ``_mp`` is a CTE with no
+      key, so anything selected from it has to be grouped explicitly. The
+      overlay's ATTRIBUTES therefore do not travel through ``_mp`` at all — the
+      aggregate carries the overlay gid out and the outer query joins the
+      overlay table back on it. Routed through the CTE, each attribute had to
+      be named in the GROUP BY, and ``json``/``xml`` have no equality operator
+      (SQLSTATE 42883) — so a nested-GeoJSON properties column, which lands as
+      ``json`` routinely, made a layer unusable as an overlay rather than
+      merely awkward. The outer query does no aggregation, so no type is
+      off-limits there.
+
+      The join back cannot change the row count: the aggregate already emits
+      one row per (source gid, overlay gid) pair, and ``gid`` is the overlay
+      table's primary key, so it matches at most one row. LEFT, not INNER —
+      every ``_gl_mask_gid`` was read from that same table in this same
+      statement so a miss is impossible, and a join that cannot drop a row
+      keeps the count claim structural instead of resting on that argument.
+      Rendered only when there are overlay columns to fetch, so the preview
+      (which carries none) is the statement it always was.
     - ``ST_LineMerge`` on single-part LineString sources only, for the reason
       spelled out in ``render_clip_layer_join``: ``ST_Union`` re-dissolves
       adjacent polygons but does not sew line segments, so a line crossing a
@@ -724,15 +745,21 @@ def render_intersect_pairs(
     statement timeout rather than by the row limit.
     """
     src_sel = "".join(f", _src.{c}" for c in src_columns)
-    mask_sel = "".join(f", _mp.{c}" for c in mask_columns)
-    mask_pick = "".join(f", {c}" for c in mask_columns)
-    mask_group = "".join(f", _mp.{c}" for c in mask_columns)
-    outer_cols = "".join(f", _p.{c}" for c in (*src_columns, *mask_columns))
+    # The two sides come from different relations now, so the output order that
+    # was one comprehension is two: source columns off the aggregate, overlay
+    # columns off the joined-back overlay table.
+    outer_cols = "".join(f", _p.{c}" for c in src_columns)
+    outer_cols += "".join(f", _mo.{c}" for c in mask_columns)
+    mask_join = (
+        f" LEFT JOIN {mask_table_ref} AS _mo ON _mo.gid = _p._gl_mask_gid"
+        if mask_columns
+        else ""
+    )
     return (
         f"WITH _mask_pieces AS MATERIALIZED ("
-        f"SELECT _o.gid AS _gl_mask_gid{mask_pick},"
+        f"SELECT _o.gid AS _gl_mask_gid,"
         f" ST_Subdivide(_o._gl_g, {MASK_SUBDIVIDE_MAX_VERTICES}) AS geom"
-        f" FROM (SELECT gid{mask_pick},"
+        f" FROM (SELECT gid,"
         f" ST_CollectionExtract(ST_MakeValid(geom_4326), 3) AS _gl_g"
         f" FROM {mask_table_ref} WHERE geom_4326 IS NOT NULL OFFSET 0) AS _o"
         f" WHERE NOT ST_IsEmpty(_o._gl_g))"
@@ -741,8 +768,8 @@ def render_intersect_pairs(
         f" CASE WHEN _p._gl_src_type = 'LINESTRING'"
         f" THEN ST_LineMerge(_p.geom) ELSE _p.geom END AS geom"
         f" FROM (SELECT _src.gid AS {INTERSECT_SOURCE_GID_COLUMN},"
-        f" GeometryType(_src.geom_4326) AS _gl_src_type"
-        f"{src_sel}{mask_sel},"
+        f" GeometryType(_src.geom_4326) AS _gl_src_type,"
+        f" _mp._gl_mask_gid{src_sel},"
         f" ST_Union(ST_CollectionExtract("
         f"ST_Intersection(_sv.g, _mp.geom),"
         f" ST_Dimension(_src.geom_4326) + 1)) AS geom"
@@ -753,7 +780,8 @@ def render_intersect_pairs(
         f" JOIN _mask_pieces AS _mp"
         f" ON _mp.geom && _src.geom_4326"
         f" AND ST_Intersects(_mp.geom, _sv.g)"
-        f" GROUP BY _src.gid, _mp._gl_mask_gid{mask_group}) AS _p"
+        f" GROUP BY _src.gid, _mp._gl_mask_gid) AS _p"
+        f"{mask_join}"
         f" WHERE _p.geom IS NOT NULL AND NOT ST_IsEmpty(_p.geom)"
     )
 

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -426,8 +426,9 @@ async def _resolve_and_validate_columns(
     built from, because resolving them is how most of these are checked.
 
     Extracted in fix(#1097 review) rather than raising the C901 threshold on
-    ``_materialize``: the set has grown to five checks over two layers, and
+    ``_materialize``: the set had grown to five checks over two layers, and
     they share a subject that the surrounding job bookkeeping does not.
+    fix(#1099) retired one of them, the overlay's ungroupable-type recheck.
     """
     carry_cols = (
         await _list_carry_columns(session, schema, src_table_name)
@@ -452,7 +453,6 @@ async def _resolve_and_validate_columns(
         )
         _reject_output_column_collision(mask_carry_cols, INTERSECT_OUTPUT_COLUMNS)
         _reject_reserved_alias_columns(mask_carry_cols)
-        await _reject_ungroupable_overlay_columns(session, schema, mask_table_name)
     return carry_cols, mask_carry_cols
 
 
@@ -532,56 +532,20 @@ def _ungroupable_type_name(data_type: str | None, udt_name: str | None) -> str |
     return None
 
 
-async def _reject_ungroupable_overlay_columns(
-    session: AsyncSession, schema: str, table_name: str
-) -> None:
-    """Worker-side half of the router's ungroupable-overlay guard.
-
-    fix(#1097 review): the enqueue guard reads ``column_info``, a catalog
-    snapshot, and a re-upload can replace the overlay between enqueue and the
-    job running — the same window ``_reject_output_column_collision`` exists
-    for, and the reason the carry-column list beside it is read live rather
-    than trusted from the snapshot. A replacement that introduces a json or xml
-    column would otherwise reach ``render_intersect_pairs``, which names every
-    carried overlay column in its GROUP BY, and fail the CTAS with SQLSTATE
-    42883. Array forms (json[]/xml[]) can ONLY be caught here: the snapshot
-    stores 'ARRAY' with no element type, so the router admits them and this
-    recheck is the sole guard (see _ungroupable_type_name).
-
-    Types, not names: reading the live names already happens and would not have
-    caught this, because the column that breaks the query is one whose NAME is
-    unremarkable.
-    """
-    rows = await session.execute(
-        text(
-            "SELECT column_name, data_type, udt_name "
-            "FROM information_schema.columns "
-            "WHERE table_schema = :schema AND table_name = :table_name "
-            "AND column_name NOT IN ('gid', 'geom', 'geom_4326') "
-            "ORDER BY ordinal_position"
-        ).bindparams(schema=schema, table_name=table_name)
-    )
-    for name, data_type, udt_name in rows:
-        bad = _ungroupable_type_name(data_type, udt_name)
-        if bad is not None:
-            raise ValueError(
-                f"The overlay layer's column {name!r} has type "
-                f"{bad!r}, which cannot be grouped, and an "
-                "overlay carries every overlay column onto its output. Choose "
-                "a different layer, or remove that column from it."
-            )
-
-
 async def _reject_ungroupable_by_field(
     session: AsyncSession, schema: str, table_name: str, by_field: str
 ) -> None:
     """Dissolve's GROUP BY column must be groupable on the LIVE schema.
 
-    fix(#1097 review): the same shape as the overlay recheck above, one
-    operation over — dissolve names ``by_field`` in its GROUP BY, the router
+    fix(#1097 review): dissolve names ``by_field`` in its GROUP BY, the router
     checked it against the snapshot, and the snapshot cannot see a json[]
     element type ('ARRAY'). One query answers both failure modes: a column the
     re-upload dropped, and one whose live type has no equality operator.
+
+    fix(#1099): the last caller. Intersect had a twin of this beside it, for
+    the overlay columns it named in the same GROUP BY; those attributes are
+    joined back outside the aggregate now, so the operation that actually
+    groups by a user-chosen column is the only one left needing it.
     """
     row = (
         await session.execute(

--- a/backend/tests/test_analysis_intersect.py
+++ b/backend/tests/test_analysis_intersect.py
@@ -269,6 +269,170 @@ class TestPairwiseRows:
         assert out.feature_count == 1, "one mask FEATURE, one row, however it split"
 
 
+class TestOverlayAttributes:
+    """fix(#1099): the overlay's attributes are joined back, not grouped by.
+
+    Only observable at materialize. The preview carries gid and source_gid
+    alone, so it never named an overlay column in a GROUP BY and never saw the
+    failure this replaces — a unit test on the rendered SQL would have the same
+    blind spot, because the statement only breaks when PostgreSQL executes it.
+    """
+
+    async def test_a_json_overlay_column_survives_into_the_output(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """json and xml have no equality operator, so naming one in a GROUP BY
+        fails the CTAS with SQLSTATE 42883. Both used to make a layer unusable
+        as an overlay; both must now land in the output table with their type
+        and their values intact.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        bar = await _create_bar(test_db_session, created_by=admin_id)
+        # Physical columns only. The worker reads LIVE columns, and json is how
+        # nested GeoJSON properties actually arrive on an ingested layer.
+        await test_db_session.execute(
+            text(
+                f"ALTER TABLE data.{zones.table_name} "  # noqa: S608
+                "ADD COLUMN props json, ADD COLUMN doc xml"
+            )
+        )
+        await test_db_session.execute(
+            text(
+                f"UPDATE data.{zones.table_name} SET"  # noqa: S608
+                " props = ('{\"code\": \"' || zone || '\"}')::json,"
+                " doc = ('<z>' || zone || '</z>')::xml"
+            )
+        )
+        await test_db_session.commit()
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(bar.id),
+            user_id=str(admin_id),
+            operation="intersect",
+            title=f"Overlay {uuid.uuid4().hex[:6]}",
+            mask_dataset_id=str(zones.id),
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        out = await test_db_session.get(Dataset, job.dataset_id)
+        assert out is not None
+
+        # The columns survived AS json and xml — not stringified on the way.
+        types = dict(
+            (
+                await test_db_session.execute(
+                    text(
+                        "SELECT column_name, data_type FROM"
+                        " information_schema.columns WHERE table_schema = 'data'"
+                        " AND table_name = :t"
+                    ).bindparams(t=out.table_name)
+                )
+            ).all()
+        )
+        assert types.get("props") == "json"
+        assert types.get("doc") == "xml"
+
+        rows = (
+            await test_db_session.execute(
+                text(
+                    "SELECT zone, props->>'code', doc::text, source_gid"  # noqa: S608
+                    f" FROM data.{out.table_name} ORDER BY zone"
+                )
+            )
+        ).all()
+        # Three zones, three rows — the count the guard-era test could never
+        # reach, and the same count the plain-text overlay produces.
+        assert len(rows) == 3
+        assert out.feature_count == 3
+        assert [r[0] for r in rows] == ["A", "B", "C"]
+        # Values ride the right row. A join on the wrong key would still
+        # populate the column, so presence alone proves nothing.
+        assert [r[1] for r in rows] == ["A", "B", "C"]
+        assert [r[2] for r in rows] == ["<z>A</z>", "<z>B</z>", "<z>C</z>"]
+        assert {r[3] for r in rows} == {1}
+
+    async def test_the_join_back_does_not_multiply_rows(
+        self,
+        test_db_session: AsyncSession,
+    ):
+        """The fix's central safety claim, as an assertion.
+
+        The aggregate emits one row per (source gid, overlay gid) pair and the
+        outer query joins the overlay table back on its primary key, so the
+        count cannot change. The case that would expose a 1:many join is one
+        overlay feature matched by SEVERAL source features — two half-height
+        bars across three zones is six pairs, each zone looked up twice.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        zones = await _create_zones(test_db_session, created_by=admin_id)
+        halves = await _create_layer(
+            test_db_session,
+            created_by=admin_id,
+            column_type="Geometry",
+            geometry_type="POLYGON",
+            feature_count=2,
+            values_sql=(
+                "('lower', ST_MakeEnvelope(0, 0, 3, 0.5, 4326),"
+                " ST_MakeEnvelope(0, 0, 3, 0.5, 4326)),"
+                "('upper', ST_MakeEnvelope(0, 0.5, 3, 1, 4326),"
+                " ST_MakeEnvelope(0, 0.5, 3, 1, 4326))"
+            ),
+            column_info=[{"name": "parcel", "type": "text"}],
+        )
+        await test_db_session.execute(
+            text(
+                f"ALTER TABLE data.{halves.table_name} "  # noqa: S608
+                "RENAME COLUMN name TO parcel"
+            )
+        )
+        # A json column on the overlay, so the count is measured on the shape
+        # the join-back exists for rather than on a plain-text fallback.
+        await test_db_session.execute(
+            text(f"ALTER TABLE data.{zones.table_name} ADD COLUMN props json")  # noqa: S608
+        )
+        await test_db_session.commit()
+        job = await _create_job(test_db_session, admin_id)
+
+        await _materialize(
+            job_id=str(job.id),
+            dataset_id=str(halves.id),
+            user_id=str(admin_id),
+            operation="intersect",
+            title=f"Pairs {uuid.uuid4().hex[:6]}",
+            mask_dataset_id=str(zones.id),
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        out = await test_db_session.get(Dataset, job.dataset_id)
+        pairs = (
+            await test_db_session.execute(
+                text(
+                    f"SELECT parcel, zone FROM data.{out.table_name}"  # noqa: S608
+                    " ORDER BY parcel, zone"
+                )
+            )
+        ).all()
+        assert [tuple(p) for p in pairs] == [
+            ("lower", "A"),
+            ("lower", "B"),
+            ("lower", "C"),
+            ("upper", "A"),
+            ("upper", "B"),
+            ("upper", "C"),
+        ]
+        assert out.feature_count == 6
+
+
 class TestPreview:
     async def test_preview_rows_carry_distinct_generated_gids(
         self,
@@ -428,50 +592,72 @@ class TestColumnCollisions:
         assert resp.status_code == 422
         assert "name" in resp.text
 
-    async def test_an_ungroupable_overlay_column_is_rejected_at_enqueue(
-        self,
-        client: AsyncClient,
-        admin_auth_header: dict,
-        test_db_session: AsyncSession,
-    ):
-        """fix(#1097 review): json and xml have no equality operator.
+    def test_an_ungroupable_overlay_column_is_admitted_at_enqueue(self):
+        """fix(#1099): the inverse of what #1097 pinned here.
 
-        render_intersect_pairs groups by the two gids plus every carried
-        OVERLAY column — the source's columns ride the functional dependency on
-        _src.gid, but _mask_pieces is a CTE with no key, so its columns must be
-        named in the GROUP BY. Grouping on json fails the CTAS with SQLSTATE
-        42883, and it fails only there: the preview carries gid and source_gid
-        alone, so it succeeds first and the operation dies after the queue wait
-        quoting a generated alias the user never wrote.
+        json and xml have no equality operator, and the aggregate used to name
+        every carried OVERLAY column in its GROUP BY, so a layer holding one
+        was refused outright — which took a real class of layer out of service,
+        since nested GeoJSON properties land as json routinely. The attributes
+        are joined back outside the aggregate now, where nothing groups, so the
+        type stops mattering.
+
+        Against the validator rather than the endpoint, for the reason the
+        SOURCE-side sibling below spells out: admitting the request means
+        enqueueing, and a 503 from the broker is not evidence about column
+        rules.
         """
-        admin_id = await get_user_id(test_db_session, "admin")
-        zones = await _create_zones(test_db_session, created_by=admin_id)
-        bar = await _create_bar(test_db_session, created_by=admin_id)
-        # Physical column AND catalog snapshot: the guard reads column_info,
-        # and the worker that would hit 42883 reads the live table.
-        await test_db_session.execute(
-            text(f"ALTER TABLE data.{zones.table_name} ADD COLUMN props json")  # noqa: S608
+        from app.modules.catalog.datasets.api.router_analysis import (
+            _validate_intersect_columns,
         )
-        zones.column_info = [
-            {"name": "zone", "type": "text"},
-            {"name": "props", "type": "json"},
-        ]
-        await test_db_session.commit()
 
-        resp = await client.post(
-            _materialize_url(bar.id),
-            json={
-                "operation": "intersect",
-                "mask_dataset_id": str(zones.id),
-                "title": "Nope",
-            },
-            headers=admin_auth_header,
+        source = SimpleNamespace(column_info=[{"name": "parcel", "type": "text"}])
+        overlay = SimpleNamespace(
+            column_info=[
+                {"name": "zone", "type": "text"},
+                {"name": "props", "type": "json"},
+                {"name": "doc", "type": "xml"},
+            ]
         )
-        assert resp.status_code == 422
-        # Names the column and its type: "cannot be grouped" with no referent
-        # sends the operator looking through both layers by hand.
-        assert "props" in resp.text
-        assert "json" in resp.text
+        _validate_intersect_columns(source, overlay)
+
+    def test_the_overlay_guards_still_refuse_what_actually_breaks(self):
+        """The other direction of #1099: admitting json admitted only json.
+
+        Each of these still fails the CTAS if it gets through, and none of them
+        is touched by moving the attributes out of the GROUP BY — so a fix that
+        pinned the admission alone would let a wholesale gutting of the guard
+        pass green.
+        """
+        from app.modules.catalog.datasets.api.router_analysis import (
+            _validate_dissolve_by_field,
+            _validate_intersect_columns,
+        )
+
+        source = SimpleNamespace(column_info=[{"name": "zone", "type": "text"}])
+        # A name in both layers: "column specified more than once".
+        with pytest.raises(HTTPException) as excinfo:
+            _validate_intersect_columns(
+                source, SimpleNamespace(column_info=[{"name": "zone", "type": "text"}])
+            )
+        assert "zone" in str(excinfo.value.detail)
+        # A name in the internal alias namespace: an ambiguous reference.
+        with pytest.raises(HTTPException) as excinfo:
+            _validate_intersect_columns(
+                source,
+                SimpleNamespace(column_info=[{"name": "_gl_src_type", "type": "text"}]),
+            )
+        assert "_gl_" in str(excinfo.value.detail)
+        # And dissolve, which shares NON_GROUPABLE_COLUMN_TYPES with the branch
+        # that came out. It really does GROUP BY a user-chosen column, so json
+        # stays fatal there — deleting the shared machinery must not read as
+        # this issue being fixed.
+        with pytest.raises(HTTPException) as excinfo:
+            _validate_dissolve_by_field(
+                SimpleNamespace(column_info=[{"name": "props", "type": "json"}]),
+                "props",
+            )
+        assert "props" in str(excinfo.value.detail)
 
     async def test_an_overlay_column_in_the_alias_namespace_is_rejected(
         self,
@@ -634,108 +820,23 @@ class TestColumnCollisions:
             test_db_session, Dataset, str(zones.id), "data", label="join"
         )
 
-    async def test_an_overlay_that_gains_a_json_column_after_enqueue_is_caught(
-        self, test_db_session: AsyncSession
-    ):
-        """fix(#1097 review): the enqueue guard reads a catalog SNAPSHOT.
-
-        A re-upload can replace the overlay between enqueue and the job
-        running, so a layer that passed the router can be grouping-hostile by
-        the time the worker builds the CTAS. That is the same window
-        _reject_output_column_collision exists for, and why the carry-column
-        list beside it is read live rather than trusted from column_info.
-
-        Types, not names: the live NAME list is already read here and would not
-        have caught this, because the column that breaks the query has a
-        perfectly ordinary name.
-        """
-        from app.processing.analysis.tasks import (
-            _reject_ungroupable_overlay_columns,
-        )
-
-        admin_id = await get_user_id(test_db_session, "admin")
-        zones = await _create_zones(test_db_session, created_by=admin_id)
-        # column_info still says text-only — the snapshot the router would read.
-        assert all(c.get("type") != "json" for c in (zones.column_info or [])), (
-            "fixture drifted: the snapshot must look clean for this to mean anything"
-        )
-        await test_db_session.execute(
-            text(f"ALTER TABLE data.{zones.table_name} ADD COLUMN props json")  # noqa: S608
-        )
-        await test_db_session.commit()
-
-        with pytest.raises(ValueError) as excinfo:
-            await _reject_ungroupable_overlay_columns(
-                test_db_session, "data", zones.table_name
-            )
-        assert "props" in str(excinfo.value)
-        assert "json" in str(excinfo.value)
-
-    async def test_a_groupable_overlay_passes_the_live_recheck(
-        self, test_db_session: AsyncSession
-    ):
-        """The negative control: the live recheck must not refuse ordinary
-        layers, or every intersect would fail at the worker."""
-        from app.processing.analysis.tasks import (
-            _reject_ungroupable_overlay_columns,
-        )
-
-        admin_id = await get_user_id(test_db_session, "admin")
-        zones = await _create_zones(test_db_session, created_by=admin_id)
-        await _reject_ungroupable_overlay_columns(
-            test_db_session, "data", zones.table_name
-        )
-
-    async def test_a_json_array_overlay_column_is_rejected_with_its_real_type(
-        self, test_db_session: AsyncSession
-    ):
-        """fix(#1097 review): arrays hide their element type from data_type.
-
-        information_schema reports a json[] column's data_type as 'ARRAY', so
-        the exact comparison the scalar guard makes never fires, and the
-        snapshot the router reads has the same blind spot — this recheck is
-        the ONLY layer that can see the element type (udt_name '_json').
-        GROUP BY on json[] fails with SQLSTATE 42883 exactly like scalar json.
-        int[] has equality and must still pass, so the check names elements,
-        not arrays.
-        """
-        from app.processing.analysis.tasks import (
-            _reject_ungroupable_overlay_columns,
-        )
-
-        admin_id = await get_user_id(test_db_session, "admin")
-        zones = await _create_zones(test_db_session, created_by=admin_id)
-        await test_db_session.execute(
-            text(
-                f"ALTER TABLE data.{zones.table_name} "  # noqa: S608
-                f"ADD COLUMN props json[], ADD COLUMN tags int[]"
-            )
-        )
-        await test_db_session.commit()
-
-        with pytest.raises(ValueError) as excinfo:
-            await _reject_ungroupable_overlay_columns(
-                test_db_session, "data", zones.table_name
-            )
-        assert "props" in str(excinfo.value)
-        assert "json[]" in str(excinfo.value)
-
-        # int[] alone passes: drop the hostile column and the layer is fine.
-        await test_db_session.execute(
-            text(f"ALTER TABLE data.{zones.table_name} DROP COLUMN props")  # noqa: S608
-        )
-        await test_db_session.commit()
-        await _reject_ungroupable_overlay_columns(
-            test_db_session, "data", zones.table_name
-        )
+    # fix(#1099): the worker-side ungroupable-overlay recheck and its two
+    # controls came out with the guard they exercised — the overlay's
+    # attributes never reach a GROUP BY now, so a re-upload that introduces a
+    # json column no longer has anything to break. _ungroupable_type_name's
+    # ARRAY branch (the json[] case those tests also covered) is still pinned,
+    # by dissolve's live recheck in
+    # test_analysis_materialize.py::test_dissolve_by_a_json_array_field_fails_with_a_clear_message.
 
     def test_an_ungroupable_SOURCE_column_is_still_allowed(self):
-        """The guard is deliberately one-sided, so pin the side it lets through.
+        """The source side never needed the guard, and still does not.
 
         A json column on the SOURCE never reaches the GROUP BY: _src.gid is a
         real table's primary key, so PostgreSQL licenses every other _src
-        column by functional dependency. Rejecting both sides would refuse
-        overlays that work.
+        column by functional dependency. Kept through fix(#1099) because it
+        pins a different fact from the overlay-side test above — that one is
+        about the join-back, this one about functional dependency, and either
+        could be broken without the other.
 
         Against the validator rather than the endpoint: enqueueing needs the
         task queue, so an HTTP assertion here would be reading a 503 from the
@@ -756,11 +857,12 @@ class TestColumnCollisions:
         overlay = SimpleNamespace(column_info=[{"name": "zone", "type": "text"}])
         _validate_intersect_columns(source, overlay)
 
-        # And the mirror image is refused, which is what makes the pass above
-        # a statement about WHICH side rather than about json in general.
-        with pytest.raises(HTTPException) as excinfo:
-            _validate_intersect_columns(overlay, source)
-        assert "props" in str(excinfo.value.detail)
+        # fix(#1099): the mirror image used to be refused, and that asymmetry
+        # is what this test was originally about. It is gone — the overlay side
+        # never needed the guard either, once its attributes stopped riding
+        # through the aggregate. Pinned here rather than dropped, because "the
+        # source side is fine" is only half the reason the sides now agree.
+        _validate_intersect_columns(overlay, source)
 
     async def test_a_source_column_named_source_gid_is_rejected(
         self,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1366,7 +1366,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # linear (add_4326_column) and migration 0034 backfilled existing rows,
     # so the per-read wraps had nothing left to guard. The invariant is
     # recorded in the module docstring instead. Cap 1260 -> 1227, exact.
-    "backend/app/platform/analysis_sql.py": 1227,
+    #
+    # fix(#1099): +28 for regrouping render_intersect_pairs. The aggregate used
+    # to carry the overlay's attributes through the _mask_pieces CTE, which has
+    # no key, so each one had to be named in the GROUP BY — and json/xml have no
+    # equality operator, so a nested-GeoJSON properties column took a layer out
+    # of service as an overlay entirely. It groups by the two gids alone now and
+    # the outer query joins the overlay table back on its primary key, where no
+    # grouping applies. Six of the lines are the render (one more join fragment,
+    # and the output column list splitting in two because the sides come from
+    # different relations); the rest is the docstring bullet carrying why the
+    # join cannot change the row count and why it is LEFT rather than INNER.
+    # Cap 1227 -> 1255, exact.
+    "backend/app/platform/analysis_sql.py": 1255,
     # tasks.py carries growth from BOTH sides of this rebase, so the number is
     # re-measured rather than taken from either. #1012 added the scoped
     # work_mem (the SET LOCAL, its budget arithmetic and the boot-time
@@ -1423,7 +1435,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # udt_name ('_json') as well, and the same check now also covers
     # dissolve's by_field, which had the identical blind spot plus no live
     # recheck at all.
-    "backend/app/processing/analysis/tasks.py": 1449,
+    #
+    # fix(#1099): -36 — _reject_ungroupable_overlay_columns is retired, along
+    # with its call site in _resolve_and_validate_columns. The overlay's
+    # attributes are joined back outside the aggregate now, so a re-upload that
+    # introduces a json column has nothing left to break; leaving the recheck
+    # would have refused, after the queue wait, exactly the layers that issue
+    # set out to admit. _ungroupable_type_name and its ARRAY branch stay —
+    # dissolve's by_field really does group by a user-chosen column. Cap
+    # 1449 -> 1413, exact.
+    "backend/app/processing/analysis/tasks.py": 1413,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.


### PR DESCRIPTION
## Problem

`render_intersect_pairs` grouped the aggregate by `_src.gid`, `_mp._gl_mask_gid`, and every carried overlay column. The source side needs no grouping, because `_src.gid` is a real table's primary key and PostgreSQL licenses the rest by functional dependency. But `_mask_pieces` is a CTE with no key, so each overlay column routed through it had to be named in the `GROUP BY`.

`json` and `xml` have no equality operator, so grouping on one fails with SQLSTATE 42883. #1097 moved that failure from the worker to enqueue, which stopped it landing after the whole queue wait quoting a generated alias the user never wrote. But refusing is not the end state: nested GeoJSON properties land as `json` routinely, so this took a real class of layer out of service as an overlay.

## Fix

Group by the two gids alone and join the overlay's attributes back afterwards. The aggregate carries `_gl_mask_gid` out; the outer query joins the overlay table on its primary key and takes the attributes from there. The outer query does no aggregation, so no type is off-limits.

The join is rendered only when there are overlay columns to fetch, so the preview path, which carries `gid` and `source_gid` only, emits the statement it always did.

**LEFT, not INNER**, which is a deviation from the issue's wording. Every `_gl_mask_gid` was read from that same table in the same statement, so a miss is impossible and INNER would be correct. But that makes the row-count guarantee rest on the snapshot argument being right, and a silent row *loss* is the worst failure available here. LEFT makes the guarantee structural instead.

## Row counts are unchanged, and that is pinned

The aggregate already emits one row per (source gid, overlay gid) pair, and `gid` is a serial primary key on every path that builds a feature table (`ogr.py:661` via `-lco FID=gid`, `parquet.py:450`, `layers/service.py:93`, `service_create.py:93`, plus `ADD PRIMARY KEY (gid)` on analysis outputs), so the join matches at most one row.

`test_the_join_back_does_not_multiply_rows` covers the case a 1:many join would actually expose: one overlay feature matched by several source features, so each overlay gid is looked up more than once. Two half-height bars across three unit-square zones, with a `json` column on the overlay so the count is measured on the shape the join exists for. Six pairs in, six rows out.

## The worker-side guard comes out too

`_reject_ungroupable_overlay_columns` in `processing/analysis/tasks.py` is the live-schema twin of the router branch this removes, and it is not in the issue's file list. Removing only the router half would have made intersect **worse than today**: enqueue accepts the layer, then the job dies minutes later after the queue wait, on a guard for a `GROUP BY` that no longer exists. That is exactly what #1097 was written to eliminate.

Nothing that still groups by a user-chosen column lost its recheck. `_ungroupable_type_name` stays, including its ARRAY/`udt_name` branch, and `_reject_ungroupable_by_field` is still called from the dissolve branch. Three tests of the removed function went with it; the `json[]` case they covered is independently pinned by `test_analysis_materialize.py::test_dissolve_by_a_json_array_field_fails_with_a_clear_message`, which drives it through `_materialize`.

## Both directions pinned

- `test_a_json_overlay_column_survives_into_the_output` drives real `_materialize` and asserts the columns arrive **as their types** (read from `information_schema.columns`) and that the values ride the right rows. Presence alone would pass under a join on the wrong key.
- `test_an_ungroupable_overlay_column_is_admitted_at_enqueue` is the inverted refusal test.
- `test_the_overlay_guards_still_refuse_what_actually_breaks` is new. Admitting `json` must not have admitted everything: it pins a duplicate name across layers, a name in the `_gl_` alias namespace, and dissolve's `by_field` still refusing `json`. That last one fails if someone removes the shared `NON_GROUPABLE_COLUMN_TYPES` machinery and calls it fixing this issue.
- `test_an_ungroupable_SOURCE_column_is_still_allowed` is kept. Its second half asserted the mirror image raises, which is the branch this removes, so that half now asserts the call passes.

## Module line caps

Both moved in this commit, measured exact: `analysis_sql.py` 1227 → 1255, `tasks.py` 1449 → 1413.

## Verification

```
cd backend
uv run pytest -n 4 --dist loadgroup        # 6827 passed, 83 skipped
uv run pytest tests/test_analysis_intersect.py               # 24 passed
uv run pytest tests/test_analysis_materialize.py tests/test_analysis_preview.py  # 156 passed
uv run pytest tests/test_layering.py -q    # 36 passed
uv run ruff check .                        # All checks passed
uv run ruff format --check .               # 875 files already formatted
```

The materialize test was checked against the old renderer rather than assumed to have teeth: restoring the previous `render_intersect_pairs` makes it fail at CTAS with `could not identify an equality operator for type json`, quoting the `GROUP BY` that carried the overlay columns.

Closes #1099