### PR TITLE
fix(admin): make the Jobs badge read as a failed-count alert, not a total

### DIFF
--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -42,24 +42,59 @@ import { useEdition } from '@/hooks/use-edition';
 import { useEnterpriseOnlyTabs } from '@/hooks/use-settings';
 import { usePermissions } from '@/hooks/use-permissions';
 import { useSettingsAdmin } from '@/hooks/use-settings-admin';
+import { semanticBadgeColors } from '@/lib/status-colors';
 import type { Capability } from '@/lib/capabilities';
+
+// fix(#1185): the destructive recipe an alert badge needs, matching the
+// `failed` pill in the jobs table (both come from `semanticBadgeColors`).
+// SidebarMenuBadge pins its color with `peer-hover/menu-button:` and
+// `peer-data-[active=true]/menu-button:` variants, so those prefixes have to
+// be re-declared here — a bare `text-destructive` reverts to the accent color
+// the moment the row is hovered or becomes the active route.
+const ALERT_BADGE_CLASSES = [
+  'border',
+  semanticBadgeColors.destructive,
+  'peer-hover/menu-button:text-destructive',
+  'peer-data-[active=true]/menu-button:text-destructive',
+].join(' ');
 
 const overviewItems = [
   { labelKey: 'adminNav.overview', to: '/admin/overview', icon: LayoutDashboard, capability: 'manage_users' },
 ] as const;
+
+// fix(#1185): a badge that counts a PROBLEM rather than a total. Every other
+// Operations badge is a row count for the list behind it, so a bare failed-job
+// count read as a broken total (badge 3, list 200). An alert badge renders in
+// destructive colors, is spoken as "N failed jobs" instead of a naked number,
+// and rewrites the nav target to the matching filtered list so the number the
+// user clicked equals the number the list shows.
+type AlertBadge = {
+  /** Query string appended to `to` while the badge is visible. */
+  filter: string;
+  /** Plural i18n key rendered with `{ count }` for the spoken/hover label. */
+  labelKey: string;
+};
 
 type OperationItem = {
   labelKey: string;
   to: string;
   icon: LucideIcon;
   badgeKey?: 'users' | 'failed' | 'audit' | 'sharedMaps';
+  alertBadge?: AlertBadge;
   enterpriseOnly?: boolean;
   capability: Capability;
 };
 
 const operationsItems: readonly OperationItem[] = [
   { labelKey: 'adminNav.users', to: '/admin/users', icon: Users, badgeKey: 'users', capability: 'manage_users' },
-  { labelKey: 'adminNav.jobs', to: '/admin/jobs', icon: Briefcase, badgeKey: 'failed', capability: 'manage_users' },
+  {
+    labelKey: 'adminNav.jobs',
+    to: '/admin/jobs',
+    icon: Briefcase,
+    badgeKey: 'failed',
+    alertBadge: { filter: 'status=failed', labelKey: 'adminNav.failedJobs' },
+    capability: 'manage_users',
+  },
   { labelKey: 'adminNav.auditLog', to: '/admin/audit', icon: ScrollText, badgeKey: 'audit', capability: 'manage_settings' },
   { labelKey: 'adminNav.sharedMaps', to: '/admin/shared-maps', icon: Link2, badgeKey: 'sharedMaps', capability: 'manage_users' },
   { labelKey: 'adminNav.saml', to: '/admin/saml', icon: Lock, enterpriseOnly: true, capability: 'manage_settings' },
@@ -107,9 +142,10 @@ const settingsItemsBase: readonly SettingsNavBaseItem[] = [
  *
  * Renders the admin navigation tree (Overview, Users, Jobs, Audit, Shared Maps,
  * Settings sub-tabs, Config Ops) with active-route highlighting, total count
- * badges for Users / Published Maps / Audit Log plus a failed-jobs badge
+ * badges for Users / Published Maps / Audit Log plus a failed-jobs ALERT badge
  * (each capped at 999+), and visibility filtering for `enterpriseOnly` items
- * via the `useEdition` hook.
+ * via the `useEdition` hook. See `AlertBadge` for why Jobs is styled and
+ * linked differently from the total badges (#1185).
  */
 export function AdminSidebar() {
   const { pathname } = useLocation();
@@ -204,8 +240,15 @@ export function AdminSidebar() {
           <SidebarGroupLabel className="eyebrow">{t('adminNav.operations')}</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {visibleOperationsItems.map(({ labelKey, to, icon: Icon, badgeKey }) => {
+              {visibleOperationsItems.map(({ labelKey, to, icon: Icon, badgeKey, alertBadge }) => {
                 const count = badgeKey ? badgeCounts[badgeKey] : undefined;
+                const showBadge = count !== undefined && count > 0;
+                // fix(#1185): the alert treatment applies only while the badge
+                // is actually showing. At zero there is nothing to alert about,
+                // so the row stays a plain link to the unfiltered list.
+                const alertLabel =
+                  showBadge && alertBadge ? t(alertBadge.labelKey, { count }) : undefined;
+                const href = alertLabel && alertBadge ? `${to}?${alertBadge.filter}` : to;
                 return (
                   <SidebarMenuItem key={to}>
                     <SidebarMenuButton
@@ -213,13 +256,27 @@ export function AdminSidebar() {
                       isActive={pathname.startsWith(to)}
                       tooltip={t(labelKey)}
                     >
-                      <NavLink to={to}>
+                      {/* `title` is a hover affordance only — a link takes its
+                          accessible name from its contents, so the row is still
+                          announced as its label. */}
+                      <NavLink to={href} title={alertLabel}>
                         <Icon />
                         <span>{t(labelKey)}</span>
                       </NavLink>
                     </SidebarMenuButton>
-                    {count !== undefined && count > 0 && (
-                      <SidebarMenuBadge>{capBadge(count)}</SidebarMenuBadge>
+                    {showBadge && (
+                      <SidebarMenuBadge
+                        className={alertLabel ? ALERT_BADGE_CLASSES : undefined}
+                      >
+                        {alertLabel ? (
+                          <>
+                            <span aria-hidden="true">{capBadge(count)}</span>
+                            <span className="sr-only">{alertLabel}</span>
+                          </>
+                        ) : (
+                          capBadge(count)
+                        )}
+                      </SidebarMenuBadge>
                     )}
                   </SidebarMenuItem>
                 );

--- a/frontend/src/components/admin/JobList.tsx
+++ b/frontend/src/components/admin/JobList.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useCallback, useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router';
+import { useLocation, useSearchParams } from 'react-router';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useAdminJobs, useRetryAdminJob, useUserNames } from '@/hooks/use-admin';
 import { formatDate } from '@/lib/format';
@@ -46,14 +46,18 @@ export function JobList() {
   // work. An unrecognized value falls back to "all statuses" instead of being
   // forwarded to the API.
   const [searchParams, setSearchParams] = useSearchParams();
+  const { key: locationKey } = useLocation();
   const statusParam = searchParams.get('status') ?? '';
   const status = STATUS_OPTIONS.some((opt) => opt.value === statusParam) ? statusParam : '';
-  // Records a status value this component itself wrote, so the effect below
-  // can tell an in-component dropdown change from an external navigation.
-  const selfWrittenStatus = useRef<string | null>(null);
+  // Set just before this component writes the status param itself, so the
+  // effect below can tell an in-component dropdown change from an external
+  // navigation. Always cleared by that effect, because a `replace: true`
+  // write still produces a new location key (measured) — so the effect is
+  // guaranteed to run and the flag cannot go stale.
+  const isSelfWrite = useRef(false);
   const setStatus = useCallback(
     (next: string) => {
-      selfWrittenStatus.current = next;
+      isSelfWrite.current = true;
       setSearchParams(
         (params) => {
           if (next) params.set('status', next);
@@ -70,25 +74,34 @@ export function JobList() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
 
-  // fix(#1185 review): arriving at ?status=failed from OUTSIDE this component
-  // — the sidebar alert badge, a bookmark, the back button — must show the
-  // count the badge advertised. React Router keeps this instance mounted for
-  // the same route, so user/search/page would survive the navigation and
-  // silently narrow the list below that number (status=failed AND user=alice
-  // AND skip=75 can render zero rows while the badge says 3). That is the
-  // badge-vs-list mismatch #1185 exists to remove, arriving through a second
-  // door. A dropdown change is left alone: combining status with an existing
-  // user or search filter is the point of the dropdown.
+  // fix(#1185 review): arriving here from OUTSIDE this component — the sidebar
+  // alert badge, a bookmark, the back button — must show the count the badge
+  // advertised. React Router keeps this instance mounted for the same route,
+  // so user/search/page would survive the navigation and silently narrow the
+  // list below that number (status=failed AND user=alice AND skip=75 can
+  // render zero rows while the badge says 3). That is the badge-vs-list
+  // mismatch #1185 exists to remove, arriving through a second door.
+  //
+  // Keyed on `location.key`, NOT on the status value. Re-clicking the alert
+  // while already at ?status=failed navigates to an identical URL, so a
+  // value-keyed effect never fires and the stale filters survive — the same
+  // defect one position over. `location.key` changes on every navigation
+  // including a same-URL one (measured: 6g37p9up -> 25bb8de4).
+  //
+  // A dropdown change is deliberately exempt, since combining status with an
+  // existing user or search filter is the point of the dropdown. Its own
+  // `replace: true` write also produces a new key (measured), so this effect
+  // always runs afterwards and always clears the flag — it cannot go stale
+  // and swallow the next external navigation.
   useEffect(() => {
-    if (selfWrittenStatus.current === statusParam) {
-      selfWrittenStatus.current = null;
+    if (isSelfWrite.current) {
+      isSelfWrite.current = false;
       return;
     }
-    selfWrittenStatus.current = null;
     setUserId('');
     setSearchQuery('');
     setPage(0);
-  }, [statusParam]);
+  }, [locationKey]);
 
   const skip = page * PAGE_SIZE;
 

--- a/frontend/src/components/admin/JobList.tsx
+++ b/frontend/src/components/admin/JobList.tsx
@@ -1,5 +1,6 @@
-import { Fragment, useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useAdminJobs, useRetryAdminJob, useUserNames } from '@/hooks/use-admin';
 import { formatDate } from '@/lib/format';
@@ -38,7 +39,28 @@ function formatDuration(startedAt: string | null, completedAt: string | null): s
 
 export function JobList() {
   const { t } = useTranslation('admin');
-  const [status, setStatus] = useState('');
+  // fix(#1185): the admin sidebar's failed-jobs badge links here as
+  // /admin/jobs?status=failed so the number the user clicked equals the number
+  // the list shows. Status therefore lives in the URL rather than in component
+  // state — that also makes a filtered view bookmarkable and the back button
+  // work. An unrecognized value falls back to "all statuses" instead of being
+  // forwarded to the API.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const statusParam = searchParams.get('status') ?? '';
+  const status = STATUS_OPTIONS.some((opt) => opt.value === statusParam) ? statusParam : '';
+  const setStatus = useCallback(
+    (next: string) => {
+      setSearchParams(
+        (params) => {
+          if (next) params.set('status', next);
+          else params.delete('status');
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
   const [userId, setUserId] = useState('');
   const [page, setPage] = useState(0);
   const [expandedId, setExpandedId] = useState<string | null>(null);

--- a/frontend/src/components/admin/JobList.tsx
+++ b/frontend/src/components/admin/JobList.tsx
@@ -48,8 +48,12 @@ export function JobList() {
   const [searchParams, setSearchParams] = useSearchParams();
   const statusParam = searchParams.get('status') ?? '';
   const status = STATUS_OPTIONS.some((opt) => opt.value === statusParam) ? statusParam : '';
+  // Records a status value this component itself wrote, so the effect below
+  // can tell an in-component dropdown change from an external navigation.
+  const selfWrittenStatus = useRef<string | null>(null);
   const setStatus = useCallback(
     (next: string) => {
+      selfWrittenStatus.current = next;
       setSearchParams(
         (params) => {
           if (next) params.set('status', next);
@@ -65,6 +69,26 @@ export function JobList() {
   const [page, setPage] = useState(0);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
+
+  // fix(#1185 review): arriving at ?status=failed from OUTSIDE this component
+  // — the sidebar alert badge, a bookmark, the back button — must show the
+  // count the badge advertised. React Router keeps this instance mounted for
+  // the same route, so user/search/page would survive the navigation and
+  // silently narrow the list below that number (status=failed AND user=alice
+  // AND skip=75 can render zero rows while the badge says 3). That is the
+  // badge-vs-list mismatch #1185 exists to remove, arriving through a second
+  // door. A dropdown change is left alone: combining status with an existing
+  // user or search filter is the point of the dropdown.
+  useEffect(() => {
+    if (selfWrittenStatus.current === statusParam) {
+      selfWrittenStatus.current = null;
+      return;
+    }
+    selfWrittenStatus.current = null;
+    setUserId('');
+    setSearchQuery('');
+    setPage(0);
+  }, [statusParam]);
 
   const skip = page * PAGE_SIZE;
 

--- a/frontend/src/components/admin/__tests__/AdminSidebar.test.tsx
+++ b/frontend/src/components/admin/__tests__/AdminSidebar.test.tsx
@@ -3,6 +3,10 @@ import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { AdminSidebar } from '../AdminSidebar';
+import enCommon from '@/i18n/locales/en/common.json';
+import esCommon from '@/i18n/locales/es/common.json';
+import frCommon from '@/i18n/locales/fr/common.json';
+import deCommon from '@/i18n/locales/de/common.json';
 
 const counts = vi.hoisted(() => ({ users: 0, failed: 0, audit: 0, published: 0 }));
 const permissionState = vi.hoisted(() => ({ manageUsers: true, manageSettings: true }));
@@ -73,7 +77,15 @@ vi.mock('@/hooks/use-settings', () => ({
 // i18n returns the key by default in tests, so we match on i18n keys' last segment
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    t: (key: string, options?: { count?: number }) => {
+      // fix(#1185): the failed-jobs label is the sidebar's only plural key.
+      // Resolve it the way i18next would so the assertions below read the
+      // rendered copy rather than a bare key. `EN_ADMIN_NAV` below pins these
+      // strings against the real bundle.
+      if (key === 'adminNav.failedJobs') {
+        const count = options?.count ?? 0;
+        return count === 1 ? `${count} failed job` : `${count} failed jobs`;
+      }
       // Return human-readable labels from keys
       const labels: Record<string, string> = {
         'adminNav.admin': 'Admin',
@@ -261,6 +273,128 @@ describe('AdminSidebar', () => {
     expect(screen.getByText('62')).toBeInTheDocument();
     expect(screen.getByText('999+')).toBeInTheDocument();
     expect(screen.getByText('10')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fix(#1185): the Jobs badge counts FAILED jobs while every sibling badge
+// counts the total behind its list, so a bare number read as a broken total
+// (badge 3, list 200). It must render as an alert: destructive colors, a
+// spoken "N failed jobs" label instead of a naked digit, and a click target
+// pre-filtered to status=failed so the number clicked equals the list landed
+// on. At zero there is no badge and the row links to the unfiltered list.
+// ---------------------------------------------------------------------------
+
+function badges() {
+  return Array.from(document.querySelectorAll('[data-slot="sidebar-menu-badge"]'));
+}
+
+// Located by POSITION (the badge in the Jobs row), not by its copy — otherwise
+// the styling assertions below would silently depend on the spoken label.
+function failedBadge() {
+  const row = screen.getByText('Jobs').closest('[data-slot="sidebar-menu-item"]');
+  return row?.querySelector('[data-slot="sidebar-menu-badge"]') ?? undefined;
+}
+
+describe('AdminSidebar failed-jobs alert badge (#1185)', () => {
+  it('renders the failed count in destructive colors, unlike the total badges', () => {
+    counts.failed = 3;
+    counts.users = 62;
+    renderSidebar();
+
+    const failed = failedBadge();
+    expect(failed).toBeDefined();
+    expect(failed?.className).toContain('text-destructive');
+    expect(failed?.className).toContain('bg-destructive/10');
+    // The hover and active variants have to be overridden too, or the badge
+    // reverts to the sidebar accent color on the active route. `cn()` must
+    // drop the base colors rather than leave both in the attribute — equal
+    // specificity would otherwise make the winner a stylesheet-order accident.
+    expect(failed?.className).toContain('peer-data-[active=true]/menu-button:text-destructive');
+    expect(failed?.className).toContain('peer-hover/menu-button:text-destructive');
+    expect(failed?.className).not.toContain('text-sidebar-foreground');
+    expect(failed?.className).not.toContain('text-sidebar-accent-foreground');
+
+    const users = badges().find((el) => el.textContent === '62');
+    expect(users).toBeDefined();
+    expect(users?.className).not.toContain('destructive');
+  });
+
+  it('speaks the badge as "N failed jobs" and hides the bare digits', () => {
+    counts.failed = 3;
+    renderSidebar();
+
+    const spoken = screen.getByText('3 failed jobs');
+    expect(spoken).toHaveClass('sr-only');
+    // The visible digits must not be announced twice.
+    expect(screen.getByText('3')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('uses the singular form for a single failed job', () => {
+    counts.failed = 1;
+    renderSidebar();
+    expect(screen.getByText('1 failed job')).toBeInTheDocument();
+  });
+
+  it('keeps the capped visible count while speaking the true count', () => {
+    counts.failed = 1500;
+    renderSidebar();
+    expect(screen.getByText('999+')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByText('1500 failed jobs')).toBeInTheDocument();
+  });
+
+  it('points Jobs at the failed-filtered list while the badge is showing', () => {
+    counts.failed = 3;
+    renderSidebar();
+    expect(screen.getByText('Jobs').closest('a')).toHaveAttribute(
+      'href',
+      '/admin/jobs?status=failed',
+    );
+  });
+
+  it('points Jobs at the unfiltered list and renders no badge at zero', () => {
+    counts.failed = 0;
+    renderSidebar();
+    expect(screen.getByText('Jobs').closest('a')).toHaveAttribute('href', '/admin/jobs');
+    expect(failedBadge()).toBeUndefined();
+  });
+
+  // A `title` is a hover affordance; it must not become the link's name. A
+  // link takes its accessible name from its contents, so this asserts the
+  // computed name rather than the JSX.
+  it('leaves the Jobs link accessible name as its label, not the tooltip', () => {
+    counts.failed = 3;
+    renderSidebar();
+
+    const link = screen.getByRole('link', { name: 'Jobs' });
+    expect(link).toHaveAttribute('title', '3 failed jobs');
+    expect(screen.queryByRole('link', { name: '3 failed jobs' })).toBeNull();
+  });
+
+  it('keeps the Jobs row highlighted on the pre-filtered route', () => {
+    counts.failed = 3;
+    renderSidebar('/admin/jobs');
+    expect(screen.getByText('Jobs').closest('a')).toHaveAttribute('data-active', 'true');
+  });
+});
+
+// The source-key guard skips keys that are not string literals inside a t()
+// call, and this one lives in the `operationsItems` table — so pin the bundle
+// contents directly. All four locales carry the pair, and every `_one` value
+// interpolates {{count}} (French resolves count 0 to `_one`, so a hardcoded
+// "1" there would render "1 failed job" for zero).
+describe('adminNav.failedJobs bundle coverage (#1185)', () => {
+  const bundles = { en: enCommon, es: esCommon, fr: frCommon, de: deCommon };
+
+  it.each(Object.entries(bundles))('%s carries both plural forms with {{count}}', (_locale, bundle) => {
+    const adminNav = (bundle as { adminNav: Record<string, string> }).adminNav;
+    expect(adminNav.failedJobs_one).toContain('{{count}}');
+    expect(adminNav.failedJobs_other).toContain('{{count}}');
+  });
+
+  it('matches the English copy the mocked translator renders', () => {
+    expect(enCommon.adminNav.failedJobs_one).toBe('{{count}} failed job');
+    expect(enCommon.adminNav.failedJobs_other).toBe('{{count}} failed jobs');
   });
 });
 

--- a/frontend/src/components/admin/__tests__/JobList.status-filter.test.tsx
+++ b/frontend/src/components/admin/__tests__/JobList.status-filter.test.tsx
@@ -130,6 +130,32 @@ describe('JobList filter reset on external navigation (#1185 review)', () => {
     expect(lastQuery()?.skip).toBe(0);
   });
 
+  // The first fix keyed this off the status VALUE, which is silent for the
+  // most likely repeat interaction: an admin already sitting on the filtered
+  // view clicks the badge again. Same URL, no value change, no reset. Keying
+  // off location.key is what makes this case fire.
+  it('clears filters when the alert is re-clicked from the same URL', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <NavLink to="/admin/jobs?status=failed">go to failed</NavLink>
+        <JobList />
+      </>,
+      { route: '/admin/jobs?status=failed' },
+    );
+    expect(lastQuery()?.status).toBe('failed');
+
+    await user.type(searchBox(), 'tiles');
+    expect(lastQuery()?.search).toBe('tiles');
+
+    // identical destination — the URL does not change at all
+    await user.click(screen.getByRole('link', { name: 'go to failed' }));
+
+    expect(lastQuery()?.status).toBe('failed');
+    expect(lastQuery()?.search).toBeUndefined();
+    expect(lastQuery()?.skip).toBe(0);
+  });
+
   it('leaves an existing search filter alone when the dropdown changes status', async () => {
     const user = userEvent.setup();
     render(<JobList />, { route: '/admin/jobs' });

--- a/frontend/src/components/admin/__tests__/JobList.status-filter.test.tsx
+++ b/frontend/src/components/admin/__tests__/JobList.status-filter.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@/test/test-utils';
 import userEvent from '@testing-library/user-event';
+import { NavLink } from 'react-router';
 import { JobList } from '../JobList';
 
 // fix(#1185): the admin sidebar's failed-jobs badge links to
@@ -24,7 +25,15 @@ beforeAll(() => {
 });
 
 function lastQuery() {
-  return mockUseAdminJobs.mock.calls.at(-1)?.[0] as { status?: string } | undefined;
+  return mockUseAdminJobs.mock.calls.at(-1)?.[0] as
+    | { status?: string; user_id?: string; search?: string; skip?: number }
+    | undefined;
+}
+
+// DataTableSearch renders a bare Input with a placeholder and no label, so
+// there is exactly one textbox in this card to address.
+function searchBox() {
+  return screen.getByRole('textbox');
 }
 
 function statusFilter() {
@@ -86,5 +95,52 @@ describe('JobList status filter from the URL (#1185)', () => {
 
     expect(lastQuery()?.status).toBeUndefined();
     expect(statusFilter()).toHaveTextContent('All Statuses');
+  });
+});
+
+// fix(#1185 review): the sidebar badge advertises a count of ALL failed jobs.
+// React Router keeps this instance mounted when the alert link only changes a
+// query param on the same route, so a search/user filter set earlier would
+// survive and narrow the list below the advertised number — the badge-vs-list
+// mismatch #1185 exists to remove, arriving through a second door.
+//
+// Both directions are pinned deliberately. A refusal test alone would let the
+// false-positive half regress silently: nothing in "external nav clears the
+// search" notices that the dropdown ALSO started clearing it, which would be a
+// real regression, since combining status with an existing filter is the whole
+// point of the dropdown.
+describe('JobList filter reset on external navigation (#1185 review)', () => {
+  it('clears a stale search filter when the alert link is followed', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <NavLink to="/admin/jobs?status=failed">go to failed</NavLink>
+        <JobList />
+      </>,
+      { route: '/admin/jobs' },
+    );
+
+    await user.type(searchBox(), 'tiles');
+    expect(lastQuery()?.search).toBe('tiles');
+
+    await user.click(screen.getByRole('link', { name: 'go to failed' }));
+
+    expect(lastQuery()?.status).toBe('failed');
+    expect(lastQuery()?.search).toBeUndefined();
+    expect(lastQuery()?.skip).toBe(0);
+  });
+
+  it('leaves an existing search filter alone when the dropdown changes status', async () => {
+    const user = userEvent.setup();
+    render(<JobList />, { route: '/admin/jobs' });
+
+    await user.type(searchBox(), 'tiles');
+    expect(lastQuery()?.search).toBe('tiles');
+
+    await user.click(statusFilter());
+    await user.click(await screen.findByRole('option', { name: 'Failed' }));
+
+    expect(lastQuery()?.status).toBe('failed');
+    expect(lastQuery()?.search).toBe('tiles');
   });
 });

--- a/frontend/src/components/admin/__tests__/JobList.status-filter.test.tsx
+++ b/frontend/src/components/admin/__tests__/JobList.status-filter.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { JobList } from '../JobList';
+
+// fix(#1185): the admin sidebar's failed-jobs badge links to
+// /admin/jobs?status=failed so the number the user clicked equals the number
+// the list shows. That only holds if JobList reads the status filter off the
+// URL, so these tests pin the read, the write-back, and the fallback for a
+// value the API would reject.
+
+const { mockUseAdminJobs } = vi.hoisted(() => ({ mockUseAdminJobs: vi.fn() }));
+
+vi.mock('@/hooks/use-admin', () => ({
+  useAdminJobs: (...args: unknown[]) => mockUseAdminJobs(...args),
+  useUserNames: () => ({ data: [] }),
+  useRetryAdminJob: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+// Radix Select needs these in jsdom.
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+function lastQuery() {
+  return mockUseAdminJobs.mock.calls.at(-1)?.[0] as { status?: string } | undefined;
+}
+
+function statusFilter() {
+  return screen.getByRole('combobox', { name: 'Status' });
+}
+
+beforeEach(() => {
+  mockUseAdminJobs.mockReset();
+  mockUseAdminJobs.mockReturnValue({
+    data: { jobs: [], total: 0 },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+});
+
+describe('JobList status filter from the URL (#1185)', () => {
+  it('queries the failed jobs when the route carries ?status=failed', () => {
+    render(<JobList />, { route: '/admin/jobs?status=failed' });
+
+    expect(mockUseAdminJobs).toHaveBeenCalled();
+    expect(lastQuery()?.status).toBe('failed');
+    expect(statusFilter()).toHaveTextContent('Failed');
+  });
+
+  it('queries every job when the route carries no status', () => {
+    render(<JobList />, { route: '/admin/jobs' });
+
+    expect(mockUseAdminJobs).toHaveBeenCalled();
+    expect(lastQuery()?.status).toBeUndefined();
+    expect(statusFilter()).toHaveTextContent('All Statuses');
+  });
+
+  it('ignores a status the filter does not offer instead of forwarding it', () => {
+    render(<JobList />, { route: '/admin/jobs?status=exploded' });
+
+    expect(mockUseAdminJobs).toHaveBeenCalled();
+    expect(lastQuery()?.status).toBeUndefined();
+    expect(statusFilter()).toHaveTextContent('All Statuses');
+  });
+
+  it('writes the dropdown selection back to the URL-owned filter', async () => {
+    const user = userEvent.setup();
+    render(<JobList />, { route: '/admin/jobs' });
+
+    await user.click(statusFilter());
+    await user.click(await screen.findByRole('option', { name: 'Running' }));
+
+    expect(lastQuery()?.status).toBe('running');
+    expect(statusFilter()).toHaveTextContent('Running');
+  });
+
+  it('clears the status filter back to all statuses', async () => {
+    const user = userEvent.setup();
+    render(<JobList />, { route: '/admin/jobs?status=failed' });
+    expect(lastQuery()?.status).toBe('failed');
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+    expect(lastQuery()?.status).toBeUndefined();
+    expect(statusFilter()).toHaveTextContent('All Statuses');
+  });
+});

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -85,6 +85,8 @@
     "overview": "Übersicht",
     "users": "Benutzer",
     "jobs": "Aufträge",
+    "failedJobs_one": "{{count}} fehlgeschlagener Auftrag",
+    "failedJobs_other": "{{count}} fehlgeschlagene Aufträge",
     "auditLog": "Protokoll",
     "sharedMaps": "Veröffentlichte Karten",
     "saml": "SAML SSO",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -86,6 +86,8 @@
     "operations": "Operations",
     "users": "Users",
     "jobs": "Jobs",
+    "failedJobs_one": "{{count}} failed job",
+    "failedJobs_other": "{{count}} failed jobs",
     "auditLog": "Audit Log",
     "sharedMaps": "Published Maps",
     "saml": "SAML SSO",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -85,6 +85,8 @@
     "overview": "Resumen",
     "users": "Usuarios",
     "jobs": "Trabajos",
+    "failedJobs_one": "{{count}} trabajo fallido",
+    "failedJobs_other": "{{count}} trabajos fallidos",
     "auditLog": "Registro de auditoría",
     "sharedMaps": "Mapas Publicados",
     "saml": "SSO SAML",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -85,6 +85,8 @@
     "overview": "Vue d'ensemble",
     "users": "Utilisateurs",
     "jobs": "Tâches",
+    "failedJobs_one": "{{count}} tâche échouée",
+    "failedJobs_other": "{{count}} tâches échouées",
     "auditLog": "Journal d'audit",
     "sharedMaps": "Cartes Publiées",
     "saml": "SSO SAML",


### PR DESCRIPTION
## Problem

The admin sidebar badge next to **Jobs** shows the failed-job count, but it renders identically to the Users / Published Maps / Audit Log badges, which are totals. Clicking Jobs opened the unfiltered list, so the badge could read 3 while the list total read 200 — it looked like a count-mismatch bug rather than an alert.

## Treatment

**Styling.** The Jobs badge takes `semanticBadgeColors.destructive` from `lib/status-colors.ts` — the same recipe the `failed` pill in the jobs table already uses, so the sidebar badge and the row it leads to are the same red by construction. No hex, no new token. The other three badges are untouched and stay neutral.

One non-obvious detail is worth calling out for reviewers: `SidebarMenuBadge` pins its color with `peer-hover/menu-button:text-sidebar-accent-foreground` and `peer-data-[active=true]/menu-button:text-sidebar-accent-foreground`. A bare `text-destructive` loses to both, so the badge would revert to the accent color on hover and stay accent-colored whenever Jobs is the active route — i.e. it would stop being red exactly when you are looking at it. Both variant prefixes are re-declared. Verified two ways: `cn()`/twMerge drops the base colors from the class attribute (asserted in a test), and both variant rules are present in the built CSS after `npm run build`.

**Accessible name.** The badge renders `<span aria-hidden="true">3</span><span class="sr-only">3 failed jobs</span>`. An `aria-label` on the badge `<div>` would be unreliable — it is a generic element with no role — so the label is real text. The digits are `aria-hidden` so it is not announced as "3, 3 failed jobs". The sr-only text uses the true count while the visible digits keep the existing 999+ cap, so at 1500 the badge shows `999+` and speaks "1500 failed jobs".

The nav row also carries `title` as a hover affordance. It could not go on the badge itself: `SidebarMenuBadge` is `pointer-events-none`, and making it `pointer-events-auto` would carve a dead zone out of the row's click target. A test asserts the row's computed accessible name is still `Jobs` and that no link resolves by the label text — the name, not the JSX, per the `<label for>` trap.

**Click target.** While the badge is showing, the row targets `/admin/jobs?status=failed`, so the number clicked equals the number the list shows. At count 0 there is no badge and the row is a plain link to the unfiltered list. `isActive` still keys off the base path, so the row highlights on `/admin/jobs` either way.

That link only means something if the page honours it, so `JobList` now owns `status` in the URL via `useSearchParams` rather than `useState`: it reads on mount, writes back on dropdown change with `{ replace: true }`, and `clearFilters` deletes the param. A status not in `STATUS_OPTIONS` falls back to "all statuses" instead of being forwarded to the API. Page resets to 0 on filter change, as before. Side benefit: a filtered jobs view is now bookmarkable. `user_id`, `search` and `page` remain local state — scope was not widened.

## i18n

New plural pair `adminNav.failedJobs_one` / `_other` in all four locales:

| | `_one` | `_other` |
|---|---|---|
| en | `{{count}} failed job` | `{{count}} failed jobs` |
| es | `{{count}} trabajo fallido` | `{{count}} trabajos fallidos` |
| fr | `{{count}} tâche échouée` | `{{count}} tâches échouées` |
| de | `{{count}} fehlgeschlagener Auftrag` | `{{count}} fehlgeschlagene Aufträge` |

Every `_one` interpolates `{{count}}` rather than hardcoding "1", because French resolves count 0 to `_one`. Only `_one`/`_other` — matching every existing plural key in these bundles; no `_many`. Wording follows each locale's existing `jobs.filters.failed` so the badge and the filter agree (fr "Échouée" takes feminine agreement with "tâche"; de "Aufträge" matches `adminNav.jobs`).

## Judgment calls worth a reviewer's attention

- **URL-owning `JobList` is the one place this goes past the issue text.** The issue says no backend change is needed; it does not say the frontend needed one. But `JobList` held `status` in `useState`, so `?status=failed` would have been silently ignored and the link would have shipped looking correct while doing nothing. The cheaper alternative — seed state from the URL once, never write back — is ~5 fewer lines but leaves the URL lying the moment the user touches the dropdown.
- **At count 0 the row reverts to unfiltered.** Landing on an empty filtered list when nothing is wrong seemed worse than landing on the full list, at the cost of the row's destination changing as jobs fail and get retried.
- **Soft fill (`bg-destructive/10`) rather than a solid red chip**, chosen for consistency with every other status surface over volume.

## Verification

- `npm run lint` — clean. `npm run typecheck` — exit 0 (the real gate; `npx tsc --noEmit` is a no-op here).
- `npm run test:coverage` — **375 test files passed, 4600 tests passed, 0 failed**. Full suite, not targeted.
- `npm run test:i18n` — source-key guard passed, then 1 file / 4 tests passed.
- `npm run build` — clean; also how the peer-variant CSS emission was confirmed.
- Targeted: `AdminSidebar.test.tsx` 29 passed; the three admin test files together 37 passed.

Four RED checks, each disabling exactly one thing, each failing on the assertion under test rather than a fixture error:

1. alert className → `undefined`: 1 failed / 28 passed, on the real base class string.
2. sr-only span + `aria-hidden` removed: 3 failed / 26 passed, "Unable to find an element with the text: 3 failed jobs".
3. `href` forced to the base path: 1 failed / 28 passed, `Expected href="/admin/jobs?status=failed"`.
4. `JobList` status forced to `''`: 3 failed / 49 passed, on the query the hook receives.

One test-quality fix made along the way: the first badge locator found the element by text containing "failed job" — the sr-only label — which made the styling assertion silently depend on the copy, so RED check 1 failed two tests instead of one. It now locates by position within the Jobs menu item, and checks 1 and 2 are disjoint.

Closes #1185
