### PR TITLE
docs(schemas): describe record_status as extension-defined, not a closed set

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_data.py
+++ b/backend/app/modules/catalog/datasets/api/router_data.py
@@ -281,8 +281,9 @@ async def update_publication_status(
 ) -> StatusUpdateResponse:
     """Transition a dataset's publication status following allowed paths.
 
-    Allowed transitions:
-      draft -> ready -> internal -> published (and back one step).
+    The allowed set comes from the workflow extension's
+    allowed_transitions(), so an overlay may define its own. The community
+    default is draft -> ready -> internal -> published (and back one step).
     """
     dataset = await db.execute(
         select(DatasetModel)
@@ -346,8 +347,10 @@ async def set_target_status(
 ) -> StatusUpdateResponse:
     """Walk the publication chain from current status to target in one request.
 
-    Executes each intermediate transition so the full chain
-    (e.g. draft -> ready -> internal -> published) completes server-side.
+    Executes each intermediate transition so the full chain completes
+    server-side. The order comes from the workflow extension's
+    status_order(), so an overlay may define its own; the community default
+    is draft -> ready -> internal -> published.
     """
     dataset = await db.execute(
         select(DatasetModel)

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -335,7 +335,13 @@ class DatasetResponse(BaseModel):
     collections: list["CollectionRef"] | None = None
     # ISO governance fields
     record_status: str = Field(
-        default="draft", description="Lifecycle status: draft, ready, published"
+        default="draft",
+        description=(
+            "Lifecycle status. Deliberately not pinned to an enum: the values "
+            "come from the workflow extension's status_order(), so an overlay "
+            "may define its own. Community default order: draft, ready, "
+            "internal, published."
+        ),
     )
     lineage_summary: str | None = Field(
         default=None, description="Free-text provenance / lineage statement"
@@ -517,7 +523,12 @@ class DatasetMeta(BaseModel):
     record_status: str | None = Field(
         default=None,
         max_length=20,
-        description="Lifecycle status: draft, ready, published",
+        description=(
+            "Lifecycle status. Deliberately not pinned to an enum: the values "
+            "come from the workflow extension's status_order(), so an overlay "
+            "may define its own. Community default order: draft, ready, "
+            "internal, published."
+        ),
     )
     owner_org: str | None = Field(
         default=None, max_length=1000, description="Owning organization name"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4819,7 +4819,7 @@
                 "type": "null"
               }
             ],
-            "description": "Lifecycle status: draft, ready, published",
+            "description": "Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.",
             "title": "Record Status"
           },
           "sensitivity_classification": {
@@ -5419,7 +5419,7 @@
           },
           "record_status": {
             "default": "draft",
-            "description": "Lifecycle status: draft, ready, published",
+            "description": "Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.",
             "title": "Record Status",
             "type": "string"
           },
@@ -37210,7 +37210,7 @@
     },
     "/datasets/{dataset_id}/status/": {
       "patch": {
-        "description": "Transition a dataset's publication status following allowed paths.\n\nAllowed transitions:\n  draft -> ready -> internal -> published (and back one step).",
+        "description": "Transition a dataset's publication status following allowed paths.\n\nThe allowed set comes from the workflow extension's\nallowed_transitions(), so an overlay may define its own. The community\ndefault is draft -> ready -> internal -> published (and back one step).",
         "operationId": "update_publication_status_datasets__dataset_id__status__patch",
         "parameters": [
           {
@@ -37364,7 +37364,7 @@
     },
     "/datasets/{dataset_id}/target-status/": {
       "patch": {
-        "description": "Walk the publication chain from current status to target in one request.\n\nExecutes each intermediate transition so the full chain\n(e.g. draft -> ready -> internal -> published) completes server-side.",
+        "description": "Walk the publication chain from current status to target in one request.\n\nExecutes each intermediate transition so the full chain completes\nserver-side. The order comes from the workflow extension's\nstatus_order(), so an overlay may define its own; the community default\nis draft -> ready -> internal -> published.",
         "operationId": "set_target_status_datasets__dataset_id__target_status__patch",
         "parameters": [
           {

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1998,7 +1998,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1178 review): +9 for the same field on StatusUpdateResponse — the
     # publication status endpoints run the disclosure check too, so their
     # response carries it. 1147 -> 1156.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1156,
+    # fix(#1183): +11 for the two record_status descriptions. Both said
+    # "draft, ready, published" — three values, omitting `internal`, and
+    # phrased as a closed set when `record_status` has no CHECK constraint
+    # and its values come from the workflow extension's status_order(). The
+    # wording now names the seam first and the community default second, so a
+    # reader cannot mistake the list for the contract. This is the SOURCE the
+    # SDKs and api.generated.ts are generated from, and #1184 already shipped
+    # a `^(draft|ready|published)$` validator read straight off it. 1156 ->
+    # 1167.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1167,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2484,8 +2484,9 @@ export interface paths {
          * Update Publication Status
          * @description Transition a dataset's publication status following allowed paths.
          *
-         *     Allowed transitions:
-         *       draft -> ready -> internal -> published (and back one step).
+         *     The allowed set comes from the workflow extension's
+         *     allowed_transitions(), so an overlay may define its own. The community
+         *     default is draft -> ready -> internal -> published (and back one step).
          */
         patch: operations["update_publication_status_datasets__dataset_id__status__patch"];
         trace?: never;
@@ -2507,8 +2508,10 @@ export interface paths {
          * Set Target Status
          * @description Walk the publication chain from current status to target in one request.
          *
-         *     Executes each intermediate transition so the full chain
-         *     (e.g. draft -> ready -> internal -> published) completes server-side.
+         *     Executes each intermediate transition so the full chain completes
+         *     server-side. The order comes from the workflow extension's
+         *     status_order(), so an overlay may define its own; the community default
+         *     is draft -> ready -> internal -> published.
          */
         patch: operations["set_target_status_datasets__dataset_id__target_status__patch"];
         trace?: never;
@@ -7086,7 +7089,7 @@ export interface components {
             quality_statement?: string | null;
             /**
              * Record Status
-             * @description Lifecycle status: draft, ready, published
+             * @description Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
              */
             record_status?: string | null;
             /**
@@ -7314,7 +7317,7 @@ export interface components {
             record_id: string;
             /**
              * Record Status
-             * @description Lifecycle status: draft, ready, published
+             * @description Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
              * @default draft
              */
             record_status: string;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -168,8 +168,16 @@ export type RecordType =
   | 'service'
   | 'collection'
   | 'table';
+// Mirrors backend chk_records_visibility CHECK constraint
+// (catalog/datasets/domain/models.py:35). Keep in sync if values change.
 export type DatasetVisibility = 'public' | 'internal' | 'restricted' | 'private';
-export type RecordStatus = 'draft' | 'published';
+/** fix(#1183): deliberately NOT a union. Unlike `visibility`, `record_status`
+ *  has no CHECK constraint backing it — the values come from the workflow
+ *  extension's `status_order()`, so an overlay may define its own. This was
+ *  typed `'draft' | 'published'`, which made the two community statuses it
+ *  omitted (`ready`, `internal`) a compile error to handle. Community default
+ *  order: draft, ready, internal, published. */
+export type RecordStatus = string;
 export type DistributionType = 'download' | 'ogc_features' | 'vector_tiles';
 
 /** Response returned by dataset publication-status mutation endpoints. */

--- a/sdks/python/geolens/api/datasets_data/set_target_status_datasets_dataset_id_target_status_patch.py
+++ b/sdks/python/geolens/api/datasets_data/set_target_status_datasets_dataset_id_target_status_patch.py
@@ -116,8 +116,10 @@ def sync_detailed(
 
      Walk the publication chain from current status to target in one request.
 
-    Executes each intermediate transition so the full chain
-    (e.g. draft -> ready -> internal -> published) completes server-side.
+    Executes each intermediate transition so the full chain completes
+    server-side. The order comes from the workflow extension's
+    status_order(), so an overlay may define its own; the community default
+    is draft -> ready -> internal -> published.
 
     Args:
         dataset_id (UUID):
@@ -153,8 +155,10 @@ def sync(
 
      Walk the publication chain from current status to target in one request.
 
-    Executes each intermediate transition so the full chain
-    (e.g. draft -> ready -> internal -> published) completes server-side.
+    Executes each intermediate transition so the full chain completes
+    server-side. The order comes from the workflow extension's
+    status_order(), so an overlay may define its own; the community default
+    is draft -> ready -> internal -> published.
 
     Args:
         dataset_id (UUID):
@@ -185,8 +189,10 @@ async def asyncio_detailed(
 
      Walk the publication chain from current status to target in one request.
 
-    Executes each intermediate transition so the full chain
-    (e.g. draft -> ready -> internal -> published) completes server-side.
+    Executes each intermediate transition so the full chain completes
+    server-side. The order comes from the workflow extension's
+    status_order(), so an overlay may define its own; the community default
+    is draft -> ready -> internal -> published.
 
     Args:
         dataset_id (UUID):
@@ -220,8 +226,10 @@ async def asyncio(
 
      Walk the publication chain from current status to target in one request.
 
-    Executes each intermediate transition so the full chain
-    (e.g. draft -> ready -> internal -> published) completes server-side.
+    Executes each intermediate transition so the full chain completes
+    server-side. The order comes from the workflow extension's
+    status_order(), so an overlay may define its own; the community default
+    is draft -> ready -> internal -> published.
 
     Args:
         dataset_id (UUID):

--- a/sdks/python/geolens/api/datasets_data/update_publication_status_datasets_dataset_id_status_patch.py
+++ b/sdks/python/geolens/api/datasets_data/update_publication_status_datasets_dataset_id_status_patch.py
@@ -116,8 +116,9 @@ def sync_detailed(
 
      Transition a dataset's publication status following allowed paths.
 
-    Allowed transitions:
-      draft -> ready -> internal -> published (and back one step).
+    The allowed set comes from the workflow extension's
+    allowed_transitions(), so an overlay may define its own. The community
+    default is draft -> ready -> internal -> published (and back one step).
 
     Args:
         dataset_id (UUID):
@@ -153,8 +154,9 @@ def sync(
 
      Transition a dataset's publication status following allowed paths.
 
-    Allowed transitions:
-      draft -> ready -> internal -> published (and back one step).
+    The allowed set comes from the workflow extension's
+    allowed_transitions(), so an overlay may define its own. The community
+    default is draft -> ready -> internal -> published (and back one step).
 
     Args:
         dataset_id (UUID):
@@ -185,8 +187,9 @@ async def asyncio_detailed(
 
      Transition a dataset's publication status following allowed paths.
 
-    Allowed transitions:
-      draft -> ready -> internal -> published (and back one step).
+    The allowed set comes from the workflow extension's
+    allowed_transitions(), so an overlay may define its own. The community
+    default is draft -> ready -> internal -> published (and back one step).
 
     Args:
         dataset_id (UUID):
@@ -220,8 +223,9 @@ async def asyncio(
 
      Transition a dataset's publication status following allowed paths.
 
-    Allowed transitions:
-      draft -> ready -> internal -> published (and back one step).
+    The allowed set comes from the workflow extension's
+    allowed_transitions(), so an overlay may define its own. The community
+    default is draft -> ready -> internal -> published (and back one step).
 
     Args:
         dataset_id (UUID):

--- a/sdks/python/geolens/models/dataset_meta.py
+++ b/sdks/python/geolens/models/dataset_meta.py
@@ -35,7 +35,9 @@ class DatasetMeta:
             lineage_summary (None | str | Unset): Free-text provenance / lineage statement
             owner_org (None | str | Unset): Owning organization name
             quality_statement (None | str | Unset):
-            record_status (None | str | Unset): Lifecycle status: draft, ready, published
+            record_status (None | str | Unset): Lifecycle status. Deliberately not pinned to an enum: the values come from
+                the workflow extension's status_order(), so an overlay may define its own. Community default order: draft,
+                ready, internal, published.
             sensitivity_classification (None | str | Unset): e.g. public, confidential, restricted
             source_organization (None | str | Unset):
             source_url (None | str | Unset): URL the data was originally fetched from

--- a/sdks/python/geolens/models/dataset_response.py
+++ b/sdks/python/geolens/models/dataset_response.py
@@ -74,7 +74,9 @@ class DatasetResponse:
         quality_detail (None | QualityDetail | Unset): Automated quality assessment results
         quality_statement (None | str | Unset):
         raster (None | RasterMetadata | Unset): Raster-specific metadata (null for vectors)
-        record_status (str | Unset): Lifecycle status: draft, ready, published Default: 'draft'.
+        record_status (str | Unset): Lifecycle status. Deliberately not pinned to an enum: the values come from the
+            workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready,
+            internal, published. Default: 'draft'.
         record_type (str | Unset): Record type: 'vector_dataset' (spatial features), 'raster_dataset' (single COG),
             'vrt_dataset' (VRT mosaic), 'table' (non-spatial tabular), 'map' (saved map), 'service' (catalogued remote
             service), 'collection' (flat dataset group). Default: 'vector_dataset'.

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -2679,8 +2679,9 @@ export const getDatasetRowsEndpointDatasetsDatasetIdRowsGet = <ThrowOnError exte
  *
  * Transition a dataset's publication status following allowed paths.
  *
- * Allowed transitions:
- * draft -> ready -> internal -> published (and back one step).
+ * The allowed set comes from the workflow extension's
+ * allowed_transitions(), so an overlay may define its own. The community
+ * default is draft -> ready -> internal -> published (and back one step).
  */
 export const updatePublicationStatusDatasetsDatasetIdStatusPatch = <ThrowOnError extends boolean = false>(options: Options<UpdatePublicationStatusDatasetsDatasetIdStatusPatchData, ThrowOnError>): RequestResult<UpdatePublicationStatusDatasetsDatasetIdStatusPatchResponses, UpdatePublicationStatusDatasetsDatasetIdStatusPatchErrors, ThrowOnError> => (options.client ?? client).patch<UpdatePublicationStatusDatasetsDatasetIdStatusPatchResponses, UpdatePublicationStatusDatasetsDatasetIdStatusPatchErrors, ThrowOnError>({
     security: [
@@ -2705,8 +2706,10 @@ export const updatePublicationStatusDatasetsDatasetIdStatusPatch = <ThrowOnError
  *
  * Walk the publication chain from current status to target in one request.
  *
- * Executes each intermediate transition so the full chain
- * (e.g. draft -> ready -> internal -> published) completes server-side.
+ * Executes each intermediate transition so the full chain completes
+ * server-side. The order comes from the workflow extension's
+ * status_order(), so an overlay may define its own; the community default
+ * is draft -> ready -> internal -> published.
  */
 export const setTargetStatusDatasetsDatasetIdTargetStatusPatch = <ThrowOnError extends boolean = false>(options: Options<SetTargetStatusDatasetsDatasetIdTargetStatusPatchData, ThrowOnError>): RequestResult<SetTargetStatusDatasetsDatasetIdTargetStatusPatchResponses, SetTargetStatusDatasetsDatasetIdTargetStatusPatchErrors, ThrowOnError> => (options.client ?? client).patch<SetTargetStatusDatasetsDatasetIdTargetStatusPatchResponses, SetTargetStatusDatasetsDatasetIdTargetStatusPatchErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -2877,7 +2877,7 @@ export type DatasetMeta = {
     /**
      * Record Status
      *
-     * Lifecycle status: draft, ready, published
+     * Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
      */
     record_status?: string | null;
     /**
@@ -3180,7 +3180,7 @@ export type DatasetResponse = {
     /**
      * Record Status
      *
-     * Lifecycle status: draft, ready, published
+     * Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
      */
     record_status?: string;
     /**


### PR DESCRIPTION
## Problem

Two `Field(description=...)` strings described the record lifecycle as a three-value set — `"Lifecycle status: draft, ready, published"` — omitting `internal`. The authoritative order is `DEFAULT_STATUS_ORDER = ("draft", "ready", "internal", "published")`.

These descriptions ship. They flow into `backend/openapi.json`, both generated SDKs, and `frontend/src/types/api.generated.ts`, so every API consumer reading the published docs or SDK docstrings was told the lifecycle has three states.

It already caused a wrong implementation: while fixing a security finding on `GET /records/{id}/keywords/`, the valid `record_status` values were read off these descriptions rather than `DEFAULT_STATUS_ORDER`, and a request validator was pinned to `^(draft|ready|published)$`. That would have 422'd `?audience_record_status=internal` — a legitimate transition the feature exists to warn about. Caught in review on #1184 and reverted.

## Fix

The set is not closed, so the wording no longer presents a list as the contract. Both descriptions now name the seam first and the default second:

> Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.

This matches the wording precedent already in `records/router.py` from #1070, so the two shipped descriptions of this set now read the same way.

### Why "extension-defined" is the accurate framing

- `status_order()` is a method on the `WorkflowExtension` Protocol; the `"workflow"` registry slot is replaceable by an enterprise overlay, and `DefaultWorkflowExtension` is only the community implementation.
- The decisive evidence is a schema fact: `visibility` is backed by the `chk_records_visibility` CHECK constraint, and **`record_status` has no CHECK constraint at all** — it is a bare `String(20)`.
- `backend/tests/test_workflow_extension.py` already registers an overlay returning `("draft", "review", "published")` and asserts it wins, so the open set is a tested property rather than a theoretical one.

## Sweep

The issue asked for a mechanical sweep of other places the set is written out by hand rather than derived. Three additional instances were in scope and are fixed:

- `router_data.py` — two FastAPI docstrings that ship as OpenAPI **operation** descriptions. `PATCH /datasets/{id}/status/` stated "Allowed transitions: draft -> ready -> internal -> published" as the rule, while the code one screen down calls `workflow.allowed_transitions(context)`.
- `frontend/src/types/api.ts` — `RecordStatus` was typed `'draft' | 'published'`. **Two** values, worse than the three-value description this issue was filed about, and a type rather than a doc: it made `ready` and `internal` a compile error to handle. Now `string`, with a comment recording why.

`DatasetVisibility` deliberately stays a union in the same file, because it does have a CHECK constraint behind it; the mirror comment now names it.

Behaviour is unchanged. `getRecordStatusLabel` already accepted `string` and falls back to `humanizeToken` for unrecognised values, so the runtime was open-set-tolerant already and only the type disagreed. The sole literal comparison, `record_status === 'published'`, is identical under `string`.

Deliberately left: `protocols.py` and `defaults_extensions.py` (already honest / the authority itself), comments describing one concrete path rather than enumerating the set, and test assertions naming all four values (correct — they pin the community default).

Out of scope, worth a follow-up: `processing/ingest/manifest_schemas.py` and `manifest_sources.py` hold a closed `Literal[...]` over this open set, mirrored by the CLI's `geolens-manifest-v1.schema.json` `enum` and pinned by `cli/tests/test_manifest_examples.py`. Widening it is a manifest-schema-version decision, not a docs fix. Consequence today: an overlay defining `review` cannot be expressed in a manifest.

## Regenerated artifacts

A description-only edit is still a full regen. `backend/openapi.json`, both SDKs, and `frontend/src/types/api.generated.ts` are regenerated and committed here; their diffs are pure description propagation.

`backend/tests/test_layering.py` raises the `schemas.py` cap 1156 -> 1167, with a comment recording what the lines bought.

## Verification

- `uv run ruff check .` — All checks passed. `ruff format --check .` — 887 files already formatted.
- `pytest tests/test_layering.py` — 40 passed.
- `pytest test_workflow_extension test_publication_lifecycle test_workflow_overlay test_layering` — 67 passed, 8 skipped (all `geolens_enterprise package is not installed`, pre-existing).
- `pytest test_datasets.py test_inherited_keywords.py test_rule1_structural.py` — 90 passed.
- `npm run lint`, `npm run typecheck` — clean.
- `npm run test:coverage` — 374 test files passed, 4582 tests passed. Full suite rather than targeted, since this is a type-shape change.
- `make openapi-check` and `make sdks-check` — exit 0, run after the commit (both false-fail on uncommitted regen).

Two gates were RED-checked rather than trusted:

1. The LOC ratchet asserts `actual != cap` fails in **both** directions, so the raise is exact at 1167, not slack.
2. `npm run typecheck` genuinely covers the hand-typed `api.ts`: temporarily setting `RecordStatus = number` failed with 11 errors naming every consumer, which both proves the clean pass was real and enumerated the consumer set.

Closes #1183
