### PR TITLE
sec(titiler): pin the GDAL rawband env and add a TITILER_WORKERS knob

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -338,6 +338,16 @@ FRONTEND_PORT=8080
 # Type: Docker byte value | Default: 1g
 # TITILER_MEM_LIMIT=1g
 #
+# Number of Titiler uvicorn worker processes. Tile rendering is CPU-bound under
+# the GIL, so one worker renders one tile at a time and concurrent cache misses
+# queue — this is the first knob to reach for when raster feels slow.
+# Raise TITILER_MEM_LIMIT above with it. GDAL_CACHEMAX is per process, so N
+# workers multiply the block-cache ceiling on top of N interpreters, and
+# TiTiler's RSS ratchet runs in each one; more workers at the same 1g cap
+# reach OOMKill sooner, not later.
+# Type: integer | Default: 1
+# TITILER_WORKERS=1
+#
 # glibc malloc arena cap inside the Titiler container. Slows (does not stop)
 # TiTiler's RSS ratchet under concurrent tile reads; raise only if malloc
 # contention shows up on many-core hosts. See the docker-compose.yml note.

--- a/backend/tests/test_titiler_gdal_security_env.py
+++ b/backend/tests/test_titiler_gdal_security_env.py
@@ -1,0 +1,138 @@
+"""fix(#1192, #1193): pin the titiler service's GDAL security env and worker knob.
+
+Two invariants, both learned from settings that read as decisions and were not.
+
+#1192 — the VRT rawband controls must be set EXPLICITLY, because their defaults
+are version-dependent and a base-image bump would otherwise move them silently.
+The stronger half is ``test_allowed_source_is_a_value_gdal_accepts``: the value
+that shipped here for months, ``NETWORK_OR_LOCAL``, is not one of GDAL's four
+accepted forms. GDAL fell through to its absolute-path branch and refused every
+VRTRawRasterBand source, so the effective policy was deny-all while the inline
+comment claimed "allow VRT bands to reference remote (S3) sources". Measured
+2026-08-04 in ghcr.io/developmentseed/titiler 2.0.5 and 2.2.1, both
+rasterio 1.5.0 / GDAL 3.12.1::
+
+    Invalid value for GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE.
+    'NETWORK_OR_LOCAL' is not an absolute path
+
+The membership check below defaults RESTRICTIVE on purpose — an unrecognised
+token fails rather than passing — because that is the direction in which this
+class of mistake is loud. A test that only asserted "the key is present" would
+have passed against the broken value.
+
+#1193 — the worker count is env-tunable, and the memory cap it must be raised
+with stays env-tunable too. ``GDAL_CACHEMAX`` is per process, so N workers
+multiply the block-cache ceiling; raising workers against a pinned memory limit
+reaches OOMKill sooner (#678).
+
+Static analysis only — no docker daemon required.
+"""
+
+import pytest
+import yaml
+
+from tests.repo_paths import repo_root
+
+_REPO_ROOT = repo_root(__file__)
+_COMPOSE_FILES = ("docker-compose.yml", "docker-compose.prod.yml")
+
+# https://gdal.org/en/stable/drivers/raster/vrt.html (GDAL >= 3.12). The fourth
+# accepted form is an absolute path, handled separately below.
+_ALLOWED_SOURCE_TOKENS = frozenset(
+    {"SIBLING_OR_CHILD_OF_VRT_PATH", "ONLY_REMOTE", "ALL"}
+)
+
+
+def _titiler_service(filename: str) -> dict:
+    body = yaml.safe_load((_REPO_ROOT / filename).read_text(encoding="utf-8"))
+    return body["services"]["titiler"]
+
+
+def _titiler_env(filename: str) -> dict:
+    return _titiler_service(filename)["environment"]
+
+
+def _titiler_command(filename: str) -> str:
+    command = _titiler_service(filename)["command"]
+    return command if isinstance(command, str) else "\n".join(command)
+
+
+@pytest.mark.parametrize("filename", _COMPOSE_FILES)
+def test_vrt_rawband_controls_are_pinned_explicitly(filename: str) -> None:
+    """Both GDAL >= 3.12 rawband options are set, not inherited (#1192)."""
+    env = _titiler_env(filename)
+    for key in (
+        "GDAL_VRT_ENABLE_RAWRASTERBAND",
+        "GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE",
+    ):
+        assert key in env, (
+            f"{filename}: titiler must pin {key} explicitly — its GDAL default is "
+            "version-dependent, so a base-image bump can relax it silently (#1192)"
+        )
+
+
+@pytest.mark.parametrize("filename", _COMPOSE_FILES)
+def test_allowed_source_is_a_value_gdal_accepts(filename: str) -> None:
+    """An unrecognised token is refused by GDAL, not treated as permissive (#1192)."""
+    value = _titiler_env(filename)["GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE"]
+    accepted = value in _ALLOWED_SOURCE_TOKENS or value.startswith("/")
+    assert accepted, (
+        f"{filename}: GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE={value!r} is not one of "
+        f"{sorted(_ALLOWED_SOURCE_TOKENS)} nor an absolute path. GDAL parses an "
+        "unrecognised token as a bogus absolute path and refuses every "
+        "VRTRawRasterBand source, so the setting will not mean what its comment "
+        "says (#1192)"
+    )
+
+
+@pytest.mark.parametrize("filename", _COMPOSE_FILES)
+def test_enable_rawrasterband_is_yes_or_no(filename: str) -> None:
+    """The enable switch is a YES/NO option; anything else is a typo (#1192)."""
+    value = _titiler_env(filename)["GDAL_VRT_ENABLE_RAWRASTERBAND"]
+    assert value in ("YES", "NO"), (
+        f"{filename}: GDAL_VRT_ENABLE_RAWRASTERBAND={value!r} — GDAL accepts only "
+        "YES or NO (#1192)"
+    )
+
+
+@pytest.mark.parametrize("filename", _COMPOSE_FILES)
+def test_header_file_kvp_toggle_is_not_set_prematurely(filename: str) -> None:
+    """CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED needs GDAL >= 3.13.2 (#1192).
+
+    The image installs rasterio from PyPI wheels, so the wheel gates the GDAL
+    version rather than the titiler tag — titiler 2.0.5 and 2.2.1 both ship
+    GDAL 3.12.1 (measured 2026-08-04). Setting it now would be inert and would
+    read as a control we do not have, which is exactly the #937 mistake. Delete
+    this test in the commit that adds the key, once a wheel bump crosses 3.13.2.
+    """
+    assert "CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED" not in _titiler_env(filename), (
+        f"{filename}: CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED requires GDAL >= 3.13.2. "
+        "Confirm rasterio.__gdal_version__ in the pinned image before adding it, and "
+        "drop this test in the same commit (#1192)"
+    )
+
+
+@pytest.mark.parametrize("filename", _COMPOSE_FILES)
+def test_titiler_worker_count_is_env_tunable(filename: str) -> None:
+    """The worker count comes from TITILER_WORKERS, defaulting to 1 (#1193)."""
+    command = _titiler_command(filename)
+    assert "--workers $${TITILER_WORKERS:-1}" in command, (
+        f"{filename}: titiler must take its worker count from TITILER_WORKERS with a "
+        f"default of 1, mirroring UVICORN_WORKERS: {command!r}"
+    )
+    env = _titiler_env(filename)
+    assert env.get("TITILER_WORKERS") == "${TITILER_WORKERS:-1}", (
+        f"{filename}: the command wrapper reads TITILER_WORKERS from the container "
+        "environment, so the service must pass it through from the host"
+    )
+
+
+@pytest.mark.parametrize("filename", _COMPOSE_FILES)
+def test_titiler_memory_cap_stays_tunable_alongside_workers(filename: str) -> None:
+    """More workers need more memory, so the cap must move with them (#1193, #678)."""
+    mem_limit = _titiler_service(filename)["mem_limit"]
+    assert "${TITILER_MEM_LIMIT" in mem_limit, (
+        f"{filename}: TITILER_MEM_LIMIT must stay env-overridable — GDAL_CACHEMAX is "
+        "per process, so raising TITILER_WORKERS against a pinned memory limit "
+        f"reaches OOMKill sooner (#678): {mem_limit!r}"
+    )

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -411,19 +411,39 @@ services:
           [ -n "$$ep" ] && export AWS_S3_ENDPOINT="$$ep"
         fi
         [ "$${S3_ADDRESSING_STYLE:-auto}" = "path" ] && export AWS_VIRTUAL_HOSTING="$${AWS_VIRTUAL_HOSTING:-FALSE}"
-        exec uvicorn titiler.application.main:app --host 0.0.0.0 --port 8000 --workers 1
+        exec uvicorn titiler.application.main:app --host 0.0.0.0 --port 8000 --workers $${TITILER_WORKERS:-1}
     environment:
       # fix(#579): inputs for the AWS_* derivation in the command wrapper above.
       S3_ENDPOINT: "${S3_ENDPOINT:-}"
       S3_ALLOW_HTTP: "${S3_ALLOW_HTTP:-}"
       S3_ADDRESSING_STYLE: "${S3_ADDRESSING_STYLE:-auto}"
+      # fix(#1193): tile rendering is CPU-bound under the GIL — one worker
+      # renders one tile at a time. Raise TITILER_MEM_LIMIT alongside this:
+      # GDAL_CACHEMAX is per process and the #678 RSS ratchet runs in each one,
+      # so more workers at the same 1g cap reach OOMKill sooner. See the
+      # docker-compose.yml note.
+      TITILER_WORKERS: "${TITILER_WORKERS:-1}"
       # fix(#678): slow TiTiler's glibc RSS ratchet under concurrent tile
       # reads — measured mitigation only; see the docker-compose.yml note.
       MALLOC_ARENA_MAX: "${TITILER_MALLOC_ARENA_MAX:-2}"
       GDAL_CACHEMAX: "200"
       GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"
       CPL_VSIL_CURL_ALLOWED_EXTENSIONS: ".tif,.tiff,.cog,.vrt"
-      GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE: "NETWORK_OR_LOCAL"
+      # fix(#1192): VRTRawRasterBand is OFF. VRT mosaics render normally — only
+      # the raw-binary band subclass, which GeoLens never emits, is refused.
+      # ALLOWED_SOURCE is the clamp that would apply if it were re-enabled.
+      #
+      # Pinned rather than inherited so a base-image bump cannot relax them. The
+      # previous "NETWORK_OR_LOCAL" is not a value GDAL accepts, so it was
+      # parsed as an absolute path and refused every source — deny-all by
+      # accident. Correcting the token alone would have LOOSENED this: the same
+      # fixture opens and reads under SIBLING_OR_CHILD_OF_VRT_PATH. NO preserves
+      # today's behaviour in a value GDAL accepts.
+      # CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED needs GDAL >= 3.13.2 and is
+      # deliberately absent — the image ships GDAL 3.12.1. See the
+      # docker-compose.yml note for the measurements.
+      GDAL_VRT_ENABLE_RAWRASTERBAND: "NO"
+      GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE: "SIBLING_OR_CHILD_OF_VRT_PATH"
       VSI_CACHE: "TRUE"
       CPL_VSIL_CURL_CACHE_SIZE: "16777216"
       GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: "YES"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -492,12 +492,24 @@ services:
           [ -n "$$ep" ] && export AWS_S3_ENDPOINT="$$ep"
         fi
         [ "$${S3_ADDRESSING_STYLE:-auto}" = "path" ] && export AWS_VIRTUAL_HOSTING="$${AWS_VIRTUAL_HOSTING:-FALSE}"
-        exec uvicorn titiler.application.main:app --host 0.0.0.0 --port 8000 --workers 1
+        exec uvicorn titiler.application.main:app --host 0.0.0.0 --port 8000 --workers $${TITILER_WORKERS:-1}
     environment:
       # fix(#579): inputs for the AWS_* derivation in the command wrapper above.
       S3_ENDPOINT: "${S3_ENDPOINT:-}"
       S3_ALLOW_HTTP: "${S3_ALLOW_HTTP:-}"
       S3_ADDRESSING_STYLE: "${S3_ADDRESSING_STYLE:-auto}"
+      # fix(#1193): tile rendering is CPU-bound under the GIL, so one worker
+      # renders one tile at a time and concurrent cache misses queue behind it.
+      # This is the first knob to reach for when raster feels slow. Default 1
+      # keeps existing installs byte-identical.
+      #
+      # RAISE TITILER_MEM_LIMIT WITH IT. GDAL_CACHEMAX below is per PROCESS, so
+      # N workers multiply the block-cache ceiling (N x 200 MB) on top of N
+      # Python interpreters, and the #678 RSS ratchet runs independently in
+      # every one of them. Leaving mem_limit at its 1g default while raising
+      # workers reaches OOMKill sooner, not later — budget roughly
+      # N x (GDAL_CACHEMAX + ~250 MB) and watch RSS before trusting it.
+      TITILER_WORKERS: "${TITILER_WORKERS:-1}"
       # fix(#678): TiTiler RSS ratchets well past GDAL_CACHEMAX under
       # concurrent tile reads — anonymous heap the allocator retains (0.3 ->
       # 1.8 GB over 20h on the demo). Capping glibc arenas slows that: an A/B
@@ -512,7 +524,50 @@ services:
       GDAL_CACHEMAX: "200"                              # GDAL block cache in MB (default 5 — raise for concurrent tile requests)
       GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"         # Skip directory listing on S3/HTTP — avoids slow LIST calls per tile
       CPL_VSIL_CURL_ALLOWED_EXTENSIONS: ".tif,.tiff,.cog,.vrt"  # Only fetch these extensions via /vsicurl
-      GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE: "NETWORK_OR_LOCAL"  # Allow VRT bands to reference remote (S3) sources
+      # fix(#1192): VRTRawRasterBand is OFF. Titiler renders VRT mosaics
+      # normally — only the raw-binary band subclass, which nothing in GeoLens
+      # emits, is refused. ALLOWED_SOURCE below is the clamp that would apply if
+      # the subclass were ever re-enabled, pinned to GDAL's narrowest value.
+      #
+      # Both options are GDAL >= 3.12 and are pinned rather than inherited so a
+      # base-image bump cannot silently relax them.
+      #
+      # ALLOWED_SOURCE previously read "NETWORK_OR_LOCAL", labelled "allow VRT
+      # bands to reference remote (S3) sources". That is not one of the values
+      # GDAL accepts (SIBLING_OR_CHILD_OF_VRT_PATH | ONLY_REMOTE | ALL |
+      # <absolute path>), so GDAL parsed it as an absolute path and refused
+      # EVERY VRTRawRasterBand source. Measured 2026-08-04 in both the 2.0.5 and
+      # 2.2.1 images (rasterio 1.5.0 / GDAL 3.12.1):
+      #   "Invalid value for GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE.
+      #    'NETWORK_OR_LOCAL' is not an absolute path"
+      # So the effective policy has always been deny-all, and the comment
+      # claiming otherwise was the only thing that read as permissive — the
+      # #937 shape again, a setting that looks like a decision and is not.
+      #
+      # Correcting the token ALONE would have been a LOOSENING, not a cleanup:
+      # the same fixture OPENED AND READ successfully under
+      # ALLOWED_SOURCE=SIBLING_OR_CHILD_OF_VRT_PATH, so switching only that
+      # value would start admitting sibling raw sources that are refused today.
+      # That is why ENABLE_RAWRASTERBAND=NO is set alongside it — it states the
+      # existing deny-all in a value GDAL accepts, and fails with an intentional
+      # message ("VRTRawRasterBand support has been disabled at run-time")
+      # instead of an accidental one.
+      #
+      # NO costs nothing: VRTRawRasterBand appears nowhere in this repo (the
+      # builder in processing/raster/vrt.py emits SimpleSource / ComplexSource /
+      # AveragedSource, as gdalbuildvrt does), and an ordinary SimpleSource VRT
+      # opens and reads unchanged under NO — also measured. ALLOWED_SOURCE stays
+      # pinned at GDAL's documented narrowest legitimate value so that flipping
+      # ENABLE back to YES lands on a sane clamp rather than whatever the base
+      # image defaults to that year.
+      GDAL_VRT_ENABLE_RAWRASTERBAND: "NO"
+      GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE: "SIBLING_OR_CHILD_OF_VRT_PATH"
+      # fix(#1192): CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED restricts the
+      # /vsicurl/ header_file option and needs GDAL >= 3.13.2. NOT SET because
+      # it is not available yet: the image installs rasterio from PyPI wheels,
+      # so the rasterio wheel gates the GDAL version, not the titiler tag —
+      # titiler 2.0.5 and 2.2.1 both ship rasterio 1.5.0 / GDAL 3.12.1
+      # (measured 2026-08-04). Add it here when a wheel bump crosses 3.13.2.
       VSI_CACHE: "TRUE"                                  # Enable /vsicurl block caching for range-request reuse
       CPL_VSIL_CURL_CACHE_SIZE: "16777216"               # /vsicurl cache size in bytes (16 MB)
       GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: "YES"          # Merge adjacent HTTP range requests into fewer round-trips


### PR DESCRIPTION
## What this does

Two changes to the titiler sidecar in both compose topologies:

**#1192 — pin the VRT rawband controls** instead of inheriting GDAL's version-dependent defaults, so a base-image bump cannot silently relax them.

**#1193 — make the worker count env-tunable** as `TITILER_WORKERS`, defaulting to 1 so existing installs are byte-identical.

## The #1192 finding: the value we were setting was never valid

`GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE` was set to `NETWORK_OR_LOCAL`, commented "Allow VRT bands to reference remote (S3) sources". That is not one of the values GDAL accepts — the set is `SIBLING_OR_CHILD_OF_VRT_PATH | ONLY_REMOTE | ALL | <absolute path>` — so GDAL parsed it as an absolute path and refused **every** VRTRawRasterBand source. Measured in both the 2.0.5 and 2.2.1 images:

```
GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE=NETWORK_OR_LOCAL
  -> REFUSED: Invalid value for GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE.
     'NETWORK_OR_LOCAL' is not an absolute path
```

So the effective policy has always been deny-all, and the comment claiming otherwise was the only thing that read as permissive. This is the #937 shape again: a line that reads as a decision and is not one.

### Why this pins `ENABLE_RAWRASTERBAND=NO` rather than just correcting the token

The issue text says `NO` is unavailable "since VRT is a product feature". That premise conflates VRT with the `VRTRawRasterBand` **subclass**, and measurement disagrees:

| setting | result |
|---|---|
| `ALLOWED_SOURCE=NETWORK_OR_LOCAL` (today) | refused — invalid value |
| `ALLOWED_SOURCE=SIBLING_OR_CHILD_OF_VRT_PATH` | **raw-band VRT opens and reads** |
| `ENABLE_RAWRASTERBAND=NO` | refused: "VRTRawRasterBand support has been disabled at run-time" |
| ordinary SimpleSource VRT under `NO` | opens and reads, unchanged |

The second row is the decisive one. Correcting the token alone would *start admitting* sibling raw sources that are refused today — a real loosening dressed up as a cleanup. `NO` states today's actual deny-all behaviour in a value GDAL accepts, so it is behaviour-preserving, and it can only ever be equal-or-stricter than any `ALLOWED_SOURCE` value.

It costs nothing here: `VRTRawRasterBand` appears nowhere in this repo — the builder in `processing/raster/vrt.py` emits `SimpleSource` / `ComplexSource` / `AveragedSource`, as `gdalbuildvrt` does. VRT mosaics as a product feature are untouched; only the raw-binary band subclass is off. `ALLOWED_SOURCE` stays pinned at GDAL's documented narrowest legitimate value so that flipping `ENABLE` back to `YES` lands on a sane clamp rather than whatever the base image defaults to that year.

**`CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED` is deliberately NOT set.** It needs GDAL >= 3.13.2 and both images ship 3.12.1. The image installs rasterio from PyPI wheels, so the **rasterio wheel** gates the GDAL version, not the titiler tag — a future titiler bump will not deliver it either. A comment marks the spot and names what gates it, and a test fails if someone adds it prematurely.

## #1193 — TITILER_WORKERS

Mirrors the existing `UVICORN_WORKERS` pattern. Tile rendering is CPU-bound under the GIL, so one worker renders one tile at a time and concurrent cache misses queue behind it.

The memory pairing is documented at the setting rather than left implicit: `GDAL_CACHEMAX` is per process, so N workers multiply the block-cache ceiling on top of N interpreters, and the #678 RSS ratchet runs independently in each one. Raising workers without raising `TITILER_MEM_LIMIT` reaches OOMKill sooner, not later.

## Verification

Compose-shape suites, from the branch: `test_titiler_gdal_security_env.py` (new, 138 lines) + `test_titiler_redirect_env.py` + `test_phase_272_compose.py` + `test_phase_275_compose_alignment.py` — **64 passed**. Widened to 12 compose/config files — **132 passed**.

`docker compose config -q` exits 0 on both files. All references are parse-safe `${VAR:-default}`; no `:?` was added (INST-01).

Two RED checks, each failing exactly one test for the right reason: reverting `ALLOWED_SOURCE` to `NETWORK_OR_LOCAL` fails `test_allowed_source_is_a_value_gdal_accepts` with the invalid-value message; restoring hardcoded `--workers 1` fails `test_titiler_worker_count_is_env_tunable`.

### Live verification on a running stack

Compose-shape tests cannot prove the container behaves, so this was also exercised end to end against a real stack with both this branch and #1190 applied:

- **Env reaches the container**: `GDAL_VRT_ENABLE_RAWRASTERBAND=NO`, `GDAL_VRT_RAWRASTERBAND_ALLOWED_SOURCE=SIBLING_OR_CHILD_OF_VRT_PATH`.
- **VRT capability, inside the running container**: an ordinary SimpleSource VRT of our writer's shape opened and read (sum 2016); a raw-band VRT was refused with "VRTRawRasterBand support has been disabled at run-time". So mosaics work and only the disabled subclass is blocked.
- **The worker knob actually interpolates**: at default the argv is `--workers 1`; with `TITILER_WORKERS=3` it is `--workers 3` with three forked worker children. The default is byte-identical to the previous hardcoded value.
- **A real tile through the API proxy** was byte-identical to the pre-change baseline (HTTP 200, 3098 bytes, same sha256).

One coverage gap stated plainly: the dev database has zero VRT generations, so no live *mosaic dataset* was rendered through the proxy. The VRT capability was verified directly in the container instead, which is the closest available substitute and is not the same thing.

Closes #1192
Closes #1193
