### PR TITLE
feat(analysis): chain another operation onto a materialized result

### DIFF
--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -591,6 +591,15 @@ export function AnalysisPanel({
 
   const datasetLayers = layers.filter(isAnalysableLayer);
   const selectedLayer = datasetLayers.find((l) => l.id === layerId);
+  // feat(#790): the layer a finished materialize produced, once it is on the
+  // map. The operation input is a LAYER id (the select below resolves it to
+  // dataset_id), so the result has to be on the stack before it can be
+  // chained — which is why the affordance appears alongside "Add to map"
+  // rather than replacing it.
+  const resultLayer =
+    job?.status === 'complete' && job.dataset_id
+      ? datasetLayers.find((l) => l.dataset_id === job.dataset_id)
+      : undefined;
   // Candidate clip-mask layers. ux(#698): filtered to polygonal layers rather
   // than deferring to the server's 422 — dataset_geometry_type is already here,
   // so offering a point or line layer only buys the user a failed request.
@@ -790,6 +799,32 @@ export function AnalysisPanel({
       setOutputTitle('');
     }
   }, [onClearPreview]);
+
+  // feat(#790): switching the source layer is now reachable from two places —
+  // the Layer select below and the chain affordance in the completion state —
+  // so the resets live here rather than being spelled twice. A second copy
+  // would drift: every one of these lines is a fix for a field that outlived
+  // the layer it belonged to (#680, #1097).
+  const selectSourceLayer = (nextLayerId: string) => {
+    handleInputsChanged();
+    setLayerId(nextLayerId);
+    // A mask layer can't clip itself.
+    if (nextLayerId === maskLayerId) setMaskLayerId(MASK_LAYER_NONE);
+    // fix(#680): a group-by column chosen for one dataset must not carry to
+    // another — it may not exist there (422 from the API) or silently group by
+    // a same-named field.
+    setByField(BY_FIELD_NONE);
+    // fix(#1097 review): the transferred field is the same problem and was
+    // left out of this reset. It belongs to the JOIN layer, so it survives a
+    // source change intact — but whether it is usable depends on the SOURCE,
+    // since join_<name> has to not collide with a source column. Picking
+    // `zone` against a source with no join_zone and then switching to one that
+    // has it left the menu filtering `zone` out while the state still held it,
+    // and the request still went (and earned a 422). A join layer can't join
+    // against itself either, so the layer goes with the field.
+    if (nextLayerId === joinLayerId) setJoinLayerId(MASK_LAYER_NONE);
+    setJoinField(BY_FIELD_NONE);
+  };
 
   // fix(#793 review), mount half: see staleRestoreRef above.
   useEffect(() => {
@@ -1214,30 +1249,7 @@ export function AnalysisPanel({
         <Label className="text-xs" htmlFor="analysis-layer">
           {t('analysisTools.layerLabel', { defaultValue: 'Layer' })}
         </Label>
-        <Select
-          value={layerId}
-          onValueChange={(v) => {
-            handleInputsChanged();
-            setLayerId(v);
-            // A mask layer can't clip itself.
-            if (v === maskLayerId) setMaskLayerId(MASK_LAYER_NONE);
-            // fix(#680): a group-by column chosen for one dataset must not
-            // carry to another — it may not exist there (422 from the API) or
-            // silently group by a same-named field.
-            setByField(BY_FIELD_NONE);
-            // fix(#1097 review): the transferred field is the same problem and
-            // was left out of this reset. It belongs to the JOIN layer, so it
-            // survives a source change intact — but whether it is usable
-            // depends on the SOURCE, since join_<name> has to not collide with
-            // a source column. Picking `zone` against a source with no
-            // join_zone and then switching to one that has it left the menu
-            // filtering `zone` out while the state still held it, and the
-            // request still went (and earned a 422). A join layer can't join
-            // against itself either, so the layer goes with the field.
-            if (v === joinLayerId) setJoinLayerId(MASK_LAYER_NONE);
-            setJoinField(BY_FIELD_NONE);
-          }}
-        >
+        <Select value={layerId} onValueChange={selectSourceLayer}>
           <SelectTrigger id="analysis-layer" className="w-full">
             <SelectValue
               placeholder={t('analysisTools.layerPlaceholder', {
@@ -1826,6 +1838,38 @@ export function AnalysisPanel({
                         name: lastRunTitle,
                       })
                     : t('analysisTools.addToMap', { defaultValue: 'Add to map' })}
+              </Button>
+            )}
+            {/* feat(#790): chain a second operation onto the result without
+                leaving the panel. Before this, running one was materialize →
+                wait → Add to map → scroll back up and hunt the new layer out
+                of the source picker.
+
+                The target is the MATERIALIZED dataset's layer, and only ever
+                that. An ephemeral preview is NOT an operation input and is not
+                going to become one: making an explicitly ephemeral result
+                addressable is a new concept the builder would have to honour
+                on every surface that can hold one (the preview stack row in
+                #1009, select-by-location in #955, the shared overlay slot the
+                chat also writes to), whereas chaining on the materialized half
+                needs no new concepts and covers the workflow complaint that
+                motivated the request. Decided on #790 — read that thread
+                before proposing preview-as-input again. */}
+            {resultLayer && resultLayer.id !== layerId && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="w-full"
+                // Goes through the same reset path as the Layer select: this
+                // is a source change, so the finished run's status line and
+                // its name clear with it (handleInputsChanged), and the
+                // completion block collapses back to a fresh form.
+                onClick={() => selectSourceLayer(resultLayer.id)}
+              >
+                {t('analysisTools.chainOnResult', {
+                  defaultValue: 'Run another operation on this result',
+                })}
               </Button>
             )}
           </div>

--- a/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/AnalysisPanel.test.tsx
@@ -2137,6 +2137,60 @@ describe('AnalysisPanel — audit remediation (v1.6.0)', () => {
     expect(useAnalysisAddedStore.getState().pendingAddIds).not.toContain('out1');
   });
 
+  // feat(#790): chaining a second operation onto a finished run. The target is
+  // always the MATERIALIZED result's layer — an ephemeral preview is not an
+  // operation input (the reasoning lives at the completion-state call site).
+  describe('chain on the materialized result (#790)', () => {
+    const completeRun = async (datasetId: string, layers: MapLayerResponse[]) => {
+      mockJobStatus.value = { status: 'complete', dataset_id: datasetId };
+      renderPanel(layers, {
+        mapId: 'm1',
+        layerActions: { onAddDataset: vi.fn() } as never,
+      });
+      fireEvent.change(screen.getByLabelText('New dataset name'), {
+        target: { value: 'Out' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Create dataset' }));
+      await screen.findByText('Dataset created');
+    };
+
+    it('withholds the affordance until the result is on the map', async () => {
+      // out1 was created but never added, so there is no layer to chain onto.
+      await completeRun('out1', [datasetLayer]);
+      expect(
+        screen.queryByRole('button', {
+          name: 'Run another operation on this result',
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('retargets the source picker at the result layer', async () => {
+      // ds2/Roads stands in for the result, already added to the map.
+      await completeRun('ds2', [datasetLayer, datasetLayer2]);
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: 'Run another operation on this result',
+        }),
+      );
+
+      expect(screen.getByLabelText('Layer')).toHaveTextContent('Roads');
+      // Chaining is a source change like any other, so the finished run's
+      // status line and its name go with it (fix(#764)) — otherwise one more
+      // click would create an identically-named dataset from new parameters.
+      expect(screen.queryByText('Dataset created')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('New dataset name')).toHaveValue('');
+    });
+
+    it('withholds the affordance when the result is already the source', async () => {
+      await completeRun('ds1', [datasetLayer]);
+      expect(
+        screen.queryByRole('button', {
+          name: 'Run another operation on this result',
+        }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it('sets aria-busy on the pending Preview button', async () => {
     let resolvePreview!: (v: unknown) => void;
     vi.mocked(previewAnalysis).mockImplementationOnce(

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1030,6 +1030,7 @@
     "saveHintNeedsName": "Geben Sie einen Namen für den neuen Datensatz ein, um „Datensatz erstellen“ zu aktivieren.",
     "saveHintNeedsParams": "Vervollständigen Sie die Einstellungen der Operation oben, um „Datensatz erstellen“ zu aktivieren.",
     "addedToMap": "Zur Karte hinzugefügt",
+    "chainOnResult": "Weitere Operation auf dieses Ergebnis anwenden",
     "openMap": "Karte öffnen",
     "joinLayerLabel": "Mit Ebene verknüpfen",
     "joinLayerPlaceholder": "Ebene auswählen",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -131,6 +131,7 @@
     "analysisSourceTooLarge": "Diese Ebene ist für diese Analyse zu groß (Grenzwert: {{limit}} Objekte). Sie muss zuerst auf einen kleineren Datensatz gefiltert werden.",
     "analysisMaskTooLarge": "Die Maskenebene hat zu viele Objekte zum Zuschneiden (Grenzwert: {{limit}}). Es muss eine kleinere Maskenebene gewählt oder die Maske auf der Karte gezeichnet werden.",
     "analysisJobAlreadyRunning": "Deine vorherige Analyse läuft noch. Warte, bis sie abgeschlossen ist, bevor du eine neue startest.",
+    "sharedQueryBusy": "Analysevorschauen und der KI-Chat teilen sich eine Datenabfrage, und eine läuft bereits. Warten Sie, bis sie abgeschlossen ist, und versuchen Sie es erneut.",
     "analysisVectorRequired": "Die Analyse benötigt einen Vektordatensatz – diese Ebene ist keiner.",
     "analysisMaskPolygonRequired": "Die Zuschneidemaske muss eine Polygon-Ebene sein.",
     "datasetVisibilityBlockedByMaps": "Diese Karten teilen den Datensatz mit einem Publikum, das ihn verlieren würde: {{maps}}. Entfernen Sie dort den Layer oder schränken Sie zuerst diese Karten ein.",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1030,6 +1030,7 @@
     "saveHintNeedsName": "Enter a name for the new dataset to enable Create dataset.",
     "saveHintNeedsParams": "Complete the operation settings above to enable Create dataset.",
     "addedToMap": "Added to map",
+    "chainOnResult": "Run another operation on this result",
     "openMap": "Open map",
     "joinLayerLabel": "Join with layer",
     "joinLayerPlaceholder": "Choose a layer",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -256,6 +256,7 @@
     "analysisSourceTooLarge": "This layer is too large for that analysis (limit {{limit}} features). Filter it to a smaller dataset first.",
     "analysisMaskTooLarge": "The mask layer has too many features to clip with (limit {{limit}}). Choose a smaller mask layer, or draw the mask on the map.",
     "analysisJobAlreadyRunning": "Your previous analysis is still running. Wait for it to finish before starting another.",
+    "sharedQueryBusy": "Analysis previews and AI chat share one data query at a time, and one is already running. Wait for it to finish and try again.",
     "analysisVectorRequired": "Analysis needs a vector dataset — this layer is not one.",
     "analysisMaskPolygonRequired": "The clip mask must be a polygon layer.",
     "datasetVisibilityBlockedByMaps": "These maps share the dataset with an audience that would lose it: {{maps}}. Remove the layer there, or narrow those maps first.",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1030,6 +1030,7 @@
     "saveHintNeedsName": "Introduce un nombre para el nuevo conjunto de datos para activar Crear conjunto de datos.",
     "saveHintNeedsParams": "Completa los ajustes de la operación de arriba para activar Crear conjunto de datos.",
     "addedToMap": "Añadido al mapa",
+    "chainOnResult": "Ejecutar otra operación sobre este resultado",
     "openMap": "Abrir mapa",
     "joinLayerLabel": "Unir con la capa",
     "joinLayerPlaceholder": "Elige una capa",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -131,6 +131,7 @@
     "analysisSourceTooLarge": "Esta capa es demasiado grande para ese análisis (límite: {{limit}} entidades). Es necesario filtrarla primero a un conjunto de datos más pequeño.",
     "analysisMaskTooLarge": "La capa de máscara tiene demasiadas entidades para recortar (límite: {{limit}}). Se debe elegir una capa de máscara más pequeña o dibujar la máscara en el mapa.",
     "analysisJobAlreadyRunning": "Tu análisis anterior sigue en curso. Espera a que termine antes de iniciar otro.",
+    "sharedQueryBusy": "Las vistas previas de análisis y el chat con IA comparten una sola consulta de datos a la vez, y ya hay una en curso. Espera a que termine e inténtalo de nuevo.",
     "analysisVectorRequired": "El análisis necesita un conjunto de datos vectorial; esta capa no lo es.",
     "analysisMaskPolygonRequired": "La máscara de recorte debe ser una capa de polígonos.",
     "datasetVisibilityBlockedByMaps": "Estos mapas comparten el conjunto de datos con un público que lo perdería: {{maps}}. Quita la capa allí o restringe primero esos mapas.",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1030,6 +1030,7 @@
     "saveHintNeedsName": "Saisissez un nom pour le nouveau jeu de données pour activer Créer un jeu de données.",
     "saveHintNeedsParams": "Renseignez les paramètres de l’opération ci-dessus pour activer Créer un jeu de données.",
     "addedToMap": "Ajouté à la carte",
+    "chainOnResult": "Lancer une autre opération sur ce résultat",
     "openMap": "Ouvrir la carte",
     "joinLayerLabel": "Joindre à la couche",
     "joinLayerPlaceholder": "Choisissez une couche",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -131,6 +131,7 @@
     "analysisSourceTooLarge": "Cette couche est trop volumineuse pour cette analyse (limite : {{limit}} entités). Il faut d'abord la filtrer vers un jeu de données plus petit.",
     "analysisMaskTooLarge": "La couche de masque contient trop d’entités pour le découpage (limite : {{limit}}). Il faut choisir une couche de masque plus petite ou dessiner le masque sur la carte.",
     "analysisJobAlreadyRunning": "Votre analyse précédente est encore en cours. Attendez qu’elle se termine avant d’en lancer une autre.",
+    "sharedQueryBusy": "Les aperçus d’analyse et le chat IA partagent une seule requête de données à la fois, et une requête est déjà en cours. Attendez qu’elle se termine, puis réessayez.",
     "analysisVectorRequired": "L’analyse nécessite un jeu de données vectoriel — cette couche n’en est pas un.",
     "analysisMaskPolygonRequired": "Le masque de découpe doit être une couche de polygones.",
     "datasetVisibilityBlockedByMaps": "Ces cartes partagent le jeu de données avec un public qui le perdrait : {{maps}}. Supprimez-y la couche, ou restreignez d'abord ces cartes.",

--- a/frontend/src/lib/__tests__/error-map.test.ts
+++ b/frontend/src/lib/__tests__/error-map.test.ts
@@ -155,6 +155,22 @@ describe('API error localization boundary', () => {
     });
   });
 
+  // fix(#790): the sandbox advisory lock is shared between analysis previews
+  // and AI chat data queries. Unmapped, this 429 collapsed to the generic
+  // rate-limit fallback, so a busy chat query refused an analysis preview
+  // without ever naming the feature holding the shared budget.
+  it('names the other feature when the shared query lock refuses a preview', () => {
+    expect(
+      classifyApiError('Another data query is already running for this user', 429),
+    ).toEqual({ key: 'errors.sharedQueryBusy' });
+    const rendered = translateApiErrorDetail(
+      'Another data query is already running for this user',
+      429,
+    );
+    expect(rendered).toContain('AI chat');
+    expect(rendered).not.toBe('Too many requests. Wait a moment and try again.');
+  });
+
   it('still falls back for an unmapped analysis-shaped message', () => {
     expect(
       translateApiErrorDetail('This dataset is too large for everything', 422),

--- a/frontend/src/lib/error-map.ts
+++ b/frontend/src/lib/error-map.ts
@@ -82,6 +82,13 @@ const EXACT_ERROR_KEYS: Record<string, ApiErrorDescriptor['key']> = {
   'Tile service unavailable': 'errors.serviceUnavailable',
   'Export temporarily unavailable': 'errors.serviceUnavailable',
   'Task queue unavailable, please retry': 'errors.serviceUnavailable',
+  // fix(#790): the sandbox advisory lock (geolens:ai-sql:<user>) is SHARED
+  // between analysis previews and AI chat data queries — one expensive read
+  // per user across both, deliberately. Unmapped this 429 collapsed to the
+  // generic rateLimited fallback, so a busy chat query refused an analysis
+  // preview with no hint that another feature was holding the budget. The
+  // locale copy names both sides, because either can be the holder.
+  'Another data query is already running for this user': 'errors.sharedQueryBusy',
 };
 
 const STATUS_FALLBACK_KEYS: Record<number, ApiErrorDescriptor['key']> = {


### PR DESCRIPTION
## Problem

Two workflow defects from the 2026-07-27 analysis audit, both decided on #790 before this branch existed.

**1. Chaining a second operation is a scavenger hunt.** Running an operation on a result meant materialize → wait → Add to map → scroll back up and hunt the new layer out of the source picker. There was no chain affordance anywhere among the `analysisTools` keys.

**2. A busy AI chat query refuses an analysis preview with no hint why.** The sandbox advisory lock `geolens:ai-sql:{user}` (`platform/sandbox/executor.py:163`) is shared between analysis previews and AI chat data queries — one expensive read per user across both features, deliberately.

The issue describes symptom 2 as surfacing "another data query is already running", which is unattributed. It is actually one notch worse than that: `error-map.ts` had no mapping for the literal, so `client.ts:252` routed the 429 through `fallbackDescriptor(429)` → `errors.rateLimited`, and the panel toasted **"Analysis failed / Too many requests. Wait a moment and try again."** — generic rate-limit advice for something that is not rate limiting.

## Fix

**Chain affordance.** A "Run another operation on this result" button in the completion state, targeting the materialized dataset's layer. The operation input is already a layer id (`selectedLayer?.dataset_id` feeds the request), so the button reuses the source-layer switch the picker uses. The switch is extracted out of the `<Select>`'s inline `onValueChange` into `selectSourceLayer()` so both paths share one reset path — the body is the previous handler verbatim with the parameter renamed, preserving the #680/#1097 resets.

**Shared-lock message.** A new exact mapping for the backend literal → `errors.sharedQueryBusy`, whose copy names *both* features rather than only the other one, because either side can be the holder.

## Why this shape

**No new concepts, by decision.** #790 settled that an ephemeral preview is **not** an operation input: making an explicitly ephemeral result addressable is a new concept every surface holding one would have to honour (#1009's preview stack row, #955's select-by-location, the shared overlay slot chat also writes to), while chaining on the materialized half covers the workflow complaint and needs nothing new. That constraint is written down at the completion-state call site, so the next person proposing preview-as-input finds the reasoning instead of re-deriving it. No store slot, no addressable-result concept, no backend surface — the only structural change is the handler extraction.

**The lock key is unchanged.** The shared per-user budget is deliberate; splitting it would change the concurrency contract for every `execute_safe` caller and oblige a newly stated per-user total. The message was the defect.

Worth knowing about the button's placement: because the input is a layer, it appears after "Add to map", beside a satisfied "Added to map". It removes the hunt-for-the-layer step, not the Add-to-map step. Collapsing that too would need a pending-chain state machine watching `layers`, which is the concept this deliberately stops short of.

Two related things left alone on purpose:
- `chat_constants.py:55` is unchanged, so in the mirror direction (a preview holding the lock, chat refused) chat's own copy is still unattributed. That string is backend prose fed to the model, not a locale key. The new user-facing copy names both sides, so the panel direction reads correctly regardless of holder.
- The backend detail literal is unchanged. `error-map.ts` treats backend English as the stable compatibility key, so editing it would only move the coupling — and CLI/SDK callers keep the string they have today.

## API / i18n impact

No API change. Four locale files, additive only, no plurals and no interpolation:

- `analysisTools.chainOnResult` — `builder.json`, en/es/fr/de
- `errors.sharedQueryBusy` — `common.json`, en/es/fr/de

## Verification

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run test:coverage` — **370 files, 4540 tests passed, 0 failed**
- `npm run test:i18n` — pass (all static source-referenced keys exist in the en bundles; 1 file, 4 tests)
- `npm run check:i18n:api-errors` — pass (83 stable keys, 62 exact mappings, 557 backend detail assignments)
- `npm run check:i18n:changed` — pass (builder.json, common.json present in all four locale dirs)
- `npm run build` — pass
- `npx vitest -t "790"` — 3 passed / 112 skipped, confirming the new tests actually run rather than being filtered out

New tests: `AnalysisPanel.test.tsx:2143` (3 tests, chain on the materialized result) and `error-map.test.ts:162`, which asserts the new key and that the rendered copy names AI chat instead of the rate-limit fallback.

Not verified here: the button's rendering is covered in jsdom only, not against a live stack.

Closes #790