### PR TITLE
refactor(datasets): delete unused update_auto_metadata

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/service.py
+++ b/backend/app/modules/catalog/datasets/domain/service.py
@@ -51,7 +51,6 @@ from app.modules.catalog.datasets.domain.service_metadata import (
     list_attributes,
     reset_attribute,
     update_attribute,
-    update_auto_metadata,
     update_user_metadata,
 )
 from app.modules.catalog.datasets.domain.service_query import (
@@ -99,6 +98,5 @@ __all__ = [
     "resolve_source_feature_count",
     "run_analysis_preview",
     "update_attribute",
-    "update_auto_metadata",
     "update_user_metadata",
 ]

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -33,7 +33,6 @@ __all__ = [
     "list_attributes",
     "reset_attribute",
     "update_attribute",
-    "update_auto_metadata",
     "update_user_metadata",
 ]
 
@@ -329,42 +328,6 @@ async def update_user_metadata(
     if {"title", "summary", "lineage_summary"} & meta.model_fields_set:
         await _maybe_defer_embedding(record.id, dataset.id)
 
-    return dataset
-
-
-async def update_auto_metadata(
-    session: AsyncSession,
-    dataset_id: uuid.UUID,
-    *,
-    srid: int | None = None,
-    geometry_type: str | None = None,
-    feature_count: int | None = None,
-    extent_wkt: str | None = None,
-    column_info: list[dict] | None = None,
-) -> Dataset:
-    """Update only auto-extracted fields. Never touches title/summary.
-
-    extent_wkt now updates Record.spatial_extent. srid, geometry_type,
-    feature_count, column_info stay on Dataset.
-    Only updates fields that are not None. Raises ValueError if dataset not found.
-    """
-    dataset = await get_dataset(session, dataset_id)
-    if dataset is None:
-        raise ValueError(f"Dataset {dataset_id} not found.")
-
-    if srid is not None:
-        dataset.srid = srid
-    if geometry_type is not None:
-        dataset.geometry_type = geometry_type
-    if feature_count is not None:
-        dataset.feature_count = feature_count
-    if extent_wkt is not None:
-        dataset.record.spatial_extent = func.ST_GeomFromText(extent_wkt, 4326)
-    if column_info is not None:
-        dataset.column_info = column_info
-
-    await session.commit()
-    await session.refresh(dataset)
     return dataset
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1558,7 +1558,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # feat(#1068): +1 — the guard call passes record_id, so the permission
         # authority can key an audience on the record and not only its dataset.
         # Cap 489 -> 490, exact.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 490,
+        # fix(#1170): -37 — delete the dead update_auto_metadata, the one
+        # geometry_type writer that never probed for geom_4326 (refs #1020).
+        # Cap 490 -> 453, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 453,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic


### PR DESCRIPTION
## Problem

`update_auto_metadata` (`service_metadata.py`) sets `geometry_type` with no `geom_4326` probe and has zero callers anywhere — backend, CLI, MCP, SDKs, frontend, or `openapi.json` (evidence on the issue). It is the one `geometry_type` writer that bypasses the impossibility argument recorded in #1020, purely dead code.

## Fix

Delete the function and its `__all__` entry, remove both façade lines in `domain/service.py` (import and `__all__`), and lower the `service_metadata.py` ceiling in `test_layering.py` 490 → 453 (exact new count) with a `fix(#1170)` comment.

Deletion over enforcement: a probe would be machinery guarding a function nobody invokes.

## Verification

- `uv run ruff check .` and `uv run ruff format --check .` clean
- `uv run pytest tests/test_layering.py -q` — 39 passed
- Full suite on the tree: 7013 passed, 89 skipped
- Repo-wide grep for `update_auto_metadata` matches only the cap comment

No API/schema impact (never exposed via any endpoint).

Closes #1170

https://claude.ai/code/session_01PnJqoYvwnHaFT3w4E9zNvE