### PR TITLE
docs(ingest): record the registered-table linear-geometry contract

### DIFF
--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -526,6 +526,18 @@ async def register_existing_table(
     Verifies the table exists, checks for duplicate registration,
     ensures geom_4326 column and reader access, extracts metadata,
     and creates a Dataset record.
+
+    fix(#1114): registered-table linear-geometry contract. ``geom_4326``
+    on a registered table must stay linear -- curved geometry types
+    (CIRCULARSTRING, COMPOUNDCURVE, CURVEPOLYGON, MULTICURVE,
+    MULTISURFACE) are not supported. GeoLens linearizes the column once
+    at registration (``linearize_existing_4326`` below) and does not
+    police the table afterward: registration copies no data and serves
+    from the live table, so the owner keeps writing to it directly. A
+    curved row written that way degrades vector tiles, feature reads,
+    and analysis for that dataset only; other datasets are unaffected.
+    STORED GENERATED ``geom_4326`` columns fall under the same
+    contract -- their generation expression must produce linear output.
     """
     table_name = request.table_name
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1892,7 +1892,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # pre-existing geom_4326 (savepoint + error contract mirroring the
     # add_4326_column branch beside it); see linearize_existing_4326.
     # Cap 1017 -> 1032, still exact.
-    "backend/app/processing/ingest/service.py": 1032,
+    # fix(#1114): +12 — register_existing_table docstring records the
+    # registered-table linear-geometry contract (linearize once at
+    # registration, no post-registration policing). Cap 1032 -> 1044.
+    "backend/app/processing/ingest/service.py": 1044,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.


### PR DESCRIPTION
## Problem

#1114's decision (2026-08-02, option 2: documented contract) left one in-repo residual: nothing in the source states the contract for externally-written curved geometries on registered tables. Operators who violate it do so from psql, not the import wizard, so the contract note belongs on `register_existing_table`, not in UI copy.

## Fix

A 12-line `fix(#1114)` paragraph in the `register_existing_table` docstring (`backend/app/processing/ingest/service.py`): `geom_4326` must stay linear; GeoLens linearizes once at registration (`linearize_existing_4326`) and does not police the table afterward; a curved row written directly degrades tiles, feature reads, and analysis for that dataset only; STORED GENERATED columns fall under the same contract.

`_MODULE_LOC_CAPS` bumped 1032 → 1044 in the same commit (the cap is exact both directions).

Docs-site half filed separately as geolens-io/getgeolens.com#84.

## Verification

- `uv run ruff check .` / `uv run ruff format --check .` clean
- `uv run pytest tests/test_layering.py -q` — 39 passed (re-run after rebase onto post-#1170 main)
- The five register tests in `test_analysis_curved_sources.py` untouched

Docs-only; no API/schema impact.

Closes #1114