### PR TITLE
docs(ingest): correct ensure_geom_4326_gist_index no-op docstring

### DIFF
--- a/backend/app/processing/ingest/metadata.py
+++ b/backend/app/processing/ingest/metadata.py
@@ -1744,9 +1744,9 @@ async def ensure_geom_4326_gist_index(
     Called from both add_4326_column (staging load) and _apply_reupload_swap
     (post-swap belt-and-braces), so any re-ingest self-heals a missing index.
 
-    No-op when the table has no geom_4326 column: a dataset can carry a
-    geometry_type while only exposing the native ``geom`` column (the
-    effective_srid=None staging path skips add_4326_column).
+    The no-geom_4326 early return is defensive, not a reachable state (#1020):
+    add_4326_column has just added the column, and the swap call is gated on a
+    geometry_type that extract_metadata cannot report without reading geom_4326.
     """
     has_col = await session.execute(
         text(

--- a/backend/tests/test_staging_pipeline.py
+++ b/backend/tests/test_staging_pipeline.py
@@ -946,7 +946,7 @@ class TestEnsureGeom4326GistIndex:
 
         await ensure_geom_4326_gist_index(session, "my_table")
 
-        # effective_srid=None staging path: geometry_type set, no geom_4326.
+        # Defensive branch (#1020): column probe only, no index DDL.
         assert session.execute.await_count == 1
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1020.

`ensure_geom_4326_gist_index` returns early when the table has no `geom_4326` column, and its docstring described that as a state production reaches: a dataset carrying a `geometry_type` while only exposing the native `geom` column, via an `effective_srid=None` staging path. No such path exists. The investigation and its evidence are recorded [on the issue](https://github.com/geolens-io/geolens/issues/1020#issuecomment-5167600193).

Short version, from both directions:

The live dev catalog produces zero rows for the contradiction, with inverse checks confirming that is not a wrong-schema false negative (17 of 17 spatial datasets have the column; no `data.*` table has `geom` without `geom_4326`). That evidence is weaker than it looks on its own, because the catalog's spatial half is only geojson and one shapefile.

Source closes the rest. `_run_staging_pipeline` does carry the `effective_srid=None` skip, but its only production caller is `reupload_file`, whose `effective_srid` falls back to 4326 and is never None. Both call sites of this function reach it with the column present: `add_4326_column` has just added it, and `_apply_reupload_swap` gates its call on a `geometry_type` that only `extract_metadata` produces, and `extract_metadata` reads `geom_4326` for the extent on both its CTE and fallback paths.

`source_format='created'` was checked specifically, since it has two distinct DDL paths and the catalog has zero `created` rows. `create_empty_dataset` declares `geom_4326` inline in its `CREATE TABLE`; the layers module calls `add_4326_column` before `create_dataset`. Both add it.

The branch is unchanged and stays as a defense. Only the claim about it changes, in the docstring and in the mirroring comment on the test that covers it.

No follow-up issue for the four call sites the investigation flagged as at risk (parquet export, export pre-count, feature reads, ogr `bbox_where_sql`). Their assumption that `geom_4326` exists whenever `geometry_type` is set holds.

## Verification

- `uv run ruff check .`: All checks passed
- `uv run ruff format --check .`: 883 files already formatted
- `uv run pytest tests/test_layering.py -q`: 39 passed
- `uv run pytest tests/test_staging_pipeline.py -k EnsureGeom4326GistIndex`: 4 passed, 14 deselected

Docs and one test comment only. No schema, API, or config impact.
