### PR TITLE
fix(ingest): stamp raster file_type on the presigned upload path

### DIFF
--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -419,6 +419,11 @@ async def complete_presigned_upload(
     )
 
     job.file_path = s3_key
+    # fix(#1186): the presigned path never stamped file_type, and on an S3
+    # deployment the frontend always uploads through it — so every GeoTIFF
+    # fell through to the vector branch: 422 at preview, a vector commit body
+    # after that, and an ogr2ogr dispatch after that.
+    _stamp_raster_metadata(job, job.source_filename)
     await db.commit()
 
     return UploadResponse(
@@ -454,49 +459,25 @@ async def _cleanup_saved_upload(
         )
 
 
-async def _stamp_raster_metadata(
-    job: "IngestJob",
-    saved_path: Path | str,
-    filename: str | None,
-) -> None:
-    """Perform raster CRS validation and stamp job.user_metadata accordingly.
+def _stamp_raster_metadata(job: "IngestJob", filename: str | None) -> None:
+    """Stamp ``user_metadata["file_type"] = "raster"`` from the filename.
 
-    Non-fatal: missing CRS is acceptable at upload time (the user can supply
-    srid_override at commit time). This helper isolates the raster-specific
-    branch from the main upload flow (KISS-N9).
+    ``file_type`` is the raster discriminator for three consumers — the
+    preview branch below, ``_pick_commit_subclass``, and the ingest dispatch
+    in ``queue_ingest_job`` — so every upload endpoint has to set it before
+    the job is previewable or committable.
+
+    fix(#1186): this used to download the whole object and run
+    ``validate_raster_crs``, which is exactly why ``complete_presigned_upload``
+    never called it — presigned uploads exist for the multi-GB case, and the
+    completion request cannot afford a full-object download (preview downloads
+    the same object seconds later anyway). The only reader of the resulting
+    ``crs_missing`` flag is ``ingest_raster``, which has the raster's metadata
+    in hand and now derives the answer there. So the stamp costs no I/O and
+    both upload endpoints can afford it.
     """
-    lower_filename = (filename or "").lower()
-    if not lower_filename.endswith((".tif", ".tiff", ".vrt")):
+    if not (filename or "").lower().endswith((".tif", ".tiff", ".vrt")):
         return
-
-    from app.processing.raster.cog import validate_raster_crs
-
-    raster_check_path: str | None = None
-    downloaded: Path | None = None
-    if isinstance(saved_path, Path):
-        raster_check_path = str(saved_path)
-    else:
-        try:
-            raster_check_path = await resolve_file_path(str(saved_path), str(job.id))
-            downloaded = Path(raster_check_path)
-        except (
-            Exception
-        ):  # broad: S3 download can fail for network/auth/key-not-found reasons
-            raster_check_path = None
-
-    if raster_check_path:
-        try:
-            await asyncio.to_thread(validate_raster_crs, raster_check_path)
-        except ValueError:
-            # Allow CRS-missing rasters through; user can provide
-            # srid_override at commit time. Store flag for ingest_raster.
-            job.user_metadata = {
-                **(job.user_metadata or {}),
-                "crs_missing": True,
-            }
-        finally:
-            if downloaded is not None:
-                downloaded.unlink(missing_ok=True)
 
     job.user_metadata = {**(job.user_metadata or {}), "file_type": "raster"}
 
@@ -557,8 +538,7 @@ async def upload_file(
                     detail=str(exc),
                 ) from exc
 
-            # Raster-specific CRS validation — reject files without valid CRS at upload time
-            await _stamp_raster_metadata(job, saved_path, file.filename)
+            _stamp_raster_metadata(job, file.filename)
 
             job.file_path = str(saved_path)
             await db.commit()

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -468,15 +468,20 @@ async def ingest_raster(
         user_compression = um.get("compression") or "DEFLATE"
         user_resampling = um.get("resampling") or None
         user_nodata = um.get("nodata_override")
-        crs_missing = um.get("crs_missing", False)
+        # fix(#1186): derive this from the raster, not from an upload-time
+        # stamp. `user_metadata["crs_missing"]` was written only by the
+        # non-presigned upload endpoint, so it was absent for every S3
+        # (presigned) upload — and `assign_crs` below is gated on it, meaning
+        # a user-supplied srid_override was silently dropped and the COG came
+        # out with no CRS. `meta` is read from the file itself, which is the
+        # authority the flag was standing in for.
+        crs_missing = not meta.get("crs_wkt")
 
-        if not meta.get("crs_wkt") and not assign_crs:
-            if crs_missing:
-                raise ValueError(
-                    "Missing CRS: raster has no coordinate reference system. "
-                    "Provide a CRS override (EPSG code) at import time."
-                )
-            raise ValueError("Missing CRS: raster has no coordinate reference system.")
+        if crs_missing and not assign_crs:
+            raise ValueError(
+                "Missing CRS: raster has no coordinate reference system. "
+                "Provide a CRS override (EPSG code) at import time."
+            )
 
         # ING-07 / P2-09: strict-mode COG gating. When the user opted in via
         # RasterCommitRequest.strict_cog=True, reject non-COG TIFFs here

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1928,9 +1928,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # Cap 2143 -> 2147, still exact.
     "backend/app/processing/ingest/metadata.py": 2151,
     # ingest/router.py is also scanned by the router-glob gate; this exact
-    # ratchet overrides its 1500 default so the remaining ~18-line runway to
-    # the cliff cannot be spent silently.
-    "backend/app/processing/ingest/router.py": 1493,
+    # ratchet overrides its 1500 default so the remaining runway to the cliff
+    # cannot be spent silently.
+    # fix(#1186): -20 — _stamp_raster_metadata gave up its download-and-
+    # validate half. It exists to set the `file_type` discriminator, and
+    # bundling a full-object CRS download into that is what kept
+    # complete_presigned_upload from calling it at all. `crs_missing` is
+    # derived in ingest_raster now, from metadata that task already reads.
+    # Cap 1493 -> 1473, still exact.
+    "backend/app/processing/ingest/router.py": 1473,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901

--- a/backend/tests/test_presigned_raster_stamp_1186.py
+++ b/backend/tests/test_presigned_raster_stamp_1186.py
@@ -1,0 +1,292 @@
+"""Regression coverage for #1186: presigned uploads must stamp file_type.
+
+Every pre-existing raster test drives the NON-presigned ``POST /ingest/upload``
+endpoint, so the presigned path had no coverage at all — and on an S3
+deployment that is the only path the frontend uses. ``file_type`` gates three
+consumers (preview's raster branch, ``_pick_commit_subclass``, and the raster
+dispatch in ``queue_ingest_job``); this file walks a real GeoTIFF through all
+three via the presigned endpoints.
+
+The synthetic-GeoTIFF helper mirrors ``test_raster_ingest.py`` /
+``test_raster_antimeridian_887.py``, which each carry their own copy.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+import pytest
+from rasterio.crs import CRS
+from rasterio.io import MemoryFile
+from rasterio.transform import from_bounds
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.platform.jobs.models import IngestJob
+
+
+pytestmark = pytest.mark.anyio
+
+
+def _geotiff_bytes(
+    *,
+    width: int = 64,
+    height: int = 64,
+    bands: int = 1,
+    crs: CRS | None = CRS.from_epsg(4326),
+) -> bytes:
+    """Create a minimal valid GeoTIFF in memory and return its bytes."""
+    profile = {
+        "driver": "GTiff",
+        "dtype": "uint8",
+        "width": width,
+        "height": height,
+        "count": bands,
+        "transform": from_bounds(-180, -90, 180, 90, width, height),
+    }
+    if crs is not None:
+        profile["crs"] = crs
+    rng = np.random.default_rng(1186)
+    buf = io.BytesIO()
+    with MemoryFile() as mem:
+        with mem.open(**profile) as ds:
+            for band in range(1, bands + 1):
+                ds.write(rng.integers(0, 200, (height, width), dtype="uint8"), band)
+        buf.write(mem.read())
+    return buf.getvalue()
+
+
+class _FakeS3Storage:
+    """In-memory stand-in for the S3 provider, keyed exactly like the real one.
+
+    Only the methods the presigned request/complete/preview path touches are
+    implemented; anything else should raise rather than silently no-op.
+    """
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    # -- presign (sync, called through run_in_thread_draining) --------------
+    def generate_presigned_put_url(self, key: str, content_type: str) -> str:
+        return f"https://s3.invalid/{key}?signed=1"
+
+    # -- completion --------------------------------------------------------
+    async def exists(self, key: str) -> bool:
+        return key in self.objects
+
+    async def size(self, key: str) -> int:
+        return len(self.objects[key])
+
+    async def delete(self, key: str) -> None:
+        self.objects.pop(key, None)
+
+    # -- preview / ingest download ----------------------------------------
+    async def get_to_file(self, key: str, dest: Path) -> Path:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(self.objects[key])
+        return dest
+
+
+async def _presigned_upload_geotiff(
+    client,
+    headers: dict,
+    storage: _FakeS3Storage,
+    *,
+    filename: str = "dem.tif",
+) -> str:
+    """Run request-presigned → (client PUTs to S3) → complete. Returns job id."""
+    payload = _geotiff_bytes()
+
+    resp = await client.post(
+        "/ingest/upload/presigned",
+        json={
+            "filename": filename,
+            "file_size": len(payload),
+            "content_type": "image/tiff",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    job_id = body["job_id"]
+
+    # Stand in for the browser's direct PUT to the presigned URL.
+    storage.objects[body["s3_key"]] = payload
+
+    resp = await client.post(
+        f"/ingest/upload/presigned/{job_id}/complete",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    return job_id
+
+
+@pytest.fixture
+def s3_mode(monkeypatch):
+    """Put the app in S3 mode with an in-memory provider on every lookup path."""
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(settings, "storage_provider", "s3")
+    # The router holds a module-level import; resolve_file_path imports from
+    # app.platform.storage at call time. Both have to see the fake.
+    monkeypatch.setattr(
+        "app.processing.ingest.router.get_storage", lambda: storage, raising=True
+    )
+    monkeypatch.setattr(
+        "app.platform.storage.get_storage", lambda: storage, raising=True
+    )
+    return storage
+
+
+async def test_presigned_upload_stamps_raster_file_type(
+    client, admin_auth_header, test_db_session, s3_mode
+) -> None:
+    """The stamp itself: complete_presigned_upload must set file_type=raster.
+
+    This is the assertion the fix exists for — the three consumers below all
+    read this one key.
+    """
+    job_id = await _presigned_upload_geotiff(client, admin_auth_header, s3_mode)
+
+    job = (
+        await test_db_session.execute(select(IngestJob).where(IngestJob.id == job_id))
+    ).scalar_one()
+    assert job.user_metadata["file_type"] == "raster"
+    # The presign bookkeeping must survive the stamp.
+    assert job.user_metadata["presigned"] is True
+    assert job.user_metadata["s3_key"].endswith("dem.tif")
+
+
+async def test_presigned_upload_previews_as_raster(
+    client, admin_auth_header, s3_mode
+) -> None:
+    """Consumer 1 — preview. The reported symptom was a 422 from ogrinfo."""
+    job_id = await _presigned_upload_geotiff(client, admin_auth_header, s3_mode)
+
+    resp = await client.post(f"/ingest/preview/{job_id}", headers=admin_auth_header)
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    # RasterPreviewResponse fields — a vector PreviewResponse has none of them.
+    assert data["band_count"] == 1
+    assert data["width"] == 64
+    assert data["height"] == 64
+    assert data["crs_epsg"] == 4326
+    assert "is_cog_compliant" in data
+
+
+async def test_presigned_upload_commits_and_dispatches_as_raster(
+    client, admin_auth_header, test_db_session, s3_mode
+) -> None:
+    """Consumers 2 and 3 — commit-body parsing and worker dispatch.
+
+    ``compression``/``resampling`` exist only on RasterCommitRequest, so their
+    survival proves the body parsed as raster; the deferred task proves the
+    dispatch branch.
+    """
+    from app.processing.ingest.tasks import ingest_raster
+
+    job_id = await _presigned_upload_geotiff(client, admin_auth_header, s3_mode)
+
+    defer = AsyncMock()
+    with patch("app.processing.ingest.service.defer_async_with_tenant", defer):
+        resp = await client.post(
+            f"/ingest/commit/{job_id}",
+            json={
+                "title": "Elevation",
+                "compression": "LZW",
+                "resampling": "bilinear",
+            },
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 202, resp.text
+    defer.assert_awaited_once()
+    deferred_task = defer.await_args.args[0]
+    assert deferred_task is ingest_raster, f"dispatched {deferred_task.name}"
+
+    job = (
+        await test_db_session.execute(select(IngestJob).where(IngestJob.id == job_id))
+    ).scalar_one()
+    assert job.user_metadata["compression"] == "LZW"
+    assert job.user_metadata["resampling"] == "bilinear"
+
+
+async def test_ingest_raster_derives_crs_missing_without_the_upload_stamp(
+    client, admin_auth_header, test_db_session, tmp_path
+) -> None:
+    """The worker half of the fix.
+
+    ``crs_missing`` used to come from ``user_metadata``, written only by the
+    non-presigned upload endpoint. A presigned job therefore arrives without
+    it — and it gates whether ``srid_override`` is handed to the COG
+    conversion, so a CRS-less raster would have been converted with the
+    override silently dropped. The task derives it from the raster now, so a
+    job with no stamp at all still gets the actionable error.
+    """
+    from app.modules.auth.models import User
+    from app.processing.ingest.tasks_raster import ingest_raster
+
+    raster = tmp_path / "nocrs.tif"
+    raster.write_bytes(_geotiff_bytes(crs=None))
+
+    admin = (
+        await test_db_session.execute(select(User).where(User.username == "admin"))
+    ).scalar_one()
+
+    job = IngestJob(
+        source_filename="nocrs.tif",
+        file_path=str(raster),
+        created_by=admin.id,
+        status="pending",
+        # Exactly what the presigned path leaves behind: the raster
+        # discriminator and no crs_missing key.
+        user_metadata={"file_type": "raster", "presigned": True},
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+    await test_db_session.refresh(job)
+
+    with pytest.raises(ValueError, match="Provide a CRS override"):
+        await ingest_raster.func(
+            job_id=str(job.id),
+            file_path=str(raster),
+            user_id=str(admin.id),
+            attempt_id=str(job.attempt_id),
+        )
+
+
+async def test_presigned_vector_upload_is_not_stamped_raster(
+    client, admin_auth_header, test_db_session, s3_mode
+) -> None:
+    """The other direction: the stamp keys off the filename, so vectors are
+    left alone and keep defaulting to the ogrinfo path."""
+    resp = await client.post(
+        "/ingest/upload/presigned",
+        json={
+            "filename": "roads.geojson",
+            "file_size": 2,
+            "content_type": "application/geo+json",
+        },
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    s3_mode.objects[body["s3_key"]] = b"{}"
+
+    resp = await client.post(
+        f"/ingest/upload/presigned/{body['job_id']}/complete",
+        json={},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+
+    job = (
+        await test_db_session.execute(
+            select(IngestJob).where(IngestJob.id == body["job_id"])
+        )
+    ).scalar_one()
+    assert "file_type" not in job.user_metadata

--- a/backend/tests/test_upload_size_limit.py
+++ b/backend/tests/test_upload_size_limit.py
@@ -179,7 +179,8 @@ async def test_upload_commit_failure_cleans_owned_staged_file(tmp_path):
         patch.object(router, "create_ingest_job", AsyncMock(return_value=job)),
         patch.object(router, "save_upload_file", AsyncMock(return_value=staged)),
         patch.object(router, "validate_file_content"),
-        patch.object(router, "_stamp_raster_metadata", AsyncMock()),
+        # fix(#1186): _stamp_raster_metadata is a synchronous filename check now.
+        patch.object(router, "_stamp_raster_metadata", MagicMock()),
         patch.object(router, "_cleanup_saved_upload", cleanup),
     ):
         with pytest.raises(HTTPException) as exc:


### PR DESCRIPTION
## Problem

`_stamp_raster_metadata` — which sets `job.user_metadata["file_type"] = "raster"` — was only called from the non-presigned `upload_file` endpoint, never from `complete_presigned_upload`. On any S3 deployment `presigned_uploads` is `True`, so the frontend always uploads through the presigned path and `file_type` was never stamped.

`file_type == "raster"` gates three consumers, and the presigned path missed all of them:

- the preview branch — the reported 422 (`ogrinfo` run against a GeoTIFF)
- `_pick_commit_subclass` — a vector commit body parsed for a raster job
- the ingest dispatch in `queue_ingest_job` — `ingest_file` (ogr2ogr) instead of `ingest_raster`

So the presigned raster pipeline was broken end to end, not just at preview. Reported against 1.6.1 and confirmed on 1.7.1.

Thanks to the reporter — the root cause in the issue was exactly right and made verification fast.

## The design decision

The triage laid out two options. This PR takes **(b): stamp `file_type` by extension unconditionally and stop validating CRS at upload time.**

`_stamp_raster_metadata` is now a synchronous extension check that sets `file_type` only, called from both upload endpoints. Its download-and-validate half is gone. Two things ruled out option (a) — calling the helper as-is from the presigned endpoint:

1. **Cost.** Preview already downloads the same object seconds later via `resolve_file_path`. Option (a) means two full downloads per raster upload, and it puts the second one on the completion request — the one that currently returns instantly. nginx allows 600s on `/api/`, so it would not have timed out; it would just hang for minutes on exactly the file class presigned uploads exist for.
2. **A failure mode the completion endpoint cannot absorb** (this one was not in the issue or the triage). The helper caught only `ValueError` around `validate_raster_crs`. A truncated GeoTIFF raises `RasterioIOError`, which `upload_file` swallows in its outer `except Exception` (500 + staged-file cleanup) and which `complete_presigned_upload` has no equivalent for. Under (a) a corrupt `.tif` would 500 at completion with the S3 object left behind, instead of getting preview's clean 422.

## Why `tasks_raster.py` is in this diff

Deferring CRS validation moves the `crs_missing` flag, so its consumers had to be read rather than assumed. There is exactly one reader: `ingest_raster`. Writes at `router.py`, reads at `tasks_raster.py` — nothing else, and no test referenced it.

- One read only picks between two error messages. Both raise, both fail the job. Cosmetic.
- The load-bearing one is `assign_crs=assign_crs if assign_crs and crs_missing else None`. **An unset flag silently drops a user-supplied `srid_override`**, so `check_and_prepare_cog` runs on a CRS-less source and the COG comes out with no CRS.

That is not pre-existing-and-separable: before this fix presigned rasters never reached `ingest_raster` at all (they dispatched to `ingest_file`), so the router fix is what first routes them there and exposes the gap. `ingest_raster` now derives `crs_missing = not meta.get("crs_wkt")` from the raster it has already opened — the authority the upload-time flag was standing in for. `validate_raster_crs` raises iff `src.crs is None`, and `crs_wkt` is `crs.to_wkt() if crs else None`, so the two conditions are equivalent; the raise condition is byte-identical for the non-presigned path. The now-unreachable short error message is deleted so the actionable one always shows.

Deferring to preview instead would not close this: `commit_import` requires only `status == "pending"`, so a client can skip preview entirely.

## Tests

New `backend/tests/test_presigned_raster_stamp_1186.py`. Every pre-existing raster test drives the non-presigned endpoint, so the presigned path had no coverage at all. The new file runs a GeoTIFF through request-presigned → complete and then asserts each of the three consumers: the stamp itself, preview returning a raster response, and commit dispatching to `ingest_raster`. A vector presigned upload is included as a control, plus direct coverage of the derived `crs_missing`.

Two RED checks, disabled separately:

1. Removing only the `_stamp_raster_metadata` call from `complete_presigned_upload` — 3 failed / 1 passed: `KeyError: 'file_type'`; the reported bug verbatim (`422 ... ogrinfo failed (exit 1): ERROR 4: ... not recognized as being in a supported file format`); and the wrong deferred task. **The vector control still passed**, which is what rules out fixture breakage.
2. Restoring the old flag-based `crs_missing` — 1 failed / 4 passed, on the error-message regex.

Only the worker test moved for edit 2 and only the router tests for edit 1, so the two edits are independently load-bearing and neither masks the other. Both files were restored by position, not by pattern.

## Verification

- `uv run ruff check .` — All checks passed. `uv run ruff format --check .` — 888 files already formatted.
- New file alone — 5 passed.
- `test_presigned_raster_stamp_1186 + test_layering + test_ingest + test_upload_size_limit + test_raster_ingest` — 116 passed.
- `test_rule1_structural + test_rule2_structural + test_api_contract_openapi + test_strict_cog_enforcement + test_raster_ingest_orphan_cleanup_gap017 + test_ingest_job_attempt_fencing` — 111 passed.
- `test_manifest_apply_roundtrip + test_manifest_apply_service + test_reupload + test_reupload_idor + test_reupload_record_type_guard + test_preview_temp_cleanup + test_ingest_fan_out + test_ingest_parquet` — 148 passed.
- `test_layering.py` — 40 passed. The `router.py` cap moves 1493 → 1473 in the same commit (caps are exact, so a shrink fails the gate too), with a comment recording what the removed lines were.

No OpenAPI regeneration: no schema, route, or endpoint-docstring change, and `test_api_contract_openapi.py` passes.

## Known limits, stated rather than glossed

- The worker test observes the derived `crs_missing` through the raise path. The `assign_crs` pass-through is the same variable but is not directly asserted — reaching it means a full COG conversion, and no existing test drives `ingest_raster`'s body.
- `complete_presigned_upload` still never calls `validate_file_content`, which the non-presigned path does. That asymmetry is real and out of scope here; worth its own issue.
- `datasets/api/router_reupload.py` has its own presigned completion with the same missing stamp, but it is unaffected: `_assert_compatible_record_type` rejects raster inputs at every reupload entry point. Checked rather than assumed.

Closes #1186
