### PR TITLE
fix(builder): measure DEM coverage from the layer extent, not the token span

### DIFF
--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -550,9 +550,20 @@ export const BuilderMap = memo(function BuilderMap({
     // of the current viewport — a small high-res DEM zoomed out reads as a
     // pedestal. Keep the active dataset's dedupe key, drop any stale one.
     resetSmallDemWarning(map, currentTerrainConfig.source_dataset_id);
+    // fix(#1128): the LAYER's extent, not the token's bounds. Both come from
+    // `records.spatial_extent`, but the token applies `extent_to_span_bbox`
+    // (processing/tiles/router.py) because a tile source cannot be bounded by a
+    // west > east pair — which flattens a Fiji-shaped DEM to [-180, s, 180, n],
+    // bit-identical to a global one, and the guard then read 100% coverage for a
+    // DEM occupying a fifth of the screen. `dataset_extent_bbox` is the RFC 7946
+    // spec form since #1112, so the crossing survives; the math needs no change.
+    //
+    // The fallback is reachable only if the two conversions disagree about the
+    // same non-null column, and it keeps today's warning rather than silently
+    // deleting it — an absent hint is the exact failure #1128 is about.
     maybeWarnSmallDemCoverage({
       map,
-      demBounds: token.bounds,
+      demBounds: demLayer.dataset_extent_bbox ?? token.bounds,
       dedupeKey: currentTerrainConfig.source_dataset_id,
     });
   }, []);

--- a/frontend/src/components/builder/__tests__/BuilderMap.terrain-visibility.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderMap.terrain-visibility.test.tsx
@@ -12,8 +12,10 @@
 // the tokenMap has an entry and the attach path can run.
 
 import type { ReactNode } from 'react';
+import { toast } from 'sonner';
 import { act, render } from '@/test/test-utils';
 import { TERRAIN_SOURCE_ID, applyBasemapConfigToMap, syncLayersToMap } from '../map-sync';
+import { resetSmallDemWarning } from '../terrain-coverage';
 import type { MapBasemapConfig, MapLayerResponse, MapTerrainConfig } from '@/types/api';
 import type { RasterTileToken } from '@/api/tiles';
 import { BuilderMap } from '../BuilderMap';
@@ -96,6 +98,7 @@ type FakeMap = {
   getSource: ReturnType<typeof vi.fn>;
   getLayer: ReturnType<typeof vi.fn>;
   getStyle: ReturnType<typeof vi.fn>;
+  getBounds: ReturnType<typeof vi.fn>;
   fitBounds: ReturnType<typeof vi.fn>;
   getZoom: ReturnType<typeof vi.fn>;
   setZoom: ReturnType<typeof vi.fn>;
@@ -104,6 +107,13 @@ type FakeMap = {
 
 const mapState = vi.hoisted(() => {
   const handlers = new Map<string, Set<(payload?: unknown) => void>>();
+  // fix(#1128): the viewport the small-DEM coverage guard measures against.
+  // getBounds() used to be absent here, so the guard threw into its own
+  // try/catch and no-oped. It defaults to the DEM fixture's own extent — full
+  // coverage, no warning — so every test written while it was inert keeps the
+  // behavior it was written against. The #1128 cases override it.
+  const DEFAULT_VIEWPORT: [number, number, number, number] = [-113, 36, -111.5, 37];
+  let viewport = DEFAULT_VIEWPORT;
   const fakeMap: FakeMap = {
     on: vi.fn((event: string, handler: (payload?: unknown) => void) => {
       const existing = handlers.get(event) ?? new Set();
@@ -133,6 +143,12 @@ const mapState = vi.hoisted(() => {
     getSource: vi.fn((id: string) => (id === TERRAIN_SOURCE_ID ? { type: 'raster-dem' } : null)),
     getLayer: vi.fn(() => null),
     getStyle: vi.fn(() => ({ layers: [] })),
+    getBounds: vi.fn(() => ({
+      getWest: () => viewport[0],
+      getSouth: () => viewport[1],
+      getEast: () => viewport[2],
+      getNorth: () => viewport[3],
+    })),
     fitBounds: vi.fn(),
     getZoom: vi.fn(() => 2),
     setZoom: vi.fn(),
@@ -145,7 +161,11 @@ const mapState = vi.hoisted(() => {
 
   return {
     fakeMap,
+    setViewport: (next: [number, number, number, number]) => {
+      viewport = next;
+    },
     reset: () => {
+      viewport = DEFAULT_VIEWPORT;
       handlers.clear();
       fakeMap.on.mockClear();
       fakeMap.off.mockClear();
@@ -159,6 +179,7 @@ const mapState = vi.hoisted(() => {
       fakeMap.getSource.mockClear();
       fakeMap.getLayer.mockClear();
       fakeMap.getStyle.mockClear();
+      fakeMap.getBounds.mockClear();
       fakeMap.fitBounds.mockClear();
       fakeMap.getZoom.mockClear();
       fakeMap.setZoom.mockClear();
@@ -386,6 +407,62 @@ describe('BuilderMap BLDR-02: terrain attach/detach on DEM layer visibility togg
     const setTerrainCalls = mapState.fakeMap.setTerrain.mock.calls;
     expect(setTerrainCalls.length).toBeGreaterThan(0);
     expect(setTerrainCalls[setTerrainCalls.length - 1][0]).toMatchObject({ source: TERRAIN_SOURCE_ID });
+  });
+});
+
+// fix(#1128): the small-DEM coverage guard must measure the DEM LAYER's
+// `dataset_extent_bbox`, not the tile token's `bounds`. The token carries the
+// span form (extent_to_span_bbox, processing/tiles/router.py), which widens a
+// seam-crossing footprint to exactly [-180, s, 180, n] — byte-identical to a
+// genuinely global DEM. Measuring from it read 100% coverage and said nothing
+// about a DEM occupying a fifth of the screen.
+//
+// Both directions are pinned. A fix that only stops the false negative could
+// regress into warning about the DEM that visibly fills the screen, which is
+// the #1122 bug arriving from the other side.
+describe('BuilderMap #1128: small-DEM coverage reads the layer extent, not the token span', () => {
+  // The issue's viewport: 10.5 x 5 degrees, straddling the antimeridian.
+  const SEAM_VIEW: [number, number, number, number] = [179.5, -20, 190, -15];
+  // What the token carries for EITHER dataset below — the ambiguity itself.
+  const TOKEN_SPAN = [-180, -20, 180, -15];
+
+  beforeEach(() => {
+    mapState.reset();
+    mapState.setViewport(SEAM_VIEW);
+    vi.mocked(toast.warning).mockClear();
+    // The dedupe store is a module-level WeakMap keyed on the map object, and
+    // every test in this file shares the one hoisted fakeMap. Clear it, or the
+    // second case below is decided by the first case's leftover key rather
+    // than by its own coverage.
+    resetSmallDemWarning(mapState.fakeMap);
+    tileTokenState.tokens = [
+      { data: { ...rasterToken, bounds: [...TOKEN_SPAN] }, isLoading: false, isError: false },
+    ];
+  });
+
+  async function renderWithExtent(extent: number[]) {
+    const demLayer: MapLayerResponse = { ...makeDemLayer(true), dataset_extent_bbox: extent };
+    await act(async () => {
+      render(
+        <BuilderMap
+          layers={[demLayer]}
+          basemapStyle="openfreemap-positron"
+          terrainConfig={terrainConfig}
+        />,
+      );
+    });
+  }
+
+  it('warns for a seam-crossing DEM the token span reports as global', async () => {
+    // RFC 7946 §5.2 spec form (#1112): 3 degrees wide, 2 of them inside the
+    // viewport → 19% coverage, under the 25% threshold.
+    await renderWithExtent([178.5, -20, -178.5, -15]);
+    expect(toast.warning).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays silent for a DEM that genuinely spans the globe', async () => {
+    await renderWithExtent([-180, -20, 180, -15]);
+    expect(toast.warning).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/components/builder/__tests__/terrain-coverage.test.ts
+++ b/frontend/src/components/builder/__tests__/terrain-coverage.test.ts
@@ -62,11 +62,11 @@ describe('demViewportCoverage', () => {
   });
 });
 
-// fix(#1112 review): the antimeridian cases. `demBounds` here is the TILE
-// TOKEN's bounds (span form, from processing/tiles/router.py), not the map
-// layer's `dataset_extent_bbox`, so both forms are exercised: the span form is
-// what ships today, and the spec form is what a crossing extent looks like if
-// this input is ever sourced seam-aware.
+// fix(#1128): the antimeridian cases, in both encodings a DEM can arrive in.
+// The spec form (`west > east`) is what BuilderMap passes today — the layer's
+// `dataset_extent_bbox`. The span form is what the tile token still carries and
+// what the builder used to pass; it survives as the no-extent fallback, and it
+// is the only encoding the viewer path has.
 //
 // The rectangle that actually crosses is the VIEWPORT: MapLibre's getBounds()
 // takes min/max over unwrapped corner longitudes, so a viewport straddling the
@@ -165,6 +165,41 @@ describe('shouldWarnSmallDemCoverage across the antimeridian', () => {
   it('still warns about a sliver DEM after the user pans past the seam', () => {
     expect(shouldWarnSmallDemCoverage(FIJI_SPEC, FAR_WIDE_VIEW)).toBe(true);
     expect(shouldWarnSmallDemCoverage(FIJI_SPAN, FAR_WIDE_VIEW)).toBe(true);
+  });
+});
+
+// fix(#1128): the issue's own table, pinned to the number. A Fiji-shaped DEM
+// and a globe-spanning one are THE SAME VALUE in the tile token's span form
+// ([-180, s, 180, n]), which is why the guard went silent for the first; the
+// spec form separates them. Both rows are pinned, because a fix that only
+// stops the false negative could regress into warning about the DEM that
+// genuinely fills the screen — the #1122 bug, back again from the other side.
+//
+// These are the pure scorers, so no `maybeWarnSmallDemCoverage` dedupe state
+// exists to bleed in and decide a result.
+describe('#1128 seam-crossing vs globe-spanning DEM in the same viewport', () => {
+  // [179.5, -20, 190, -15] — 10.5 x 5 degrees, straddling the seam.
+  const ISSUE_VIEW = [179.5, -20, 190, -15];
+  // The crossing footprint as `dataset_extent_bbox` delivers it (RFC 7946 §5.2,
+  // #1112): 3 degrees wide, 2 of them inside the viewport.
+  const CROSSING_SPEC = [178.5, -20, -178.5, -15];
+  // What BOTH a crossing DEM (via extent_to_span_bbox) and a genuinely global
+  // DEM look like on the tile token. Indistinguishable — that is the defect.
+  const GLOBAL_SPAN = [-180, -20, 180, -15];
+
+  it('scores the crossing DEM at the true 19%, not the token span 100%', () => {
+    // 2 of 10.5 degrees wide, full height: 10 / 52.5.
+    expect(demViewportCoverage(CROSSING_SPEC, ISSUE_VIEW)).toBeCloseTo(10 / 52.5, 6);
+    expect(demViewportCoverage(CROSSING_SPEC, ISSUE_VIEW) as number).toBeLessThan(0.2);
+  });
+
+  it('warns for the crossing DEM (the false negative this fixes)', () => {
+    expect(shouldWarnSmallDemCoverage(CROSSING_SPEC, ISSUE_VIEW)).toBe(true);
+  });
+
+  it('stays silent for a DEM that genuinely spans the globe', () => {
+    expect(demViewportCoverage(GLOBAL_SPAN, ISSUE_VIEW)).toBe(1);
+    expect(shouldWarnSmallDemCoverage(GLOBAL_SPAN, ISSUE_VIEW)).toBe(false);
   });
 });
 

--- a/frontend/src/components/builder/terrain-coverage.ts
+++ b/frontend/src/components/builder/terrain-coverage.ts
@@ -28,12 +28,22 @@ interface MapWithBounds {
  * lng/lat degree plane. This is an approximation (it ignores Mercator area
  * distortion), which is fine for a UX threshold check.
  *
- * fix(#1112 review): where `demBounds` comes from, because it is easy to get
- * wrong. It is the tile token's `bounds` (`RasterTileToken.bounds`, built by
- * `extent_to_span_bbox` at processing/tiles/router.py), NOT the map layer's
- * `dataset_extent_bbox`. Both call sites read it from a token map fed only by
- * the tile-token API, so #1112's flip of `dataset_extent_bbox` to the RFC 7946
- * spec form does not reach here.
+ * fix(#1128): where `demBounds` comes from, because it is easy to get wrong,
+ * and it is no longer the same on both call sites.
+ *
+ * BuilderMap passes the DEM layer's `dataset_extent_bbox` — the RFC 7946 §5.2
+ * spec form since #1112, so a seam-crossing footprint arrives as a `west > east`
+ * pair with its real width intact. It used to pass the tile token's `bounds`
+ * (`RasterTileToken.bounds`, built by `extent_to_span_bbox` at
+ * processing/tiles/router.py), which widens a crossing extent to exactly
+ * [-180, s, 180, n] and is therefore indistinguishable from a global DEM; see
+ * `lonOverlap` below for what that cost. The token span survives only as the
+ * fallback for a layer with no extent.
+ *
+ * use-viewer-terrain still passes the token bounds, because `SharedLayerResponse`
+ * carries no extent field (maps/schemas.py) — and it does not matter: that call
+ * site passes `audience: 'viewer'`, which returns below before `demBounds` is
+ * ever read (#430 V-06). The viewer emits no coverage toast at all.
  *
  * The seam still matters, for the other rectangle. `map.getBounds()` is always
  * monotonic — MapLibre takes min/max over four UNWRAPPED corner longitudes —
@@ -106,24 +116,23 @@ function lonOverlap(dem: [number, number], view: [number, number]): number {
   const demWidth = dem[1] - dem[0];
   // A DEM spanning the globe covers every longitude, at every pan distance.
   //
-  // KNOWINGLY OPTIMISTIC for a seam-crossing DEM, and not fixable here (#1128).
-  // `extent_to_span_bbox` (processing/tiles/router.py) widens a crossing extent
-  // to exactly [-180, s, 180, n], which is the same value a genuinely global
-  // raster produces. The two are indistinguishable by the time they reach this
-  // function, so no arithmetic on `dem` can tell them apart and this branch has
-  // to guess. It guesses "global", which under-warns rather than crying wolf.
+  // fix(#1128): this branch used to swallow every seam-crossing DEM too, and no
+  // arithmetic here could have separated them. `extent_to_span_bbox`
+  // (processing/tiles/router.py) widens a crossing extent to exactly
+  // [-180, s, 180, n] — the same value a genuinely global raster produces — so
+  // by the time the pair reached this function the footprint was already gone
+  // and the branch had to guess. It guessed "global", which under-warned: a
+  // Fiji footprint in viewport [179.5, -20, 190, -15] is truly 19% covered
+  // (warn) and this returned 100% (silent). The pre-#1122 planar math happened
+  // to return 4.8% and warn, but only as a side effect of the +180 clipping bug
+  // that produced the far worse false alarm this module was changed to fix.
   //
-  // Concretely, a Fiji footprint in viewport [179.5, -20, 190, -15]: the true
-  // coverage is 19% (warn), this returns 100% (silent). The pre-#1122 planar
-  // math happened to return 4.8% and warn, but only as a side effect of the
-  // +180 clipping bug that produced the far worse false alarm this module was
-  // changed to fix; it was not reading the seam correctly either.
-  //
-  // The fix is a change of DATA SOURCE, not of this math: feed `demBounds` from
-  // the layer's `dataset_extent_bbox`, which became RFC 7946 spec form in
-  // #1112, and the crossing case arrives as [178.5, …, -178.5, …]. This
-  // function then already returns the correct 19% with no edit, because the
-  // interval is a real 3 degrees wide and never reaches this branch. #1128.
+  // The cure was a change of DATA SOURCE, not of this math: BuilderMap now
+  // passes `dataset_extent_bbox`, so the crossing case arrives as
+  // [178.5, …, -178.5, …] — a real 3 degrees wide, never reaching this branch,
+  // and already scored at the correct 19% by the lines below. What is left here
+  // is the honest case it was always right about: a DEM that really does wrap
+  // the world. Do not point the builder back at the token span.
   if (demWidth >= 360) return view[1] - view[0];
   return Math.max(
     0,

--- a/frontend/src/components/viewer/hooks/use-viewer-terrain.ts
+++ b/frontend/src/components/viewer/hooks/use-viewer-terrain.ts
@@ -143,6 +143,13 @@ export function useViewerTerrain({
     // the viewport. demBounds come from the raster token (the only bounds source
     // available here; SharedLayerResponse carries no bounds). When the terrain is
     // driven by a non-raster token (no bounds), the guard simply no-ops.
+    //
+    // fix(#1128): BuilderMap switched to the layer's `dataset_extent_bbox`,
+    // because the token span cannot distinguish a seam-crossing DEM from a
+    // global one. This site deliberately did NOT follow: `SharedLayerResponse`
+    // has no extent field, and adding one would buy nothing — `audience:
+    // 'viewer'` below suppresses the toast before `demBounds` is read (#430
+    // V-06), so there is no under-warning here to fix.
     const demBounds = terrainToken?.kind === 'raster' ? terrainToken.bounds : null;
     resetSmallDemWarning(map, terrainDatasetId);
     // fix(#430 V-06): suppress the builder-oriented small-DEM advice toast for viewers —


### PR DESCRIPTION
## Problem

The small-DEM viewport warning measured coverage from `RasterTileToken.bounds`. The tile-token producer builds that with `extent_to_span_bbox` (`backend/app/processing/tiles/router.py`), because a MapLibre source cannot be bounded by a `west > east` pair — so a seam-crossing raster is widened to exactly `[-180, s, 180, n]`, byte-identical to what a genuinely global raster produces.

The two are therefore indistinguishable by the time they reach the coverage math, and no arithmetic on that value can separate them. Post-#1122 the circle-aware math reads the widened pair as full coverage and stays silent for a DEM occupying a fifth of the screen. For a Fiji footprint in viewport `[179.5, -20, 190, -15]`:

| | longitudinal overlap | coverage | warns? |
|---|---|---|---|
| before #1122 (planar, clipped at +180) | 0.5 | 4.8% | yes, for the wrong reason |
| after #1122 (circle-aware) | full | 100% | no |
| truth | 2.0 | 19% | should warn |

## Fix

Feed the guard the DEM layer's `dataset_extent_bbox` instead of the token's bounds. That field has been the RFC 7946 §5.2 spec form since #1112, so a crossing extent arrives as a `west > east` pair with its real width intact, and the coverage math needs no edit at all — one line changes at the caller.

## Why this shape

The coverage module was given a value that had already lost the footprint, so the fix has to move up a layer rather than get cleverer about the arithmetic. #1122 is correct and is untouched here; this is the residual false negative in the other direction (a missing hint, not a false statement).

Both preconditions the issue flagged as unconfirmed were checked before building:

- **`dataset_extent_bbox` is populated for raster and VRT records.** It is produced at `maps/_router_helpers.py:122` from `Record.spatial_extent`, selected at `maps/service_shared.py:233` with no record-type filter; raster writes the column at `processing/ingest/tasks_raster.py:152`, VRT at `tasks_vrt.py:124` and `:939`. Decisively, the tile token reads the *same* column at `tiles/router.py:1274-1278` — so the new source is populated in exactly the cases the old one was.
- **The viewer path needs no change.** `use-viewer-terrain.ts` has a `SharedLayerResponse`, which carries no extent field — but it passes `audience: 'viewer'`, and the guard returns at `terrain-coverage.ts:234` before `demBounds` is read (#430 V-06). The viewer emits no coverage toast for any DEM, so there is no under-warning there to fix. That call site keeps the token bounds deliberately, with a comment saying why.

A layer with no extent falls back to the token span. That branch is reachable only if the two converters disagree about the same non-null `records.spatial_extent`, and where it is reached it keeps today's warning rather than silently dropping one — an absent hint is the exact failure this issue is about.

The module docstring and the `lonOverlap` branch comment both asserted the opposite of what is now true (they documented the token span as the only possible source), so they are rewritten rather than left to mislead the next reader.

## Verification

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run test:coverage` — **370 files, 4541 tests passed, 0 failed** (baseline +5)
- `npm run test:i18n` — 1 file, 4 tests passed (no `t()` key added; run for completeness)

5 new tests pin **both directions at two levels**: the pure scorers in `terrain-coverage.test.ts` reproduce the issue's numbers (crossing = 19.05% → warns, global = 100% → silent), and `BuilderMap.terrain-visibility.test.tsx` pins the caller, where both cases get the identical token `bounds: [-180,-20,180,-15]` and differ only in layer extent. Reverting the one behavioral line fails the crossing case while the global case still passes, so the test bites on this fix specifically.

Note for the record: that caller harness's fake map had no `getBounds`, so the guard had been throwing into its own try/catch and the caller path had zero real coverage before this. The new default viewport keeps pre-existing tests behaving identically.

Closes #1128