### PR TITLE
feat(admin): make the Users list sortable

### DIFF
--- a/backend/app/modules/admin/router.py
+++ b/backend/app/modules/admin/router.py
@@ -26,8 +26,10 @@ from app.modules.admin.schemas import (
     CatalogStatsResponse,
     EmbeddingStatsResponse,
     SamlToLocalConversion,
+    SortDirection,
     UserListResponse,
     UserNameItem,
+    UserSortField,
     UserUpdate,
 )
 from app.modules.admin.service import (
@@ -171,12 +173,29 @@ async def list_users(
     limit: int = Query(50, ge=1, le=200),
     status_filter: str | None = Query(None, alias="status", max_length=50),
     search: str | None = Query(None, max_length=200),
+    sort: UserSortField = Query(
+        "created_at",
+        description=(
+            "Column to order by. Roles and storage are not sortable: roles is a "
+            "many-to-many and storage is aggregated per page after the query."
+        ),
+    ),
+    order: SortDirection = Query("asc", description="Sort direction."),
     db: AsyncSession = Depends(get_db),
 ) -> UserListResponse:
-    """List all users with pagination and optional status/search filter (admin only)."""
+    """List all users with pagination and optional status/search/sort filter (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
+    """
     service = AdminService(db)
     users, total = await service.list_users(
-        skip=skip, limit=limit, status=status_filter, search=search
+        skip=skip,
+        limit=limit,
+        status=status_filter,
+        search=search,
+        sort=sort,
+        order=order,
     )
     # QUOTA-04: quota usage for the page. fix(#435): genuinely batched now — this
     # said "batch" but ran one three-table aggregate per user, 200 users per page.

--- a/backend/app/modules/admin/schemas.py
+++ b/backend/app/modules/admin/schemas.py
@@ -23,6 +23,19 @@ JobStatus = Literal[
     "pending", "running", "complete", "failed", "cancelled", "fanned_out"
 ]
 
+# Sortable columns for the admin user list. This Literal is the OUTER half of a
+# two-layer allowlist: FastAPI rejects anything outside it with a 422 before the
+# service runs, and USER_SORT_COLUMNS in service.py resolves the surviving value
+# to a mapped column. A caller-supplied string is therefore never interpolated
+# into an ORDER BY clause.
+#
+# Membership is limited to real `users` columns. Roles is a many-to-many and
+# storage is computed per page after the query returns, so neither can be
+# ordered by the database without restructuring the endpoint.
+UserSortField = Literal["username", "email", "status", "last_login_at", "created_at"]
+
+SortDirection = Literal["asc", "desc"]
+
 
 class AdminUserCreate(BaseModel):
     username: str = Field(

--- a/backend/app/modules/admin/service.py
+++ b/backend/app/modules/admin/service.py
@@ -4,8 +4,9 @@ import uuid
 from typing import Any
 
 import structlog
-from sqlalchemy import delete, func, select, text, update
+from sqlalchemy import delete, func, nulls_last, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import InstrumentedAttribute
 
 from app.modules.admin.schemas import (
     CatalogStatsResponse,
@@ -24,6 +25,24 @@ logger = structlog.stdlib.get_logger(__name__)
 # locking individual User rows is insufficient when two admins concurrently
 # deactivate each other (each operation targets a different row).
 _ADMIN_LIFECYCLE_LOCK_KEY = 0x47454F4C41444D49  # "GEOLADMI"
+
+# Inner half of the user-list sort allowlist (the outer half is the
+# UserSortField Literal in schemas.py, which FastAPI enforces at the boundary).
+# A sort key is only ever a dict lookup here, so an unmapped value cannot reach
+# SQL as text; list_users raises rather than falling back, because a permissive
+# fallback would silently serve the default ordering under a typo'd key.
+USER_SORT_COLUMNS: dict[str, InstrumentedAttribute] = {
+    "username": User.username,
+    "email": User.email,
+    "status": User.status,
+    "last_login_at": User.last_login_at,
+    "created_at": User.created_at,
+}
+
+# Nullable members of USER_SORT_COLUMNS. Postgres defaults NULLs to the end on
+# ASC and the front on DESC, which would float never-logged-in accounts to the
+# top of a descending "Last Login" sort. Pin them last in both directions.
+_NULLABLE_USER_SORT_COLUMNS = frozenset({"email", "last_login_at"})
 
 
 class PendingUserMutationError(ValueError):
@@ -471,14 +490,42 @@ class AdminService:
         await self.db.refresh(user)
         return user, provider_slug
 
+    @staticmethod
+    def _user_ordering(sort: str, order: str) -> list[Any]:
+        """Resolve a sort key/direction pair to ORDER BY clauses.
+
+        Raises ValueError for anything outside the allowlist, so a bad key
+        fails loudly here instead of silently degrading to a default order.
+        """
+        column = USER_SORT_COLUMNS.get(sort)
+        if column is None:
+            raise ValueError(f"Unsupported sort field: {sort!r}")
+        if order not in ("asc", "desc"):
+            raise ValueError(f"Unsupported sort order: {order!r}")
+
+        clause = column.desc() if order == "desc" else column.asc()
+        if sort in _NULLABLE_USER_SORT_COLUMNS:
+            clause = nulls_last(clause)
+
+        # Every sortable column except created_at admits duplicates, and OFFSET
+        # paging over a non-unique key lets Postgres return a row twice (or skip
+        # it) across page boundaries. The id tiebreak makes the order total.
+        return [clause, User.id]
+
     async def list_users(
         self,
         skip: int = 0,
         limit: int = 50,
         status: str | None = None,
         search: str | None = None,
+        sort: str = "created_at",
+        order: str = "asc",
     ) -> tuple[list[User], int]:
         """List users with pagination and optional status/search filter.
+
+        `sort` must be a key of USER_SORT_COLUMNS and `order` one of
+        asc/desc; anything else raises ValueError. The default ordering
+        (created_at ascending) is the historical one and is unchanged.
 
         Returns (users, total_count).
         """
@@ -508,7 +555,9 @@ class AdminService:
             )
 
         count_query = select(func.count()).select_from(User).where(*filters)
-        list_query = select(User).where(*filters).order_by(User.created_at)
+        list_query = (
+            select(User).where(*filters).order_by(*self._user_ordering(sort, order))
+        )
 
         total = (await self.db.execute(count_query)).scalar() or 0
         result = await self.db.execute(list_query.offset(skip).limit(limit))

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -20509,7 +20509,7 @@
     },
     "/admin/users/": {
       "get": {
-        "description": "List all users with pagination and optional status/search filter (admin only).",
+        "description": "List all users with pagination and optional status/search/sort filter (admin only).\n\n`sort` and `order` are closed enums, so an unrecognised value is refused\nwith a 422 and never reaches the query.",
         "operationId": "list_users_admin_users__get",
         "parameters": [
           {
@@ -20567,6 +20567,41 @@
                 }
               ],
               "title": "Search"
+            }
+          },
+          {
+            "description": "Column to order by. Roles and storage are not sortable: roles is a many-to-many and storage is aggregated per page after the query.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "created_at",
+              "description": "Column to order by. Roles and storage are not sortable: roles is a many-to-many and storage is aggregated per page after the query.",
+              "enum": [
+                "username",
+                "email",
+                "status",
+                "last_login_at",
+                "created_at"
+              ],
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "asc",
+              "description": "Sort direction.",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "title": "Order",
+              "type": "string"
             }
           }
         ],

--- a/backend/tests/test_admin_user_sort.py
+++ b/backend/tests/test_admin_user_sort.py
@@ -1,0 +1,312 @@
+"""Tests for sortable GET /admin/users/ (sort + order query params).
+
+Every assertion here is scoped to users the test itself creates, via a unique
+search token in the username. The per-worker database is shared and dozens of
+other tests mint accounts into it, so an assertion about the *whole* list would
+be a claim about the worker rather than about this test.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+PASSWORD = "TestPass1234!"  # SEC-S16: meets 12-char + 3-class policy
+
+
+async def _create_user(
+    client: AsyncClient,
+    admin_headers: dict,
+    username: str,
+    *,
+    email: str | None = None,
+    role: str = "viewer",
+) -> str:
+    """Create a user with an exact username and return its id."""
+    body: dict = {"username": username, "password": PASSWORD, "role": role}
+    if email is not None:
+        body["email"] = email
+    resp = await client.post("/admin/users/", json=body, headers=admin_headers)
+    assert resp.status_code == 201, f"Create {username} failed: {resp.text}"
+    return resp.json()["id"]
+
+
+async def _list(
+    client: AsyncClient,
+    admin_headers: dict,
+    *,
+    search: str,
+    **params: object,
+) -> dict:
+    resp = await client.get(
+        "/admin/users/",
+        params={"search": search, "limit": 200, **params},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _usernames(payload: dict) -> list[str]:
+    return [u["username"] for u in payload["users"]]
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_sort_by_username_orders_both_directions(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """sort=username returns the scoped users in alphabetical order."""
+    token = f"srt{uuid.uuid4().hex[:10]}"
+    # Created in an order that is deliberately NOT alphabetical, so a response
+    # that merely preserved insertion order would fail this test.
+    for suffix in ("mike", "alpha", "zulu"):
+        await _create_user(client, admin_auth_header, f"{token}_{suffix}")
+
+    asc = _usernames(
+        await _list(
+            client, admin_auth_header, search=token, sort="username", order="asc"
+        )
+    )
+    desc = _usernames(
+        await _list(
+            client, admin_auth_header, search=token, sort="username", order="desc"
+        )
+    )
+
+    assert asc == [f"{token}_alpha", f"{token}_mike", f"{token}_zulu"]
+    assert desc == [f"{token}_zulu", f"{token}_mike", f"{token}_alpha"]
+
+
+@pytest.mark.anyio
+async def test_default_sort_is_unchanged_created_at_ascending(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """Omitting sort/order preserves the historical created_at ASC ordering."""
+    token = f"srt{uuid.uuid4().hex[:10]}"
+    created = [
+        await _create_user(client, admin_auth_header, f"{token}_{suffix}")
+        for suffix in ("zulu", "mike", "alpha")  # reverse-alphabetical on purpose
+    ]
+
+    payload = await _list(client, admin_auth_header, search=token)
+
+    assert [u["id"] for u in payload["users"]] == created
+
+
+@pytest.mark.anyio
+async def test_null_last_login_sorts_last_in_both_directions(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """Never-logged-in accounts stay at the bottom on ASC and DESC alike.
+
+    Postgres puts NULLs first on DESC by default, which would float every
+    never-logged-in account to the top of a "most recent login" view.
+    """
+    token = f"srt{uuid.uuid4().hex[:10]}"
+    logged_in = f"{token}_seen"
+    await _create_user(client, admin_auth_header, logged_in)
+    await _create_user(client, admin_auth_header, f"{token}_never")
+
+    # Give exactly one of them a last_login_at by authenticating as them.
+    resp = await client.post(
+        "/auth/login",
+        data={"username": logged_in, "password": PASSWORD},
+    )
+    assert resp.status_code == 200, resp.text
+
+    for order in ("asc", "desc"):
+        payload = await _list(
+            client, admin_auth_header, search=token, sort="last_login_at", order=order
+        )
+        rows = payload["users"]
+        # Guard against a vacuous pass: this only tests anything if the scoped
+        # set really does contain both a null and a non-null last_login_at.
+        assert any(r["last_login_at"] is None for r in rows), rows
+        assert any(r["last_login_at"] is not None for r in rows), rows
+
+        first_null = next(i for i, r in enumerate(rows) if r["last_login_at"] is None)
+        assert all(r["last_login_at"] is None for r in rows[first_null:]), (
+            f"{order}: a non-null last_login_at followed a null one: {rows}"
+        )
+
+
+@pytest.mark.anyio
+async def test_sort_composes_with_status_and_search_filters(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """sort applies on top of the status filter rather than replacing it."""
+    token = f"srt{uuid.uuid4().hex[:10]}"
+    for suffix in ("mike", "alpha", "zulu"):
+        await _create_user(client, admin_auth_header, f"{token}_{suffix}")
+
+    payload = await _list(
+        client,
+        admin_auth_header,
+        search=token,
+        status="active",
+        sort="username",
+        order="desc",
+    )
+
+    assert _usernames(payload) == [
+        f"{token}_zulu",
+        f"{token}_mike",
+        f"{token}_alpha",
+    ]
+    assert all(u["status"] == "active" for u in payload["users"])
+    assert payload["total"] == 3
+
+
+@pytest.mark.anyio
+async def test_paging_a_non_unique_sort_key_never_repeats_a_row(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """Paging by `status` (identical for every row) yields each user once.
+
+    OFFSET paging over a non-unique ORDER BY key is free to return a row on
+    two consecutive pages; the id tiebreak makes the ordering total.
+    """
+    token = f"srt{uuid.uuid4().hex[:10]}"
+    expected = {
+        await _create_user(client, admin_auth_header, f"{token}_{n}") for n in range(6)
+    }
+
+    seen: list[str] = []
+    for skip in (0, 2, 4):
+        resp = await client.get(
+            "/admin/users/",
+            params={
+                "search": token,
+                "sort": "status",
+                "order": "asc",
+                "skip": skip,
+                "limit": 2,
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        seen.extend(u["id"] for u in resp.json()["users"])
+
+    assert len(seen) == len(set(seen)), f"a row appeared on two pages: {seen}"
+    assert set(seen) == expected
+
+
+def test_ordering_clause_carries_a_unique_tiebreak_and_pins_nulls():
+    """Assert the ORDER BY shape directly, because behaviour cannot prove it.
+
+    The paging test above passes with or without the id tiebreak: at these row
+    counts Postgres seq-scans and happens to return a stable order, so it
+    cannot detect the regression it describes. Compiling the clause can.
+    """
+    from app.modules.auth.models import User
+    from app.modules.admin.service import USER_SORT_COLUMNS, AdminService
+
+    for field in USER_SORT_COLUMNS:
+        for order in ("asc", "desc"):
+            clauses = AdminService._user_ordering(field, order)
+            assert clauses[-1] is User.id, (
+                f"{field}/{order} has no unique tiebreak: {[str(c) for c in clauses]}"
+            )
+            assert order.upper() in str(clauses[0]).upper(), str(clauses[0])
+
+    nulls_last_asc = str(AdminService._user_ordering("last_login_at", "asc")[0])
+    nulls_last_desc = str(AdminService._user_ordering("last_login_at", "desc")[0])
+    assert "NULLS LAST" in nulls_last_asc.upper(), nulls_last_asc
+    assert "NULLS LAST" in nulls_last_desc.upper(), nulls_last_desc
+
+    # A non-nullable column should not carry the NULLS LAST decoration.
+    assert (
+        "NULLS LAST"
+        not in str(AdminService._user_ordering("username", "asc")[0]).upper()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allowlist enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bogus_sort",
+    [
+        "password_hash",  # a real column, deliberately not sortable
+        "roles",  # not a column at all
+        "username; DROP TABLE catalog.users",
+        "(SELECT 1)",
+        "",
+    ],
+)
+@pytest.mark.anyio
+async def test_unknown_sort_field_is_refused_not_executed(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    bogus_sort: str,
+):
+    """A sort field outside the allowlist is a 422, never a silent default."""
+    resp = await client.get(
+        "/admin/users/",
+        params={"sort": bogus_sort, "limit": 1},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, f"{bogus_sort!r} -> {resp.status_code} {resp.text}"
+
+
+@pytest.mark.parametrize("bogus_order", ["sideways", "ASC; --", "1"])
+@pytest.mark.anyio
+async def test_unknown_sort_order_is_refused(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    bogus_order: str,
+):
+    """A direction outside asc/desc is a 422."""
+    resp = await client.get(
+        "/admin/users/",
+        params={"order": bogus_order, "limit": 1},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, f"{bogus_order!r} -> {resp.status_code}"
+
+
+@pytest.mark.anyio
+async def test_every_advertised_sort_field_is_accepted(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """The refusal tests above must not be passing by refusing everything."""
+    from app.modules.admin.service import USER_SORT_COLUMNS
+
+    assert USER_SORT_COLUMNS, "allowlist is empty; the tests below prove nothing"
+    for field in USER_SORT_COLUMNS:
+        for order in ("asc", "desc"):
+            resp = await client.get(
+                "/admin/users/",
+                params={"sort": field, "order": order, "limit": 1},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200, f"{field}/{order} -> {resp.text}"
+
+
+@pytest.mark.anyio
+async def test_service_layer_rejects_unmapped_sort_key(test_db_session):
+    """The service refuses an unmapped key even if the router is bypassed."""
+    from app.modules.admin.service import AdminService
+
+    service = AdminService(test_db_session)
+    with pytest.raises(ValueError, match="Unsupported sort field"):
+        await service.list_users(sort="password_hash")
+    with pytest.raises(ValueError, match="Unsupported sort order"):
+        await service.list_users(order="sideways")

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -24,13 +24,22 @@ export async function getCatalogStats(): Promise<CatalogStatsResponse> {
 }
 
 export async function listUsers(
-  params: { skip?: number; limit?: number; status?: string; search?: string } = {},
+  params: {
+    skip?: number;
+    limit?: number;
+    status?: string;
+    search?: string;
+    sort?: string;
+    order?: string;
+  } = {},
 ): Promise<UserListResponse> {
   const query = new URLSearchParams();
   if (params.skip !== undefined) query.set('skip', String(params.skip));
   if (params.limit !== undefined) query.set('limit', String(params.limit));
   if (params.status) query.set('status', params.status);
   if (params.search) query.set('search', params.search);
+  if (params.sort) query.set('sort', params.sort);
+  if (params.order) query.set('order', params.order);
   const qs = query.toString();
   return apiFetch<UserListResponse>(`/admin/users/${qs ? `?${qs}` : ''}`);
 }

--- a/frontend/src/components/admin/SortableColumnHeader.tsx
+++ b/frontend/src/components/admin/SortableColumnHeader.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from 'react-i18next';
+import { ArrowDown, ArrowUp, ChevronsUpDown } from 'lucide-react';
+import { TableHead } from '@/components/ui/table';
+
+export type SortDirection = 'asc' | 'desc';
+
+interface SortableColumnHeaderProps {
+  /** Visible, already-localized column label. */
+  label: string;
+  /** Sort key sent to the API. Must be one the endpoint allowlists. */
+  field: string;
+  /** Currently active sort key across the whole table. */
+  activeField: string;
+  /** Direction of the active sort. Ignored unless `field === activeField`. */
+  direction: SortDirection;
+  /** Called with this column's field when the header is activated. */
+  onSort: (field: string) => void;
+  className?: string;
+}
+
+/**
+ * A sortable `<th>` for the admin data tables.
+ *
+ * Shared on purpose: the admin surfaces (Users, Jobs, Audit, Shared Maps) all
+ * render the same paginated-table shape, so the sort affordance and its
+ * accessibility contract live in one place rather than per table.
+ *
+ * Accessibility notes:
+ *  - the `<th>` carries `aria-sort`, which is where assistive tech reads sort
+ *    STATE from; the button carries the ACTION.
+ *  - the control is a real `<button>`, so it is keyboard-operable and
+ *    focusable without any extra key handling.
+ *  - the accessible name starts with the visible label and appends what
+ *    activating will do ("Username, sort descending"), satisfying WCAG 2.5.3.
+ *    The hint is a sibling text node rather than an aria-label because an
+ *    aria-label would REPLACE the visible label instead of extending it.
+ */
+export function SortableColumnHeader({
+  label,
+  field,
+  activeField,
+  direction,
+  onSort,
+  className,
+}: SortableColumnHeaderProps) {
+  const { t } = useTranslation('admin');
+  const isActive = field === activeField;
+  // Activating an inactive column starts ascending; activating the active one
+  // flips it. The hint always describes the NEXT state, not the current one.
+  const nextDirection: SortDirection = isActive && direction === 'asc' ? 'desc' : 'asc';
+  const hint =
+    nextDirection === 'asc' ? t('sortable.sortAscending') : t('sortable.sortDescending');
+
+  const SortIcon = !isActive ? ChevronsUpDown : direction === 'asc' ? ArrowUp : ArrowDown;
+
+  return (
+    <TableHead
+      className={className}
+      aria-sort={isActive ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <button
+        type="button"
+        onClick={() => onSort(field)}
+        className="inline-flex items-center gap-1 rounded-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {label}
+        <span className="sr-only">, {hint}</span>
+        <SortIcon
+          aria-hidden="true"
+          className={isActive ? 'h-3.5 w-3.5' : 'h-3.5 w-3.5 opacity-50'}
+        />
+      </button>
+    </TableHead>
+  );
+}

--- a/frontend/src/components/admin/UserList.tsx
+++ b/frontend/src/components/admin/UserList.tsx
@@ -114,9 +114,13 @@ export function UserList() {
   const [deactivatingUser, setDeactivatingUser] = useState<UserResponse | null>(null);
   const [isExporting, setIsExporting] = useState(false);
 
-  // Sort lives in the URL so a sorted view is shareable and the back button
-  // steps through orderings. An unrecognised ?sort= falls back to the default
-  // rather than erroring the page; the API refuses it independently.
+  // Sort lives in the URL so a sorted view is shareable. Sort clicks REPLACE
+  // the history entry rather than pushing — deliberately, per #1200 review:
+  // pushing would make five header clicks cost five Back presses to leave the
+  // page, and it matches JobList's replace-on-refinement pattern (#1185). The
+  // trade is that Back leaves the page instead of stepping through orderings.
+  // An unrecognised ?sort= falls back to the default rather than erroring the
+  // page; the API refuses it independently.
   const [searchParams, setSearchParams] = useSearchParams();
   const sortField = parseSortField(searchParams.get('sort'));
   const sortOrder = parseSortOrder(searchParams.get('order'));

--- a/frontend/src/components/admin/UserList.tsx
+++ b/frontend/src/components/admin/UserList.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import {
@@ -58,6 +59,7 @@ import { UserCreateDialog } from './UserCreateDialog';
 import { UserEditDialog } from './UserEditDialog';
 import { UserDeleteDialog } from './UserDeleteDialog';
 import { DataTablePagination } from './DataTablePagination';
+import { SortableColumnHeader, type SortDirection } from './SortableColumnHeader';
 import { DataTableSearch } from './DataTableSearch';
 import { DataTableSkeleton } from './DataTableSkeleton';
 import { FilterSelect } from './FilterSelect';
@@ -67,6 +69,25 @@ import { EmptyState } from '@/components/layout/EmptyState';
 import { useAuthStore } from '@/stores/auth-store';
 
 const PAGE_SIZE = 20;
+
+/** Mirrors the UserSortField allowlist on GET /admin/users/. Roles and storage
+ *  are absent by design: roles is a many-to-many and storage is aggregated per
+ *  page after the query, so neither can be ordered by the database. Offering a
+ *  header for them would sort only the visible page, which looks correct and
+ *  is not. */
+const SORTABLE_FIELDS = ['username', 'email', 'status', 'last_login_at', 'created_at'] as const;
+type SortField = (typeof SORTABLE_FIELDS)[number];
+
+const DEFAULT_SORT: SortField = 'created_at';
+const DEFAULT_ORDER: SortDirection = 'asc';
+
+function parseSortField(raw: string | null): SortField {
+  return SORTABLE_FIELDS.includes(raw as SortField) ? (raw as SortField) : DEFAULT_SORT;
+}
+
+function parseSortOrder(raw: string | null): SortDirection {
+  return raw === 'desc' || raw === 'asc' ? raw : DEFAULT_ORDER;
+}
 
 const STATUS_OPTIONS = [
   { value: '', labelKey: 'users.filters.allUsers' },
@@ -93,8 +114,36 @@ export function UserList() {
   const [deactivatingUser, setDeactivatingUser] = useState<UserResponse | null>(null);
   const [isExporting, setIsExporting] = useState(false);
 
+  // Sort lives in the URL so a sorted view is shareable and the back button
+  // steps through orderings. An unrecognised ?sort= falls back to the default
+  // rather than erroring the page; the API refuses it independently.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sortField = parseSortField(searchParams.get('sort'));
+  const sortOrder = parseSortOrder(searchParams.get('order'));
+
+  function handleSort(field: string) {
+    // Compare against the EFFECTIVE field, not the raw param: with no ?sort=
+    // the Created column already renders as the active ascending sort, so
+    // clicking it must flip to descending rather than re-assert ascending.
+    const next = sortField === field && sortOrder === 'asc' ? 'desc' : 'asc';
+    const params = new URLSearchParams(searchParams);
+    params.set('sort', field);
+    params.set('order', next);
+    setSearchParams(params, { replace: true });
+    // A new ordering renumbers every page, so page 3 of the old sort is
+    // meaningless under the new one.
+    setPage(0);
+  }
+
   const skip = page * PAGE_SIZE;
-  const { data, isLoading, error, refetch } = useUserList(skip, PAGE_SIZE, statusFilter || undefined, searchQuery || undefined);
+  const { data, isLoading, error, refetch } = useUserList({
+    skip,
+    limit: PAGE_SIZE,
+    status: statusFilter || undefined,
+    search: searchQuery || undefined,
+    sort: sortField,
+    order: sortOrder,
+  });
 
   const approveUser = useApproveUser();
   const rejectUser = useRejectUser();
@@ -213,13 +262,45 @@ export function UserList() {
           <Table aria-label={t('users.title')}>
             <TableHeader>
               <TableRow>
-                <TableHead>{t('users.table.username')}</TableHead>
-                <TableHead>{t('users.table.email')}</TableHead>
+                <SortableColumnHeader
+                  label={t('users.table.username')}
+                  field="username"
+                  activeField={sortField}
+                  direction={sortOrder}
+                  onSort={handleSort}
+                />
+                <SortableColumnHeader
+                  label={t('users.table.email')}
+                  field="email"
+                  activeField={sortField}
+                  direction={sortOrder}
+                  onSort={handleSort}
+                />
+                {/* Roles and storage are intentionally not sortable — see
+                    SORTABLE_FIELDS. */}
                 <TableHead>{t('users.table.roles')}</TableHead>
-                <TableHead>{t('users.table.status')}</TableHead>
+                <SortableColumnHeader
+                  label={t('users.table.status')}
+                  field="status"
+                  activeField={sortField}
+                  direction={sortOrder}
+                  onSort={handleSort}
+                />
                 <TableHead>{t('users.table.storage')}</TableHead>
-                <TableHead>{t('users.table.lastLogin')}</TableHead>
-                <TableHead>{t('users.table.created')}</TableHead>
+                <SortableColumnHeader
+                  label={t('users.table.lastLogin')}
+                  field="last_login_at"
+                  activeField={sortField}
+                  direction={sortOrder}
+                  onSort={handleSort}
+                />
+                <SortableColumnHeader
+                  label={t('users.table.created')}
+                  field="created_at"
+                  activeField={sortField}
+                  direction={sortOrder}
+                  onSort={handleSort}
+                />
                 <TableHead>{t('users.table.actions')}</TableHead>
               </TableRow>
             </TableHeader>

--- a/frontend/src/components/admin/__tests__/UserList.sorting.test.tsx
+++ b/frontend/src/components/admin/__tests__/UserList.sorting.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen, within } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { useLocation } from 'react-router';
+import { UserList } from '../UserList';
+
+const { mockUseUserList } = vi.hoisted(() => ({ mockUseUserList: vi.fn() }));
+
+vi.mock('@/hooks/use-admin', () => ({
+  useUserList: (...args: unknown[]) => mockUseUserList(...args),
+  useApproveUser: () => ({ mutateAsync: vi.fn(), error: null, isPending: false }),
+  useRejectUser: () => ({ mutateAsync: vi.fn(), error: null, isPending: false }),
+  useDeactivateUser: () => ({ mutateAsync: vi.fn(), error: null, isPending: false }),
+}));
+
+// Radix Select needs pointer-capture APIs jsdom does not implement; the
+// sibling CardHeaderPatterns suite swaps in a native select for the same
+// reason. The filter's own behaviour is covered there, not here.
+vi.mock('../FilterSelect', () => ({
+  FilterSelect: ({
+    ariaLabel,
+    value,
+    onChange,
+    options,
+  }: {
+    ariaLabel?: string;
+    value: string;
+    onChange: (value: string) => void;
+    options: { value: string; label: string }[];
+  }) => (
+    <select
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock('../UserCreateDialog', () => ({ UserCreateDialog: () => null }));
+vi.mock('../UserEditDialog', () => ({ UserEditDialog: () => null }));
+vi.mock('../UserDeleteDialog', () => ({ UserDeleteDialog: () => null }));
+
+/** Surfaces the live URL so state->URL can be asserted, not just URL->state. */
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{location.search}</output>;
+}
+
+function lastCall() {
+  return mockUseUserList.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+}
+
+function renderList(route = '/admin/users') {
+  return render(
+    <>
+      <UserList />
+      <LocationProbe />
+    </>,
+    { route },
+  );
+}
+
+beforeEach(() => {
+  mockUseUserList.mockReset();
+  mockUseUserList.mockReturnValue({
+    data: { users: [], total: 0 },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+});
+
+describe('UserList sorting', () => {
+  it('requests the historical created_at ascending order by default', () => {
+    renderList();
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'asc' });
+  });
+
+  it('names the sortable header with its visible label plus the next action', () => {
+    renderList();
+
+    // The accessible name must CONTAIN the visible label (WCAG 2.5.3) — an
+    // aria-label would have replaced it.
+    expect(
+      screen.getByRole('button', { name: 'Username, sort ascending' }),
+    ).toBeInTheDocument();
+  });
+
+  it('marks sort state with aria-sort on the th, not on the button', () => {
+    renderList('/admin/users?sort=username&order=desc');
+
+    expect(screen.getByRole('columnheader', { name: /Username/ })).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+    expect(screen.getByRole('columnheader', { name: /Email/ })).toHaveAttribute(
+      'aria-sort',
+      'none',
+    );
+    // The active header now offers the opposite direction.
+    expect(
+      screen.getByRole('button', { name: 'Username, sort ascending' }),
+    ).toBeInTheDocument();
+  });
+
+  it('sorts ascending on first activation and flips on the second', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole('button', { name: /^Username/ }));
+    expect(lastCall()).toMatchObject({ sort: 'username', order: 'asc' });
+
+    await user.click(screen.getByRole('button', { name: /^Username/ }));
+    expect(lastCall()).toMatchObject({ sort: 'username', order: 'desc' });
+  });
+
+  it('flips the default column to descending on first activation', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    // Created is already the active ascending sort, so activating it must
+    // reverse rather than re-assert ascending.
+    await user.click(screen.getByRole('button', { name: /^Created/ }));
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'desc' });
+  });
+
+  it('is operable from the keyboard', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    const header = screen.getByRole('button', { name: /^Email/ });
+    header.focus();
+    await user.keyboard('{Enter}');
+
+    expect(lastCall()).toMatchObject({ sort: 'email', order: 'asc' });
+  });
+
+  it('owns sort state in the URL', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole('button', { name: /^Status/ }));
+
+    const search = screen.getByTestId('location').textContent ?? '';
+    expect(new URLSearchParams(search).get('sort')).toBe('status');
+    expect(new URLSearchParams(search).get('order')).toBe('asc');
+  });
+
+  it('reads sort state back out of the URL', () => {
+    renderList('/admin/users?sort=last_login_at&order=desc');
+
+    expect(lastCall()).toMatchObject({ sort: 'last_login_at', order: 'desc' });
+  });
+
+  it('falls back to the default for a sort field the API would refuse', () => {
+    renderList('/admin/users?sort=password_hash&order=sideways');
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'asc' });
+  });
+
+  it('returns to the first page when the ordering changes', async () => {
+    const user = userEvent.setup();
+    mockUseUserList.mockReturnValue({
+      data: { users: [], total: 100 },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderList();
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    expect(lastCall()).toMatchObject({ skip: 20 });
+
+    await user.click(screen.getByRole('button', { name: /^Username/ }));
+    // Page 3 of the old ordering names different rows under the new one.
+    expect(lastCall()).toMatchObject({ skip: 0, sort: 'username' });
+  });
+
+  it('composes sort with the status filter instead of replacing it', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Status' }), 'pending');
+    await user.click(screen.getByRole('button', { name: /^Username/ }));
+
+    expect(lastCall()).toMatchObject({
+      status: 'pending',
+      sort: 'username',
+      order: 'asc',
+    });
+  });
+
+  it('offers no sort control for columns the API cannot order', () => {
+    renderList();
+
+    for (const label of ['Roles', 'File storage', 'Actions']) {
+      const header = screen.getByRole('columnheader', { name: label });
+      expect(within(header).queryByRole('button')).toBeNull();
+      expect(header).not.toHaveAttribute('aria-sort');
+    }
+  });
+});

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -40,10 +40,18 @@ export function useCatalogStats() {
   });
 }
 
-export function useUserList(skip: number, limit: number, status?: string, search?: string) {
+export function useUserList(params: {
+  skip: number;
+  limit: number;
+  status?: string;
+  search?: string;
+  sort?: string;
+  order?: string;
+}) {
+  const { skip, limit, status, search, sort, order } = params;
   return useQuery({
-    queryKey: queryKeys.admin.users(skip, limit, status, search),
-    queryFn: () => listUsers({ skip, limit, status, search }),
+    queryKey: queryKeys.admin.users(skip, limit, status, search, sort, order),
+    queryFn: () => listUsers({ skip, limit, status, search, sort, order }),
     placeholderData: keepPreviousData,
   });
 }

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -765,5 +765,9 @@
       "editor": "Bearbeiter",
       "admin": "Administrator"
     }
+  },
+  "sortable": {
+    "sortAscending": "aufsteigend sortieren",
+    "sortDescending": "absteigend sortieren"
   }
 }

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -765,5 +765,9 @@
       "editor": "Editor",
       "admin": "Admin"
     }
+  },
+  "sortable": {
+    "sortAscending": "sort ascending",
+    "sortDescending": "sort descending"
   }
 }

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -765,5 +765,9 @@
       "editor": "Editor",
       "admin": "Administrador"
     }
+  },
+  "sortable": {
+    "sortAscending": "ordenar de forma ascendente",
+    "sortDescending": "ordenar de forma descendente"
   }
 }

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -765,5 +765,9 @@
       "editor": "Éditeur",
       "admin": "Administrateur"
     }
+  },
+  "sortable": {
+    "sortAscending": "trier par ordre croissant",
+    "sortDescending": "trier par ordre décroissant"
   }
 }

--- a/frontend/src/lib/__tests__/query-keys.test.ts
+++ b/frontend/src/lib/__tests__/query-keys.test.ts
@@ -178,9 +178,17 @@ describe('queryKeys factory', () => {
       expect(queryKeys.admin.stats[0]).toBe('admin');
     });
 
-    it('users includes skip, limit, status, search', () => {
-      expect(queryKeys.admin.users(0, 50)).toEqual(['admin', 'users', 0, 50, undefined, undefined]);
-      expect(queryKeys.admin.users(0, 50, 'active', 'bob')).toEqual(['admin', 'users', 0, 50, 'active', 'bob']);
+    it('users includes skip, limit, status, search, sort, order', () => {
+      expect(queryKeys.admin.users(0, 50)).toEqual([
+        'admin', 'users', 0, 50, undefined, undefined, undefined, undefined,
+      ]);
+      expect(queryKeys.admin.users(0, 50, 'active', 'bob')).toEqual([
+        'admin', 'users', 0, 50, 'active', 'bob', undefined, undefined,
+      ]);
+      // Two orderings of the same page must not share a cache entry.
+      expect(queryKeys.admin.users(0, 50, undefined, undefined, 'username', 'asc')).not.toEqual(
+        queryKeys.admin.users(0, 50, undefined, undefined, 'username', 'desc'),
+      );
     });
 
     it('aiStatus returns expected key', () => {

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -127,8 +127,16 @@ export const queryKeys = {
   admin: {
     all: ['admin'] as const,
     stats: ['admin', 'stats'] as const,
-    users: (skip: number, limit: number, status?: string, search?: string) =>
-      ['admin', 'users', skip, limit, status, search] as const,
+    // sort/order belong in the key: two orderings of the same page are
+    // different responses, and sharing a key would serve one for the other.
+    users: (
+      skip: number,
+      limit: number,
+      status?: string,
+      search?: string,
+      sort?: string,
+      order?: string,
+    ) => ['admin', 'users', skip, limit, status, search, sort, order] as const,
     userNames: ['admin', 'users', 'names'] as const,
     pendingCount: ['admin', 'users', 'pending-count'] as const,
     allUsers: ['admin', 'users'] as const,

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -326,7 +326,10 @@ export interface paths {
         };
         /**
          * List Users
-         * @description List all users with pagination and optional status/search filter (admin only).
+         * @description List all users with pagination and optional status/search/sort filter (admin only).
+         *
+         *     `sort` and `order` are closed enums, so an unrecognised value is refused
+         *     with a 422 and never reaches the query.
          */
         get: operations["list_users_admin_users__get"];
         put?: never;
@@ -14482,6 +14485,10 @@ export interface operations {
                 limit?: number;
                 status?: string | null;
                 search?: string | null;
+                /** @description Column to order by. Roles and storage are not sortable: roles is a many-to-many and storage is aggregated per page after the query. */
+                sort?: "username" | "email" | "status" | "last_login_at" | "created_at";
+                /** @description Sort direction. */
+                order?: "asc" | "desc";
             };
             header?: never;
             path?: never;

--- a/sdks/python/geolens/api/admin/list_users_admin_users_get.py
+++ b/sdks/python/geolens/api/admin/list_users_admin_users_get.py
@@ -7,6 +7,8 @@ from ...client import AuthenticatedClient, Client
 from ...types import Response, UNSET
 from ... import errors
 
+from ...models.list_users_admin_users_get_order import ListUsersAdminUsersGetOrder
+from ...models.list_users_admin_users_get_sort import ListUsersAdminUsersGetSort
 from ...models.problem_detail import ProblemDetail
 from ...models.user_list_response import UserListResponse
 from ...types import Unset
@@ -18,6 +20,8 @@ def _get_kwargs(
     limit: int | Unset = 50,
     status: None | str | Unset = UNSET,
     search: None | str | Unset = UNSET,
+    sort: ListUsersAdminUsersGetSort | Unset = "created_at",
+    order: ListUsersAdminUsersGetOrder | Unset = "asc",
 ) -> dict[str, Any]:
 
     params: dict[str, Any] = {}
@@ -39,6 +43,18 @@ def _get_kwargs(
     else:
         json_search = search
     params["search"] = json_search
+
+    json_sort: str | Unset = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort
+
+    params["sort"] = json_sort
+
+    json_order: str | Unset = UNSET
+    if not isinstance(order, Unset):
+        json_order = order
+
+    params["order"] = json_order
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -123,16 +139,25 @@ def sync_detailed(
     limit: int | Unset = 50,
     status: None | str | Unset = UNSET,
     search: None | str | Unset = UNSET,
+    sort: ListUsersAdminUsersGetSort | Unset = "created_at",
+    order: ListUsersAdminUsersGetOrder | Unset = "asc",
 ) -> Response[ProblemDetail | UserListResponse]:
     """List Users
 
-     List all users with pagination and optional status/search filter (admin only).
+     List all users with pagination and optional status/search/sort filter (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
         status (None | str | Unset):
         search (None | str | Unset):
+        sort (ListUsersAdminUsersGetSort | Unset): Column to order by. Roles and storage are not
+            sortable: roles is a many-to-many and storage is aggregated per page after the query.
+            Default: 'created_at'.
+        order (ListUsersAdminUsersGetOrder | Unset): Sort direction. Default: 'asc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -147,6 +172,8 @@ def sync_detailed(
         limit=limit,
         status=status,
         search=search,
+        sort=sort,
+        order=order,
     )
 
     response = client.get_httpx_client().request(
@@ -163,16 +190,25 @@ def sync(
     limit: int | Unset = 50,
     status: None | str | Unset = UNSET,
     search: None | str | Unset = UNSET,
+    sort: ListUsersAdminUsersGetSort | Unset = "created_at",
+    order: ListUsersAdminUsersGetOrder | Unset = "asc",
 ) -> ProblemDetail | UserListResponse | None:
     """List Users
 
-     List all users with pagination and optional status/search filter (admin only).
+     List all users with pagination and optional status/search/sort filter (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
         status (None | str | Unset):
         search (None | str | Unset):
+        sort (ListUsersAdminUsersGetSort | Unset): Column to order by. Roles and storage are not
+            sortable: roles is a many-to-many and storage is aggregated per page after the query.
+            Default: 'created_at'.
+        order (ListUsersAdminUsersGetOrder | Unset): Sort direction. Default: 'asc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -188,6 +224,8 @@ def sync(
         limit=limit,
         status=status,
         search=search,
+        sort=sort,
+        order=order,
     ).parsed
 
 
@@ -198,16 +236,25 @@ async def asyncio_detailed(
     limit: int | Unset = 50,
     status: None | str | Unset = UNSET,
     search: None | str | Unset = UNSET,
+    sort: ListUsersAdminUsersGetSort | Unset = "created_at",
+    order: ListUsersAdminUsersGetOrder | Unset = "asc",
 ) -> Response[ProblemDetail | UserListResponse]:
     """List Users
 
-     List all users with pagination and optional status/search filter (admin only).
+     List all users with pagination and optional status/search/sort filter (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
         status (None | str | Unset):
         search (None | str | Unset):
+        sort (ListUsersAdminUsersGetSort | Unset): Column to order by. Roles and storage are not
+            sortable: roles is a many-to-many and storage is aggregated per page after the query.
+            Default: 'created_at'.
+        order (ListUsersAdminUsersGetOrder | Unset): Sort direction. Default: 'asc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -222,6 +269,8 @@ async def asyncio_detailed(
         limit=limit,
         status=status,
         search=search,
+        sort=sort,
+        order=order,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -236,16 +285,25 @@ async def asyncio(
     limit: int | Unset = 50,
     status: None | str | Unset = UNSET,
     search: None | str | Unset = UNSET,
+    sort: ListUsersAdminUsersGetSort | Unset = "created_at",
+    order: ListUsersAdminUsersGetOrder | Unset = "asc",
 ) -> ProblemDetail | UserListResponse | None:
     """List Users
 
-     List all users with pagination and optional status/search filter (admin only).
+     List all users with pagination and optional status/search/sort filter (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
         status (None | str | Unset):
         search (None | str | Unset):
+        sort (ListUsersAdminUsersGetSort | Unset): Column to order by. Roles and storage are not
+            sortable: roles is a many-to-many and storage is aggregated per page after the query.
+            Default: 'created_at'.
+        order (ListUsersAdminUsersGetOrder | Unset): Sort direction. Default: 'asc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -262,5 +320,7 @@ async def asyncio(
             limit=limit,
             status=status,
             search=search,
+            sort=sort,
+            order=order,
         )
     ).parsed

--- a/sdks/python/geolens/models/__init__.py
+++ b/sdks/python/geolens/models/__init__.py
@@ -364,6 +364,8 @@ from .list_features_datasets_dataset_id_features_get_geo_json_feature_collection
 )
 from .list_maps_endpoint_maps_get_sort_by import ListMapsEndpointMapsGetSortBy
 from .list_maps_endpoint_maps_get_sort_dir import ListMapsEndpointMapsGetSortDir
+from .list_users_admin_users_get_order import ListUsersAdminUsersGetOrder
+from .list_users_admin_users_get_sort import ListUsersAdminUsersGetSort
 from .manifest_apply_entry_result import ManifestApplyEntryResult
 from .manifest_apply_entry_result_action import ManifestApplyEntryResultAction
 from .manifest_apply_request import ManifestApplyRequest
@@ -989,6 +991,8 @@ __all__ = (
     "ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionLink",
     "ListMapsEndpointMapsGetSortBy",
     "ListMapsEndpointMapsGetSortDir",
+    "ListUsersAdminUsersGetOrder",
+    "ListUsersAdminUsersGetSort",
     "ManifestApplyEntryResult",
     "ManifestApplyEntryResultAction",
     "ManifestApplyRequest",

--- a/sdks/python/geolens/models/list_users_admin_users_get_order.py
+++ b/sdks/python/geolens/models/list_users_admin_users_get_order.py
@@ -1,0 +1,16 @@
+from typing import Literal, cast
+
+ListUsersAdminUsersGetOrder = Literal["asc", "desc"]
+
+LIST_USERS_ADMIN_USERS_GET_ORDER_VALUES: set[ListUsersAdminUsersGetOrder] = {
+    "asc",
+    "desc",
+}
+
+
+def check_list_users_admin_users_get_order(value: str) -> ListUsersAdminUsersGetOrder:
+    if value in LIST_USERS_ADMIN_USERS_GET_ORDER_VALUES:
+        return cast(ListUsersAdminUsersGetOrder, value)
+    raise TypeError(
+        f"Unexpected value {value!r}. Expected one of {LIST_USERS_ADMIN_USERS_GET_ORDER_VALUES!r}"
+    )

--- a/sdks/python/geolens/models/list_users_admin_users_get_sort.py
+++ b/sdks/python/geolens/models/list_users_admin_users_get_sort.py
@@ -1,0 +1,21 @@
+from typing import Literal, cast
+
+ListUsersAdminUsersGetSort = Literal[
+    "created_at", "email", "last_login_at", "status", "username"
+]
+
+LIST_USERS_ADMIN_USERS_GET_SORT_VALUES: set[ListUsersAdminUsersGetSort] = {
+    "created_at",
+    "email",
+    "last_login_at",
+    "status",
+    "username",
+}
+
+
+def check_list_users_admin_users_get_sort(value: str) -> ListUsersAdminUsersGetSort:
+    if value in LIST_USERS_ADMIN_USERS_GET_SORT_VALUES:
+        return cast(ListUsersAdminUsersGetSort, value)
+    raise TypeError(
+        f"Unexpected value {value!r}. Expected one of {LIST_USERS_ADMIN_USERS_GET_SORT_VALUES!r}"
+    )

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -349,7 +349,10 @@ export const getCatalogStatsAdminStatsGet = <ThrowOnError extends boolean = fals
 /**
  * List Users
  *
- * List all users with pagination and optional status/search filter (admin only).
+ * List all users with pagination and optional status/search/sort filter (admin only).
+ *
+ * `sort` and `order` are closed enums, so an unrecognised value is refused
+ * with a 422 and never reaches the query.
  */
 export const listUsersAdminUsersGet = <ThrowOnError extends boolean = false>(options?: Options<ListUsersAdminUsersGetData, ThrowOnError>): RequestResult<ListUsersAdminUsersGetResponses, ListUsersAdminUsersGetErrors, ThrowOnError> => (options?.client ?? client).get<ListUsersAdminUsersGetResponses, ListUsersAdminUsersGetErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -11653,6 +11653,18 @@ export type ListUsersAdminUsersGetData = {
          * Search
          */
         search?: string | null;
+        /**
+         * Sort
+         *
+         * Column to order by. Roles and storage are not sortable: roles is a many-to-many and storage is aggregated per page after the query.
+         */
+        sort?: 'username' | 'email' | 'status' | 'last_login_at' | 'created_at';
+        /**
+         * Order
+         *
+         * Sort direction.
+         */
+        order?: 'asc' | 'desc';
     };
     url: '/admin/users/';
 };


### PR DESCRIPTION
## What

Adds server-side sorting to the admin Users list. `GET /admin/users/` gains `sort` (`username|email|status|last_login_at|created_at`, default `created_at`) and `order` (`asc|desc`, default `asc`), both closed enums — an unrecognised value 422s before the query runs. The frontend gets a reusable `SortableColumnHeader` for the admin tables, with sort state owned by the URL.

Server-side because the list is server-paginated: a client-side sort would order only the visible page, which looks correct and is not. Same reasoning excludes Roles (many-to-many) and File storage (aggregated per page after the query) from sortability.

## API / schema impact

- OpenAPI regen (3 artifacts: `backend/openapi.json`, both SDKs, `frontend/src/types/api.generated.ts`)
- No DB schema change; default ordering (`created_at` asc) unchanged and pinned by test

## Security

Two-layer allowlist, no interpolation: the `Literal` 422s at the boundary; `USER_SORT_COLUMNS` resolves the survivor via dict lookup to a mapped column and **raises** on an unmapped key rather than silently serving the default order. Tests cover `password_hash`, `roles`, SQL-injection shapes, and empty string. Satisfies the standing CodeQL `py/sql-injection` policy by construction.

## Correctness details

- `NULLS LAST` pinned in both directions on the two nullable sortable columns (`email`, `last_login_at`) — Postgres would otherwise float never-logged-in accounts to the top of a descending Last Login sort. Verified against the model: exactly those two are `nullable=True`.
- `User.id` tiebreak on every ordering — OFFSET paging over a non-unique key can return a row on two pages. The behavioural paging test **cannot** detect this regression at seed-scale row counts (Postgres seq-scans stably), so `test_ordering_clause_carries_a_unique_tiebreak_and_pins_nulls` compiles the ORDER BY and asserts the shape directly; removing the tiebreak fails only that test (verified).
- `sort`/`order` participate in the TanStack query key — two orderings of the same page are different responses.
- Header click compares against the *effective* field, not the raw param, so clicking the default-sorted column with no `?sort=` flips to descending instead of re-asserting ascending.

## a11y

`aria-sort` on the `<th>` (state), real `<button>` (action, keyboard-operable), accessible name extends the visible label via `sr-only` sibling ("Username, sort ascending") — an `aria-label` would replace it (WCAG 2.5.3). Asserted by computed accessible name; keyboard path tested with real `{Enter}`. New i18n keys in all four locales.

## Verification

- Rebased onto `256a02d32` (post-wave main); `make openapi-check` and `make sdks-check` both exit 0 on the rebased tree — the committed artifacts are byte-identical to regen
- Backend: `test_admin_user_sort.py` (16) + `test_layering.py` + `test_rule1_structural.py` → 62 passed; ruff clean whole-tree
- Frontend: lint, typecheck, i18n parity, full `test:coverage` → 376 files / 4615 tests passed
- RED checks (each disabled separately): ordering revert, `nulls_last` removal (with vacuity guards), tiebreak removal (fails the clause-shape test), raw-param comparison (fails the flip test), `aria-sort` removal

## Follow-up (not in this PR)

JobList / AuditLogViewer / AdminSharedMapsPage share the same table pattern but each needs its own backend ordering param first; adoption analysis recorded in the session. The shared header component needs zero changes to be reused.

https://claude.ai/code/session_0155zaLii3Whpcg2UknXBcRn