### PR TITLE
chore(audit): drop the inert brace-expansion allowlist entry

### DIFF
--- a/scripts/js-audit-gate.mjs
+++ b/scripts/js-audit-gate.mjs
@@ -19,23 +19,6 @@ const ALLOWLIST = [
       'advisory range is corrected upstream or the router moves to >=8.3.0.',
     expires: '2026-09-01',
   },
-  {
-    id: 'GHSA-mh99-v99m-4gvg', // brace-expansion DoS via unbounded expansion (high)
-    reason:
-      'Reached only through the eslint toolchain — eslint / ' +
-      '@typescript-eslint/typescript-estree, and eslint-plugin-jsx-a11y via ' +
-      'minimatch@3. It is a devDependency in every path, so the vulnerable ' +
-      'code is never in the shipped bundle; exploiting it needs an ' +
-      'attacker-controlled glob handed to eslint, and our globs come from ' +
-      'repo-authored config. No in-range fix exists: 1.1.16 is the last of the ' +
-      '1.x line (unpatched), and overriding to the patched 5.0.8 breaks ' +
-      'linting outright — minimatch@3 throws in `new Minimatch` against the ' +
-      '5.x API (verified locally). npm’s only suggested fix is the eslint 10 ' +
-      'major. Drop this entry when eslint 10 lands (Dependabot #595) or a ' +
-      'patched 1.x ships. Shares the react-router expiry so both allowlist ' +
-      'entries get one review date.',
-    expires: '2026-09-01',
-  },
 ];
 
 let raw;
@@ -80,16 +63,28 @@ for (const e of ALLOWLIST.filter((e) => e.expires < today)) {
 // entries are transitive references rooted at one of those objects, so
 // checking the objects alone covers the whole tree.
 const failing = new Map();
+const matched = new Set();
 for (const vuln of Object.values(report.vulnerabilities ?? {})) {
   for (const via of vuln.via ?? []) {
     if (typeof via !== 'object') continue;
     if (via.severity !== 'high' && via.severity !== 'critical') continue;
     const id = (via.url ?? '').split('/').pop() ?? '';
     if (active.has(id)) {
+      matched.add(id);
       console.log(`allowlisted ${via.severity}: ${via.name} — ${via.title} (${id}, expires ${active.get(id).expires})`);
     } else {
       failing.set(id || `${via.name}: ${via.title}`, via);
     }
+  }
+}
+
+// fix(#1181): an entry whose advisory stopped firing is dead weight carrying a
+// justification that quietly goes out of date — this one claimed "1.1.16 is the
+// last of the 1.x line (unpatched)" months after 1.1.18 shipped. Warn, never
+// block: an advisory can legitimately stop appearing on one lockfile state.
+for (const [id, entry] of active) {
+  if (!matched.has(id)) {
+    console.warn(`allowlist entry ${id} matched no advisory — delete it (expires ${entry.expires})`);
   }
 }
 


### PR DESCRIPTION
Closes #1181. Re-scoped per the issue's own follow-up comment: **item 2 was already done** — the postcss 8.5.22 → 8.5.25 bump landed as #1174 — so this PR does the item-1 half only and makes no claim about postcss.

## What changed

Deletes the `GHSA-mh99-v99m-4gvg` (brace-expansion) entry from `scripts/js-audit-gate.mjs`. It has suppressed nothing since #1173 landed brace-expansion 1.1.18/5.0.9, and its stated reason — "1.1.16 is the last of the 1.x line (unpatched)" — was false against the installed tree.

The gate also now warns when an active allowlist entry matches no advisory in the report. That is what would have caught this one. Warning only, never blocking: an advisory can legitimately stop appearing on one lockfile state without the entry being wrong to keep, so this must not be able to fail a build.

The react-router entry (`GHSA-qwww-vcr4-c8h2`) stays. Worth flagging: its expiry is **2026-09-01**, so the v8 migration wants scheduling before the gate starts blocking on it.

## Verification

`npm ls brace-expansion --all` → `1.1.18` and `5.0.9` only; `npm audit` reports react-router as the sole remaining advisory, confirming the deleted entry was unreachable.

Running the gate from `frontend/`:

- exit 0, react-router still matches and draws **no** warning (so the new check does not fire on a live entry)
- with a probe entry added for a nonexistent advisory, the warning appears and the exit code stays 0
- probe removed; the diff is the deletion plus the warning

## Not in scope

The eslint 10 major (Dependabot #595) is no longer coupled to anything here — it was the "drop this entry when" condition, and the entry is gone.