### PR TITLE
chore(titiler): bump the sidecar image 2.0.5 -> 2.2.1

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -373,7 +373,8 @@ services:
 
   titiler:
     # Third-party image — identical to docker-compose.yml.
-    image: ghcr.io/developmentseed/titiler:2.0.5
+    # 2.2.1 per the 2026-08 reassessment (#1190); see the note there.
+    image: ghcr.io/developmentseed/titiler:2.2.1
     init: true
     restart: unless-stopped
     stop_grace_period: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -451,8 +451,22 @@ services:
 
   titiler:
     # Pinned to 2.x stable (held back from 3.x without contract testing).
-    # 2.0.5 bump per the 2026-07 TiTiler assessment (patch-level, same contract).
-    image: ghcr.io/developmentseed/titiler:2.0.5
+    # 2.2.1 bump per the 2026-08 TiTiler reassessment (#1190). Upstream ships
+    # security fixes as ordinary bugfix releases with no advisory, and OSV and
+    # the GitHub advisory database carry nothing for rio-tiler or titiler.core,
+    # so Dependabot cannot see this drift — a deliberate bump is the only
+    # control. 2.1.0 -> 2.2.1 is additive against our surface (tileset min/max
+    # zoom params, a WMTS zooms param, httpx -> httpx2); the four endpoints we
+    # consume and all six query params were exercised against both images and
+    # returned identical status + content-type.
+    #
+    # NOTE: this does NOT move GDAL. The image installs rasterio from PyPI
+    # wheels, so the wheel pins GDAL, not the titiler tag — 2.0.5 and 2.2.1 both
+    # resolve rasterio 1.5.0 / GDAL 3.12.1 (measured). Only rio-tiler moves,
+    # 9.2.1 -> 9.4.2. CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED (the /vsicurl
+    # header_file clamp) needs GDAL >= 3.13.2, so it stays unavailable and the
+    # #1192 gap is gated on a rasterio wheel bump, not on a titiler tag.
+    image: ghcr.io/developmentseed/titiler:2.2.1
     init: true
     restart: unless-stopped
     stop_grace_period: 15s


### PR DESCRIPTION
## What this does

Bumps the titiler sidecar `ghcr.io/developmentseed/titiler` from **2.0.5 to 2.2.1** in both compose topologies. The chart half ships as a separate PR in `geolens-deployments`.

Upstream ships security fixes as ordinary bugfix releases with no advisory — both published exploit chains against this stack were fixed without a GHSA, and OSV plus the GitHub advisory database return nothing for `rio-tiler` or `titiler.core`. Dependabot cannot see this drift, so a deliberate bump is the only control. This is hygiene, not an emergency: the running 2.0.5 sidecar resolves `rio-tiler 9.2.1`, which already carries the AST expression validator from 9.1.0.

## What the bump actually moves — measured, not predicted

| tag | rio-tiler | rasterio | GDAL | titiler.core |
|---|---|---|---|---|
| 2.0.5 | 9.2.1 | 1.5.0 | 3.12.1 | 2.0.5 |
| 2.2.1 | **9.4.2** | 1.5.0 | 3.12.1 | **2.2.1** |

**Only rio-tiler moves.** The issue asked to confirm the GDAL version as part of this work, and the answer is that it does not change: the image installs rasterio from PyPI wheels, so the **rasterio wheel** pins GDAL, not the titiler tag.

The consequence matters for #1192 and is recorded in a comment at the pin: `CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED` — the direct fix for MapRoot's `header_file` arbitrary read — needs GDAL >= 3.13.2 and remains unavailable. That gap should be tracked against a **rasterio** bump; a future titiler bump will not deliver it either.

## Contract verification

Changelog reading alone is weak for a contract claim, so both images were run and the surface exercised directly against a purpose-built 3-band uint16 COG and a 1-band float32 DEM.

- Endpoints: `/healthz`, `/cog/info`, `/cog/statistics`, `/cog/tiles` (png and webp).
- Query params: `url`, `p` (repeated), `bidx` (×3), `rescale` (×3), `colormap_name`, `algorithm=terrainrgb`. That list came from `_titiler_render_params` and the call sites in `processing/tiles/router.py` and `sources/stac_router.py`, not from the issue.
- **16 probes, 8 per image, identical status and content-type across 2.0.5 and 2.2.1.** Also re-run with the #1192 GDAL env applied, so the pinning does not break rendering either.

The 2.1.0 → 2.2.1 changelog is additive against our surface as the issue predicted: tileset min/max zoom params, a WMTS `zooms` param, httpx → httpx2, projjson headers, XML layer identifiers, error-logging changes. Nothing removes or renames anything we call.

## Live verification on a running stack

An image bump across two minors is not something a compose-shape test can clear, so this was verified against a real stack:

- A real tile through the API proxy layer — `GET /api/tiles/raster-proxy/{dataset}/12/2135/1457.png` on a swissALTI3D GeoTIFF — returned **HTTP 200, 3098 bytes, sha256 identical to the pre-bump baseline**, decoding to a valid 256×256 RGBA PNG. Byte-identical output was stronger than the pass condition required (a differing hash would have been acceptable, since 9.2.1 → 9.4.2 may legitimately change PNG encoding).
- The stack was then restored to 2.0.5 and the same request re-run to confirm the baseline still reproduces.

Stated coverage gap: the dev database has zero VRT generations, so no live VRT-mosaic dataset was rendered through the proxy. VRT capability was verified directly inside the running container instead.

Compose-shape suites: 120 passed across 11 files. `docker compose config -q` exits 0 on both topologies.

## Landing note

This and #1197 (#1192 + #1193) touch the same two compose files in disjoint regions — this one only the image-pin comment block, that one only the command line and environment block. `git merge-tree` across the two branches exits 0 with no conflict markers, so they can land in either order.

Closes #1190
