### PR TITLE
fix(frontend): define the SAML providers query key in query-keys.ts

### DIFF
--- a/frontend/src/components/admin/saml/SamlProvidersSection.tsx
+++ b/frontend/src/components/admin/saml/SamlProvidersSection.tsx
@@ -122,7 +122,7 @@ export function SamlProvidersSection() {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['saml', 'providers'] as const,
+    queryKey: queryKeys.saml.providers,
     queryFn: listSamlProviders,
   });
 
@@ -136,7 +136,7 @@ export function SamlProvidersSection() {
   const createMutation = useMutation({
     mutationFn: (data: SamlProviderCreateData) => createSamlProvider(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['saml', 'providers'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.saml.providers });
       invalidateAuthProviders();
       toast.success(t('saml.created'));
     },
@@ -149,7 +149,7 @@ export function SamlProvidersSection() {
     mutationFn: ({ id, data }: { id: string; data: SamlProviderUpdateData }) =>
       updateSamlProvider(id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['saml', 'providers'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.saml.providers });
       invalidateAuthProviders();
       toast.success(t('saml.updated'));
     },
@@ -161,7 +161,7 @@ export function SamlProvidersSection() {
   const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteSamlProvider(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['saml', 'providers'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.saml.providers });
       invalidateAuthProviders();
       toast.success(t('saml.deleted'));
     },

--- a/frontend/src/components/admin/saml/__tests__/SamlProvidersSection.test.tsx
+++ b/frontend/src/components/admin/saml/__tests__/SamlProvidersSection.test.tsx
@@ -62,6 +62,15 @@ const SAML_PROVIDER: SamlProviderConfig = {
 // mutation changes the login buttons too. This section invalidated its own list and
 // the admin OAuth list but never authConfig.oauthProviders.
 describe('SamlProvidersSection provider mutations', () => {
+  // Call history only — mockReset would drop the module factory's resolved value for
+  // listSamlProviders, which is set once. Mirrors the sibling SettingsAuthTab test.
+  beforeEach(() => {
+    vi.mocked(listSamlProviders).mockClear();
+    vi.mocked(createSamlProvider).mockClear();
+    vi.mocked(updateSamlProvider).mockClear();
+    vi.mocked(deleteSamlProvider).mockClear();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -72,9 +81,15 @@ describe('SamlProvidersSection provider mutations', () => {
       .mockResolvedValue(undefined);
   }
 
-  function expectBothProviderCaches(
+  // fix(#1164): the SAML list key is asserted here too. It used to be an inline
+  // `['saml', 'providers']` literal repeated at all four call sites, so nothing
+  // bound the invalidations to the key the list actually reads.
+  function expectEveryProviderCache(
     invalidateQueries: ReturnType<typeof spyOnInvalidate>,
   ) {
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.saml.providers,
+    });
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: queryKeys.settingsOAuth.providers,
     });
@@ -83,13 +98,7 @@ describe('SamlProvidersSection provider mutations', () => {
     });
   }
 
-  it('invalidates both provider caches after a create', async () => {
-    vi.mocked(createSamlProvider).mockResolvedValueOnce(SAML_PROVIDER);
-    const invalidateQueries = spyOnInvalidate();
-    const user = userEvent.setup();
-
-    render(<SamlProvidersSection />);
-
+  async function fillAndSubmitCreateForm(user: ReturnType<typeof userEvent.setup>) {
     await user.click(screen.getByRole('button', { name: /add saml provider/i }));
     await user.type(await screen.findByLabelText('Display Name'), 'Okta');
     await user.type(
@@ -102,12 +111,22 @@ describe('SamlProvidersSection provider mutations', () => {
     );
     await user.type(screen.getByLabelText('IdP Signing Certificate (PEM)'), 'cert-pem');
     await user.click(screen.getByRole('button', { name: 'Create Provider' }));
+  }
+
+  it('invalidates every provider cache after a create', async () => {
+    vi.mocked(createSamlProvider).mockResolvedValueOnce(SAML_PROVIDER);
+    const invalidateQueries = spyOnInvalidate();
+    const user = userEvent.setup();
+
+    render(<SamlProvidersSection />);
+
+    await fillAndSubmitCreateForm(user);
 
     await waitFor(() => expect(createSamlProvider).toHaveBeenCalledOnce());
-    expectBothProviderCaches(invalidateQueries);
+    expectEveryProviderCache(invalidateQueries);
   });
 
-  it('invalidates both provider caches after an update', async () => {
+  it('invalidates every provider cache after an update', async () => {
     vi.mocked(listSamlProviders).mockResolvedValueOnce([SAML_PROVIDER]);
     vi.mocked(updateSamlProvider).mockResolvedValueOnce(SAML_PROVIDER);
     const invalidateQueries = spyOnInvalidate();
@@ -123,10 +142,10 @@ describe('SamlProvidersSection provider mutations', () => {
     await user.click(screen.getByRole('button', { name: 'Save Changes' }));
 
     await waitFor(() => expect(updateSamlProvider).toHaveBeenCalledOnce());
-    expectBothProviderCaches(invalidateQueries);
+    expectEveryProviderCache(invalidateQueries);
   });
 
-  it('invalidates both provider caches after a delete', async () => {
+  it('invalidates every provider cache after a delete', async () => {
     vi.mocked(listSamlProviders).mockResolvedValueOnce([SAML_PROVIDER]);
     vi.mocked(deleteSamlProvider).mockResolvedValueOnce(undefined);
     const invalidateQueries = spyOnInvalidate();
@@ -139,6 +158,25 @@ describe('SamlProvidersSection provider mutations', () => {
     await user.click(await screen.findByRole('button', { name: 'Delete' }));
 
     await waitFor(() => expect(deleteSamlProvider).toHaveBeenCalledWith(SAML_PROVIDER.id));
-    expectBothProviderCaches(invalidateQueries);
+    expectEveryProviderCache(invalidateQueries);
+  });
+
+  // fix(#1164): the three tests above stub invalidateQueries, so they prove the call
+  // was made with the right key but not that the LIST reads that same key. Those were
+  // two independent literals until now. This one lets the real invalidation run and
+  // watches for the refetch, so a read/invalidate mismatch surfaces as a list that
+  // never reloads — the silent no-op the issue is about.
+  it('refetches its own provider list after a mutation', async () => {
+    vi.mocked(createSamlProvider).mockResolvedValueOnce(SAML_PROVIDER);
+    const user = userEvent.setup();
+
+    render(<SamlProvidersSection />);
+
+    await waitFor(() => expect(listSamlProviders).toHaveBeenCalledOnce());
+
+    await fillAndSubmitCreateForm(user);
+
+    await waitFor(() => expect(createSamlProvider).toHaveBeenCalledOnce());
+    await waitFor(() => expect(listSamlProviders).toHaveBeenCalledTimes(2));
   });
 });

--- a/frontend/src/lib/__tests__/query-keys.test.ts
+++ b/frontend/src/lib/__tests__/query-keys.test.ts
@@ -315,6 +315,34 @@ describe('queryKeys factory', () => {
   });
 
   // -------------------------------------------------------------------------
+  // SAML providers
+  // -------------------------------------------------------------------------
+  describe('saml', () => {
+    it('providers returns expected key', () => {
+      // fix(#1164): pins the string the admin SAML list has always cached under.
+      // It used to live only in inline literals at the call sites, so nothing
+      // caught a typo that turned an invalidation into a no-op.
+      expect(queryKeys.saml.providers).toEqual(['saml', 'providers']);
+    });
+
+    it('does not prefix-match the OAuth provider families', () => {
+      // SamlProvidersSection invalidates this key AND both OAuth families on every
+      // mutation (via hooks/use-auth-providers.ts). Those are three separate calls
+      // because none of the keys covers another — TanStack matches by prefix, so
+      // re-rooting this one under 'settings' would silently make one of them
+      // redundant and the other over-broad.
+      const saml = queryKeys.saml.providers;
+      for (const other of [
+        queryKeys.settingsOAuth.providers,
+        queryKeys.authConfig.oauthProviders,
+      ]) {
+        expect(other.slice(0, saml.length)).not.toEqual([...saml]);
+        expect(saml.slice(0, other.length)).not.toEqual([...other]);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Relationships
   // -------------------------------------------------------------------------
   describe('relationships', () => {

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -245,6 +245,27 @@ export const queryKeys = {
   },
 
   // -------------------------------------------------------------------------
+  // SAML providers
+  // -------------------------------------------------------------------------
+  /**
+   * fix(#1164): the admin SAML section read and invalidated its list through four
+   * independent `['saml', 'providers']` literals that agreed only by convention.
+   * A typo in any one of them produced an invalidation that silently did nothing.
+   * The key string is unchanged so existing cache entries still match (see the
+   * deployment rule at the top of this file).
+   *
+   * This gets its own root rather than sitting under `settingsOAuth` even though
+   * `listSamlProviders` (api/saml.ts) fetches the same `/settings/oauth-providers/`
+   * endpoint: it filters the response down to the SAML rows, so the two caches hold
+   * different payloads and must not prefix-match each other. Fanning a provider
+   * mutation out across both is `useInvalidateAuthProviders`
+   * (hooks/use-auth-providers.ts), which the SAML section calls alongside this key.
+   */
+  saml: {
+    providers: ['saml', 'providers'] as const,
+  },
+
+  // -------------------------------------------------------------------------
   // Relationships
   // -------------------------------------------------------------------------
   relationships: {


### PR DESCRIPTION
Closes #1164.

`SamlProvidersSection` read its provider list under an inline `['saml', 'providers']` literal and invalidated it under three more, one per create/update/delete mutation. Four independent literals that agreed only by convention. A typo in any one of them gives an invalidation that silently does nothing, which is the #1021 class of defect that took a dedicated sweep to find last time.

The key is now defined once in `lib/query-keys.ts` and all four sites reference it. The key string itself is unchanged, so cached entries still match across a deploy.

## Why `saml` gets its own root

`listSamlProviders` fetches the same `/settings/oauth-providers/` endpoint as `queryKeys.settingsOAuth.providers` and filters the response down to the SAML rows. Same endpoint, different payload, so the two caches must not prefix-match. Nesting this under `settingsOAuth` would make `invalidateAuthProviders()` sweep the SAML list as a side effect. Fanning a provider mutation across both is what `useInvalidateAuthProviders` (#1117) already does, and this section calls it alongside the new key.

## One test beyond the issue's scope

The parity test in `lib/__tests__/query-keys.test.ts` is extended, and the invalidation spies in `SamlProvidersSection.test.tsx` now cover all three mutation paths.

There is also one test the issue did not ask for. Under the exact defect #1164 describes, a read key and an invalidation key drifting apart, the parity test and all three spy tests still pass. Only a test that lets the real invalidation run and watches for the resulting refetch catches it. That case is covered now.

## Verification

Four sabotage runs, each reverted afterwards:

| sabotage | failures |
|---|---|
| key factory to `['saml','provider']` | 1 (parity) |
| key factory to `['settings','oauth-providers','saml']` | 3 (parity, prefix-match, refetch) |
| delete the create-path `invalidateQueries` | 2 |
| read key only to `['saml','provider']` | 1, the refetch test alone |

Gates from `frontend/`:

- `npx vitest run`: 373 files, 4570 tests, all passing
- `npm run lint`: clean
- `npm run typecheck`: clean

No new `t()` keys, so locale parity is untouched. No API, schema, or config impact.
