### PR TITLE
fix(records): honor the keyword counterfactual only for the record owner

### DIFF
--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -199,6 +199,23 @@ async def _check_record_read_access(
     )
 
 
+async def _is_record_owner_or_admin(
+    db: AsyncSession, record: Record, user: Identity | None
+) -> bool:
+    """Return whether ``user`` owns ``record`` or is a global admin.
+
+    The non-raising twin of the predicate `_check_record_ownership` enforces
+    (and the same notion `check_dataset_write_access` uses on the dataset side):
+    creator match on `created_by`, else the `admin` role. Read endpoints that
+    need to branch on ownership without rejecting the request use this.
+    """
+    if user is None:
+        return False
+    if record.created_by is not None and record.created_by == user.id:
+        return True
+    return "admin" in await get_user_roles(db, user)
+
+
 async def _check_record_ownership(
     db: AsyncSession, record_id: uuid.UUID, user: Identity
 ) -> Record:
@@ -494,7 +511,9 @@ async def list_keywords_endpoint(
         description=(
             "Compute inherited_audience_gap as if the record had this "
             "visibility — the counterfactual an owner asks before widening "
-            "access (feat #1070). Keywords themselves are unaffected."
+            "access (feat #1070). Honored only for the record's owner and "
+            "admins; ignored for everyone else, who get the gap at the "
+            "record's stored state. Keywords themselves are unaffected."
         ),
     ),
     audience_record_status: str | None = Query(
@@ -502,7 +521,14 @@ async def list_keywords_endpoint(
         max_length=30,
         description=(
             "Compute inherited_audience_gap as if the record had this status — "
-            "the counterfactual an owner asks before publishing (feat #1070)."
+            "the counterfactual an owner asks before publishing (feat #1070). "
+            "Honored only for the record's owner and admins; ignored for "
+            "everyone else, who get the gap at the record's stored state. "
+            "Deliberately not pinned to an enum: the lifecycle statuses come "
+            "from the workflow extension's status_order(), so an overlay may "
+            "define its own. An unrecognized status is treated conservatively "
+            "(it reaches only the owner, which errs toward warning) rather "
+            "than rejected."
         ),
     ),
     user: Identity | None = Depends(get_optional_user),
@@ -535,13 +561,21 @@ async def list_keywords_endpoint(
                             select(Dataset.id).where(Dataset.record_id == record_id)
                         )
                     ).scalar_one_or_none()
+                    # fix(#1070 sec-audit): the counterfactual collapses the
+                    # derived audience to "the owner", turning the gap into an
+                    # oracle for whether that named owner holds a grant on a
+                    # restricted source — so honor the overrides only for the
+                    # owner (or an admin) and otherwise answer at stored state.
+                    counterfactual = await _is_record_owner_or_admin(db, record, user)
                     audience_gap = await audience_exceeds_source(
                         db,
                         record=record,
                         dataset_id=dataset_id,
                         source=source,
-                        visibility=audience_visibility,
-                        record_status=audience_record_status,
+                        visibility=audience_visibility if counterfactual else None,
+                        record_status=(
+                            audience_record_status if counterfactual else None
+                        ),
                     )
 
     def _to_response(k) -> KeywordResponse:

--- a/backend/app/modules/catalog/records/schemas.py
+++ b/backend/app/modules/catalog/records/schemas.py
@@ -182,7 +182,8 @@ class KeywordListResponse(BaseModel):
         description=(
             "True when at least one keyword is inherited AND this record's "
             "audience — at its stored state, or at the counterfactual "
-            "audience_visibility/audience_record_status query parameters — "
+            "audience_visibility/audience_record_status query parameters, "
+            "which are honored only for the record's owner and admins — "
             "includes someone who cannot open the source dataset (feat #1070)."
         ),
     )

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7861,7 +7861,7 @@
         "properties": {
           "inherited_audience_gap": {
             "default": false,
-            "description": "True when at least one keyword is inherited AND this record's audience \u2014 at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters \u2014 includes someone who cannot open the source dataset (feat #1070).",
+            "description": "True when at least one keyword is inherited AND this record's audience \u2014 at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters, which are honored only for the record's owner and admins \u2014 includes someone who cannot open the source dataset (feat #1070).",
             "title": "Inherited Audience Gap",
             "type": "boolean"
           },
@@ -48320,7 +48320,7 @@
             }
           },
           {
-            "description": "Compute inherited_audience_gap as if the record had this visibility \u2014 the counterfactual an owner asks before widening access (feat #1070). Keywords themselves are unaffected.",
+            "description": "Compute inherited_audience_gap as if the record had this visibility \u2014 the counterfactual an owner asks before widening access (feat #1070). Honored only for the record's owner and admins; ignored for everyone else, who get the gap at the record's stored state. Keywords themselves are unaffected.",
             "in": "query",
             "name": "audience_visibility",
             "required": false,
@@ -48334,12 +48334,12 @@
                   "type": "null"
                 }
               ],
-              "description": "Compute inherited_audience_gap as if the record had this visibility \u2014 the counterfactual an owner asks before widening access (feat #1070). Keywords themselves are unaffected.",
+              "description": "Compute inherited_audience_gap as if the record had this visibility \u2014 the counterfactual an owner asks before widening access (feat #1070). Honored only for the record's owner and admins; ignored for everyone else, who get the gap at the record's stored state. Keywords themselves are unaffected.",
               "title": "Audience Visibility"
             }
           },
           {
-            "description": "Compute inherited_audience_gap as if the record had this status \u2014 the counterfactual an owner asks before publishing (feat #1070).",
+            "description": "Compute inherited_audience_gap as if the record had this status \u2014 the counterfactual an owner asks before publishing (feat #1070). Honored only for the record's owner and admins; ignored for everyone else, who get the gap at the record's stored state. Deliberately not pinned to an enum: the lifecycle statuses come from the workflow extension's status_order(), so an overlay may define its own. An unrecognized status is treated conservatively (it reaches only the owner, which errs toward warning) rather than rejected.",
             "in": "query",
             "name": "audience_record_status",
             "required": false,
@@ -48353,7 +48353,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Compute inherited_audience_gap as if the record had this status \u2014 the counterfactual an owner asks before publishing (feat #1070).",
+              "description": "Compute inherited_audience_gap as if the record had this status \u2014 the counterfactual an owner asks before publishing (feat #1070). Honored only for the record's owner and admins; ignored for everyone else, who get the gap at the record's stored state. Deliberately not pinned to an enum: the lifecycle statuses come from the workflow extension's status_order(), so an overlay may define its own. An unrecognized status is treated conservatively (it reaches only the owner, which errs toward warning) rather than rejected.",
               "title": "Audience Record Status"
             }
           }

--- a/backend/tests/test_inherited_keywords.py
+++ b/backend/tests/test_inherited_keywords.py
@@ -20,9 +20,10 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.modules.auth.models import User
+from app.modules.auth.models import Role, User, UserRole
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
+    DatasetGrant,
     Record,
     RecordKeyword,
 )
@@ -34,6 +35,7 @@ from app.modules.catalog.records.inherited import (
     resolve_inherited_source,
 )
 
+from tests.conftest import _create_test_user
 from tests.factories import create_dataset, get_user_id
 
 pytestmark = pytest.mark.anyio
@@ -403,6 +405,117 @@ class TestKeywordsEndpointShape:
         )
         assert resp.status_code == 200, resp.text
         assert [k["inherited"] for k in resp.json()["keywords"]] == [True]
+
+    async def test_counterfactual_ignored_for_non_owner_with_source_access(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1070 sec-audit): the counterfactual is an ownership oracle.
+
+        ``audience_visibility=private`` collapses the derived audience to
+        "the owner (plus admins)", so the returned gap reduces to "the output's
+        OWNER lacks access to the source" — and ``created_by`` is already on the
+        dataset response, so the attacker knows whose grant they are probing.
+        The live case is this one: a grant holder on a restricted+published
+        source, reading someone else's derived output. Grant lists are not
+        otherwise readable by non-owners, so the bit must not be answerable.
+
+        The state is built here rather than borrowed from a fixture role
+        because the whole point is the actor's exact position: a NON-owner who
+        DOES hold source access, the one actor the file did not previously
+        cover.
+        """
+        grant_role = Role(name=f"kw-audit-{uuid.uuid4().hex[:8]}")
+        test_db_session.add(grant_role)
+        await test_db_session.flush()
+
+        # Two accounts in that role: the derived output's owner, and the
+        # attacker. Both can open the source; only one owns the output.
+        owner_header, output_owner_id = await _create_test_user(
+            client, admin_auth_header, "viewer"
+        )
+        actor_header, actor_id = await _create_test_user(
+            client, admin_auth_header, "viewer"
+        )
+        for user_id in (output_owner_id, actor_id):
+            test_db_session.add(
+                UserRole(user_id=uuid.UUID(user_id), role_id=grant_role.id)
+            )
+        # An active account in NO role: inside the internal output's audience,
+        # outside the restricted source's. It is what makes the stored-state
+        # answer True, so the two answers can be told apart.
+        await _add_plain_user(test_db_session)
+
+        source_owner = await _add_plain_user(test_db_session)
+        source, _, _, derived_record = await _derived_pair(
+            test_db_session,
+            source_owner.id,
+            source_visibility="restricted",
+            derived_visibility="internal",
+            derived_status="published",
+            derived_owner_id=uuid.UUID(output_owner_id),
+        )
+        test_db_session.add(DatasetGrant(dataset_id=source.id, role_id=grant_role.id))
+        await test_db_session.commit()
+
+        probe = "?audience_visibility=private&audience_record_status=published"
+
+        # The attacker: identical answers with and without the overrides, so
+        # the response carries no information about the owner's grant.
+        stored = await client.get(
+            f"/records/{derived_record.id}/keywords/", headers=actor_header
+        )
+        assert stored.status_code == 200, stored.text
+        # Precondition: the actor really can resolve the inheritance, so a
+        # False below would be the gate and not a redaction.
+        assert [k["inherited"] for k in stored.json()["keywords"]] == [True]
+        assert stored.json()["inherited_audience_gap"] is True
+
+        probed = await client.get(
+            f"/records/{derived_record.id}/keywords/{probe}",
+            headers=actor_header,
+        )
+        assert probed.status_code == 200, probed.text
+        assert (
+            probed.json()["inherited_audience_gap"]
+            == stored.json()["inherited_audience_gap"]
+        )
+
+        # Positive control: the OWNER passing the SAME overrides still gets the
+        # counterfactual answer, and it differs from their stored-state one —
+        # narrowing to private closes the gap, because the only reader left is
+        # the owner and the owner does hold the source grant. The gate is what
+        # changed, not the feature.
+        owner_stored = await client.get(
+            f"/records/{derived_record.id}/keywords/", headers=owner_header
+        )
+        assert owner_stored.status_code == 200, owner_stored.text
+        assert owner_stored.json()["inherited_audience_gap"] is True
+
+        owner_view = await client.get(
+            f"/records/{derived_record.id}/keywords/{probe}",
+            headers=owner_header,
+        )
+        assert owner_view.status_code == 200, owner_view.text
+        assert owner_view.json()["inherited_audience_gap"] is False
+
+        # ADMISSION direction, pinned separately: `internal` is the fourth
+        # lifecycle status (DEFAULT_STATUS_ORDER in defaults_extensions.py) and
+        # the other transition this feature warns about. It must be answered,
+        # not rejected — a pattern pinned to the community default would 422
+        # here, and would also 422 a status an enterprise workflow overlay
+        # defines, since the set comes from `status_order()`.
+        owner_internal = await client.get(
+            f"/records/{derived_record.id}/keywords/"
+            "?audience_visibility=private&audience_record_status=internal",
+            headers=owner_header,
+        )
+        assert owner_internal.status_code == 200, owner_internal.text
+        # Not merely accepted — honored: the stored-state answer is True, so a
+        # False here means the override reached record_audience.
+        assert owner_internal.json()["inherited_audience_gap"] is False
 
 
 class TestStatusEndpointWarningSurface:

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -8402,7 +8402,7 @@ export interface components {
         KeywordListResponse: {
             /**
              * Inherited Audience Gap
-             * @description True when at least one keyword is inherited AND this record's audience — at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters — includes someone who cannot open the source dataset (feat #1070).
+             * @description True when at least one keyword is inherited AND this record's audience — at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters, which are honored only for the record's owner and admins — includes someone who cannot open the source dataset (feat #1070).
              * @default false
              */
             inherited_audience_gap: boolean;
@@ -33563,9 +33563,9 @@ export interface operations {
             query?: {
                 skip?: number;
                 limit?: number;
-                /** @description Compute inherited_audience_gap as if the record had this visibility — the counterfactual an owner asks before widening access (feat #1070). Keywords themselves are unaffected. */
+                /** @description Compute inherited_audience_gap as if the record had this visibility — the counterfactual an owner asks before widening access (feat #1070). Honored only for the record's owner and admins; ignored for everyone else, who get the gap at the record's stored state. Keywords themselves are unaffected. */
                 audience_visibility?: string | null;
-                /** @description Compute inherited_audience_gap as if the record had this status — the counterfactual an owner asks before publishing (feat #1070). */
+                /** @description Compute inherited_audience_gap as if the record had this status — the counterfactual an owner asks before publishing (feat #1070). Honored only for the record's owner and admins; ignored for everyone else, who get the gap at the record's stored state. Deliberately not pinned to an enum: the lifecycle statuses come from the workflow extension's status_order(), so an overlay may define its own. An unrecognized status is treated conservatively (it reaches only the owner, which errs toward warning) rather than rejected. */
                 audience_record_status?: string | null;
             };
             header?: never;

--- a/sdks/python/geolens/api/records/list_keywords_endpoint_records_record_id_keywords_get.py
+++ b/sdks/python/geolens/api/records/list_keywords_endpoint_records_record_id_keywords_get.py
@@ -145,9 +145,15 @@ def sync_detailed(
         limit (int | Unset):  Default: 100.
         audience_visibility (None | str | Unset): Compute inherited_audience_gap as if the record
             had this visibility — the counterfactual an owner asks before widening access (feat
-            #1070). Keywords themselves are unaffected.
+            #1070). Honored only for the record's owner and admins; ignored for everyone else, who get
+            the gap at the record's stored state. Keywords themselves are unaffected.
         audience_record_status (None | str | Unset): Compute inherited_audience_gap as if the
             record had this status — the counterfactual an owner asks before publishing (feat #1070).
+            Honored only for the record's owner and admins; ignored for everyone else, who get the gap
+            at the record's stored state. Deliberately not pinned to an enum: the lifecycle statuses
+            come from the workflow extension's status_order(), so an overlay may define its own. An
+            unrecognized status is treated conservatively (it reaches only the owner, which errs
+            toward warning) rather than rejected.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -191,9 +197,15 @@ def sync(
         limit (int | Unset):  Default: 100.
         audience_visibility (None | str | Unset): Compute inherited_audience_gap as if the record
             had this visibility — the counterfactual an owner asks before widening access (feat
-            #1070). Keywords themselves are unaffected.
+            #1070). Honored only for the record's owner and admins; ignored for everyone else, who get
+            the gap at the record's stored state. Keywords themselves are unaffected.
         audience_record_status (None | str | Unset): Compute inherited_audience_gap as if the
             record had this status — the counterfactual an owner asks before publishing (feat #1070).
+            Honored only for the record's owner and admins; ignored for everyone else, who get the gap
+            at the record's stored state. Deliberately not pinned to an enum: the lifecycle statuses
+            come from the workflow extension's status_order(), so an overlay may define its own. An
+            unrecognized status is treated conservatively (it reaches only the owner, which errs
+            toward warning) rather than rejected.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -232,9 +244,15 @@ async def asyncio_detailed(
         limit (int | Unset):  Default: 100.
         audience_visibility (None | str | Unset): Compute inherited_audience_gap as if the record
             had this visibility — the counterfactual an owner asks before widening access (feat
-            #1070). Keywords themselves are unaffected.
+            #1070). Honored only for the record's owner and admins; ignored for everyone else, who get
+            the gap at the record's stored state. Keywords themselves are unaffected.
         audience_record_status (None | str | Unset): Compute inherited_audience_gap as if the
             record had this status — the counterfactual an owner asks before publishing (feat #1070).
+            Honored only for the record's owner and admins; ignored for everyone else, who get the gap
+            at the record's stored state. Deliberately not pinned to an enum: the lifecycle statuses
+            come from the workflow extension's status_order(), so an overlay may define its own. An
+            unrecognized status is treated conservatively (it reaches only the owner, which errs
+            toward warning) rather than rejected.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -276,9 +294,15 @@ async def asyncio(
         limit (int | Unset):  Default: 100.
         audience_visibility (None | str | Unset): Compute inherited_audience_gap as if the record
             had this visibility — the counterfactual an owner asks before widening access (feat
-            #1070). Keywords themselves are unaffected.
+            #1070). Honored only for the record's owner and admins; ignored for everyone else, who get
+            the gap at the record's stored state. Keywords themselves are unaffected.
         audience_record_status (None | str | Unset): Compute inherited_audience_gap as if the
             record had this status — the counterfactual an owner asks before publishing (feat #1070).
+            Honored only for the record's owner and admins; ignored for everyone else, who get the gap
+            at the record's stored state. Deliberately not pinned to an enum: the lifecycle statuses
+            come from the workflow extension's status_order(), so an overlay may define its own. An
+            unrecognized status is treated conservatively (it reaches only the owner, which errs
+            toward warning) rather than rejected.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/models/keyword_list_response.py
+++ b/sdks/python/geolens/models/keyword_list_response.py
@@ -23,8 +23,9 @@ class KeywordListResponse:
         keywords (list[KeywordResponse]):
         total (int):
         inherited_audience_gap (bool | Unset): True when at least one keyword is inherited AND this record's audience —
-            at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters —
-            includes someone who cannot open the source dataset (feat #1070). Default: False.
+            at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters, which
+            are honored only for the record's owner and admins — includes someone who cannot open the source dataset (feat
+            #1070). Default: False.
     """
 
     keywords: list[KeywordResponse]

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -4630,7 +4630,7 @@ export type KeywordListResponse = {
     /**
      * Inherited Audience Gap
      *
-     * True when at least one keyword is inherited AND this record's audience — at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters — includes someone who cannot open the source dataset (feat #1070).
+     * True when at least one keyword is inherited AND this record's audience — at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters, which are honored only for the record's owner and admins — includes someone who cannot open the source dataset (feat #1070).
      */
     inherited_audience_gap?: boolean;
     /**
@@ -23367,13 +23367,13 @@ export type ListKeywordsEndpointRecordsRecordIdKeywordsGetData = {
         /**
          * Audience Visibility
          *
-         * Compute inherited_audience_gap as if the record had this visibility — the counterfactual an owner asks before widening access (feat #1070). Keywords themselves are unaffected.
+         * Compute inherited_audience_gap as if the record had this visibility — the counterfactual an owner asks before widening access (feat #1070). Honored only for the record's owner and admins; ignored for everyone else, who get the gap at the record's stored state. Keywords themselves are unaffected.
          */
         audience_visibility?: string | null;
         /**
          * Audience Record Status
          *
-         * Compute inherited_audience_gap as if the record had this status — the counterfactual an owner asks before publishing (feat #1070).
+         * Compute inherited_audience_gap as if the record had this status — the counterfactual an owner asks before publishing (feat #1070). Honored only for the record's owner and admins; ignored for everyone else, who get the gap at the record's stored state. Deliberately not pinned to an enum: the lifecycle statuses come from the workflow extension's status_order(), so an overlay may define its own. An unrecognized status is treated conservatively (it reaches only the owner, which errs toward warning) rather than rejected.
          */
         audience_record_status?: string | null;
     };


### PR DESCRIPTION
Found by the 2026-08-04 security audit of the #1070 surface (`docs-internal/audits/sec-audit-20260804.md`, finding S01, Low / CVSS 3.1).

## Problem

`list_keywords_endpoint` honored `audience_visibility` and `audience_record_status` from **any** requester who cleared the read gate — which admits anonymous. Those params answer one question, the counterfactual an owner asks before widening access, and their only caller is `AccessTab`, owner-only UI.

With `?audience_visibility=private&audience_record_status=published`, `record_audience` collapses the derived audience to "admin OR the output's owner". `audience_exceeds_source` then looks for a user in the derived audience but not the source's: admins satisfy both sides and cancel, every non-owner fails the first clause. The returned `inherited_audience_gap` therefore reduces to **"this output's owner does not have access to the source dataset"** — a fact about a named third party, since `created_by` is already on the dataset response. Grant lists are not otherwise readable by non-owners.

Live case is narrow: a **restricted + published** source, where a grant holder reading someone else's derived output learns whether that output's owner also holds a grant. A private or unpublished source means only the owner/admin clears the outer `visible_derived_from` gate; a public or internal source makes the gap always false.

## Fix

The overrides reach `audience_exceeds_source` only when `_is_record_owner_or_admin(db, record, user)` holds; otherwise the gap is computed at the record's **stored state**. No 403, response shape unchanged, `AccessTab` unaffected — a non-owner still gets a correct answer, just not a hypothetical one.

`_is_record_owner_or_admin` is a new non-raising helper mirroring the two places the codebase already writes that predicate — `_check_record_ownership` (same file) and `check_dataset_write_access` (`catalog/authorization.py`): `created_by is not None and created_by == user.id`, else the `admin` role. Both existing helpers raise, which a read endpoint cannot do.

Also documents on `audience_record_status` why it is deliberately **not** pinned to an enum: the lifecycle set comes from the workflow extension's `status_order()`, so a literal pattern would 422 a valid status in an overlay deployment. (An earlier revision of this branch pinned one and would have rejected `internal`.)

## Tests

`test_counterfactual_ignored_for_non_owner_with_source_access` adds the actor the file did not cover — a non-owner **with** source access — building its own role + grant rather than borrowing a fixture:

- attacker, with and without the params: **identical** `inherited_audience_gap`, so the response carries no information about the owner's grant (with a precondition asserting the inherited flags really resolve, so a redaction cannot masquerade as the gate)
- owner control: the same params still flip the answer — the feature is intact, only the gate changed
- admission control: owner with `audience_record_status=internal` is honored, not merely accepted

Negative control run twice: forcing the gate open makes the new test fail.

## Verification

`ruff check` / `format --check` clean · full backend suite 7032 passed, 89 skipped · targeted re-run at the committed tree 73 passed (`test_inherited_keywords` + `test_layering` + `test_workflow_extension` + `test_rule1_structural`) · `make openapi-check`, `make sdks-check`, frontend `npm run types:check`, `make cli-test` all pass.

Regen touched four artifacts (openapi.json, both SDKs, `frontend/src/types/api.generated.ts`) — description text only; `git diff backend/openapi.json | grep -E '^[-+].*(maxLength|pattern)'` is empty, so no constraint or field changed.

Refs #1070