### PR TITLE
feat(extensions): let the permission seam answer who a record's audience is

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -178,6 +178,7 @@ async def _apply_visibility_change(
         old_visibility=record.visibility,
         new_visibility=new_visibility,
         record_status=record.record_status,
+        record_id=record.id,
         owner_id=record.created_by,
     )
     if broken_maps:

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -225,6 +225,19 @@ async def find_maps_broken_by_dataset_visibility(
 
     Empty = safe to apply.
     """
+    # fix(#1126 codex P2): a change that changes nothing strands nobody, and
+    # that is true of every authority, which is why it is settled before asking
+    # one. `_apply_visibility_change` runs for any non-null `visibility` in the
+    # body without comparing it to the stored value, so a client that round
+    # trips the whole record resubmits the current one — and both branches
+    # below got that wrong. The fallback named every shared map using the
+    # dataset. The seam-answering branch was subtler: `before` and `after` are
+    # the same predicate for a no-op, and NULL passes `IS NOT false` and
+    # `IS NOT true` alike, so an overlay that cannot classify an account
+    # reported it as stranded by a move that did not happen. Until #1068 the
+    # rank comparison absorbed both, since `X < X` is false.
+    if old_visibility == new_visibility:
+        return []
     permission = get_permission_extension()
     if _answers_audience_questions(permission):
         query = RecordAudienceQuery(

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -3,6 +3,7 @@
 import hashlib
 import secrets
 import uuid
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,8 @@ from app.modules.embed_tokens.models import EmbedToken
 from app.modules.embed_tokens.service import resolve_embed_scope_for_map
 from app.platform.extensions import (
     DefaultPermissionExtension,
+    RecordAudience,
+    RecordAudienceQuery,
     get_catalog_port,
     get_permission_extension,
 )
@@ -79,131 +82,98 @@ async def validate_public_visibility(
     return [row[0] for row in result.all()]
 
 
-# fix(#931): the two shared map audiences and what a dataset must be to reach
-# each. A private map has no audience beyond its owner and grantees, so a
-# dataset visibility change can never strand it.
+# fix(#931): the two shared map audiences. A private map has no audience beyond
+# its owner and grantees, so a dataset visibility change can never strand it.
+# Who a MAP reaches is core's own rule (`_apply_map_visibility_filter`), not the
+# permission seam's, so this pair is not something an overlay narrows.
 _SHARED_MAP_AUDIENCES = ("public", "internal")
 
 
-# How much of a shared map's audience a dataset at each visibility reaches. The
-# four rungs nest — the owner is a grantee is a signed-in user is everyone — so
-# this is a total order, and "does this change strand someone" is a comparison
-# rather than a table of allowed moves.
-#
-# fix(#1068): this encodes the COMMUNITY ladder, matching
-# `DefaultPermissionExtension`. An overlay that narrows a rung — ABAC excluding
-# some active non-owner users from `internal`, say — makes the real audience
-# smaller than the rank assumes, and this guard cannot see that: the seam's
-# `filter_visible`/`can_access_dataset` both take a CONCRETE user, and a map's
-# audience is a set with no representative member to pass them. Answering it
-# properly needs a new protocol method and an EXTENSION_API_VERSION bump, so it
-# is tracked separately rather than folded into a visibility fix.
-#
-# The two overlay directions do NOT fail the same way, and this paragraph said
-# they did until the guard stopped being rank-only. `_stranded_viewer_exists`
-# reads `users`/`user_roles` directly rather than going through
-# `filter_visible`, and its answer is what makes this function `return []`, so
-# the community answer can now be permissive as well as conservative:
-#
-#   NARROWING overlay (ABAC excluding some active non-owner users) — the query
-#   finds a user the overlay would have excluded, the guard refuses, and nobody
-#   was actually stranded. A refusal that lies, which is the safe direction and
-#   the same class as the grant and publication-status cases above.
-#
-#   WIDENING overlay (extra visible rows OR'd in — the additive shape SLOT-02's
-#   wrap-don't-replace rule is written for, and what `PermissionExtension`'s own
-#   docstring offers as "advanced RBAC, ABAC, or row-level filters") — the
-#   community query finds nobody stranded, the guard returns [], the change
-#   applies, and a user the overlay HAD granted access to silently loses the
-#   layer. That is the break this guard exists to prevent, reappearing one level
-#   up.
-#
-# Both need the seam, and neither is fixable here: `filter_visible` and
-# `can_access_dataset` take a CONCRETE user, and a map's audience is a set with
-# no representative member to pass them. See #1068 for the protocol method.
-#
-# fix(#931 codex r1): `restricted` is a PARTIAL audience, not an absent one.
-# Treating it as unreachable made `restricted -> private` look like it stranded
-# nobody, when it drops the grant holders who could render the layer.
-_DATASET_AUDIENCE_RANK = {"private": 0, "restricted": 1, "internal": 2, "public": 3}
+def _answers_audience_questions(permission: object) -> bool:
+    """Can this permission authority say who a record's audience is?
 
+    feat(#1068): the guard used to rebuild the audience from the community
+    ladder — a rank over the four visibility rungs — and #1111 had to refuse
+    outright under ANY registered overlay, because that reconstruction is only
+    true while the community ladder IS the policy. Every overlay deployment
+    therefore got a blanket 422 on visibility changes touching a shared map.
+    ``record_audience`` lets the authority answer for itself, so the refusal
+    narrows to the authorities that still cannot:
 
-def _reach_rank(map_visibility: str, dataset_visibility: str) -> int:
-    """How much of ``map_visibility``'s audience the dataset COULD reach.
+    - No ``record_audience`` at all. Only a legacy overlay declaring no
+      EXTENSION_API_VERSION reaches this; a declared-but-stale version is a hard
+      boot failure, so anything loading against v4 has been updated.
+    - It inherits the community answer while overriding one of the two methods
+      that decide reads. Then the audience it reports and the rows its viewers
+      actually get are two policies, and the disagreement is invisible from
+      here. #1111 gated this with ``type(...) is DefaultPermissionExtension``,
+      which also refused a subclass that changes nothing about reads; keying on
+      the read methods themselves keeps a wrap cheap and still catches the case
+      the identity check was really aimed at.
 
-    An internal map's audience is every signed-in user, and both ``internal``
-    and ``public`` reach all of them — so the two tie there, which is what makes
-    the public-to-internal move safe on an internal map and not on a public one.
-
-    This is the upper bound, not the answer. A drop here says the audience
-    narrows; whether anyone is standing in the part being cut is a separate
-    question that :func:`_stranded_viewer_exists` asks against real accounts.
+    ``check_permission`` is deliberately not in the set: capabilities do not
+    decide which records a viewer can read.
     """
-    rank = _DATASET_AUDIENCE_RANK.get(dataset_visibility, 0)
-    if map_visibility == "internal":
-        return min(rank, _DATASET_AUDIENCE_RANK["internal"])
-    return rank
+    default = DefaultPermissionExtension
+    own = getattr(type(permission), "record_audience", None)
+    if own is None:
+        return False
+    if own is not default.record_audience:
+        return True
+    return all(
+        getattr(type(permission), name, None) is getattr(default, name)
+        for name in ("filter_visible", "can_access_dataset")
+    )
 
 
 async def _stranded_viewer_exists(
     session: AsyncSession,
-    dataset_id: uuid.UUID,
-    owner_id: uuid.UUID | None,
-    *,
-    slice_: str,
+    before: RecordAudience,
+    after: RecordAudience,
 ) -> bool:
-    """Does a real viewer sit in the audience a change is about to remove?
+    """Does a real account sit in the audience this change removes?
 
-    fix(#931 codex r5): a rank DROP is not the same as someone losing access.
-    The rank says how wide the audience could be; this asks whether anyone is
-    actually in the part being cut. Both directions were wrong without it:
-    `internal -> restricted` was refused even when every active user is in a
-    granted role, and `internal -> private` was refused on an instance whose
-    only other accounts are admins.
+    fix(#931 codex r5): a narrower audience is not the same as someone losing
+    access, so this asks whether anyone is actually standing in the part being
+    cut. Both directions were wrong without it: `internal -> restricted` was
+    refused even when every active user is in a granted role, and
+    `internal -> private` was refused on an instance whose only other accounts
+    are admins.
 
-    ``slice_`` names the part being cut, and there are three:
-    ``"granted"`` for `restricted -> private`, which drops the grant holders;
-    ``"ungranted"`` for `internal -> restricted`, which drops everyone no grant
-    reaches; and ``"any"`` for `internal -> private`, which drops all of them.
+    feat(#1068): the cut used to be a named slice (granted / ungranted / any)
+    with the owner and every admin excluded by hand, because the community
+    ladder was the only thing the guard could reason about. All of that falls
+    out of the difference now — an account the AUTHORITY puts in both audiences
+    is not stranded, and the community authority puts the owner and the admins
+    in every one of them. One less restatement of the ladder, and the
+    exclusions follow the policy instead of assuming "admin" is what bypasses
+    it.
 
-    The exclusions are the same in both cases and are what make this a question
-    about real viewers. The owner keeps access through the creator exemption
-    and an admin bypasses the filter, so neither is ever stranded. And the
-    account must be able to authenticate at all: `get_optional_user` rejects a
-    non-active user before they can render a layer, so pending, suspended and
-    deactivated accounts are not an audience. Both columns are tested,
-    mirroring `auth/dependencies.py`'s
+    The account must also be able to authenticate at all. That is the MAP's
+    audience rather than the dataset's, which is why it stays here and not in
+    the seam: `get_optional_user` rejects a non-active user before they can
+    render a layer, so pending, suspended and deactivated accounts are not an
+    audience. Both columns are tested, mirroring `auth/dependencies.py`'s
     `not user.is_active or user.status != "active"` — the
     `chk_users_status_active_consistency` CHECK keeps them equal, so this is one
     test written the way the gate writes it rather than two, and the mirror
     cannot drift.
-    """
-    from app.modules.auth.models import Role, User, UserRole
-    from app.modules.catalog.datasets.domain.models import DatasetGrant
 
-    admin_user_ids = (
-        select(UserRole.user_id)
-        .join(Role, Role.id == UserRole.role_id)
-        .where(Role.name == "admin")
-    )
-    granted_user_ids = (
-        select(UserRole.user_id)
-        .join(DatasetGrant, DatasetGrant.role_id == UserRole.role_id)
-        .where(DatasetGrant.dataset_id == dataset_id)
-    )
+    ``IS NOT false`` / ``IS NOT true`` rather than the predicate and its
+    negation: an overlay predicate reading a nullable column yields NULL for a
+    row, `NOT NULL` is NULL, and a NULL in a WHERE drops the row — answering
+    "nobody is stranded" for precisely the accounts the authority could not
+    classify. Both spellings send NULL to the refusing side instead.
+    """
     stmt = (
         select(User.id)
         .where(User.is_active.is_(True))
         .where(User.status == "active")
-        .where(User.id.notin_(admin_user_ids))
+        .where(before.users.is_not(False))
+        .where(after.users.is_not(True))
+        .limit(1)
     )
-    if slice_ == "granted":
-        stmt = stmt.where(User.id.in_(granted_user_ids))
-    elif slice_ == "ungranted":
-        stmt = stmt.where(User.id.notin_(granted_user_ids))
-    if owner_id is not None:
-        stmt = stmt.where(User.id != owner_id)
-    return (await session.execute(stmt.limit(1))).scalar_one_or_none() is not None
+    return (await session.execute(stmt)).scalar_one_or_none() is not None
 
 
 async def find_maps_broken_by_dataset_visibility(
@@ -213,6 +183,7 @@ async def find_maps_broken_by_dataset_visibility(
     old_visibility: str,
     new_visibility: str,
     record_status: str,
+    record_id: uuid.UUID,
     owner_id: uuid.UUID | None,
 ) -> list[str]:
     """Names of shared maps that work at ``old_visibility`` and would not at ``new``.
@@ -222,75 +193,68 @@ async def find_maps_broken_by_dataset_visibility(
     was not matched, so the flip succeeded and every signed-in viewer of that
     map silently lost the layer's tiles and features, with no signal to anyone.
 
-    Framed as a before/after comparison rather than a list of forbidden target
-    values, because #930 turned the rule into a matrix. An internal map keeps
-    working when its dataset moves from public to internal, and breaks only on
-    the move to private — a rule expressed against today's target value alone
-    would fire on a move that is in fact safe.
+    feat(#1068): the question is now asked of the permission authority instead
+    of reconstructed from the community ladder. "Who could read this before, and
+    who can read it after" is a set difference over real accounts, which is why
+    the rank table and its per-move slices are gone: a rank drop was only ever a
+    proxy for the difference being non-empty, and the proxy was community math
+    the authority is free to contradict. Both directions did contradict it, and
+    they failed in opposite ways, which is what made the old comment here wrong
+    for the widening half:
+
+      NARROWING overlay (ABAC excluding some active non-owner users from a rung)
+      — the community query found a user the overlay would have excluded, the
+      guard refused, and nobody was stranded. A refusal that lies: annoying,
+      visible, safe.
+
+      WIDENING overlay (extra visible rows OR'd in — the additive shape SLOT-02
+      is written for) — the community query found nobody stranded, the guard
+      returned [], the change applied, and a viewer the overlay HAD admitted
+      lost the layer in silence. That is the break this guard exists to prevent,
+      reappearing one level up, and it is why #1111 shipped a stopgap rather
+      than trusting the direction argument.
+
+    An authority that cannot answer (see :func:`_answers_audience_questions`)
+    still gets the conservative refusal, now naming every shared map that uses
+    the dataset rather than the ones a rank comparison happened to reach: an
+    unanswerable question is not evidence that the move is safe.
+
+    An unpublished record needs no special case either — the status gate lives
+    inside the audience, so a draft reaches only its owner and the admins both
+    before and after, and the difference is empty.
 
     Empty = safe to apply.
     """
-    # fix(#931 codex r3): an unpublished record is already invisible to every
-    # shared-map audience. `filter_visible`'s status gate is
-    # `published OR created_by == <caller>`, so a draft/ready/internal-status
-    # record reaches only its creator, and admins bypass the filter entirely —
-    # both keep access after any visibility change. Nobody is stranded, so a
-    # rank comparison here would invent a 422 for a move that costs nothing.
-    if record_status != "published":
-        return []
-    audiences = [
-        visibility
-        for visibility in _SHARED_MAP_AUDIENCES
-        if _reach_rank(visibility, new_visibility)
-        < _reach_rank(visibility, old_visibility)
-    ]
-    if not audiences:
-        return []
-    # fix(#931 codex r5): the rank narrowing says the audience COULD shrink;
-    # whether anyone is standing in the part being cut is a separate question.
-    #
-    # fix(#931 codex r6): asked PER AUDIENCE. A public map losing a public
-    # dataset always strands its anonymous visitors — they see nothing else,
-    # always exist, and are never a row in `users` — but that says nothing about
-    # the internal map beside it, whose viewers may all hold grants. Answering
-    # once for both listed maps that were not stranded, sending the operator to
-    # remove a layer from a map that renders fine.
-    signed_in_stranded: bool | None = None
-    stranded: list[str] = []
-    for visibility in audiences:
-        if visibility == "public" and old_visibility == "public":
-            stranded.append(visibility)
-            continue
-        if signed_in_stranded is None:
-            # fix(#1111 review): the community query below mirrors
-            # DefaultPermissionExtension's grants+ladder exactly, so its answer
-            # is authoritative only while that default IS the permission
-            # authority. A registered overlay can additively widen a dataset's
-            # audience (the SLOT-02 wrap shape), and a viewer only the overlay
-            # admits is invisible to this query — under the rank-only #1056
-            # guard such a viewer was protected by the over-refusal, so
-            # permitting on community math here would strip that accidental
-            # protection. Until #1068 lets the seam answer audience questions,
-            # a non-default authority keeps the conservative refusal.
-            # `type(...) is` on purpose: a subclassing overlay must not read
-            # as the default.
-            if type(get_permission_extension()) is not DefaultPermissionExtension:
-                signed_in_stranded = True
-            else:
-                # The same question whichever map asks it: the dataset's own
-                # audience, so it is resolved once and reused.
-                if old_visibility in ("public", "internal"):
-                    cut = "ungranted" if new_visibility == "restricted" else "any"
-                else:
-                    cut = "granted"
-                signed_in_stranded = await _stranded_viewer_exists(
-                    session, dataset_id, owner_id, slice_=cut
-                )
-        if signed_in_stranded:
-            stranded.append(visibility)
-    if not stranded:
-        return []
-    audiences = stranded
+    permission = get_permission_extension()
+    if _answers_audience_questions(permission):
+        query = RecordAudienceQuery(
+            dataset_id=dataset_id,
+            record_id=record_id,
+            owner_id=owner_id,
+            visibility=old_visibility,
+            record_status=record_status,
+        )
+        before = await permission.record_audience(query, User, grant_cls=DatasetGrant)
+        after = await permission.record_audience(
+            replace(query, visibility=new_visibility), User, grant_cls=DatasetGrant
+        )
+        # fix(#931 codex r6): asked PER AUDIENCE. A public map losing a public
+        # dataset strands its anonymous visitors — they see nothing else, always
+        # exist, and are never a row in `users` — but that says nothing about
+        # the internal map beside it, whose viewers may all hold grants.
+        # Answering once for both listed maps that were not stranded, sending
+        # the operator to remove a layer from a map that renders fine.
+        signed_in_stranded = await _stranded_viewer_exists(session, before, after)
+        anonymous_stranded = before.includes_anonymous and not after.includes_anonymous
+        audiences = [
+            visibility
+            for visibility in _SHARED_MAP_AUDIENCES
+            if signed_in_stranded or (visibility == "public" and anonymous_stranded)
+        ]
+        if not audiences:
+            return []
+    else:
+        audiences = list(_SHARED_MAP_AUDIENCES)
     stmt = (
         select(Map.name)
         .select_from(MapLayer)

--- a/backend/app/platform/extensions/__init__.py
+++ b/backend/app/platform/extensions/__init__.py
@@ -49,6 +49,11 @@ from app.platform.extensions.protocols import (
     ConnectorDefinition as ConnectorDefinition,
     ConnectorResource as ConnectorResource,
     NotificationSink,  # NEW (Phase 1229)
+    # feat(#1068): the audience seam's two DTOs. Runtime re-exports, not
+    # TYPE_CHECKING ones — an overlay implementing record_audience has to
+    # CONSTRUCT a RecordAudience, so the name must resolve at run time.
+    RecordAudience as RecordAudience,
+    RecordAudienceQuery as RecordAudienceQuery,
 )
 
 if TYPE_CHECKING:

--- a/backend/app/platform/extensions/defaults_extensions.py
+++ b/backend/app/platform/extensions/defaults_extensions.py
@@ -177,6 +177,67 @@ class DefaultPermissionExtension:
 
         return True
 
+    async def record_audience(self, query, user_cls, *, grant_cls=None):  # type: ignore[no-untyped-def]
+        """The same ladder as ``filter_visible``, read from the user end.
+
+        ``filter_visible`` asks which RECORDS a user may read; this asks which
+        USERS may read a record, at whatever visibility the caller names. One
+        rule, two directions, changed as a pair — ``test_permission_audience.py``
+        compares them account by account across every visibility, status and
+        role, so a change to one that is not mirrored here fails there instead of
+        quietly making the shared-map guard disagree with what viewers see.
+        """
+        from sqlalchemy import and_, false, or_, select, true
+
+        from app.modules.auth.models import Role, UserRole
+        from app.platform.extensions.protocols import RecordAudience
+
+        # `filter_visible` returns the statement unchanged for an admin, so an
+        # admin is in every audience. Resolved against the role table because
+        # there is no user here to read a `user_roles` set off.
+        is_admin = user_cls.id.in_(
+            select(UserRole.user_id)
+            .join(Role, Role.id == UserRole.role_id)
+            .where(Role.name == "admin")
+        )
+        # A record with no recorded owner matches no owner branch: over there
+        # `created_by == user.id` is NULL for every row.
+        is_owner = false() if query.owner_id is None else user_cls.id == query.owner_id
+
+        if query.visibility in ("public", "internal"):
+            # fix(#930): internal = any signed-in user. Bare, like `public`, for
+            # the reason spelled out over there — the status gate below is ANDed
+            # across every rung and already carries the published check.
+            reaches = true()
+        elif query.visibility == "private":
+            reaches = is_owner
+        elif query.visibility == "restricted" and grant_cls is not None:
+            # fix(#929): creator exemption, then the grant. `filter_visible`
+            # walks record -> dataset -> grant -> role -> user; this is the same
+            # edge traversed from the user end.
+            reaches = or_(
+                is_owner,
+                user_cls.id.in_(
+                    select(UserRole.user_id)
+                    .join(grant_cls, grant_cls.role_id == UserRole.role_id)
+                    .where(grant_cls.dataset_id == query.dataset_id)
+                ),
+            )
+        else:
+            # Restricted without a grant class, and any value the ladder does
+            # not name: both reach nobody in `filter_visible` too, where the
+            # condition is simply absent rather than denied.
+            reaches = false()
+
+        # `record_status == "published" OR created_by == <caller>`.
+        published = true() if query.record_status == "published" else is_owner
+        return RecordAudience(
+            users=or_(is_admin, and_(reaches, published)),
+            includes_anonymous=(
+                query.visibility == "public" and query.record_status == "published"
+            ),
+        )
+
 
 class DefaultWorkflowExtension:
     """Community-edition default publication workflow policy."""

--- a/backend/app/platform/extensions/protocols.py
+++ b/backend/app/platform/extensions/protocols.py
@@ -391,6 +391,48 @@ class EmbeddingProviderExtension(Protocol):
     async def resolve_runtime_config(self, db: AsyncSession) -> dict[str, object]: ...
 
 
+@dataclass(frozen=True)
+class RecordAudienceQuery:
+    """The record a caller is asking about, at a STATED visibility.
+
+    ``visibility`` and ``record_status`` are passed as values rather than read
+    off the record, so a caller can ask the counterfactual — "who would be able
+    to read this if it were private?" — which is the question neither
+    ``filter_visible`` nor ``can_access_dataset`` can answer: both take a
+    concrete user, and the answer is a set with no representative member.
+
+    ``dataset_id`` / ``record_id`` / ``owner_id`` stay ``Any`` for the same
+    reason ``WorkflowTransitionContext.dataset`` does — this platform-level
+    contract does not import catalog ORM classes at module load time. Both ids
+    are carried because grants key the DATASET while visibility lives on the
+    RECORD, so an overlay keying policy on either does not have to join.
+    """
+
+    dataset_id: Any
+    record_id: Any
+    owner_id: Any | None
+    visibility: str
+    record_status: str
+
+
+@dataclass(frozen=True)
+class RecordAudience:
+    """Who can read a record: the signed-in half as SQL, the anonymous half as a flag.
+
+    ``users`` is a SQLAlchemy boolean expression over the ``user_cls`` handed to
+    :meth:`PermissionExtension.record_audience` — a PREDICATE, not a result set.
+    That is what lets a caller compare two audiences inside one statement, and
+    lets an overlay widen with ``or_()`` rather than unioning queries.
+
+    Anonymous visitors are rows in no table, so they cannot appear in ``users``
+    and carry their own flag. A public map's audience includes them and an
+    internal map's does not, which is the distinction it exists for.
+    """
+
+    users: Any
+    includes_anonymous: bool
+
+
 @runtime_checkable
 class PermissionExtension(Protocol):
     """Policy seam for permission checks and catalog visibility filtering.
@@ -407,6 +449,27 @@ class PermissionExtension(Protocol):
     behavior MUST wrap the prior implementation retrieved via
     ``get_permission_extension()`` at construction time — never bare
     re-register the ``"permission"`` key (the slot-conflict guard rejects that).
+
+    **The stored matrix does not bound ``check_permission``.**
+    ``validate_permission_matrix`` refuses to persist some combinations
+    (``manage_tenants`` on any role, ``manage_users`` or ``manage_settings`` on
+    a non-admin one), which reads like a statement about what a caller can hold.
+    It is not: the seam is the authority and the matrix is only what the
+    database will store. An overlay may deny a stored grant or add one
+    out-of-band, and that is how a fleet operator gets ``manage_tenants`` at
+    all (see the constant's own note in ``app/core/permissions.py``). Any
+    argument of the form "the matrix cannot store X, so no caller has X" is
+    true of the table and false of the deployment. Two of us reasoned that way
+    on #1021 and both got it wrong.
+
+    **The three methods are one policy (feat(#1068), EXTENSION_API_VERSION 4).**
+    ``filter_visible`` and ``can_access_dataset`` were already a pair — the same
+    rule asked of a list and of one row (see #929/#930). ``record_audience`` is
+    the third reading of it: the same rule asked about a whole audience, for a
+    caller that has no user to pass. An overlay that changes either of the first
+    two and leaves this one on the community answer is reporting one policy and
+    serving another, and core cannot see the disagreement — so it treats such an
+    authority as unable to answer and takes the conservative refusal instead.
     """
 
     async def check_permission(
@@ -438,6 +501,36 @@ class PermissionExtension(Protocol):
         *,
         user_roles: set[str],
     ) -> bool: ...
+
+    async def record_audience(
+        self,
+        query: RecordAudienceQuery,
+        user_cls: Any,
+        *,
+        grant_cls: Any | None = None,
+    ) -> RecordAudience:
+        """Which principals can read the record described by ``query``.
+
+        ``user_cls`` is the ORM class the returned predicate must be written
+        against (core passes its ``User``); ``grant_cls`` is the dataset-grant
+        class, absent when the caller has no grant table to offer — mirroring
+        ``filter_visible``, where a missing ``grant_cls`` makes a restricted
+        record unreachable rather than ungated.
+
+        Implementations must agree with ``filter_visible`` exactly: a user the
+        predicate admits must be a user whose filtered query returns the record,
+        at the visibility and status named in ``query``. Core proves that
+        equivalence for the community default account by account and expects an
+        overlay to hold itself to the same standard. An overlay whose reads
+        reach further than the audience it reports makes the shared-map guard
+        permit a change that strands somebody, and nothing on the calling side
+        can see the gap.
+
+        Async so an overlay may resolve tenant or policy state before composing
+        the predicate, for the same reason ``can_access_dataset`` is async; the
+        community default performs no I/O.
+        """
+        ...
 
 
 @dataclass(frozen=True)

--- a/backend/app/platform/extensions/version.py
+++ b/backend/app/platform/extensions/version.py
@@ -50,7 +50,15 @@ logger = logging.getLogger(__name__)
 # is a signature change to a Protocol method and therefore a bump. The caller
 # also omits the keyword entirely when it is None, so a legacy overlay that
 # declares no version keeps working for buffer and centroid.
-EXTENSION_API_VERSION: int = 3
+# 3 -> 4 (feat(#1068)): PermissionExtension gained a required
+# ``record_audience`` method — the audience-shaped reading of the same policy
+# ``filter_visible`` and ``can_access_dataset`` already express per user. An
+# overlay that replaces the ``permission`` slot must implement it, and must
+# implement it whenever it changes either of those two: core cannot tell a
+# missing answer from a wrong one, so an authority that overrides reads while
+# inheriting the community audience is treated as unable to answer and gets the
+# conservative refusal (see find_maps_broken_by_dataset_visibility).
+EXTENSION_API_VERSION: int = 4
 
 
 def check_extension_api_version(name: str, declared_version: int | None) -> None:

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -984,6 +984,137 @@ class TestUpdateMetadata:
         assert resp.status_code == 422, resp.text
         assert map_name in resp.text
 
+    async def test_resubmitting_the_current_visibility_is_not_a_change(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+        monkeypatch,
+    ):
+        """fix(#1126 codex P2): a PATCH that changes nothing strands nobody.
+
+        `_apply_visibility_change` runs for every non-null `visibility` in the
+        body without comparing it to the stored one, and any client that round
+        trips the whole record resubmits the current value. Under an authority
+        that cannot answer, the conservative fallback named every shared map
+        using the dataset, so that no-op 422'd with "this would strand
+        viewers". Before #1068 the rank comparison absorbed it: `X < X` is
+        false for both audiences, so an unchanged visibility returned [] on
+        its way past. Deleting the rank deleted that accident too.
+
+        Both directions under the SAME authority, because a fix that only
+        stopped the false 422 could equally have stopped the true one.
+        """
+        from app.modules.catalog.maps import service_public
+
+        class _PreSeamAuthority:
+            async def check_permission(self, db, user, capability, **kwargs):
+                return True
+
+            def filter_visible(
+                self, stmt, user, user_roles, record_cls, grant_cls=None
+            ):
+                return stmt
+
+            async def can_access_dataset(
+                self, db, dataset, dataset_id, user, *, user_roles
+            ):
+                return True
+
+        monkeypatch.setattr(
+            service_public,
+            "get_permission_extension",
+            lambda: _PreSeamAuthority(),
+        )
+
+        assert viewer_auth_header  # an active non-admin the real move strands
+        admin_id = await _get_user_id(test_db_session, "admin")
+        map_name = f"Unchanged Visibility Map {uuid.uuid4().hex[:6]}"
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="internal",
+            map_visibility="internal",
+            map_name=map_name,
+        )
+
+        unchanged = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "internal"},
+            headers=admin_auth_header,
+        )
+        assert unchanged.status_code == 200, unchanged.text
+        assert unchanged.json()["visibility"] == "internal"
+
+        # The guard still fires for a move that does narrow the audience.
+        narrowed = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "private"},
+            headers=admin_auth_header,
+        )
+        assert narrowed.status_code == 422, narrowed.text
+        assert map_name in narrowed.json()["detail"]
+
+    async def test_an_unchanged_visibility_never_consults_the_audience_predicate(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        monkeypatch,
+    ):
+        """fix(#1126 codex P2): the early return belongs ABOVE the authority split.
+
+        This pins the placement rather than the symptom. An overlay predicate
+        that reads a nullable column yields NULL for a row, and
+        `_stranded_viewer_exists` deliberately sends NULL to the refusing side
+        on BOTH halves of the difference: `NULL IS NOT false` and
+        `NULL IS NOT true` are each true, so an unclassifiable account counts
+        as stranded. That is the right answer for a real change and the wrong
+        one for a no-op, where the same predicate sits on both sides. An early
+        return scoped to the fallback branch would leave this 422 standing.
+        """
+        from sqlalchemy import Boolean, literal
+
+        from app.modules.catalog.maps import service_public
+        from app.platform.extensions import (
+            DefaultPermissionExtension,
+            RecordAudience,
+        )
+
+        class _CannotClassifyAnyone(DefaultPermissionExtension):
+            async def record_audience(self, query, user_cls, *, grant_cls=None):
+                base = await super().record_audience(
+                    query, user_cls, grant_cls=grant_cls
+                )
+                return RecordAudience(
+                    users=literal(None, Boolean),
+                    includes_anonymous=base.includes_anonymous,
+                )
+
+        monkeypatch.setattr(
+            service_public,
+            "get_permission_extension",
+            lambda: _CannotClassifyAnyone(),
+        )
+
+        admin_id = await _get_user_id(test_db_session, "admin")
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="internal",
+            map_visibility="internal",
+            map_name=f"Null Predicate Map {uuid.uuid4().hex[:6]}",
+        )
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "internal"},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 200, resp.text
+
     async def test_an_overlay_that_answers_permits_what_its_own_audience_allows(
         self,
         client: AsyncClient,

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -794,7 +794,12 @@ class TestUpdateMetadata:
 
         assert resp.status_code == 200, resp.text
 
-    async def test_precision_yields_to_conservative_under_a_permission_overlay(
+    async def _viewer_id(self, client: AsyncClient, viewer_auth_header: dict):
+        return uuid.UUID(
+            (await client.get("/auth/me/", headers=viewer_auth_header)).json()["id"]
+        )
+
+    async def test_an_authority_that_answers_reads_but_not_audiences_refuses(
         self,
         client: AsyncClient,
         admin_auth_header: dict,
@@ -802,31 +807,30 @@ class TestUpdateMetadata:
         test_db_session,
         monkeypatch,
     ):
-        """fix(#1111 review): a non-default permission authority disables precision.
+        """feat(#1068): overriding reads while inheriting the community audience.
 
-        The stranded-viewer query mirrors DefaultPermissionExtension's
-        grants+ladder, so its answer is authoritative only while that default IS
-        the permission authority. An overlay that additively widens a dataset's
-        audience (the SLOT-02 wrap shape) admits viewers the query cannot see —
-        under the rank-only #1056 guard they were protected by the
-        over-refusal, and permitting on community math would strip that.
-        Same setup as the everyone-granted permit above; the only difference is
-        a registered non-default authority, and the move must refuse again.
-        `type(...) is` gates it, so even a subclass of the default counts as an
-        overlay.
+        Such an authority reports one policy and serves another, and core cannot
+        see the disagreement — so it counts as unable to answer and takes the
+        refusal. This is #1111's protection, re-keyed from "is this object
+        literally the default class" to "does this object still resolve reads
+        the way the audience it is borrowing assumes". Same setup as the
+        everyone-granted permit above, which returns 200 without the overlay.
         """
         from app.modules.auth.models import Role, UserRole
         from app.modules.catalog.datasets.domain.models import DatasetGrant
         from app.modules.catalog.maps import service_public
         from app.platform.extensions import DefaultPermissionExtension
 
-        class _WrappedAuthority(DefaultPermissionExtension):
-            """Stand-in for an enterprise wrap of the default authority."""
+        class _WidensReadsOnly(DefaultPermissionExtension):
+            def filter_visible(
+                self, stmt, user, user_roles, record_cls, grant_cls=None
+            ):
+                return stmt
 
         monkeypatch.setattr(
             service_public,
             "get_permission_extension",
-            lambda: _WrappedAuthority(),
+            lambda: _WidensReadsOnly(),
         )
 
         admin_id = await _get_user_id(test_db_session, "admin")
@@ -838,9 +842,7 @@ class TestUpdateMetadata:
             map_visibility="internal",
             map_name=map_name,
         )
-        viewer_id = uuid.UUID(
-            (await client.get("/auth/me/", headers=viewer_auth_header)).json()["id"]
-        )
+        viewer_id = await self._viewer_id(client, viewer_auth_header)
         role = Role(name=f"granted-all-{uuid.uuid4().hex[:8]}")
         test_db_session.add(role)
         await test_db_session.flush()
@@ -857,6 +859,293 @@ class TestUpdateMetadata:
 
         assert resp.status_code == 422, resp.text
         assert map_name in resp.text
+
+    async def test_an_authority_that_only_diverges_on_capabilities_keeps_precision(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+        monkeypatch,
+    ):
+        """The mirror of the refusal above, and the reason `check_permission`
+        is not in the set that triggers it.
+
+        Capabilities and record readership are separate axes: an overlay can
+        grant `manage_settings` and `use_ai_chat` while withholding
+        `manage_users` without touching who may read a dataset. That
+        combination is unreachable in a STORED matrix, since
+        `validate_permission_matrix` rejects `manage_settings` on a non-admin
+        role, but the seam is the authority and the matrix is only what the
+        database will store (#1021). So it is a supported configuration, and
+        counting it as "cannot answer audience questions" would blanket-refuse
+        visibility changes on a deployment whose read policy is the community
+        one. Same setup as the everyone-granted permit, which returns 200.
+        """
+        from app.modules.auth.models import Role, UserRole
+        from app.modules.catalog.datasets.domain.models import DatasetGrant
+        from app.modules.catalog.maps import service_public
+        from app.platform.extensions import DefaultPermissionExtension
+
+        class _DivergesOnCapabilitiesOnly(DefaultPermissionExtension):
+            async def check_permission(self, db, user, capability, **kwargs):
+                return capability in ("manage_settings", "use_ai_chat")
+
+        monkeypatch.setattr(
+            service_public,
+            "get_permission_extension",
+            lambda: _DivergesOnCapabilitiesOnly(),
+        )
+
+        admin_id = await _get_user_id(test_db_session, "admin")
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="internal",
+            map_visibility="internal",
+            map_name=f"Capability Overlay Map {uuid.uuid4().hex[:6]}",
+        )
+        viewer_id = await self._viewer_id(client, viewer_auth_header)
+        role = Role(name=f"granted-all-{uuid.uuid4().hex[:8]}")
+        test_db_session.add(role)
+        await test_db_session.flush()
+        test_db_session.add(UserRole(user_id=viewer_id, role_id=role.id))
+        test_db_session.add(DatasetGrant(dataset_id=ds.id, role_id=role.id))
+        await test_db_session.commit()
+
+        async with self._only_admins_active(test_db_session, keep={viewer_id}):
+            resp = await client.patch(
+                f"/datasets/{ds.id}",
+                json={"visibility": "restricted"},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["visibility"] == "restricted"
+
+    async def test_a_legacy_authority_refuses_even_a_widening_move(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        monkeypatch,
+    ):
+        """feat(#1068): an authority predating the seam cannot vouch for anything.
+
+        Only an overlay declaring no EXTENSION_API_VERSION gets here — a
+        declared-but-stale version fails the boot check outright. `restricted ->
+        public` strands nobody under the community ladder and 200s without an
+        overlay, but community math is exactly what an unknown authority is
+        free to contradict, so the refusal covers every shared map using the
+        dataset. This is stricter than #1111's stopgap, which pre-filtered on a
+        rank comparison and so let widening moves through on the same community
+        math it had just declared untrustworthy.
+        """
+        from app.modules.catalog.maps import service_public
+
+        class _PreSeamAuthority:
+            """Everything EXTENSION_API_VERSION 3 required, and nothing more."""
+
+            async def check_permission(self, db, user, capability, **kwargs):
+                return True
+
+            def filter_visible(
+                self, stmt, user, user_roles, record_cls, grant_cls=None
+            ):
+                return stmt
+
+            async def can_access_dataset(
+                self, db, dataset, dataset_id, user, *, user_roles
+            ):
+                return True
+
+        monkeypatch.setattr(
+            service_public,
+            "get_permission_extension",
+            lambda: _PreSeamAuthority(),
+        )
+
+        admin_id = await _get_user_id(test_db_session, "admin")
+        map_name = f"Legacy Authority Map {uuid.uuid4().hex[:6]}"
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="restricted",
+            map_visibility="internal",
+            map_name=map_name,
+        )
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "public"},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert map_name in resp.text
+
+    async def test_an_overlay_that_answers_permits_what_its_own_audience_allows(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+        monkeypatch,
+    ):
+        """feat(#1068): the payoff — an overlay deployment stops being refused blind.
+
+        The overlay widens the `restricted` rung to reach the fixture viewer,
+        who holds no grant. That is exactly the viewer the community query
+        cannot see and that #1111 had to assume the worst about.
+
+        Both requests run against the same dataset in the same world and differ
+        only in who the permission authority is: the community answer refuses,
+        because the ungranted viewer really does lose the layer under the
+        community ladder, and the overlay's own answer permits, because under
+        its policy nobody is stranded. Asserting the pair inside one test is
+        what makes the 200 evidence of precision rather than of a guard that
+        stopped looking.
+        """
+        from sqlalchemy import or_
+
+        from app.modules.catalog.maps import service_public
+        from app.platform.extensions import (
+            DefaultPermissionExtension,
+            RecordAudience,
+        )
+
+        viewer_id = await self._viewer_id(client, viewer_auth_header)
+
+        class _WidensRestricted(DefaultPermissionExtension):
+            async def record_audience(self, query, user_cls, *, grant_cls=None):
+                base = await super().record_audience(
+                    query, user_cls, grant_cls=grant_cls
+                )
+                if query.visibility != "restricted":
+                    return base
+                return RecordAudience(
+                    users=or_(base.users, user_cls.id == viewer_id),
+                    includes_anonymous=base.includes_anonymous,
+                )
+
+        admin_id = await _get_user_id(test_db_session, "admin")
+        map_name = f"Overlay Precise Map {uuid.uuid4().hex[:6]}"
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="internal",
+            map_visibility="internal",
+            map_name=map_name,
+        )
+
+        async with self._only_admins_active(test_db_session, keep={viewer_id}):
+            refused = await client.patch(
+                f"/datasets/{ds.id}",
+                json={"visibility": "restricted"},
+                headers=admin_auth_header,
+            )
+            assert refused.status_code == 422, refused.text
+            assert map_name in refused.json()["detail"]
+
+            monkeypatch.setattr(
+                service_public,
+                "get_permission_extension",
+                lambda: _WidensRestricted(),
+            )
+            permitted = await client.patch(
+                f"/datasets/{ds.id}",
+                json={"visibility": "restricted"},
+                headers=admin_auth_header,
+            )
+
+        assert permitted.status_code == 200, permitted.text
+        assert permitted.json()["visibility"] == "restricted"
+
+    async def test_an_overlay_that_answers_still_refuses_a_real_stranding(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+        monkeypatch,
+    ):
+        """The mirror of the permit above: answering is not the same as agreeing.
+
+        Same overlay shape — it implements ``record_audience`` and so is trusted
+        — but this one reports the community audience unchanged, and the
+        ungranted fixture viewer really does lose the layer. A fix that only
+        pinned the permit would let the guard degrade into "an overlay is
+        installed, therefore fine".
+        """
+        from app.modules.catalog.maps import service_public
+        from app.platform.extensions import DefaultPermissionExtension
+
+        class _DelegatesUnchanged(DefaultPermissionExtension):
+            async def record_audience(self, query, user_cls, *, grant_cls=None):
+                return await super().record_audience(
+                    query, user_cls, grant_cls=grant_cls
+                )
+
+        monkeypatch.setattr(
+            service_public,
+            "get_permission_extension",
+            lambda: _DelegatesUnchanged(),
+        )
+
+        assert viewer_auth_header  # the fixture's account is the stranded viewer
+        admin_id = await _get_user_id(test_db_session, "admin")
+        map_name = f"Overlay Honest Refusal Map {uuid.uuid4().hex[:6]}"
+        ds = await self._dataset_on_map(
+            test_db_session,
+            admin_id,
+            dataset_visibility="internal",
+            map_visibility="internal",
+            map_name=map_name,
+        )
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"visibility": "restricted"},
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert map_name in resp.json()["detail"]
+
+    async def test_a_non_admin_owner_is_never_stranded_by_their_own_change(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+    ):
+        """feat(#1068): the owner exclusion is a consequence now, not a clause.
+
+        The old query excluded the owner and every admin by hand. Both fall out
+        of the audience difference instead — an account in BOTH audiences was
+        never stranded — and the owner's exemption travels with whatever policy
+        is in force rather than assuming the community one. Every other guard
+        test owns its dataset as the seeded admin, which makes "the owner keeps
+        access" and "an admin keeps access" the same assertion; here the owner
+        is the non-admin viewer, and they are the only active non-admin left.
+        """
+        viewer_id = await self._viewer_id(client, viewer_auth_header)
+        ds = await self._dataset_on_map(
+            test_db_session,
+            viewer_id,
+            dataset_visibility="internal",
+            map_visibility="internal",
+            map_name=f"Owner Keeps Access Map {uuid.uuid4().hex[:6]}",
+        )
+
+        async with self._only_admins_active(test_db_session, keep={viewer_id}):
+            resp = await client.patch(
+                f"/datasets/{ds.id}",
+                json={"visibility": "private"},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 200, resp.text
 
     async def test_internal_to_restricted_blocks_when_someone_is_ungranted(
         self,

--- a/backend/tests/test_extension_api_version.py
+++ b/backend/tests/test_extension_api_version.py
@@ -52,13 +52,15 @@ class TestExtensionApiVersionConstant:
         (feat(#683), chat clip-by-layer) — the ``processing_port`` registry key
         is overlay-populated, so changing that method's signature changes the
         expected type of a registry key, which version.py's bump convention
-        names explicitly.
+        names explicitly. v4 adds the required ``record_audience`` method to
+        ``PermissionExtension`` (feat(#1068)), which the convention names
+        outright: a required method added to a Protocol.
 
         Update this pin, and the note above it, whenever the constant moves.
         """
         from app.platform.extensions.version import EXTENSION_API_VERSION
 
-        assert EXTENSION_API_VERSION == 3
+        assert EXTENSION_API_VERSION == 4
 
 
 class TestCheckExtensionApiVersion:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -913,7 +913,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # the stranded-viewer query mirrors only the default's grants+ladder,
         # so an additive overlay's viewers are invisible to it (#1068 tracks
         # the seam-aware answer). Cap 918 -> 937, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 937,
+        # feat(#1068): -36. The rank table, its per-map reach function and the
+        # three named cut slices are gone: the audience seam answers "who could
+        # read this before, and who can after" directly, and a rank drop was
+        # only ever a proxy for that difference being non-empty. The guard is
+        # shorter than it was before #1111's stopgap and now asks the
+        # authority rather than restating the community ladder at it.
+        # Cap 937 -> 901, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 901,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in
@@ -961,7 +968,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # `new != public and old == public` gate — that gate is what hid the
         # internal-map case — and delegates the whole before/after audience
         # comparison to the maps helper. Cap 480 -> 489, exact.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 489,
+        # feat(#1068): +1 — the guard call passes record_id, so the permission
+        # authority can key an audience on the record and not only its dataset.
+        # Cap 489 -> 490, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 490,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic
@@ -1024,7 +1034,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # two functions, whose comments carry why the obvious stricter variant
         # is wrong (it hides an owner's own draft from the owner). Cap exact,
         # zero headroom.
-        "backend/app/platform/extensions/defaults_extensions.py": 372,
+        # feat(#1068): +61 — record_audience, the audience-shaped reading of
+        # the same ladder filter_visible applies per user. Roughly half the
+        # lines are the mapping between the two: which condition over there
+        # each branch here inverts, so the pair can be kept in step by reading
+        # rather than by running the equivalence suite. Cap 372 -> 433, exact.
+        "backend/app/platform/extensions/defaults_extensions.py": 433,
     }
 
     files_to_check = list(facade_line_budgets)

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -920,7 +920,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # shorter than it was before #1111's stopgap and now asks the
         # authority rather than restating the community ladder at it.
         # Cap 937 -> 901, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 901,
+        # fix(#1126 codex P2): +13 — an unchanged visibility returns before the
+        # authority is asked at all. The rank comparison used to absorb the
+        # no-op (`X < X` is false); without it the fallback named every shared
+        # map, and the seam-answering branch reported an account the overlay
+        # could not classify as stranded by a move that did not happen. Most of
+        # the lines are why it sits above the branch rather than inside one.
+        # Cap 901 -> 914, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 914,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in

--- a/backend/tests/test_permission_audience.py
+++ b/backend/tests/test_permission_audience.py
@@ -1,0 +1,297 @@
+"""The audience seam agrees with the ladder it claims to mirror (feat(#1068)).
+
+``DefaultPermissionExtension.record_audience`` answers "which principals can
+read this record?" — the set-shaped reading of the rule ``filter_visible``
+already applies per user. Nothing structural keeps the two in step, so this
+file compares them account by account against a real database, across every
+visibility rung, every publication status, and the owner / admin / grantee /
+stranger roles that each rung treats differently.
+
+That equivalence is the whole warrant for
+``find_maps_broken_by_dataset_visibility`` trusting the seam: if the two ever
+disagree, the shared-map guard reports an audience that is not the one viewers
+actually get, and the disagreement is invisible from the calling side.
+"""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from app.modules.auth.models import Role, User, UserRole
+from app.modules.catalog.datasets.domain.models import DatasetGrant, Record
+from app.platform.extensions import RecordAudienceQuery
+from app.platform.extensions.defaults import DefaultPermissionExtension
+from tests.factories import create_dataset as _create_dataset
+
+# Every value the `chk_records_visibility` CHECK admits, and every status the
+# ladder distinguishes (`published` vs anything else).
+_VISIBILITIES = ("public", "internal", "restricted", "private")
+_STATUSES = ("published", "draft")
+
+
+class _Principals:
+    """The four accounts the ladder treats differently, plus their role sets."""
+
+    def __init__(self, owner, admin, grantee, stranger):
+        self.owner = owner
+        self.admin = admin
+        self.grantee = grantee
+        self.stranger = stranger
+
+    @property
+    def all(self):
+        return (self.owner, self.admin, self.grantee, self.stranger)
+
+    def roles(self, user):
+        """What ``get_user_roles`` would return for this account.
+
+        Only ``admin`` matters to ``filter_visible``, and it must agree with the
+        role rows ``record_audience`` resolves from the database — otherwise the
+        two sides are answering about different people and the comparison proves
+        nothing.
+        """
+        return {"admin"} if user is self.admin else set()
+
+
+async def _make_user(session, label: str) -> User:
+    suffix = uuid.uuid4().hex[:10]
+    user = User(
+        username=f"aud_{label}_{suffix}",
+        email=f"aud_{label}_{suffix}@example.test",
+        is_active=True,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+@pytest.fixture
+async def principals(test_db_session) -> _Principals:
+    """Four fresh accounts: a non-admin owner, an admin, a grantee, a stranger.
+
+    The owner is deliberately NOT an admin. Every existing guard test owns its
+    dataset as the seeded admin, which makes "the owner keeps access" and "an
+    admin keeps access" the same assertion — and the audience difference relies
+    on them being separate.
+    """
+    owner = await _make_user(test_db_session, "owner")
+    admin = await _make_user(test_db_session, "admin")
+    grantee = await _make_user(test_db_session, "grantee")
+    stranger = await _make_user(test_db_session, "stranger")
+
+    admin_role = (
+        await test_db_session.execute(select(Role).where(Role.name == "admin"))
+    ).scalar_one()
+    test_db_session.add(UserRole(user_id=admin.id, role_id=admin_role.id))
+    await test_db_session.commit()
+    return _Principals(owner, admin, grantee, stranger)
+
+
+@pytest.fixture
+async def granted_dataset(test_db_session, principals: _Principals):
+    """A dataset owned by ``principals.owner`` with a grant reaching the grantee."""
+    dataset = await _create_dataset(
+        test_db_session,
+        created_by=principals.owner.id,
+        name=f"Audience DS {uuid.uuid4().hex[:6]}",
+        visibility="private",
+        record_status="published",
+    )
+    role = Role(name=f"aud-grant-{uuid.uuid4().hex[:8]}")
+    test_db_session.add(role)
+    await test_db_session.flush()
+    test_db_session.add(UserRole(user_id=principals.grantee.id, role_id=role.id))
+    test_db_session.add(DatasetGrant(dataset_id=dataset.id, role_id=role.id))
+    await test_db_session.commit()
+    return dataset
+
+
+async def _readers_via_filter_visible(
+    session, record, principals: _Principals, grant_cls
+) -> set[uuid.UUID]:
+    """The accounts whose filtered query returns the record — the per-user rule."""
+    extension = DefaultPermissionExtension()
+    readers = set()
+    for user in principals.all:
+        stmt = extension.filter_visible(
+            select(Record.id).where(Record.id == record.id),
+            SimpleNamespace(id=user.id),
+            principals.roles(user),
+            Record,
+            grant_cls,
+        )
+        if (await session.execute(stmt)).scalar_one_or_none() is not None:
+            readers.add(user.id)
+    return readers
+
+
+async def _readers_via_record_audience(
+    session, dataset, record, principals: _Principals, grant_cls
+) -> set[uuid.UUID]:
+    """The same accounts, selected by the audience predicate — the set-shaped rule."""
+    audience = await DefaultPermissionExtension().record_audience(
+        RecordAudienceQuery(
+            dataset_id=dataset.id,
+            record_id=record.id,
+            owner_id=record.created_by,
+            visibility=record.visibility,
+            record_status=record.record_status,
+        ),
+        User,
+        grant_cls=grant_cls,
+    )
+    rows = await session.execute(
+        select(User.id)
+        .where(audience.users)
+        .where(User.id.in_([user.id for user in principals.all]))
+    )
+    return set(rows.scalars())
+
+
+@pytest.mark.parametrize("visibility", _VISIBILITIES)
+@pytest.mark.parametrize("record_status", _STATUSES)
+async def test_the_audience_is_exactly_who_filter_visible_admits(
+    test_db_session,
+    principals: _Principals,
+    granted_dataset,
+    visibility: str,
+    record_status: str,
+):
+    """feat(#1068): the two readings of the ladder name the same accounts.
+
+    Sixteen cells, each covering a rung the ladder handles differently: the
+    creator exemption on ``private`` and ``restricted``, the grant on
+    ``restricted``, the admin bypass everywhere, and the status gate that hides
+    an unpublished record from everyone but its owner.
+    """
+    record = granted_dataset.record
+    record.visibility = visibility
+    record.record_status = record_status
+    await test_db_session.commit()
+
+    via_filter = await _readers_via_filter_visible(
+        test_db_session, record, principals, DatasetGrant
+    )
+    via_audience = await _readers_via_record_audience(
+        test_db_session, granted_dataset, record, principals, DatasetGrant
+    )
+
+    assert via_audience == via_filter
+    # A cell where nobody at all can read would satisfy the equality above
+    # trivially; the admin bypass means no cell is ever empty.
+    assert principals.admin.id in via_filter
+
+
+@pytest.mark.parametrize("visibility", _VISIBILITIES)
+async def test_the_audience_is_empty_of_grantees_without_a_grant_class(
+    test_db_session,
+    principals: _Principals,
+    granted_dataset,
+    visibility: str,
+):
+    """A missing ``grant_cls`` drops the restricted rung on both sides.
+
+    ``filter_visible`` appends no restricted condition when it has no grant
+    class, which makes a restricted record unreachable rather than ungated —
+    even by its owner. The audience has to be unreachable in the same way, or a
+    caller that cannot supply the grant table gets a more permissive answer than
+    the reads it is reasoning about.
+    """
+    record = granted_dataset.record
+    record.visibility = visibility
+    record.record_status = "published"
+    await test_db_session.commit()
+
+    via_filter = await _readers_via_filter_visible(
+        test_db_session, record, principals, None
+    )
+    via_audience = await _readers_via_record_audience(
+        test_db_session, granted_dataset, record, principals, None
+    )
+
+    assert via_audience == via_filter
+    if visibility == "restricted":
+        assert via_filter == {principals.admin.id}
+
+
+async def test_the_anonymous_flag_matches_the_anonymous_filter(
+    test_db_session,
+    principals: _Principals,
+    granted_dataset,
+):
+    """``includes_anonymous`` tracks ``filter_visible(user=None)`` on every cell.
+
+    Anonymous visitors are rows in no table, so the flag is the only place the
+    public map's audience can come from. Public+published is the one cell that
+    admits them, and the assertion is written as an equivalence over all of them
+    so a widened anonymous rung cannot pass by matching the one expected True.
+    """
+    extension = DefaultPermissionExtension()
+    record = granted_dataset.record
+
+    for visibility in _VISIBILITIES:
+        for record_status in _STATUSES:
+            record.visibility = visibility
+            record.record_status = record_status
+            await test_db_session.commit()
+
+            anonymous_stmt = extension.filter_visible(
+                select(Record.id).where(Record.id == record.id),
+                None,
+                set(),
+                Record,
+                DatasetGrant,
+            )
+            anonymous_reads = (
+                await test_db_session.execute(anonymous_stmt)
+            ).scalar_one_or_none() is not None
+            audience = await extension.record_audience(
+                RecordAudienceQuery(
+                    dataset_id=granted_dataset.id,
+                    record_id=record.id,
+                    owner_id=record.created_by,
+                    visibility=visibility,
+                    record_status=record_status,
+                ),
+                User,
+                grant_cls=DatasetGrant,
+            )
+            assert audience.includes_anonymous is anonymous_reads, (
+                f"{visibility}/{record_status}"
+            )
+
+
+async def test_an_unrecognised_visibility_reaches_only_admins(
+    test_db_session,
+    principals: _Principals,
+    granted_dataset,
+):
+    """A rung the ladder does not name is unreachable, not ungated.
+
+    ``chk_records_visibility`` keeps such a value out of the database, so this
+    one cannot be cross-checked against a stored record — but the branch exists
+    because ``filter_visible`` builds no condition for an unknown value either,
+    and a fall-through that admitted everyone would be the same class of silent
+    widening this seam was added to close.
+    """
+    audience = await DefaultPermissionExtension().record_audience(
+        RecordAudienceQuery(
+            dataset_id=granted_dataset.id,
+            record_id=granted_dataset.record_id,
+            owner_id=principals.owner.id,
+            visibility="sensitive",
+            record_status="published",
+        ),
+        User,
+        grant_cls=DatasetGrant,
+    )
+    rows = await test_db_session.execute(
+        select(User.id)
+        .where(audience.users)
+        .where(User.id.in_([user.id for user in principals.all]))
+    )
+    assert set(rows.scalars()) == {principals.admin.id}
+    assert audience.includes_anonymous is False


### PR DESCRIPTION
## Problem

`PermissionExtension` exposed two methods and both take a concrete user: `filter_visible` and `can_access_dataset`. Neither can answer "who is the audience for this map?", because an audience is a set with no representative member to pass in. A guard needing to reason about a whole audience therefore had to reconstruct it from the community ladder directly, which an overlay is free to change.

#931 / #1056 added exactly such a guard, refusing a dataset visibility change that would strand a shared map's audience.

## Why this is more urgent than the issue says

The issue argues the failure direction is safe, on the grounds that an overlay can only narrow a rung, which makes the guard more conservative. **That is out of date.** #1111 landed afterwards and documents the opposite for a widening overlay: the guard returns `[]`, the change applies, and a granted viewer silently loses the layer. Both directions are wrong, one loudly and one silently, and the silent one is why #1111 fell back to a stopgap rather than trusting the argument.

That stopgap refused the operation whenever `type(get_permission_extension()) is not DefaultPermissionExtension`. In practice **every overlay deployment got blanket refusals** on visibility changes touching shared maps.

## Fix

`PermissionExtension.record_audience` answers the set-shaped question: which principals can read this record, at a named visibility, without inventing a user. `EXTENSION_API_VERSION` goes 3 → 4, since this is a required method on an existing Protocol.

The community implementation is the same ladder `filter_visible` walks, read from the user end: admins always, `public`/`internal` any signed-in account, `private` the owner, `restricted` the owner plus grant-holding roles, with the status gate ANDed across every rung.

## The refusal narrows rather than disappearing

An authority that cannot answer still gets a conservative refusal, but the test is now what the overlay actually overrides, not its type:

- No `record_audience` at all. Only an overlay declaring no `EXTENSION_API_VERSION` reaches this, because a declared-but-mismatched version is already a hard boot failure.
- It inherits the community audience while overriding `filter_visible` or `can_access_dataset`. Then the audience it reports and the rows its viewers get are two different policies, and core cannot tell a missing answer from a wrong one.

`check_permission` is deliberately not in that set: capabilities do not decide which records a viewer can read.

This is a real widening over #1111. A subclass that changes nothing about reads, or one that implements `record_audience`, now gets a real answer instead of a refusal.

## Compatibility

Behaviour is unchanged for community deployments, and that is tested rather than asserted. `test_permission_audience.py` computes the reader set through `filter_visible` and compares it account by account against `record_audience`, across every visibility, record status and role, plus the anonymous flag against `filter_visible(user=None)`. A change to one direction that is not mirrored in the other fails there rather than quietly making the shared-map guard disagree with what viewers actually see.

Overlay authors must implement `record_audience` when replacing the `permission` slot, and must implement it whenever they change either read method.

## Verification

```
cd backend
uv run pytest -n 4 --dist loadgroup        # 6846 passed, 83 skipped
uv run pytest tests/test_layering.py -q            # 36 passed
uv run pytest tests/test_rule1_structural.py -q    # 6 passed
uv run pytest tests/test_rule2_structural.py -q    # 76 passed
uv run ruff check . && uv run ruff format --check .  # clean, 876 files
```

Closes #1068