### PR TITLE
feat(builder): show the ephemeral preview as a row in the layer stack

### DIFF
--- a/e2e/dataset-chat.spec.ts
+++ b/e2e/dataset-chat.spec.ts
@@ -215,9 +215,9 @@ test.describe('Dataset AI chat', () => {
     expect(createdMapId).toBeTruthy();
 
     await expect(page.locator('canvas.maplibregl-canvas')).toBeVisible({ timeout: 15_000 });
-    // Two independent assertions on purpose: the badge is React state, the
-    // camera fit is map state. The fix(#542) race kept the badge visible while
-    // the overlay and fitBounds silently never applied. The race itself is
+    // Two independent assertions on purpose: the preview row is React state,
+    // the camera fit is map state. The fix(#542) race kept the preview visible
+    // while the overlay and fitBounds silently never applied. The race is
     // timing-dependent (it needs the style transiently unloaded at pickup, so
     // a fast local run may not reproduce it — the deterministic regression
     // test lives in use-ephemeral-layers.test.ts); what this spec pins down is
@@ -225,10 +225,13 @@ test.describe('Dataset AI chat', () => {
     // fix(#894): #674 renamed this badge's copy "Query result" → "Result" (the
     // badge stopped being query-only once analysis previews reused it) and this
     // assertion was never updated, so the spec has failed every nightly since.
-    // Scope to role="status": EphemeralBadge renders the label twice — the
+    // Scope to role="status": the preview surface renders the label twice — the
     // sr-only live region plus an aria-hidden visible copy — so a bare getByText
     // matches two nodes and trips strict mode. The aria-hidden copy is out of
     // the accessibility tree, so the role lookup resolves to exactly one.
+    // fix(#1009): the surface under test is now the ephemeral stack row
+    // (EphemeralPreviewRow) rather than the corner badge — the assertion is
+    // unchanged because the row carries the same live-region sentence.
     await expect(
       page.getByRole('status').filter({ hasText: 'Result · 2 features' }),
     ).toBeVisible({ timeout: 15_000 });

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -513,15 +513,20 @@ export function ChatPanel({
       if (minX < -180 || minY < -90 || maxX > 180 || maxY > 90) return;
       // fix(#527 B-054/C-06): inverted bounds also throw in fitBounds.
       if (minX > maxX || minY > maxY) return;
-      // fix(#674 audit): forward the truncation pair so EphemeralBadge can say
-      // "500 of 10,651 features". Both query_data and run_analysis emit them
-      // only when the server-side cap actually bit.
+      // fix(#674 audit): forward the truncation pair so the preview surface can
+      // say "500 of 10,651 features". Both query_data and run_analysis emit
+      // them only when the server-side cap actually bit.
+      // fix(#1009): that surface is the ephemeral stack row in this (builder)
+      // path — EphemeralPreviewRow, via UnifiedStackPanel's `preview` prop.
+      // The badge still consumes the same pair in the viewer and in the
+      // builder's <1100px rail layout.
       //
       // fix(#1076): the flag no longer waits for the total. A clip filters
       // rows, so the server reports no source total for it, and requiring one
       // dropped the disclosure entirely — a capped clip preview then read as
-      // complete. The total rides along when there is one; the badge picks its
-      // wording from whether it arrived.
+      // complete. The total rides along when there is one; the surface picks
+      // its wording from whether it arrived (ephemeralCountLabel in
+      // components/builder/ephemeral-preview.ts, shared by row and badge).
       //
       // The producer half is #1071: until that lands, collect_run_analysis_action
       // still omits `truncated` whenever the total is absent, so this branch is
@@ -531,7 +536,8 @@ export function ChatPanel({
         ? { truncated: true, ...(total != null ? { totalCount: total } : {}) }
         : undefined;
       // feat(#675): a run_analysis action carries its reconstruction params so
-      // the badge can offer "Save as dataset" (prefilled Analysis panel).
+      // the preview surface can offer "Save as dataset" (prefilled Analysis
+      // panel) — fix(#1009): the stack row in this path, the badge in the rail.
       const analysis: EphemeralAnalysisHandoff | undefined =
         (action.operation === 'buffer' || action.operation === 'centroid') && action.layer_id
           ? {

--- a/frontend/src/components/builder/EphemeralBadge.tsx
+++ b/frontend/src/components/builder/EphemeralBadge.tsx
@@ -1,8 +1,16 @@
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { ephemeralStatusLabel, useAnnouncedLabel } from '@/components/builder/ephemeral-preview';
 
+// fix(#1009): the builder's full stack panel now surfaces the preview as a row
+// (EphemeralPreviewRow), so this badge no longer renders there. It survives as
+// the surface for the two places that have NO layer stack to put a row in:
+//   - the public viewer (ViewerChatPanel — fix(#542) added it precisely because
+//     the viewer's overlay had no legend entry, badge, or dismissal), and
+//   - the builder below 1100px, where the sidebar collapses to SidebarRail.
+// One ephemeral object still gets exactly one surface; which surface depends on
+// whether a stack exists to host the row.
 interface EphemeralBadgeProps {
   featureCount: number;
   onDismiss: () => void;
@@ -21,39 +29,11 @@ interface EphemeralBadgeProps {
 export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount, onSaveAsDataset, className }: EphemeralBadgeProps) {
   const { t } = useTranslation('builder');
 
-  // fix(#1076): three cases, not two. A clip filters rows, so the server
-  // cannot report a source total for it — the honest answer to "of how many?"
-  // is unknown. Falling back to the plain count there presented a capped
-  // preview as the complete result, which is #674's concern through a new
-  // door. Capped-with-a-total keeps its "N of M"; capped-without says so
-  // without inventing one.
-  const countLabel = truncated
-    ? totalCount != null
-      ? t('ephemeralBadge.featureCountTruncated', {
-          count: featureCount,
-          // fix(#788): both numbers passed raw — the locale strings group them
-          // via {{count, number}}/{{total, number}} (one sentence, one
-          // grouping), and count keeps driving plural selection.
-          total: totalCount,
-          defaultValue: '{{count, number}} of {{total, number}} features',
-        })
-      : t('ephemeralBadge.featureCountCapped', {
-          count: featureCount,
-          defaultValue: 'first {{count, number}} features',
-        })
-    : t('ephemeralBadge.featureCount', { count: featureCount });
-  const statusLabel = `${t('ephemeralBadge.queryResult')} · ${countLabel}`;
-
-  // fix(#784): live regions only announce mutations made while the region is
-  // already in the accessibility tree — this badge mounts WITH its text, so
-  // role="status" on the wrapper alone would stay silent. Mount the region
-  // empty and populate it a frame later so the preview success (and any later
-  // count change) arrives as a mutation assistive tech actually reads.
-  const [announcedLabel, setAnnouncedLabel] = useState('');
-  useEffect(() => {
-    const frame = requestAnimationFrame(() => setAnnouncedLabel(statusLabel));
-    return () => cancelAnimationFrame(frame);
-  }, [statusLabel]);
+  // fix(#1009): the count sentence and the announced-label pattern moved to
+  // ephemeral-preview.ts so this badge and the stack row cannot drift apart.
+  const counts = { featureCount, truncated, totalCount };
+  const statusLabel = ephemeralStatusLabel(t, counts);
+  const announcedLabel = useAnnouncedLabel(statusLabel);
 
   // fix(#787 item 1): z-20, above the z-10 PluginHost slots. The bottom-left slot
   // is offset to clear this badge, but a panel taller than that offset overlaps it

--- a/frontend/src/components/builder/EphemeralPreviewRow.tsx
+++ b/frontend/src/components/builder/EphemeralPreviewRow.tsx
@@ -1,0 +1,105 @@
+// fix(#1009): the analysis/chat preview drew an ephemeral overlay the layer
+// stack knew nothing about — with several layers on screen nothing said which
+// one was the preview, or how to get rid of it short of finding the badge in
+// the map's corner. This is that preview as a row in the stack.
+//
+// Deliberately NOT a StackRow and deliberately NOT wrapped in SortableStackRow:
+// the preview is not a MapLayerResponse and must never register with dnd-kit.
+// `dragDisabled` on the sortable wrapper would not do — a disabled sortable is
+// still a member of the sortable collection, so its id would sit in
+// UnifiedStackPanel's `sortableIds` with no layer behind it, and MapBuilderPage's
+// handleDragEnd resolves those ids back to real layers to write sort_order.
+// UnifiedStackPanel renders this row BEFORE the SortableContext opens, the same
+// way the DragOverlay ghost renders a bare StackRow.
+import { X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { semanticBadgeColors } from '@/lib/status-colors';
+import {
+  ephemeralCountLabel,
+  ephemeralStatusLabel,
+  useAnnouncedLabel,
+  type EphemeralCountInput,
+} from '@/components/builder/ephemeral-preview';
+
+export interface EphemeralPreviewRowProps extends EphemeralCountInput {
+  onDismiss: () => void;
+  /** feat(#675): opens the Analysis panel prefilled with the operation behind
+   *  this preview. Absent for previews with no analysis behind them (a plain
+   *  chat query result), which is why the action is conditional. */
+  onSaveAsDataset?: () => void;
+}
+
+export function EphemeralPreviewRow({
+  featureCount,
+  truncated,
+  totalCount,
+  onDismiss,
+  onSaveAsDataset,
+}: EphemeralPreviewRowProps) {
+  const { t } = useTranslation('builder');
+
+  const counts = { featureCount, truncated, totalCount };
+  const countLabel = ephemeralCountLabel(t, counts);
+  const announcedLabel = useAnnouncedLabel(ephemeralStatusLabel(t, counts));
+
+  return (
+    // Visual treatment reuses the vocabulary the badge established rather than
+    // introducing tokens: the warning tint every other ephemeral/attention
+    // affordance in the stack already uses (semanticBadgeColors.warning), made
+    // dashed so the row reads as provisional next to the solid real rows.
+    <div
+      data-testid="ephemeral-preview-row"
+      className="mx-2 mt-2 mb-1 rounded-md border border-dashed border-warning/30 bg-warning/10 px-2 py-1.5 text-xs"
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true" className="h-2 w-2 shrink-0 rounded-full bg-warning" />
+        {/* The visible copies below are aria-hidden so browse mode doesn't read
+            the row twice — this region carries the same sentence the badge
+            announced, so screen-reader output is unchanged by the move. */}
+        <span role="status" className="sr-only">{announcedLabel}</span>
+        <span aria-hidden="true" className="truncate font-medium">
+          {t('ephemeralBadge.queryResult')}
+        </span>
+        <span
+          aria-hidden="true"
+          data-testid="ephemeral-preview-tag"
+          className={cn(
+            'shrink-0 rounded-sm px-1 text-2xs font-medium leading-tight',
+            semanticBadgeColors.warning,
+          )}
+        >
+          {t('previewRow.ephemeralTag', { defaultValue: 'Ephemeral — not saved' })}
+        </span>
+        <button
+          type="button"
+          onClick={onDismiss}
+          data-testid="ephemeral-preview-dismiss"
+          className="ms-auto shrink-0 cursor-pointer rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          title={t('ephemeralBadge.dismiss')}
+          aria-label={t('ephemeralBadge.dismiss')}
+        >
+          <X className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      </div>
+      {/* Second line, indented past the status dot: the truncation count the
+          badge carried, plus the #675 hand-off. Both were badge-only affordances
+          before this row existed. */}
+      <div className="mt-0.5 flex items-center gap-2 ps-4">
+        <span aria-hidden="true" className="truncate text-muted-foreground">
+          {countLabel}
+        </span>
+        {onSaveAsDataset && (
+          <button
+            type="button"
+            onClick={onSaveAsDataset}
+            data-testid="ephemeral-preview-save"
+            className="shrink-0 cursor-pointer rounded-sm font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('ephemeralBadge.saveAsDataset', { defaultValue: 'Save as dataset…' })}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/builder/UnifiedStackPanel.tsx
+++ b/frontend/src/components/builder/UnifiedStackPanel.tsx
@@ -21,6 +21,8 @@ import { SortableStackRow } from '@/components/builder/SortableStackRow';
 import { BasemapGroupRowWrapper } from '@/components/builder/BasemapGroupRowWrapper';
 import { FolderGroupRowWrapper } from '@/components/builder/FolderGroupRowWrapper';
 import { CatalogDragGhost } from '@/components/builder/CatalogDragGhost';
+// fix(#1009): the ephemeral analysis/chat preview as a non-persisting stack row.
+import { EphemeralPreviewRow, type EphemeralPreviewRowProps } from '@/components/builder/EphemeralPreviewRow';
 import { EmptyStackState, eyebrowClassName } from '@/components/builder/EmptyStackState';
 import { BulkActionBar } from '@/components/builder/BulkActionBar';
 // builder-audit #338 STACK-01: use the single typed helper instead of a local
@@ -157,6 +159,11 @@ interface UnifiedStackPanelProps {
    *  basemap row above data layers; 'bottom' (default) renders below. Persisted
    *  via MapBasemapConfig.basemap_position. */
   basemapPosition?: 'top' | 'bottom';
+  /** fix(#1009): the live ephemeral preview, rendered as a non-persisting row
+   *  pinned at the very top of the stack. Null/omitted when no preview is on
+   *  the map. It is NOT a layer: it never enters `layers`, never enters
+   *  `sortableIds`, and carries no sort_order — see the render site. */
+  preview?: EphemeralPreviewRowProps | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -364,6 +371,7 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
   deletingCount,
   freshLayerId = null,
   basemapPosition = 'bottom',
+  preview = null,
 }: UnifiedStackPanelProps) {
   const { t } = useTranslation('builder');
 
@@ -720,6 +728,16 @@ export const UnifiedStackPanel = memo(function UnifiedStackPanel({
         className="flex-1 overflow-y-auto"
         aria-label={t('unifiedStack.listboxLabel', { defaultValue: 'Map layers' })}
       >
+        {/* fix(#1009): the ephemeral preview, pinned at the very top — the
+            overlay paints above every layer on the map, so any other position
+            would have the stack lying about what covers what. Rendered HERE,
+            before the SortableContext opens, so its id is structurally
+            incapable of reaching `sortableIds`; a "non-draggable" flag on the
+            sortable wrapper would still leave a member of the sortable
+            collection with no layer behind it for handleDragEnd to resolve.
+            Also outside the isEmpty branch, so a preview on a map with no
+            layers still has a dismiss affordance. */}
+        {preview && <EphemeralPreviewRow {...preview} />}
         {isEmpty ? (
           <>
             <EmptyStackState

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -167,7 +167,9 @@ describe('ChatPanel', () => {
     });
   });
 
-  it('forwards the truncation pair so the badge can disclose "N of TOTAL" (#674 audit)', async () => {
+  // fix(#1009): "the preview surface" throughout, not "the badge" — the builder
+  // path this panel feeds now renders the ephemeral stack row.
+  it('forwards the truncation pair so the preview can disclose "N of TOTAL" (#674 audit)', async () => {
     const geojson = { type: 'FeatureCollection', features: [] };
     const bbox = [-74, 40, -73, 41];
 
@@ -197,7 +199,7 @@ describe('ChatPanel', () => {
 
   // fix(#1076): a clip filters rows, so run_analysis reports no source total —
   // the flag arrives alone. Requiring a total dropped it here and a capped
-  // clip preview reached the badge looking complete.
+  // clip preview reached the preview surface looking complete.
   it('forwards a cap that arrives without a total', async () => {
     const geojson = { type: 'FeatureCollection', features: [] };
     const bbox = [-74, 40, -73, 41];
@@ -225,8 +227,8 @@ describe('ChatPanel', () => {
     });
   });
 
-  // The other direction: an uncapped result must forward nothing, or the badge
-  // discloses a truncation that did not happen.
+  // The other direction: an uncapped result must forward nothing, or the
+  // preview discloses a truncation that did not happen.
   it('forwards no truncation for an uncapped result', async () => {
     const geojson = { type: 'FeatureCollection', features: [] };
     const bbox = [-74, 40, -73, 41];

--- a/frontend/src/components/builder/__tests__/EphemeralBadge.test.tsx
+++ b/frontend/src/components/builder/__tests__/EphemeralBadge.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen } from '@/test/test-utils';
 import { EphemeralBadge } from '../EphemeralBadge';
 
+// fix(#1009): still live, and every case below still load-bearing. The badge
+// stopped being the builder's wide-layout surface (that is the ephemeral stack
+// row now) but remains the surface for the public viewer and the builder's
+// <1100px rail, neither of which has a layer stack to host a row. Nothing here
+// was builder-specific: the count strings are shared with the row via
+// ephemeral-preview.ts, and the z-20 case still guards the rail layout, where
+// PluginHost's bottom-left slot is a real neighbour.
+//
 // fix(#788): the badge strings carry plural variants and locale-grouped
 // numbers ({{count, number}} / {{total, number}}) — these tests pin the
 // singular form and the grouping of BOTH numbers in the truncated sentence

--- a/frontend/src/components/builder/__tests__/UnifiedStackPanel.preview-row.test.tsx
+++ b/frontend/src/components/builder/__tests__/UnifiedStackPanel.preview-row.test.tsx
@@ -1,0 +1,288 @@
+// fix(#1009): the ephemeral analysis/chat preview renders as a non-persisting
+// row pinned at the top of the layer stack.
+//
+// The load-bearing tests here are the sortable-collection ones. A preview row
+// wired through SortableStackRow with `dragDisabled` would LOOK right and still
+// be a bug: a disabled sortable stays a member of the collection, so its id
+// would sit in UnifiedStackPanel's `sortableIds` with no layer behind it, and
+// MapBuilderPage's handleDragEnd maps those ids back to real layers by index to
+// write sort_order. These pin that the row is structurally outside dnd-kit.
+
+import { fireEvent, render, screen } from '@/test/test-utils';
+import { UnifiedStackPanel } from '../UnifiedStackPanel';
+import type { MapLayerResponse } from '@/types/api';
+
+// Capture what UnifiedStackPanel actually hands SortableContext as `items`.
+// `useSortable` and the strategy stay real (spread from the original module) so
+// the rows still register with dnd-kit exactly as they do in production.
+const { sortableItemsSpy } = vi.hoisted(() => ({ sortableItemsSpy: vi.fn() }));
+
+vi.mock('@dnd-kit/sortable', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/sortable')>();
+  const { createElement } = await import('react');
+  return {
+    ...actual,
+    SortableContext: (props: React.ComponentProps<typeof actual.SortableContext>) => {
+      sortableItemsSpy(props.items);
+      return createElement(actual.SortableContext, props);
+    },
+  };
+});
+
+// react-i18next is deliberately NOT mocked here (unlike the sibling
+// UnifiedStackPanel suites): the count strings carry plural variants and
+// locale-grouped numbers ({{count, number}} / {{total, number}}), which only
+// the real i18n instance renders. Same reasoning as EphemeralBadge.test.tsx.
+
+vi.mock('@/components/map/layer-icons', () => ({
+  ColorizedGeometryIcon: ({ layerId }: { layerId: string }) => (
+    <span data-testid={`type-icon-${layerId}`} />
+  ),
+  LayerTypeIcon: ({ iconId }: { iconId: string }) => <span data-testid={`type-icon-${iconId}`} />,
+  getLayerColors: () => ({ fill: '#000', stroke: '#fff', outline: '#000' }),
+  isDiscreteColorStyle: () => false,
+  extractStyleHints: () => ({}),
+}));
+
+vi.mock('../EmptyStackState', () => ({
+  eyebrowClassName: 'block text-2xs',
+  EmptyStackState: () => <div data-testid="empty-stack-state" />,
+}));
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  });
+});
+
+beforeEach(() => {
+  sortableItemsSpy.mockClear();
+});
+
+function makeLayer(overrides: Partial<MapLayerResponse> = {}): MapLayerResponse {
+  return {
+    id: 'layer-1',
+    dataset_id: 'dataset-1',
+    dataset_name: 'Population',
+    dataset_geometry_type: 'POLYGON',
+    dataset_table_name: 'population',
+    dataset_extent_bbox: [0, 0, 1, 1],
+    dataset_column_info: null,
+    dataset_feature_count: null,
+    dataset_sample_values: null,
+    display_name: null,
+    sort_order: 0,
+    visible: true,
+    opacity: 1,
+    paint: {},
+    layout: {},
+    filter: null,
+    label_config: null,
+    popup_config: null,
+    style_config: null,
+    layer_type: null,
+    dataset_record_type: 'vector_dataset',
+    show_in_legend: true,
+    is_dem: false,
+    dem_vertical_units: null,
+    ...overrides,
+  } as MapLayerResponse;
+}
+
+const basemapGroup = {
+  id: 'basemap-group',
+  presetName: 'Positron',
+  providerLabel: 'OpenFreeMap',
+  visible: true,
+  opacity: 1,
+  sublayers: [],
+};
+
+function defaultProps(overrides: Partial<React.ComponentProps<typeof UnifiedStackPanel>> = {}) {
+  return {
+    layers: [],
+    selectedLayerId: null,
+    onSelectLayer: vi.fn(),
+    onToggleVisibility: vi.fn(),
+    onReorder: vi.fn(),
+    onOpacityChange: vi.fn(),
+    onRemove: vi.fn(),
+    onRename: vi.fn(),
+    onDuplicate: vi.fn(),
+    onAddDataClick: vi.fn(),
+    onSettingsClick: vi.fn(),
+    groupMeta: {},
+    basemapGroup,
+    onBulkVisibility: vi.fn(),
+    onBulkOpacity: vi.fn(),
+    onBulkGroup: vi.fn(),
+    onBulkUngroup: vi.fn(),
+    onBulkDelete: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makePreview(overrides: Partial<React.ComponentProps<typeof UnifiedStackPanel>['preview'] & object> = {}) {
+  return {
+    featureCount: 240,
+    onDismiss: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** The `items` array from the most recent SortableContext render. */
+function lastSortableItems(): string[] {
+  const calls = sortableItemsSpy.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1][0] as string[];
+}
+
+describe('#1009: the preview row stays out of the sortable collection', () => {
+  const layers = [
+    makeLayer({ id: 'data-1', dataset_name: 'Roads', sort_order: 0 }),
+    makeLayer({ id: 'data-2', dataset_name: 'Parcels', sort_order: 1 }),
+    makeLayer({ id: 'data-3', dataset_name: 'Zoning', sort_order: 2 }),
+  ];
+
+  it('the preview id never enters sortableIds', () => {
+    render(<UnifiedStackPanel {...defaultProps({ layers, preview: makePreview() })} />);
+
+    const items = lastSortableItems();
+    // Exactly the real layers plus the basemap group — nothing else.
+    expect(items).toEqual(['data-1', 'data-2', 'data-3', 'basemap-group']);
+  });
+
+  it('renders the same sortable collection with and without a preview', () => {
+    const { rerender } = render(<UnifiedStackPanel {...defaultProps({ layers })} />);
+    const withoutPreview = lastSortableItems();
+
+    rerender(<UnifiedStackPanel {...defaultProps({ layers, preview: makePreview() })} />);
+    const withPreview = lastSortableItems();
+
+    // Showing a preview must not perturb the collection at all — same ids, same
+    // order, same length. Any difference is an index shift the sorting strategy
+    // would apply to real rows.
+    expect(withPreview).toEqual(withoutPreview);
+  });
+
+  // This is the sort_order criterion. handleDragEnd (MapBuilderPage) resolves
+  // active.id and over.id back into localLayers by index and writes sort_order
+  // from the resulting array; an id in the sortable collection with no layer
+  // behind it is the whole corruption vector. Dragging a real layer to the top
+  // of the stack drags it ACROSS the preview row (asserted below to be above
+  // every sortable row) — and this pins that no id a drag can name is anything
+  // other than a real layer or the basemap.
+  it('every id a drag can name resolves to a real layer, so a drag across the preview cannot corrupt sort_order', () => {
+    render(<UnifiedStackPanel {...defaultProps({ layers, preview: makePreview() })} />);
+
+    const items = lastSortableItems();
+    for (const id of items) {
+      const resolves = id === basemapGroup.id || layers.some((l) => l.id === id);
+      expect({ id, resolves }).toEqual({ id, resolves: true });
+    }
+    expect(items).toHaveLength(layers.length + 1);
+  });
+
+  it('the preview row registers nothing with dnd-kit', () => {
+    render(<UnifiedStackPanel {...defaultProps({ layers, preview: makePreview() })} />);
+
+    const row = screen.getByTestId('ephemeral-preview-row');
+    // dnd-kit stamps its draggable attributes onto the activator element; the
+    // sortable wrappers additionally stamp data-row-id (which the panel's
+    // Shift+Arrow walker reads). The preview row carries neither, so it is
+    // invisible to both the drag machinery and range selection.
+    expect(row.querySelector('[aria-roledescription]')).toBeNull();
+    expect(row.querySelector('[data-row-id]')).toBeNull();
+    expect(row.closest('[data-row-id]')).toBeNull();
+    // No grip: the row advertises no reorder affordance it cannot honour.
+    expect(row.querySelector('svg.lucide-grip-vertical')).toBeNull();
+  });
+
+  it('pins the preview above every sortable row, matching the overlay drawing above every layer', () => {
+    render(<UnifiedStackPanel {...defaultProps({ layers, preview: makePreview() })} />);
+
+    const row = screen.getByTestId('ephemeral-preview-row');
+    const sortableRows = [...document.querySelectorAll('[data-row-id]')];
+    expect(sortableRows.length).toBeGreaterThan(0);
+    for (const sortable of sortableRows) {
+      expect(row.compareDocumentPosition(sortable) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
+  });
+
+  it('stays above the basemap row even when the basemap is pinned to the top', () => {
+    render(
+      <UnifiedStackPanel
+        {...defaultProps({ layers, preview: makePreview(), basemapPosition: 'top' })}
+      />,
+    );
+    const row = screen.getByTestId('ephemeral-preview-row');
+    const basemapRow = document.querySelector('[data-row-id="basemap-group"]')!;
+    expect(row.compareDocumentPosition(basemapRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
+describe('#1009: the row carries everything the badge offered', () => {
+  const layers = [makeLayer({ id: 'data-1' })];
+
+  it('renders no row when there is no preview', () => {
+    render(<UnifiedStackPanel {...defaultProps({ layers })} />);
+    expect(screen.queryByTestId('ephemeral-preview-row')).not.toBeInTheDocument();
+  });
+
+  it('marks the row as ephemeral and not saved', () => {
+    render(<UnifiedStackPanel {...defaultProps({ layers, preview: makePreview() })} />);
+    expect(screen.getByTestId('ephemeral-preview-tag')).toHaveTextContent('Ephemeral — not saved');
+  });
+
+  it('carries the truncation count (badge parity — #674/#1076)', () => {
+    render(
+      <UnifiedStackPanel
+        {...defaultProps({
+          layers,
+          preview: makePreview({ featureCount: 500, totalCount: 10651, truncated: true }),
+        })}
+      />,
+    );
+    expect(screen.getByText('500 of 10,651 features')).toBeInTheDocument();
+  });
+
+  it('says a capped preview was capped when no total is known (#1076)', () => {
+    render(
+      <UnifiedStackPanel
+        {...defaultProps({ layers, preview: makePreview({ featureCount: 500, truncated: true }) })}
+      />,
+    );
+    expect(screen.getByText('first 500 features')).toBeInTheDocument();
+  });
+
+  it('carries the #675 "Save as dataset" hand-off', () => {
+    const onSaveAsDataset = vi.fn();
+    render(
+      <UnifiedStackPanel {...defaultProps({ layers, preview: makePreview({ onSaveAsDataset }) })} />,
+    );
+    fireEvent.click(screen.getByTestId('ephemeral-preview-save'));
+    expect(onSaveAsDataset).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits "Save as dataset" for previews with no analysis behind them', () => {
+    render(<UnifiedStackPanel {...defaultProps({ layers, preview: makePreview() })} />);
+    expect(screen.queryByTestId('ephemeral-preview-save')).not.toBeInTheDocument();
+  });
+
+  it('dismisses the preview from the row', () => {
+    const onDismiss = vi.fn();
+    render(<UnifiedStackPanel {...defaultProps({ layers, preview: makePreview({ onDismiss }) })} />);
+    fireEvent.click(screen.getByTestId('ephemeral-preview-dismiss'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('still shows the row on a map with no layers', () => {
+    render(<UnifiedStackPanel {...defaultProps({ layers: [], preview: makePreview() })} />);
+    // The empty state renders too — a preview must never be stranded without a
+    // dismiss affordance just because the map has no layers yet.
+    expect(screen.getByTestId('empty-stack-state')).toBeInTheDocument();
+    expect(screen.getByTestId('ephemeral-preview-row')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/builder/ephemeral-preview.ts
+++ b/frontend/src/components/builder/ephemeral-preview.ts
@@ -1,0 +1,73 @@
+// fix(#1009): the ephemeral preview now has two surfaces — the builder's
+// non-persisting stack row (EphemeralPreviewRow) and the badge that covers the
+// surfaces with no layer stack (public viewer, <1100px builder rail). The count
+// sentence is identical on both, so it lives here instead of being copy-pasted
+// into the second one and drifting.
+
+import { useEffect, useState } from 'react';
+
+type BuilderTranslator = (key: string, options?: Record<string, unknown>) => string;
+
+export interface EphemeralCountInput {
+  featureCount: number;
+  /** Whether the result was truncated server-side. */
+  truncated?: boolean;
+  /** Total feature count before truncation. */
+  totalCount?: number;
+}
+
+/**
+ * The preview's "how many features?" sentence.
+ *
+ * fix(#1076): three cases, not two. A clip filters rows, so the server cannot
+ * report a source total for it — the honest answer to "of how many?" is
+ * unknown. Falling back to the plain count there presented a capped preview as
+ * the complete result, which is #674's concern through a new door.
+ * Capped-with-a-total keeps its "N of M"; capped-without says so without
+ * inventing one.
+ */
+export function ephemeralCountLabel(
+  t: BuilderTranslator,
+  { featureCount, truncated, totalCount }: EphemeralCountInput,
+): string {
+  if (!truncated) return t('ephemeralBadge.featureCount', { count: featureCount });
+  if (totalCount != null) {
+    return t('ephemeralBadge.featureCountTruncated', {
+      count: featureCount,
+      // fix(#788): both numbers passed raw — the locale strings group them via
+      // {{count, number}}/{{total, number}} (one sentence, one grouping), and
+      // count keeps driving plural selection.
+      total: totalCount,
+      defaultValue: '{{count, number}} of {{total, number}} features',
+    });
+  }
+  return t('ephemeralBadge.featureCountCapped', {
+    count: featureCount,
+    defaultValue: 'first {{count, number}} features',
+  });
+}
+
+/**
+ * The sentence assistive tech hears when a preview appears or its count
+ * changes: "Result · 240 of 10,651 features". Shared so the row and the badge
+ * announce the same thing.
+ */
+export function ephemeralStatusLabel(t: BuilderTranslator, input: EphemeralCountInput): string {
+  return `${t('ephemeralBadge.queryResult')} · ${ephemeralCountLabel(t, input)}`;
+}
+
+/**
+ * fix(#784): live regions only announce mutations made while the region is
+ * already in the accessibility tree — both preview surfaces mount WITH their
+ * text, so role="status" on the wrapper alone would stay silent. Mount the
+ * region empty and populate it a frame later so the preview success (and any
+ * later count change) arrives as a mutation assistive tech actually reads.
+ */
+export function useAnnouncedLabel(statusLabel: string): string {
+  const [announcedLabel, setAnnouncedLabel] = useState('');
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setAnnouncedLabel(statusLabel));
+    return () => cancelAnimationFrame(frame);
+  }, [statusLabel]);
+  return announcedLabel;
+}

--- a/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
+++ b/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
@@ -24,9 +24,11 @@ export function useEphemeralLayers(
   const [ephemeralResult, setEphemeralResult] = useState<{
     geojson: GeoJSON.FeatureCollection;
     bbox: [number, number, number, number];
-    /** fix(#674 audit): set when the server capped the result, so the badge
-     *  can disclose "N of TOTAL" instead of passing a capped preview off as
-     *  the whole answer. */
+    /** fix(#674 audit): set when the server capped the result, so the preview
+     *  surface can disclose "N of TOTAL" instead of passing a capped preview
+     *  off as the whole answer. fix(#1009): this hook feeds both surfaces —
+     *  the builder's stack row and the badge (viewer, and the builder's
+     *  <1100px rail) — so the field is deliberately surface-agnostic. */
     truncated?: boolean;
     totalCount?: number;
     /** feat(#675): present when the overlay came from a chat run_analysis

--- a/frontend/src/components/map-plugins/PluginHost.tsx
+++ b/frontend/src/components/map-plugins/PluginHost.tsx
@@ -10,7 +10,10 @@ import type { PluginContext, PluginAnchor, PluginDefinition } from './types';
 // Anchor offsets account for map overlay controls:
 // top-left: below MapToolbar (h-8 + top-3 = ~44px ≈ top-12)
 // top-right: below MapToolbar row
-// bottom-left: above ScaleControl (~24px) + EphemeralBadge (~32px)
+// bottom-left: above ScaleControl (~24px) + EphemeralBadge (~32px). fix(#1009):
+//   the badge now renders only below 1100px (above that the preview is a stack
+//   row), so this clearance is load-bearing in the rail layout and spare in the
+//   wide one — kept at one value rather than made responsive for a few pixels.
 // bottom-right: above NavigationControl
 const ANCHOR_POSITIONS: Record<PluginAnchor, string> = {
   'top-left': 'absolute top-12 left-3 z-10 flex flex-col gap-2',

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -275,6 +275,11 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
           badge, or dismissal — orange highlights persisted unexplained. Reuse
           the builder's badge; the viewer's bottom-left column is occupied by
           BasemapToggle (bottom-8) and the Map data button (bottom-20). */}
+      {/* fix(#1009): the builder moved this affordance into its layer stack
+          (EphemeralPreviewRow) and dropped the badge there. Do NOT finish the
+          deletion here: the viewer has no layer stack to host a row, so this
+          badge is #542's only dismissal surface. Removing it re-opens #542
+          verbatim — an orange overlay with no way to explain or dismiss it. */}
       {ephemeralResult && (
         <EphemeralBadge
           featureCount={ephemeralResult.geojson.features.length}

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1065,6 +1065,9 @@
     "featureCountCapped_other": "erste {{count, number}} Features",
     "saveAsDataset": "Als Datensatz speichern…"
   },
+  "previewRow": {
+    "ephemeralTag": "Flüchtig – nicht gespeichert"
+  },
   "plugins": {
     "measurement": {
       "label": "Messen",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1065,6 +1065,9 @@
     "dismiss": "Dismiss result",
     "saveAsDataset": "Save as dataset…"
   },
+  "previewRow": {
+    "ephemeralTag": "Ephemeral — not saved"
+  },
   "plugins": {
     "measurement": {
       "label": "Measure",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1065,6 +1065,9 @@
     "featureCountCapped_other": "primeras {{count, number}} entidades",
     "saveAsDataset": "Guardar como conjunto de datos…"
   },
+  "previewRow": {
+    "ephemeralTag": "Efímero: sin guardar"
+  },
   "plugins": {
     "measurement": {
       "label": "Medir",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1065,6 +1065,9 @@
     "featureCountCapped_other": "{{count, number}} premières entités",
     "saveAsDataset": "Enregistrer comme jeu de données…"
   },
+  "previewRow": {
+    "ephemeralTag": "Éphémère — non enregistré"
+  },
   "plugins": {
     "measurement": {
       "label": "Mesurer",

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -929,7 +929,7 @@ export function MapBuilderPage() {
     };
   });
 
-  // feat(#675): "Save as dataset" on the ephemeral badge — open the Analysis
+  // feat(#675): "Save as dataset" on the ephemeral preview — open the Analysis
   // panel prefilled with the operation behind the chat preview.
   const ephemeralAnalysis = layers.ephemeralResult?.analysis;
   const handleSaveAnalysisPreview = useCallback(() => {
@@ -937,6 +937,21 @@ export function MapBuilderPage() {
     setAnalysisPrefill({ ...ephemeralAnalysis, nonce: Date.now() });
     setRailPanel('analysis');
   }, [ephemeralAnalysis]);
+
+  // fix(#1009): the preview's stack-row props. Memoized because a fresh object
+  // literal on the UnifiedStackPanel prop would defeat its memo() on every
+  // render of this (very large) page.
+  const previewRowProps = useMemo(() => {
+    const result = layers.ephemeralResult;
+    if (!result) return null;
+    return {
+      featureCount: result.geojson.features.length,
+      truncated: result.truncated,
+      totalCount: result.totalCount,
+      onDismiss: layers.handleDismissEphemeral,
+      onSaveAsDataset: ephemeralAnalysis ? handleSaveAnalysisPreview : undefined,
+    };
+  }, [layers.ephemeralResult, layers.handleDismissEphemeral, ephemeralAnalysis, handleSaveAnalysisPreview]);
 
   // ux(#772): stack-row kebab "Analyze this layer" — the same handoff path the
   // chat preview uses, so the panel opens (or remounts, via the prefill nonce
@@ -1939,6 +1954,10 @@ export function MapBuilderPage() {
               deletingCount={layers.deletingCount}
               freshLayerId={layers.freshLayerId}
               basemapPosition={basemapState.config.basemap_position ?? 'bottom'}
+              // fix(#1009): the ephemeral preview as a non-persisting row pinned
+              // above the sortable region. Not a member of `layers`, so it can
+              // never be reordered, styled, grouped, or saved into the map.
+              preview={previewRowProps}
             />
           )}
           {/* Sidebar-placement plugins render below the layer stack. No built-in
@@ -2058,13 +2077,19 @@ export function MapBuilderPage() {
               />
             </Suspense>
           </MapErrorBoundary>
-          {layers.ephemeralResult && (
+          {/* fix(#1009): the preview's surface is the stack row above — but the
+              stack panel only exists at ≥1100px; below that the sidebar
+              collapses to SidebarRail, which has no rows. Keep the badge for
+              exactly that case, so the narrow layout doesn't lose the count,
+              the dismiss, and the #675 hand-off altogether. Still one surface
+              at a time, never both. */}
+          {isRail && previewRowProps && (
             <EphemeralBadge
-              featureCount={layers.ephemeralResult.geojson.features.length}
-              onDismiss={layers.handleDismissEphemeral}
-              truncated={layers.ephemeralResult.truncated}
-              totalCount={layers.ephemeralResult.totalCount}
-              onSaveAsDataset={ephemeralAnalysis ? handleSaveAnalysisPreview : undefined}
+              featureCount={previewRowProps.featureCount}
+              onDismiss={previewRowProps.onDismiss}
+              truncated={previewRowProps.truncated}
+              totalCount={previewRowProps.totalCount}
+              onSaveAsDataset={previewRowProps.onSaveAsDataset}
             />
           )}
 


### PR DESCRIPTION
## What

An analysis preview drew an ephemeral overlay the layer stack and legend knew nothing about. With several layers on screen nothing said which one was the preview, or how to remove it short of finding the badge in the map corner. This adds a dismissible, non-persisting row pinned to the top of the stack.

Design settled on the issue: pinned above the sortable region, reusing the ephemeral vocabulary the badge established (dashed outline, existing muted/accent tint, an explicit "Ephemeral — not saved" tag), no new tokens.

## How the row stays out of the sortable collection

Structurally, not by a flag — two independent facts:

**It cannot enter `sortableIds`.** That memo (`UnifiedStackPanel.tsx:514-520`) is built only from `visibleStackLayers.map(l => l.id)` plus the basemap group id. The preview is never in `layers` — it lives in `useEphemeralLayers` state and arrives as its own prop. No filter or exclusion was added because there is nothing to exclude.

**It renders outside the `SortableContext`.** The row renders inside the scroll container but *before* the `isEmpty` ternary, and `<SortableContext>` only opens inside the non-empty branch. It is a sibling preceding the provider, exactly like the `DragOverlay` ghost's bare `StackRow`. It calls no `useSortable`, carries no `data-row-id` (what the Shift+Arrow walker reads), and renders no grip.

That placement also satisfies pinned-at-top for free: it precedes the basemap row even when `basemapPosition === 'top'`.

## The badge is not deleted — it is now the no-stack surface

The recorded decision was "badge removed in the same PR". Taken literally that breaks two places, because **the decision's rationale presumes a layer stack exists and there are two contexts where none does**:

1. **The public viewer.** `ViewerChatPanel.tsx:279` renders the badge, under a `fix(#542)` comment reading *"the viewer applied the query overlay with no legend entry, badge, or dismissal — orange highlights persisted unexplained."* The viewer has no layer stack.
2. **The <1100px builder rail.** `MapBuilderPage.tsx:1856` swaps the entire `UnifiedStackPanel` for `SidebarRail` below `BUILDER_RAIL_BREAKPOINT = 1100`. `SidebarRail` is a 64px icon strip — zero `StackRow`, zero `data-row-id` in its 171 lines.

Deleting the badge would lose the count, the dismiss control and the #675 save-as-dataset hand-off entirely in both — not degraded, absent, and #542 re-opens verbatim.

So the badge is gated on `isRail` in the builder and kept in the viewer. **Row and badge are now mutually exclusive by construction — never both mounted** — which makes "one ephemeral object gets one surface" literally true rather than approximately, and loses nothing at any width.

Net rule, recorded in-source in three places (`EphemeralBadge.tsx` header, the viewer render site, the badge test file): **the row is the surface wherever a layer stack exists; the badge is the surface where none does.**

## Verification

```
npm run typecheck      clean
npm run lint           clean
npm run test:i18n      4 passed
npm run test:coverage  371 files, 4559 tests passed
```

14 new tests in `__tests__/UnifiedStackPanel.preview-row.test.tsx`. The collection invariant is asserted directly: every id the panel hands `SortableContext` resolves to a real layer or the basemap, and `items.length === layers.length + 1` — which is what `handleDragEnd` depends on, since it does `findIndex(l => l.id === active.id)` and writes `sort_order` from the result, so a member with no layer behind it is the whole corruption vector. Also pinned: identical collections with and without a preview, and `compareDocumentPosition` proving the row precedes every `[data-row-id]`.

Non-vacuity checked rather than assumed: prepending a fake id to the `sortableIds` memo produced exactly 2 failed / 12 passed (the two collection tests), then restored to 14/14.

Stated plainly: this pins the id boundary, not a simulated drag. No test here drives dnd-kit end-to-end — `handleDragEnd` is a `useCallback` inside a 2250-line page with no exported seam.

`EphemeralBadge.test.tsx` passes unchanged (6 cases); only an 8-line scope note was added so the file does not read as something the deletion missed.

## Locale keys

Exactly one added, in all four locales: `previewRow.ephemeralTag`. None removed, none relocated — `featureCountTruncated` must stay because the badge still needs it, so both surfaces now read the same `ephemeralBadge.*` keys through a shared `ephemeral-preview.ts` and there is no duplicate to drift. No plural key was touched; verified every `_one` interpolates `{{count}}` and `_many` count is 0 in all four.

## Note for the e2e run

`e2e/dataset-chat.spec.ts` edits are comments only; the assertion is unchanged and still valid because the row carries the same `role="status"` sentence the badge did. Playwright's `Desktop Chrome` is 1280px — above the rail breakpoint — so that spec now exercises the row, not the badge.

Closes #1009