### PR TITLE
fix(core): keep redact_url_credentials from raising on a malformed authority

### DIFF
--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -120,8 +120,26 @@ def redact_query_credentials(query: str) -> str:
 # These two patterns are enough to cover the fallback, because urlsplit reaches
 # its bracket and NFKC checks only inside `if url[:2] == '//'`: a string that
 # raised always has a `//` authority for the userinfo pattern to anchor on.
-_UNPARSED_USERINFO_RE = re.compile(r"//[^/?#\s]*@")
-_UNPARSED_QUERY_PAIR_RE = re.compile(r"([?&])([^?&=#\s]+)=([^&#\s]*)")
+#
+# fix(#1119 review 2): they delimit on URL syntax — `/?#` for the authority,
+# `&#` for a query value — and NOT on whitespace. An earlier `\s` in these
+# classes made the fallback stop at a space that the parser keeps, so it leaked
+# strictly MORE than the parsed path, breaking this module's own invariant that
+# the fallback only ever keeps what the parsed path would have kept:
+#
+#   https://user:hunter 2@[::1        returned verbatim; urlsplit ends a netloc
+#                                     at `/?#`, never at a space, so the parsed
+#                                     path would have redacted the whole userinfo
+#   https://[::1?token=prefix hunter2  became `token=<redacted> hunter2`; parse_qsl
+#                                     takes the value to the next `&`/`#`, so the
+#                                     parsed path would have redacted all of it
+#
+# Widening is the safe direction for a redactor and the reason is asymmetric:
+# over-redaction costs a less informative log line, under-redaction leaks a
+# credential and does it silently. Greedy is also correct here rather than
+# incidental — urlsplit takes userinfo to the LAST `@` in the authority.
+_UNPARSED_USERINFO_RE = re.compile(r"//[^/?#]*@")
+_UNPARSED_QUERY_PAIR_RE = re.compile(r"([?&])([^?&=#]+)=([^&#]*)")
 
 # fix(#1119 review): urlsplit DELETES these three characters from anywhere in the
 # string before it parses (CPython's `_UNSAFE_URL_BYTES_TO_REMOVE`). Every reader

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import unicodedata
 from urllib.parse import parse_qsl, unquote_plus, urlencode, urlsplit, urlunsplit
 
 REDACTED_QUERY_VALUE = "<redacted>"
@@ -195,7 +196,24 @@ def _redact_without_parsing(value: str) -> str:
     Reusing ``_is_sensitive_query_param`` is what keeps this honest: the fallback
     leaks a credential only in a parameter the parsed path would also have kept,
     so it adds no leak class of its own.
+
+    fix(#1119 review 3): NFKC first, which CLOSES this class rather than adding
+    another character to it. ``urlsplit`` can only reach a ValueError here two
+    ways (CPython ``urllib/parse.py``): a bracket/IPvFuture/IPv4-in-brackets
+    problem, where the ASCII delimiters are already visible to the patterns
+    below, or ``_checknetloc`` (:441) refusing a netloc *because NFKC would
+    introduce one of* ``/?#@:``. So normalising exactly as that check does makes
+    every delimiter urlsplit objected to visible here too, and there is no third
+    source of divergence to be found later. Without it a fullwidth
+    ``＠`` or ``？`` sailed through: ``https://user:hunter2＠example.com/path``
+    came back whole.
+
+    The returned string is the normalised one — a fullwidth character reads as
+    its ASCII form in the log. That only affects strings that already failed to
+    parse, and mapping offsets back through a length-changing normalisation to
+    preserve them would be a far better way to introduce a bug than to avoid one.
     """
+    value = unicodedata.normalize("NFKC", value)
     scrubbed = _UNPARSED_USERINFO_RE.sub(
         lambda _match: f"//{REDACTED_USERINFO}@", value
     )

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -197,27 +197,44 @@ def _redact_without_parsing(value: str) -> str:
     leaks a credential only in a parameter the parsed path would also have kept,
     so it adds no leak class of its own.
 
-    fix(#1119 review 3): NFKC first, which CLOSES this class rather than adding
-    another character to it. ``urlsplit`` can only reach a ValueError here two
-    ways (CPython ``urllib/parse.py``): a bracket/IPvFuture/IPv4-in-brackets
-    problem, where the ASCII delimiters are already visible to the patterns
-    below, or ``_checknetloc`` (:441) refusing a netloc *because NFKC would
-    introduce one of* ``/?#@:``. So normalising exactly as that check does makes
-    every delimiter urlsplit objected to visible here too, and there is no third
-    source of divergence to be found later. Without it a fullwidth
-    ``＠`` or ``？`` sailed through: ``https://user:hunter2＠example.com/path``
-    came back whole.
+    fix(#1119 reviews 3+4): scrub BOTH lexical views, raw first and NFKC second,
+    because normalisation cuts both ways and one pass is blind in one direction:
+
+    - normalising REVEALS a delimiter, which is why the fallback is reached at
+      all. ``urlsplit``'s ``_checknetloc`` (CPython ``urllib/parse.py:441``)
+      refuses a netloc precisely because NFKC would introduce one of ``/?#@:``.
+      The raw view cannot see it, so ``https://user:hunter2＠example.com/path``
+      shows no ASCII ``@`` and comes back whole.
+    - normalising also INTRODUCES a delimiter mid-credential, which truncates a
+      match that was intact before. ``https://user:hunter2／@[::1`` normalises to
+      ``…hunter2/@…``, and the userinfo pattern then stops at the new ``/``.
+      Same for ``?token=prefix＃hunter2``, where only ``prefix`` gets redacted.
+
+    Two passes, so a credential is redacted when EITHER view shows its bounds.
+    Evading both needs a delimiter at the same position in both views — and a
+    delimiter present in the RAW view is ASCII, so urlsplit draws that same
+    boundary and the parsed path (the reference this fallback is measured
+    against) treats it identically. The invariant therefore still holds: the
+    fallback never keeps more than the parsed path would.
 
     The returned string is the normalised one — a fullwidth character reads as
     its ASCII form in the log. That only affects strings that already failed to
     parse, and mapping offsets back through a length-changing normalisation to
     preserve them would be a far better way to introduce a bug than to avoid one.
     """
-    value = unicodedata.normalize("NFKC", value)
-    scrubbed = _UNPARSED_USERINFO_RE.sub(
+    # Pass 2 normalises the OUTPUT of pass 1, not the original: chaining is what
+    # keeps pass 1's redactions: `//redacted@` survives NFKC unchanged, so the
+    # second pass adds to the first rather than replacing it.
+    scrubbed = _scrub_one_view(value)
+    return _scrub_one_view(unicodedata.normalize("NFKC", scrubbed))
+
+
+def _scrub_one_view(value: str) -> str:
+    """Apply both fallback patterns to a single lexical view of the string."""
+    userinfo_scrubbed = _UNPARSED_USERINFO_RE.sub(
         lambda _match: f"//{REDACTED_USERINFO}@", value
     )
-    return _UNPARSED_QUERY_PAIR_RE.sub(_redact_unparsed_query_pair, scrubbed)
+    return _UNPARSED_QUERY_PAIR_RE.sub(_redact_unparsed_query_pair, userinfo_scrubbed)
 
 
 def redact_url_credentials(url: str) -> str:

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -123,6 +123,38 @@ def redact_query_credentials(query: str) -> str:
 _UNPARSED_USERINFO_RE = re.compile(r"//[^/?#\s]*@")
 _UNPARSED_QUERY_PAIR_RE = re.compile(r"([?&])([^?&=#\s]+)=([^&#\s]*)")
 
+# fix(#1119 review): urlsplit DELETES these three characters from anywhere in the
+# string before it parses (CPython's `_UNSAFE_URL_BYTES_TO_REMOVE`). Every reader
+# in this module has to delete them too, or it is redacting a different string
+# from the one the parser saw — and that gap leaked a credential in THREE
+# positions, only one of which was reported:
+#
+#   https://user:hunter2\n@[::1      the fallback's `\s` stopped the userinfo
+#                                    match at the control character
+#   https://[::1?to\nken=hunter2     the same `\s` hid a sensitive parameter NAME
+#   ogrinfo failed: https://user:hunter2\n@[::1 bad
+#                                    URL_LIKE_RE stopped at the control character
+#                                    and handed the recursion `https://user:hunter2`,
+#                                    which has no `@` and so parses as host:port
+#                                    with no credential in it at all
+#
+# The third is the one that matters most (it is the GDAL-stderr path) and it is
+# not reachable from the fallback at all, so patching the fallback alone would
+# have left the widest hole open. Stripping once at the entry point is what
+# collapses the class: the direct parse, URL_LIKE_RE and the unparsable fallback
+# then all read the identical string.
+#
+# The cost, accepted deliberately: a multi-line stderr blob comes back as one
+# line. Replacing with a space instead would read better and would NOT fix this —
+# a space re-breaks the token for URL_LIKE_RE and the credential survives again.
+_URLSPLIT_STRIPS = ("\t", "\r", "\n")
+
+
+def _strip_urlsplit_removals(value: str) -> str:
+    for removed in _URLSPLIT_STRIPS:
+        value = value.replace(removed, "")
+    return value
+
 
 def _redact_unparsed_query_pair(match: re.Match[str]) -> str:
     delimiter, name, _value = match.groups()
@@ -154,6 +186,9 @@ def _redact_without_parsing(value: str) -> str:
 
 def redact_url_credentials(url: str) -> str:
     """Redact known credential query values and userinfo in a URL-like string."""
+    # fix(#1119 review): normalise to urlsplit's own view FIRST, so every reader
+    # below judges the same string the parser does. See _URLSPLIT_STRIPS.
+    url = _strip_urlsplit_removals(url)
     prefixed = _split_prefixed_url(url)
     if prefixed is not None:
         prefix, nested_url = prefixed

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, unquote_plus, urlencode, urlsplit, urlunsplit
 
 REDACTED_QUERY_VALUE = "<redacted>"
 REDACTED_USERINFO = "redacted"
@@ -110,6 +110,48 @@ def redact_query_credentials(query: str) -> str:
     )
 
 
+# fix(#1119): urlsplit raises ValueError on a malformed bracketed authority
+# ("https://.[::1]", "https://[::1"), and redact_url_credentials let it escape —
+# so a call whose whole contract is "return something safe to log" raised
+# instead. sources/preview.py and the three processing/ingest/validation.py sites
+# interpolate the result into an IngestionError, so a malformed authority in GDAL
+# stderr or in an uploaded VRT's <SourceFilename> became an unhandled 500.
+#
+# These two patterns are enough to cover the fallback, because urlsplit reaches
+# its bracket and NFKC checks only inside `if url[:2] == '//'`: a string that
+# raised always has a `//` authority for the userinfo pattern to anchor on.
+_UNPARSED_USERINFO_RE = re.compile(r"//[^/?#\s]*@")
+_UNPARSED_QUERY_PAIR_RE = re.compile(r"([?&])([^?&=#\s]+)=([^&#\s]*)")
+
+
+def _redact_unparsed_query_pair(match: re.Match[str]) -> str:
+    delimiter, name, _value = match.groups()
+    # unquote_plus mirrors what parse_qsl does on the parsed path, so an encoded
+    # name ("%74oken") is judged sensitive by both and cannot slip through here.
+    if not _is_sensitive_query_param(unquote_plus(name)):
+        return match.group(0)
+    return f"{delimiter}{name}={REDACTED_QUERY_VALUE}"
+
+
+def _redact_without_parsing(value: str) -> str:
+    """Redact a string ``urlsplit`` rejects, lexically and without recursing.
+
+    Deletes credentials in place instead of reconstructing the URL: the caller is
+    about to put this in a log line or an error message, and a string the parser
+    refused is most useful to whoever reads it unchanged apart from the secrets.
+    Handing it back to the URL_LIKE_RE fallback instead would recurse forever,
+    because the match would be the same substring that just failed to parse.
+
+    Reusing ``_is_sensitive_query_param`` is what keeps this honest: the fallback
+    leaks a credential only in a parameter the parsed path would also have kept,
+    so it adds no leak class of its own.
+    """
+    scrubbed = _UNPARSED_USERINFO_RE.sub(
+        lambda _match: f"//{REDACTED_USERINFO}@", value
+    )
+    return _UNPARSED_QUERY_PAIR_RE.sub(_redact_unparsed_query_pair, scrubbed)
+
+
 def redact_url_credentials(url: str) -> str:
     """Redact known credential query values and userinfo in a URL-like string."""
     prefixed = _split_prefixed_url(url)
@@ -117,7 +159,13 @@ def redact_url_credentials(url: str) -> str:
         prefix, nested_url = prefixed
         return prefix + redact_url_credentials(nested_url)
 
-    parts = urlsplit(url)
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        # fix(#1119): a malformed authority must not turn a redaction call into a
+        # raise. Reached both directly and from the URL_LIKE_RE.sub callback
+        # below, which recurses here on each matched substring of free text.
+        return _redact_without_parsing(url)
     # Only a scheme-less string (free text, GDAL stderr) goes to the regex
     # fallback. An http(s) URL with an EMPTY host (e.g. "https://?token=x") must
     # still be reconstructed below — routing it to the fallback would match the

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -165,6 +165,11 @@ CREDENTIALED_MALFORMED_URLS = [
     "https://user:hunter2\r\n@[::1]/cog.tif",
     "https://[::1?to\nken=hunter2",
     "ESRIJSON:https://user:hunter2\n@[::1",
+    # fix(#1119 review 3): urlsplit's _checknetloc refuses a netloc BECAUSE NFKC
+    # would introduce one of /?#@: — so these reach the fallback for a reason the
+    # ASCII patterns cannot see until the value is normalised the same way.
+    "https://user:hunter2＠example.com/path",
+    "https://example.com？token=hunter2",
 ]
 
 # fix(#1119 review 2): urlsplit ends an authority at `/?#` and parse_qsl ends a

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -266,6 +266,40 @@ def test_redact_url_credentials_survives_nfkc_delimiters_anywhere(
     assert "hunter" not in redact_url_credentials(f"ogrinfo failed: {value} bad")
 
 
+@pytest.mark.parametrize(
+    ("unparsable", "parsable_equivalent"),
+    [
+        # ＃ normalises to a fragment delimiter, so the tail is a FRAGMENT.
+        (
+            "https://[::1？token=prefix＃hunter2",
+            "https://example.com?token=prefix#hunter2",
+        ),
+        # ／ normalises to a path delimiter, so there is no userinfo at all:
+        # urlsplit reports username=None, password=None, netloc='user:hunter2'.
+        ("https://user:hunter2／＠[::1", "https://user:hunter2/@example.com"),
+    ],
+)
+def test_fallback_does_not_out_redact_the_parsed_path(
+    unparsable: str, parsable_equivalent: str
+) -> None:
+    """The fallback keeps exactly what the parsed path keeps — no more, no less.
+
+    fix(#1119 review 5): both shapes were reported as fallback leaks. They are
+    not. Once normalised, the tail of the first is a fragment and the second has
+    no userinfo for any client to resolve, so the PRIMARY path keeps them too —
+    asserted below so this stays a measurement rather than an argument.
+
+    This is the invariant the whole fallback is defined against, and it cuts both
+    ways. If the primary path is ever tightened to redact fragments or
+    port-position material, this test fails and the fallback must follow rather
+    than quietly diverge. Contrast the round-3 case, which WAS a real leak: there
+    ＠ normalises to a genuine `@`, so an NFKC-normalising client resolves real
+    userinfo, which is precisely why `_checknetloc` refuses the string.
+    """
+    assert "hunter2" in redact_url_credentials(parsable_equivalent)
+    assert "hunter2" in redact_url_credentials(unparsable)
+
+
 @pytest.mark.parametrize("value", WHITESPACE_CREDENTIALED_MALFORMED_URLS)
 def test_redact_url_credentials_masks_credentials_across_inner_whitespace(
     value: str,

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -170,7 +170,18 @@ CREDENTIALED_MALFORMED_URLS = [
     # ASCII patterns cannot see until the value is normalised the same way.
     "https://user:hunter2＠example.com/path",
     "https://example.com？token=hunter2",
+    # fix(#1119 review 4): the other direction — NFKC INTRODUCES a delimiter
+    # mid-credential and truncates a match that was intact in the raw view.
+    "https://user:hunter2／@[::1",
+    "https://[::1?token=prefix＃hunter2",
 ]
+
+# fix(#1119 review 4): the two NFKC directions are one class, so sweep it rather
+# than pinning the four strings that happened to get reported. Each of these
+# characters normalises to a URL delimiter, so dropping one into a credential
+# either reveals a boundary the raw view cannot see or invents one that
+# truncates the raw view's match — and the fallback has to survive both.
+NFKC_DELIMITER_EQUIVALENTS = ["＠", "／", "？", "＃", "：", "＆", "＝"]
 
 # fix(#1119 review 2): urlsplit ends an authority at `/?#` and parse_qsl ends a
 # query value at `&`/`#` — neither stops at whitespace. Delimiting the fallback
@@ -227,6 +238,32 @@ def test_redact_url_credentials_masks_credentials_in_unparsable_free_text(
     value: str,
 ) -> None:
     assert "hunter2" not in redact_url_credentials(f"ogrinfo failed: {value} bad")
+
+
+@pytest.mark.parametrize("delimiter", NFKC_DELIMITER_EQUIVALENTS)
+@pytest.mark.parametrize(
+    "template",
+    [
+        "https://user:hunter{d}2@[::1",
+        "https://user:hunter2{d}@[::1",
+        "https://user{d}:hunter2@[::1",
+        "https://[::1?token=prefix{d}hunter2",
+        # NOT tested: a delimiter inside the parameter NAME ("to{d}ken"). None of
+        # these characters vanishes under NFKC, so "to＠ken" normalises to
+        # "to@ken" and is a genuinely different parameter from "token" — the
+        # PARSED path keeps it too, measured: redact_url_credentials(
+        # "https://example.com?to＠ken=hunter2") returns it unchanged. Asserting
+        # on it would demand the fallback out-redact the reference it is defined
+        # against, which is how a redactor starts destroying valid data.
+    ],
+)
+def test_redact_url_credentials_survives_nfkc_delimiters_anywhere(
+    template: str, delimiter: str
+) -> None:
+    value = template.format(d=delimiter)
+    redacted = redact_url_credentials(value)
+    assert "hunter" not in redacted, f"{value!r} -> {redacted!r}"
+    assert "hunter" not in redact_url_credentials(f"ogrinfo failed: {value} bad")
 
 
 @pytest.mark.parametrize("value", WHITESPACE_CREDENTIALED_MALFORMED_URLS)

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -1,5 +1,6 @@
 """Security tests for URL query credential rejection/redaction."""
 
+import random
 import time
 
 import pytest
@@ -111,6 +112,117 @@ def test_redact_url_credentials_masks_url_after_long_free_text_run() -> None:
     assert "t0ken" not in redacted
     assert "redacted@example.com" in redacted
     assert "token=%3Credacted%3E" in redacted
+
+
+# fix(#1119): urlsplit raises ValueError on a malformed bracketed authority and
+# redact_url_credentials let it escape, so a call whose entire contract is "return
+# something safe to log" raised instead. sources/preview.py and the three
+# processing/ingest/validation.py sites interpolate the result into an
+# IngestionError, so a malformed authority in GDAL stderr or in an uploaded VRT's
+# <SourceFilename> became an unhandled 500 rather than a clean ingest failure.
+#
+# Checked against CPython 3.13 (what CI pins) and 3.14, which agree on all of
+# these. Every entry makes urlsplit raise except ":notaport", which parses; there
+# the ValueError comes from SplitResult.port, read only when userinfo is present,
+# and _redacted_netloc already guards that read. It is in the list to keep that
+# guard pinned alongside the new one, not because it reproduces #1119.
+MALFORMED_AUTHORITY_URLS = [
+    "https://.[::1]",  # data before the opening bracket
+    "https://[::1",  # unclosed bracket
+    "https://]::1[",  # closing bracket before the opening one
+    "https://[]",  # empty bracketed host
+    "https://[::1]x",  # data after the bracket with no port delimiter
+    "https://[[::1]]",  # nested brackets
+    "https://[127.0.0.1]",  # IPv4 in brackets
+    "https://[vZ.x]",  # malformed IPvFuture
+    "https://[::1]:notaport",  # non-numeric port
+    "//[::1",  # scheme-less unclosed bracket
+]
+
+# Malformed authorities that also carry a credential. Making the function stop
+# raising is easy to get wrong in the one way that matters: a fallback returning
+# the input verbatim trades a 500 for a credential leak, which is strictly worse
+# than the bug. Every secret below is the same literal so the assertion is blunt.
+CREDENTIALED_MALFORMED_URLS = [
+    "https://user:hunter2@.[::1]/cog.tif",
+    "https://user:hunter2@[::1/cog.tif",
+    "https://user:hunter2@[[::1]]/cog.tif",
+    "https://user:hunter2@[::1]:notaport/cog.tif",
+    "https://.[::1]/wfs?f=json&token=hunter2",
+    "https://[::1/wfs?api_key=hunter2",
+    "https://[]/x?X-Amz-Signature=hunter2",
+    # An encoded parameter name: parse_qsl unquotes on the parsed path, so the
+    # unparsable path has to as well or the two disagree about what is sensitive.
+    "https://[vZ.x]/x?%74oken=hunter2",
+]
+
+
+@pytest.mark.parametrize("value", MALFORMED_AUTHORITY_URLS)
+def test_redact_url_credentials_never_raises_on_malformed_authority(
+    value: str,
+) -> None:
+    assert isinstance(redact_url_credentials(value), str)
+
+
+@pytest.mark.parametrize("value", MALFORMED_AUTHORITY_URLS)
+def test_redact_url_credentials_never_raises_on_malformed_authority_in_free_text(
+    value: str,
+) -> None:
+    # A different code path from the bare-URL form above: the free text parses
+    # fine and the ValueError surfaces from inside the URL_LIKE_RE.sub callback
+    # recursing on the matched substring. This is the shape GDAL/ogr2ogr stderr
+    # and source-preview text actually arrive in, so covering only the bare form
+    # would be narrower than it reads.
+    assert isinstance(redact_url_credentials(f"ogrinfo failed: {value} bad"), str)
+
+
+@pytest.mark.parametrize("value", CREDENTIALED_MALFORMED_URLS)
+def test_redact_url_credentials_masks_credentials_in_unparsable_url(
+    value: str,
+) -> None:
+    assert "hunter2" not in redact_url_credentials(value)
+
+
+@pytest.mark.parametrize("value", CREDENTIALED_MALFORMED_URLS)
+def test_redact_url_credentials_masks_credentials_in_unparsable_free_text(
+    value: str,
+) -> None:
+    assert "hunter2" not in redact_url_credentials(f"ogrinfo failed: {value} bad")
+
+
+def test_redact_url_credentials_keeps_free_text_around_an_unparsable_url() -> None:
+    # The unparsable fallback deletes credentials in place rather than dropping
+    # the string, so the stderr line an operator needs is still readable and a
+    # non-sensitive parameter survives — same as on the parsed path.
+    redacted = redact_url_credentials(
+        "ogrinfo failed: https://user:hunter2@.[::1]/wfs?f=json&token=hunter2 exiting"
+    )
+
+    assert "hunter2" not in redacted
+    assert redacted.startswith("ogrinfo failed: ")
+    assert redacted.endswith(" exiting")
+    assert "redacted@" in redacted
+    assert "f=json" in redacted
+
+
+FUZZ_SEED = 1119
+FUZZ_ITERATIONS = 2_000
+FUZZ_ALPHABET = [*"ab:/[]@?&=.%#-_ +1", "https://", "http://", "::1", "token="]
+
+
+def test_redact_url_credentials_never_raises_on_randomized_input() -> None:
+    # The list above is a sample; the property callers depend on is "never
+    # raises, for any input". This is the differential fuzz that turned up #1119,
+    # seeded so a failure is reproducible. Against the unfixed function it raises
+    # ValueError on roughly one input in eight, so it is not a decorative test.
+    rng = random.Random(FUZZ_SEED)
+
+    for _ in range(FUZZ_ITERATIONS):
+        value = "".join(rng.choice(FUZZ_ALPHABET) for _ in range(rng.randint(1, 14)))
+        try:
+            redact_url_credentials(value)
+        except Exception as exc:
+            pytest.fail(f"redact_url_credentials({value!r}) raised {exc!r}")
 
 
 def test_redact_query_credentials_preserves_non_sensitive_query() -> None:

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -167,6 +167,29 @@ CREDENTIALED_MALFORMED_URLS = [
     "ESRIJSON:https://user:hunter2\n@[::1",
 ]
 
+# fix(#1119 review 2): urlsplit ends an authority at `/?#` and parse_qsl ends a
+# query value at `&`/`#` — neither stops at whitespace. Delimiting the fallback
+# patterns on `\s` made them keep MORE than the parsed path would, which is the
+# one thing the fallback is not allowed to do.
+#
+# These are DIRECT-CALL ONLY, and deliberately not in the list above. Inside free
+# text a space genuinely ends the URL: URL_LIKE_RE stops there, so the recursion
+# never receives the tail and no redactor downstream can. That is not a gap in
+# the fallback — the PARSED path is identical, measured:
+#
+#   "ogrinfo failed: https://example.com?token=prefix hunter2 bad"
+#     -> "...token=%3Credacted%3E hunter2 bad"     (well-formed URL, parsed path)
+#
+# so the invariant still holds in free text. Widening URL_LIKE_RE to span spaces
+# would swallow the remainder of every stderr sentence into "the URL" and reopen
+# the unbounded-quantifier backtracking #1116 exists to prevent.
+WHITESPACE_CREDENTIALED_MALFORMED_URLS = [
+    "https://user:hunter 2@[::1",
+    "https://[::1?token=prefix hunter2",
+    "https://user:hunter\x0c2@[::1",
+    "https://[::1?token=prefix\x0bhunter2",
+]
+
 
 @pytest.mark.parametrize("value", MALFORMED_AUTHORITY_URLS)
 def test_redact_url_credentials_never_raises_on_malformed_authority(
@@ -199,6 +222,36 @@ def test_redact_url_credentials_masks_credentials_in_unparsable_free_text(
     value: str,
 ) -> None:
     assert "hunter2" not in redact_url_credentials(f"ogrinfo failed: {value} bad")
+
+
+@pytest.mark.parametrize("value", WHITESPACE_CREDENTIALED_MALFORMED_URLS)
+def test_redact_url_credentials_masks_credentials_across_inner_whitespace(
+    value: str,
+) -> None:
+    # Assert on the stem, not on "hunter2"/"hunter 2": with a form feed or
+    # vertical tab between the halves the literal never appears in the output
+    # either way, so those two cases would pass vacuously and the RED check
+    # would look like proof while covering nothing.
+    assert "hunter" not in redact_url_credentials(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "kept"),
+    [
+        # fix(#1119 review 2): the admission half of the widened delimiters. A
+        # refusal assertion cannot notice that a legitimate input started being
+        # destroyed, so the non-sensitive cases are pinned separately — widening
+        # `[^&#\s]` to `[^&#]` must not swallow a benign value or the text after
+        # it, and must not invent a userinfo where the string has no `@`.
+        ("https://[::1?f=json text", "json text"),
+        ("https://[::1?f=json&token=x", "f=json"),
+        ("ogrinfo failed: https://[::1 no credentials here", "no credentials here"),
+    ],
+)
+def test_redact_url_credentials_keeps_non_sensitive_text_in_unparsable_url(
+    value: str, kept: str
+) -> None:
+    assert kept in redact_url_credentials(value)
 
 
 def test_redact_url_credentials_keeps_free_text_around_an_unparsable_url() -> None:

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -154,6 +154,17 @@ CREDENTIALED_MALFORMED_URLS = [
     # An encoded parameter name: parse_qsl unquotes on the parsed path, so the
     # unparsable path has to as well or the two disagree about what is sensitive.
     "https://[vZ.x]/x?%74oken=hunter2",
+    # fix(#1119 review): urlsplit deletes \t, \r and \n before parsing, so any
+    # reader that does not delete them is judging a different string. That gap
+    # leaked in three positions — the fallback's userinfo match, the fallback's
+    # query-NAME match, and (widest, and reachable only through the free-text
+    # wrapper below) URL_LIKE_RE truncating at the control character and handing
+    # the recursion a token with no `@` left in it.
+    "https://user:hunter2\n@[::1",
+    "https://user:hunter2\t@[::1",
+    "https://user:hunter2\r\n@[::1]/cog.tif",
+    "https://[::1?to\nken=hunter2",
+    "ESRIJSON:https://user:hunter2\n@[::1",
 ]
 
 


### PR DESCRIPTION
## Problem

`urlsplit` raises `ValueError` on a malformed bracketed authority, and `redact_url_credentials` let it escape:

```
>>> redact_url_credentials("https://.[::1]")
ValueError: Invalid IPv6 URL
>>> redact_url_credentials("ogrinfo failed: https://.[::1] bad")
ValueError: Invalid IPv6 URL
```

A function whose entire contract is "return something safe to log" was replacing the error it was handed with a different, unhandled one. The second form is the one that matters most: it is the scheme-less free-text path, which is what GDAL/ogr2ogr stderr and source-preview text go through.

`modules/catalog/sources/preview.py:187` interpolates the redacted string into an `IngestionError`, and the three `processing/ingest/validation.py` sites do the same with `redact_url_credentials(raw_path)[:200]`, where `raw_path` is the `<SourceFilename>` of a user-uploaded VRT. So a malformed authority in caller-influenced input converted a clean, user-facing ingest failure into a 500.

## Fix

Catch the `ValueError` and redact lexically instead, via `_redact_without_parsing`.

## Why this shape

Two properties drove it, and both are failure modes a simpler fallback walks straight into:

- **It must not return the input verbatim.** That would trade a 500 for a credential leak, which is strictly worse than the bug being fixed. The fallback scrubs `//userinfo@` and sensitive query values in place, reusing `_is_sensitive_query_param` so the unparsable path leaks a credential only in a parameter the *parsed* path would also have kept — it adds no leak class of its own. Encoded parameter names go through `unquote_plus`, mirroring what `parse_qsl` does on the parsed path, so `%74oken` is judged sensitive by both.
- **It must not route back through `URL_LIKE_RE`.** The match would be the same substring that just failed to parse, so it would recurse forever.

Two anchor patterns are sufficient because `urlsplit` reaches its bracket and NFKC checks only inside `if url[:2] == '//'` — a string that raised always has a `//` authority for the userinfo pattern to anchor on.

The fallback deletes credentials in place rather than reconstructing the URL, because the caller is about to put this into a log line or an error message and a string the parser refused is most useful to whoever reads it unchanged apart from the secrets.

This does not touch #1116's bounded quantifier or change any parsing behaviour for input that already parsed.

## Verification

Gates re-run on the pushed head:

- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 877 files already formatted
- `uv run pytest tests/test_url_redaction_sec.py -q` — **64 passed** (13 before this change)
- `uv run pytest tests/test_layering.py -q` — **36 passed**; no `_MODULE_LOC_CAPS` entry moved
- Caller suites — `test_ingest.py`, `test_commit_revalidates_source_url.py`, `test_vrt_hardening.py`, `test_vrt_vsi_allowlist.py`, `test_upload_validation.py`, `test_ingest_parquet.py`, `test_sec013_ssrf_cgnat.py` — **129 passed**

The new tests pin the property rather than the instance: ten malformed authorities driven through **both** the bare-URL and the free-text paths (two different code paths, the second being the shape GDAL stderr arrives in), a credential-preservation negative control that puts credentials inside a malformed-IPv6 input and asserts they do not survive, and the seeded fuzz that found this, which raised on roughly one input in eight before the fix.

A differential run over 50,000 randomized inputs reported 5,279 inputs that used to raise and now return, and — for the first commit alone — 0 output drift for anything that already parsed.

## Review round 1: redact across the control characters urlsplit deletes

Codex found that `https://user:hunter2\n@[::1` leaked: `urlsplit` deletes `\t`, `\r` and `\n` from anywhere in the string before parsing (CPython's `_UNSAFE_URL_BYTES_TO_REMOVE`), so the parser and the fallback were reading different strings, and `\s` in the fallback's patterns stopped the userinfo match at the control character.

Reproducing it turned up **two more positions of the same defect**, only one of which was reported:

| input | what leaked it |
|---|---|
| `https://user:hunter2\n@[::1` | the fallback's `\s` stopped the userinfo match |
| `https://[::1?to\nken=hunter2` | the same `\s` hid a sensitive parameter **name** |
| `ogrinfo failed: https://user:hunter2\n@[::1 bad` | `URL_LIKE_RE` stopped at the control character and handed the recursion `https://user:hunter2`, which has no `@` and parses as host:port with no credential in it at all |

The third is the widest and is the GDAL-stderr path this function exists to serve. It is **not reachable from the fallback at all**, so fixing only what was reported would have left the biggest hole open.

So the strip moved to the entry point rather than into the fallback: the direct parse, `URL_LIKE_RE` and the unparsable fallback then all read the identical string, which collapses the class instead of patching one position of it.

**Accepted cost, stated plainly:** a multi-line stderr blob now comes back as one line. Substituting a space would read better and does not work — a space re-breaks the token for `URL_LIKE_RE` and the credential survives again. This also means output is no longer byte-identical for input containing those three characters, which is the point of the change.

Five cases joined `CREDENTIALED_MALFORMED_URLS`, which both the bare-URL and the free-text negative controls drive. Disabling the entry strip fails **9 of those 10** with the credential visible in the assertion output; the tenth is a `\r\n` pair that reassembles into a well-formed authority and never reached the fallback.

Gates re-run at `2b66d126f`: ruff clean, `test_url_redaction_sec.py` **74 passed**, callers + layering **179 passed**.

## Review round 2: delimit on URL syntax, not whitespace

The fallback's classes excluded all whitespace, but `urlsplit` ends an authority at `/?#` and `parse_qsl` ends a value at `&#` — neither stops at a space. So the fallback stopped early where the parser would not and kept **more** than the parsed path would, breaking the invariant that is its whole claim to safety. `https://user:hunter 2@[::1` came back verbatim; `https://[::1?token=prefix hunter2` became `token=<redacted> hunter2`.

Delimiting on `/?#` and `&#` fixes it. Greedy is correct rather than incidental — `urlsplit` takes userinfo to the *last* `@` in the authority.

**Scoped to the direct call on purpose.** Inside free text a space genuinely ends the URL, because `URL_LIKE_RE` stops there and the recursion never receives the tail. That is not a gap in the fallback — the **parsed** path is identical, measured: `"ogrinfo failed: https://example.com?token=prefix hunter2 bad"` → `"...token=%3Credacted%3E hunter2 bad"`. Widening `URL_LIKE_RE` to span spaces would swallow the remainder of every stderr sentence into "the URL" and reopen the unbounded-quantifier backtracking #1116 exists to prevent.

Both directions are pinned, because a refusal assertion cannot notice that a legitimate input started being destroyed: four inner-whitespace credentials must not survive, and three benign strings must keep their non-sensitive text.

## Review rounds 3 and 4: scrub the raw AND the NFKC view

`_checknetloc` refuses a netloc precisely **because** NFKC normalization would introduce one of `/?#@:`, so a fullwidth delimiter reached the fallback for a reason the ASCII patterns could not see — `https://user:hunter2＠example.com/path` came back whole.

Normalising the same way that check does closes this class by construction instead of adding one more character to it. `urlsplit` can only reach a `ValueError` on this path two ways (CPython `urllib/parse.py`): a bracket / IPvFuture / IPv4-in-brackets problem, where the ASCII delimiters are already visible to these patterns, or `_checknetloc` at `:441`. NFKC covers the second exactly, so there is no third source of divergence left to find.

The returned string is the normalised one, so a fullwidth character reads as its ASCII form in the log. That affects only strings which already failed to parse, and mapping offsets back through a length-changing normalisation to preserve them would be a better way to introduce a bug than to avoid one.

Round 3 normalised and stopped there, and the claim that this "closed the class" was wrong in one direction — round 4 found the other. Normalisation cuts both ways:

- it **reveals** a delimiter, which is why the fallback is reached at all (`_checknetloc` refuses a netloc *because* NFKC would introduce one of `/?#@:`). The raw view cannot see it, so `https://user:hunter2＠example.com/path` shows no ASCII `@`.
- it **introduces** a delimiter mid-credential, truncating a match that was intact before. `https://user:hunter2／@[::1` normalises to `…hunter2/@…` and the userinfo pattern stops at the new `/`; `?token=prefix＃hunter2` redacts only `prefix`.

So both views get scrubbed — raw first, then the normalised form of that result. Chaining rather than branching preserves the first pass, since `//redacted@` survives NFKC unchanged.

**Why this is the closure and not another patch:** evading both views requires a delimiter at the same position in each. A delimiter present in the raw view is ASCII, so `urlsplit` draws that same boundary and the parsed path treats it identically — the invariant this fallback is measured against (never keep more than the parsed path) still holds. The class is swept rather than enumerated: seven NFKC-equivalent delimiters across four credential positions, through both the direct and free-text paths.

**One case deliberately not asserted, with the measurement in the test:** a delimiter inside the parameter *name*. None of these characters vanishes under NFKC, so `to＠ken` is a genuinely different parameter from `token`, and the parsed path keeps it too — `redact_url_credentials("https://example.com?to＠ken=hunter2")` returns it unchanged. Demanding the fallback out-redact its own reference is how a redactor starts destroying valid data.

**Out of scope, noted for the record:** `_is_sensitive_query_param` lowercases but does not NFKC-normalise, so a fullwidth `ｔｏｋｅｎ` is not recognised as `token` on *either* path. That is a property of the sensitivity check rather than of this fallback, it predates #1119, and a remote service would have to normalise the name for it to matter.

## Final verification (head `36656f920`)

- `uv run ruff check .` / `ruff format --check .` — clean, 877 files formatted
- `uv run pytest tests/test_url_redaction_sec.py` — **117 passed**
- Callers + layering in one run — **296 passed**

Each round's fix carries its own RED check: disabling the entry strip fails 9 of 10 control-character cases, reverting the delimiters fails all 4 whitespace cases, removing the NFKC normalise fails 4 NFKC cases, and collapsing the two views back to one fails 15 of the swept cases — all with the credential visible in the assertion output. The whitespace assertions deliberately test the `hunter` stem rather than `hunter2`/`hunter 2`, because with a form feed or vertical tab between the halves neither literal appears either way and two of those cases were passing vacuously.

Closes #1119
