### PR TITLE
fix(maps): serve dataset_extent_bbox in the RFC 7946 spec form

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -183,10 +183,13 @@ def dataset_to_response(
         # extent to [-180, s, 180, n], which is bit-identical to a genuinely
         # global dataset, so isLargeExtent fired first and no client-side test
         # could tell the two apart. The seam information has to survive the
-        # wire. Do NOT flip the sibling `dataset_extent_bbox` in
-        # maps/_router_helpers.py: it bounds a vector tile source, where an
-        # inverted pair yields no tiles at all. One column, two contracts —
-        # both pinned in tests/test_antimeridian_extent.py.
+        # wire. fix(#1112): the sibling `dataset_extent_bbox` in
+        # maps/_router_helpers.py now serves the same form for the same reason.
+        # It reaches a MapLibre source `bounds`, where an inverted pair yields
+        # no tiles at all, but the span conversion belongs at that boundary
+        # (normalizeRasterBounds in layer-adapters/shared.ts) rather than on the
+        # wire, so the builder's fit paths still get the seam. One column, one
+        # contract — pinned in tests/test_antimeridian_extent.py.
         extent_bbox=extent_to_bbox(record.spatial_extent),
         column_info=dataset.column_info,
         quality_detail=dataset.quality_detail,

--- a/backend/app/modules/catalog/maps/_router_helpers.py
+++ b/backend/app/modules/catalog/maps/_router_helpers.py
@@ -12,7 +12,7 @@ import structlog
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.geo import extent_to_span_bbox
+from app.core.geo import extent_to_bbox
 from app.core.identity import Identity
 from app.modules.catalog.authorization import get_user_roles
 from app.modules.catalog.maps.models import Map, MapLayer
@@ -108,13 +108,18 @@ def _build_layer_response(
         dataset_name=meta.get("dataset_name", ""),
         dataset_geometry_type=meta.get("geometry_type"),
         dataset_table_name=meta.get("table_name", ""),
-        # fix(#892 codex P2): the SPAN, not the RFC 7946 spec bbox. Per MVT-06
-        # this value bounds tile fetching, and it lands in a MapLibre source
-        # `bounds` (map-sync.ts) where a west > east pair matches NO tile, so a
-        # seam-crossing layer would render blank. The two builder fit-bounds
-        # paths also skip an inverted bbox, which silently disables auto-fit and
-        # Zoom to Layer. -180..180 is over-broad but keeps all three working.
-        dataset_extent_bbox=extent_to_span_bbox(meta.get("extent")),
+        # fix(#1112): the RFC 7946 §5.2 spec bbox, west > east on a crossing.
+        # This was the span form under #892, when all three consumers below were
+        # seam-blind. They no longer are, and the span form defeated the guards
+        # they grew: it flattens a Fiji extent to [-180, s, 180, n], which is
+        # bit-identical to a genuinely global dataset, so auto-fit and Zoom to
+        # Layer framed the whole world with nothing left to detect. Each
+        # consumer now declares the form it wants: the two builder fit paths
+        # (BuilderMap.getVisibleLayerBounds, use-builder-layers.handleZoomToLayer)
+        # unwrap the crossing past 180 and fit the few degrees the data occupies,
+        # and normalizeRasterBounds (layer-adapters/shared.ts) spans it back at
+        # the MapLibre source boundary, where an inverted pair matches NO tile.
+        dataset_extent_bbox=extent_to_bbox(meta.get("extent")),
         dataset_column_info=meta.get("column_info"),
         dataset_feature_count=meta.get("feature_count"),
         dataset_sample_values=meta.get("sample_values"),

--- a/backend/tests/test_antimeridian_extent.py
+++ b/backend/tests/test_antimeridian_extent.py
@@ -479,15 +479,18 @@ async def test_make_bbox_filter_finds_a_seam_extent_from_either_side(
 # ---------------------------------------------------------------------------
 
 
-def test_map_layer_response_bbox_stays_monotonic():
-    """fix(#892 codex P2): ``dataset_extent_bbox`` is documented as
-    ``[minx, miny, maxx, maxy]`` and feeds map viewers, not a standards
-    serializer.
+def test_map_layer_response_bbox_uses_the_spec_form():
+    """fix(#1112): ``dataset_extent_bbox`` carries the seam to the map builder.
 
-    A west > east pair there breaks three things at once. MapLibre bounds the
-    layer's tile source to no tiles at all (``map-sync.ts``), so a seam-crossing
-    layer renders blank; the builder's auto-fit and Zoom to Layer both reject an
-    inverted bbox and silently do nothing. Build the response for real, so this
+    Held the span form under #892, when all three consumers were seam-blind. The
+    two builder fit paths have since grown #903 guards that unwrap a crossing
+    pair past 180, and the span form made them unreachable — it flattens a Fiji
+    extent to the same ``[-180, s, 180, n]`` a genuinely global dataset
+    produces, so auto-fit and Zoom to Layer framed the whole world with nothing
+    left to detect. The third consumer still needs the span, because a MapLibre
+    source ``bounds`` matches no tile at all when inverted, but it converts at
+    that boundary (``normalizeRasterBounds`` in ``layer-adapters/shared.ts``)
+    instead of demanding it on the wire. Build the response for real, so this
     holds through any refactor of the helper.
     """
     from app.modules.catalog.maps._router_helpers import _build_layer_response
@@ -509,8 +512,8 @@ def test_map_layer_response_bbox_stays_monotonic():
         show_in_legend=True,
     )
     resp = _build_layer_response(layer, {"extent": _extent(SEAM_MULTIPOLYGON)})
-    assert resp.dataset_extent_bbox == [-180.0, -20.0, 180.0, -15.0]
-    assert resp.dataset_extent_bbox[0] < resp.dataset_extent_bbox[2]
+    assert resp.dataset_extent_bbox == [170.0, -20.0, -170.0, -15.0]
+    assert resp.dataset_extent_bbox[0] > resp.dataset_extent_bbox[2]
 
 
 def test_dataset_response_bbox_uses_the_spec_form():
@@ -522,8 +525,10 @@ def test_dataset_response_bbox_uses_the_spec_form():
     global dataset produces — so ``isLargeExtent`` fired first and the guards
     were unreachable. The seam has to survive the wire.
 
-    These two tests sit together deliberately: one column, two consumers with
-    opposite requirements. A refactor that unifies them fails here.
+    These two tests sit together deliberately: one column, two response fields
+    that reached opposite forms at different times (#1004, then #1112). Both are
+    the spec form now, and the span conversion has moved to the one consumer
+    that needs it, at that consumer's own boundary.
     """
     from app.modules.catalog.datasets.domain.helpers import dataset_to_response
     from app.modules.catalog.datasets.domain.models import Dataset, Record

--- a/frontend/src/components/builder/__tests__/map-sync.seam-bounds.test.ts
+++ b/frontend/src/components/builder/__tests__/map-sync.seam-bounds.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import { syncLayersToMap, toSyncInput } from '../map-sync';
+import type { TileToken } from '@/api/tiles';
+import type { MapLayerResponse } from '@/types/api';
+
+vi.mock('@/lib/tile-utils', () => ({
+  getMvtSourceLayerName: (table: string) => `data.${table}`,
+  buildSignedTileUrl: vi.fn(() => '/tiles/mock/{z}/{x}/{y}.pbf'),
+  buildClusterTileUrl: vi.fn(() => '/tiles/clusters/mock/{z}/{x}/{y}.pbf'),
+}));
+
+// fix(#1112): the producer (maps/_router_helpers.py) now sends
+// `dataset_extent_bbox` in the RFC 7946 §5.2 spec form, so a seam-crossing
+// dataset arrives as `west > east` instead of the world-wide span it used to be
+// flattened to. Two properties have to hold together, and neither is provable
+// from the backend test alone:
+//
+//   1. `toSyncInput` passes the crossing pair through UNCONVERTED, so the
+//      builder's #903 fit guards still see the seam they were written for.
+//   2. It is nonetheless spanned by the time it reaches a MapLibre source
+//      `bounds`, where an inverted pair matches no tile and the layer renders
+//      blank. `normalizeRasterBounds` (layer-adapters/shared.ts) owns that
+//      conversion; this pins that the source path actually goes through it.
+//
+// Fiji: [178.5, -20, -178.5, -15] crossing, [-180, -20, 180, -15] spanned.
+const FIJI_SPEC_BBOX = [178.5, -20, -178.5, -15];
+const FIJI_SPAN_BBOX = [-180, -20, 180, -15];
+
+function makeMockMap() {
+  const sources = new Map<string, { type: string }>();
+  const layerIds = new Set<string>();
+
+  return {
+    getSource: vi.fn((id: string) => sources.get(id) ?? null),
+    addSource: vi.fn((id: string, spec: { type: string }) => {
+      sources.set(id, { ...spec });
+    }),
+    removeSource: vi.fn((id: string) => { sources.delete(id); }),
+    addLayer: vi.fn((layer: { id: string }) => { layerIds.add(layer.id); }),
+    getLayer: vi.fn((id: string) => layerIds.has(id) ? { id } : null),
+    removeLayer: vi.fn((id: string) => { layerIds.delete(id); }),
+    setLayoutProperty: vi.fn(),
+    setPaintProperty: vi.fn(),
+    getPaintProperty: vi.fn(),
+    getFilter: vi.fn().mockReturnValue(null),
+    setFilter: vi.fn(),
+    setLayerZoomRange: vi.fn(),
+    isStyleLoaded: vi.fn(() => true),
+    getStyle: vi.fn(() => ({ layers: Array.from(layerIds).map((id) => ({ id })) })),
+    moveLayer: vi.fn(),
+  } as unknown as import('maplibre-gl').Map;
+}
+
+function makeSeamLayer(bbox: number[] | null): MapLayerResponse {
+  return {
+    id: 'seam-1',
+    dataset_id: 'ds-seam',
+    dataset_table_name: 'fiji_reefs',
+    dataset_geometry_type: 'MultiPoint',
+    dataset_extent_bbox: bbox,
+    opacity: 1,
+    visible: true,
+    paint: { 'circle-color': '#2255aa' },
+    layout: {},
+    filter: null,
+  } as unknown as MapLayerResponse;
+}
+
+/** Sync one layer and return the vector source spec it created. The source id
+ *  is deliberately not asserted — the SF-04 dedupe keys it by dataset table, and
+ *  this test is about the bounds value, not the naming scheme. */
+function syncAndReadSourceSpec(bbox: number[] | null): Record<string, unknown> {
+  const map = makeMockMap();
+  syncLayersToMap(
+    map,
+    [toSyncInput(makeSeamLayer(bbox))],
+    new Map<string, TileToken>([['ds-seam', VECTOR_TOKEN]]),
+    undefined,
+    { current: new Set() },
+    { current: '' },
+  );
+  return (map.addSource as ReturnType<typeof vi.fn>).mock.calls[0][1] as Record<string, unknown>;
+}
+
+const VECTOR_TOKEN: TileToken = {
+  kind: 'vector',
+  sig: 'mock',
+  exp: 9999999999,
+  scope: 'test',
+  expires_in: 3600,
+};
+
+describe('antimeridian bounds through the builder sync path (#1112)', () => {
+  it('carries the crossing bbox through toSyncInput unconverted', () => {
+    expect(toSyncInput(makeSeamLayer(FIJI_SPEC_BBOX)).bounds).toEqual(FIJI_SPEC_BBOX);
+  });
+
+  it('spans the crossing bbox by the time it reaches the vector source', () => {
+    const spec = syncAndReadSourceSpec(FIJI_SPEC_BBOX);
+    expect(spec.type).toBe('vector');
+    expect(spec.bounds).toEqual(FIJI_SPAN_BBOX);
+  });
+
+  it('leaves a non-crossing bbox alone on the same path', () => {
+    const nyc = [-74.5, 40.5, -73.5, 41.5];
+    expect(syncAndReadSourceSpec(nyc).bounds).toEqual(nyc);
+  });
+
+  it('omits bounds entirely when the dataset has no extent', () => {
+    expect(syncAndReadSourceSpec(null)).not.toHaveProperty('bounds');
+  });
+});

--- a/frontend/src/components/builder/map-sync.ts
+++ b/frontend/src/components/builder/map-sync.ts
@@ -245,6 +245,13 @@ export function toSyncInput(layer: MapLayerResponse): SyncLayerInput {
     tile_version: layer.tile_version,
     // MVT-06: surface the dataset spatial extent so the vector source can bound
     // tile fetching to the data footprint (the raster path already passes bounds).
+    // fix(#1112): this is the RFC 7946 spec form now — `west > east` on an
+    // antimeridian crossing — and it is passed through unconverted on purpose.
+    // Every reader of `bounds` reaches a MapLibre source through
+    // `normalizeRasterBounds` (layer-adapters/shared.ts), which spans it there,
+    // at the one boundary that cannot express a crossing. Converting here would
+    // be a second copy of that rule and would discard the seam before anything
+    // downstream could use it.
     bounds: layer.dataset_extent_bbox ?? null,
   };
 }


### PR DESCRIPTION
## Problem

`_router_helpers.py` built a map layer's `dataset_extent_bbox` with `extent_to_span_bbox`, which widens a seam-crossing extent to the monotonic `[-180, s, 180, n]`. Honest, but world-wide.

The two builder fit paths read exactly that field and both carry a `fix(#903)` guard that unwraps a `west > east` pair past 180 so a crossing layer fits the few degrees it occupies. Those guards can never fire on this path: by the time the frontend sees the value it is a well-formed world bbox, with nothing left to detect.

Net effect: a seam-crossing dataset added to a map auto-fits and "Zoom to Layer"s to the whole world. No error and no visual cue, because a flattened Fiji extent is bit-identical to a genuinely global one. #1040 and #1060 flipped the dataset and collection endpoints to spec form for this reason; this producer was not part of that change.

## Fix

Serve the spec form. Each consumer now declares the form it wants, rather than the producer flattening for the most restrictive one.

## Consumer audit

The issue asks whether any consumer assumes `west <= east`, because one would mean a second field rather than changing this one. Every reference, excluding tests:

| Consumer | Verdict |
|---|---|
| `maps/_router_helpers.py` | the producer, changed here |
| `maps/schemas.py` | type only, `list[float] \| None`, unchanged |
| `BuilderMap.getVisibleLayerBounds` | seam-aware, unwraps past 180 (`fix(#903)`) |
| `use-builder-layers.handleZoomToLayer` | seam-aware, `bbox[0] > bbox[2]` is explicitly not a rejection (`fix(#903)`) |
| `map-sync.toSyncInput` | passes through; every downstream MapLibre source normalizes |
| `use-builder-editor-scene` | writes `null`, never reads |
| `frontend/src/types/api.ts`, `api.generated.ts` | type only, unchanged |
| Python SDK `map_layer_response.py` | (de)serialization only, no arithmetic |
| TypeScript SDK `types.gen.ts` | type only |
| MCP server, CLI | no references |

No consumer assumes a monotonic pair, so no second field is needed.

## Why map-sync is not wrapped

The obvious-looking edit is to span the value back at `map-sync.ts` before it reaches a MapLibre source, where an inverted pair matches no tiles. That would be both redundant and harmful.

Redundant, because every path from `SyncLayerInput.bounds` to a source already normalizes: `ensureRasterDemTerrainSource` and the vector source in `map-sync.ts`, and the raster and hillshade adapters. `normalizeRasterBounds` in `layer-adapters/shared.ts` is the keystone, and its docstring already names those four as inheriting the guard from it.

Harmful, because `map-sync` output feeds the fit paths as well. Converting there would discard the seam before those guards could use it, re-breaking the exact defect this PR fixes. The conversion belongs at the MapLibre boundary, which is the one place that cannot express a crossing.

## API impact

No OpenAPI or SDK regeneration: the type is unchanged, `list[float] | None` either way.

**The VALUE changes for SDK and MCP consumers.** A seam-crossing layer now returns `west > east` where it previously returned `[-180, s, 180, n]`. Anything consuming this field arithmetically outside this repo should expect the RFC 7946 §5.2 form.

The span form is deliberately kept where it is still correct: TileJSON `bounds` in `processing/tiles/router.py` and the three DCAT services for external harvesters. Neither is swept along.

## Verification

```
cd backend
uv run pytest tests/test_antimeridian_extent.py -q   # 45 passed
uv run pytest tests/test_layering.py -q              # 36 passed
uv run ruff check . && uv run ruff format --check .  # clean, 875 files

cd frontend
npm run lint && npm run typecheck                    # clean
npm run test:coverage                                # 370 files, 4525 tests passed
```

`test_map_layer_response_bbox_stays_monotonic` is inverted, and the "do NOT flip the sibling" comment in `datasets/domain/helpers.py` is rewritten, since it documented the opposite of what is now true. New `map-sync.seam-bounds.test.ts` pins the crossing bbox travelling unconverted through `toSyncInput` and being spanned by the time it reaches the vector source, plus the non-crossing case being left alone.

Closes #1112