### PR TITLE
fix(core): refuse an unparsable authority in has_url_credentials

### DIFF
--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -57,14 +57,33 @@ def query_has_credentials(query: str) -> bool:
 
 
 def has_url_credentials(url: str) -> bool:
-    """Return True if a URL carries credential-like userinfo or query params."""
+    """Return True if a URL carries credential-like userinfo or query params.
+
+    Also True when the authority is unparsable: callers use this to admit or
+    refuse a string, so "cannot tell" has to resolve to refusal, not to "no".
+    """
     # fix(#430 BA-04): strip GDAL-style prefixes (ESRIJSON:, WFS:, ...) before
     # inspecting userinfo — otherwise urlsplit sees no netloc and misses
     # `user:pass@` behind the prefix, mirroring redact_url_credentials.
     prefixed = _split_prefixed_url(url)
     if prefixed is not None:
         return has_url_credentials(prefixed[1])
-    parts = urlsplit(url)
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        # fix(#1132): the same malformed-authority raise #1119 fixed in
+        # redact_url_credentials — the mirror stopped at the happy path. The
+        # caller that makes it a bug is _metadata_contains_secret in
+        # modules/catalog/sources/router.py, which asks this question of every
+        # string in a connector config from OUTSIDE the handler's try block, so
+        # a raise there is an unhandled 500 instead of the gate's 400.
+        #
+        # True, not False, and the asymmetry is the whole point: this is a
+        # detector, so refusing an authority nobody can parse costs a rejected
+        # config that fails loudly and gets fixed, while admitting it makes the
+        # gate silently permissive on exactly the input an attacker controls.
+        # No credential is reported as absent because the parser gave up.
+        return True
     return bool(parts.username or parts.password) or query_has_credentials(parts.query)
 
 

--- a/backend/tests/test_connector_routes.py
+++ b/backend/tests/test_connector_routes.py
@@ -273,6 +273,53 @@ async def test_connector_routes_reject_nested_inline_secrets_before_validation(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "inline_config",
+    [
+        {"endpoint": "https://.[::1]/data"},
+        {"endpoint": "https://[::1/data"},
+        {"warehouse": {"endpoint": "https://user:do-not-log-this-value@.[::1]/x"}},
+        {"endpoints": [{"url": "https://[]/x?f=json"}]},
+    ],
+)
+async def test_connector_routes_answer_malformed_authority_config_with_400(
+    connector_context, inline_config
+):
+    """fix(#1132): the inline-secret gate must decide, not raise.
+
+    ``_reject_inline_connector_secrets`` walks every string in the config and
+    asks ``has_url_credentials``, which called ``urlsplit`` unguarded — and both
+    handlers call it BEFORE their try block, so a bracketed authority nothing
+    can parse escaped as an unhandled 500 instead of this gate's 400. Both
+    handlers are driven because both reach the gate at that same unprotected
+    point; covering one would leave the other free to regress.
+    """
+    router_module, extension, db, _audit = connector_context
+    user = SimpleNamespace(id=uuid.uuid4())
+
+    with pytest.raises(HTTPException) as discover_error:
+        await router_module.discover_connector_resources_endpoint(
+            "warehouse",
+            ConnectorDiscoverRequest(config=inline_config),
+            user,
+            db,
+        )
+    with pytest.raises(HTTPException) as ingest_error:
+        await router_module.dispatch_connector_ingest_endpoint(
+            "warehouse",
+            ConnectorIngestRequest(config=inline_config, resource_id="roads"),
+            user,
+            db,
+        )
+
+    assert discover_error.value.status_code == 400
+    assert ingest_error.value.status_code == 400
+    assert "do-not-log-this-value" not in str(discover_error.value.detail)
+    extension.validate_config.assert_not_awaited()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_connector_ingest_dispatches_through_overlay(connector_context):
     router_module, extension, db, audit = connector_context
     user = SimpleNamespace(id=uuid.uuid4())

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -2,6 +2,7 @@
 
 import random
 import time
+from urllib.parse import urlsplit
 
 import pytest
 from pydantic import ValidationError
@@ -389,6 +390,89 @@ def test_has_url_credentials_detects_userinfo_behind_gdal_prefix(url: str) -> No
     # .username/.password were None and the credential slipped through. The
     # validator must strip the GDAL prefix before inspecting userinfo.
     assert has_url_credentials(url)
+
+
+def _urlsplit_rejects(value: str) -> bool:
+    try:
+        urlsplit(value)
+    except ValueError:
+        return True
+    return False
+
+
+# fix(#1132): has_url_credentials carried the identical unguarded urlsplit — the
+# mirror #430 BA-04 established between these two functions never reached the
+# error path. It is therefore measured against the SAME inputs as its sibling
+# rather than a fresh list, so the two cannot drift apart again silently.
+#
+# The list is partitioned, not reused whole: ":notaport" parses, and its
+# ValueError comes from SplitResult.port, which this function never reads. So it
+# belongs on the admission side, and splitting by the guard's actual
+# precondition beats a hand-written exception that rots as the list grows.
+UNPARSABLE_AUTHORITY_URLS = [
+    value for value in MALFORMED_AUTHORITY_URLS if _urlsplit_rejects(value)
+]
+PARSABLE_MALFORMED_AUTHORITY_URLS = [
+    value for value in MALFORMED_AUTHORITY_URLS if not _urlsplit_rejects(value)
+]
+
+
+def test_malformed_authority_partition_has_both_halves() -> None:
+    # A partition computed at import time can quietly empty out, and an empty
+    # parametrize list is a test that passes while asserting nothing. Both of
+    # the two tests below depend on this, so assert it once rather than
+    # discovering it as a silently green suite.
+    assert UNPARSABLE_AUTHORITY_URLS
+    assert PARSABLE_MALFORMED_AUTHORITY_URLS
+
+
+@pytest.mark.parametrize("value", MALFORMED_AUTHORITY_URLS)
+def test_has_url_credentials_never_raises_on_malformed_authority(value: str) -> None:
+    assert isinstance(has_url_credentials(value), bool)
+
+
+@pytest.mark.parametrize("value", UNPARSABLE_AUTHORITY_URLS)
+def test_has_url_credentials_refuses_an_unparsable_authority(value: str) -> None:
+    """A detector that cannot parse must not answer "no".
+
+    fix(#1132): returning False is the smaller change and the worse answer. The
+    caller that matters is _metadata_contains_secret in
+    modules/catalog/sources/router.py, which asks this question of every string
+    in a caller-supplied connector config — so False makes the inline-secret gate
+    silently permissive on exactly the malformed input an attacker controls.
+    Refusing is self-correcting: it surfaces as a 400 somebody has to look at.
+    """
+    assert has_url_credentials(value) is True
+
+
+@pytest.mark.parametrize("value", PARSABLE_MALFORMED_AUTHORITY_URLS)
+def test_has_url_credentials_admits_what_the_parser_accepts(value: str) -> None:
+    # The admission half. A refusal assertion cannot notice the guard widening
+    # into "anything bracket-shaped is a credential" and starting to reject
+    # legitimate config, so the parsing entries are pinned separately.
+    assert has_url_credentials(value) is False
+
+
+@pytest.mark.parametrize("value", CREDENTIALED_MALFORMED_URLS)
+def test_has_url_credentials_detects_credentials_in_malformed_url(value: str) -> None:
+    # The property the gate actually depends on: no credential is ever reported
+    # as absent because the parser gave up on the string carrying it.
+    assert has_url_credentials(value) is True
+
+
+def test_has_url_credentials_never_raises_on_randomized_input() -> None:
+    # fix(#1132): the sibling of the #1119 differential fuzz, same seed and
+    # alphabet so both functions are held to the same "never raises, for any
+    # input" property over the same corpus. Against the unguarded function this
+    # raises ValueError; it is not a decorative test.
+    rng = random.Random(FUZZ_SEED)
+
+    for _ in range(FUZZ_ITERATIONS):
+        value = "".join(rng.choice(FUZZ_ALPHABET) for _ in range(rng.randint(1, 14)))
+        try:
+            has_url_credentials(value)
+        except Exception as exc:
+            pytest.fail(f"has_url_credentials({value!r}) raised {exc!r}")
 
 
 def test_redact_url_credentials_masks_userinfo_and_gcs_signature() -> None:


### PR DESCRIPTION
## Problem

`has_url_credentials` called `urlsplit` unguarded, so a malformed bracketed authority raised instead of answering:

```
>>> has_url_credentials("https://.[::1]")
ValueError: Invalid IPv6 URL
```

Same escape #1119 fixed in its sibling `redact_url_credentials` — whose own `fix(#430 BA-04)` comment says the two functions mirror each other. The mirror never reached the error path.

Most callers absorb the raise acceptably: three pydantic validators run `HttpUrl()` before asking and it rejects every one of these strings first, so the detector never sees them; `_validate_connector_job` catches `ValueError` into a 502.

`_metadata_contains_secret` is the exception. It walks a caller-supplied connector config asking this question of **every string it finds**, and both handlers reach it through `_reject_inline_connector_secrets` *before* their `try` block. A bracketed authority nothing can parse therefore escaped as an unhandled 500 instead of the gate's intended 400.

## Fix

Guard the `urlsplit` the way #1119 guarded its own, and answer **True**.

The asymmetry is the whole point. This is a detector, so refusing an authority nobody can parse costs a rejected config that fails loudly and gets fixed; admitting it leaves the inline-secret gate silently permissive on exactly the malformed input an attacker controls. No credential gets reported as absent because the parser gave up.

## Why this shape

Tests reuse #1119's corpus rather than a fresh list, so the two mirrored functions cannot drift apart again without something failing.

The malformed-authority list is partitioned by whether `urlsplit` actually rejects the string: `":notaport"` parses, and this function never reads `SplitResult.port`, so it belongs on the admission side and is asserted `False` there. That partition matters — a refusal assertion alone cannot notice the guard widening into "anything bracket-shaped is a credential". Alongside it: the sibling seeded fuzz, the credentialed-malformed list, and four connector configs driving the real gate to its 400.

## Verification

Measured against the unguarded function: **38 new failures, four of them raw `ValueError`s out of the handlers** — so the tests fail without the fix.

```
uv run ruff check .                                    All checks passed!
uv run ruff format --check .                           883 files already formatted
uv run pytest tests/test_layering.py -q                39 passed
uv run pytest tests/test_url_redaction_sec.py \
              tests/test_connector_routes.py -q       190 passed
```

Closes #1132