### PR TITLE
test(conftest): restore process-global logging config around every test

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,10 +1,11 @@
 import asyncio
+import logging
 import os
 import time
 import uuid
 import tempfile
 import warnings
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 
 import asyncpg.exceptions
 import pytest
@@ -372,6 +373,133 @@ def _restore_process_global_config():
             os.environ[_MODE_KEY] = _original_mode  # type: ignore[assignment]
         else:
             os.environ.pop(_MODE_KEY, None)
+
+
+# Every logger setup_logging() reaches, read off app/core/logging_config.py:102-112.
+# "" is the root logger. tests/_logging_state.py keeps the same list for the
+# per-test helper; both are derived from that source, not from each other.
+_LOGGING_MUTATED_LOGGERS = ("", "uvicorn", "uvicorn.error", "uvicorn.access")
+
+
+@contextmanager
+def _global_logging_repair():
+    """Repair process-global logging config leaked inside the window.
+
+    Logging is the seam ``_restore_process_global_config`` above does not cover,
+    and it is the one seam where a leak makes a SECURITY assertion pass
+    vacuously — a disconnected tripwire and a working one look identical from
+    the outside. Three recurrences (#1066):
+
+      * ``test_tile_signing.py:648-656`` — neither ``caplog`` nor
+        ``capture_logs()`` reliably sees the tile logger, worked around per
+        call site.
+      * #1024's EXISTS negative controls went red on main, fixed in #1063.
+      * #1064 / #1065 — three SMTP/webhook credential-leak assertions that had
+        never been able to fail. Injecting a real password leak made the old
+        assertion report ``CAPLOG_RECORDS: 0`` and PASS.
+
+    ``setup_logging()`` mutates two independent globals, so this restores two
+    independent things. Measured across one leaking test with the guard off:
+
+      1. structlog config — ``cache_logger_on_first_use`` False -> True,
+         plus the chain/factory. **The caching flag is the protection that
+         carries the fix.** A ``BoundLoggerLazyProxy`` that emits while caching
+         is on freezes against the then-current chain ON THE PROXY OBJECT, and
+         no later restore can thaw it (#1063 mechanism, spelled out at
+         test_sec025_sandbox_allowlist.py:52-71). Preventing the freeze is the
+         only thing that closes the class, so the flag is forced back OFF
+         rather than restored: a faithfully restored ``True`` hands the next
+         test the exact global that makes its captures go blind. The rest of
+         the snapshot IS restored faithfully — a blanket
+         ``structlog.reset_defaults()`` would drop ``_redact_sensitive_fields``
+         and the stdlib routing that later tests rely on (caught on #1065).
+      2. stdlib loggers — root level 30 -> 10, and ``uvicorn.access.propagate``
+         True -> False. Both survive into every later test on the worker.
+
+    The two halves normalise differently, and the difference is deliberate.
+    The caching flag is forced to a fixed value, so it is an ABSOLUTE invariant
+    every test can rely on: caching is off when any test body starts.
+    Everything else is restored RELATIVE to the snapshot this test arrived
+    with, because the app legitimately owns that state. Collection imports
+    ``app/api/main.py``, whose module-level ``setup_logging()`` call leaves
+    ``uvicorn.access.propagate`` False and root at LOG_LEVEL before any test
+    runs, and forcing those back would fight the app rather than the leak.
+
+    That same collection-time call arms caching before any test exists, which
+    is why the flag is cleared on the way IN as well as on the way out. A
+    teardown-only guard leaves it armed for the whole of a worker's first test;
+    measured under a shuffled run, the first test on a worker observed
+    ``cache_logger_on_first_use`` True. Nothing a per-test helper does can
+    reach that, since it predates every test.
+
+    Every branch is conditional, so once the flag is clear the fixture does
+    nothing at all for a test that never touches logging: ``get_config()``
+    already equals the wanted mapping, so ``configure()`` is not called and
+    ``structlog.is_configured()`` is left as it was.
+
+    Handlers are only restored when a snapshotted handler actually went
+    MISSING, which is ``setup_logging()``'s ``handlers.clear()`` signature.
+    Assigning the snapshot unconditionally is wrong: pytest adds and removes
+    its own ``LogCaptureHandler``s around each phase, and on the first test of
+    a worker the session-scoped migration's ``fileConfig()`` clears them
+    mid-setup, so the setup-time snapshot can legitimately be SHORTER than the
+    teardown-time list. Restoring that verbatim would strip pytest's live
+    capture handlers from a test that leaked nothing.
+
+    Does not configure logging during setup, only after ``yield``: pytest swaps
+    ``sys.stdout``/``sys.stderr`` for the call phase only, so a handler built in
+    fixture setup binds to a stream nothing is capturing and every write fails
+    with ``--- Logging error ---``. Tests that legitimately call
+    ``setup_logging()`` mid-body are unaffected while they run; see
+    ``tests/_logging_state.py``, which owns the different job of leaving no
+    trace, where this owns repairing a leak that is already there.
+
+    Split out of the autouse fixture below so the guard's contract can be
+    driven directly by a test. Reaching for the fixture's underlying function
+    instead would mean depending on a private pytest attribute — pytest 9
+    replaced ``__pytest_wrapped__`` with ``FixtureFunctionDefinition``, so that
+    test would have rotted at the next bump.
+    """
+    saved_loggers = {
+        name: (
+            logging.getLogger(name).handlers[:],
+            logging.getLogger(name).propagate,
+            logging.getLogger(name).level,
+        )
+        for name in _LOGGING_MUTATED_LOGGERS
+    }
+    saved_structlog = dict(structlog.get_config())
+    # get_config() hands back the LIVE processor list; copy it so a test that
+    # mutates the chain in place cannot edit our snapshot too.
+    saved_structlog["processors"] = list(saved_structlog["processors"])
+    # Disarm BEFORE the body too, not only after it. Teardown alone leaves the
+    # collection-time True armed for the whole of a worker's first test, and a
+    # module-level logger that emits there freezes for the rest of the run.
+    # Flipping one flag creates no handler, so this does not trip the
+    # setup-phase stream problem described below.
+    if structlog.get_config()["cache_logger_on_first_use"]:
+        structlog.configure(cache_logger_on_first_use=False)
+    try:
+        yield
+    finally:
+        wanted = {**saved_structlog, "cache_logger_on_first_use": False}
+        if structlog.get_config() != wanted:
+            structlog.configure(**wanted)
+        for name, (handlers, propagate, level) in saved_loggers.items():
+            logger = logging.getLogger(name)
+            if any(h not in logger.handlers for h in handlers):
+                logger.handlers[:] = handlers
+            if logger.propagate != propagate:
+                logger.propagate = propagate
+            if logger.level != level:
+                logger.setLevel(level)
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_logging_config():
+    """Run ``_global_logging_repair()`` around every test; see it for the why."""
+    with _global_logging_repair():
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -426,6 +426,47 @@ def _configure_without_caching(*args, **kwargs):
 structlog.configure = _configure_without_caching
 
 
+def _install_stdout_safe_structlog_baseline():
+    """Route the session's structlog baseline through stdlib, off ``sys.stdout``.
+
+    structlog's UNCONFIGURED default is ``PrintLoggerFactory(file=None)`` plus
+    ``ConsoleRenderer``, and ``PrintLogger(None)`` resolves ``sys.stdout`` when
+    the logger is CONSTRUCTED, which for an uncached proxy is every call. So
+    the out-of-the-box baseline writes application log lines to whatever
+    ``sys.stdout`` happens to be at emission time.
+
+    In a test process stdout belongs to the code under test.
+    ``tests/test_cli_round_trip.py`` runs a CLI through click's ``CliRunner``
+    and parses its stdout as JSON; a console-rendered line landing there fails
+    as ``JSONDecodeError: Extra data: line 1 column 5 (char 4)``, because the
+    timestamp's ``2026`` parses as a JSON number and the rest is trailing junk.
+
+    The guard below made that reachable and this is where it gets paid for. The
+    app configures structlog at import (stdlib routing, off stdout), the guard
+    faithfully restores the arrival snapshot, and the arrival snapshot is the
+    stdout-writing default — so from the second test onward the process sits in
+    a state it would never otherwise be in. Caching previously hid it: a frozen
+    proxy kept the ONE ``PrintLogger`` it built at freeze time, so later
+    emissions went wherever that first one pointed rather than into the
+    CliRunner buffer of the moment. Removing the freeze (correctly) removed the
+    accident that was covering this.
+
+    Fixing it by rebasing the BASELINE rather than by loosening the restore
+    keeps the ABSOLUTE/RELATIVE split intact: the floor is established once,
+    before any snapshot is taken, and the guard stays perfectly faithful to it.
+    "Application logs never reach stdout" is an absolute the whole session
+    needs, exactly like the caching flag, not something each stdout-parsing
+    module should have to defend for itself.
+
+    stdlib routing is also what ``setup_logging()`` installs, so the baseline
+    now matches production instead of diverging from it.
+    """
+    structlog.configure(logger_factory=structlog.stdlib.LoggerFactory())
+
+
+_install_stdout_safe_structlog_baseline()
+
+
 # Every logger setup_logging() reaches, read off app/core/logging_config.py:102-112.
 # "" is the root logger. tests/_logging_state.py keeps the same list for the
 # per-test helper; both are derived from that source, not from each other.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -375,10 +375,72 @@ def _restore_process_global_config():
             os.environ.pop(_MODE_KEY, None)
 
 
+_UNCLAMPED_STRUCTLOG_CONFIGURE = structlog.configure
+
+
+def _configure_without_caching(*args, **kwargs):
+    """``structlog.configure()`` with ``cache_logger_on_first_use`` forced off.
+
+    Installed process-wide below. This is the primary fix for the freeze class
+    (#1066 / PR #1127 codex P1); the per-test clears in the guard are a
+    backstop, not the mechanism.
+
+    ``setup_logging()`` sets the flag True unconditionally
+    (``app/core/logging_config.py:82``), so clearing it around each test cannot
+    hold: a test that imports an entrypoint, or calls ``setup_logging()``
+    directly, re-arms it MID-BODY. A ``BoundLoggerLazyProxy`` that emits while
+    it is armed replaces its own ``bind`` with a closure over the processor
+    list in force at that moment (``structlog/_config.py``), and no later
+    restore can thaw it.
+
+    That freeze is only half of the failure. Measured on structlog 25.5.0:
+
+        frozen proxy, processor list kept as the same object -> captured 1
+        frozen proxy, processor list REBOUND to a copy       -> captured 0
+        unfrozen proxy, list rebound                         -> captured 1
+
+    ``capture_logs()`` clears and extends the live list in place precisely "to
+    not break references held by bound loggers", so a freeze alone no longer
+    blinds it the way the older notes at ``test_tile_signing.py:648-656`` and
+    ``test_sec025_sandbox_allowlist.py:52-71`` describe. Blindness now needs a
+    freeze AND a processor-list identity change, and ``setup_logging()`` builds
+    a fresh list on every call, so a second call after a freeze supplies one.
+    Keeping the proxy unfrozen makes the whole conjunction unreachable: an
+    unfrozen proxy re-binds per call and survives any list rebind.
+
+    Clamping here rather than in ``setup_logging()`` keeps production code
+    test-unaware, which ``backend/app/`` is throughout (no PYTEST/sys.modules
+    branch anywhere in it). Clamping ``structlog.configure`` rather than
+    wrapping ``setup_logging`` keys the invariant off the resolved STATE at the
+    single choke point instead of chasing call paths: ``logging_config.py`` is
+    the only non-test writer of the flag and reaches structlog by module
+    attribute lookup at call time, so this intercepts it whatever the import
+    order, including the import that happens during collection.
+    """
+    kwargs["cache_logger_on_first_use"] = False
+    return _UNCLAMPED_STRUCTLOG_CONFIGURE(*args, **kwargs)
+
+
+# Module level, so it is in force before the test modules are imported and
+# therefore before app/api/main.py's import-time setup_logging() call.
+structlog.configure = _configure_without_caching
+
+
 # Every logger setup_logging() reaches, read off app/core/logging_config.py:102-112.
 # "" is the root logger. tests/_logging_state.py keeps the same list for the
 # per-test helper; both are derived from that source, not from each other.
 _LOGGING_MUTATED_LOGGERS = ("", "uvicorn", "uvicorn.error", "uvicorn.access")
+
+
+def _is_pytest_owned_handler(handler: logging.Handler) -> bool:
+    """True for the capture handlers pytest attaches and detaches per phase.
+
+    pytest's live handlers (``LogCaptureHandler``, the live-log handlers) are
+    all defined under ``_pytest``; nothing a test or the app installs is. The
+    module of the handler's CLASS is the discriminator, so this reads pytest's
+    surface without importing its internals.
+    """
+    return type(handler).__module__.split(".")[0] == "_pytest"
 
 
 @contextmanager
@@ -398,53 +460,43 @@ def _global_logging_repair():
         never been able to fail. Injecting a real password leak made the old
         assertion report ``CAPLOG_RECORDS: 0`` and PASS.
 
-    ``setup_logging()`` mutates two independent globals, so this restores two
-    independent things. Measured across one leaking test with the guard off:
+    What closes the freeze class is ``_configure_without_caching`` above, not
+    this fixture. Read its docstring first; the flag clears here are a backstop
+    for the case where something bypasses that clamp. What this fixture owns is
+    everything else ``setup_logging()`` moves. Measured across one leaking test
+    with the guard off:
 
-      1. structlog config — ``cache_logger_on_first_use`` False -> True,
-         plus the chain/factory. **The caching flag is the protection that
-         carries the fix.** A ``BoundLoggerLazyProxy`` that emits while caching
-         is on freezes against the then-current chain ON THE PROXY OBJECT, and
-         no later restore can thaw it (#1063 mechanism, spelled out at
-         test_sec025_sandbox_allowlist.py:52-71). Preventing the freeze is the
-         only thing that closes the class, so the flag is forced back OFF
-         rather than restored: a faithfully restored ``True`` hands the next
-         test the exact global that makes its captures go blind. The rest of
-         the snapshot IS restored faithfully — a blanket
-         ``structlog.reset_defaults()`` would drop ``_redact_sensitive_fields``
-         and the stdlib routing that later tests rely on (caught on #1065).
+      1. structlog config — the processor chain, factory and wrapper. Restored
+         faithfully; a blanket ``structlog.reset_defaults()`` would drop
+         ``_redact_sensitive_fields`` and the stdlib routing that later tests
+         rely on (caught on #1065). The processor LIST OBJECT is restored by
+         identity rather than replaced, because bound loggers hold references
+         to it.
       2. stdlib loggers — root level 30 -> 10, and ``uvicorn.access.propagate``
          True -> False. Both survive into every later test on the worker.
 
-    The two halves normalise differently, and the difference is deliberate.
-    The caching flag is forced to a fixed value, so it is an ABSOLUTE invariant
-    every test can rely on: caching is off when any test body starts.
-    Everything else is restored RELATIVE to the snapshot this test arrived
-    with, because the app legitimately owns that state. Collection imports
-    ``app/api/main.py``, whose module-level ``setup_logging()`` call leaves
-    ``uvicorn.access.propagate`` False and root at LOG_LEVEL before any test
-    runs, and forcing those back would fight the app rather than the leak.
+    Only the caching flag is normalised to a fixed value. Everything else is
+    restored RELATIVE to the snapshot this test arrived with, because the app
+    legitimately owns that state. Collection imports ``app/api/main.py``, whose
+    module-level ``setup_logging()`` call leaves ``uvicorn.access.propagate``
+    False and root at LOG_LEVEL before any test runs, and forcing those back
+    would fight the app rather than the leak.
 
-    That same collection-time call arms caching before any test exists, which
-    is why the flag is cleared on the way IN as well as on the way out. A
-    teardown-only guard leaves it armed for the whole of a worker's first test;
-    measured under a shuffled run, the first test on a worker observed
-    ``cache_logger_on_first_use`` True. Nothing a per-test helper does can
-    reach that, since it predates every test.
+    Every branch is conditional, so the fixture does nothing at all for a test
+    that never touches logging: ``get_config()`` already equals the wanted
+    mapping, so ``configure()`` is not called and ``structlog.is_configured()``
+    is left as it was.
 
-    Every branch is conditional, so once the flag is clear the fixture does
-    nothing at all for a test that never touches logging: ``get_config()``
-    already equals the wanted mapping, so ``configure()`` is not called and
-    ``structlog.is_configured()`` is left as it was.
-
-    Handlers are only restored when a snapshotted handler actually went
-    MISSING, which is ``setup_logging()``'s ``handlers.clear()`` signature.
-    Assigning the snapshot unconditionally is wrong: pytest adds and removes
-    its own ``LogCaptureHandler``s around each phase, and on the first test of
-    a worker the session-scoped migration's ``fileConfig()`` clears them
-    mid-setup, so the setup-time snapshot can legitimately be SHORTER than the
-    teardown-time list. Restoring that verbatim would strip pytest's live
-    capture handlers from a test that leaked nothing.
+    Handlers are restored to the baseline plus whatever pytest currently owns.
+    Assigning the snapshot verbatim is wrong in one direction: pytest adds and
+    removes its own ``LogCaptureHandler``s around each phase, and on the first
+    test of a worker the session-scoped migration's ``fileConfig()`` clears
+    them mid-setup, so the setup-time snapshot can legitimately be SHORTER than
+    the teardown-time list, and restoring it flat would strip pytest's live
+    capture handlers from a test that leaked nothing. Keying off "a saved
+    handler went missing" instead is wrong in the other direction, which is
+    what ``_is_pytest_owned_handler`` exists to settle; see the comment at the
+    restore itself.
 
     Does not configure logging during setup, only after ``yield``: pytest swaps
     ``sys.stdout``/``sys.stderr`` for the call phase only, so a handler built in
@@ -469,26 +521,51 @@ def _global_logging_repair():
         for name in _LOGGING_MUTATED_LOGGERS
     }
     saved_structlog = dict(structlog.get_config())
-    # get_config() hands back the LIVE processor list; copy it so a test that
-    # mutates the chain in place cannot edit our snapshot too.
-    saved_structlog["processors"] = list(saved_structlog["processors"])
-    # Disarm BEFORE the body too, not only after it. Teardown alone leaves the
-    # collection-time True armed for the whole of a worker's first test, and a
-    # module-level logger that emits there freezes for the rest of the run.
-    # Flipping one flag creates no handler, so this does not trip the
-    # setup-phase stream problem described below.
+    # The processor list is restored by IDENTITY, not by value. get_config()
+    # hands back the live list, and a frozen bound logger holds a reference to
+    # that exact object, so handing structlog a copy is what actually blinds a
+    # later capture_logs() (measured above). Keep the object; snapshot its
+    # contents separately so a test mutating the chain in place cannot edit the
+    # snapshot too.
+    saved_processors_list = saved_structlog["processors"]
+    saved_processors = list(saved_processors_list)
+    # Backstop only; _configure_without_caching above is what keeps this False.
+    # Retained because it is the one thing that still repairs the flag if the
+    # clamp is ever bypassed, and clearing on the way in as well as out costs
+    # a comparison. Flipping the flag creates no handler, so this does not trip
+    # the setup-phase stream problem described above.
     if structlog.get_config()["cache_logger_on_first_use"]:
         structlog.configure(cache_logger_on_first_use=False)
     try:
         yield
     finally:
-        wanted = {**saved_structlog, "cache_logger_on_first_use": False}
+        if list(saved_processors_list) != saved_processors:
+            saved_processors_list[:] = saved_processors
+        wanted = {
+            **saved_structlog,
+            "processors": saved_processors_list,
+            "cache_logger_on_first_use": False,
+        }
         if structlog.get_config() != wanted:
             structlog.configure(**wanted)
         for name, (handlers, propagate, level) in saved_loggers.items():
             logger = logging.getLogger(name)
-            if any(h not in logger.handlers for h in handlers):
-                logger.handlers[:] = handlers
+            if logger.handlers != handlers:
+                # Put the baseline back and re-add only the capture handlers
+                # pytest itself attaches and detaches around each phase. Using
+                # "did a saved handler go missing" as the sole leak signal has
+                # a hole: pytest reattaches the SAME handler objects for the
+                # teardown phase before this finalizer runs, so in a run whose
+                # snapshot held only those handlers, every saved handler is
+                # present again and a StreamHandler the test installed rides
+                # along into later tests (PR #1127 codex P2). Ownership is the
+                # discriminator that closes it — pytest's live handlers are
+                # defined in _pytest, ours never are.
+                logger.handlers[:] = handlers + [
+                    h
+                    for h in logger.handlers
+                    if h not in handlers and _is_pytest_owned_handler(h)
+                ]
             if logger.propagate != propagate:
                 logger.propagate = propagate
             if logger.level != level:

--- a/backend/tests/test_logging_conftest_guard.py
+++ b/backend/tests/test_logging_conftest_guard.py
@@ -11,9 +11,21 @@ import logging
 
 import pytest
 import structlog
+from structlog.testing import capture_logs
 
 from app.core.logging_config import setup_logging
-from tests.conftest import _global_logging_repair, _LOGGING_MUTATED_LOGGERS
+from tests.conftest import (
+    _UNCLAMPED_STRUCTLOG_CONFIGURE,
+    _global_logging_repair,
+    _is_pytest_owned_handler,
+    _LOGGING_MUTATED_LOGGERS,
+)
+
+# A module-level lazy proxy, the shape every app module's `logger` has. It is
+# what freezes: `structlog.get_logger()` returns a BoundLoggerLazyProxy, and
+# emitting through one while caching is armed replaces its `bind` with a
+# closure over the processor list in force at that moment.
+module_logger = structlog.get_logger("tests.logging_conftest_guard")
 
 
 def _snapshot():
@@ -37,6 +49,10 @@ def test_guard_repairs_a_setup_logging_leak():
     before = _snapshot()
     with _global_logging_repair():
         setup_logging(json_logs=True, log_level="DEBUG")
+        # Arm caching THROUGH the clamp, so the flag backstop still has
+        # coverage. Nothing reaches this state while the clamp is installed;
+        # the point is that the guard repairs it if anything ever does.
+        _UNCLAMPED_STRUCTLOG_CONFIGURE(cache_logger_on_first_use=True)
 
         # The leak is real: assert it INSIDE the window, so this test cannot
         # pass by the leak having quietly stopped happening.
@@ -51,6 +67,57 @@ def test_guard_repairs_a_setup_logging_leak():
         assert after[name] == before[name], f"{name or '<root>'} not restored"
 
 
+def test_mid_test_setup_logging_does_not_blind_capture_logs():
+    """The vacuous pass this whole issue exists to prevent (#1127 codex P1).
+
+    A test calls ``setup_logging()`` mid-body, emits through a module-level
+    logger, and something calls ``setup_logging()`` again. Without the clamp
+    the first call arms caching, the emit freezes the proxy against that call's
+    processor list, and the second call rebinds the live list to a fresh one,
+    so ``capture_logs()`` mutating the new list in place is invisible to the
+    frozen logger: the assertion below sees zero records and a credential-leak
+    check written this way would pass while asserting nothing.
+
+    Both halves are needed to reproduce it. On structlog 25.5.0 a freeze alone
+    does NOT blind ``capture_logs()``, because it clears and extends the live
+    list in place rather than replacing it.
+    """
+    setup_logging(json_logs=True, log_level="DEBUG")
+    module_logger.info("warm up")  # freezes the proxy if caching is armed
+    setup_logging(json_logs=True, log_level="DEBUG")  # rebinds the live list
+
+    with capture_logs() as events:
+        module_logger.info("sentinel", password="hunter2")
+
+    assert [e["event"] for e in events] == ["sentinel"], (
+        "capture_logs() went blind: the proxy froze against a stale processor "
+        "list, so a log assertion here could never fail"
+    )
+
+
+def test_configure_cannot_arm_caching_during_the_test_session():
+    """The clamp itself, at the choke point, independent of who calls it."""
+    structlog.configure(cache_logger_on_first_use=True)
+    assert structlog.get_config()["cache_logger_on_first_use"] is False
+
+    setup_logging(json_logs=True, log_level="DEBUG")
+    assert structlog.get_config()["cache_logger_on_first_use"] is False
+
+
+def test_guard_restores_the_processor_list_object_not_a_copy():
+    """Identity matters: bound loggers hold a reference to the live list.
+
+    Handing structlog a copy is itself the second half of the blinding
+    conjunction above, so the guard must put the same object back.
+    """
+    before = structlog.get_config()["processors"]
+    with _global_logging_repair():
+        setup_logging(json_logs=True, log_level="DEBUG")
+        assert structlog.get_config()["processors"] is not before
+
+    assert structlog.get_config()["processors"] is before
+
+
 def test_guard_clears_caching_before_the_body_runs():
     """Cover the entry-side clear, which the teardown-side one does not imply.
 
@@ -59,11 +126,36 @@ def test_guard_clears_caching_before_the_body_runs():
     import. A module-level logger that emits in that window freezes against the
     chain in force and goes invisible to every later capture on the worker.
     """
-    structlog.configure(cache_logger_on_first_use=True)
+    _UNCLAMPED_STRUCTLOG_CONFIGURE(cache_logger_on_first_use=True)
     assert structlog.get_config()["cache_logger_on_first_use"] is True
 
     with _global_logging_repair():
         assert structlog.get_config()["cache_logger_on_first_use"] is False
+
+
+def test_guard_drops_a_leaked_handler_pytest_reattached_around(monkeypatch):
+    """Presence of every saved handler is not proof nothing leaked.
+
+    Reproduces the run shape where the snapshot holds only pytest's own
+    capture handlers: the test clears them and installs its own, pytest
+    reattaches the same objects for the next phase, and a leak signal based on
+    "did a saved handler go missing" reports clean while the installed handler
+    survives (#1127 codex P2).
+    """
+    root = logging.getLogger()
+    pytest_owned = [h for h in root.handlers if _is_pytest_owned_handler(h)]
+    assert pytest_owned, "expected pytest's capture handlers on root"
+    monkeypatch.setattr(root, "handlers", list(pytest_owned))
+
+    leaked = logging.StreamHandler()
+    with _global_logging_repair():
+        root.handlers.clear()  # what setup_logging() does
+        root.addHandler(leaked)
+        for handler in pytest_owned:  # what pytest does for the next phase
+            root.addHandler(handler)
+
+    assert leaked not in root.handlers
+    assert root.handlers == pytest_owned
 
 
 # Recorded by the leaker so its partner can compare against the state THIS
@@ -94,9 +186,8 @@ def test_a_setup_logging_leaks_process_global_state():
     leaked = "ERROR" if _PRE_LEAK["root_level"] != logging.ERROR else "DEBUG"
     setup_logging(json_logs=True, log_level=leaked)
 
-    # Baseline-independent, unlike propagate: setup_logging() always turns
-    # caching on, and the guard always leaves it off again.
-    assert structlog.get_config()["cache_logger_on_first_use"] is True
+    # setup_logging() asks for caching, and the clamp refuses on its behalf.
+    assert structlog.get_config()["cache_logger_on_first_use"] is False
     assert logging.getLogger("uvicorn.access").propagate is False
     assert logging.getLogger().level != _PRE_LEAK["root_level"]
 

--- a/backend/tests/test_logging_conftest_guard.py
+++ b/backend/tests/test_logging_conftest_guard.py
@@ -7,7 +7,9 @@ test asserts the guard cleaned it up. A leak that stopped reproducing would go
 red here instead of turning the guard into untested dead code.
 """
 
+import io
 import logging
+import sys
 
 import pytest
 import structlog
@@ -92,6 +94,36 @@ def test_mid_test_setup_logging_does_not_blind_capture_logs():
     assert [e["event"] for e in events] == ["sentinel"], (
         "capture_logs() went blind: the proxy froze against a stale processor "
         "list, so a log assertion here could never fail"
+    )
+
+
+def test_app_logging_never_reaches_stdout():
+    """stdout belongs to the code under test, at every point in the session.
+
+    structlog's unconfigured default builds a ``PrintLogger`` on ``sys.stdout``
+    at emission time, so an uncached module-level logger writes a
+    console-rendered line into whatever has captured stdout. That is how a
+    ``CliRunner`` invocation in ``test_cli_round_trip.py`` ends up parsing
+    ``2026-08-02 ... [info ]`` as JSON and failing with "Extra data".
+
+    Asserted after a ``setup_logging()`` round trip through the guard, since it
+    is the RESTORED baseline that has to be stdout-safe, not just the initial
+    one.
+    """
+    with _global_logging_repair():
+        setup_logging(json_logs=True, log_level="DEBUG")
+
+    captured = io.StringIO()
+    real_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        module_logger.info("this belongs on a log stream, not on stdout")
+    finally:
+        sys.stdout = real_stdout
+
+    assert captured.getvalue() == "", (
+        "application log output reached sys.stdout, which the code under test "
+        f"owns: {captured.getvalue()!r}"
     )
 
 

--- a/backend/tests/test_logging_conftest_guard.py
+++ b/backend/tests/test_logging_conftest_guard.py
@@ -1,0 +1,122 @@
+"""Cover the autouse logging guard in conftest.py (#1066).
+
+The guard exists because a leaked logging config makes later log assertions
+pass vacuously, so these tests are written to fail rather than to pass quietly:
+the leaking test asserts that its leak REALLY happened before the follow-on
+test asserts the guard cleaned it up. A leak that stopped reproducing would go
+red here instead of turning the guard into untested dead code.
+"""
+
+import logging
+
+import pytest
+import structlog
+
+from app.core.logging_config import setup_logging
+from tests.conftest import _global_logging_repair, _LOGGING_MUTATED_LOGGERS
+
+
+def _snapshot():
+    return {
+        name: (
+            logging.getLogger(name).handlers[:],
+            logging.getLogger(name).propagate,
+            logging.getLogger(name).level,
+        )
+        for name in _LOGGING_MUTATED_LOGGERS
+    }
+
+
+def test_guard_repairs_a_setup_logging_leak():
+    """Drive the guard's own window around a real ``setup_logging()``.
+
+    Order-independent and xdist-independent, unlike the pair below: it runs the
+    guard's own body, so it pins the contract even if this module's tests get
+    shuffled or split across workers.
+    """
+    before = _snapshot()
+    with _global_logging_repair():
+        setup_logging(json_logs=True, log_level="DEBUG")
+
+        # The leak is real: assert it INSIDE the window, so this test cannot
+        # pass by the leak having quietly stopped happening.
+        assert structlog.get_config()["cache_logger_on_first_use"] is True
+        assert logging.getLogger("uvicorn.access").propagate is False
+        assert logging.getLogger().level == logging.DEBUG
+        assert logging.getLogger().handlers != before[""][0]
+
+    assert structlog.get_config()["cache_logger_on_first_use"] is False
+    after = _snapshot()
+    for name in _LOGGING_MUTATED_LOGGERS:
+        assert after[name] == before[name], f"{name or '<root>'} not restored"
+
+
+def test_guard_clears_caching_before_the_body_runs():
+    """Cover the entry-side clear, which the teardown-side one does not imply.
+
+    A worker's first test would otherwise run with the collection-time True
+    still armed, because ``app/api/main.py`` calls ``setup_logging()`` at
+    import. A module-level logger that emits in that window freezes against the
+    chain in force and goes invisible to every later capture on the worker.
+    """
+    structlog.configure(cache_logger_on_first_use=True)
+    assert structlog.get_config()["cache_logger_on_first_use"] is True
+
+    with _global_logging_repair():
+        assert structlog.get_config()["cache_logger_on_first_use"] is False
+
+
+# Recorded by the leaker so its partner can compare against the state THIS
+# worker started from. A hardcoded expectation does not work for the stdlib
+# side: collection imports app/api/main.py, whose module-level
+# `setup_logging()` call leaves uvicorn.access.propagate False and root at
+# LOG_LEVEL before any test runs. Which modules get collected therefore decides
+# the baseline, so the only stable comparison is against the leaker's own
+# reading (#1066).
+_PRE_LEAK: dict[str, object] = {}
+
+
+@pytest.mark.xdist_group("logging_conftest_guard")
+def test_a_setup_logging_leaks_process_global_state():
+    """The leaker. Must stay defined ahead of its partner below.
+
+    Marked into a group so ``--dist loadgroup`` keeps it on the same worker as
+    that partner; without the marker the two can be scheduled apart and the
+    partner asserts an invariant nothing disturbed.
+    """
+    _PRE_LEAK["propagate"] = logging.getLogger("uvicorn.access").propagate
+    _PRE_LEAK["root_level"] = logging.getLogger().level
+
+    # Leak a level that DIFFERS from whatever the collected app modules already
+    # installed. Hardcoding DEBUG makes the stdlib half of the leak invisible
+    # whenever LOG_LEVEL is already DEBUG, which turns the partner test below
+    # into a check that cannot fail.
+    leaked = "ERROR" if _PRE_LEAK["root_level"] != logging.ERROR else "DEBUG"
+    setup_logging(json_logs=True, log_level=leaked)
+
+    # Baseline-independent, unlike propagate: setup_logging() always turns
+    # caching on, and the guard always leaves it off again.
+    assert structlog.get_config()["cache_logger_on_first_use"] is True
+    assert logging.getLogger("uvicorn.access").propagate is False
+    assert logging.getLogger().level != _PRE_LEAK["root_level"]
+
+
+@pytest.mark.xdist_group("logging_conftest_guard")
+def test_b_leak_does_not_survive_into_the_next_test():
+    """End-to-end proof that the guard is actually registered as autouse.
+
+    The caching flag is asserted unconditionally: the guard clears it on the
+    way into every test as well as on the way out, so it holds at the start of
+    any test anywhere in the suite, including the first one on a worker. That
+    last case is why the entry-side clear exists — under a shuffled run this
+    test landed first on its worker and saw the collection-time True.
+
+    The stdlib facts are restored RELATIVE to each test's own snapshot, so they
+    are only checked when the leaker really did run first on this worker;
+    ``test_guard_repairs_a_setup_logging_leak`` above carries that half
+    unconditionally.
+    """
+    assert structlog.get_config()["cache_logger_on_first_use"] is False
+    if _PRE_LEAK:
+        assert logging.getLogger("uvicorn.access").propagate == _PRE_LEAK["propagate"]
+        assert logging.getLogger().level == _PRE_LEAK["root_level"]


### PR DESCRIPTION
## Problem

`backend/tests/conftest.py` has seven autouse fixtures that snapshot and restore process-global state. None covered logging, and that seam has produced three separate defects. It is also the one seam where a leak can make a **security assertion pass vacuously**.

- `test_tile_signing.py` documents that neither `caplog` nor `capture_logs()` reliably sees the tile logger, and works around it per call site.
- #1024's EXISTS negative controls went red on main, fixed in #1063.
- #1064 / #1065: three SMTP and webhook credential-leak assertions that had never been able to fail. Injecting a real password leak made the old assertion report `CAPLOG_RECORDS: 0` and pass.

A disconnected tripwire and a working one are indistinguishable from outside.

## What actually causes the blindness

Worth stating precisely, because the existing notes in the tree describe an incomplete model and the fix follows from the real one. Measured on structlog 25.5.0:

| proxy | processor list | records captured |
|---|---|---|
| frozen | same object | 1 |
| frozen | rebound to a copy | **0** |
| unfrozen | rebound to a copy | 1 |

`capture_logs()` clears and extends the live list *in place*, explicitly "to not break references held by bound loggers". So a frozen `BoundLoggerLazyProxy` alone does **not** blind it. Blindness needs a freeze **and** a processor-list identity change — and `setup_logging()` builds a fresh list on every call, so a second call after a freeze supplies the missing half.

Keeping the proxy unfrozen makes the whole conjunction unreachable.

## Fix

**Primary: `structlog.configure` is clamped for the test session** so `cache_logger_on_first_use` can never arm. Installed at conftest module level, in force before test modules import and therefore before `app/api/main.py`'s import-time `setup_logging()`. Clamping `configure` rather than wrapping `setup_logging` keys the invariant off the resolved state at the single choke point instead of chasing call paths; clamping in conftest keeps `backend/app/` test-unaware.

**The baseline is rebased off `sys.stdout`, once, at conftest import.** Unfreezing the proxies exposed a second latent state: from the second test onward, each test's arrival config was structlog's *unconfigured default* — `PrintLoggerFactory` + `ConsoleRenderer` — measured by dumping the config around every test. `PrintLogger` resolves `sys.stdout` at logger construction, which for an uncached proxy is every call. The freeze had been hiding this by pinning emissions to wherever the first one pointed. With it gone, an app emission during a `CliRunner.invoke()` rendered a console line into the runner's captured stdout, and `test_cli_round_trip.py` failed parsing CLI JSON with `Extra data: char 4` (the timestamp's `2026` parses; the rest does not). "Application logs never reach stdout" is an absolute the whole session needs, like the caching flag, rather than something every stdout-parsing module defends for itself — so the guard's floor is stdlib routing, which is also exactly what `setup_logging()` installs.

**Secondary: an autouse fixture restores everything else `setup_logging()` moves**, *relative* to the snapshot the test arrived with, because the app legitimately owns that state. A blanket `structlog.reset_defaults()` is wrong for the same reason — it drops `_redact_sensitive_fields` and the stdlib routing.

**Handlers are restored by identifying pytest's own** (handler class's root module is `_pytest`), not by saved-handler presence — pytest reattaches its capture handlers for the teardown phase before the finalizer runs, so a leaked `StreamHandler` can ride along while every saved handler is present.

**Nothing is configured during setup, only after `yield`** — pytest swaps `sys.stdout`/`stderr` for the call phase only.

## Which part carries which fix

- The clamp closes the freeze class: disabling it fails `test_mid_test_setup_logging_does_not_blind_capture_logs` with `capture_logs() went blind` / `assert [] == ['sentinel']`.
- The stdout-safe baseline carries the round-trip fix: reverting it alone re-fails `test_cli_round_trip.py` (2 failed), restoring it passes (8).
- The fixture's relative restore covers root level and `uvicorn.access.propagate` surviving into later tests.

None of the three is dead code, and each has the test that fails without it.

## Verification

```
cd backend
uv run pytest -n 4 --dist loadgroup                      # 6844 passed, 84 skipped
uv run pytest tests/test_logging_conftest_guard.py -q    # 9 passed
uv run pytest tests/test_cli_round_trip.py -q            # 8 passed, 2 skipped
uv run pytest tests/test_layering.py -q                  # 36 passed
uv run ruff check . && uv run ruff format --check .      # clean, 876 files
```

The round-trip file needs the CLI deps installed into the backend venv to run at all on the host (it module-skips otherwise), which is why the regression only surfaced in the CLI Tests CI job. Ordering was varied explicitly (no randomizer plugin is installed in this repo, so `-p no:randomly` disables nothing): the logging-adjacent files pass in forward and reversed order, and the round-trip file passes in both positions relative to the guard tests.

Closes #1066