### PR TITLE
feat(catalog): surface inherited keywords on analysis-derived datasets

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -311,6 +311,10 @@ async def update_dataset_metadata(
         list(dataset.tile_columns) if dataset.tile_columns is not None else None
     )
 
+    # feat(#1070): advisory warnings from the metadata chokepoint — e.g. a
+    # visibility/status change exposing inherited keywords beyond the analysis
+    # source's audience. Collected here, attached to the response below.
+    metadata_warnings: list[str] = []
     try:
         dataset = await update_user_metadata(
             db,
@@ -318,6 +322,7 @@ async def update_dataset_metadata(
             meta,
             actor_id=user.id,
             actor=user,
+            warnings_out=metadata_warnings,
         )
     except ValueError as e:
         msg = str(e)
@@ -369,7 +374,7 @@ async def update_dataset_metadata(
         db,
         [dataset.record.created_by, dataset.record.updated_by],
     )
-    return dataset_to_response(
+    response = dataset_to_response(
         dataset,
         actors_by_id=actors_by_id,
         base_url=await get_dataset_service_url(db, request=request),
@@ -380,6 +385,9 @@ async def update_dataset_metadata(
             db, dataset.record, user, user_roles
         ),
     )
+    if metadata_warnings:
+        response.metadata_warnings = metadata_warnings
+    return response
 
 
 # ROUTE-01 (Phase 1092): dual-shape decorator — both trailing-slash and

--- a/backend/app/modules/catalog/datasets/api/router_data.py
+++ b/backend/app/modules/catalog/datasets/api/router_data.py
@@ -34,6 +34,9 @@ from app.modules.catalog.datasets.domain.schemas import (
     StatusUpdateResponse,
 )
 from app.modules.catalog.maps.schemas import MapListResponse
+from app.modules.catalog.records.inherited import (
+    inherited_keyword_disclosure_warning,
+)
 from app.modules.catalog.datasets.domain.service import (
     get_dataset,
     get_dataset_rows,
@@ -318,9 +321,17 @@ async def update_publication_status(
 
     dataset.record.record_status = target
     await workflow.on_transition(context)
+    # fix(#1178 review): this endpoint writes record_status without going
+    # through update_user_metadata, so it must run the same resolved-state
+    # inherited-keyword check or the ordinary publish flow warns nobody.
+    warning = await inherited_keyword_disclosure_warning(db, dataset.record, dataset_id)
     await db.commit()
     await db.refresh(dataset)
-    return StatusUpdateResponse(id=str(dataset.id), record_status=target)
+    return StatusUpdateResponse(
+        id=str(dataset.id),
+        record_status=target,
+        metadata_warnings=[warning] if warning else None,
+    )
 
 
 @router.patch("/{dataset_id}/target-status/", response_model=StatusUpdateResponse)
@@ -394,6 +405,14 @@ async def set_target_status(
         await workflow.on_transition(context)
         idx = next_idx
 
+    # fix(#1178 review): the ordinary publish flow (DatasetPage's publish
+    # toggle) lands here, not in update_user_metadata — the resolved-state
+    # inherited-keyword check has to run after the chain completes.
+    warning = await inherited_keyword_disclosure_warning(db, dataset.record, dataset_id)
     await db.commit()
     await db.refresh(dataset)
-    return StatusUpdateResponse(id=str(dataset.id), record_status=target)
+    return StatusUpdateResponse(
+        id=str(dataset.id),
+        record_status=target,
+        metadata_warnings=[warning] if warning else None,
+    )

--- a/backend/app/modules/catalog/datasets/api/router_data.py
+++ b/backend/app/modules/catalog/datasets/api/router_data.py
@@ -324,7 +324,9 @@ async def update_publication_status(
     # fix(#1178 review): this endpoint writes record_status without going
     # through update_user_metadata, so it must run the same resolved-state
     # inherited-keyword check or the ordinary publish flow warns nobody.
-    warning = await inherited_keyword_disclosure_warning(db, dataset.record, dataset_id)
+    warning = await inherited_keyword_disclosure_warning(
+        db, dataset.record, dataset_id, actor=user
+    )
     await db.commit()
     await db.refresh(dataset)
     return StatusUpdateResponse(
@@ -408,7 +410,9 @@ async def set_target_status(
     # fix(#1178 review): the ordinary publish flow (DatasetPage's publish
     # toggle) lands here, not in update_user_metadata — the resolved-state
     # inherited-keyword check has to run after the chain completes.
-    warning = await inherited_keyword_disclosure_warning(db, dataset.record, dataset_id)
+    warning = await inherited_keyword_disclosure_warning(
+        db, dataset.record, dataset_id, actor=user
+    )
     await db.commit()
     await db.refresh(dataset)
     return StatusUpdateResponse(

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -397,6 +397,15 @@ class DatasetResponse(BaseModel):
 class StatusUpdateResponse(BaseModel):
     id: str
     record_status: str
+    metadata_warnings: list[str] | None = Field(
+        default=None,
+        description=(
+            "Advisory warnings from the status change — the same "
+            "inherited-keyword disclosure check the metadata PATCH runs "
+            "(feat #1070, fix #1178 review). The transition has already "
+            "applied."
+        ),
+    )
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -381,6 +381,15 @@ class DatasetResponse(BaseModel):
     language: str | None = Field(
         default=None, description="ISO 639-1 language code, e.g. en, fr"
     )
+    metadata_warnings: list[str] | None = Field(
+        default=None,
+        description=(
+            "Advisory warnings produced by a metadata update — e.g. a "
+            "visibility or status change exposing keywords inherited from an "
+            "analysis source the new audience cannot open (feat #1070). Only "
+            "ever set on the PATCH response; the change has already applied."
+        ),
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -271,12 +271,17 @@ async def update_user_metadata(
     *,
     actor_id: uuid.UUID | None = None,
     actor: "Identity | None" = None,
+    warnings_out: list[str] | None = None,
 ) -> Dataset:
     """Update user-editable fields including extended metadata.
 
     Accepts a DatasetMeta Pydantic model. Only updates fields that are
     explicitly set (not None). Raises ValueError if dataset not found.
     Does not commit; caller controls transaction scope.
+
+    ``warnings_out``, when provided, collects advisory (non-blocking) warnings
+    for the caller to surface — currently the inherited-keyword disclosure
+    check below (feat #1070).
 
     Decomposed into 5 step helpers for readability:
     simple field assignments, visibility, record_status, is_dem, embedding-defer.
@@ -317,6 +322,31 @@ async def update_user_metadata(
         )
     if meta.is_dem is not None:
         mutated_flags.append(await _apply_is_dem(session, dataset_id, meta.is_dem))
+
+    # feat(#1070): after the visibility/record_status helpers resolve, ask —
+    # of the RESOLVED state, so both widening axes route through this one
+    # check — whether keywords inherited from the analysis source now reach
+    # anyone who cannot open that source. Advisory, never blocking: exposure
+    # requires the owner's deliberate act on metadata they can already edit,
+    # so the owner is told, not stopped.
+    if meta.visibility is not None or meta.record_status is not None:
+        from app.modules.catalog.records.inherited import (
+            disclosed_inherited_keywords,
+        )
+
+        disclosed = await disclosed_inherited_keywords(session, record, dataset_id)
+        if disclosed:
+            logger.warning(
+                "dataset.inherited_keywords_reach_beyond_source",
+                dataset_id=str(dataset_id),
+                keywords=disclosed,
+            )
+            if warnings_out is not None:
+                warnings_out.append(
+                    "Keywords inherited from the source dataset are now "
+                    "visible to people who cannot open that source: "
+                    + ", ".join(disclosed)
+                )
 
     if actor_id is not None and any(mutated_flags):
         record.updated_by = actor_id

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -338,7 +338,7 @@ async def update_user_metadata(
         )
 
         warning = await inherited_keyword_disclosure_warning(
-            session, record, dataset_id
+            session, record, dataset_id, actor=actor
         )
         if warning is not None and warnings_out is not None:
             warnings_out.append(warning)

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -328,25 +328,20 @@ async def update_user_metadata(
     # check — whether keywords inherited from the analysis source now reach
     # anyone who cannot open that source. Advisory, never blocking: exposure
     # requires the owner's deliberate act on metadata they can already edit,
-    # so the owner is told, not stopped.
+    # so the owner is told, not stopped. fix(#1178 review): the check is a
+    # shared helper because the publication-status endpoints write
+    # record_status without coming through here — see its docstring for the
+    # writer enumeration.
     if meta.visibility is not None or meta.record_status is not None:
         from app.modules.catalog.records.inherited import (
-            disclosed_inherited_keywords,
+            inherited_keyword_disclosure_warning,
         )
 
-        disclosed = await disclosed_inherited_keywords(session, record, dataset_id)
-        if disclosed:
-            logger.warning(
-                "dataset.inherited_keywords_reach_beyond_source",
-                dataset_id=str(dataset_id),
-                keywords=disclosed,
-            )
-            if warnings_out is not None:
-                warnings_out.append(
-                    "Keywords inherited from the source dataset are now "
-                    "visible to people who cannot open that source: "
-                    + ", ".join(disclosed)
-                )
+        warning = await inherited_keyword_disclosure_warning(
+            session, record, dataset_id
+        )
+        if warning is not None and warnings_out is not None:
+            warnings_out.append(warning)
 
     if actor_id is not None and any(mutated_flags):
         record.updated_by = actor_id

--- a/backend/app/modules/catalog/records/inherited.py
+++ b/backend/app/modules/catalog/records/inherited.py
@@ -38,7 +38,9 @@ import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.identity import Identity
 from app.modules.auth.models import User
+from app.modules.catalog.authorization import get_user_roles, visible_derived_from
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
     DatasetGrant,
@@ -179,7 +181,11 @@ async def audience_exceeds_source(
 
 
 async def disclosed_inherited_keywords(
-    session: AsyncSession, record: Record, dataset_id: uuid.UUID | None
+    session: AsyncSession,
+    record: Record,
+    dataset_id: uuid.UUID | None,
+    *,
+    actor: "Identity | None",
 ) -> list[str]:
     """Inherited keywords readable, at the record's CURRENT state, by someone
     who cannot open the source. Empty when there is nothing to warn about.
@@ -188,7 +194,27 @@ async def disclosed_inherited_keywords(
     visibility or record_status change resolves — keyed off resolved state, so
     both widening axes (visibility, and record_status to published) route
     through one check.
+
+    fix(#1178 review r2): gated on ``actor``'s access to the SOURCE, with the
+    same ``visible_derived_from`` rule the keywords endpoint applies. Without
+    it this function was a membership oracle: an output owner who had LOST
+    access to a now-private source could add a guessed keyword to their own
+    record, send a no-op metadata PATCH, and read the warning as confirmation
+    that the guess exists on the inaccessible source. An actor who cannot
+    access the source therefore gets no disclosure warning either — the
+    accepted consequence of the redaction rule, since warning them would
+    disclose the very association the redaction hides.
     """
+    # Settle "not derived at all" before any query — role resolution and the
+    # gate itself only make sense once there is a source to gate.
+    if not record.derived_from:
+        return []
+    actor_roles = set() if actor is None else await get_user_roles(session, actor)
+    source_ref = await visible_derived_from(
+        session, record.derived_from, actor, actor_roles
+    )
+    if source_ref is None:
+        return []
     source = await resolve_inherited_source(session, record)
     if source is None:
         return []
@@ -203,7 +229,11 @@ async def disclosed_inherited_keywords(
 
 
 async def inherited_keyword_disclosure_warning(
-    session: AsyncSession, record: Record, dataset_id: uuid.UUID | None
+    session: AsyncSession,
+    record: Record,
+    dataset_id: uuid.UUID | None,
+    *,
+    actor: "Identity | None",
 ) -> str | None:
     """The advisory warning every resolved-state audience writer emits, or None.
 
@@ -222,8 +252,15 @@ async def inherited_keyword_disclosure_warning(
     analysis-derived — ``derived_from`` and inherited keywords are written by
     ``apply_analysis_provenance`` on outputs registered private — and a
     worker has no owner on the wire to warn.
+
+    ``actor`` is the account making the change; the disclosure check reads
+    the source's keywords, so it is gated on the actor's access to the source
+    (see ``disclosed_inherited_keywords`` — fix #1178 review r2). No access,
+    no warning.
     """
-    disclosed = await disclosed_inherited_keywords(session, record, dataset_id)
+    disclosed = await disclosed_inherited_keywords(
+        session, record, dataset_id, actor=actor
+    )
     if not disclosed:
         return None
     logger.warning(

--- a/backend/app/modules/catalog/records/inherited.py
+++ b/backend/app/modules/catalog/records/inherited.py
@@ -1,0 +1,190 @@
+"""Inherited-keyword derivation for analysis-derived records (feat #1070).
+
+``apply_analysis_provenance`` copies the source record's keyword rows onto a
+materialized analysis output. Nothing marks those rows, by decision: marking
+them would cost a migration and a backfill, while the inherited set is
+recoverable at read time by resolving ``Record.derived_from`` to the source
+record and intersecting keyword sets. That derivation lives here.
+
+Two questions, two audiences:
+
+* Which of this record's keywords are inherited? The intersection of its
+  keyword triples with the source record's. Read-side callers gate this on the
+  requester being able to access the source (the ``visible_derived_from``
+  rule), so a requester who cannot see the source also cannot tell "not
+  derived" from "derived from something you cannot see".
+* Does this record's audience reach beyond the source's? Asked of the
+  permission authority via ``record_audience`` (#1068), so an overlay's policy
+  answers rather than a restatement of the community ladder. This is what
+  makes an inherited keyword worth warning about: it is only consequential
+  when someone who cannot open the source can read it here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.auth.models import User
+from app.modules.catalog.datasets.domain.models import (
+    Dataset,
+    DatasetGrant,
+    Record,
+    RecordKeyword,
+)
+from app.platform.extensions import get_permission_extension
+from app.platform.extensions.protocols import RecordAudienceQuery
+
+KeywordKey = tuple[str, str | None, str]
+"""(keyword, vocabulary_uri, keyword_type) — the copied columns, so identity
+matches what ``apply_analysis_provenance``'s INSERT..SELECT carried across."""
+
+
+@dataclass(frozen=True)
+class InheritedSource:
+    """The dataset a record was derived from, resolved to its catalog record."""
+
+    dataset_id: uuid.UUID
+    record: Record
+
+
+async def resolve_inherited_source(
+    session: AsyncSession, record: Record
+) -> InheritedSource | None:
+    """The source record ``record`` inherited keywords from, or None.
+
+    None for a record that is not analysis-derived, for an unparseable
+    ``derived_from.dataset_id``, and for a source dataset that has since been
+    deleted — in every case there is nothing left to attribute inheritance to,
+    matching how ``visible_derived_from`` treats a gone source.
+    """
+    derived_from = record.derived_from
+    raw = derived_from.get("dataset_id") if isinstance(derived_from, dict) else None
+    try:
+        source_dataset_id = uuid.UUID(str(raw))
+    except (TypeError, ValueError):
+        return None
+    source_record = (
+        await session.execute(
+            select(Record)
+            .join(Dataset, Dataset.record_id == Record.id)
+            .where(Dataset.id == source_dataset_id)
+        )
+    ).scalar_one_or_none()
+    if source_record is None:
+        return None
+    return InheritedSource(dataset_id=source_dataset_id, record=source_record)
+
+
+async def inherited_keyword_keys(
+    session: AsyncSession, record: Record, source: InheritedSource
+) -> set[KeywordKey]:
+    """Keyword triples present on BOTH the record and its source.
+
+    The intersection, not the source set: a copied keyword the owner has since
+    deleted is no longer theirs to disclose, and a keyword they typed that
+    happens to match one on the source is indistinguishable from the copy —
+    treating it as inherited errs toward warning, which is the cheap error.
+    """
+    own = select(
+        RecordKeyword.keyword,
+        RecordKeyword.vocabulary_uri,
+        RecordKeyword.keyword_type,
+    ).where(RecordKeyword.record_id == record.id)
+    theirs = select(
+        RecordKeyword.keyword,
+        RecordKeyword.vocabulary_uri,
+        RecordKeyword.keyword_type,
+    ).where(RecordKeyword.record_id == source.record.id)
+    rows = await session.execute(own.intersect(theirs))
+    return {(row[0], row[1], row[2]) for row in rows.all()}
+
+
+async def audience_exceeds_source(
+    session: AsyncSession,
+    *,
+    record: Record,
+    dataset_id: uuid.UUID | None,
+    source: InheritedSource,
+    visibility: str | None = None,
+    record_status: str | None = None,
+) -> bool:
+    """Can anyone read ``record`` who cannot read its source?
+
+    ``visibility`` / ``record_status`` override the record's stored state so a
+    caller can ask the counterfactual — "would publishing this widen past the
+    source?" — which is the publish-moment question #1070 exists for.
+
+    An authority without ``record_audience`` cannot answer, and an
+    unanswerable question is not evidence the audiences nest — so it warns.
+    Over-warning is the cheap error here: this gates prose in a dialog, not a
+    row in a result set.
+
+    The NULL handling (``IS NOT false`` / ``IS NOT true``) follows
+    ``_stranded_viewer_exists`` in ``maps/service_public.py``: an overlay
+    predicate that cannot classify an account must send it to the warning
+    side, not silently out of the WHERE.
+    """
+    permission = get_permission_extension()
+    if getattr(type(permission), "record_audience", None) is None:
+        return True
+    derived_audience = await permission.record_audience(
+        RecordAudienceQuery(
+            dataset_id=dataset_id,
+            record_id=record.id,
+            owner_id=record.created_by,
+            visibility=visibility or record.visibility,
+            record_status=record_status or record.record_status,
+        ),
+        User,
+        grant_cls=DatasetGrant,
+    )
+    source_audience = await permission.record_audience(
+        RecordAudienceQuery(
+            dataset_id=source.dataset_id,
+            record_id=source.record.id,
+            owner_id=source.record.created_by,
+            visibility=source.record.visibility,
+            record_status=source.record.record_status,
+        ),
+        User,
+        grant_cls=DatasetGrant,
+    )
+    if derived_audience.includes_anonymous and not source_audience.includes_anonymous:
+        return True
+    stmt = (
+        select(User.id)
+        .where(User.is_active.is_(True))
+        .where(User.status == "active")
+        .where(derived_audience.users.is_not(False))
+        .where(source_audience.users.is_not(True))
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none() is not None
+
+
+async def disclosed_inherited_keywords(
+    session: AsyncSession, record: Record, dataset_id: uuid.UUID | None
+) -> list[str]:
+    """Inherited keywords readable, at the record's CURRENT state, by someone
+    who cannot open the source. Empty when there is nothing to warn about.
+
+    The single question the ``update_user_metadata`` chokepoint asks after a
+    visibility or record_status change resolves — keyed off resolved state, so
+    both widening axes (visibility, and record_status to published) route
+    through one check.
+    """
+    source = await resolve_inherited_source(session, record)
+    if source is None:
+        return []
+    keys = await inherited_keyword_keys(session, record, source)
+    if not keys:
+        return []
+    if not await audience_exceeds_source(
+        session, record=record, dataset_id=dataset_id, source=source
+    ):
+        return []
+    return sorted({key[0] for key in keys})

--- a/backend/app/modules/catalog/records/inherited.py
+++ b/backend/app/modules/catalog/records/inherited.py
@@ -18,6 +18,15 @@ Two questions, two audiences:
   answers rather than a restatement of the community ladder. This is what
   makes an inherited keyword worth warning about: it is only consequential
   when someone who cannot open the source can read it here.
+
+Accepted limitation (#1178 review): deleting a keyword on the SOURCE also
+empties the intersection here, so the copied row on the derived record loses
+its badge and stops triggering the publish-moment warning even though the
+copy still exists. That is the read-time route working as decided: row
+marking was rejected (it costs a migration and a backfill), and a source
+that no longer carries the keyword no longer has its association disclosed
+by it — the copy is just a word the owner can keep or delete. Revisit only
+if the read-time derivation route is itself replaced.
 """
 
 from __future__ import annotations
@@ -25,6 +34,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 
+import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -37,6 +47,8 @@ from app.modules.catalog.datasets.domain.models import (
 )
 from app.platform.extensions import get_permission_extension
 from app.platform.extensions.protocols import RecordAudienceQuery
+
+logger = structlog.stdlib.get_logger(__name__)
 
 KeywordKey = tuple[str, str | None, str]
 """(keyword, vocabulary_uri, keyword_type) — the copied columns, so identity
@@ -188,3 +200,38 @@ async def disclosed_inherited_keywords(
     ):
         return []
     return sorted({key[0] for key in keys})
+
+
+async def inherited_keyword_disclosure_warning(
+    session: AsyncSession, record: Record, dataset_id: uuid.UUID | None
+) -> str | None:
+    """The advisory warning every resolved-state audience writer emits, or None.
+
+    fix(#1178 review): the check lived inline in ``update_user_metadata`` and
+    the ordinary publish flow bypassed it — ``set_target_status`` writes
+    ``record_status`` directly, so a draft public analysis output published
+    with no warning. One shared helper, called AFTER each writer resolves the
+    new state, is the boundary that keeps the next status writer from
+    reopening the gap. Current callers: ``update_user_metadata``
+    (metadata PATCH, both axes) and the two publication-status endpoints in
+    ``datasets/api/router_data.py``.
+
+    Creation-time writers are deliberately not callers: ingest finalize
+    (``processing/ingest/tasks_common.py``) and the registration paths assign
+    an initial status/visibility to a record that cannot yet be
+    analysis-derived — ``derived_from`` and inherited keywords are written by
+    ``apply_analysis_provenance`` on outputs registered private — and a
+    worker has no owner on the wire to warn.
+    """
+    disclosed = await disclosed_inherited_keywords(session, record, dataset_id)
+    if not disclosed:
+        return None
+    logger.warning(
+        "dataset.inherited_keywords_reach_beyond_source",
+        dataset_id=str(dataset_id),
+        keywords=disclosed,
+    )
+    return (
+        "Keywords inherited from the source dataset are now visible to "
+        "people who cannot open that source: " + ", ".join(disclosed)
+    )

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -15,6 +15,7 @@ from app.modules.auth.dependencies import get_optional_user, require_permission
 from app.modules.catalog.authorization import (
     check_dataset_access_or_anonymous,
     get_user_roles,
+    visible_derived_from,
 )
 from app.core.dependencies import get_db
 from app.platform.cache.tiles import invalidate_catalog_cache
@@ -36,6 +37,11 @@ from app.modules.catalog.records.schemas import (
     TranslationResponse,
     TranslationUpsert,
     normalize_language_tag,
+)
+from app.modules.catalog.records.inherited import (
+    audience_exceeds_source,
+    inherited_keyword_keys,
+    resolve_inherited_source,
 )
 from app.modules.catalog.records.service import (
     create_contact,
@@ -482,18 +488,71 @@ async def list_keywords_endpoint(
     record_id: uuid.UUID,
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=500),
+    audience_visibility: str | None = Query(
+        None,
+        pattern="^(private|restricted|internal|public)$",
+        description=(
+            "Compute inherited_audience_gap as if the record had this "
+            "visibility — the counterfactual an owner asks before widening "
+            "access (feat #1070). Keywords themselves are unaffected."
+        ),
+    ),
+    audience_record_status: str | None = Query(
+        None,
+        max_length=30,
+        description=(
+            "Compute inherited_audience_gap as if the record had this status — "
+            "the counterfactual an owner asks before publishing (feat #1070)."
+        ),
+    ),
     user: Identity | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
 ) -> KeywordListResponse:
-    """List all keywords for a record."""
+    """List all keywords for a record, marking analysis-inherited ones."""
     await _check_record_read_access(db, record_id, user)
     keywords, total = (
         await list_keywords(db, record_id, skip=skip, limit=limit),
         await count_keywords(db, record_id),
     )
+
+    # feat(#1070): derive the inherited set from derived_from at read time.
+    # Gated exactly like the derived_from reference itself: a requester who
+    # cannot access the source gets all-false flags, so the flags cannot tell
+    # them "derived from something you cannot see" (#765's rule).
+    inherited_keys: set[tuple[str, str | None, str]] = set()
+    audience_gap = False
+    record = await get_record(db, record_id)
+    if record is not None and record.derived_from:
+        user_roles = await get_user_roles(db, user) if user is not None else set()
+        visible = await visible_derived_from(db, record.derived_from, user, user_roles)
+        if visible is not None:
+            source = await resolve_inherited_source(db, record)
+            if source is not None:
+                inherited_keys = await inherited_keyword_keys(db, record, source)
+                if inherited_keys:
+                    dataset_id = (
+                        await db.execute(
+                            select(Dataset.id).where(Dataset.record_id == record_id)
+                        )
+                    ).scalar_one_or_none()
+                    audience_gap = await audience_exceeds_source(
+                        db,
+                        record=record,
+                        dataset_id=dataset_id,
+                        source=source,
+                        visibility=audience_visibility,
+                        record_status=audience_record_status,
+                    )
+
+    def _to_response(k) -> KeywordResponse:
+        resp = KeywordResponse.model_validate(k)
+        resp.inherited = (k.keyword, k.vocabulary_uri, k.keyword_type) in inherited_keys
+        return resp
+
     return KeywordListResponse(
-        keywords=[KeywordResponse.model_validate(k) for k in keywords],
+        keywords=[_to_response(k) for k in keywords],
         total=total,
+        inherited_audience_gap=audience_gap,
     )
 
 

--- a/backend/app/modules/catalog/records/schemas.py
+++ b/backend/app/modules/catalog/records/schemas.py
@@ -161,6 +161,15 @@ class KeywordResponse(BaseModel):
     keyword: str
     vocabulary_uri: str | None
     keyword_type: str
+    inherited: bool = Field(
+        default=False,
+        description=(
+            "True when this keyword also exists on the dataset this record was "
+            "derived from (feat #1070). Derived at read time from derived_from; "
+            "only ever true for a requester who can access that source dataset, "
+            "so everyone else sees false — matching the derived_from redaction."
+        ),
+    )
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -168,6 +177,15 @@ class KeywordResponse(BaseModel):
 class KeywordListResponse(BaseModel):
     keywords: list[KeywordResponse]
     total: int
+    inherited_audience_gap: bool = Field(
+        default=False,
+        description=(
+            "True when at least one keyword is inherited AND this record's "
+            "audience — at its stored state, or at the counterfactual "
+            "audience_visibility/audience_record_status query parameters — "
+            "includes someone who cannot open the source dataset (feat #1070)."
+        ),
+    )
 
 
 # --- Distributions ---

--- a/backend/app/processing/analysis/provenance.py
+++ b/backend/app/processing/analysis/provenance.py
@@ -256,8 +256,9 @@ async def apply_analysis_provenance(
       who already held access to the source, so an inherited keyword reaches
       anyone else only when that owner publishes or shares the dataset. That
       is their deliberate act, on ordinary editable record metadata they can
-      delete first. Warning an owner what they inherited before they publish
-      is #1070.
+      delete first. The inherited set is derived back out of ``derived_from``
+      at read time (records/inherited.py, feat #1070), which is what marks the
+      keywords in the UI and warns the owner at the publish moment.
     * The source (and mask) title inside the lineage sentence. The output is
       registered private and owned by that same caller, so the title only
       reaches anyone else if its owner publishes or shares the dataset —

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -16356,6 +16356,21 @@
             "title": "Id",
             "type": "string"
           },
+          "metadata_warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Advisory warnings from the status change \u2014 the same inherited-keyword disclosure check the metadata PATCH runs (feat #1070, fix #1178 review). The transition has already applied.",
+            "title": "Metadata Warnings"
+          },
           "record_status": {
             "title": "Record Status",
             "type": "string"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5315,6 +5315,21 @@
             "description": "Free-text provenance / lineage statement",
             "title": "Lineage Summary"
           },
+          "metadata_warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Advisory warnings produced by a metadata update \u2014 e.g. a visibility or status change exposing keywords inherited from an analysis source the new audience cannot open (feat #1070). Only ever set on the PATCH response; the change has already applied.",
+            "title": "Metadata Warnings"
+          },
           "n_dims": {
             "anyOf": [
               {
@@ -7844,6 +7859,12 @@
       },
       "KeywordListResponse": {
         "properties": {
+          "inherited_audience_gap": {
+            "default": false,
+            "description": "True when at least one keyword is inherited AND this record's audience \u2014 at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters \u2014 includes someone who cannot open the source dataset (feat #1070).",
+            "title": "Inherited Audience Gap",
+            "type": "boolean"
+          },
           "keywords": {
             "items": {
               "$ref": "#/components/schemas/KeywordResponse"
@@ -7869,6 +7890,12 @@
             "format": "uuid",
             "title": "Id",
             "type": "string"
+          },
+          "inherited": {
+            "default": false,
+            "description": "True when this keyword also exists on the dataset this record was derived from (feat #1070). Derived at read time from derived_from; only ever true for a requester who can access that source dataset, so everyone else sees false \u2014 matching the derived_from redaction.",
+            "title": "Inherited",
+            "type": "boolean"
           },
           "keyword": {
             "title": "Keyword",
@@ -48241,7 +48268,7 @@
     },
     "/records/{record_id}/keywords/": {
       "get": {
-        "description": "List all keywords for a record.",
+        "description": "List all keywords for a record, marking analysis-inherited ones.",
         "operationId": "list_keywords_endpoint_records__record_id__keywords__get",
         "parameters": [
           {
@@ -48275,6 +48302,44 @@
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Compute inherited_audience_gap as if the record had this visibility \u2014 the counterfactual an owner asks before widening access (feat #1070). Keywords themselves are unaffected.",
+            "in": "query",
+            "name": "audience_visibility",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^(private|restricted|internal|public)$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Compute inherited_audience_gap as if the record had this visibility \u2014 the counterfactual an owner asks before widening access (feat #1070). Keywords themselves are unaffected.",
+              "title": "Audience Visibility"
+            }
+          },
+          {
+            "description": "Compute inherited_audience_gap as if the record had this status \u2014 the counterfactual an owner asks before publishing (feat #1070).",
+            "in": "query",
+            "name": "audience_record_status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 30,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Compute inherited_audience_gap as if the record had this status \u2014 the counterfactual an owner asks before publishing (feat #1070).",
+              "title": "Audience Record Status"
             }
           }
         ],

--- a/backend/tests/test_inherited_keywords.py
+++ b/backend/tests/test_inherited_keywords.py
@@ -1,0 +1,372 @@
+"""Inherited-keyword derivation and disclosure warnings (feat #1070).
+
+An analysis output carries a COPY of its source record's keywords
+(``apply_analysis_provenance``); nothing marks the copied rows. These tests
+pin the read-time derivation in ``records/inherited.py``: the inherited set is
+the intersection of the record's keyword triples with its ``derived_from``
+source's, the keywords endpoint marks it (gated on source access, like the
+``derived_from`` reference itself), and the ``update_user_metadata``
+chokepoint warns — on BOTH widening axes, visibility and record_status —
+when the resolved state lets someone who cannot open the source read them.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.auth.models import User
+from app.modules.catalog.datasets.domain.models import (
+    Dataset,
+    Record,
+    RecordKeyword,
+)
+from app.modules.catalog.datasets.domain.schemas import DatasetMeta
+from app.modules.catalog.datasets.domain.service import update_user_metadata
+from app.modules.catalog.records.inherited import (
+    disclosed_inherited_keywords,
+    inherited_keyword_keys,
+    resolve_inherited_source,
+)
+
+from tests.factories import create_dataset, get_user_id
+
+pytestmark = pytest.mark.anyio
+
+
+async def _derived_pair(
+    session: AsyncSession,
+    owner_id: uuid.UUID,
+    *,
+    source_visibility: str = "private",
+    derived_visibility: str = "private",
+    derived_status: str = "published",
+    source_keywords: tuple[str, ...] = ("codename",),
+    copy_keywords: bool = True,
+    own_keywords: tuple[str, ...] = (),
+) -> tuple[Dataset, Dataset, Record, Record]:
+    """A source dataset and a dataset derived from it, keywords included.
+
+    Constructs its own rows rather than running the worker's materialize path:
+    the derivation under test reads only ``derived_from`` and the keyword
+    tables, and building the absence cases (no copy, deleted source) needs
+    direct control over both.
+    """
+    source = await create_dataset(
+        session,
+        created_by=owner_id,
+        visibility=source_visibility,
+        name=f"Source {uuid.uuid4().hex[:6]}",
+    )
+    derived = await create_dataset(
+        session,
+        created_by=owner_id,
+        visibility=derived_visibility,
+        record_status=derived_status,
+        name=f"Derived {uuid.uuid4().hex[:6]}",
+    )
+    source_record = await session.get(Record, source.record_id)
+    derived_record = await session.get(Record, derived.record_id)
+    assert source_record is not None and derived_record is not None
+    for kw in source_keywords:
+        session.add(
+            RecordKeyword(record_id=source_record.id, keyword=kw, keyword_type="theme")
+        )
+        if copy_keywords:
+            session.add(
+                RecordKeyword(
+                    record_id=derived_record.id, keyword=kw, keyword_type="theme"
+                )
+            )
+    for kw in own_keywords:
+        session.add(
+            RecordKeyword(record_id=derived_record.id, keyword=kw, keyword_type="theme")
+        )
+    derived_record.derived_from = {
+        "dataset_id": str(source.id),
+        "operation": "buffer",
+        "params": {},
+        "created_at": "2026-08-03T00:00:00+00:00",
+    }
+    await session.commit()
+    return source, derived, source_record, derived_record
+
+
+async def _add_plain_user(session: AsyncSession) -> User:
+    """An active, role-less, non-admin account this test constructs itself.
+
+    The audience-gap query needs a real signed-in account standing in the
+    widened audience; admin fixtures cannot serve (admins are in every
+    audience), and borrowing a shared fixture role would couple the test to
+    fixture ordering.
+    """
+    user = User(
+        username=f"plain_{uuid.uuid4().hex[:10]}",
+        email=f"plain_{uuid.uuid4().hex[:10]}@example.com",
+        is_active=True,
+        status="active",
+    )
+    session.add(user)
+    await session.commit()
+    return user
+
+
+class TestInheritedDerivation:
+    async def test_inherited_set_is_the_intersection(
+        self, test_db_session: AsyncSession
+    ):
+        """Only keywords present on BOTH records count as inherited."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, _, _, derived_record = await _derived_pair(
+            test_db_session,
+            admin_id,
+            source_keywords=("codename", "deleted-after-copy"),
+            copy_keywords=False,
+            own_keywords=("codename", "riverine"),
+        )
+        source = await resolve_inherited_source(test_db_session, derived_record)
+        assert source is not None
+        keys = await inherited_keyword_keys(test_db_session, derived_record, source)
+        assert keys == {("codename", None, "theme")}
+
+    async def test_record_without_derived_from_has_no_source(
+        self, test_db_session: AsyncSession
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(test_db_session, created_by=admin_id)
+        record = await test_db_session.get(Record, ds.record_id)
+        assert await resolve_inherited_source(test_db_session, record) is None
+
+    async def test_deleted_source_dataset_yields_no_source(
+        self, test_db_session: AsyncSession
+    ):
+        """A gone source leaves nothing to attribute inheritance to."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        source, _, _, derived_record = await _derived_pair(test_db_session, admin_id)
+        await test_db_session.delete(source)
+        await test_db_session.commit()
+        assert await resolve_inherited_source(test_db_session, derived_record) is None
+
+    async def test_unparseable_source_id_yields_no_source(
+        self, test_db_session: AsyncSession
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, _, _, derived_record = await _derived_pair(test_db_session, admin_id)
+        derived_record.derived_from = {"dataset_id": "not-a-uuid"}
+        await test_db_session.commit()
+        assert await resolve_inherited_source(test_db_session, derived_record) is None
+
+
+class TestDisclosureWarning:
+    """The update_user_metadata chokepoint, keyed off resolved state."""
+
+    async def test_warning_fires_on_visibility_widening(
+        self, test_db_session: AsyncSession
+    ):
+        """Axis 1: internal -> public reaches anonymous; a private source does not."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, derived, _, _ = await _derived_pair(
+            test_db_session, admin_id, derived_visibility="internal"
+        )
+        warnings: list[str] = []
+        await update_user_metadata(
+            test_db_session,
+            derived.id,
+            DatasetMeta(visibility="public"),
+            warnings_out=warnings,
+        )
+        await test_db_session.commit()
+        assert len(warnings) == 1
+        assert "codename" in warnings[0]
+
+    async def test_warning_fires_on_publish(self, test_db_session: AsyncSession):
+        """Axis 2: record_status internal -> published widens to all signed-in."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        await _add_plain_user(test_db_session)
+        _, derived, _, _ = await _derived_pair(
+            test_db_session,
+            admin_id,
+            derived_visibility="internal",
+            derived_status="internal",
+        )
+        warnings: list[str] = []
+        await update_user_metadata(
+            test_db_session,
+            derived.id,
+            DatasetMeta(record_status="published"),
+            warnings_out=warnings,
+        )
+        await test_db_session.commit()
+        assert len(warnings) == 1
+        assert "codename" in warnings[0]
+
+    async def test_no_warning_without_inherited_keywords(
+        self, test_db_session: AsyncSession
+    ):
+        """The same widening move is silent when nothing was inherited."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, derived, _, _ = await _derived_pair(
+            test_db_session,
+            admin_id,
+            derived_visibility="internal",
+            copy_keywords=False,
+            own_keywords=("riverine",),
+        )
+        warnings: list[str] = []
+        await update_user_metadata(
+            test_db_session,
+            derived.id,
+            DatasetMeta(visibility="public"),
+            warnings_out=warnings,
+        )
+        await test_db_session.commit()
+        assert warnings == []
+
+    async def test_no_warning_when_source_audience_covers(
+        self, test_db_session: AsyncSession
+    ):
+        """A public+published source is readable by everyone the move admits."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, derived, _, _ = await _derived_pair(
+            test_db_session,
+            admin_id,
+            source_visibility="public",
+            derived_visibility="internal",
+        )
+        warnings: list[str] = []
+        await update_user_metadata(
+            test_db_session,
+            derived.id,
+            DatasetMeta(visibility="public"),
+            warnings_out=warnings,
+        )
+        await test_db_session.commit()
+        assert warnings == []
+
+    async def test_no_warning_on_non_audience_edit(self, test_db_session: AsyncSession):
+        """A title edit never asks the audience question, gap or no gap."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, derived, _, _ = await _derived_pair(
+            test_db_session, admin_id, derived_visibility="internal"
+        )
+        warnings: list[str] = []
+        await update_user_metadata(
+            test_db_session,
+            derived.id,
+            DatasetMeta(title="Renamed, audience untouched"),
+            warnings_out=warnings,
+        )
+        await test_db_session.commit()
+        assert warnings == []
+
+    async def test_disclosed_list_survives_a_deleted_source(
+        self, test_db_session: AsyncSession
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        source, derived, _, derived_record = await _derived_pair(
+            test_db_session, admin_id, derived_visibility="public"
+        )
+        await test_db_session.delete(source)
+        await test_db_session.commit()
+        assert (
+            await disclosed_inherited_keywords(
+                test_db_session, derived_record, derived.id
+            )
+            == []
+        )
+
+
+class TestKeywordsEndpointShape:
+    async def test_inherited_flags_and_counterfactual_gap(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, _, _, derived_record = await _derived_pair(
+            test_db_session, admin_id, own_keywords=("riverine",)
+        )
+
+        resp = await client.get(
+            f"/records/{derived_record.id}/keywords/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        flags = {k["keyword"]: k["inherited"] for k in body["keywords"]}
+        assert flags == {"codename": True, "riverine": False}
+        # Private derived, private source, same owner: the audiences coincide.
+        assert body["inherited_audience_gap"] is False
+
+        # The counterfactual an owner asks before widening: at public+published
+        # the audience includes anonymous, which a private source never does.
+        resp = await client.get(
+            f"/records/{derived_record.id}/keywords/"
+            "?audience_visibility=public&audience_record_status=published",
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["inherited_audience_gap"] is True
+
+    async def test_flags_redacted_without_source_access(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """A requester who cannot open the source sees all-false flags —
+        indistinguishable from a record that was never derived (#765's rule)."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, _, _, derived_record = await _derived_pair(
+            test_db_session, admin_id, derived_visibility="public"
+        )
+
+        resp = await client.get(
+            f"/records/{derived_record.id}/keywords/", headers=viewer_auth_header
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert [k["inherited"] for k in body["keywords"]] == [False]
+        assert body["inherited_audience_gap"] is False
+
+        # The owner-side view of the SAME record does resolve the flags.
+        resp = await client.get(
+            f"/records/{derived_record.id}/keywords/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200, resp.text
+        assert [k["inherited"] for k in resp.json()["keywords"]] == [True]
+
+
+class TestPatchWarningSurface:
+    async def test_patch_response_carries_metadata_warnings(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, derived, _, _ = await _derived_pair(
+            test_db_session, admin_id, derived_visibility="internal"
+        )
+        resp = await client.patch(
+            f"/datasets/{derived.id}",
+            json={"visibility": "public"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        warnings = resp.json()["metadata_warnings"]
+        assert warnings and "codename" in warnings[0]
+
+        # The move applied — the warning is advisory, not a refusal.
+        resp = await client.patch(
+            f"/datasets/{derived.id}",
+            json={"title": "still public"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["metadata_warnings"] is None

--- a/backend/tests/test_inherited_keywords.py
+++ b/backend/tests/test_inherited_keywords.py
@@ -17,6 +17,7 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.auth.models import User
@@ -48,6 +49,7 @@ async def _derived_pair(
     source_keywords: tuple[str, ...] = ("codename",),
     copy_keywords: bool = True,
     own_keywords: tuple[str, ...] = (),
+    derived_owner_id: uuid.UUID | None = None,
 ) -> tuple[Dataset, Dataset, Record, Record]:
     """A source dataset and a dataset derived from it, keywords included.
 
@@ -64,7 +66,7 @@ async def _derived_pair(
     )
     derived = await create_dataset(
         session,
-        created_by=owner_id,
+        created_by=derived_owner_id if derived_owner_id is not None else owner_id,
         visibility=derived_visibility,
         record_status=derived_status,
         name=f"Derived {uuid.uuid4().hex[:6]}",
@@ -94,6 +96,11 @@ async def _derived_pair(
     }
     await session.commit()
     return source, derived, source_record, derived_record
+
+
+async def _user_row(session: AsyncSession, user_id: uuid.UUID) -> User:
+    """The concrete User row for an id — the actor the disclosure gate reads."""
+    return (await session.execute(select(User).where(User.id == user_id))).scalar_one()
 
 
 async def _add_plain_user(session: AsyncSession) -> User:
@@ -177,6 +184,7 @@ class TestDisclosureWarning:
             test_db_session,
             derived.id,
             DatasetMeta(visibility="public"),
+            actor=await _user_row(test_db_session, admin_id),
             warnings_out=warnings,
         )
         await test_db_session.commit()
@@ -198,6 +206,7 @@ class TestDisclosureWarning:
             test_db_session,
             derived.id,
             DatasetMeta(record_status="published"),
+            actor=await _user_row(test_db_session, admin_id),
             warnings_out=warnings,
         )
         await test_db_session.commit()
@@ -221,6 +230,7 @@ class TestDisclosureWarning:
             test_db_session,
             derived.id,
             DatasetMeta(visibility="public"),
+            actor=await _user_row(test_db_session, admin_id),
             warnings_out=warnings,
         )
         await test_db_session.commit()
@@ -242,6 +252,7 @@ class TestDisclosureWarning:
             test_db_session,
             derived.id,
             DatasetMeta(visibility="public"),
+            actor=await _user_row(test_db_session, admin_id),
             warnings_out=warnings,
         )
         await test_db_session.commit()
@@ -258,10 +269,59 @@ class TestDisclosureWarning:
             test_db_session,
             derived.id,
             DatasetMeta(title="Renamed, audience untouched"),
+            actor=await _user_row(test_db_session, admin_id),
             warnings_out=warnings,
         )
         await test_db_session.commit()
         assert warnings == []
+
+    async def test_no_warning_for_actor_without_source_access(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1178 review r2): the warning must not be a membership oracle.
+
+        An output owner whose access to the now-private source was revoked
+        adds a GUESSED keyword to their own record and sends a no-op
+        visibility echo. Before the actor gate, the warning named the guess —
+        confirming it exists on a source the actor cannot open. The gate is
+        the same ``visible_derived_from`` rule the keywords endpoint applies,
+        so no access means silence, on the same grounds as the reference
+        redaction. This test constructs its own access loss: the derived
+        record's owner is a role-less account that never held a grant on the
+        admin's private source.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        outsider = await _add_plain_user(test_db_session)
+        _, derived, _, _ = await _derived_pair(
+            test_db_session,
+            admin_id,
+            derived_visibility="private",
+            derived_owner_id=outsider.id,
+        )
+        warnings: list[str] = []
+        await update_user_metadata(
+            test_db_session,
+            derived.id,
+            DatasetMeta(visibility="private"),  # no-op echo carrying the probe
+            actor=outsider,
+            warnings_out=warnings,
+        )
+        await test_db_session.commit()
+        assert warnings == []
+
+        # The same state read by an actor who CAN open the source still warns
+        # (outsider sits in the derived audience but not the source's), so the
+        # silence above is the gate, not a missing gap.
+        warnings_admin: list[str] = []
+        await update_user_metadata(
+            test_db_session,
+            derived.id,
+            DatasetMeta(visibility="private"),
+            actor=await _user_row(test_db_session, admin_id),
+            warnings_out=warnings_admin,
+        )
+        await test_db_session.commit()
+        assert warnings_admin and "codename" in warnings_admin[0]
 
     async def test_disclosed_list_survives_a_deleted_source(
         self, test_db_session: AsyncSession
@@ -274,7 +334,10 @@ class TestDisclosureWarning:
         await test_db_session.commit()
         assert (
             await disclosed_inherited_keywords(
-                test_db_session, derived_record, derived.id
+                test_db_session,
+                derived_record,
+                derived.id,
+                actor=await _user_row(test_db_session, admin_id),
             )
             == []
         )

--- a/backend/tests/test_inherited_keywords.py
+++ b/backend/tests/test_inherited_keywords.py
@@ -342,6 +342,79 @@ class TestKeywordsEndpointShape:
         assert [k["inherited"] for k in resp.json()["keywords"]] == [True]
 
 
+class TestStatusEndpointWarningSurface:
+    """fix(#1178 review): the publication-status endpoints bypass
+    update_user_metadata, so they must run the same resolved-state check."""
+
+    async def test_target_status_publish_carries_the_warning(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """The ordinary publish flow (DatasetPage's toggle) lands here."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, derived, _, _ = await _derived_pair(
+            test_db_session,
+            admin_id,
+            derived_visibility="public",
+            derived_status="draft",
+        )
+        resp = await client.patch(
+            f"/datasets/{derived.id}/target-status/",
+            json={"status": "published"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["record_status"] == "published"
+        assert body["metadata_warnings"] and "codename" in body["metadata_warnings"][0]
+
+    async def test_single_step_status_publish_carries_the_warning(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        _, derived, _, _ = await _derived_pair(
+            test_db_session,
+            admin_id,
+            derived_visibility="public",
+            derived_status="internal",
+        )
+        resp = await client.patch(
+            f"/datasets/{derived.id}/status/",
+            json={"status": "published"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["metadata_warnings"] and "codename" in body["metadata_warnings"][0]
+
+    async def test_status_endpoint_silent_without_inheritance(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            visibility="public",
+            record_status="draft",
+            name=f"Plain {uuid.uuid4().hex[:6]}",
+        )
+        resp = await client.patch(
+            f"/datasets/{ds.id}/target-status/",
+            json={"status": "published"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["metadata_warnings"] is None
+
+
 class TestPatchWarningSurface:
     async def test_patch_response_carries_metadata_warnings(
         self,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1561,7 +1561,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#1170): -37 — delete the dead update_auto_metadata, the one
         # geometry_type writer that never probed for geom_4326 (refs #1020).
         # Cap 490 -> 453, exact.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 453,
+        # feat(#1070): +30 — the inherited-keyword disclosure warning at the
+        # metadata chokepoint: after visibility/record_status resolve, one
+        # check of the resolved state warns (never blocks) when keywords
+        # inherited from the analysis source reach beyond that source's
+        # audience. Cap 453 -> 483, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 483,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic
@@ -1923,7 +1928,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # frontend mirror are generated from or checked against, so it had been
     # corrected in the mirror and left wrong here — backwards, and the reason
     # the wrong text shipped into both SDKs.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1138,
+    # feat(#1070): +9 for DatasetResponse.metadata_warnings — the advisory
+    # warnings a metadata PATCH can attach (inherited-keyword disclosure at a
+    # visibility/status change). 1138 -> 1147.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1147,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -586,6 +586,13 @@ def test_cross_domain_does_not_import_user_from_auth_models() -> None:
                                               for batched user resolution (Pitfall 1)
     - `catalog/search/service_semantic.py` - `select(User).where(User.id.in_(actor_ids))`
                                               for search-result enrichment (Pitfall 1)
+    - `catalog/records/inherited.py` - `record_audience` predicate target
+                                        (the ORM class the audience predicate
+                                        is written against) plus the
+                                        `select(User.id)` audience-difference
+                                        query (Pitfall 1, feat #1070) — the
+                                        same InstrumentedAttribute use the
+                                        maps service entries above cover
     - `tests/`          - fixtures construct `User(...)` directly; structurally
                           valid as Identity at the call site
 
@@ -619,6 +626,7 @@ def test_cross_domain_does_not_import_user_from_auth_models() -> None:
             ":!backend/app/modules/catalog/datasets/api/router_export.py",
             ":!backend/app/modules/catalog/datasets/domain/helpers.py",
             ":!backend/app/modules/catalog/search/service_semantic.py",
+            ":!backend/app/modules/catalog/records/inherited.py",
             ":!backend/tests/",
         ],
         cwd=REPO_ROOT,
@@ -1566,7 +1574,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # check of the resolved state warns (never blocks) when keywords
         # inherited from the analysis source reach beyond that source's
         # audience. Cap 453 -> 483, exact.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 483,
+        # fix(#1178 review): -5 — the check body moved into the shared
+        # inherited_keyword_disclosure_warning helper so the publication
+        # status endpoints run it too. Cap 483 -> 478, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 478,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic
@@ -1931,7 +1942,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # feat(#1070): +9 for DatasetResponse.metadata_warnings — the advisory
     # warnings a metadata PATCH can attach (inherited-keyword disclosure at a
     # visibility/status change). 1138 -> 1147.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1147,
+    # fix(#1178 review): +9 for the same field on StatusUpdateResponse — the
+    # publication status endpoints run the disclosure check too, so their
+    # response carries it. 1147 -> 1156.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1156,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/backend/tests/test_publication_lifecycle.py
+++ b/backend/tests/test_publication_lifecycle.py
@@ -194,7 +194,13 @@ class TestTargetStatus:
             headers=admin_auth_header,
         )
         assert resp.status_code == 200, resp.text
-        assert resp.json() == {"id": str(dataset.id), "record_status": "ready"}
+        # fix(#1178 review): metadata_warnings joined the response shape (the
+        # inherited-keyword disclosure check); a no-op change carries none.
+        assert resp.json() == {
+            "id": str(dataset.id),
+            "record_status": "ready",
+            "metadata_warnings": None,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_workflow_extension.py
+++ b/backend/tests/test_workflow_extension.py
@@ -78,7 +78,11 @@ def _dataset(record_status: str):
         # fix(#458 E-48): the PATCH handler snapshots tile_columns pre-update
         # to detect no-op echoes, so the fake needs the attribute.
         tile_columns=None,
-        record=SimpleNamespace(record_status=record_status),
+        # fix(#1178 review): the status endpoints run the inherited-keyword
+        # disclosure check on the resolved state, which starts from
+        # record.derived_from — None models a record that is not
+        # analysis-derived, so the check exits before touching the fake DB.
+        record=SimpleNamespace(record_status=record_status, derived_from=None),
     )
 
 

--- a/frontend/src/api/records.ts
+++ b/frontend/src/api/records.ts
@@ -26,8 +26,17 @@ export async function deleteContact(recordId: string, contactId: string): Promis
 }
 
 // Keywords
-export async function listKeywords(recordId: string): Promise<KeywordListResponse> {
-  return apiFetch<KeywordListResponse>(`/records/${recordId}/keywords/`);
+export async function listKeywords(
+  recordId: string,
+  // feat(#1070): counterfactual audience for inherited_audience_gap — "would
+  // this visibility/status expose inherited keywords past their source?"
+  opts?: { audienceVisibility?: string; audienceRecordStatus?: string },
+): Promise<KeywordListResponse> {
+  const params = new URLSearchParams();
+  if (opts?.audienceVisibility) params.set('audience_visibility', opts.audienceVisibility);
+  if (opts?.audienceRecordStatus) params.set('audience_record_status', opts.audienceRecordStatus);
+  const qs = params.size > 0 ? `?${params.toString()}` : '';
+  return apiFetch<KeywordListResponse>(`/records/${recordId}/keywords/${qs}`);
 }
 
 export async function createKeyword(recordId: string, data: KeywordCreate): Promise<KeywordResponse> {

--- a/frontend/src/components/dataset/KeywordsEditor.tsx
+++ b/frontend/src/components/dataset/KeywordsEditor.tsx
@@ -90,6 +90,17 @@ export function KeywordsEditor({ recordId, canEdit }: KeywordsEditorProps) {
         {keywords.map((kw) => (
           <Badge key={kw.id} variant="secondary" className="gap-1">
             {kw.keyword}
+            {/* feat(#1070): a keyword copied from the analysis source is marked
+                so the owner knows they did not author it. The flag is only ever
+                true for a requester who can access the source. */}
+            {kw.inherited && (
+              <span
+                className="text-mini text-muted-foreground italic"
+                title={t('keywords.inheritedTooltip')}
+              >
+                {t('keywords.inherited')}
+              </span>
+            )}
             {canEdit && (
               <button
                 type="button"
@@ -113,6 +124,14 @@ export function KeywordsEditor({ recordId, canEdit }: KeywordsEditorProps) {
           />
         )}
       </div>
+
+      {/* feat(#1070): some current readers cannot open the source these
+          keywords came from — worth a line before the owner widens access. */}
+      {canEdit && data?.inherited_audience_gap && (
+        <p className="text-xs text-warning">
+          {t('keywords.inheritedGapHint')}
+        </p>
+      )}
 
       {canEdit && (
         <p className="text-xs text-muted-foreground">{t('keywords.normalizeHelp')}</p>

--- a/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
@@ -26,7 +26,7 @@ vi.mock('@/components/dataset/hooks/use-dataset', () => ({
 }));
 
 vi.mock('sonner', () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
 }));
 
 const mockUseDistributions = vi.mocked(useDistributions);
@@ -351,6 +351,43 @@ describe('AccessTab', () => {
         fireEvent.click(screen.getByRole('option', { name: 'Public' }));
 
         await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+      });
+
+      // fix(#1178 review): the fallback is only a fallback if the PATCH
+      // response's warnings actually reach the user when the probe failed.
+      it('surfaces the PATCH warning when the probe failed', async () => {
+        mockListKeywords.mockRejectedValue(new Error('boom'));
+        mutate.mockImplementation((_vars, opts) =>
+          opts?.onSuccess?.({
+            metadata_warnings: [
+              'Keywords inherited from the source dataset are now visible: codename',
+            ],
+          }),
+        );
+        render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
+
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Public' }));
+
+        await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+        expect(toast.warning).toHaveBeenCalledWith(
+          'Keywords inherited from the source dataset are now visible: codename',
+        );
+      });
+
+      it('no warning toast when the response carries none', async () => {
+        // The toast mocks are module-level and survive the previous test.
+        vi.mocked(toast.warning).mockClear();
+        mutate.mockImplementation((_vars, opts) =>
+          opts?.onSuccess?.({ metadata_warnings: null }),
+        );
+        render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
+
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Public' }));
+
+        await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+        expect(toast.warning).not.toHaveBeenCalled();
       });
     });
 

--- a/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
@@ -406,6 +406,79 @@ describe('AccessTab', () => {
         await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
       });
 
+      // fix(#1178 r4): two quick selections leave both probes in flight, and
+      // the LAST response to arrive used to write pendingChange — possibly
+      // for the earlier, no-longer-intended value. Only the newest selection
+      // may produce anything.
+      it('a superseded probe response is discarded, even resolving last', async () => {
+        vi.mocked(toast.warning).mockClear();
+        const resolvers: Array<(v: unknown) => void> = [];
+        mockListKeywords.mockImplementation(
+          () =>
+            new Promise((res) => {
+              resolvers.push(res as (v: unknown) => void);
+            }) as ReturnType<typeof listKeywords>,
+        );
+        render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
+
+        // First selection: Internal. Second selection: Public. Both widen.
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Internal' }));
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Public' }));
+        await waitFor(() => expect(resolvers).toHaveLength(2));
+
+        // The newest probe resolves FIRST with no gap: direct mutate for
+        // public. The stale probe resolves LAST claiming a gap: discarded.
+        resolvers[1]({ keywords: [], total: 0, inherited_audience_gap: false });
+        await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+        expect(mutate.mock.calls[0][0]).toEqual({
+          datasetId: 'ds-1',
+          data: { visibility: 'public' },
+        });
+
+        resolvers[0](inheritedProbe);
+        // Give the stale response a tick to (wrongly) act, then assert it
+        // produced nothing: no dialog, no extra mutate.
+        await waitFor(() =>
+          expect(
+            screen.queryByText('Share inherited keywords?'),
+          ).not.toBeInTheDocument(),
+        );
+        expect(mutate).toHaveBeenCalledTimes(1);
+      });
+
+      // fix(#1178 r4): a superseded FAILED probe must not fire the direct
+      // PATCH for its stale value.
+      it('a superseded failed probe does not mutate its stale value', async () => {
+        const handlers: Array<{ resolve: (v: unknown) => void; reject: (e: unknown) => void }> = [];
+        mockListKeywords.mockImplementation(
+          () =>
+            new Promise((resolve, reject) => {
+              handlers.push({ resolve: resolve as (v: unknown) => void, reject });
+            }) as ReturnType<typeof listKeywords>,
+        );
+        render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
+
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Internal' }));
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Public' }));
+        await waitFor(() => expect(handlers).toHaveLength(2));
+
+        handlers[1].resolve({ keywords: [], total: 0, inherited_audience_gap: false });
+        await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+
+        // The stale probe FAILS after being superseded: without the guard the
+        // catch fell through to applyVisibility('internal').
+        handlers[0].reject(new Error('boom'));
+        await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+        expect(mutate.mock.calls[0][0]).toEqual({
+          datasetId: 'ds-1',
+          data: { visibility: 'public' },
+        });
+      });
+
       // fix(#1178 review): the fallback is only a fallback if the PATCH
       // response's warnings actually reach the user when the probe failed.
       it('surfaces the PATCH warning when the probe failed', async () => {

--- a/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
@@ -1,13 +1,20 @@
-import { fireEvent, render, screen } from '@/test/test-utils';
+import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
 import { useDistributions } from '@/components/dataset/hooks/use-records';
 import { useUpdateDataset } from '@/components/dataset/hooks/use-dataset';
 import { useTileConfig } from '@/hooks/use-settings';
+import { listKeywords } from '@/api/records';
 import { toast } from 'sonner';
 import { AccessTab } from '../tabs/AccessTab';
 import type { DatasetResponse } from '@/types/api';
 
 vi.mock('@/components/dataset/hooks/use-records', () => ({
   useDistributions: vi.fn(),
+}));
+
+// feat(#1070): the visibility change probes the keywords endpoint for
+// inherited keywords before mutating.
+vi.mock('@/api/records', () => ({
+  listKeywords: vi.fn(),
 }));
 
 vi.mock('@/hooks/use-settings', () => ({
@@ -25,6 +32,7 @@ vi.mock('sonner', () => ({
 const mockUseDistributions = vi.mocked(useDistributions);
 const mockUseTileConfig = vi.mocked(useTileConfig);
 const mockUseUpdateDataset = vi.mocked(useUpdateDataset);
+const mockListKeywords = vi.mocked(listKeywords);
 const mutate = vi.fn();
 
 function makeDataset(overrides: Partial<DatasetResponse> = {}): DatasetResponse {
@@ -111,6 +119,12 @@ describe('AccessTab', () => {
       isLoading: false,
     } as unknown as ReturnType<typeof useDistributions>);
     mutate.mockReset();
+    mockListKeywords.mockReset();
+    mockListKeywords.mockResolvedValue({
+      keywords: [],
+      total: 0,
+      inherited_audience_gap: false,
+    });
     mockUseUpdateDataset.mockReturnValue({
       mutate,
       isPending: false,
@@ -182,13 +196,13 @@ describe('AccessTab', () => {
       expect(screen.getByText('Private')).toBeInTheDocument();
     });
 
-    it('lets an owner or admin move a dataset from private to public', () => {
+    it('lets an owner or admin move a dataset from private to public', async () => {
       render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
 
       openVisibilitySelect();
       fireEvent.click(screen.getByRole('option', { name: 'Public' }));
 
-      expect(mutate).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
       expect(mutate.mock.calls[0][0]).toEqual({
         datasetId: 'ds-1',
         data: { visibility: 'public' },
@@ -205,7 +219,7 @@ describe('AccessTab', () => {
 
     // fix(#930): `internal` joined the ladder once its permission branches
     // landed. The import pickers deliberately stay at private/public.
-    it('offers internal as a move, between private and public', () => {
+    it('offers internal as a move, between private and public', async () => {
       render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
 
       openVisibilitySelect();
@@ -217,7 +231,7 @@ describe('AccessTab', () => {
 
       fireEvent.click(screen.getByRole('option', { name: 'Internal' }));
 
-      expect(mutate).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
       expect(mutate.mock.calls[0][0]).toEqual({
         datasetId: 'ds-1',
         data: { visibility: 'internal' },
@@ -263,14 +277,81 @@ describe('AccessTab', () => {
     // The backend rejects public → private with a 422 while a public map uses
     // the dataset. #931 owns turning that prose into its own message; what must
     // not happen here is the select snapping back with nothing said.
-    it('surfaces a rejected change instead of swallowing it', () => {
+    it('surfaces a rejected change instead of swallowing it', async () => {
       mutate.mockImplementation((_vars, opts) => opts?.onError?.(new Error('nope')));
       render(<AccessTab dataset={makeDataset({ visibility: 'public' })} canEdit />);
 
       openVisibilitySelect();
       fireEvent.click(screen.getByRole('option', { name: 'Private' }));
 
-      expect(toast.error).toHaveBeenCalled();
+      await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    });
+
+    // feat(#1070): inherited keywords get a confirm/diff step before the
+    // audience widens past the source they came from.
+    describe('inherited-keyword confirm', () => {
+      const inheritedProbe = {
+        keywords: [
+          {
+            id: 'kw-1',
+            record_id: 'rec-1',
+            keyword: 'codename',
+            vocabulary_uri: null,
+            keyword_type: 'theme',
+            inherited: true,
+          },
+        ],
+        total: 1,
+        inherited_audience_gap: true,
+      };
+
+      it('holds the change behind a dialog naming the inherited keywords', async () => {
+        mockListKeywords.mockResolvedValue(inheritedProbe);
+        render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
+
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Public' }));
+
+        expect(await screen.findByText('Share inherited keywords?')).toBeInTheDocument();
+        expect(screen.getByText('codename')).toBeInTheDocument();
+        expect(mockListKeywords).toHaveBeenCalledWith('rec-1', {
+          audienceVisibility: 'public',
+        });
+        expect(mutate).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Change visibility' }));
+        await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+        expect(mutate.mock.calls[0][0]).toEqual({
+          datasetId: 'ds-1',
+          data: { visibility: 'public' },
+        });
+      });
+
+      it('cancelling the dialog leaves the visibility untouched', async () => {
+        mockListKeywords.mockResolvedValue(inheritedProbe);
+        render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
+
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Public' }));
+
+        expect(await screen.findByText('Share inherited keywords?')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        await waitFor(() =>
+          expect(screen.queryByText('Share inherited keywords?')).not.toBeInTheDocument(),
+        );
+        expect(mutate).not.toHaveBeenCalled();
+      });
+
+      it('a failed probe never blocks the change', async () => {
+        mockListKeywords.mockRejectedValue(new Error('boom'));
+        render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
+
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Public' }));
+
+        await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+      });
     });
 
     it('does not fire a mutation when the value is unchanged', () => {

--- a/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
@@ -353,6 +353,59 @@ describe('AccessTab', () => {
         await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
       });
 
+      // fix(#1178 r3): the probe asks an absolute question, so a NARROWING
+      // move (already-public output moving down the ladder) must not be
+      // blocked behind a dialog claiming a "wider audience" — that dialog
+      // was standing in front of the remediation.
+      it('a narrowing move skips the probe and the dialog entirely', async () => {
+        mockListKeywords.mockResolvedValue(inheritedProbe);
+        render(<AccessTab dataset={makeDataset({ visibility: 'public' })} canEdit />);
+
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Internal' }));
+
+        await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+        expect(mockListKeywords).not.toHaveBeenCalled();
+        expect(
+          screen.queryByText('Share inherited keywords?'),
+        ).not.toBeInTheDocument();
+      });
+
+      // fix(#1178 r3): inherited_audience_gap is computed server-side over
+      // ALL keyword rows; the fetched page only supplies names. A page
+      // without the inherited entries must still produce the dialog.
+      it('shows the dialog on a gap even when no inherited names are on the page', async () => {
+        mockListKeywords.mockResolvedValue({
+          keywords: [
+            {
+              id: 'kw-2',
+              record_id: 'rec-1',
+              keyword: 'riverine',
+              vocabulary_uri: null,
+              keyword_type: 'theme',
+              inherited: false,
+            },
+          ],
+          total: 150,
+          inherited_audience_gap: true,
+        });
+        render(<AccessTab dataset={makeDataset({ visibility: 'private' })} canEdit />);
+
+        openVisibilitySelect();
+        fireEvent.click(screen.getByRole('option', { name: 'Public' }));
+
+        expect(await screen.findByText('Share inherited keywords?')).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            'This dataset carries keywords inherited from its source. Review the full keyword list before sharing.',
+          ),
+        ).toBeInTheDocument();
+        expect(mutate).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Change visibility' }));
+        await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+      });
+
       // fix(#1178 review): the fallback is only a fallback if the PATCH
       // response's warnings actually reach the user when the probe failed.
       it('surfaces the PATCH warning when the probe failed', async () => {

--- a/frontend/src/components/dataset/__tests__/KeywordsEditor.inherited.test.tsx
+++ b/frontend/src/components/dataset/__tests__/KeywordsEditor.inherited.test.tsx
@@ -1,0 +1,104 @@
+// feat(#1070): keywords copied from the analysis source carry an "inherited"
+// marker, and an audience gap (readers who cannot open that source) surfaces
+// as a hint line for the editor.
+import { render, screen, waitFor } from '@/test/test-utils';
+import { KeywordsEditor } from '../KeywordsEditor';
+import { listKeywords } from '@/api/records';
+import type { KeywordListResponse } from '@/types/api';
+
+vi.mock('@/api/records', () => ({
+  listContacts: vi.fn(),
+  createContact: vi.fn(),
+  deleteContact: vi.fn(),
+  listKeywords: vi.fn(),
+  createKeyword: vi.fn(),
+  deleteKeyword: vi.fn(),
+}));
+
+function keywordList(overrides?: Partial<KeywordListResponse>): KeywordListResponse {
+  return {
+    keywords: [
+      {
+        id: 'kw-1',
+        record_id: 'rec-1',
+        keyword: 'codename',
+        vocabulary_uri: null,
+        keyword_type: 'theme',
+        inherited: true,
+      },
+      {
+        id: 'kw-2',
+        record_id: 'rec-1',
+        keyword: 'riverine',
+        vocabulary_uri: null,
+        keyword_type: 'theme',
+        inherited: false,
+      },
+    ],
+    total: 2,
+    inherited_audience_gap: false,
+    ...overrides,
+  };
+}
+
+describe('KeywordsEditor inherited marker (feat #1070)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('marks inherited keywords and leaves authored ones unmarked', async () => {
+    vi.mocked(listKeywords).mockResolvedValue(keywordList());
+    render(<KeywordsEditor recordId="rec-1" canEdit />);
+
+    await waitFor(() => {
+      expect(screen.getByText('codename')).toBeInTheDocument();
+    });
+    expect(screen.getByText('riverine')).toBeInTheDocument();
+    // Exactly one marker: the copied keyword's badge, not the authored one's.
+    expect(screen.getAllByText('inherited')).toHaveLength(1);
+    expect(screen.getByTitle('Copied from the dataset this one was derived from'))
+      .toBeInTheDocument();
+  });
+
+  it('shows the audience-gap hint to editors only when the gap exists', async () => {
+    vi.mocked(listKeywords).mockResolvedValue(
+      keywordList({ inherited_audience_gap: true }),
+    );
+    render(<KeywordsEditor recordId="rec-1" canEdit />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Some keywords were inherited from a source dataset that not every reader here can open.',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('renders no marker or hint when nothing was inherited', async () => {
+    vi.mocked(listKeywords).mockResolvedValue(
+      keywordList({
+        keywords: [
+          {
+            id: 'kw-2',
+            record_id: 'rec-1',
+            keyword: 'riverine',
+            vocabulary_uri: null,
+            keyword_type: 'theme',
+            inherited: false,
+          },
+        ],
+        total: 1,
+      }),
+    );
+    render(<KeywordsEditor recordId="rec-1" canEdit />);
+
+    await waitFor(() => {
+      expect(screen.getByText('riverine')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('inherited')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Some keywords were inherited from a source dataset that not every reader here can open.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dataset/tabs/AccessTab.tsx
+++ b/frontend/src/components/dataset/tabs/AccessTab.tsx
@@ -5,7 +5,18 @@ import { Copy, Check } from 'lucide-react';
 import { toast } from 'sonner';
 import { useDatasetAccessEndpoints } from '@/components/dataset/hooks/use-dataset-access';
 import { useUpdateDataset } from '@/components/dataset/hooks/use-dataset';
+import { listKeywords } from '@/api/records';
 import type { DatasetResponse, DatasetVisibility } from '@/types/api';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -241,10 +252,17 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
     dataset.visibility as (typeof SELECTABLE_VISIBILITIES)[number],
   );
 
-  function handleVisibilityChange(value: string) {
-    if (value === dataset.visibility) return;
+  // feat(#1070): a visibility change held back while the owner confirms that
+  // keywords inherited from the analysis source may reach readers who cannot
+  // open that source.
+  const [pendingChange, setPendingChange] = useState<{
+    visibility: DatasetVisibility;
+    keywords: string[];
+  } | null>(null);
+
+  function applyVisibility(visibility: DatasetVisibility) {
     updateDataset.mutate(
-      { datasetId: dataset.id, data: { visibility: value as DatasetVisibility } },
+      { datasetId: dataset.id, data: { visibility } },
       {
         onSuccess: () => toast.success(t('metadataEdit.visibilityUpdated')),
         // fix(#927): moving a dataset away from public while a public map uses
@@ -256,6 +274,29 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
           toast.error(formatMutationError('dataset:metadataEdit.visibilityFailed', err)),
       },
     );
+  }
+
+  async function handleVisibilityChange(value: string) {
+    if (value === dataset.visibility) return;
+    const visibility = value as DatasetVisibility;
+    // feat(#1070): ask the counterfactual — "at this visibility, would
+    // inherited keywords reach someone who cannot open their source?" — and
+    // put the diff in front of the owner before the change applies. Advisory
+    // only: a failed probe never blocks the change (the backend PATCH response
+    // still carries the warning).
+    try {
+      const kw = await listKeywords(dataset.record_id, {
+        audienceVisibility: visibility,
+      });
+      const inherited = kw.keywords.filter((k) => k.inherited).map((k) => k.keyword);
+      if (kw.inherited_audience_gap && inherited.length > 0) {
+        setPendingChange({ visibility, keywords: inherited });
+        return;
+      }
+    } catch {
+      // fall through to the plain mutate
+    }
+    applyVisibility(visibility);
   }
   const isRaster = dataset.record_type === 'raster_dataset';
   const isVrt = dataset.record_type === 'vrt_dataset';
@@ -362,6 +403,42 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
           </p>
         </CardContent>
       </Card>
+
+      {/* feat(#1070): the publish-moment diff — which inherited keywords the
+          wider audience would see, with the option to back out and prune. */}
+      <AlertDialog
+        open={pendingChange !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingChange(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('keywords.inheritedConfirmTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('keywords.inheritedConfirmBody')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="flex flex-wrap gap-1.5">
+            {pendingChange?.keywords.map((kw) => (
+              <Badge key={kw} variant="secondary">
+                {kw}
+              </Badge>
+            ))}
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common:cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (pendingChange) applyVisibility(pendingChange.visibility);
+                setPendingChange(null);
+              }}
+            >
+              {t('keywords.inheritedConfirmContinue')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/frontend/src/components/dataset/tabs/AccessTab.tsx
+++ b/frontend/src/components/dataset/tabs/AccessTab.tsx
@@ -265,6 +265,11 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
     visibility: DatasetVisibility;
     keywords: string[];
   } | null>(null);
+  // fix(#1178 r4): probe sequence. Two quick selections leave both probes in
+  // flight, and whichever resolved LAST wrote pendingChange — possibly for
+  // the earlier, no-longer-intended value. Each invocation takes a fresh id;
+  // a response whose id is no longer current is discarded outright.
+  const probeSeq = useRef(0);
 
   function applyVisibility(visibility: DatasetVisibility) {
     updateDataset.mutate(
@@ -293,6 +298,7 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
   async function handleVisibilityChange(value: string) {
     if (value === dataset.visibility) return;
     const visibility = value as DatasetVisibility;
+    const seq = ++probeSeq.current;
     // fix(#1178 r3): only a move that ADDS readers warrants the dialog. The
     // probe asks an absolute question ("does this audience exceed the
     // source?"), so running it on a narrowing move (public -> internal on an
@@ -314,6 +320,9 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
         const kw = await listKeywords(dataset.record_id, {
           audienceVisibility: visibility,
         });
+        // fix(#1178 r4): superseded by a newer selection while awaiting —
+        // this response must produce nothing, not even the fall-through.
+        if (seq !== probeSeq.current) return;
         // fix(#1178 r3): the gap flag is authoritative (computed server-side
         // over ALL keyword rows); the fetched page only supplies display
         // names. Keying the dialog on the page's inherited entries let a page
@@ -326,6 +335,9 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
           return;
         }
       } catch {
+        // fix(#1178 r4): a superseded FAILED probe must not fire the direct
+        // PATCH for its stale value either.
+        if (seq !== probeSeq.current) return;
         // fall through to the plain mutate
       }
     }

--- a/frontend/src/components/dataset/tabs/AccessTab.tsx
+++ b/frontend/src/components/dataset/tabs/AccessTab.tsx
@@ -264,7 +264,15 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
     updateDataset.mutate(
       { datasetId: dataset.id, data: { visibility } },
       {
-        onSuccess: () => toast.success(t('metadataEdit.visibilityUpdated')),
+        onSuccess: (result) => {
+          toast.success(t('metadataEdit.visibilityUpdated'));
+          // fix(#1178 review): when the preflight probe failed, the PATCH
+          // response is the only warning surface left — reading it is what
+          // makes "a failed probe never blocks" a fallback instead of a hole.
+          if (result?.metadata_warnings?.length) {
+            toast.warning(result.metadata_warnings[0]);
+          }
+        },
         // fix(#927): moving a dataset away from public while a public map uses
         // it is a 422 from `_apply_visibility_change`. This control is the
         // first UI that can trigger it, so the message has to reach the user

--- a/frontend/src/components/dataset/tabs/AccessTab.tsx
+++ b/frontend/src/components/dataset/tabs/AccessTab.tsx
@@ -62,6 +62,12 @@ interface AccessTabProps {
  * the import pickers deliberately stay at private/public. */
 const SELECTABLE_VISIBILITIES = ['private', 'internal', 'public'] as const;
 
+/** fix(#1178 r3): the full ladder in widening order, for deciding whether a
+ * visibility move ADDS readers. `restricted` sits between private and
+ * internal even though this control cannot move TO it — a stored restricted
+ * dataset can still be moved FROM it, and that move's direction matters. */
+const VISIBILITY_LADDER = ['private', 'restricted', 'internal', 'public'] as const;
+
 /** Copy text to clipboard with textarea fallback for non-HTTPS contexts. */
 async function copyText(value: string): Promise<void> {
   try {
@@ -287,22 +293,41 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
   async function handleVisibilityChange(value: string) {
     if (value === dataset.visibility) return;
     const visibility = value as DatasetVisibility;
-    // feat(#1070): ask the counterfactual — "at this visibility, would
-    // inherited keywords reach someone who cannot open their source?" — and
-    // put the diff in front of the owner before the change applies. Advisory
-    // only: a failed probe never blocks the change (the backend PATCH response
-    // still carries the warning).
-    try {
-      const kw = await listKeywords(dataset.record_id, {
-        audienceVisibility: visibility,
-      });
-      const inherited = kw.keywords.filter((k) => k.inherited).map((k) => k.keyword);
-      if (kw.inherited_audience_gap && inherited.length > 0) {
-        setPendingChange({ visibility, keywords: inherited });
-        return;
+    // fix(#1178 r3): only a move that ADDS readers warrants the dialog. The
+    // probe asks an absolute question ("does this audience exceed the
+    // source?"), so running it on a narrowing move (public -> internal on an
+    // output already wider than its source) blocked the REMEDIATION behind a
+    // dialog claiming a wider audience. An unknown stored value indexes to
+    // -1 and counts as widening — over-warning is the safe direction.
+    const widens =
+      VISIBILITY_LADDER.indexOf(visibility as (typeof VISIBILITY_LADDER)[number]) >
+      VISIBILITY_LADDER.indexOf(
+        dataset.visibility as (typeof VISIBILITY_LADDER)[number],
+      );
+    if (widens) {
+      // feat(#1070): ask the counterfactual — "at this visibility, would
+      // inherited keywords reach someone who cannot open their source?" — and
+      // put the diff in front of the owner before the change applies.
+      // Advisory only: a failed probe never blocks the change (the backend
+      // PATCH response still carries the warning).
+      try {
+        const kw = await listKeywords(dataset.record_id, {
+          audienceVisibility: visibility,
+        });
+        // fix(#1178 r3): the gap flag is authoritative (computed server-side
+        // over ALL keyword rows); the fetched page only supplies display
+        // names. Keying the dialog on the page's inherited entries let a page
+        // boundary skip the confirmation entirely.
+        if (kw.inherited_audience_gap) {
+          setPendingChange({
+            visibility,
+            keywords: kw.keywords.filter((k) => k.inherited).map((k) => k.keyword),
+          });
+          return;
+        }
+      } catch {
+        // fall through to the plain mutate
       }
-    } catch {
-      // fall through to the plain mutate
     }
     applyVisibility(visibility);
   }
@@ -427,13 +452,22 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
               {t('keywords.inheritedConfirmBody')}
             </AlertDialogDescription>
           </AlertDialogHeader>
-          <div className="flex flex-wrap gap-1.5">
-            {pendingChange?.keywords.map((kw) => (
-              <Badge key={kw} variant="secondary">
-                {kw}
-              </Badge>
-            ))}
-          </div>
+          {/* fix(#1178 r3): the fetched page supplies display names only; a
+              gap with no inherited names on the page still gets the dialog,
+              with a generic line in place of the badges. */}
+          {pendingChange && pendingChange.keywords.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {pendingChange.keywords.map((kw) => (
+                <Badge key={kw} variant="secondary">
+                  {kw}
+                </Badge>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {t('keywords.inheritedGeneric')}
+            </p>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>{t('common:cancel')}</AlertDialogCancel>
             <AlertDialogAction

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -543,7 +543,13 @@
     "removeFailed": "Schlüsselwort konnte nicht entfernt werden",
     "loadError": "Schlüsselwörter konnten nicht geladen werden.",
     "retry": "Erneut versuchen",
-    "normalizeHelp": "Schlüsselwörter werden in Kleinbuchstaben normalisiert"
+    "normalizeHelp": "Schlüsselwörter werden in Kleinbuchstaben normalisiert",
+    "inherited": "geerbt",
+    "inheritedTooltip": "Aus dem Datensatz übernommen, von dem dieser abgeleitet wurde",
+    "inheritedGapHint": "Einige Schlüsselwörter wurden von einem Quelldatensatz geerbt, den nicht alle Lesenden öffnen können.",
+    "inheritedConfirmTitle": "Geerbte Schlüsselwörter teilen?",
+    "inheritedConfirmBody": "Diese Schlüsselwörter wurden aus einem Quelldatensatz kopiert, den das erweiterte Publikum nicht öffnen kann. Fahren Sie fort, um sie zu teilen, oder brechen Sie ab und entfernen Sie sie zuerst.",
+    "inheritedConfirmContinue": "Sichtbarkeit ändern"
   },
   "attributeMetadata": {
     "title": "Attribut-Metadaten",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -549,7 +549,8 @@
     "inheritedGapHint": "Einige Schlüsselwörter wurden von einem Quelldatensatz geerbt, den nicht alle Lesenden öffnen können.",
     "inheritedConfirmTitle": "Geerbte Schlüsselwörter teilen?",
     "inheritedConfirmBody": "Diese Schlüsselwörter wurden aus einem Quelldatensatz kopiert, den das erweiterte Publikum nicht öffnen kann. Fahren Sie fort, um sie zu teilen, oder brechen Sie ab und entfernen Sie sie zuerst.",
-    "inheritedConfirmContinue": "Sichtbarkeit ändern"
+    "inheritedConfirmContinue": "Sichtbarkeit ändern",
+    "inheritedGeneric": "Dieser Datensatz enthält Schlüsselwörter, die vom Quelldatensatz geerbt wurden. Prüfen Sie die vollständige Schlüsselwortliste vor dem Teilen."
   },
   "attributeMetadata": {
     "title": "Attribut-Metadaten",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -434,7 +434,13 @@
     "removeFailed": "Failed to remove keyword",
     "loadError": "Failed to load keywords.",
     "retry": "Retry",
-    "normalizeHelp": "Keywords are normalized to lowercase"
+    "normalizeHelp": "Keywords are normalized to lowercase",
+    "inherited": "inherited",
+    "inheritedTooltip": "Copied from the dataset this one was derived from",
+    "inheritedGapHint": "Some keywords were inherited from a source dataset that not every reader here can open.",
+    "inheritedConfirmTitle": "Share inherited keywords?",
+    "inheritedConfirmBody": "These keywords were copied from a source dataset the wider audience cannot open. Continue to share them, or cancel and remove them first.",
+    "inheritedConfirmContinue": "Change visibility"
   },
   "validation": {
     "title": "Validation Status",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -440,7 +440,8 @@
     "inheritedGapHint": "Some keywords were inherited from a source dataset that not every reader here can open.",
     "inheritedConfirmTitle": "Share inherited keywords?",
     "inheritedConfirmBody": "These keywords were copied from a source dataset the wider audience cannot open. Continue to share them, or cancel and remove them first.",
-    "inheritedConfirmContinue": "Change visibility"
+    "inheritedConfirmContinue": "Change visibility",
+    "inheritedGeneric": "This dataset carries keywords inherited from its source. Review the full keyword list before sharing."
   },
   "validation": {
     "title": "Validation Status",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -543,7 +543,13 @@
     "removeFailed": "Error al eliminar palabra clave",
     "loadError": "Error al cargar palabras clave.",
     "retry": "Reintentar",
-    "normalizeHelp": "Las palabras clave se normalizan a minúsculas"
+    "normalizeHelp": "Las palabras clave se normalizan a minúsculas",
+    "inherited": "heredada",
+    "inheritedTooltip": "Copiada del conjunto de datos del que se derivó este",
+    "inheritedGapHint": "Algunas palabras clave se heredaron de un conjunto de datos de origen que no todos los lectores pueden abrir.",
+    "inheritedConfirmTitle": "¿Compartir las palabras clave heredadas?",
+    "inheritedConfirmBody": "Estas palabras clave se copiaron de un conjunto de datos de origen que la nueva audiencia no puede abrir. Continúe para compartirlas, o cancele y elimínelas primero.",
+    "inheritedConfirmContinue": "Cambiar visibilidad"
   },
   "attributeMetadata": {
     "title": "Metadatos de atributos",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -549,7 +549,8 @@
     "inheritedGapHint": "Algunas palabras clave se heredaron de un conjunto de datos de origen que no todos los lectores pueden abrir.",
     "inheritedConfirmTitle": "¿Compartir las palabras clave heredadas?",
     "inheritedConfirmBody": "Estas palabras clave se copiaron de un conjunto de datos de origen que la nueva audiencia no puede abrir. Continúe para compartirlas, o cancele y elimínelas primero.",
-    "inheritedConfirmContinue": "Cambiar visibilidad"
+    "inheritedConfirmContinue": "Cambiar visibilidad",
+    "inheritedGeneric": "Este conjunto de datos contiene palabras clave heredadas de su origen. Revise la lista completa de palabras clave antes de compartir."
   },
   "attributeMetadata": {
     "title": "Metadatos de atributos",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -549,7 +549,8 @@
     "inheritedGapHint": "Certains mots-clés ont été hérités d'un jeu de données source que tous les lecteurs ne peuvent pas ouvrir.",
     "inheritedConfirmTitle": "Partager les mots-clés hérités ?",
     "inheritedConfirmBody": "Ces mots-clés ont été copiés depuis un jeu de données source que le nouveau public ne peut pas ouvrir. Continuez pour les partager, ou annulez et supprimez-les d'abord.",
-    "inheritedConfirmContinue": "Changer la visibilité"
+    "inheritedConfirmContinue": "Changer la visibilité",
+    "inheritedGeneric": "Ce jeu de données contient des mots-clés hérités de sa source. Vérifiez la liste complète des mots-clés avant de partager."
   },
   "attributeMetadata": {
     "title": "Métadonnées des attributs",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -543,7 +543,13 @@
     "removeFailed": "Échec de la suppression du mot-clé",
     "loadError": "Échec du chargement des mots-clés.",
     "retry": "Réessayer",
-    "normalizeHelp": "Les mots-clés sont normalisés en minuscules"
+    "normalizeHelp": "Les mots-clés sont normalisés en minuscules",
+    "inherited": "hérité",
+    "inheritedTooltip": "Copié du jeu de données dont celui-ci est dérivé",
+    "inheritedGapHint": "Certains mots-clés ont été hérités d'un jeu de données source que tous les lecteurs ne peuvent pas ouvrir.",
+    "inheritedConfirmTitle": "Partager les mots-clés hérités ?",
+    "inheritedConfirmBody": "Ces mots-clés ont été copiés depuis un jeu de données source que le nouveau public ne peut pas ouvrir. Continuez pour les partager, ou annulez et supprimez-les d'abord.",
+    "inheritedConfirmContinue": "Changer la visibilité"
   },
   "attributeMetadata": {
     "title": "Métadonnées des attributs",

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -371,8 +371,14 @@ export function DatasetPage() {
       return;
     }
     try {
-      await setTargetStatus.mutateAsync({ datasetId: id, status: PUBLISH_TARGET });
+      const result = await setTargetStatus.mutateAsync({ datasetId: id, status: PUBLISH_TARGET });
       toast.success(t('publish.success'));
+      // fix(#1178 review): this toggle publishes through target-status, not
+      // the metadata PATCH, so it reads the same inherited-keyword disclosure
+      // warning from this response (feat #1070).
+      if (result.metadata_warnings?.length) {
+        toast.warning(result.metadata_warnings[0]);
+      }
     } catch {
       toast.error(t('publish.failed'));
     }

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3882,7 +3882,7 @@ export interface paths {
         };
         /**
          * List Keywords Endpoint
-         * @description List all keywords for a record.
+         * @description List all keywords for a record, marking analysis-inherited ones.
          */
         get: operations["list_keywords_endpoint_records__record_id__keywords__get"];
         put?: never;
@@ -7279,6 +7279,11 @@ export interface components {
              */
             lineage_summary?: string | null;
             /**
+             * Metadata Warnings
+             * @description Advisory warnings produced by a metadata update — e.g. a visibility or status change exposing keywords inherited from an analysis source the new audience cannot open (feat #1070). Only ever set on the PATCH response; the change has already applied.
+             */
+            metadata_warnings?: string[] | null;
+            /**
              * N Dims
              * @description Number of coordinate dimensions (2, 3, or 4)
              */
@@ -8395,6 +8400,12 @@ export interface components {
         };
         /** KeywordListResponse */
         KeywordListResponse: {
+            /**
+             * Inherited Audience Gap
+             * @description True when at least one keyword is inherited AND this record's audience — at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters — includes someone who cannot open the source dataset (feat #1070).
+             * @default false
+             */
+            inherited_audience_gap: boolean;
             /** Keywords */
             keywords: components["schemas"]["KeywordResponse"][];
             /** Total */
@@ -8407,6 +8418,12 @@ export interface components {
              * Format: uuid
              */
             id: string;
+            /**
+             * Inherited
+             * @description True when this keyword also exists on the dataset this record was derived from (feat #1070). Derived at read time from derived_from; only ever true for a requester who can access that source dataset, so everyone else sees false — matching the derived_from redaction.
+             * @default false
+             */
+            inherited: boolean;
             /** Keyword */
             keyword: string;
             /** Keyword Type */
@@ -33541,6 +33558,10 @@ export interface operations {
             query?: {
                 skip?: number;
                 limit?: number;
+                /** @description Compute inherited_audience_gap as if the record had this visibility — the counterfactual an owner asks before widening access (feat #1070). Keywords themselves are unaffected. */
+                audience_visibility?: string | null;
+                /** @description Compute inherited_audience_gap as if the record had this status — the counterfactual an owner asks before publishing (feat #1070). */
+                audience_record_status?: string | null;
             };
             header?: never;
             path: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -12143,6 +12143,11 @@ export interface components {
         StatusUpdateResponse: {
             /** Id */
             id: string;
+            /**
+             * Metadata Warnings
+             * @description Advisory warnings from the status change — the same inherited-keyword disclosure check the metadata PATCH runs (feat #1070, fix #1178 review). The transition has already applied.
+             */
+            metadata_warnings?: string[] | null;
             /** Record Status */
             record_status: string;
         };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -254,6 +254,10 @@ export interface DatasetResponse {
   n_dims?: number | null;
   z_min?: number | null;
   z_max?: number | null;
+  /** feat(#1070): advisory warnings a metadata PATCH can attach — e.g. a
+   * visibility/status change exposing keywords inherited from an analysis
+   * source the new audience cannot open. PATCH responses only. */
+  metadata_warnings?: string[] | null;
 }
 
 export interface DatasetListResponse {
@@ -328,11 +332,19 @@ export interface KeywordResponse {
   keyword: string;
   vocabulary_uri: string | null;
   keyword_type: string;
+  /** feat(#1070): true when the keyword also exists on the dataset this record
+   * was derived from. Only ever true for a requester who can access that
+   * source; everyone else sees false, matching the derived_from redaction. */
+  inherited?: boolean;
 }
 
 export interface KeywordListResponse {
   keywords: KeywordResponse[];
   total: number;
+  /** feat(#1070): true when at least one keyword is inherited AND the record's
+   * audience — stored, or at the counterfactual audience_* query params —
+   * includes someone who cannot open the source dataset. */
+  inherited_audience_gap?: boolean;
 }
 
 export interface DistributionResponse {

--- a/sdks/python/geolens/api/records/list_keywords_endpoint_records_record_id_keywords_get.py
+++ b/sdks/python/geolens/api/records/list_keywords_endpoint_records_record_id_keywords_get.py
@@ -19,6 +19,8 @@ def _get_kwargs(
     *,
     skip: int | Unset = 0,
     limit: int | Unset = 100,
+    audience_visibility: None | str | Unset = UNSET,
+    audience_record_status: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
 
     params: dict[str, Any] = {}
@@ -26,6 +28,20 @@ def _get_kwargs(
     params["skip"] = skip
 
     params["limit"] = limit
+
+    json_audience_visibility: None | str | Unset
+    if isinstance(audience_visibility, Unset):
+        json_audience_visibility = UNSET
+    else:
+        json_audience_visibility = audience_visibility
+    params["audience_visibility"] = json_audience_visibility
+
+    json_audience_record_status: None | str | Unset
+    if isinstance(audience_record_status, Unset):
+        json_audience_record_status = UNSET
+    else:
+        json_audience_record_status = audience_record_status
+    params["audience_record_status"] = json_audience_record_status
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -116,15 +132,22 @@ def sync_detailed(
     client: AuthenticatedClient,
     skip: int | Unset = 0,
     limit: int | Unset = 100,
+    audience_visibility: None | str | Unset = UNSET,
+    audience_record_status: None | str | Unset = UNSET,
 ) -> Response[KeywordListResponse | ProblemDetail]:
     """List Keywords Endpoint
 
-     List all keywords for a record.
+     List all keywords for a record, marking analysis-inherited ones.
 
     Args:
         record_id (UUID):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 100.
+        audience_visibility (None | str | Unset): Compute inherited_audience_gap as if the record
+            had this visibility — the counterfactual an owner asks before widening access (feat
+            #1070). Keywords themselves are unaffected.
+        audience_record_status (None | str | Unset): Compute inherited_audience_gap as if the
+            record had this status — the counterfactual an owner asks before publishing (feat #1070).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -138,6 +161,8 @@ def sync_detailed(
         record_id=record_id,
         skip=skip,
         limit=limit,
+        audience_visibility=audience_visibility,
+        audience_record_status=audience_record_status,
     )
 
     response = client.get_httpx_client().request(
@@ -153,15 +178,22 @@ def sync(
     client: AuthenticatedClient,
     skip: int | Unset = 0,
     limit: int | Unset = 100,
+    audience_visibility: None | str | Unset = UNSET,
+    audience_record_status: None | str | Unset = UNSET,
 ) -> KeywordListResponse | ProblemDetail | None:
     """List Keywords Endpoint
 
-     List all keywords for a record.
+     List all keywords for a record, marking analysis-inherited ones.
 
     Args:
         record_id (UUID):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 100.
+        audience_visibility (None | str | Unset): Compute inherited_audience_gap as if the record
+            had this visibility — the counterfactual an owner asks before widening access (feat
+            #1070). Keywords themselves are unaffected.
+        audience_record_status (None | str | Unset): Compute inherited_audience_gap as if the
+            record had this status — the counterfactual an owner asks before publishing (feat #1070).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -176,6 +208,8 @@ def sync(
         client=client,
         skip=skip,
         limit=limit,
+        audience_visibility=audience_visibility,
+        audience_record_status=audience_record_status,
     ).parsed
 
 
@@ -185,15 +219,22 @@ async def asyncio_detailed(
     client: AuthenticatedClient,
     skip: int | Unset = 0,
     limit: int | Unset = 100,
+    audience_visibility: None | str | Unset = UNSET,
+    audience_record_status: None | str | Unset = UNSET,
 ) -> Response[KeywordListResponse | ProblemDetail]:
     """List Keywords Endpoint
 
-     List all keywords for a record.
+     List all keywords for a record, marking analysis-inherited ones.
 
     Args:
         record_id (UUID):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 100.
+        audience_visibility (None | str | Unset): Compute inherited_audience_gap as if the record
+            had this visibility — the counterfactual an owner asks before widening access (feat
+            #1070). Keywords themselves are unaffected.
+        audience_record_status (None | str | Unset): Compute inherited_audience_gap as if the
+            record had this status — the counterfactual an owner asks before publishing (feat #1070).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -207,6 +248,8 @@ async def asyncio_detailed(
         record_id=record_id,
         skip=skip,
         limit=limit,
+        audience_visibility=audience_visibility,
+        audience_record_status=audience_record_status,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -220,15 +263,22 @@ async def asyncio(
     client: AuthenticatedClient,
     skip: int | Unset = 0,
     limit: int | Unset = 100,
+    audience_visibility: None | str | Unset = UNSET,
+    audience_record_status: None | str | Unset = UNSET,
 ) -> KeywordListResponse | ProblemDetail | None:
     """List Keywords Endpoint
 
-     List all keywords for a record.
+     List all keywords for a record, marking analysis-inherited ones.
 
     Args:
         record_id (UUID):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 100.
+        audience_visibility (None | str | Unset): Compute inherited_audience_gap as if the record
+            had this visibility — the counterfactual an owner asks before widening access (feat
+            #1070). Keywords themselves are unaffected.
+        audience_record_status (None | str | Unset): Compute inherited_audience_gap as if the
+            record had this status — the counterfactual an owner asks before publishing (feat #1070).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -244,5 +294,7 @@ async def asyncio(
             client=client,
             skip=skip,
             limit=limit,
+            audience_visibility=audience_visibility,
+            audience_record_status=audience_record_status,
         )
     ).parsed

--- a/sdks/python/geolens/models/dataset_response.py
+++ b/sdks/python/geolens/models/dataset_response.py
@@ -64,6 +64,9 @@ class DatasetResponse:
         last_edited_by_display (None | str | Unset):
         license_ (None | str | Unset):
         lineage_summary (None | str | Unset): Free-text provenance / lineage statement
+        metadata_warnings (list[str] | None | Unset): Advisory warnings produced by a metadata update — e.g. a
+            visibility or status change exposing keywords inherited from an analysis source the new audience cannot open
+            (feat #1070). Only ever set on the PATCH response; the change has already applied.
         n_dims (int | None | Unset): Number of coordinate dimensions (2, 3, or 4)
         original_srid (int | None | Unset): EPSG SRID of the uploaded source file
         owner_org (None | str | Unset): Owning organization name
@@ -120,6 +123,7 @@ class DatasetResponse:
     last_edited_by_display: None | str | Unset = UNSET
     license_: None | str | Unset = UNSET
     lineage_summary: None | str | Unset = UNSET
+    metadata_warnings: list[str] | None | Unset = UNSET
     n_dims: int | None | Unset = UNSET
     original_srid: int | None | Unset = UNSET
     owner_org: None | str | Unset = UNSET
@@ -294,6 +298,15 @@ class DatasetResponse:
             lineage_summary = UNSET
         else:
             lineage_summary = self.lineage_summary
+
+        metadata_warnings: list[str] | None | Unset
+        if isinstance(self.metadata_warnings, Unset):
+            metadata_warnings = UNSET
+        elif isinstance(self.metadata_warnings, list):
+            metadata_warnings = self.metadata_warnings
+
+        else:
+            metadata_warnings = self.metadata_warnings
 
         n_dims: int | None | Unset
         if isinstance(self.n_dims, Unset):
@@ -494,6 +507,8 @@ class DatasetResponse:
             field_dict["license"] = license_
         if lineage_summary is not UNSET:
             field_dict["lineage_summary"] = lineage_summary
+        if metadata_warnings is not UNSET:
+            field_dict["metadata_warnings"] = metadata_warnings
         if n_dims is not UNSET:
             field_dict["n_dims"] = n_dims
         if original_srid is not UNSET:
@@ -813,6 +828,23 @@ class DatasetResponse:
 
         lineage_summary = _parse_lineage_summary(d.pop("lineage_summary", UNSET))
 
+        def _parse_metadata_warnings(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                metadata_warnings_type_0 = cast(list[str], data)
+
+                return metadata_warnings_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        metadata_warnings = _parse_metadata_warnings(d.pop("metadata_warnings", UNSET))
+
         def _parse_n_dims(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -1105,6 +1137,7 @@ class DatasetResponse:
             last_edited_by_display=last_edited_by_display,
             license_=license_,
             lineage_summary=lineage_summary,
+            metadata_warnings=metadata_warnings,
             n_dims=n_dims,
             original_srid=original_srid,
             owner_org=owner_org,

--- a/sdks/python/geolens/models/keyword_list_response.py
+++ b/sdks/python/geolens/models/keyword_list_response.py
@@ -6,6 +6,8 @@ from typing import Any, TypeVar, TYPE_CHECKING
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
 
 if TYPE_CHECKING:
     from ..models.keyword_response import KeywordResponse
@@ -20,10 +22,14 @@ class KeywordListResponse:
     Attributes:
         keywords (list[KeywordResponse]):
         total (int):
+        inherited_audience_gap (bool | Unset): True when at least one keyword is inherited AND this record's audience —
+            at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters —
+            includes someone who cannot open the source dataset (feat #1070). Default: False.
     """
 
     keywords: list[KeywordResponse]
     total: int
+    inherited_audience_gap: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -34,6 +40,8 @@ class KeywordListResponse:
 
         total = self.total
 
+        inherited_audience_gap = self.inherited_audience_gap
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -42,6 +50,8 @@ class KeywordListResponse:
                 "total": total,
             }
         )
+        if inherited_audience_gap is not UNSET:
+            field_dict["inherited_audience_gap"] = inherited_audience_gap
 
         return field_dict
 
@@ -59,9 +69,12 @@ class KeywordListResponse:
 
         total = d.pop("total")
 
+        inherited_audience_gap = d.pop("inherited_audience_gap", UNSET)
+
         keyword_list_response = cls(
             keywords=keywords,
             total=total,
+            inherited_audience_gap=inherited_audience_gap,
         )
 
         keyword_list_response.additional_properties = d

--- a/sdks/python/geolens/models/keyword_response.py
+++ b/sdks/python/geolens/models/keyword_response.py
@@ -6,6 +6,7 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
 
 from typing import cast
 from uuid import UUID
@@ -23,6 +24,9 @@ class KeywordResponse:
         keyword_type (str):
         record_id (UUID):
         vocabulary_uri (None | str):
+        inherited (bool | Unset): True when this keyword also exists on the dataset this record was derived from (feat
+            #1070). Derived at read time from derived_from; only ever true for a requester who can access that source
+            dataset, so everyone else sees false — matching the derived_from redaction. Default: False.
     """
 
     id: UUID
@@ -30,6 +34,7 @@ class KeywordResponse:
     keyword_type: str
     record_id: UUID
     vocabulary_uri: None | str
+    inherited: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -44,6 +49,8 @@ class KeywordResponse:
         vocabulary_uri: None | str
         vocabulary_uri = self.vocabulary_uri
 
+        inherited = self.inherited
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -55,6 +62,8 @@ class KeywordResponse:
                 "vocabulary_uri": vocabulary_uri,
             }
         )
+        if inherited is not UNSET:
+            field_dict["inherited"] = inherited
 
         return field_dict
 
@@ -76,12 +85,15 @@ class KeywordResponse:
 
         vocabulary_uri = _parse_vocabulary_uri(d.pop("vocabulary_uri"))
 
+        inherited = d.pop("inherited", UNSET)
+
         keyword_response = cls(
             id=id,
             keyword=keyword,
             keyword_type=keyword_type,
             record_id=record_id,
             vocabulary_uri=vocabulary_uri,
+            inherited=inherited,
         )
 
         keyword_response.additional_properties = d

--- a/sdks/python/geolens/models/status_update_response.py
+++ b/sdks/python/geolens/models/status_update_response.py
@@ -6,6 +6,10 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
 
 T = TypeVar("T", bound="StatusUpdateResponse")
 
@@ -16,16 +20,29 @@ class StatusUpdateResponse:
     Attributes:
         id (str):
         record_status (str):
+        metadata_warnings (list[str] | None | Unset): Advisory warnings from the status change — the same inherited-
+            keyword disclosure check the metadata PATCH runs (feat #1070, fix #1178 review). The transition has already
+            applied.
     """
 
     id: str
     record_status: str
+    metadata_warnings: list[str] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         record_status = self.record_status
+
+        metadata_warnings: list[str] | None | Unset
+        if isinstance(self.metadata_warnings, Unset):
+            metadata_warnings = UNSET
+        elif isinstance(self.metadata_warnings, list):
+            metadata_warnings = self.metadata_warnings
+
+        else:
+            metadata_warnings = self.metadata_warnings
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -35,6 +52,8 @@ class StatusUpdateResponse:
                 "record_status": record_status,
             }
         )
+        if metadata_warnings is not UNSET:
+            field_dict["metadata_warnings"] = metadata_warnings
 
         return field_dict
 
@@ -45,9 +64,27 @@ class StatusUpdateResponse:
 
         record_status = d.pop("record_status")
 
+        def _parse_metadata_warnings(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                metadata_warnings_type_0 = cast(list[str], data)
+
+                return metadata_warnings_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        metadata_warnings = _parse_metadata_warnings(d.pop("metadata_warnings", UNSET))
+
         status_update_response = cls(
             id=id,
             record_status=record_status,
+            metadata_warnings=metadata_warnings,
         )
 
         status_update_response.additional_properties = d

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -4351,7 +4351,7 @@ export const updateDistributionEndpointRecordsRecordIdDistributionsDistributionI
 /**
  * List Keywords Endpoint
  *
- * List all keywords for a record.
+ * List all keywords for a record, marking analysis-inherited ones.
  */
 export const listKeywordsEndpointRecordsRecordIdKeywordsGet = <ThrowOnError extends boolean = false>(options: Options<ListKeywordsEndpointRecordsRecordIdKeywordsGetData, ThrowOnError>): RequestResult<ListKeywordsEndpointRecordsRecordIdKeywordsGetResponses, ListKeywordsEndpointRecordsRecordIdKeywordsGetErrors, ThrowOnError> => (options.client ?? client).get<ListKeywordsEndpointRecordsRecordIdKeywordsGetResponses, ListKeywordsEndpointRecordsRecordIdKeywordsGetErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -9628,6 +9628,12 @@ export type StatusUpdateResponse = {
      */
     id: string;
     /**
+     * Metadata Warnings
+     *
+     * Advisory warnings from the status change — the same inherited-keyword disclosure check the metadata PATCH runs (feat #1070, fix #1178 review). The transition has already applied.
+     */
+    metadata_warnings?: Array<string> | null;
+    /**
      * Record Status
      */
     record_status: string;

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3132,6 +3132,12 @@ export type DatasetResponse = {
      */
     lineage_summary?: string | null;
     /**
+     * Metadata Warnings
+     *
+     * Advisory warnings produced by a metadata update — e.g. a visibility or status change exposing keywords inherited from an analysis source the new audience cannot open (feat #1070). Only ever set on the PATCH response; the change has already applied.
+     */
+    metadata_warnings?: Array<string> | null;
+    /**
      * N Dims
      *
      * Number of coordinate dimensions (2, 3, or 4)
@@ -4622,6 +4628,12 @@ export type KeywordCreate = {
  */
 export type KeywordListResponse = {
     /**
+     * Inherited Audience Gap
+     *
+     * True when at least one keyword is inherited AND this record's audience — at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters — includes someone who cannot open the source dataset (feat #1070).
+     */
+    inherited_audience_gap?: boolean;
+    /**
      * Keywords
      */
     keywords: Array<KeywordResponse>;
@@ -4639,6 +4651,12 @@ export type KeywordResponse = {
      * Id
      */
     id: string;
+    /**
+     * Inherited
+     *
+     * True when this keyword also exists on the dataset this record was derived from (feat #1070). Derived at read time from derived_from; only ever true for a requester who can access that source dataset, so everyone else sees false — matching the derived_from redaction.
+     */
+    inherited?: boolean;
     /**
      * Keyword
      */
@@ -23340,6 +23358,18 @@ export type ListKeywordsEndpointRecordsRecordIdKeywordsGetData = {
          * Limit
          */
         limit?: number;
+        /**
+         * Audience Visibility
+         *
+         * Compute inherited_audience_gap as if the record had this visibility — the counterfactual an owner asks before widening access (feat #1070). Keywords themselves are unaffected.
+         */
+        audience_visibility?: string | null;
+        /**
+         * Audience Record Status
+         *
+         * Compute inherited_audience_gap as if the record had this status — the counterfactual an owner asks before publishing (feat #1070).
+         */
+        audience_record_status?: string | null;
     };
     url: '/records/{record_id}/keywords/';
 };


### PR DESCRIPTION
## Problem

`apply_analysis_provenance` copies the source record's keywords onto a materialized analysis output, and the owner is never told. Widening the derived dataset's visibility or publishing it can expose keywords inherited from a source the new audience cannot read. (#1070; route decision on the issue: derive at read time, no migration, no row marking.)

## Fix

**Backend** — new `records/inherited.py` resolves `Record.derived_from` to the source record and intersects keyword sets at read time:

- `GET /records/{id}/keywords/`: each keyword gains `inherited: bool`; the list response gains `inherited_audience_gap: bool`. Optional `audience_visibility` / `audience_record_status` query params answer the counterfactual an owner asks before widening access. Both flags resolve only for a requester who can access the source — the same rule that already redacts `derived_from`, so non-source-readers cannot distinguish "not derived" from "derived from something hidden".
- Disclosure warning at every audience-widening writer: the shared `inherited_keyword_disclosure_warning` helper runs after resolved state in `update_user_metadata` (PATCH `/datasets/{id}` → `DatasetResponse.metadata_warnings`) AND in both publication-status endpoints (`/status/`, `/target-status/` → `StatusUpdateResponse.metadata_warnings`). The remaining `record_status`/`visibility` writers are creation-time only (enumerated in the helper docstring) and act on records that cannot yet be analysis-derived. Advisory, not a refusal. The audience question goes through `record_audience` (#1068) so permission overlays answer for themselves.
- Accepted limitation (documented in the module docstring, per the recorded route decision): a source-side keyword deletion declassifies the still-present copy — read-time derivation cannot see historical source state, and copy-time row marking was explicitly rejected (migration + backfill).

**Frontend** — inherited marker + audience-gap hint in `KeywordsEditor`; `AccessTab` probes the counterfactual and holds visibility changes behind a confirm dialog naming the inherited keywords, and surfaces PATCH `metadata_warnings` as a warning toast when the probe fails; `DatasetPage`'s publish toggle surfaces the status-endpoint warning. Keys in all four locales.

## API/schema impact

Additive response fields (`inherited`, `inherited_audience_gap`, `metadata_warnings` on dataset + status responses) + optional query params; OpenAPI and both SDKs regenerated. No migration.

## Verification

- Backend full suite (host :5434): 7030 passed, 88 skipped; `tests/test_inherited_keywords.py` covers derivation, gone/unparseable sources, warnings on both widening axes AND both publish endpoints, negatives, endpoint shape, viewer redaction, PATCH surface
- `ruff check` / `format --check` clean; layering caps raised with #1070 comments; `inherited.py` allowlisted in the cross-domain User-import guard (SQL InstrumentedAttribute use, documented)
- `make openapi-check && make sdks-check` exit 0; `make cli-test` 8 passed, 2 skipped
- Frontend: build/lint/typecheck green; vitest 4578 passed; `test:i18n` green

Closes #1070