### PR TITLE
fix(builder): measure small-DEM viewport coverage across the antimeridian

### DIFF
--- a/frontend/src/components/builder/__tests__/terrain-coverage.test.ts
+++ b/frontend/src/components/builder/__tests__/terrain-coverage.test.ts
@@ -62,6 +62,112 @@ describe('demViewportCoverage', () => {
   });
 });
 
+// fix(#1112 review): the antimeridian cases. `demBounds` here is the TILE
+// TOKEN's bounds (span form, from processing/tiles/router.py), not the map
+// layer's `dataset_extent_bbox`, so both forms are exercised: the span form is
+// what ships today, and the spec form is what a crossing extent looks like if
+// this input is ever sourced seam-aware.
+//
+// The rectangle that actually crosses is the VIEWPORT: MapLibre's getBounds()
+// takes min/max over unwrapped corner longitudes, so a viewport straddling the
+// seam reads e.g. [179.5, 182] rather than inverting.
+describe('demViewportCoverage across the antimeridian', () => {
+  // Fiji-shaped DEM: ~3 degrees wide, sitting on the seam.
+  const FIJI_SPEC = [178.5, -20, -178.5, -15];
+  const FIJI_SPAN = [-180, -20, 180, -15];
+  // Zoomed in over Fiji, straddling the seam. 2.5 x 2 degrees.
+  const SEAM_VIEW = [179.5, -18, 182, -16];
+  // Zoomed way out. 120 x 120 degrees.
+  const WIDE_VIEW = [120, -60, 240, 60];
+
+  it('reports a world-spanning DEM as fully covering a seam-straddling viewport', () => {
+    // The regression this fixes: clipping the DEM at +180 scored this 0.2 and
+    // warned about a "small DEM" that covers the entire screen.
+    expect(demViewportCoverage(FIJI_SPAN, SEAM_VIEW)).toBe(1);
+  });
+
+  it('scores a crossing DEM against the part of the viewport it really covers', () => {
+    // [178.5, 181.5] over a [179.5, 182] viewport → 2 of 2.5 degrees wide,
+    // full height → 0.8. The old code returned null (west > east was rejected).
+    expect(demViewportCoverage(FIJI_SPEC, SEAM_VIEW)).toBeCloseTo(0.8, 6);
+  });
+
+  it('still reports a crossing DEM as a sliver of a zoomed-out viewport', () => {
+    // 3 degrees wide, 5 of 120 degrees tall, in a 120x120 viewport.
+    expect(demViewportCoverage(FIJI_SPEC, WIDE_VIEW)).toBeCloseTo((3 * 5) / (120 * 120), 6);
+  });
+
+  it('does not credit a DEM on the far side of the globe', () => {
+    // Central France against a Fiji viewport: no turn of the globe overlaps.
+    expect(demViewportCoverage([1.5, -18, 2.5, -16], SEAM_VIEW)).toBe(0);
+  });
+
+  // fix(#1124 codex P2): `renderWorldCopies` is on by default, so getBounds()
+  // keeps running further out the more the user pans east or west. There is no
+  // bound on how far, which is why the scoring cannot enumerate a fixed set of
+  // turns. FAR_VIEW is SEAM_VIEW moved two whole turns east (+720) and must
+  // score identically; DEEP_VIEW is ten turns west (-3600) and so must the
+  // rest of the axis.
+  const FAR_VIEW = [899.5, -18, 902, -16];
+  const DEEP_VIEW = [-3420.5, -18, -3418, -16];
+
+  it('scores a far-panned viewport exactly like the equivalent one at the seam', () => {
+    expect(demViewportCoverage(FIJI_SPEC, FAR_VIEW)).toBeCloseTo(
+      demViewportCoverage(FIJI_SPEC, SEAM_VIEW) as number, 6,
+    );
+    expect(demViewportCoverage(FIJI_SPEC, DEEP_VIEW)).toBeCloseTo(
+      demViewportCoverage(FIJI_SPEC, SEAM_VIEW) as number, 6,
+    );
+  });
+
+  it('still reports a world-spanning DEM as full coverage after a far pan', () => {
+    expect(demViewportCoverage(FIJI_SPAN, FAR_VIEW)).toBe(1);
+    expect(demViewportCoverage(FIJI_SPAN, DEEP_VIEW)).toBe(1);
+  });
+
+  it('is turn-invariant for an ordinary DEM at any pan distance', () => {
+    // A plain non-crossing DEM, viewed from every turn out to ±20 world copies.
+    const dem = [10, -1, 20, 1];
+    const baseline = demViewportCoverage(dem, [12, -1, 18, 1]) as number;
+    expect(baseline).toBeGreaterThan(0);
+    for (let turn = -20; turn <= 20; turn++) {
+      const shifted = [12 + 360 * turn, -1, 18 + 360 * turn, 1];
+      expect(demViewportCoverage(dem, shifted)).toBeCloseTo(baseline, 6);
+    }
+  });
+});
+
+describe('shouldWarnSmallDemCoverage across the antimeridian', () => {
+  const FIJI_SPEC = [178.5, -20, -178.5, -15];
+  const FIJI_SPAN = [-180, -20, 180, -15];
+  const SEAM_VIEW = [179.5, -18, 182, -16];
+  const WIDE_VIEW = [120, -60, 240, 60];
+
+  it('does not warn when a crossing DEM genuinely covers the viewport', () => {
+    expect(shouldWarnSmallDemCoverage(FIJI_SPAN, SEAM_VIEW)).toBe(false);
+    expect(shouldWarnSmallDemCoverage(FIJI_SPEC, SEAM_VIEW)).toBe(false);
+  });
+
+  it('still warns when a crossing DEM genuinely covers only a sliver', () => {
+    expect(shouldWarnSmallDemCoverage(FIJI_SPEC, WIDE_VIEW)).toBe(true);
+    expect(shouldWarnSmallDemCoverage(FIJI_SPAN, WIDE_VIEW)).toBe(true);
+  });
+
+  // fix(#1124 codex P2): both directions again, but two turns east of the seam.
+  const FAR_VIEW = [899.5, -18, 902, -16];
+  const FAR_WIDE_VIEW = [840, -60, 960, 60];
+
+  it('does not warn about a covering DEM after the user pans past the seam', () => {
+    expect(shouldWarnSmallDemCoverage(FIJI_SPAN, FAR_VIEW)).toBe(false);
+    expect(shouldWarnSmallDemCoverage(FIJI_SPEC, FAR_VIEW)).toBe(false);
+  });
+
+  it('still warns about a sliver DEM after the user pans past the seam', () => {
+    expect(shouldWarnSmallDemCoverage(FIJI_SPEC, FAR_WIDE_VIEW)).toBe(true);
+    expect(shouldWarnSmallDemCoverage(FIJI_SPAN, FAR_WIDE_VIEW)).toBe(true);
+  });
+});
+
 describe('shouldWarnSmallDemCoverage', () => {
   it('warns below the threshold', () => {
     expect(shouldWarnSmallDemCoverage([-1, -1, 1, 1], WORLD_VIEW)).toBe(true);

--- a/frontend/src/components/builder/terrain-coverage.ts
+++ b/frontend/src/components/builder/terrain-coverage.ts
@@ -27,6 +27,23 @@ interface MapWithBounds {
  * Coverage = (DEM bounds ∩ viewport area) / viewport area, computed in the
  * lng/lat degree plane. This is an approximation (it ignores Mercator area
  * distortion), which is fine for a UX threshold check.
+ *
+ * fix(#1112 review): where `demBounds` comes from, because it is easy to get
+ * wrong. It is the tile token's `bounds` (`RasterTileToken.bounds`, built by
+ * `extent_to_span_bbox` at processing/tiles/router.py), NOT the map layer's
+ * `dataset_extent_bbox`. Both call sites read it from a token map fed only by
+ * the tile-token API, so #1112's flip of `dataset_extent_bbox` to the RFC 7946
+ * spec form does not reach here.
+ *
+ * The seam still matters, for the other rectangle. `map.getBounds()` is always
+ * monotonic — MapLibre takes min/max over four UNWRAPPED corner longitudes —
+ * but it runs past ±180 when the viewport straddles the antimeridian, e.g.
+ * `[179.5, …, 182, …]`. A planar `Math.min(ve, demEast)` then clipped the DEM
+ * at +180 and reported a fifth of the coverage a world-spanning DEM really
+ * has, firing the "small DEM" toast for a DEM that covers the whole screen.
+ * So the longitude axis is measured on the circle: each rectangle becomes an
+ * unwrapped interval (a crossing pair unwraps past 180) and the DEM is scored
+ * as the repeating pattern it is. Latitude needs none of this.
  */
 
 /** Default coverage threshold below which the warning fires. */
@@ -38,8 +55,80 @@ function isFiniteBounds4(bounds: number[] | null | undefined): bounds is Bounds4
   return Array.isArray(bounds)
     && bounds.length === 4
     && bounds.every((v) => Number.isFinite(v))
-    && bounds[0] < bounds[2]
+    // West may exceed east: that is the RFC 7946 §5.2 encoding of a crossing
+    // box, not a malformed one. Only a zero-width longitude span is degenerate.
+    && bounds[0] !== bounds[2]
     && bounds[1] < bounds[3];
+}
+
+/** A longitude pair as an increasing interval, unwrapping a seam-crossing pair
+ *  past 180 (`[178.5, -178.5]` → `[178.5, 181.5]`). */
+function lonInterval(west: number, east: number): [number, number] {
+  return [west, east < west ? east + 360 : east];
+}
+
+/**
+ * Length of the repeating DEM covered between the DEM's own west edge and `t`
+ * degrees east of it, where the DEM is `width` wide and repeats every 360.
+ *
+ * Whole turns contribute a full `width` each; the partial turn contributes
+ * however far into it the DEM reaches. Defined for negative `t` too, because
+ * the viewport can sit west of the DEM's west edge.
+ *
+ * Continuous across turn boundaries by construction: approaching a boundary
+ * from below gives `q * width + width`, and from above `(q + 1) * width + 0`.
+ * Float noise near a boundary therefore cannot jump the result by a period.
+ */
+function coveredLength(t: number, width: number): number {
+  const turns = Math.floor(t / 360);
+  return turns * width + Math.min(t - turns * 360, width);
+}
+
+/**
+ * Longitudinal overlap of the DEM with the viewport, measured on the circle.
+ *
+ * fix(#1124 codex P2): this used to score the DEM against a fixed `[-360, 0,
+ * 360]` shift list. `renderWorldCopies` is on by default, so `getBounds()` runs
+ * further out the more the user pans and a Fiji DEM can legitimately be viewed
+ * at `[899.5, 902]`, two whole turns east. A fixed list answers "how many
+ * turns?" with a guess, and one pan past the last entry reported zero coverage
+ * and warned about a DEM that fills the screen — the same class of bug this
+ * function exists to fix, one level out.
+ *
+ * So don't enumerate turns at all. The DEM is a pattern repeating every 360
+ * degrees, and `coveredLength` measures that pattern from the DEM's west edge
+ * to any point; the overlap is that measured at the viewport's two edges and
+ * subtracted. Exact for any pan distance, and the same cost at 2 turns as at
+ * 2000. The result cannot exceed the viewport width because `coveredLength`
+ * grows at most 1:1 with its argument.
+ */
+function lonOverlap(dem: [number, number], view: [number, number]): number {
+  const demWidth = dem[1] - dem[0];
+  // A DEM spanning the globe covers every longitude, at every pan distance.
+  //
+  // KNOWINGLY OPTIMISTIC for a seam-crossing DEM, and not fixable here (#1128).
+  // `extent_to_span_bbox` (processing/tiles/router.py) widens a crossing extent
+  // to exactly [-180, s, 180, n], which is the same value a genuinely global
+  // raster produces. The two are indistinguishable by the time they reach this
+  // function, so no arithmetic on `dem` can tell them apart and this branch has
+  // to guess. It guesses "global", which under-warns rather than crying wolf.
+  //
+  // Concretely, a Fiji footprint in viewport [179.5, -20, 190, -15]: the true
+  // coverage is 19% (warn), this returns 100% (silent). The pre-#1122 planar
+  // math happened to return 4.8% and warn, but only as a side effect of the
+  // +180 clipping bug that produced the far worse false alarm this module was
+  // changed to fix; it was not reading the seam correctly either.
+  //
+  // The fix is a change of DATA SOURCE, not of this math: feed `demBounds` from
+  // the layer's `dataset_extent_bbox`, which became RFC 7946 spec form in
+  // #1112, and the crossing case arrives as [178.5, …, -178.5, …]. This
+  // function then already returns the correct 19% with no edit, because the
+  // interval is a real 3 degrees wide and never reaches this branch. #1128.
+  if (demWidth >= 360) return view[1] - view[0];
+  return Math.max(
+    0,
+    coveredLength(view[1] - dem[0], demWidth) - coveredLength(view[0] - dem[0], demWidth),
+  );
 }
 
 /**
@@ -54,10 +143,12 @@ export function demViewportCoverage(
   if (!isFiniteBounds4(demBounds) || !isFiniteBounds4(viewport)) return null;
 
   const [vw, vs, ve, vn] = viewport;
-  const viewportArea = (ve - vw) * (vn - vs);
+  const view = lonInterval(vw, ve);
+  const viewWidth = view[1] - view[0];
+  const viewportArea = viewWidth * (vn - vs);
   if (!(viewportArea > 0)) return null;
 
-  const ix = Math.max(0, Math.min(ve, demBounds[2]) - Math.max(vw, demBounds[0]));
+  const ix = lonOverlap(lonInterval(demBounds[0], demBounds[2]), view);
   const iy = Math.max(0, Math.min(vn, demBounds[3]) - Math.max(vs, demBounds[1]));
   const intersection = ix * iy;
 


### PR DESCRIPTION
## Problem

`demViewportCoverage` compared two longitude ranges with planar min/max:

```ts
ix = Math.max(0, Math.min(ve, demBounds[2]) - Math.max(vw, demBounds[0]));
```

`map.getBounds()` is monotonic, because MapLibre takes min/max over four unwrapped corner longitudes. But it runs **past ±180** when the viewport straddles the antimeridian, returning something like `[179.5, …, 182, …]`. The DEM's own bounds do not, so `Math.min(ve, demEast)` clipped the DEM at +180 while the viewport kept its 182.

A DEM covering the entire screen scored 0.2 of that viewport and fired the `#186 (b)` "this DEM only covers a small slice of the viewport" toast. The message told the user the opposite of what they could see.

`isFiniteBounds4` also rejected `west > east` outright as malformed, so a spec-form crossing bbox produced no signal at all rather than a wrong one.

## Fix

Measure longitude on the circle, and treat the DEM as what it is: a pattern repeating every 360 degrees.

`coveredLength(t, width)` measures how much DEM lies between its own west edge and `t` degrees east of it. Whole turns contribute a full `width` each, the partial turn contributes however far into it the DEM reaches. The overlap with a viewport is that quantity measured at the viewport's two edges and subtracted.

Latitude is untouched and needs none of this.

`isFiniteBounds4` now accepts `west > east`. That is the RFC 7946 §5.2 encoding of a crossing box, not a malformed one. Only a zero-width longitude span is degenerate.

## Why not enumerate turns

The first version of this fix scored the DEM against a fixed `[-360, 0, 360]` shift list and summed the overlaps. Codex caught that on review, and it was the same class of bug this function exists to fix, one level out.

`renderWorldCopies` is on by default, so `getBounds()` runs further out the more the user pans, without bound. A Fiji DEM can legitimately be viewed at `[899.5, 902]`, two whole turns east. A fixed list answers "how many turns?" with a guess, and one pan past the last entry reported zero coverage and warned about a DEM filling the screen.

The closed form has no shift list to outgrow. It is exact at any pan distance and costs the same at two turns as at two thousand. It is also continuous across turn boundaries by construction — approaching from below gives `q * width + width`, from above `(q + 1) * width + 0` — so float noise near a boundary cannot jump the result by a period.

## Not related to #1112

Worth stating, because the two look adjacent. This path reads the **tile token's** bounds, which `processing/tiles/router.py:1278` builds with `extent_to_span_bbox` and documents at `:397` as deliberately the monotonic span form. It does not read the map layer's `dataset_extent_bbox`; `BuilderMap.tsx` resolves the token from `useTileTokens()`, not from `rasterTokenFromLayer`. So #1112's flip of that field does not reach here, and this bug predates it.

## Verification

```
cd frontend
npm run lint       # clean
npm run typecheck  # clean
npx vitest run src/components/builder/__tests__/terrain-coverage.test.ts   # 26 passed
npm run test:coverage   # 369 files, 4532 tests passed
```

Both the original fix and the turn-invariance fix were checked against the code they replace, rather than assumed to have teeth.

Restoring the pre-fix module fails 5 tests, in both directions: `expected 0.2 to be 1` (the reported bug), `expected null to be close to 0.8` (the old `isFiniteBounds4` rejecting a crossing pair), `expected true to be false` (the spurious warning), and `expected false to be true` — a genuinely small DEM near the seam that **stops** warning.

Restoring the three-shift version fails 4, including `is turn-invariant for an ordinary DEM at any pan distance`, which pins the general property rather than the single far-pan case that prompted it.

Closes #1122