### PR TITLE
ci(codeql): move init/autobuild/analyze to v3.37.4 together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,13 @@ updates:
       interval: "weekly"
     labels: ["dependencies", "ci"]
     open-pull-requests-limit: 5
+    groups:
+      # init/autobuild/analyze must move together. CodeQL fails with
+      # "CodeQL job status was configuration error" when init and analyze
+      # resolve to different versions, so a per-action PR is red the moment
+      # it opens — as #1147/#1150/#1155 each were for v3.37.4.
+      codeql-action:
+        patterns: ["github/codeql-action*"]
 
   # --- Docker images ---
   # Root multi-stage Dockerfile (python + node + nginx) — was MISSING; this is

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,14 +34,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07  # v3
+        uses: github/codeql-action/init@a2983b8bed1923f44751c5c43237f479442827b3  # v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@4187e74d05793876e9989daffde9c3e66b4acd07  # v3
+        uses: github/codeql-action/autobuild@a2983b8bed1923f44751c5c43237f479442827b3  # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07  # v3
+        uses: github/codeql-action/analyze@a2983b8bed1923f44751c5c43237f479442827b3  # v3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

Dependabot opened the `github/codeql-action` v3.37.4 bump as three separate PRs — #1147 (`analyze`), #1150 (`autobuild`), #1155 (`init`) — one per action path. All three are red, and none of them can go green on its own.

`.github/workflows/codeql.yml` pins all three action paths to a single sha. Bumping one leaves `init` and `analyze` on different versions, which CodeQL rejects:

```
Analysis upload status is failed.
CodeQL job status was configuration error.
```

Both matrix legs (`python`, `javascript-typescript`) fail this way on each of the three PRs. The run log shows the mismatch directly: `analyze@a2983b8b` alongside `autobuild@4187e74d` and `init@4187e74d`.

## Fix

Bump all three pins to `a2983b8bed1923f44751c5c43237f479442827b3` in one commit. That sha is what the `v3.37.4` annotated tag dereferences to, and it is the same sha all three dependabot PRs independently targeted.

Then group `github/codeql-action*` in `.github/dependabot.yml`, so the next release arrives as one PR rather than three that are broken by construction. The `github-actions` ecosystem entry had no `groups` block at all; the other three ecosystems already use one.

## Why this shape

Landing the three dependabot PRs back-to-back would also work, but only if all three merge — main is red-by-configuration in between, and the queue would have to pass a merge group that is mid-sequence. Grouping in dependabot config is the part that stops this recurring: codeql-action ships often, and every release reproduces this exact three-red-PRs state otherwise.

## Verification

- `v3.37.4` → commit sha confirmed via `repos/github/codeql-action/git/tags/dfbc6164…` → `a2983b8bed…`
- `4187e74d05793876e9989daffde9c3e66b4acd07` occurs 3× in the repo, all in `codeql.yml`; no other workflow references it
- Both changed files parse: `python3 -c "import yaml; yaml.safe_load(...)"`
- The CodeQL check on this PR is the real gate — it runs the bumped workflow against itself

Closes #1147
Closes #1150
Closes #1155