### PR TITLE
test(ai): observe which tool chat routes a message to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1877,7 +1877,7 @@ jobs:
       - name: Run migrations
         run: uv run alembic upgrade heads
 
-      - name: Run live NL→SQL evals
+      - name: Run live AI evals (NL→SQL and tool choice)
         run: uv run pytest tests/evals/ -v --tb=short
 
   # ---- E2E / A11Y trigger matrix (REL-03) ----

--- a/backend/tests/evals/test_tool_choice_evals.py
+++ b/backend/tests/evals/test_tool_choice_evals.py
@@ -1,0 +1,400 @@
+"""Live-provider AI evals for chat TOOL CHOICE (#1007, follow-up to #549).
+
+``test_sql_generation_evals.py`` asserts what the model WRITES once a tool has
+been chosen. These watch WHICH TOOL it chooses for a given user message, which
+is the layer routing bugs actually live in. #549 was "show me X" landing on
+``set_filter`` instead of ``query_data``; its fix is prompt and tool-description
+prose whose entire risk is that a later edit quietly reverses it, with nothing
+in CI or in ``make ai-evals`` to notice.
+
+Every case drives the production routing inputs rather than a reconstruction:
+
+* the tool set comes from ``select_chat_tools(can_edit, has_map)``, and
+* the system prompt from the same builders the chat surfaces use,
+  ``build_chat_system_prompt`` for map chat (streaming.py:773,
+  chat_service.py:370) and ``build_dataset_chat_system_prompt`` for
+  dataset-scoped chat (router.py:716),
+
+so an edit to either is what the eval sees. Nothing here restates a tool
+description or a verb-class rule. If it did, the eval would keep passing after
+the prose it protects changed, which is the failure mode this file exists to
+prevent.
+
+## What is checked
+
+The emitted tool NAME, and for the surface cases the ABSENCE of tools the
+surface does not offer. Never the response prose: a routing eval that reads
+prose fails on wording changes that broke nothing.
+
+## Cost and gating
+
+Live-provider, real tokens. SKIPPED unless ``RUN_AI_EVALS=1``; run with::
+
+    make ai-evals
+    # or, this file only:
+    cd backend && set -a && source ../.env.test && set +a && \\
+        RUN_AI_EVALS=1 uv run pytest tests/evals/test_tool_choice_evals.py -v
+
+Each case costs exactly ONE provider round-trip: ``_route()`` passes
+``max_rounds=1`` and never executes a tool, so the loop stops as soon as the
+routing decision is visible. No database rows are seeded, because tool choice
+is decided entirely by the prompt and the tool set; the layers are in-memory
+``ChatMapLayer`` values.
+
+## Flake policy
+
+Inherited from the SQL evals, with one caveat worth stating plainly:
+``temperature=0.0`` is passed, but ``DefaultAnthropicProvider.complete`` deletes
+the argument (Claude 4.6+ rejects a non-default temperature), so on the
+Anthropic path determinism comes from the provider default rather than from
+this call. It is honoured on the OpenAI-compatible path.
+
+Checks therefore leave the model freedom everywhere it legitimately has it: a
+case names one tool, or an absence, never a tool ARGUMENT and never the
+accompanying text.
+
+## Read the case table before you trust a result
+
+Every row currently ships ``stable=False``: observed and reported, never
+asserted. The block comment above ``_CASES`` says why and gives the procedure
+that promotes a row. Do not read the reported-only set as a considered
+judgement about which cases are flaky. It is an unrun set.
+"""
+
+import os
+import warnings
+from dataclasses import dataclass
+
+import pytest
+
+from app.platform.extensions import get_ai_provider
+from app.processing.ai.chat_service import (
+    _EDIT_TOOLS,
+    build_chat_system_prompt,
+    build_dataset_chat_system_prompt,
+)
+from app.processing.ai.llm_loop import ToolLoopExhaustedError, resolve_provider
+from app.processing.ai.schemas import ChatMapLayer
+from app.processing.ai.tools import select_chat_tools
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.skipif(
+        os.environ.get("RUN_AI_EVALS") != "1",
+        reason="live-provider AI evals; set RUN_AI_EVALS=1 to run",
+    ),
+]
+
+# Fixed ids, not uuid4(): identical prompts across runs keep Anthropic's
+# ephemeral prompt cache warm, which is most of the token cost of a rerun.
+_STATIONS_LAYER = ChatMapLayer(
+    id="11111111-1111-4111-8111-111111111111",
+    name="Subway Stations",
+    dataset_id="aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa",
+    dataset_table_name="eval_subway_stations",
+    geometry_type="Point",
+    dataset_title="Subway Stations",
+    feature_count=472,
+    column_info=[
+        {"name": "gid", "type": "integer"},
+        {"name": "name", "type": "text"},
+        {"name": "line", "type": "text"},
+        {"name": "ada_accessible", "type": "boolean"},
+    ],
+    sample_values={
+        "name": ["Hoyt St", "Nostrand Av", "Utica Av"],
+        "line": ["A", "C", "E"],
+        "ada_accessible": [True, False],
+    },
+)
+
+_PARCELS_LAYER = ChatMapLayer(
+    id="22222222-2222-4222-8222-222222222222",
+    name="Parcels",
+    dataset_id="bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb",
+    dataset_table_name="eval_parcels",
+    geometry_type="Polygon",
+    dataset_title="Tax Parcels",
+    feature_count=18340,
+    column_info=[
+        {"name": "gid", "type": "integer"},
+        {"name": "parcel_id", "type": "text"},
+        {"name": "zoning", "type": "text"},
+        {"name": "area_sqm", "type": "double precision"},
+    ],
+    sample_values={"zoning": ["R6", "C4-3", "M1-1"]},
+)
+
+_SCHOOLS_LAYER = ChatMapLayer(
+    id="33333333-3333-4333-8333-333333333333",
+    name="Schools",
+    dataset_id="cccccccc-3333-4333-8333-cccccccccccc",
+    dataset_table_name="eval_schools",
+    geometry_type="Point",
+    dataset_title="Public Schools",
+    feature_count=1621,
+    column_info=[
+        {"name": "gid", "type": "integer"},
+        {"name": "name", "type": "text"},
+        {"name": "grade_span", "type": "text"},
+    ],
+)
+
+_MAP_LAYERS = [_STATIONS_LAYER, _PARCELS_LAYER, _SCHOOLS_LAYER]
+
+# The basemap string reaches the prompt's colour-guidance line. Pin it so the
+# prompt is byte-identical run to run.
+_BASEMAP = "light"
+
+
+@dataclass(frozen=True)
+class ToolChoiceCase:
+    """One routing expectation.
+
+    ``expects`` names the tool that should be emitted, alone. ``forbids`` names
+    tools that must not appear at all. A case sets one or the other: the
+    routing pairs name a tool, the surface cases check an absence because the
+    model is legitimately free to answer those in prose instead.
+
+    ``stable`` is the promotion flag. False means observe and report; True
+    means fail the run on the wrong tool. Flipping it is the entire promotion
+    procedure, see the block comment below.
+    """
+
+    name: str
+    message: str
+    expects: str | None = None
+    forbids: frozenset[str] = frozenset()
+    can_edit: bool = True
+    has_map: bool = True
+    stable: bool = False
+    note: str = ""
+
+
+# ---------------------------------------------------------------------------
+# THE CASE TABLE. NOT ONE ROW HAS EVER BEEN RUN AGAINST A LIVE PROVIDER.
+#
+# Every row ships stable=False, so this file observes routing and warns. It
+# asserts nothing and cannot fail a run on a routing verdict. That is NOT a
+# judgement that these cases are flaky. No provider key was reachable when
+# #1007 landed, so their stability is simply unknown, and the nightly
+# live-provider job runs with RUN_AI_EVALS=1, where an assertion nobody had
+# ever executed could turn a nightly red for a reason no one had seen.
+#
+# PROMOTION PROCEDURE, do this before trusting any row:
+#   1. Run the file live THREE times:
+#        cd backend && set -a && source ../.env.test && set +a && \
+#          RUN_AI_EVALS=1 uv run pytest tests/evals/test_tool_choice_evals.py -v
+#      Each case emits a warning carrying the tool it actually routed to, so
+#      the warnings summary at the end of the run IS the report. Add -s to see
+#      the same line inline as each case finishes.
+#   2. Record the emitted tool per case per run.
+#   3. Same correct tool all three times, set stable=True on that row. One
+#      line, no test-code changes.
+#   4. Varied across runs, leave stable=False and replace `note` with what you
+#      saw. A flaky case must never assert.
+#   5. Consistently WRONG is a live routing bug, not a bad case. Fix the
+#      prompt, then promote.
+#
+# Until step 3 happens for a row, its `note` is a prior about why the routing
+# ought to hold, not evidence that it does.
+# ---------------------------------------------------------------------------
+
+_CASES = (
+    # -- Pair 1 (#549): the QUESTION / CHANGE split on the same subject. Both
+    # directions, because a prompt edit that fixes one commonly breaks the
+    # other. That is how #549 happened.
+    ToolChoiceCase(
+        name="show_ada_stations",
+        message="Show the ADA accessible stations served by the A line",
+        expects="query_data",
+        note=(
+            "The #549 regression itself: this landed on set_filter, leaving a "
+            "persistent filter on the layer instead of answering. The prompt's "
+            "worked QUESTION example is the same sentence plus one word "
+            '("Show me the ..."), so the case also checks that the rule '
+            "generalises one word past the example instead of being memorised "
+            "from it."
+        ),
+    ),
+    ToolChoiceCase(
+        name="filter_ada_stations",
+        message="Filter to ADA accessible stations on the A line",
+        expects="set_filter",
+        note=(
+            "The over-correction guard: a prompt edit pushing 'show' towards "
+            "query_data must not drag 'filter to' along with it. The prompt "
+            "carries this sentence verbatim as its worked CHANGE example."
+        ),
+    ),
+    # -- Pair 2: run_analysis vs query_data, settled in prompt prose only and
+    # with the same unprotected shape as pair 1.
+    ToolChoiceCase(
+        name="centroid_of_parcels",
+        message="Show the centre point of each parcel",
+        expects="run_analysis",
+        note=(
+            "'Show' is a QUESTION verb, so this only routes correctly if the "
+            "TRANSFORM rule outranks the verb, the exact ordering the prompt "
+            "states and the exact thing an edit to that section disturbs. The "
+            "prompt cites 'the centre point of each parcel' verbatim."
+        ),
+    ),
+    ToolChoiceCase(
+        name="count_near_schools",
+        message="How many parcels are within 500 meters of a school?",
+        expects="query_data",
+        note=(
+            "The adversarial direction of pair 2: reuses the buffer phrasing "
+            "the prompt cites for run_analysis ('within 500 m of the schools') "
+            "but asks for a COUNT, which no buffer/centroid/clip preview can "
+            "produce. Ground truth is two prompt rules read against each other "
+            "rather than a worked example, which is the shape most likely to "
+            "vary between runs."
+        ),
+    ),
+    # -- Surface variations. Each constructs its own restricted surface rather
+    # than borrowing the map-chat one, so the absence checked is real.
+    ToolChoiceCase(
+        name="readonly_surface_no_edit_tool",
+        message="Filter to ADA accessible stations on the A line",
+        forbids=frozenset(_EDIT_TOOLS),
+        can_edit=False,
+        note=(
+            "can_edit=False builds BOTH restricted inputs from production "
+            "code, CHAT_TOOLS_READONLY and the prompt's read-only directive, "
+            "then sends the request that routes to set_filter on the editable "
+            "surface. Native tool-calling cannot name an unadvertised tool, "
+            "but the OpenAI-compatible path also parses XML tool calls out of "
+            "plain text (parse_xml_tool_calls), which can, and that is why "
+            "chat_service keeps a name check at execution and collection. The "
+            "model stays free to answer with query_data or with prose."
+        ),
+    ),
+    ToolChoiceCase(
+        name="mapless_surface_no_run_analysis",
+        message="Show the centre point of each parcel",
+        forbids=frozenset({"run_analysis"}),
+        can_edit=False,
+        has_map=False,
+        note=(
+            "run_analysis's whole output is a map overlay, so offering it on "
+            "dataset-scoped chat would let the model promise a preview the "
+            "surface cannot render. Sends the message that routes to "
+            "run_analysis on a map surface, under the map-less tool set and "
+            "the dataset-chat prompt."
+        ),
+    ),
+)
+
+
+async def _route(session, case: ToolChoiceCase) -> tuple[list[str], set[str]]:
+    """Ask the live provider to route ``case`` and return (emitted, offered).
+
+    Drives the production tool set and prompt builder, executes nothing, and
+    costs exactly one provider round-trip:
+
+    * ``max_rounds=1``. A tool-calling turn appends its tool results and
+      ``continue``s, so the loop falls out of ``range(1)`` and raises
+      ``ToolLoopExhaustedError`` before it can bill a second round. That
+      exception IS the tool-use outcome here, not a failure.
+    * A plain text answer returns normally from ``complete()`` with nothing
+      recorded, which is a legitimate outcome for the surface cases.
+
+    Returns every tool name in the first assistant turn, in order, not just the
+    first, so an "and also emitted an editing tool" regression is visible.
+    Provider errors (a missing key above all) propagate: those are not routing
+    verdicts and must stay loud.
+    """
+    tools = select_chat_tools(case.can_edit, case.has_map)
+    if case.has_map:
+        system_prompt = build_chat_system_prompt(
+            _MAP_LAYERS, basemap_style=_BASEMAP, can_edit=case.can_edit
+        )
+    else:
+        # The map-less surface is dataset-scoped chat, which overrides the
+        # map-framed prompt entirely (router.py:716 -> system_prompt_override).
+        system_prompt = build_dataset_chat_system_prompt(_PARCELS_LAYER)
+
+    provider, model, runtime_config = await resolve_provider(session)
+    provider_ext = get_ai_provider(provider)
+
+    emitted: list[str] = []
+
+    async def record_only(tool_name: str, tool_input: dict) -> dict:
+        emitted.append(tool_name)
+        return {"error": "tool-choice eval: tool not executed"}
+
+    try:
+        await provider_ext.complete(
+            model=model,
+            system_prompt=system_prompt,
+            user_message=case.message,
+            tools=tools,
+            tool_executor=record_only,
+            base_url=runtime_config.get("base_url"),
+            temperature=0.0,
+            max_rounds=1,
+        )
+    except ToolLoopExhaustedError:
+        pass
+
+    return emitted, {t["name"] for t in tools}
+
+
+def _misroute(
+    case: ToolChoiceCase, emitted: list[str], offered: set[str]
+) -> str | None:
+    """Describe how ``emitted`` violates ``case``, or None if it is correct.
+
+    ``expects`` demands the tool ALONE, deliberately. The prompt does invite a
+    second tool for compound requests ("both a question and a map change"), but
+    none of these messages are compound, and emitting query_data *plus*
+    set_filter for a question still leaves the persistent filter #549 was
+    about. A case that genuinely needs a compound expectation should grow a set
+    field rather than loosen this to a membership test.
+    """
+    if case.expects is not None and emitted != [case.expects]:
+        return f"expected exactly [{case.expects!r}]"
+    forbidden = case.forbids & set(emitted)
+    if forbidden:
+        return f"emitted forbidden tool(s) {sorted(forbidden)}"
+    outside = set(emitted) - offered
+    if outside:
+        return f"emitted {sorted(outside)} outside the offered set {sorted(offered)}"
+    return None
+
+
+@pytest.mark.parametrize("case", _CASES, ids=lambda c: c.name)
+async def test_tool_choice(client, test_db_session, case: ToolChoiceCase):
+    """Route one case, then assert it (stable) or report it (not yet).
+
+    The only hard assertion that runs today is a table-consistency check: a
+    case expecting a tool its own surface does not offer is a bug in the table
+    rather than a model outcome, and it is deterministic, with no live
+    behaviour involved.
+    """
+    emitted, offered = await _route(test_db_session, case)
+
+    if case.expects is not None:
+        assert case.expects in offered, (
+            f"[{case.name}] case table bug: {case.expects!r} is not offered on "
+            f"this surface ({sorted(offered)}), so the case can never pass"
+        )
+
+    problem = _misroute(case, emitted, offered)
+    observed = f"[{case.name}] {case.message!r} -> {emitted or 'no tool (text answer)'}"
+    print(observed + (f"  MISROUTED: {problem}" if problem else "  ok"))
+
+    if case.stable:
+        assert problem is None, f"{observed}; {problem}"
+    else:
+        # Reported, not asserted: this row has never been validated live. The
+        # warnings summary of the run is the report the promotion procedure
+        # above _CASES asks you to record.
+        warnings.warn(
+            f"{observed}; {problem or 'matches expectation'} "
+            "[reported only, never validated live; see the promotion "
+            "procedure above _CASES]",
+            stacklevel=2,
+        )


### PR DESCRIPTION
## Gap

The repo has AI evals, but none can catch a tool-routing regression. `tests/evals/test_sql_generation_evals.py` calls `generate_sql()` directly and asserts on SQL text and executed values. It never runs the tool-calling loop, so nothing anywhere asserts **which tool the model chose** for a given message.

That is where routing bugs live. #549 was one — "show me X" landing on `set_filter` instead of `query_data`. Its fix has already landed (`tools.py` carries `fix(#549)` comments on `set_filter`, `set_style`, `query_data` and `run_analysis`; `chat_service.py:268-305` is now the single owner of verb classification), which strengthens rather than weakens the premise: that prose exists today and nothing protects it.

## What this adds

`backend/tests/evals/test_tool_choice_evals.py` — six cases driving the live chat loop and observing the emitted tool name.

| case | message | expects |
|---|---|---|
| `show_ada_stations` | "Show the ADA accessible stations served by the A line" | `query_data` (the #549 regression itself) |
| `filter_ada_stations` | "Filter to ADA accessible stations on the A line" | `set_filter` (the over-correction guard — other direction of the pair) |
| `centroid_of_parcels` | "Show the centre point of each parcel" | `run_analysis` (transform must outrank the "show" question verb) |
| `count_near_schools` | "How many parcels are within 500 meters of a school?" | `query_data` (reuses buffer phrasing but asks a count, which no preview can produce) |
| `readonly_surface_no_edit_tool` | `can_edit=False`, the `set_filter` message | forbids all of `_EDIT_TOOLS` |
| `mapless_surface_no_run_analysis` | `has_map=False`, the `run_analysis` message | forbids `run_analysis` |

It drives the real path, not a reconstruction: the tool set comes from `select_chat_tools(case.can_edit, case.has_map)` and the prompt from `build_chat_system_prompt` / `build_dataset_chat_system_prompt`, the same builders chat uses. The read-only case forbids the production `_EDIT_TOOLS` set rather than a transcribed literal, so adding an editing tool extends the guard for free.

## Every case ships reported-only, and that is deliberate

**Not one row has ever been executed against a live provider.** No provider key was reachable when this was built, and validating tool-name stability is an observation, not something that can be reasoned out — the issue says as much.

This matters because the nightly job (`ci.yml`) runs `pytest tests/evals/` with `RUN_AI_EVALS=1`, so this file is picked up there automatically. An assertion nobody had ever run could turn a nightly red for a reason no one had seen. So every row carries `stable=False` and warns instead of asserting; verified safe rather than assumed — there is no `filterwarnings=error` in `pyproject.toml`/`pytest.ini`/`setup.cfg`/`conftest.py` and no `-W error` in the job, so `warnings.warn` reports without failing.

The never-run state is loud in the file, not just here: a block comment above the case table opens "THE CASE TABLE. NOT ONE ROW HAS EVER BEEN RUN AGAINST A LIVE PROVIDER", states that `stable=False` is **not** a flakiness judgement, and gives the five-step promotion procedure. Promotion is editing `stable=False` → `stable=True` on one line — proven, not asserted: feeding the same wrong tool through the real provider loop, `stable=False` warned and passed, `stable=True` raised `AssertionError` and failed.

One hard assertion does run — `assert case.expects in offered` — which catches a table row naming a tool its own surface does not offer. It is deterministic, has no live behaviour, and cannot flake.

## Two things found on the way

- **`temperature=0.0` is a no-op on the Anthropic path.** `DefaultAnthropicProvider.complete` does `del temperature` (`defaults_ai_anthropic.py:50` and `:253`) because Claude 4.6+ rejects a non-default value. The flake policy both eval files describe therefore only binds on the OpenAI-compatible path, and production chat runs at 0.3 (`chat_service.py:420`, `streaming.py:495`) rather than 0.0. Documented in the new module docstring instead of repeating the claim as fact.
- The nightly step was named "Run live NL→SQL evals" but globs `tests/evals/`, so it now runs both. Renamed in this PR, since this is the change that made the old name wrong.

## Verification

- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 878 files already formatted
- `uv run pytest tests/evals/ -v` — **16 collected, 16 skipped, 0 failed** (10 pre-existing + 6 new), zero provider calls: the skip is evaluated at collection, so no test body runs
- `uv run pytest tests/test_layering.py -q` — 36 passed (nothing under `backend/app/` touched)

Surface differences were confirmed against the real provider with a stubbed SDK client (zero tokens): `select_chat_tools(True,True)` → 11 tools, `(False,True)` → `['query_data','run_analysis']`, `(False,False)` → `['query_data']`; the read-only prompt carries its "Read-Only Access" block; the dataset prompt never mentions `run_analysis`; `max_rounds=1` bills exactly one call across all three response shapes; and two tool blocks in one turn are both captured, so "also emitted an editing tool" is visible.

**Follow-up required before any row can be trusted:** three live runs of this file, then flip `stable=True` per row that agreed every time.

Closes #1007