### PR TITLE
docs(runbook): add API worker memory recycling guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -257,7 +257,10 @@ GEOLENS_ADMIN_PASSWORD=
 
 # fix(#643): recycle each API worker after this many requests — a graceful exit +
 # supervisor respawn, so slow memory growth can't ride a worker into the container
-# memory cap. Leave empty to disable; must be a positive integer (0 is invalid).
+# memory cap. Must be a positive integer (0 is invalid). Leaving it empty
+# disables recycling only for direct image runs; docker-compose.prod.yml maps
+# an unset or empty value to its own default of 10000, so disabling it there
+# means editing the compose value.
 # Type: integer (minimum 1) or empty | Default: 10000 (prod compose)
 # UVICORN_MAX_REQUESTS=10000
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -633,9 +633,13 @@ targets just need network reach to `api:8000` and `worker:8001`.
 
 Each API worker samples its own RSS from `/proc/self/status` every 60 seconds
 and exports it as the Prometheus gauge `geolens_worker_rss_bytes` (labelled by
-`pid`) on the API `/metrics` endpoint. The same sampler writes structured log
-lines, so a growth curve exists in `docker compose logs api` even if `/metrics`
-is never scraped:
+`pid`) on the API `/metrics` endpoint. One caveat when running more than one
+worker: each process has its own metrics registry and a scrape is answered by
+whichever worker takes it, so a single scrape reports one worker's gauge and
+successive scrapes alternate pid series (multiprocess aggregation is tracked
+in #651). The structured log lines the same sampler writes are therefore the
+authoritative per-worker signal, and a growth curve exists in
+`docker compose logs api` even if `/metrics` is never scraped:
 
 | Log message | Level | Meaning |
 |---|---|---|
@@ -653,9 +657,15 @@ image CMD in `Dockerfile`; `docker-compose.prod.yml` does the same and defaults
 the value to 10000). This applies to production deployments only — the
 development `docker-compose.yml` overrides that command with a `--reload`
 invocation that does not pass `--limit-max-requests`, so setting the variable
-there has no effect. A worker exits gracefully after that many requests and the
-uvicorn supervisor respawns it, so slow growth cannot ride one worker into the
-OOM killer. If the watermark WARNING still fires between recycles, lower the
+there has no effect. A worker exits gracefully after that many requests. With
+more than one worker (the production Compose default is `UVICORN_WORKERS=2`)
+the uvicorn supervisor respawns it in place, so slow growth cannot ride one
+worker into the OOM killer. With a single worker there is no supervisor: the
+process exits at the threshold and the container's restart policy
+(`restart: unless-stopped` in `docker-compose.prod.yml`) restarts it, which is
+a brief API outage per recycle — direct image deployments that keep the baked
+`UVICORN_WORKERS=1` default must run under such a policy for recycling to be
+safe. If the watermark WARNING still fires between recycles, lower the
 value; the `UVICORN_MAX_REQUESTS` entry in `.env.example` documents the value
 rules. Recycling caps the blast radius — it does not explain what grows. That
 investigation is tracked in #643.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -636,7 +636,8 @@ and exports it as the Prometheus gauge `geolens_worker_rss_bytes` (labelled by
 `pid`) on the API `/metrics` endpoint. One caveat when running more than one
 worker: each process has its own metrics registry and a scrape is answered by
 whichever worker takes it, so a single scrape reports one worker's gauge and
-successive scrapes alternate pid series (multiprocess aggregation is tracked
+successive scrapes may alternate pid series — or keep reaching the same worker
+and never observe the one that is growing (multiprocess aggregation is tracked
 in #651). The structured log lines the same sampler writes are therefore the
 authoritative per-worker signal, and a growth curve exists in
 `docker compose logs api` even if `/metrics` is never scraped:
@@ -667,7 +668,11 @@ a brief API outage per recycle — direct image deployments that keep the baked
 `UVICORN_WORKERS=1` default must run under such a policy for recycling to be
 safe. If the watermark WARNING still fires between recycles, lower the
 value; the `UVICORN_MAX_REQUESTS` entry in `.env.example` documents the value
-rules. Recycling caps the blast radius — it does not explain what grows. That
+rules. Note that under production Compose an unset or empty value falls back
+to the compose default of 10000 — disabling recycling there means editing the
+`docker-compose.prod.yml` value, not blanking the variable (blanking works
+only for direct image runs). Recycling caps the blast radius — it does not
+explain what grows. That
 investigation is tracked in #643.
 
 ### Database temp-file ceiling (`temp_file_limit`)

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -650,7 +650,10 @@ requests; the only trace outside these logs is host `dmesg` (#643).
 The backstop is bounded worker recycling via `UVICORN_MAX_REQUESTS`: when it is
 set, the api command appends uvicorn's `--limit-max-requests` (wired in the
 image CMD in `Dockerfile`; `docker-compose.prod.yml` does the same and defaults
-the value to 10000). A worker exits gracefully after that many requests and the
+the value to 10000). This applies to production deployments only — the
+development `docker-compose.yml` overrides that command with a `--reload`
+invocation that does not pass `--limit-max-requests`, so setting the variable
+there has no effect. A worker exits gracefully after that many requests and the
 uvicorn supervisor respawns it, so slow growth cannot ride one worker into the
 OOM killer. If the watermark WARNING still fires between recycles, lower the
 value; the `UVICORN_MAX_REQUESTS` entry in `.env.example` documents the value

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -629,6 +629,34 @@ targets just need network reach to `api:8000` and `worker:8001`.
 > the `geolens_db_pool_*` gauges are not emitted and `GeoLensDbPoolSaturated`
 > never fires — pool health is the provider's responsibility there.
 
+### API worker memory & recycling
+
+Each API worker samples its own RSS from `/proc/self/status` every 60 seconds
+and exports it as the Prometheus gauge `geolens_worker_rss_bytes` (labelled by
+`pid`) on the API `/metrics` endpoint. The same sampler writes structured log
+lines, so a growth curve exists in `docker compose logs api` even if `/metrics`
+is never scraped:
+
+| Log message | Level | Meaning |
+|---|---|---|
+| `API worker memory` | INFO | Startup baseline, then an hourly heartbeat (`rss_mb`, `pid`) |
+| `API worker memory above watermark` | WARNING | Worker RSS crossed 60% of the container memory limit (1200 MB fallback when no cgroup limit is readable); repeats at most every 5 minutes |
+
+A steadily climbing `rss_mb` — or the watermark WARNING — means one worker is
+heading for the container memory cap (`API_MEM_LIMIT`, default 2 GB). When it
+gets there, the cgroup OOM killer terminates that worker and drops its in-flight
+requests; the only trace outside these logs is host `dmesg` (#643).
+
+The backstop is bounded worker recycling via `UVICORN_MAX_REQUESTS`: when it is
+set, the api command appends uvicorn's `--limit-max-requests` (wired in the
+image CMD in `Dockerfile`; `docker-compose.prod.yml` does the same and defaults
+the value to 10000). A worker exits gracefully after that many requests and the
+uvicorn supervisor respawns it, so slow growth cannot ride one worker into the
+OOM killer. If the watermark WARNING still fires between recycles, lower the
+value; the `UVICORN_MAX_REQUESTS` entry in `.env.example` documents the value
+rules. Recycling caps the blast radius — it does not explain what grows. That
+investigation is tracked in #643.
+
 ### Database temp-file ceiling (`temp_file_limit`)
 
 The bundled Postgres config sets `temp_file_limit = 4GB` (`db/postgresql.conf`).


### PR DESCRIPTION
## Problem

RUNBOOK.md had zero mentions of uvicorn, max-requests, or recycling, even though `UVICORN_MAX_REQUESTS` is the shipped backstop for the #643 signature (worker RSS growth toward the container cap ending in a silent OOM kill).

## Fix

New "API worker memory & recycling" section in RUNBOOK §4 (Monitoring), between the alert-rules table and the temp-file ceiling:

- The `geolens_worker_rss_bytes` gauge and the two structured-log markers from #650 ("API worker memory" baseline/heartbeat, "API worker memory above watermark" at 60% of cgroup limit) as the per-worker signal — verified against `backend/app/observability/metrics/memory.py`. Notes that one `/metrics` scrape reports one worker (per-process registries, aggregation tracked in #651), so the logs stay authoritative.
- What `UVICORN_MAX_REQUESTS` does and when to reach for it, qualified per review: production-only (the dev compose overrides the CMD with `--reload` and no `--limit-max-requests`), in-place respawn only under `workers>1` (single-worker deployments rely on the container restart policy), and disabling under production Compose requires editing the compose value because `${UVICORN_MAX_REQUESTS:-10000}` maps an empty value to 10000.
- That last fact also corrects `.env.example`'s "leave empty to disable" rule at its source — blanking disables recycling only for direct image runs.

This is the bounded documentation slice; the root-cause investigation stays open. No `scripts/*.sh` paths named (env-doc-check rule 6).

## Verification

- `make env-doc-check` — "env-doc-check OK: 135 documented key(s) … aligned" (re-run after every revision)

Docs-only; no code, no API/schema impact.

Refs #643