### PR TITLE
fix(auth): refresh the login page provider list on admin OAuth/SAML changes

### DIFF
--- a/frontend/src/components/admin/saml/SamlProvidersSection.tsx
+++ b/frontend/src/components/admin/saml/SamlProvidersSection.tsx
@@ -72,6 +72,7 @@ import {
   type SamlProviderUpdateData,
 } from '@/api/saml';
 import { queryKeys } from '@/lib/query-keys';
+import { useInvalidateAuthProviders } from '@/hooks/use-auth-providers';
 import { triggerDownload } from '@/lib/download';
 import { Textarea } from '@/components/ui/textarea';
 
@@ -111,6 +112,10 @@ const EMPTY_FORM: SamlFormData = {
 export function SamlProvidersSection() {
   const { t } = useTranslation('admin');
   const queryClient = useQueryClient();
+  // fix(#1117): SAML rows live in the same table as OAuth and are returned by the
+  // login page's /auth/oauth/providers/, so every mutation here also has to refresh
+  // the login buttons — see hooks/use-auth-providers.ts.
+  const invalidateAuthProviders = useInvalidateAuthProviders();
 
   const {
     data: providers = [],
@@ -132,7 +137,7 @@ export function SamlProvidersSection() {
     mutationFn: (data: SamlProviderCreateData) => createSamlProvider(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['saml', 'providers'] });
-      queryClient.invalidateQueries({ queryKey: queryKeys.settingsOAuth.providers });
+      invalidateAuthProviders();
       toast.success(t('saml.created'));
     },
     onError: () => {
@@ -145,7 +150,7 @@ export function SamlProvidersSection() {
       updateSamlProvider(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['saml', 'providers'] });
-      queryClient.invalidateQueries({ queryKey: queryKeys.settingsOAuth.providers });
+      invalidateAuthProviders();
       toast.success(t('saml.updated'));
     },
     onError: () => {
@@ -157,7 +162,7 @@ export function SamlProvidersSection() {
     mutationFn: (id: string) => deleteSamlProvider(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['saml', 'providers'] });
-      queryClient.invalidateQueries({ queryKey: queryKeys.settingsOAuth.providers });
+      invalidateAuthProviders();
       toast.success(t('saml.deleted'));
     },
     onError: () => {

--- a/frontend/src/components/admin/saml/__tests__/SamlProvidersSection.test.tsx
+++ b/frontend/src/components/admin/saml/__tests__/SamlProvidersSection.test.tsx
@@ -1,0 +1,144 @@
+import { QueryClient } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { SamlProvidersSection } from '../SamlProvidersSection';
+import { queryKeys } from '@/lib/query-keys';
+import {
+  listSamlProviders,
+  createSamlProvider,
+  updateSamlProvider,
+  deleteSamlProvider,
+  type SamlProviderConfig,
+} from '@/api/saml';
+
+vi.mock('@/api/saml', () => ({
+  listSamlProviders: vi.fn().mockResolvedValue([]),
+  createSamlProvider: vi.fn(),
+  updateSamlProvider: vi.fn(),
+  deleteSamlProvider: vi.fn(),
+  fetchSamlMetadata: vi.fn(),
+}));
+
+// The section pre-fills sp_entity_id from the authoritative public_api_url; stub it
+// so the component never reaches the network for tile-config.
+vi.mock('@/api/settings', async () => {
+  const actual = await vi.importActual<typeof import('@/api/settings')>('@/api/settings');
+  return {
+    ...actual,
+    getTileConfig: vi.fn().mockResolvedValue({
+      cdn_base_url: null,
+      public_app_url: 'https://geo.example.com',
+      public_api_url: 'https://geo.example.com/api',
+      public_base_url: 'https://geo.example.com',
+      mvt_source_layer_prefix: null,
+    }),
+  };
+});
+
+const SAML_PROVIDER: SamlProviderConfig = {
+  id: 'saml-1',
+  slug: 'okta',
+  display_name: 'Okta',
+  provider_type: 'saml',
+  client_id: '',
+  discovery_url: null,
+  authorize_url: null,
+  token_url: null,
+  userinfo_url: null,
+  scopes: '',
+  default_role: 'viewer',
+  group_claim: null,
+  group_role_mapping: null,
+  enabled: true,
+  created_at: '2026-07-10T00:00:00Z',
+  updated_at: '2026-07-10T00:00:00Z',
+  idp_entity_id: 'https://okta.example.com/saml/metadata',
+  idp_sso_url: 'https://okta.example.com/saml/sso',
+  sp_entity_id: 'https://geo.example.com/api/auth/saml/okta',
+};
+
+// fix(#1117): SAML rows live in the same catalog.oauth_providers table as OAuth and
+// are returned unfiltered by the login page's /auth/oauth/providers/, so a SAML
+// mutation changes the login buttons too. This section invalidated its own list and
+// the admin OAuth list but never authConfig.oauthProviders.
+describe('SamlProvidersSection provider mutations', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function spyOnInvalidate() {
+    return vi
+      .spyOn(QueryClient.prototype, 'invalidateQueries')
+      .mockResolvedValue(undefined);
+  }
+
+  function expectBothProviderCaches(
+    invalidateQueries: ReturnType<typeof spyOnInvalidate>,
+  ) {
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.settingsOAuth.providers,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.authConfig.oauthProviders,
+    });
+  }
+
+  it('invalidates both provider caches after a create', async () => {
+    vi.mocked(createSamlProvider).mockResolvedValueOnce(SAML_PROVIDER);
+    const invalidateQueries = spyOnInvalidate();
+    const user = userEvent.setup();
+
+    render(<SamlProvidersSection />);
+
+    await user.click(screen.getByRole('button', { name: /add saml provider/i }));
+    await user.type(await screen.findByLabelText('Display Name'), 'Okta');
+    await user.type(
+      screen.getByLabelText('IdP Entity ID'),
+      'https://okta.example.com/saml/metadata',
+    );
+    await user.type(
+      screen.getByLabelText('IdP SSO URL'),
+      'https://okta.example.com/saml/sso',
+    );
+    await user.type(screen.getByLabelText('IdP Signing Certificate (PEM)'), 'cert-pem');
+    await user.click(screen.getByRole('button', { name: 'Create Provider' }));
+
+    await waitFor(() => expect(createSamlProvider).toHaveBeenCalledOnce());
+    expectBothProviderCaches(invalidateQueries);
+  });
+
+  it('invalidates both provider caches after an update', async () => {
+    vi.mocked(listSamlProviders).mockResolvedValueOnce([SAML_PROVIDER]);
+    vi.mocked(updateSamlProvider).mockResolvedValueOnce(SAML_PROVIDER);
+    const invalidateQueries = spyOnInvalidate();
+    const user = userEvent.setup();
+
+    render(<SamlProvidersSection />);
+
+    const providerRow = (await screen.findByText('Okta')).closest('tr');
+    await user.click(within(providerRow!).getByRole('button', { name: 'Edit provider' }));
+    const displayName = await screen.findByLabelText('Display Name');
+    await user.clear(displayName);
+    await user.type(displayName, 'Okta Prod');
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    await waitFor(() => expect(updateSamlProvider).toHaveBeenCalledOnce());
+    expectBothProviderCaches(invalidateQueries);
+  });
+
+  it('invalidates both provider caches after a delete', async () => {
+    vi.mocked(listSamlProviders).mockResolvedValueOnce([SAML_PROVIDER]);
+    vi.mocked(deleteSamlProvider).mockResolvedValueOnce(undefined);
+    const invalidateQueries = spyOnInvalidate();
+    const user = userEvent.setup();
+
+    render(<SamlProvidersSection />);
+
+    const providerRow = (await screen.findByText('Okta')).closest('tr');
+    await user.click(within(providerRow!).getByRole('button', { name: 'Delete provider' }));
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(deleteSamlProvider).toHaveBeenCalledWith(SAML_PROVIDER.id));
+    expectBothProviderCaches(invalidateQueries);
+  });
+});

--- a/frontend/src/components/admin/settings/SettingsAuthTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAuthTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Pencil, Trash2, Plus, Copy } from 'lucide-react';
 import { Input } from '@/components/ui/input';
@@ -46,6 +46,7 @@ import {
   deleteOAuthProvider,
 } from '@/api/settings';
 import { queryKeys } from '@/lib/query-keys';
+import { useInvalidateAuthProviders } from '@/hooks/use-auth-providers';
 import { useTileConfig } from '@/hooks/use-settings';
 import { getPublicApiBaseUrl } from '@/lib/dataset-access';
 import { Textarea } from '@/components/ui/textarea';
@@ -132,7 +133,9 @@ const EMPTY_FORM: ProviderFormData = {
 function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
   const { t } = useTranslation('admin');
   const PROVIDER_TYPE_LABELS = useProviderTypeLabels();
-  const queryClient = useQueryClient();
+  // fix(#1117): invalidates the login page's provider buttons alongside this
+  // table — the two used to drift, see hooks/use-auth-providers.ts.
+  const invalidateAuthProviders = useInvalidateAuthProviders();
 
   const { data: providers = [], isLoading, isError } = useQuery({
     queryKey: queryKeys.settingsOAuth.providers,
@@ -142,7 +145,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
   const createMutation = useMutation({
     mutationFn: (data: OAuthProviderCreateData) => createOAuthProvider(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.settingsOAuth.providers });
+      invalidateAuthProviders();
       toast.success(t('settings.oauth.created'));
     },
     onError: () => {
@@ -154,7 +157,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
     mutationFn: ({ id, data }: { id: string; data: OAuthProviderUpdateData }) =>
       updateOAuthProvider(id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.settingsOAuth.providers });
+      invalidateAuthProviders();
       toast.success(t('settings.oauth.updated'));
     },
     onError: () => {
@@ -165,7 +168,7 @@ function OAuthProvidersSection({ envOnly }: { envOnly: boolean }) {
   const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteOAuthProvider(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.settingsOAuth.providers });
+      invalidateAuthProviders();
       toast.success(t('settings.oauth.deleted'));
     },
     onError: () => {

--- a/frontend/src/components/admin/settings/__tests__/SettingsAuthTab.test.tsx
+++ b/frontend/src/components/admin/settings/__tests__/SettingsAuthTab.test.tsx
@@ -1,10 +1,14 @@
+import { QueryClient } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@/test/test-utils';
 import userEvent from '@testing-library/user-event';
 import { SettingsAuthTab } from '../SettingsAuthTab';
 import { buildOAuthEndpointFields } from '../oauth-endpoint-fields';
+import { queryKeys } from '@/lib/query-keys';
 import {
   listOAuthProviders,
+  createOAuthProvider,
   updateOAuthProvider,
+  deleteOAuthProvider,
   type OAuthProviderConfig,
   type SettingItem,
 } from '@/api/settings';
@@ -16,9 +20,30 @@ vi.mock('@/api/settings', async () => {
   return {
     ...actual,
     listOAuthProviders: vi.fn().mockResolvedValue([]),
+    createOAuthProvider: vi.fn(),
     updateOAuthProvider: vi.fn(),
+    deleteOAuthProvider: vi.fn(),
   };
 });
+
+const OIDC_PROVIDER: OAuthProviderConfig = {
+  id: 'provider-1',
+  slug: 'legacy-oidc',
+  display_name: 'Legacy OIDC',
+  provider_type: 'oidc',
+  client_id: 'client-id',
+  discovery_url: null,
+  authorize_url: 'https://idp.example.com/authorize',
+  token_url: 'https://idp.example.com/token',
+  userinfo_url: 'https://idp.example.com/userinfo',
+  scopes: 'openid profile email',
+  default_role: 'viewer',
+  group_claim: null,
+  group_role_mapping: null,
+  enabled: true,
+  created_at: '2026-07-10T00:00:00Z',
+  updated_at: '2026-07-10T00:00:00Z',
+};
 
 function makeSetting(key: string, value: unknown): SettingItem {
   return { key, value, source: 'overridden', label: key };
@@ -125,24 +150,7 @@ describe('SettingsAuthTab', () => {
     );
 
     it('retains explicit OIDC endpoints when saving an unrelated edit', async () => {
-      const provider: OAuthProviderConfig = {
-        id: 'provider-1',
-        slug: 'legacy-oidc',
-        display_name: 'Legacy OIDC',
-        provider_type: 'oidc',
-        client_id: 'client-id',
-        discovery_url: null,
-        authorize_url: 'https://idp.example.com/authorize',
-        token_url: 'https://idp.example.com/token',
-        userinfo_url: 'https://idp.example.com/userinfo',
-        scopes: 'openid profile email',
-        default_role: 'viewer',
-        group_claim: null,
-        group_role_mapping: null,
-        enabled: true,
-        created_at: '2026-07-10T00:00:00Z',
-        updated_at: '2026-07-10T00:00:00Z',
-      };
+      const provider = OIDC_PROVIDER;
       vi.mocked(listOAuthProviders).mockResolvedValueOnce([provider]);
       vi.mocked(updateOAuthProvider).mockResolvedValueOnce(provider);
       const user = userEvent.setup();
@@ -288,6 +296,93 @@ describe('SettingsAuthTab', () => {
       const payload = capturedCalls[0];
       expect(Array.isArray(payload.allowed_email_domains)).toBe(true);
       expect(payload.allowed_email_domains).toContain('corp.io');
+    });
+  });
+
+  // fix(#1117): every OAuth mutation has to refresh BOTH the admin table
+  // (settingsOAuth.providers, read here) and the login page's buttons
+  // (authConfig.oauthProviders, read by components/auth/OAuthButtons.tsx). Only the
+  // first was invalidated, so an admin who added or removed a provider and then
+  // logged out kept the stale button set for the rest of the session.
+  describe('OAuth provider mutations refresh the login page too', () => {
+    beforeEach(() => {
+      // Call history only — mockReset would drop listOAuthProviders' resolved value,
+      // which the module factory sets once.
+      vi.mocked(createOAuthProvider).mockClear();
+      vi.mocked(updateOAuthProvider).mockClear();
+      vi.mocked(deleteOAuthProvider).mockClear();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function spyOnInvalidate() {
+      return vi
+        .spyOn(QueryClient.prototype, 'invalidateQueries')
+        .mockResolvedValue(undefined);
+    }
+
+    function expectBothProviderCaches(
+      invalidateQueries: ReturnType<typeof spyOnInvalidate>,
+    ) {
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: queryKeys.settingsOAuth.providers,
+      });
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: queryKeys.authConfig.oauthProviders,
+      });
+    }
+
+    it('invalidates both provider caches after a create', async () => {
+      vi.mocked(createOAuthProvider).mockResolvedValueOnce(OIDC_PROVIDER);
+      const invalidateQueries = spyOnInvalidate();
+      const user = userEvent.setup();
+
+      renderTab();
+
+      await user.click(screen.getByRole('button', { name: /add provider/i }));
+      await user.type(await screen.findByLabelText('Client ID'), 'new-client-id');
+      await user.type(screen.getByLabelText('Client Secret'), 'new-client-secret');
+      await user.click(screen.getByRole('button', { name: 'Create Provider' }));
+
+      await waitFor(() => expect(createOAuthProvider).toHaveBeenCalledOnce());
+      expectBothProviderCaches(invalidateQueries);
+    });
+
+    it('invalidates both provider caches after an update', async () => {
+      vi.mocked(listOAuthProviders).mockResolvedValueOnce([OIDC_PROVIDER]);
+      vi.mocked(updateOAuthProvider).mockResolvedValueOnce(OIDC_PROVIDER);
+      const invalidateQueries = spyOnInvalidate();
+      const user = userEvent.setup();
+
+      renderTab();
+
+      const providerRow = (await screen.findByText('Legacy OIDC')).closest('tr');
+      await user.click(within(providerRow!).getAllByRole('button')[0]);
+      const displayName = await screen.findByLabelText('Display Name');
+      await user.clear(displayName);
+      await user.type(displayName, 'Renamed OIDC');
+      await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => expect(updateOAuthProvider).toHaveBeenCalledOnce());
+      expectBothProviderCaches(invalidateQueries);
+    });
+
+    it('invalidates both provider caches after a delete', async () => {
+      vi.mocked(listOAuthProviders).mockResolvedValueOnce([OIDC_PROVIDER]);
+      vi.mocked(deleteOAuthProvider).mockResolvedValueOnce(undefined);
+      const invalidateQueries = spyOnInvalidate();
+      const user = userEvent.setup();
+
+      renderTab();
+
+      const providerRow = (await screen.findByText('Legacy OIDC')).closest('tr');
+      await user.click(within(providerRow!).getAllByRole('button')[1]);
+      await user.click(await screen.findByRole('button', { name: 'Delete' }));
+
+      await waitFor(() => expect(deleteOAuthProvider).toHaveBeenCalledWith(OIDC_PROVIDER.id));
+      expectBothProviderCaches(invalidateQueries);
     });
   });
 });

--- a/frontend/src/hooks/__tests__/use-auth-providers.test.ts
+++ b/frontend/src/hooks/__tests__/use-auth-providers.test.ts
@@ -1,0 +1,36 @@
+import { QueryClient } from '@tanstack/react-query';
+import { renderHook } from '@/test/test-utils';
+import { useInvalidateAuthProviders } from '@/hooks/use-auth-providers';
+import { queryKeys } from '@/lib/query-keys';
+
+describe('useInvalidateAuthProviders', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('invalidates the admin provider table and the login page buttons together', () => {
+    const invalidateQueries = vi
+      .spyOn(QueryClient.prototype, 'invalidateQueries')
+      .mockResolvedValue(undefined);
+    const { result } = renderHook(() => useInvalidateAuthProviders());
+
+    result.current();
+
+    // fix(#1117): the pairing IS the fix — the admin surfaces already hit the first
+    // key and the bug was the second one going unrefreshed.
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.settingsOAuth.providers,
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.authConfig.oauthProviders,
+    });
+  });
+
+  it('returns a stable callback so mutation options do not churn', () => {
+    const { result, rerender } = renderHook(() => useInvalidateAuthProviders());
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/frontend/src/hooks/use-auth-providers.ts
+++ b/frontend/src/hooks/use-auth-providers.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/query-keys';
+
+/**
+ * Invalidate every cache that holds a list of login providers.
+ *
+ * fix(#1117): the admin surfaces that CRUD providers (OAuthProvidersSection in
+ * `components/admin/settings/SettingsAuthTab.tsx`, `SamlProvidersSection`) used to
+ * invalidate only `settingsOAuth.providers` — their own admin table. The login
+ * page's buttons read a different key, `authConfig.oauthProviders`
+ * (`components/auth/OAuthButtons.tsx`), so an admin who added or removed a provider
+ * and then logged out kept seeing the old button set until a full reload.
+ *
+ * The two key families always move together: both admin surfaces write the same
+ * `catalog.oauth_providers` rows through `/settings/oauth-providers/`, and the login
+ * page's `/auth/oauth/providers/` returns every enabled row with no provider_type
+ * filter — so SAML edits change that button set too. One invalidator called from both
+ * surfaces keeps the pairing from drifting apart again.
+ */
+export function useInvalidateAuthProviders(): () => void {
+  const queryClient = useQueryClient();
+  return useCallback(() => {
+    // Admin provider tables (Settings → Auth, Admin → SAML).
+    queryClient.invalidateQueries({ queryKey: queryKeys.settingsOAuth.providers });
+    // Login-page provider buttons.
+    queryClient.invalidateQueries({ queryKey: queryKeys.authConfig.oauthProviders });
+  }, [queryClient]);
+}

--- a/frontend/src/hooks/use-config-ops.ts
+++ b/frontend/src/hooks/use-config-ops.ts
@@ -74,9 +74,11 @@ export function useImportConfig() {
       queryClient.invalidateQueries({ queryKey: queryKeys.settings.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.authConfig.config });
       // chore(#1021): the login page's OAuth buttons. The sibling admin surfaces that
-      // mutate the same providers (SettingsAuthTab, SamlProvidersSection) invalidate
-      // only settingsOAuth.providers and miss this key. That gap is #1117, the inverse
-      // of this issue, and is not fixed here.
+      // mutate the same providers (SettingsAuthTab, SamlProvidersSection) used to
+      // invalidate only settingsOAuth.providers and miss this key; fix(#1117) routes
+      // them through useInvalidateAuthProviders (hooks/use-auth-providers.ts), which
+      // hits both. This surface stays inline — it invalidates far more than the
+      // provider pair.
       queryClient.invalidateQueries({ queryKey: queryKeys.authConfig.oauthProviders });
       // chore(#1021): the two AI-readiness keys below are a mutually-exclusive PAIR,
       // not a duplicate. useAIAvailability mounts admin.aiStatus when


### PR DESCRIPTION
## Problem

Both admin provider surfaces invalidated only their own table key, `settingsOAuth.providers`. The login page's buttons read a different key, `authConfig.oauthProviders` (`components/auth/OAuthButtons.tsx:86`). Neither surface invalidated the other's key, so an admin who added or removed a provider and then logged out kept the stale button set until a full reload.

Six mutation sites had the gap — create/update/delete in each of two files:

- `components/admin/settings/SettingsAuthTab.tsx:145,157,168`
- `components/admin/saml/SamlProvidersSection.tsx:135,148,160`

## Fix

A shared `useInvalidateAuthProviders()` hook (`hooks/use-auth-providers.ts`) that invalidates both key families together. All six `onSuccess` handlers call it. The issue offered either six extra inline lines or one hook; the hook is what stops the pairing drifting apart again, which is the actual failure mode here.

`SamlProvidersSection` keeps its own `['saml', 'providers']` invalidation — that key is uniquely its own and unrelated to the login page.

## Why SAML is included

Not defensive — verified from source. An enabled SAML row is returned to the login page verbatim:

1. `OAuthButtons.tsx:86` reads `queryKeys.authConfig.oauthProviders` via `getOAuthProviders`
2. `api/auth.ts:100-108` → `GET /auth/oauth/providers/`
3. `backend/app/modules/auth/oauth/router.py:501` → `get_enabled_providers(db)`
4. `service.py:468-470` → `list_providers(db, enabled_only=True)`
5. `service.py:452-465` builds `select(OAuthProvider)` + `.where(enabled.is_(True))` — **no `provider_type` filter anywhere in that query**
6. SAML providers persist in the same `catalog.oauth_providers` table (`SamlProviderConfig extends Omit<OAuthProviderConfig, 'provider_type'>`) via the same `/settings/oauth-providers/` endpoints

So creating or deleting a SAML provider changes the login button set.

## Also corrected

`hooks/use-config-ops.ts` carried a stale comment asserting this gap "is not fixed here". `useImportConfig` already invalidated `authConfig.oauthProviders` (#1021), so it never had the bug and the note is now false. Comment-only change; the call site stays inline because it invalidates six unrelated key families, not just the provider pair.

## Verification

```
npm run typecheck      clean
npm run lint           clean
npm run test:coverage  372 files, 4553 tests passed
npm run test:i18n      4 passed (no locale keys touched; run as insurance)
```

New tests assert **both** key families for create/update/delete in three files, including a new `__tests__/` dir for `SamlProvidersSection` (which had none).

Non-vacuity checked rather than assumed: stubbing the second `invalidateQueries` out of the hook produced 7 failed / 13 passed, and the 7 failures were exactly the 7 new assertions.

## Noted, not fixed

`SamlProvidersSection` reads and invalidates its own list under a raw inline `['saml', 'providers']` array literal instead of an entry in `lib/query-keys.ts` — the same class of drift risk this PR is about, but out of scope and it would touch the query-keys parity test.

Closes #1117