### PR TITLE
feat(admin): adopt sortable headers on Jobs, Audit Log, and Published Maps

### DIFF
--- a/backend/app/modules/admin/router.py
+++ b/backend/app/modules/admin/router.py
@@ -25,6 +25,7 @@ from app.modules.admin.schemas import (
     BackfillResponse,
     CatalogStatsResponse,
     EmbeddingStatsResponse,
+    JobSortField,
     SamlToLocalConversion,
     SortDirection,
     UserListResponse,
@@ -713,12 +714,30 @@ async def list_admin_jobs(
     search: str | None = Query(None),
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
+    sort: JobSortField = Query(
+        "created_at",
+        description=(
+            "Column to order by. Duration orders by the completed_at - "
+            "started_at interval, so unfinished jobs sort last either way."
+        ),
+    ),
+    order: SortDirection = Query("desc", description="Sort direction."),
     db: AsyncSession = Depends(get_db),
 ) -> AdminJobListResponse:
-    """List all ingestion jobs with optional status/user/search filters (admin only)."""
+    """List all ingestion jobs with optional status/user/search/sort filters (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
+    """
     service = AdminService(db)
     rows, total = await service.list_jobs(
-        status=status, user_id=user_id, search=search, skip=skip, limit=limit
+        status=status,
+        user_id=user_id,
+        search=search,
+        skip=skip,
+        limit=limit,
+        sort=sort,
+        order=order,
     )
     retry_capabilities = await asyncio.gather(
         *(get_retry_capability(job) for job, _username in rows)

--- a/backend/app/modules/admin/router_operations.py
+++ b/backend/app/modules/admin/router_operations.py
@@ -19,6 +19,8 @@ from app.modules.admin.schemas import (
     AdminShareTokenResponse,
     InfrastructureConfig,
     InfrastructureResponse,
+    ShareTokenSortField,
+    SortDirection,
 )
 from app.modules.admin.service import AdminService
 from app.modules.audit.service import AuditEvent, audit_emit
@@ -252,13 +254,31 @@ async def list_share_tokens_endpoint(
     status_filter: str | None = Query(
         None, alias="status", pattern="^(active|expired|revoked)$"
     ),
+    sort: ShareTokenSortField = Query(
+        "created_at",
+        description=(
+            "Column to order by. Link status is not sortable: it is derived "
+            "from is_active and expires_at after the query returns."
+        ),
+    ),
+    order: SortDirection = Query("desc", description="Sort direction."),
     db: AsyncSession = Depends(get_db),
 ) -> AdminShareTokenListResponse:
-    """List basic share-token inventory with map info; no quotas or domain controls (admin only)."""
+    """List basic share-token inventory with map info; no quotas or domain controls (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
+    """
     from app.modules.catalog.maps.service import list_share_tokens
 
     tokens, total = await list_share_tokens(
-        db, skip, limit, search=search, status_filter=status_filter
+        db,
+        skip,
+        limit,
+        search=search,
+        status_filter=status_filter,
+        sort=sort,
+        order=order,
     )
     return AdminShareTokenListResponse(
         tokens=[AdminShareTokenResponse(**token) for token in tokens], total=total

--- a/backend/app/modules/admin/schemas.py
+++ b/backend/app/modules/admin/schemas.py
@@ -34,6 +34,27 @@ JobStatus = Literal[
 # ordered by the database without restructuring the endpoint.
 UserSortField = Literal["username", "email", "status", "last_login_at", "created_at"]
 
+# Sortable columns for the admin job list, same two-layer shape as
+# UserSortField above (inner half: _job_sort_columns() in service.py).
+#
+# `username` orders by the already-joined users row, and `duration` by the
+# completed_at - started_at interval, which is NULL for exactly the jobs whose
+# Duration cell renders "-". Nothing else the row displays is orderable: the
+# retry affordance is computed per page after the query returns.
+JobSortField = Literal[
+    "created_at", "source_filename", "status", "username", "duration"
+]
+
+# Sortable columns for the admin published-maps list (inner half:
+# _share_token_ordering() in catalog/maps/service_public.py).
+#
+# Link status is absent: it is derived in Python from is_active plus expires_at
+# against now(), so ordering by it would need a CASE expression the listing
+# does not have. See AdminSharedMapsPage for the matching UI comment.
+ShareTokenSortField = Literal[
+    "map_name", "created_at", "creator", "expires_at", "embed_token_count"
+]
+
 SortDirection = Literal["asc", "desc"]
 
 

--- a/backend/app/modules/admin/service.py
+++ b/backend/app/modules/admin/service.py
@@ -44,6 +44,32 @@ USER_SORT_COLUMNS: dict[str, InstrumentedAttribute] = {
 # top of a descending "Last Login" sort. Pin them last in both directions.
 _NULLABLE_USER_SORT_COLUMNS = frozenset({"email", "last_login_at"})
 
+# Inner half of the job-list sort allowlist (outer half: the JobSortField
+# Literal in schemas.py). Built by a function rather than held as a module
+# constant because IngestJob is imported lazily inside list_jobs; hoisting it to
+# module scope would put a platform.jobs import in every importer of this module.
+_NULLABLE_JOB_SORT_COLUMNS = frozenset({"source_filename", "username", "duration"})
+
+
+def _job_sort_columns() -> dict[str, Any]:
+    """Map an allowlisted job sort key to the expression that orders it."""
+    from app.platform.jobs.models import IngestJob
+
+    return {
+        "created_at": IngestJob.created_at,
+        "source_filename": IngestJob.source_filename,
+        "status": IngestJob.status,
+        # The list query already outer-joins users for the displayed username,
+        # so ordering by it costs nothing extra.
+        "username": User.username,
+        # What the UI's Duration column shows, as a column expression: the
+        # elapsed time of a finished job. The interval is NULL for exactly the
+        # rows that render "-" (either timestamp missing), so the ordering and
+        # the cell agree without a second rule. Pinned NULLS LAST below, which
+        # keeps pending and running jobs off the top of a descending sort.
+        "duration": IngestJob.completed_at - IngestJob.started_at,
+    }
+
 
 class PendingUserMutationError(ValueError):
     """Raised when generic user PATCH attempts an approval-only mutation."""
@@ -667,6 +693,32 @@ class AdminService:
         await self.db.flush()
         return username
 
+    @staticmethod
+    def _job_ordering(sort: str, order: str) -> list[Any]:
+        """Resolve a job sort key/direction pair to ORDER BY clauses.
+
+        Raises ValueError outside the allowlist rather than degrading to the
+        default order, so a typo'd key fails loudly instead of silently
+        serving a differently-ordered page.
+        """
+        from app.platform.jobs.models import IngestJob
+
+        column = _job_sort_columns().get(sort)
+        if column is None:
+            raise ValueError(f"Unsupported sort field: {sort!r}")
+        if order not in ("asc", "desc"):
+            raise ValueError(f"Unsupported sort order: {order!r}")
+
+        clause = column.desc() if order == "desc" else column.asc()
+        if sort in _NULLABLE_JOB_SORT_COLUMNS:
+            clause = nulls_last(clause)
+
+        # Every sortable job column admits duplicates — created_at included,
+        # since a fan-out enqueues its children in one transaction. OFFSET
+        # paging over a non-unique key lets Postgres return a row on two
+        # consecutive pages; the id tiebreak makes the order total.
+        return [clause, IngestJob.id]
+
     async def list_jobs(
         self,
         *,
@@ -675,8 +727,15 @@ class AdminService:
         search: str | None = None,
         skip: int = 0,
         limit: int = 50,
+        sort: str = "created_at",
+        order: str = "desc",
     ) -> tuple[list, int]:
-        """List ingestion jobs with optional filters. Returns (rows, total)."""
+        """List ingestion jobs with optional filters. Returns (rows, total).
+
+        `sort` must be a key of _job_sort_columns() and `order` one of
+        asc/desc; anything else raises ValueError. The default ordering
+        (created_at descending) is the historical one and is unchanged.
+        """
         from app.modules.auth.models import User as UserModel
         from app.platform.jobs.models import IngestJob
 
@@ -702,7 +761,7 @@ class AdminService:
             select(IngestJob, UserModel.username)
             .outerjoin(UserModel, IngestJob.created_by == UserModel.id)
             .where(*filters)
-            .order_by(IngestJob.created_at.desc())
+            .order_by(*self._job_ordering(sort, order))
             .offset(skip)
             .limit(limit)
         )

--- a/backend/app/modules/audit/router.py
+++ b/backend/app/modules/audit/router.py
@@ -36,8 +36,10 @@ from app.core.db.tenant_session import tenant_job_context
 from app.modules.audit.schemas import (
     AuditLogListResponse,
     AuditLogResponse,
+    AuditSortField,
     ColumnDdlEntry,
     ColumnDdlFeedResponse,
+    SortDirection,
 )
 from app.modules.audit.service import (
     AuditEvent,
@@ -293,10 +295,22 @@ async def list_audit_logs(
     search: str | None = Query(None, max_length=200),
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
+    sort: AuditSortField = Query(
+        "created_at",
+        description=(
+            "Column to order by. Resource name is not sortable: it is resolved "
+            "per page after the query, so the database cannot order by it."
+        ),
+    ),
+    order: SortDirection = Query("desc", description="Sort direction."),
     user: Identity = Depends(require_permission("manage_settings")),
     db: AsyncSession = Depends(get_db),
 ) -> AuditLogListResponse:
-    """Query audit logs with optional filters (admin only)."""
+    """Query audit logs with optional filters and sort (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
+    """
     logs, total = await query_audit_logs(
         db,
         user_id=user_id,
@@ -308,6 +322,8 @@ async def list_audit_logs(
         search=search,
         skip=skip,
         limit=limit,
+        sort=sort,
+        order=order,
     )
     resource_names = await resolve_resource_names(db, logs)
     return AuditLogListResponse(
@@ -352,7 +368,15 @@ async def export_audit_logs(
     user: Identity = Depends(require_permission("manage_settings")),
     db: AsyncSession = Depends(get_db),
 ) -> StreamingResponse:
-    """Export up to 100,000 audit log rows as CSV or JSON."""
+    """Export up to 100,000 audit log rows as CSV or JSON, newest first."""
+    # fix(#1204): no sort/order here, deliberately. The list endpoint became
+    # sortable and this export shares its FILTER parameters, so the omission
+    # reads like an oversight and is not. The export streams through
+    # stream_audit_logs — a different function from the list's
+    # query_audit_logs, with its own created_at DESC — and an export is an
+    # archive the recipient reorders in their own tool. Adding a sort would
+    # change the row order of every existing consumer's file to no benefit.
+    # Pinned by test_admin_audit_sort.py::test_export_endpoint_takes_no_sort_parameters.
     if format not in FORMAT_HANDLERS:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 

--- a/backend/app/modules/audit/schemas.py
+++ b/backend/app/modules/audit/schemas.py
@@ -1,8 +1,24 @@
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
+
+# Sortable columns for the admin audit-log list. This Literal is the OUTER half
+# of a two-layer allowlist: FastAPI rejects anything outside it with a 422
+# before the service runs, and _audit_sort_columns() in service.py resolves the
+# surviving value to a mapped column. A caller-supplied string is therefore
+# never interpolated into an ORDER BY clause.
+#
+# `resource_name` is absent because resolve_resource_names() runs against the
+# page after the query returns; the database has nothing to order by.
+AuditSortField = Literal[
+    "created_at", "action", "resource_type", "ip_address", "username"
+]
+
+# Declared here rather than imported from the admin module: audit is a peer
+# domain, and a two-value literal is not worth a cross-module dependency.
+SortDirection = Literal["asc", "desc"]
 
 
 class AuditLogResponse(BaseModel):

--- a/backend/app/modules/audit/service.py
+++ b/backend/app/modules/audit/service.py
@@ -2,10 +2,11 @@ import uuid
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from datetime import datetime
+from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import func, nulls_last, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import aliased, joinedload
 
 from app.platform.audit import (
     AuditEvent,
@@ -59,6 +60,56 @@ async def audit_emit_durable(event: AuditEvent) -> None:
         except BaseException:  # includes stream-task cancellation during shutdown
             await session.rollback()
             raise
+
+
+# Nullable members of the audit sort allowlist. Postgres puts NULLs first on
+# DESC, which would fill the top of a descending "IP address" or "User" view
+# with the rows that have neither. Pinned last in both directions.
+_NULLABLE_AUDIT_SORT_COLUMNS = frozenset({"ip_address", "username"})
+
+
+def _audit_sort_columns(sort_user: Any) -> dict[str, Any]:
+    """Map an allowlisted audit sort key to the expression that orders it.
+
+    Inner half of a two-layer allowlist; the outer half is the AuditSortField
+    Literal in schemas.py, which FastAPI enforces at the boundary. Resolution
+    here is a dict lookup, so a caller-supplied string never reaches SQL.
+
+    `resource_name` is deliberately absent: resolve_resource_names() runs
+    against the page AFTER the query returns, so the database cannot order by
+    it — a header for it would sort the visible page only.
+    """
+    return {
+        "created_at": AuditLog.created_at,
+        "action": AuditLog.action,
+        "resource_type": AuditLog.resource_type,
+        "ip_address": AuditLog.ip_address,
+        "username": sort_user.username,
+    }
+
+
+def _audit_ordering(sort: str, order: str, sort_user: Any) -> list[Any]:
+    """Resolve a sort key/direction pair to ORDER BY clauses.
+
+    Raises ValueError outside the allowlist rather than falling back to the
+    default ordering, so a bad key fails loudly instead of silently serving a
+    differently-ordered page.
+    """
+    column = _audit_sort_columns(sort_user).get(sort)
+    if column is None:
+        raise ValueError(f"Unsupported sort field: {sort!r}")
+    if order not in ("asc", "desc"):
+        raise ValueError(f"Unsupported sort order: {order!r}")
+
+    clause = column.desc() if order == "desc" else column.asc()
+    if sort in _NULLABLE_AUDIT_SORT_COLUMNS:
+        clause = nulls_last(clause)
+
+    # Every sortable audit column admits duplicates, created_at included: one
+    # request can write several rows inside a single transaction. OFFSET paging
+    # over a non-unique key lets Postgres hand back a row on two consecutive
+    # pages; the id tiebreak makes the ordering total.
+    return [clause, AuditLog.id]
 
 
 def _apply_filters(
@@ -169,10 +220,20 @@ async def query_audit_logs(
     search: str | None = None,
     skip: int = 0,
     limit: int = 50,
+    sort: str = "created_at",
+    order: str = "desc",
 ) -> tuple[list[AuditLog], int]:
     """Query audit logs with optional filters and pagination.
 
-    Returns (logs, total_count) ordered by created_at descending.
+    Returns (logs, total_count), ordered by created_at descending unless
+    `sort`/`order` say otherwise. `sort` must be a key of
+    _audit_sort_columns() and `order` one of asc/desc; anything else raises
+    ValueError. The default is the historical ordering and is unchanged.
+
+    fix(#1204): sorting stops here. The CSV/JSON export runs through
+    stream_audit_logs, a separate cursor-based generator with its own
+    created_at DESC ordering, and it was deliberately left alone — see the
+    export endpoint's docstring in router.py.
 
     Uses ``COUNT(*) OVER ()`` so the total count rides along with the
     filtered slice in a single round trip, instead of running a
@@ -194,7 +255,28 @@ async def query_audit_logs(
         snapshot_at=snapshot_at,
         search=search,
     )
-    query = query.order_by(AuditLog.created_at.desc()).offset(skip).limit(limit)
+    # fix(#1204): a dedicated alias rather than the bare User entity, so this
+    # ORDER BY join can never interact with the `users` that _apply_filters
+    # already references in its username search
+    # (`AuditLog.user_id.in_(select(User.id)...)`).
+    #
+    # Measured, so nobody has to re-derive it: joining the bare entity compiles
+    # to the SAME SQL today. SQLAlchemy auto-correlates a subquery against the
+    # enclosing FROM only when doing so leaves it with another FROM, and that
+    # subquery has exactly one. The alias is therefore insurance, not a bug
+    # fix — it keeps the ordering independent of how the filter is written, so
+    # a future filter that joins users instead of sub-selecting cannot quietly
+    # change which rows the search returns.
+    from app.modules.auth.models import User
+
+    sort_user = aliased(User, name="audit_sort_user")
+    if sort == "username":
+        query = query.outerjoin(sort_user, AuditLog.user_id == sort_user.id)
+    query = (
+        query.order_by(*_audit_ordering(sort, order, sort_user))
+        .offset(skip)
+        .limit(limit)
+    )
 
     result = await session.execute(query)
     rows = result.unique().all()

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -5,9 +5,9 @@ import secrets
 import uuid
 from dataclasses import replace
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, nulls_last, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
@@ -679,12 +679,68 @@ async def get_shared_map(
     return map_data, layers, allowed_origins
 
 
+# Nullable members of the published-maps sort allowlist. `creator` is null for
+# a map whose owner was deleted (created_by is ON DELETE SET NULL) and
+# `expires_at` for a never-expiring link AND for every map with no link at all,
+# since the share join is an outer one. Postgres puts NULLs first on DESC,
+# which would fill the top of a descending "Expires" view with linkless maps.
+_NULLABLE_SHARE_TOKEN_SORT_FIELDS = frozenset({"creator", "expires_at"})
+
+
+def _share_token_ordering(
+    sort: str, order: str, *, share: Any, embed_count: Any
+) -> list[Any]:
+    """Resolve a published-maps sort key/direction pair to ORDER BY clauses.
+
+    Inner half of a two-layer allowlist; the outer half is the
+    ShareTokenSortField Literal in admin/schemas.py, which FastAPI enforces at
+    the boundary. Resolution is a dict lookup, so a caller-supplied string
+    never reaches SQL as text, and an unmapped key raises rather than
+    degrading to the default order.
+
+    `share` and `embed_count` are passed in because both are per-call
+    constructs — an alias over a DISTINCT ON subquery and a COALESCE over an
+    aggregate — so the mapping cannot be a module constant.
+    """
+    columns = {
+        "map_name": Map.name,
+        "created_at": Map.created_at,
+        "creator": User.username,
+        "expires_at": share.expires_at,
+        # The COALESCE'd count, i.e. the number the cell actually renders. The
+        # raw aggregate is NULL for a map with no ACTIVE embed token; ordering
+        # by that would sort those maps at an end of their own rather than
+        # among the zeroes. Note the range is only ever 0 or 1 —
+        # uq_embed_tokens_one_active_per_map is a partial unique index on
+        # map_id WHERE is_active — so this separates "has a live embed" from
+        # "does not" rather than ranking volumes.
+        "embed_token_count": embed_count,
+    }
+    column = columns.get(sort)
+    if column is None:
+        raise ValueError(f"Unsupported sort field: {sort!r}")
+    if order not in ("asc", "desc"):
+        raise ValueError(f"Unsupported sort order: {order!r}")
+
+    clause = column.desc() if order == "desc" else column.asc()
+    if sort in _NULLABLE_SHARE_TOKEN_SORT_FIELDS:
+        clause = nulls_last(clause)
+
+    # The listing is one row per map, so Map.id is the unique tiebreak. Every
+    # sortable column here admits duplicates (two maps can share a name, a
+    # creator, an expiry, or a count), and OFFSET paging over a non-unique key
+    # lets Postgres return a row on two consecutive pages.
+    return [clause, Map.id]
+
+
 async def list_share_tokens(
     session: AsyncSession,
     skip: int = 0,
     limit: int = 50,
     search: str | None = None,
     status_filter: str | None = None,
+    sort: str = "created_at",
+    order: str = "desc",
 ) -> tuple[list[dict], int]:
     """List published (``visibility='public'``) maps with their latest share-link
     status and active embed-token count for the admin "Published Maps" view.
@@ -695,6 +751,13 @@ async def list_share_tokens(
     carry null ``id``/``token``/``is_active``. ``created_at``/``created_by`` are
     the map's, so the column is meaningful for unshared maps too. The optional
     status filter narrows to maps whose latest link is active/expired/revoked.
+
+    ``sort`` must be a key of the _share_token_ordering allowlist and ``order``
+    one of asc/desc; anything else raises ValueError. The default ordering
+    (the map's created_at descending) is the historical one and is unchanged.
+    Link status is NOT sortable: it is derived in Python from is_active plus
+    expires_at against now(), and ordering by it would need a CASE the listing
+    does not build.
     """
     from sqlalchemy.orm import aliased
     from sqlalchemy.sql import ColumnElement
@@ -725,6 +788,10 @@ async def list_share_tokens(
         .group_by(EmbedToken.map_id)
         .subquery()
     )
+    # Built once and used for both the SELECT list and (when sorted on) the
+    # ORDER BY, so the number the row displays and the number it is ordered by
+    # cannot drift apart.
+    embed_count = func.coalesce(embed_count_sub.c.embed_count, 0)
 
     # Base conditions scope to published maps; the status filter (when given)
     # narrows on the joined share-link state.
@@ -764,14 +831,16 @@ async def list_share_tokens(
             Map.id.label("map_id"),
             Map.name.label("map_name"),
             Map.created_at.label("map_created_at"),
-            func.coalesce(embed_count_sub.c.embed_count, 0).label("embed_token_count"),
+            embed_count.label("embed_token_count"),
             User.username.label("creator_username"),
         )
         .select_from(Map)
         .outerjoin(share, share.map_id == Map.id)
         .outerjoin(User, Map.created_by == User.id)
         .outerjoin(embed_count_sub, embed_count_sub.c.map_id == Map.id)
-        .order_by(Map.created_at.desc())
+        .order_by(
+            *_share_token_ordering(sort, order, share=share, embed_count=embed_count)
+        )
         .offset(skip)
         .limit(limit)
     )

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18625,7 +18625,7 @@
     },
     "/admin/audit-logs/": {
       "get": {
-        "description": "Query audit logs with optional filters (admin only).",
+        "description": "Query audit logs with optional filters and sort (admin only).\n\n`sort` and `order` are closed enums, so an unrecognised value is refused\nwith a 422 and never reaches the query.",
         "operationId": "list_audit_logs_admin_audit_logs__get",
         "parameters": [
           {
@@ -18769,6 +18769,41 @@
               "title": "Limit",
               "type": "integer"
             }
+          },
+          {
+            "description": "Column to order by. Resource name is not sortable: it is resolved per page after the query, so the database cannot order by it.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "created_at",
+              "description": "Column to order by. Resource name is not sortable: it is resolved per page after the query, so the database cannot order by it.",
+              "enum": [
+                "created_at",
+                "action",
+                "resource_type",
+                "ip_address",
+                "username"
+              ],
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "desc",
+              "description": "Sort direction.",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "title": "Order",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -18891,7 +18926,7 @@
     },
     "/admin/audit-logs/export/{format}": {
       "get": {
-        "description": "Export up to 100,000 audit log rows as CSV or JSON.",
+        "description": "Export up to 100,000 audit log rows as CSV or JSON, newest first.",
         "operationId": "export_audit_logs_admin_audit_logs_export__format__get",
         "parameters": [
           {
@@ -19880,7 +19915,7 @@
     },
     "/admin/jobs/": {
       "get": {
-        "description": "List all ingestion jobs with optional status/user/search filters (admin only).",
+        "description": "List all ingestion jobs with optional status/user/search/sort filters (admin only).\n\n`sort` and `order` are closed enums, so an unrecognised value is refused\nwith a 422 and never reaches the query.",
         "operationId": "list_admin_jobs_admin_jobs__get",
         "parameters": [
           {
@@ -19953,6 +19988,41 @@
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Column to order by. Duration orders by the completed_at - started_at interval, so unfinished jobs sort last either way.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "created_at",
+              "description": "Column to order by. Duration orders by the completed_at - started_at interval, so unfinished jobs sort last either way.",
+              "enum": [
+                "created_at",
+                "source_filename",
+                "status",
+                "username",
+                "duration"
+              ],
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "desc",
+              "description": "Sort direction.",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "title": "Order",
+              "type": "string"
             }
           }
         ],
@@ -20076,7 +20146,7 @@
     },
     "/admin/share-tokens/": {
       "get": {
-        "description": "List basic share-token inventory with map info; no quotas or domain controls (admin only).",
+        "description": "List basic share-token inventory with map info; no quotas or domain controls (admin only).\n\n`sort` and `order` are closed enums, so an unrecognised value is refused\nwith a 422 and never reaches the query.",
         "operationId": "list_share_tokens_endpoint_admin_share_tokens__get",
         "parameters": [
           {
@@ -20134,6 +20204,41 @@
                 }
               ],
               "title": "Status"
+            }
+          },
+          {
+            "description": "Column to order by. Link status is not sortable: it is derived from is_active and expires_at after the query returns.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "created_at",
+              "description": "Column to order by. Link status is not sortable: it is derived from is_active and expires_at after the query returns.",
+              "enum": [
+                "map_name",
+                "created_at",
+                "creator",
+                "expires_at",
+                "embed_token_count"
+              ],
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "desc",
+              "description": "Sort direction.",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "title": "Order",
+              "type": "string"
             }
           }
         ],

--- a/backend/tests/test_admin_audit_sort.py
+++ b/backend/tests/test_admin_audit_sort.py
@@ -1,0 +1,424 @@
+"""Tests for sortable GET /admin/audit-logs/ (sort + order query params).
+
+Every assertion is scoped to rows this test creates, via a unique token in the
+`action` value that the endpoint's own search filter selects on. The per-worker
+database is shared and most tests emit audit rows into it, so an assertion
+about the whole list would be a claim about the worker rather than this test.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from app.modules.audit.service import (
+    _audit_ordering,
+    _audit_sort_columns,
+    query_audit_logs,
+)
+
+PASSWORD = "TestPass1234!"  # SEC-S16: meets 12-char + 3-class policy
+
+
+async def _log(
+    session,
+    *,
+    action,
+    resource_type="dataset",
+    user_id=None,
+    ip_address=None,
+):
+    from app.modules.audit.models import AuditLog
+
+    entry = AuditLog(
+        user_id=user_id,
+        action=action,
+        resource_type=resource_type,
+        resource_id=uuid.uuid4(),
+        ip_address=ip_address,
+    )
+    session.add(entry)
+    await session.commit()
+    await session.refresh(entry)
+    return entry
+
+
+def _actions(logs) -> list[str]:
+    return [log.action for log in logs]
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+async def test_sort_by_action_orders_both_directions(test_db_session):
+    """sort=action returns the scoped rows in alphabetical order."""
+    token = f"asrt{uuid.uuid4().hex[:10]}"
+    # Written in a deliberately non-alphabetical order, so a response that
+    # merely preserved insertion order would fail this test.
+    for suffix in ("mike", "alpha", "zulu"):
+        await _log(test_db_session, action=f"{token}.{suffix}")
+
+    asc, _ = await query_audit_logs(
+        test_db_session, search=token, sort="action", order="asc"
+    )
+    desc, _ = await query_audit_logs(
+        test_db_session, search=token, sort="action", order="desc"
+    )
+
+    assert _actions(asc) == [f"{token}.alpha", f"{token}.mike", f"{token}.zulu"]
+    assert _actions(desc) == [f"{token}.zulu", f"{token}.mike", f"{token}.alpha"]
+
+
+async def test_default_sort_is_unchanged_created_at_descending(test_db_session):
+    """Omitting sort/order preserves the historical created_at DESC ordering."""
+    token = f"asrt{uuid.uuid4().hex[:10]}"
+    created = [
+        (await _log(test_db_session, action=f"{token}.{n}")).id for n in range(3)
+    ]
+
+    logs, _ = await query_audit_logs(test_db_session, search=token)
+
+    # Newest first: the reverse of the order they were written in.
+    assert [log.id for log in logs] == list(reversed(created))
+
+
+async def test_sort_by_username_orders_by_the_joined_users_row(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """sort=username orders on the joined account name, not on user_id."""
+    token = f"asrt{uuid.uuid4().hex[:10]}"
+    ids = {}
+    for suffix in ("mike", "alpha", "zulu"):
+        resp = await client.post(
+            "/admin/users/",
+            json={
+                "username": f"{token}_{suffix}",
+                "password": PASSWORD,
+                "role": "viewer",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, resp.text
+        ids[suffix] = uuid.UUID(resp.json()["id"])
+
+    for suffix in ("mike", "alpha", "zulu"):
+        await _log(test_db_session, action=f"{token}.evt", user_id=ids[suffix])
+
+    logs, _ = await query_audit_logs(
+        test_db_session, search=f"{token}.evt", sort="username", order="asc"
+    )
+
+    assert [log.user.username for log in logs] == [
+        f"{token}_alpha",
+        f"{token}_mike",
+        f"{token}_zulu",
+    ]
+
+
+async def test_username_sort_does_not_break_the_username_search_filter(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """Sorting by username must not change WHICH rows the search returns.
+
+    The search filter reaches rows through two arms — the action text and a
+    ``AuditLog.user_id.in_(select(User.id)...)`` sub-select on the username —
+    and sorting by username adds a second reference to `users`. That is the
+    kind of change that alters a result set rather than erroring, so this
+    asserts set equality against the unsorted query instead of just a
+    non-empty response.
+
+    Honest limit: this does NOT discriminate the aliased ORDER BY join from a
+    bare-entity one. Measured on 2026-08-05, both compile to identical SQL,
+    because SQLAlchemy only auto-correlates a subquery when that leaves it
+    another FROM. The alias in query_audit_logs is insurance against a future
+    filter rewrite, and this test pins the property that would break.
+    """
+    token = f"asrt{uuid.uuid4().hex[:10]}"
+    resp = await client.post(
+        "/admin/users/",
+        json={"username": f"{token}_actor", "password": PASSWORD, "role": "viewer"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+    actor_id = uuid.UUID(resp.json()["id"])
+
+    # One row reachable ONLY through the username arm of the search filter
+    # (its action does not contain the token), plus one reachable only through
+    # the action arm (it has no user at all).
+    by_username = await _log(test_db_session, action="unrelated.evt", user_id=actor_id)
+    by_action = await _log(test_db_session, action=f"{token}.evt")
+
+    default_logs, default_total = await query_audit_logs(test_db_session, search=token)
+    sorted_logs, sorted_total = await query_audit_logs(
+        test_db_session, search=token, sort="username", order="asc"
+    )
+
+    # Guard against a vacuous pass: the search must really be reaching both
+    # arms, or the correlation regression would have nothing to break.
+    assert {by_username.id, by_action.id} <= {log.id for log in default_logs}
+    assert {log.id for log in sorted_logs} == {log.id for log in default_logs}
+    assert sorted_total == default_total
+
+
+@pytest.mark.parametrize("order", ["asc", "desc"])
+async def test_rows_without_a_user_sort_last_in_both_directions(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    order,
+):
+    """A row whose user was deleted (user_id NULL) stays at the bottom.
+
+    Postgres puts NULLs first on DESC, which would fill the top of a
+    descending "User" view with anonymous and orphaned rows.
+    """
+    token = f"asrt{uuid.uuid4().hex[:10]}"
+    resp = await client.post(
+        "/admin/users/",
+        json={"username": f"{token}_actor", "password": PASSWORD, "role": "viewer"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+    actor_id = uuid.UUID(resp.json()["id"])
+
+    named = await _log(test_db_session, action=f"{token}.evt", user_id=actor_id)
+    anonymous = await _log(test_db_session, action=f"{token}.evt", user_id=None)
+
+    logs, _ = await query_audit_logs(
+        test_db_session, search=f"{token}.evt", sort="username", order=order
+    )
+    positions = {log.id: i for i, log in enumerate(logs)}
+
+    assert {named.id, anonymous.id} <= positions.keys()
+    assert positions[named.id] < positions[anonymous.id], (
+        f"{order}: a row with no user outranked one with a username"
+    )
+
+
+@pytest.mark.parametrize("order", ["asc", "desc"])
+async def test_null_ip_address_sorts_last_in_both_directions(test_db_session, order):
+    """ip_address is nullable (background jobs); nulls stay at the bottom."""
+    token = f"asrt{uuid.uuid4().hex[:10]}"
+    with_ip = await _log(
+        test_db_session, action=f"{token}.evt", ip_address="203.0.113.7"
+    )
+    without_ip = await _log(test_db_session, action=f"{token}.evt", ip_address=None)
+
+    logs, _ = await query_audit_logs(
+        test_db_session, search=token, sort="ip_address", order=order
+    )
+    positions = {log.id: i for i, log in enumerate(logs)}
+
+    assert {with_ip.id, without_ip.id} <= positions.keys()
+    assert positions[with_ip.id] < positions[without_ip.id], (
+        f"{order}: a NULL ip_address outranked a real one"
+    )
+
+
+async def test_sort_composes_with_the_resource_type_filter(test_db_session):
+    """sort applies on top of the existing filters rather than replacing them."""
+    token = f"asrt{uuid.uuid4().hex[:10]}"
+    await _log(test_db_session, action=f"{token}.mike", resource_type="dataset")
+    await _log(test_db_session, action=f"{token}.alpha", resource_type="dataset")
+    await _log(test_db_session, action=f"{token}.zulu", resource_type="map")
+
+    logs, total = await query_audit_logs(
+        test_db_session,
+        search=token,
+        resource_type="dataset",
+        sort="action",
+        order="desc",
+    )
+
+    assert _actions(logs) == [f"{token}.mike", f"{token}.alpha"]
+    assert total == 2
+
+
+async def test_paging_a_non_unique_sort_key_never_repeats_a_row(test_db_session):
+    """Paging by `resource_type` (identical for every row) yields each row once.
+
+    OFFSET paging over a non-unique ORDER BY key is free to return a row on two
+    consecutive pages; the id tiebreak makes the ordering total.
+    """
+    token = f"asrt{uuid.uuid4().hex[:10]}"
+    expected = {
+        (await _log(test_db_session, action=f"{token}.{n}")).id for n in range(6)
+    }
+
+    seen: list = []
+    for skip in (0, 2, 4):
+        logs, _ = await query_audit_logs(
+            test_db_session,
+            search=token,
+            sort="resource_type",
+            order="asc",
+            skip=skip,
+            limit=2,
+        )
+        seen.extend(log.id for log in logs)
+
+    assert len(seen) == len(set(seen)), f"a row appeared on two pages: {seen}"
+    assert set(seen) == expected
+
+
+def test_ordering_clause_carries_a_unique_tiebreak_and_pins_nulls():
+    """Assert the ORDER BY shape directly, because behaviour cannot prove it.
+
+    The paging test above passes with or without the id tiebreak: at these row
+    counts Postgres seq-scans and happens to return a stable order, so it
+    cannot detect the regression it describes. Compiling the clause can.
+    """
+    from sqlalchemy.orm import aliased
+
+    from app.modules.audit.models import AuditLog
+    from app.modules.audit.service import _NULLABLE_AUDIT_SORT_COLUMNS
+    from app.modules.auth.models import User
+
+    sort_user = aliased(User, name="audit_sort_user")
+
+    for field in _audit_sort_columns(sort_user):
+        for order in ("asc", "desc"):
+            clauses = _audit_ordering(field, order, sort_user)
+            assert clauses[-1] is AuditLog.id, (
+                f"{field}/{order} has no unique tiebreak: {[str(c) for c in clauses]}"
+            )
+            rendered = str(clauses[0]).upper()
+            assert order.upper() in rendered, rendered
+            if field in _NULLABLE_AUDIT_SORT_COLUMNS:
+                assert "NULLS LAST" in rendered, f"{field}/{order}: {rendered}"
+            else:
+                assert "NULLS LAST" not in rendered, f"{field}/{order}: {rendered}"
+
+    assert _NULLABLE_AUDIT_SORT_COLUMNS <= set(_audit_sort_columns(sort_user))
+
+
+def test_resource_name_is_not_offered_as_a_sort_key():
+    """resource_name is resolved per page after the query, so it cannot sort.
+
+    Pinned as a test because the column IS in the response model, which makes
+    adding it to the allowlist look harmless; it would order by nothing.
+    """
+    from sqlalchemy.orm import aliased
+
+    from app.modules.auth.models import User
+
+    assert "resource_name" not in _audit_sort_columns(aliased(User))
+
+
+# ---------------------------------------------------------------------------
+# Allowlist enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bogus_sort",
+    [
+        "details",  # a real column, deliberately not sortable
+        "resource_name",  # resolved after the query, not a column
+        "action; DROP TABLE catalog.audit_logs",
+        "(SELECT 1)",
+        "",
+    ],
+)
+@pytest.mark.anyio
+async def test_unknown_sort_field_is_refused_not_executed(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    bogus_sort: str,
+):
+    """A sort field outside the allowlist is a 422, never a silent default."""
+    resp = await client.get(
+        "/admin/audit-logs/",
+        params={"sort": bogus_sort, "limit": 1},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, f"{bogus_sort!r} -> {resp.status_code} {resp.text}"
+
+
+@pytest.mark.parametrize("bogus_order", ["sideways", "ASC; --", "1"])
+@pytest.mark.anyio
+async def test_unknown_sort_order_is_refused(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    bogus_order: str,
+):
+    """A direction outside asc/desc is a 422."""
+    resp = await client.get(
+        "/admin/audit-logs/",
+        params={"order": bogus_order, "limit": 1},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, f"{bogus_order!r} -> {resp.status_code}"
+
+
+@pytest.mark.anyio
+async def test_every_advertised_sort_field_is_accepted(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """The refusal tests above must not be passing by refusing everything."""
+    from sqlalchemy.orm import aliased
+
+    from app.modules.auth.models import User
+
+    fields = _audit_sort_columns(aliased(User))
+    assert fields, "allowlist is empty; the tests above prove nothing"
+    for field in fields:
+        for order in ("asc", "desc"):
+            resp = await client.get(
+                "/admin/audit-logs/",
+                params={"sort": field, "order": order, "limit": 1},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200, f"{field}/{order} -> {resp.text}"
+
+
+async def test_service_layer_rejects_unmapped_sort_key(test_db_session):
+    """The service refuses an unmapped key even if the router is bypassed."""
+    with pytest.raises(ValueError, match="Unsupported sort field"):
+        await query_audit_logs(test_db_session, sort="details")
+    with pytest.raises(ValueError, match="Unsupported sort order"):
+        await query_audit_logs(test_db_session, order="sideways")
+
+
+def test_export_endpoint_takes_no_sort_parameters():
+    """fix(#1204): the CSV export shares the list's FILTERS, not its ordering.
+
+    Asserted rather than merely commented, so a later change that wires sort
+    into the export has to delete this test and say why.
+
+    Reads the route table through _iter_api_routes: fastapi 0.140 keeps
+    included-router routes nested, so scanning app.routes directly finds
+    neither endpoint and every assertion below would be vacuous.
+    """
+    from app.api.main import _iter_api_routes, app
+
+    params = {
+        ctx.path: {p.name for p in ctx.route.dependant.query_params}
+        for ctx in _iter_api_routes(app)
+        if ctx.path in ("/admin/audit-logs/", "/admin/audit-logs/export/{format}")
+    }
+    assert set(params) == {
+        "/admin/audit-logs/",
+        "/admin/audit-logs/export/{format}",
+    }, f"route probe found {sorted(params)}"
+
+    listing, export = (
+        params["/admin/audit-logs/"],
+        params["/admin/audit-logs/export/{format}"],
+    )
+    # Positive control: the two endpoints really do share their filters, so
+    # "the export lacks sort" is a fact about ordering and not about the probe.
+    assert {"search", "action", "user_id"} <= listing & export
+    assert {"sort", "order"} <= listing
+    assert not {"sort", "order"} & export

--- a/backend/tests/test_admin_job_sort.py
+++ b/backend/tests/test_admin_job_sort.py
@@ -1,0 +1,377 @@
+"""Tests for sortable GET /admin/jobs/ (sort + order query params).
+
+Every assertion is scoped to jobs this test creates, via a unique token in the
+source_filename that the endpoint's own search filter selects on. The
+per-worker database is shared and other tests seed ingest jobs into it, so an
+assertion about the whole list would be a claim about the worker rather than
+about this test.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+
+from app.modules.admin.service import AdminService, _job_sort_columns
+
+from tests.factories import get_user_id
+
+
+async def _create_job(
+    session,
+    *,
+    created_by,
+    source_filename,
+    status="pending",
+    started_at=None,
+    completed_at=None,
+):
+    from app.platform.jobs.models import IngestJob
+
+    job = IngestJob(
+        status=status,
+        created_by=created_by,
+        source_filename=source_filename,
+        started_at=started_at,
+        completed_at=completed_at,
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+def _filenames(rows) -> list[str]:
+    return [job.source_filename for job, _username in rows]
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+async def test_sort_by_filename_orders_both_directions(test_db_session):
+    """sort=source_filename returns the scoped jobs in alphabetical order."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    token = f"jsrt{uuid.uuid4().hex[:10]}"
+    # Deliberately not created in alphabetical order, so a response that merely
+    # preserved insertion order would fail this test.
+    for suffix in ("mike", "alpha", "zulu"):
+        await _create_job(
+            test_db_session, created_by=admin_id, source_filename=f"{token}_{suffix}"
+        )
+
+    svc = AdminService(test_db_session)
+    asc, _ = await svc.list_jobs(search=token, sort="source_filename", order="asc")
+    desc, _ = await svc.list_jobs(search=token, sort="source_filename", order="desc")
+
+    assert _filenames(asc) == [f"{token}_alpha", f"{token}_mike", f"{token}_zulu"]
+    assert _filenames(desc) == [f"{token}_zulu", f"{token}_mike", f"{token}_alpha"]
+
+
+async def test_default_sort_is_unchanged_created_at_descending(test_db_session):
+    """Omitting sort/order preserves the historical created_at DESC ordering."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    token = f"jsrt{uuid.uuid4().hex[:10]}"
+    created = [
+        (
+            await _create_job(
+                test_db_session,
+                created_by=admin_id,
+                source_filename=f"{token}_{n}",
+            )
+        ).id
+        for n in range(3)
+    ]
+
+    svc = AdminService(test_db_session)
+    rows, _ = await svc.list_jobs(search=token)
+
+    # Newest first: the reverse of the order they were created in.
+    assert [job.id for job, _username in rows] == list(reversed(created))
+
+
+async def test_duration_sorts_by_elapsed_time_not_by_timestamp(test_db_session):
+    """sort=duration orders by completed_at - started_at, not by either end.
+
+    The two are different orderings and a naive implementation could satisfy
+    one while claiming the other, so the fixture below is built to separate
+    them: the SHORTEST job starts last and finishes last.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    token = f"jsrt{uuid.uuid4().hex[:10]}"
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    # (suffix, start offset minutes, duration minutes)
+    fixtures = [
+        ("long", 0, 90),
+        ("medium", 30, 45),
+        ("short", 120, 5),
+    ]
+    for suffix, start_offset, minutes in fixtures:
+        started = base + timedelta(minutes=start_offset)
+        await _create_job(
+            test_db_session,
+            created_by=admin_id,
+            source_filename=f"{token}_{suffix}",
+            status="complete",
+            started_at=started,
+            completed_at=started + timedelta(minutes=minutes),
+        )
+
+    svc = AdminService(test_db_session)
+    asc, _ = await svc.list_jobs(search=token, sort="duration", order="asc")
+
+    assert _filenames(asc) == [
+        f"{token}_short",
+        f"{token}_medium",
+        f"{token}_long",
+    ]
+    # Guard against a vacuous pass: sorting by started_at ascending would have
+    # produced long/medium/short, the exact reverse, so the assertion above
+    # cannot be satisfied by ordering on either endpoint timestamp.
+    by_created, _ = await svc.list_jobs(search=token, sort="created_at", order="asc")
+    assert _filenames(by_created) != _filenames(asc)
+
+
+@pytest.mark.parametrize("order", ["asc", "desc"])
+async def test_unfinished_jobs_sort_last_by_duration(test_db_session, order):
+    """A job with no completed_at has a NULL duration and stays at the bottom.
+
+    Postgres puts NULLs first on DESC by default, which would fill the top of a
+    "longest first" view with jobs that have not finished at all.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    token = f"jsrt{uuid.uuid4().hex[:10]}"
+    started = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    await _create_job(
+        test_db_session,
+        created_by=admin_id,
+        source_filename=f"{token}_done",
+        status="complete",
+        started_at=started,
+        completed_at=started + timedelta(minutes=10),
+    )
+    await _create_job(
+        test_db_session,
+        created_by=admin_id,
+        source_filename=f"{token}_running",
+        status="running",
+        started_at=started,
+    )
+    await _create_job(
+        test_db_session,
+        created_by=admin_id,
+        source_filename=f"{token}_pending",
+        status="pending",
+    )
+
+    svc = AdminService(test_db_session)
+    rows, _ = await svc.list_jobs(search=token, sort="duration", order=order)
+    names = _filenames(rows)
+
+    # Only meaningful if the scoped set really mixes finished and unfinished.
+    assert f"{token}_done" in names, names
+    assert len(names) == 3, names
+    assert names[0] == f"{token}_done", (
+        f"{order}: an unfinished job outranked a finished one: {names}"
+    )
+
+
+@pytest.mark.parametrize("order", ["asc", "desc"])
+async def test_null_filename_sorts_last_in_both_directions(test_db_session, order):
+    """source_filename is nullable (URL ingests); nulls stay at the bottom."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    token = f"jsrt{uuid.uuid4().hex[:10]}"
+    named = await _create_job(
+        test_db_session, created_by=admin_id, source_filename=f"{token}_named"
+    )
+    unnamed = await _create_job(
+        test_db_session, created_by=admin_id, source_filename=None
+    )
+
+    svc = AdminService(test_db_session)
+    # The search filter is on source_filename, so it cannot reach the NULL row.
+    # Scope by id instead and assert only on the two rows this test owns.
+    rows, _ = await svc.list_jobs(sort="source_filename", order=order, limit=200)
+    positions = {
+        job.id: i
+        for i, (job, _username) in enumerate(rows)
+        if job.id in (named.id, unnamed.id)
+    }
+
+    assert len(positions) == 2, "both fixtures must be on the first page"
+    assert positions[named.id] < positions[unnamed.id], (
+        f"{order}: a NULL filename outranked a real one"
+    )
+
+
+async def test_sort_composes_with_status_filter(test_db_session):
+    """sort applies on top of the status filter rather than replacing it."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    token = f"jsrt{uuid.uuid4().hex[:10]}"
+    for suffix, status in (
+        ("mike", "failed"),
+        ("alpha", "failed"),
+        ("zulu", "pending"),
+    ):
+        await _create_job(
+            test_db_session,
+            created_by=admin_id,
+            source_filename=f"{token}_{suffix}",
+            status=status,
+        )
+
+    svc = AdminService(test_db_session)
+    rows, total = await svc.list_jobs(
+        search=token, status="failed", sort="source_filename", order="desc"
+    )
+
+    assert _filenames(rows) == [f"{token}_mike", f"{token}_alpha"]
+    assert total == 2
+
+
+async def test_paging_a_non_unique_sort_key_never_repeats_a_row(test_db_session):
+    """Paging by `status` (identical for every row) yields each job once.
+
+    OFFSET paging over a non-unique ORDER BY key is free to return a row on two
+    consecutive pages; the id tiebreak makes the ordering total.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    token = f"jsrt{uuid.uuid4().hex[:10]}"
+    expected = {
+        (
+            await _create_job(
+                test_db_session, created_by=admin_id, source_filename=f"{token}_{n}"
+            )
+        ).id
+        for n in range(6)
+    }
+
+    svc = AdminService(test_db_session)
+    seen: list = []
+    for skip in (0, 2, 4):
+        rows, _ = await svc.list_jobs(
+            search=token, sort="status", order="asc", skip=skip, limit=2
+        )
+        seen.extend(job.id for job, _username in rows)
+
+    assert len(seen) == len(set(seen)), f"a row appeared on two pages: {seen}"
+    assert set(seen) == expected
+
+
+def test_ordering_clause_carries_a_unique_tiebreak_and_pins_nulls():
+    """Assert the ORDER BY shape directly, because behaviour cannot prove it.
+
+    The paging test above passes with or without the id tiebreak: at these row
+    counts Postgres seq-scans and happens to return a stable order, so it
+    cannot detect the regression it describes. Compiling the clause can.
+    """
+    from app.modules.admin.service import _NULLABLE_JOB_SORT_COLUMNS
+    from app.platform.jobs.models import IngestJob
+
+    for field in _job_sort_columns():
+        for order in ("asc", "desc"):
+            clauses = AdminService._job_ordering(field, order)
+            assert clauses[-1] is IngestJob.id, (
+                f"{field}/{order} has no unique tiebreak: {[str(c) for c in clauses]}"
+            )
+            assert order.upper() in str(clauses[0]).upper(), str(clauses[0])
+
+            rendered = str(clauses[0]).upper()
+            if field in _NULLABLE_JOB_SORT_COLUMNS:
+                assert "NULLS LAST" in rendered, f"{field}/{order}: {rendered}"
+            else:
+                assert "NULLS LAST" not in rendered, f"{field}/{order}: {rendered}"
+
+    # The nullable set must not have drifted out of the allowlist it annotates.
+    assert _NULLABLE_JOB_SORT_COLUMNS <= set(_job_sort_columns())
+
+
+def test_duration_is_an_interval_expression_not_a_timestamp():
+    """sort=duration must order by the elapsed time, not by an endpoint.
+
+    A regression that quietly aliased duration to completed_at would still
+    order rows, still pass the allowlist tests, and only be visible on data
+    where start times and durations disagree.
+    """
+    rendered = str(_job_sort_columns()["duration"])
+
+    assert "completed_at" in rendered and "started_at" in rendered, rendered
+    assert "-" in rendered, rendered
+
+
+# ---------------------------------------------------------------------------
+# Allowlist enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bogus_sort",
+    [
+        "file_path",  # a real column, deliberately not sortable
+        "can_retry",  # computed per page after the query, not a column
+        "created_at; DROP TABLE catalog.ingest_jobs",
+        "(SELECT 1)",
+        "",
+    ],
+)
+@pytest.mark.anyio
+async def test_unknown_sort_field_is_refused_not_executed(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    bogus_sort: str,
+):
+    """A sort field outside the allowlist is a 422, never a silent default."""
+    resp = await client.get(
+        "/admin/jobs/",
+        params={"sort": bogus_sort, "limit": 1},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, f"{bogus_sort!r} -> {resp.status_code} {resp.text}"
+
+
+@pytest.mark.parametrize("bogus_order", ["sideways", "ASC; --", "1"])
+@pytest.mark.anyio
+async def test_unknown_sort_order_is_refused(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    bogus_order: str,
+):
+    """A direction outside asc/desc is a 422."""
+    resp = await client.get(
+        "/admin/jobs/",
+        params={"order": bogus_order, "limit": 1},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, f"{bogus_order!r} -> {resp.status_code}"
+
+
+@pytest.mark.anyio
+async def test_every_advertised_sort_field_is_accepted(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """The refusal tests above must not be passing by refusing everything."""
+    assert _job_sort_columns(), "allowlist is empty; the tests above prove nothing"
+    for field in _job_sort_columns():
+        for order in ("asc", "desc"):
+            resp = await client.get(
+                "/admin/jobs/",
+                params={"sort": field, "order": order, "limit": 1},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200, f"{field}/{order} -> {resp.text}"
+
+
+async def test_service_layer_rejects_unmapped_sort_key(test_db_session):
+    """The service refuses an unmapped key even if the router is bypassed."""
+    svc = AdminService(test_db_session)
+    with pytest.raises(ValueError, match="Unsupported sort field"):
+        await svc.list_jobs(sort="file_path")
+    with pytest.raises(ValueError, match="Unsupported sort order"):
+        await svc.list_jobs(order="sideways")

--- a/backend/tests/test_admin_share_token_sort.py
+++ b/backend/tests/test_admin_share_token_sort.py
@@ -1,0 +1,424 @@
+"""Tests for sortable GET /admin/share-tokens/ (sort + order query params).
+
+Every assertion is scoped to maps this test creates, via a unique token in the
+map name that the endpoint's own search filter selects on. The per-worker
+database is shared and other tests publish maps into it, so an assertion about
+the whole list would be a claim about the worker rather than about this test.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.factories import create_map_via_api
+
+PASSWORD = "TestPass1234!"  # SEC-S16: meets 12-char + 3-class policy
+
+
+async def _publish(client: AsyncClient, headers: dict, name: str) -> str:
+    """Create a map, publish it, and return its id. No share link is minted."""
+    created = await create_map_via_api(client, headers, name=name)
+    map_id = created["id"]
+    resp = await client.put(
+        f"/maps/{map_id}", json={"visibility": "public"}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    return map_id
+
+
+async def _list(client: AsyncClient, headers: dict, *, search: str, **params) -> dict:
+    resp = await client.get(
+        "/admin/share-tokens/",
+        params={"search": search, "limit": 200, **params},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _names(payload: dict) -> list[str]:
+    return [row["map_name"] for row in payload["tokens"]]
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_sort_by_map_name_orders_both_directions(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """sort=map_name returns the scoped maps in alphabetical order."""
+    token = f"msrt{uuid.uuid4().hex[:10]}"
+    # Published in a deliberately non-alphabetical order.
+    for suffix in ("mike", "alpha", "zulu"):
+        await _publish(client, admin_auth_header, f"{token}_{suffix}")
+
+    asc = _names(
+        await _list(
+            client, admin_auth_header, search=token, sort="map_name", order="asc"
+        )
+    )
+    desc = _names(
+        await _list(
+            client, admin_auth_header, search=token, sort="map_name", order="desc"
+        )
+    )
+
+    assert asc == [f"{token}_alpha", f"{token}_mike", f"{token}_zulu"]
+    assert desc == [f"{token}_zulu", f"{token}_mike", f"{token}_alpha"]
+
+
+@pytest.mark.anyio
+async def test_default_sort_is_unchanged_created_at_descending(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """Omitting sort/order preserves the historical created_at DESC ordering."""
+    token = f"msrt{uuid.uuid4().hex[:10]}"
+    created = [
+        await _publish(client, admin_auth_header, f"{token}_{n}") for n in range(3)
+    ]
+
+    payload = await _list(client, admin_auth_header, search=token)
+
+    # Newest first: the reverse of publication order.
+    assert [row["map_id"] for row in payload["tokens"]] == list(reversed(created))
+
+
+async def _add_embed_token(session, map_id: str, *, is_active: bool) -> None:
+    """Attach one embed token to a map, bypassing the edition-gated mint API.
+
+    At most ONE ACTIVE token per map: `uq_embed_tokens_one_active_per_map` is a
+    partial unique index on map_id WHERE is_active. The listing's count filters
+    on is_active, so embed_token_count is only ever 0 or 1 — the sort separates
+    "has a live embed" from "does not" rather than ranking volumes.
+    """
+    import uuid as _uuid
+    from datetime import datetime, timedelta, timezone
+
+    from app.modules.embed_tokens.models import EmbedToken
+
+    raw = _uuid.uuid4().hex
+    session.add(
+        EmbedToken(
+            map_id=_uuid.UUID(map_id),
+            token_hash=raw + raw[:24],
+            token_hint=raw[:8],
+            scoped_dataset_ids=[],
+            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+            is_active=is_active,
+        )
+    )
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_sort_by_embed_count_treats_no_tokens_as_zero(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """A map with no active embed token sorts as 0, not as a NULL at one end.
+
+    The count comes from a LEFT JOIN against an aggregate subquery filtered to
+    active tokens, so the raw value is NULL — not 0 — both for a map that never
+    had an embed token and for one whose only token is revoked. The listing
+    COALESCEs it for display and the ordering uses that same expression;
+    ordering by the raw aggregate would put those maps at an end of their own,
+    leading the DESC view above the map that actually has a live embed.
+    """
+    token = f"msrt{uuid.uuid4().hex[:10]}"
+    never_id = await _publish(client, admin_auth_header, f"{token}_never")
+    revoked_id = await _publish(client, admin_auth_header, f"{token}_revoked")
+    active_id = await _publish(client, admin_auth_header, f"{token}_active")
+    await _add_embed_token(test_db_session, revoked_id, is_active=False)
+    await _add_embed_token(test_db_session, active_id, is_active=True)
+
+    asc = await _list(
+        client, admin_auth_header, search=token, sort="embed_token_count", order="asc"
+    )
+    desc = await _list(
+        client, admin_auth_header, search=token, sort="embed_token_count", order="desc"
+    )
+
+    # Guard against a vacuous pass: the NULL-backed zeroes must really read 0
+    # in the payload, and the counts must actually differ across the fixtures.
+    assert [r["embed_token_count"] for r in asc["tokens"]] == [0, 0, 1], asc["tokens"]
+    assert [r["embed_token_count"] for r in desc["tokens"]] == [1, 0, 0]
+    # The two zeroes tie, so only the counted row's position is deterministic.
+    assert asc["tokens"][-1]["map_id"] == active_id
+    assert desc["tokens"][0]["map_id"] == active_id
+    assert {r["map_id"] for r in asc["tokens"][:2]} == {never_id, revoked_id}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("order", ["asc", "desc"])
+async def test_maps_without_an_expiry_sort_last_in_both_directions(
+    client: AsyncClient, admin_auth_header: dict, enterprise_edition, order
+):
+    """expires_at is null for never-expiring links AND for maps with no link.
+
+    Postgres puts NULLs first on DESC, which would fill the top of a
+    descending "Expires" view with every map that has no expiry at all.
+    """
+    token = f"msrt{uuid.uuid4().hex[:10]}"
+    dated_id = await _publish(client, admin_auth_header, f"{token}_dated")
+    share = await client.post(f"/maps/{dated_id}/share/", headers=admin_auth_header)
+    assert share.status_code in (200, 201), share.text
+    patch = await client.patch(
+        f"/maps/{dated_id}/share/",
+        json={"expires_at": "2030-06-01T00:00:00Z"},
+        headers=admin_auth_header,
+    )
+    assert patch.status_code == 200, patch.text
+    # No share link at all, so expires_at is null through the outer join.
+    await _publish(client, admin_auth_header, f"{token}_nolink")
+
+    payload = await _list(
+        client, admin_auth_header, search=token, sort="expires_at", order=order
+    )
+    rows = payload["tokens"]
+
+    # Only meaningful if the scoped set really mixes a null and a non-null.
+    assert any(r["expires_at"] is None for r in rows), rows
+    assert any(r["expires_at"] is not None for r in rows), rows
+
+    first_null = next(i for i, r in enumerate(rows) if r["expires_at"] is None)
+    assert all(r["expires_at"] is None for r in rows[first_null:]), (
+        f"{order}: a non-null expires_at followed a null one: {rows}"
+    )
+
+
+@pytest.mark.anyio
+async def test_sort_by_creator_orders_on_the_joined_username(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """sort=creator orders on the joined account name, not on created_by."""
+    token = f"msrt{uuid.uuid4().hex[:10]}"
+    names = []
+    for suffix in ("mike", "alpha"):
+        username = f"{token}_{suffix}"
+        resp = await client.post(
+            "/admin/users/",
+            json={"username": username, "password": PASSWORD, "role": "editor"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, resp.text
+        login = await client.post(
+            "/auth/login", data={"username": username, "password": PASSWORD}
+        )
+        assert login.status_code == 200, login.text
+        headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+        await _publish(client, headers, f"{token}_by_{suffix}")
+        names.append(username)
+
+    payload = await _list(
+        client, admin_auth_header, search=token, sort="creator", order="asc"
+    )
+
+    assert [row["created_by"] for row in payload["tokens"]] == sorted(names)
+
+
+@pytest.mark.anyio
+async def test_sort_composes_with_the_status_filter(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """sort applies on top of the status filter rather than replacing it."""
+    token = f"msrt{uuid.uuid4().hex[:10]}"
+    for suffix in ("mike", "alpha"):
+        map_id = await _publish(client, admin_auth_header, f"{token}_{suffix}")
+        share = await client.post(f"/maps/{map_id}/share/", headers=admin_auth_header)
+        assert share.status_code in (200, 201), share.text
+    # A published map with no link: excluded by status=active regardless of sort.
+    await _publish(client, admin_auth_header, f"{token}_nolink")
+
+    payload = await _list(
+        client,
+        admin_auth_header,
+        search=token,
+        status="active",
+        sort="map_name",
+        order="desc",
+    )
+
+    assert _names(payload) == [f"{token}_mike", f"{token}_alpha"]
+    assert payload["total"] == 2
+
+
+@pytest.mark.anyio
+async def test_paging_a_non_unique_sort_key_never_repeats_a_row(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """Paging by embed count (0 for every row) yields each map once.
+
+    OFFSET paging over a non-unique ORDER BY key is free to return a row on two
+    consecutive pages; the Map.id tiebreak makes the ordering total.
+    """
+    token = f"msrt{uuid.uuid4().hex[:10]}"
+    expected = {
+        await _publish(client, admin_auth_header, f"{token}_{n}") for n in range(6)
+    }
+
+    seen: list[str] = []
+    for skip in (0, 2, 4):
+        resp = await client.get(
+            "/admin/share-tokens/",
+            params={
+                "search": token,
+                "sort": "embed_token_count",
+                "order": "asc",
+                "skip": skip,
+                "limit": 2,
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        seen.extend(row["map_id"] for row in resp.json()["tokens"])
+
+    assert len(seen) == len(set(seen)), f"a row appeared on two pages: {seen}"
+    assert set(seen) == expected
+
+
+def test_ordering_clause_carries_a_unique_tiebreak_and_pins_nulls():
+    """Assert the ORDER BY shape directly, because behaviour cannot prove it.
+
+    The paging test above passes with or without the id tiebreak: at these row
+    counts Postgres seq-scans and happens to return a stable order, so it
+    cannot detect the regression it describes. Compiling the clause can.
+
+    The helper takes the share alias and embed-count expression as arguments
+    (both are per-call constructs), so this passes the unaliased model and a
+    bare literal — enough to compile a clause and read its decorations.
+    """
+    from sqlalchemy import literal_column
+
+    from app.modules.catalog.maps.models import Map, MapShareToken
+    from app.modules.catalog.maps.service_public import (
+        _NULLABLE_SHARE_TOKEN_SORT_FIELDS,
+        _share_token_ordering,
+    )
+
+    fields = ("map_name", "created_at", "creator", "expires_at", "embed_token_count")
+    for field in fields:
+        for order in ("asc", "desc"):
+            clauses = _share_token_ordering(
+                field,
+                order,
+                share=MapShareToken,
+                embed_count=literal_column("embed_count"),
+            )
+            assert clauses[-1] is Map.id, (
+                f"{field}/{order} has no unique tiebreak: {[str(c) for c in clauses]}"
+            )
+            rendered = str(clauses[0]).upper()
+            assert order.upper() in rendered, rendered
+            if field in _NULLABLE_SHARE_TOKEN_SORT_FIELDS:
+                assert "NULLS LAST" in rendered, f"{field}/{order}: {rendered}"
+            else:
+                assert "NULLS LAST" not in rendered, f"{field}/{order}: {rendered}"
+
+    assert _NULLABLE_SHARE_TOKEN_SORT_FIELDS <= set(fields)
+
+
+def test_link_status_is_not_offered_as_a_sort_key():
+    """Link status is derived in Python, so the database cannot order by it.
+
+    Pinned as a test because the column IS in the response, which makes adding
+    it to the allowlist look harmless; it would need a CASE the query lacks.
+    """
+    from sqlalchemy import literal_column
+
+    from app.modules.catalog.maps.models import MapShareToken
+    from app.modules.catalog.maps.service_public import _share_token_ordering
+
+    for field in ("link_status", "is_active", "status"):
+        with pytest.raises(ValueError, match="Unsupported sort field"):
+            _share_token_ordering(
+                field,
+                "asc",
+                share=MapShareToken,
+                embed_count=literal_column("embed_count"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Allowlist enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bogus_sort",
+    [
+        "basemap_style",  # a real Map column, deliberately not sortable
+        "link_status",  # derived in Python after the query
+        "map_name; DROP TABLE catalog.maps",
+        "(SELECT 1)",
+        "",
+    ],
+)
+@pytest.mark.anyio
+async def test_unknown_sort_field_is_refused_not_executed(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    bogus_sort: str,
+):
+    """A sort field outside the allowlist is a 422, never a silent default."""
+    resp = await client.get(
+        "/admin/share-tokens/",
+        params={"sort": bogus_sort, "limit": 1},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, f"{bogus_sort!r} -> {resp.status_code} {resp.text}"
+
+
+@pytest.mark.parametrize("bogus_order", ["sideways", "ASC; --", "1"])
+@pytest.mark.anyio
+async def test_unknown_sort_order_is_refused(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    bogus_order: str,
+):
+    """A direction outside asc/desc is a 422."""
+    resp = await client.get(
+        "/admin/share-tokens/",
+        params={"order": bogus_order, "limit": 1},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 422, f"{bogus_order!r} -> {resp.status_code}"
+
+
+@pytest.mark.anyio
+async def test_every_advertised_sort_field_is_accepted(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """The refusal tests above must not be passing by refusing everything."""
+    from typing import get_args
+
+    from app.modules.admin.schemas import ShareTokenSortField
+
+    fields = get_args(ShareTokenSortField)
+    assert fields, "allowlist is empty; the tests above prove nothing"
+    for field in fields:
+        for order in ("asc", "desc"):
+            resp = await client.get(
+                "/admin/share-tokens/",
+                params={"sort": field, "order": order, "limit": 1},
+                headers=admin_auth_header,
+            )
+            assert resp.status_code == 200, f"{field}/{order} -> {resp.text}"
+
+
+@pytest.mark.anyio
+async def test_service_layer_rejects_unmapped_sort_key(test_db_session):
+    """The service refuses an unmapped key even if the router is bypassed."""
+    from app.modules.catalog.maps.service import list_share_tokens
+
+    with pytest.raises(ValueError, match="Unsupported sort field"):
+        await list_share_tokens(test_db_session, sort="basemap_style")
+    with pytest.raises(ValueError, match="Unsupported sort order"):
+        await list_share_tokens(test_db_session, order="sideways")

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1568,7 +1568,16 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # could not classify as stranded by a move that did not happen. Most of
         # the lines are why it sits above the branch rather than inside one.
         # Cap 901 -> 914, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 914,
+        # fix(#1204): +66 — sortable column headers on the admin Published Maps
+        # table need list_share_tokens to order by more than the map's
+        # created_at. Most of the lines are _share_token_ordering: the sort
+        # allowlist, the NULLS LAST pinning for creator/expires_at (an outer
+        # join makes every linkless map null there), and why the embed count is
+        # ordered by the COALESCE'd expression the cell renders rather than the
+        # raw aggregate (which is NULL, not 0, for a map with no ACTIVE embed
+        # token — and the count never exceeds 1, per the partial unique index).
+        # Cap 914 -> 983, exact.
+        "backend/app/modules/catalog/maps/service_public.py": 983,
         "backend/app/modules/catalog/search/service_records.py": 500,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in
@@ -1798,7 +1807,10 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # detail + response) and maps the inactive-owner mint refusal to 409.
     # fix(#875): +7 lines — admin key mint accepts scope, and surfaces it
     # in the audit detail, the create response, and the list item.
-    "backend/app/modules/admin/router_operations.py": 296,
+    # fix(#1204): +20 lines — the published-maps listing takes sort/order as
+    # closed enums, with the descriptions that say which columns are absent
+    # (link status) and why.
+    "backend/app/modules/admin/router_operations.py": 316,
     "backend/app/modules/settings/router_public.py": 150,
 }
 

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,4 +1,18 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+// fix(#1204): the sortable column headers are tabbable buttons sitting between
+// the filter bar and the row toggles, so the first row control is a bounded
+// number of Tabs away from "Clear" rather than exactly one. Tab until the
+// target gains focus; the final assertion still fails loudly if it never does.
+async function tabUntilFocused(page: Page, target: Locator, maxTabs = 12) {
+  for (let i = 0; i < maxTabs; i += 1) {
+    await page.keyboard.press('Tab');
+    if (await target.evaluate((el) => el === document.activeElement).catch(() => false)) {
+      break;
+    }
+  }
+  await expect(target).toBeFocused();
+}
 
 test.describe('Admin Panel', () => {
   test('overview page loads with stats', async ({ page }) => {
@@ -47,8 +61,7 @@ test.describe('Admin Panel', () => {
     await expect(detailsToggle).toBeVisible();
 
     await page.getByRole('button', { name: 'Clear' }).focus();
-    await page.keyboard.press('Tab');
-    await expect(detailsToggle).toBeFocused();
+    await tabUntilFocused(page, detailsToggle);
 
     const jobToggleCount = await detailsToggles.count();
     if (jobToggleCount > 1) {
@@ -104,8 +117,7 @@ test.describe('Admin Panel', () => {
     await expect(firstToggle).toBeVisible();
 
     await page.getByRole('button', { name: 'Clear' }).focus();
-    await page.keyboard.press('Tab');
-    await expect(firstToggle).toBeFocused();
+    await tabUntilFocused(page, firstToggle);
 
     const auditToggleCount = await detailsToggles.count();
     if (auditToggleCount > 1) {

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -49,7 +49,15 @@ export async function listUserNames(): Promise<{ id: string; username: string }[
 }
 
 export async function listAdminJobs(
-  params: { status?: string; user_id?: string; search?: string; skip?: number; limit?: number } = {},
+  params: {
+    status?: string;
+    user_id?: string;
+    search?: string;
+    skip?: number;
+    limit?: number;
+    sort?: string;
+    order?: string;
+  } = {},
 ): Promise<AdminJobListResponse> {
   const query = new URLSearchParams();
   if (params.status) query.set('status', params.status);
@@ -57,6 +65,8 @@ export async function listAdminJobs(
   if (params.search) query.set('search', params.search);
   if (params.skip !== undefined) query.set('skip', String(params.skip));
   if (params.limit !== undefined) query.set('limit', String(params.limit));
+  if (params.sort) query.set('sort', params.sort);
+  if (params.order) query.set('order', params.order);
   const qs = query.toString();
   return apiFetch<AdminJobListResponse>(`/admin/jobs/${qs ? `?${qs}` : ''}`);
 }
@@ -72,6 +82,8 @@ export async function listAuditLogs(
     search?: string;
     skip?: number;
     limit?: number;
+    sort?: string;
+    order?: string;
   } = {},
 ): Promise<AuditLogListResponse> {
   const query = new URLSearchParams();
@@ -84,6 +96,8 @@ export async function listAuditLogs(
   if (params.search) query.set('search', params.search);
   if (params.skip !== undefined) query.set('skip', String(params.skip));
   if (params.limit !== undefined) query.set('limit', String(params.limit));
+  if (params.sort) query.set('sort', params.sort);
+  if (params.order) query.set('order', params.order);
   const qs = query.toString();
   return apiFetch<AuditLogListResponse>(`/admin/audit-logs/${qs ? `?${qs}` : ''}`);
 }
@@ -153,13 +167,22 @@ export async function revokeApiKey(keyId: string): Promise<void> {
 
 // Share tokens
 export async function listShareTokens(
-  params: { skip?: number; limit?: number; search?: string; status?: string } = {},
+  params: {
+    skip?: number;
+    limit?: number;
+    search?: string;
+    status?: string;
+    sort?: string;
+    order?: string;
+  } = {},
 ): Promise<AdminShareTokenListResponse> {
   const query = new URLSearchParams();
   if (params.skip !== undefined) query.set('skip', String(params.skip));
   if (params.limit !== undefined) query.set('limit', String(params.limit));
   if (params.search) query.set('search', params.search);
   if (params.status) query.set('status', params.status);
+  if (params.sort) query.set('sort', params.sort);
+  if (params.order) query.set('order', params.order);
   const qs = query.toString();
   return apiFetch<AdminShareTokenListResponse>(`/admin/share-tokens/${qs ? `?${qs}` : ''}`);
 }

--- a/frontend/src/components/admin/AuditLogViewer.tsx
+++ b/frontend/src/components/admin/AuditLogViewer.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useAuditLogs } from '@/hooks/use-admin';
 import { formatDateTimeSmart } from '@/lib/format';
@@ -11,6 +11,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table';
 import { DataTablePagination } from './DataTablePagination';
+import { SortableColumnHeader, type SortDirection } from './SortableColumnHeader';
 import { DataTableSearch } from './DataTableSearch';
 import { DataTableSkeleton } from './DataTableSkeleton';
 import { ExportSplitButton } from './ExportSplitButton';
@@ -19,6 +20,31 @@ import { ErrorState } from '@/components/layout/ErrorState';
 
 const PAGE_SIZE = 25;
 const UUID_PATTERN = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i;
+
+/** Mirrors the AuditSortField allowlist on GET /admin/audit-logs/. Resource
+ *  name and resource id are absent by design: the name is resolved per page
+ *  AFTER the query returns, and the id is an opaque uuid nobody orders by.
+ *  A header for the name would sort only the visible page, which looks
+ *  correct and is not. */
+const SORTABLE_FIELDS = [
+  'created_at',
+  'username',
+  'action',
+  'resource_type',
+  'ip_address',
+] as const;
+type SortField = (typeof SORTABLE_FIELDS)[number];
+
+const DEFAULT_SORT: SortField = 'created_at';
+const DEFAULT_ORDER: SortDirection = 'desc';
+
+function parseSortField(raw: string | null): SortField {
+  return SORTABLE_FIELDS.includes(raw as SortField) ? (raw as SortField) : DEFAULT_SORT;
+}
+
+function parseSortOrder(raw: string | null): SortDirection {
+  return raw === 'desc' || raw === 'asc' ? raw : DEFAULT_ORDER;
+}
 
 // fix(#620): resource types with a frontend detail route the name can link to.
 const RESOURCE_ROUTES: Record<string, string> = {
@@ -109,6 +135,16 @@ const CURRENT_AUDIT_ACTIONS = [
 
 export function AuditLogViewer() {
   const { t } = useTranslation('admin');
+  // Sort lives in the URL so a sorted view is shareable. Sort clicks REPLACE
+  // the history entry rather than pushing — deliberately, per the #1200
+  // review: pushing would make five header clicks cost five Back presses to
+  // leave the page, and it matches JobList's replace-on-refinement pattern
+  // (#1185). The trade is that Back leaves the page instead of stepping
+  // through orderings. An unrecognised ?sort= falls back to the default
+  // rather than erroring the page; the API refuses it independently.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sortField = parseSortField(searchParams.get('sort'));
+  const sortOrder = parseSortOrder(searchParams.get('order'));
   const [action, setAction] = useState('');
   const [userId, setUserId] = useState('');
   const [resourceType, setResourceType] = useState('');
@@ -119,6 +155,24 @@ export function AuditLogViewer() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const toggleRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  function handleSort(field: string) {
+    // Compare against the EFFECTIVE field, not the raw param: with no ?sort=
+    // the Timestamp column already renders as the active descending sort, so
+    // clicking it must flip to ascending rather than re-assert descending.
+    const next = sortField === field && sortOrder === 'asc' ? 'desc' : 'asc';
+    setSearchParams(
+      (params) => {
+        params.set('sort', field);
+        params.set('order', next);
+        return params;
+      },
+      { replace: true },
+    );
+    // A new ordering renumbers every page, so page 3 of the old sort names
+    // different rows under the new one.
+    setPage(0);
+  }
 
   const skip = page * PAGE_SIZE;
   const normalizedUserId = userId.trim();
@@ -144,6 +198,8 @@ export function AuditLogViewer() {
     search: searchQuery || undefined,
     skip,
     limit: PAGE_SIZE,
+    sort: sortField,
+    order: sortOrder,
   }, { enabled: filtersValid });
   // keepPreviousData must not leave a broad prior result visible beside an
   // invalid, visibly populated identity filter.
@@ -385,16 +441,49 @@ export function AuditLogViewer() {
                 <Table aria-label={t('audit.title')} containerFocusable={false}>
                 <TableHeader>
                   <TableRow>
+                    {/* The disclosure column has no data to order by. */}
                     <TableHead className="w-12">
                       <span className="sr-only">{t('audit.table.details', { defaultValue: 'Details' })}</span>
                     </TableHead>
-                    <TableHead>{t('audit.table.timestamp')}</TableHead>
-                    <TableHead>{t('audit.table.user')}</TableHead>
-                    <TableHead>{t('audit.table.action')}</TableHead>
-                    <TableHead>{t('audit.table.resource')}</TableHead>
+                    <SortableColumnHeader
+                      label={t('audit.table.timestamp')}
+                      field="created_at"
+                      activeField={sortField}
+                      direction={sortOrder}
+                      onSort={handleSort}
+                    />
+                    <SortableColumnHeader
+                      label={t('audit.table.user')}
+                      field="username"
+                      activeField={sortField}
+                      direction={sortOrder}
+                      onSort={handleSort}
+                    />
+                    <SortableColumnHeader
+                      label={t('audit.table.action')}
+                      field="action"
+                      activeField={sortField}
+                      direction={sortOrder}
+                      onSort={handleSort}
+                    />
+                    <SortableColumnHeader
+                      label={t('audit.table.resource')}
+                      field="resource_type"
+                      activeField={sortField}
+                      direction={sortOrder}
+                      onSort={handleSort}
+                    />
+                    {/* Resource name and id are intentionally not sortable —
+                        see SORTABLE_FIELDS. */}
                     <TableHead>{t('audit.table.resourceName')}</TableHead>
                     <TableHead>{t('audit.table.resourceId')}</TableHead>
-                    <TableHead>{t('audit.table.ipAddress')}</TableHead>
+                    <SortableColumnHeader
+                      label={t('audit.table.ipAddress')}
+                      field="ip_address"
+                      activeField={sortField}
+                      direction={sortOrder}
+                      onSort={handleSort}
+                    />
                   </TableRow>
                 </TableHeader>
                 <TableBody>

--- a/frontend/src/components/admin/JobList.tsx
+++ b/frontend/src/components/admin/JobList.tsx
@@ -11,12 +11,36 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table';
 import { DataTablePagination } from './DataTablePagination';
+import { SortableColumnHeader, type SortDirection } from './SortableColumnHeader';
 import { DataTableSearch } from './DataTableSearch';
 import { DataTableSkeleton } from './DataTableSkeleton';
 import { FilterSelect } from './FilterSelect';
 import { ErrorState } from '@/components/layout/ErrorState';
 
 const PAGE_SIZE = 25;
+
+/** Mirrors the JobSortField allowlist on GET /admin/jobs/. The retry control
+ *  is absent by design: it is computed per page after the query, so a header
+ *  for it would sort only the visible page, which looks correct and is not. */
+const SORTABLE_FIELDS = [
+  'created_at',
+  'username',
+  'source_filename',
+  'status',
+  'duration',
+] as const;
+type SortField = (typeof SORTABLE_FIELDS)[number];
+
+const DEFAULT_SORT: SortField = 'created_at';
+const DEFAULT_ORDER: SortDirection = 'desc';
+
+function parseSortField(raw: string | null): SortField {
+  return SORTABLE_FIELDS.includes(raw as SortField) ? (raw as SortField) : DEFAULT_SORT;
+}
+
+function parseSortOrder(raw: string | null): SortDirection {
+  return raw === 'desc' || raw === 'asc' ? raw : DEFAULT_ORDER;
+}
 
 const STATUS_OPTIONS = [
   { value: '', labelKey: 'jobs.filters.allStatuses' },
@@ -69,6 +93,16 @@ export function JobList() {
     },
     [setSearchParams],
   );
+  // Sort lives in the URL alongside status, so a sorted view is shareable.
+  // Sort clicks REPLACE the history entry rather than pushing — deliberately,
+  // per the #1200 review: pushing would make five header clicks cost five Back
+  // presses to leave the page, and it matches this component's own
+  // replace-on-refinement pattern (#1185). The trade is that Back leaves the
+  // page instead of stepping through orderings. An unrecognised ?sort= falls
+  // back to the default rather than erroring; the API refuses it independently.
+  const sortField = parseSortField(searchParams.get('sort'));
+  const sortOrder = parseSortOrder(searchParams.get('order'));
+
   const [userId, setUserId] = useState('');
   const [page, setPage] = useState(0);
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -103,6 +137,29 @@ export function JobList() {
     setPage(0);
   }, [locationKey]);
 
+  function handleSort(field: string) {
+    // Compare against the EFFECTIVE field, not the raw param: with no ?sort=
+    // the Created column already renders as the active descending sort, so
+    // clicking it must flip to ascending rather than re-assert descending.
+    const next = sortField === field && sortOrder === 'asc' ? 'desc' : 'asc';
+    // fix(#1204): sorting is a refinement of the current view, so it takes the
+    // same self-write exemption the status dropdown does. Without the flag the
+    // effect above would read this write as an external navigation and clear
+    // the user's search and user filters on every header click.
+    isSelfWrite.current = true;
+    setSearchParams(
+      (params) => {
+        params.set('sort', field);
+        params.set('order', next);
+        return params;
+      },
+      { replace: true },
+    );
+    // A new ordering renumbers every page, so page 3 of the old sort names
+    // different rows under the new one.
+    setPage(0);
+  }
+
   const skip = page * PAGE_SIZE;
 
   const { data, isLoading, error, refetch } = useAdminJobs({
@@ -111,6 +168,8 @@ export function JobList() {
     search: searchQuery || undefined,
     skip,
     limit: PAGE_SIZE,
+    sort: sortField,
+    order: sortOrder,
   });
 
   const { data: userNames } = useUserNames();
@@ -257,14 +316,48 @@ export function JobList() {
                 <Table aria-label={t('jobs.title')} containerFocusable={false}>
                 <TableHeader>
                   <TableRow>
+                    {/* The disclosure column has no data to order by. */}
                     <TableHead className="w-12">
                       <span className="sr-only">{t('jobs.table.details', { defaultValue: 'Details' })}</span>
                     </TableHead>
-                    <TableHead>{t('jobs.table.createdAt')}</TableHead>
-                    <TableHead>{t('jobs.table.user')}</TableHead>
-                    <TableHead>{t('jobs.table.filename')}</TableHead>
-                    <TableHead>{t('jobs.table.status')}</TableHead>
-                    <TableHead>{t('jobs.table.duration')}</TableHead>
+                    <SortableColumnHeader
+                      label={t('jobs.table.createdAt')}
+                      field="created_at"
+                      activeField={sortField}
+                      direction={sortOrder}
+                      onSort={handleSort}
+                    />
+                    <SortableColumnHeader
+                      label={t('jobs.table.user')}
+                      field="username"
+                      activeField={sortField}
+                      direction={sortOrder}
+                      onSort={handleSort}
+                    />
+                    <SortableColumnHeader
+                      label={t('jobs.table.filename')}
+                      field="source_filename"
+                      activeField={sortField}
+                      direction={sortOrder}
+                      onSort={handleSort}
+                    />
+                    <SortableColumnHeader
+                      label={t('jobs.table.status')}
+                      field="status"
+                      activeField={sortField}
+                      direction={sortOrder}
+                      onSort={handleSort}
+                    />
+                    {/* Duration is displayed from started_at/completed_at but
+                        ordered by the same interval in SQL, so the column and
+                        the sort agree. */}
+                    <SortableColumnHeader
+                      label={t('jobs.table.duration')}
+                      field="duration"
+                      activeField={sortField}
+                      direction={sortOrder}
+                      onSort={handleSort}
+                    />
                   </TableRow>
                 </TableHeader>
                 <TableBody>

--- a/frontend/src/components/admin/__tests__/AuditLogViewer.sorting.test.tsx
+++ b/frontend/src/components/admin/__tests__/AuditLogViewer.sorting.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, within } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { useLocation } from 'react-router';
+import { AuditLogViewer } from '../AuditLogViewer';
+
+// fix(#1204): the audit log is server-paginated, so ordering had to go through
+// the API — sorting only the current page would leave page 1 sorted and page 2
+// unrelated, which looks correct in the UI and is not. These tests pin the
+// URL-owned sort state, the accessibility contract, and the two columns that
+// deliberately have no sort control.
+
+const { mockUseAuditLogs } = vi.hoisted(() => ({ mockUseAuditLogs: vi.fn() }));
+
+vi.mock('@/hooks/use-admin', () => ({
+  useAuditLogs: (...args: unknown[]) => mockUseAuditLogs(...args),
+}));
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+/** Surfaces the live URL so state->URL can be asserted, not just URL->state. */
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{location.search}</output>;
+}
+
+function lastCall() {
+  return mockUseAuditLogs.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+}
+
+// The headers only render when the list has rows, so every test needs one.
+const LOG = {
+  id: '22222222-2222-4222-8222-222222222222',
+  user_id: null,
+  username: 'alice',
+  action: 'metadata.edit',
+  resource_type: 'dataset',
+  resource_id: '33333333-3333-4333-8333-333333333333',
+  resource_name: 'Parcels',
+  details: null,
+  ip_address: '203.0.113.7',
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+function renderViewer(route = '/admin/audit', total = 1) {
+  mockUseAuditLogs.mockReturnValue({
+    data: { logs: [LOG], total },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  return render(
+    <>
+      <AuditLogViewer />
+      <LocationProbe />
+    </>,
+    { route },
+  );
+}
+
+beforeEach(() => {
+  mockUseAuditLogs.mockReset();
+});
+
+describe('AuditLogViewer sorting', () => {
+  it('requests the historical created_at descending order by default', () => {
+    renderViewer();
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'desc' });
+  });
+
+  it('names the sortable header with its visible label plus the next action', () => {
+    renderViewer();
+
+    // The accessible name must CONTAIN the visible label (WCAG 2.5.3) — an
+    // aria-label would have replaced it.
+    expect(
+      screen.getByRole('button', { name: 'Action, sort ascending' }),
+    ).toBeInTheDocument();
+  });
+
+  it('marks sort state with aria-sort on the th, not on the button', () => {
+    renderViewer('/admin/audit?sort=action&order=desc');
+
+    expect(screen.getByRole('columnheader', { name: /Action/ })).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+    expect(screen.getByRole('columnheader', { name: /IP Address/ })).toHaveAttribute(
+      'aria-sort',
+      'none',
+    );
+    // The active header now offers the opposite direction.
+    expect(
+      screen.getByRole('button', { name: 'Action, sort ascending' }),
+    ).toBeInTheDocument();
+  });
+
+  it('sorts ascending on first activation and flips on the second', async () => {
+    const user = userEvent.setup();
+    renderViewer();
+
+    await user.click(screen.getByRole('button', { name: /^Action/ }));
+    expect(lastCall()).toMatchObject({ sort: 'action', order: 'asc' });
+
+    await user.click(screen.getByRole('button', { name: /^Action/ }));
+    expect(lastCall()).toMatchObject({ sort: 'action', order: 'desc' });
+  });
+
+  it('flips the default column to ascending on first activation', async () => {
+    const user = userEvent.setup();
+    renderViewer();
+
+    // Timestamp is already the active DESCENDING sort, so activating it must
+    // reverse rather than re-assert descending.
+    await user.click(screen.getByRole('button', { name: /^Timestamp/ }));
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'asc' });
+  });
+
+  it('is operable from the keyboard', async () => {
+    const user = userEvent.setup();
+    renderViewer();
+
+    const header = screen.getByRole('button', { name: /^IP Address/ });
+    header.focus();
+    await user.keyboard('{Enter}');
+
+    expect(lastCall()).toMatchObject({ sort: 'ip_address', order: 'asc' });
+  });
+
+  it('owns sort state in the URL', async () => {
+    const user = userEvent.setup();
+    renderViewer();
+
+    await user.click(screen.getByRole('button', { name: /^User/ }));
+
+    const search = screen.getByTestId('location').textContent ?? '';
+    expect(new URLSearchParams(search).get('sort')).toBe('username');
+    expect(new URLSearchParams(search).get('order')).toBe('asc');
+  });
+
+  it('reads sort state back out of the URL', () => {
+    renderViewer('/admin/audit?sort=resource_type&order=asc');
+
+    expect(lastCall()).toMatchObject({ sort: 'resource_type', order: 'asc' });
+  });
+
+  it('falls back to the default for a sort field the API would refuse', () => {
+    // resource_name is the trap: it IS a visible column, but it is resolved
+    // per page after the query, so the API refuses it.
+    renderViewer('/admin/audit?sort=resource_name&order=sideways');
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'desc' });
+  });
+
+  it('composes sort with the resource-type filter instead of replacing it', async () => {
+    const user = userEvent.setup();
+    renderViewer();
+
+    await user.type(screen.getByLabelText('Resource type'), 'dataset');
+    await vi.waitFor(() =>
+      expect(lastCall()).toMatchObject({ resource_type: 'dataset' }),
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Action/ }));
+
+    expect(lastCall()).toMatchObject({ resource_type: 'dataset', sort: 'action' });
+  });
+
+  it('returns to the first page when the ordering changes', async () => {
+    const user = userEvent.setup();
+    renderViewer('/admin/audit', 100);
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    expect(lastCall()).toMatchObject({ skip: 25 });
+
+    await user.click(screen.getByRole('button', { name: /^Action/ }));
+    // Page 3 of the old ordering names different rows under the new one.
+    expect(lastCall()).toMatchObject({ skip: 0, sort: 'action' });
+  });
+
+  it('offers no sort control for columns the API cannot order', () => {
+    renderViewer();
+
+    // Name is resolved after the query; Resource ID is an opaque uuid; the
+    // disclosure column has no data at all.
+    for (const label of ['Name', 'Resource ID', 'Details']) {
+      const header = screen.getByRole('columnheader', { name: label });
+      expect(within(header).queryByRole('button')).toBeNull();
+      expect(header).not.toHaveAttribute('aria-sort');
+    }
+  });
+});

--- a/frontend/src/components/admin/__tests__/JobList.sorting.test.tsx
+++ b/frontend/src/components/admin/__tests__/JobList.sorting.test.tsx
@@ -1,0 +1,224 @@
+import { render, screen, within } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { useLocation } from 'react-router';
+import { JobList } from '../JobList';
+
+// fix(#1204): the Jobs list is server-paginated, so ordering had to go through
+// the API — sorting only the current page would leave page 1 sorted and page 2
+// unrelated, which looks correct in the UI and is not. These tests pin the
+// URL-owned sort state, the accessibility contract, and the columns that
+// deliberately have no sort control.
+
+const { mockUseAdminJobs } = vi.hoisted(() => ({ mockUseAdminJobs: vi.fn() }));
+
+vi.mock('@/hooks/use-admin', () => ({
+  useAdminJobs: (...args: unknown[]) => mockUseAdminJobs(...args),
+  useUserNames: () => ({ data: [] }),
+  useRetryAdminJob: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+/** Surfaces the live URL so state->URL can be asserted, not just URL->state. */
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{location.search}</output>;
+}
+
+function lastCall() {
+  return mockUseAdminJobs.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+}
+
+// The headers only render when the list has rows, so every test needs one.
+const JOB = {
+  id: '11111111-1111-4111-8111-111111111111',
+  status: 'complete',
+  source_filename: 'parcels.geojson',
+  dataset_id: null,
+  error_message: null,
+  can_retry: false,
+  retry_reason: null,
+  user_metadata: null,
+  created_by: null,
+  username: 'alice',
+  started_at: '2026-01-01T00:00:00Z',
+  completed_at: '2026-01-01T00:01:00Z',
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+function renderList(route = '/admin/jobs') {
+  return render(
+    <>
+      <JobList />
+      <LocationProbe />
+    </>,
+    { route },
+  );
+}
+
+beforeEach(() => {
+  mockUseAdminJobs.mockReset();
+  mockUseAdminJobs.mockReturnValue({
+    data: { jobs: [JOB], total: 1 },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+});
+
+describe('JobList sorting', () => {
+  it('requests the historical created_at descending order by default', () => {
+    renderList();
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'desc' });
+  });
+
+  it('names the sortable header with its visible label plus the next action', () => {
+    renderList();
+
+    // The accessible name must CONTAIN the visible label (WCAG 2.5.3) — an
+    // aria-label would have replaced it.
+    expect(
+      screen.getByRole('button', { name: 'Filename, sort ascending' }),
+    ).toBeInTheDocument();
+  });
+
+  it('marks sort state with aria-sort on the th, not on the button', () => {
+    renderList('/admin/jobs?sort=status&order=desc');
+
+    expect(screen.getByRole('columnheader', { name: /Status/ })).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+    expect(screen.getByRole('columnheader', { name: /Duration/ })).toHaveAttribute(
+      'aria-sort',
+      'none',
+    );
+    // The active header now offers the opposite direction.
+    expect(
+      screen.getByRole('button', { name: 'Status, sort ascending' }),
+    ).toBeInTheDocument();
+  });
+
+  it('sorts ascending on first activation and flips on the second', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole('button', { name: /^Filename/ }));
+    expect(lastCall()).toMatchObject({ sort: 'source_filename', order: 'asc' });
+
+    await user.click(screen.getByRole('button', { name: /^Filename/ }));
+    expect(lastCall()).toMatchObject({ sort: 'source_filename', order: 'desc' });
+  });
+
+  it('flips the default column to ascending on first activation', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    // Created At is already the active DESCENDING sort, so activating it must
+    // reverse rather than re-assert descending.
+    await user.click(screen.getByRole('button', { name: /^Created At/ }));
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'asc' });
+  });
+
+  it('offers Duration as a sort key, ordered by the elapsed interval', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    // Duration is rendered from started_at/completed_at but IS orderable: the
+    // API sorts by the completed_at - started_at interval.
+    await user.click(screen.getByRole('button', { name: /^Duration/ }));
+
+    expect(lastCall()).toMatchObject({ sort: 'duration', order: 'asc' });
+  });
+
+  it('is operable from the keyboard', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    const header = screen.getByRole('button', { name: /^User/ });
+    header.focus();
+    await user.keyboard('{Enter}');
+
+    expect(lastCall()).toMatchObject({ sort: 'username', order: 'asc' });
+  });
+
+  it('owns sort state in the URL', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole('button', { name: /^Status/ }));
+
+    const search = screen.getByTestId('location').textContent ?? '';
+    expect(new URLSearchParams(search).get('sort')).toBe('status');
+    expect(new URLSearchParams(search).get('order')).toBe('asc');
+  });
+
+  it('reads sort state back out of the URL', () => {
+    renderList('/admin/jobs?sort=duration&order=asc');
+
+    expect(lastCall()).toMatchObject({ sort: 'duration', order: 'asc' });
+  });
+
+  it('falls back to the default for a sort field the API would refuse', () => {
+    renderList('/admin/jobs?sort=file_path&order=sideways');
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'desc' });
+  });
+
+  it('keeps the status filter that arrived in the URL', async () => {
+    const user = userEvent.setup();
+    renderList('/admin/jobs?status=failed');
+
+    await user.click(screen.getByRole('button', { name: /^Filename/ }));
+
+    expect(lastCall()).toMatchObject({ status: 'failed', sort: 'source_filename' });
+  });
+
+  it('does not clear the search filter when a header is activated', async () => {
+    // fix(#1204): JobList resets its filters on any navigation it did not make
+    // itself (#1185), keyed on location.key. A sort write produces a new key,
+    // so without the self-write exemption every header click would silently
+    // wipe the user's search — the list would reorder AND widen at once.
+    const user = userEvent.setup();
+    renderList();
+
+    await user.type(screen.getByRole('textbox'), 'parcels');
+    await vi.waitFor(() => expect(lastCall()).toMatchObject({ search: 'parcels' }));
+
+    await user.click(screen.getByRole('button', { name: /^Filename/ }));
+
+    expect(lastCall()).toMatchObject({ search: 'parcels', sort: 'source_filename' });
+  });
+
+  it('returns to the first page when the ordering changes', async () => {
+    const user = userEvent.setup();
+    mockUseAdminJobs.mockReturnValue({
+      data: { jobs: [JOB], total: 100 },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderList();
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    expect(lastCall()).toMatchObject({ skip: 25 });
+
+    await user.click(screen.getByRole('button', { name: /^Filename/ }));
+    // Page 3 of the old ordering names different rows under the new one.
+    expect(lastCall()).toMatchObject({ skip: 0, sort: 'source_filename' });
+  });
+
+  it('offers no sort control for the disclosure column', () => {
+    renderList();
+
+    const header = screen.getByRole('columnheader', { name: 'Details' });
+    expect(within(header).queryByRole('button')).toBeNull();
+    expect(header).not.toHaveAttribute('aria-sort');
+  });
+});

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -74,6 +74,8 @@ export function useAuditLogs(params: {
   search?: string;
   skip?: number;
   limit?: number;
+  sort?: string;
+  order?: string;
 }, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: queryKeys.admin.auditLogs(params),
@@ -102,6 +104,8 @@ export function useAdminJobs(params: {
   search?: string;
   skip?: number;
   limit?: number;
+  sort?: string;
+  order?: string;
 }) {
   return useQuery({
     queryKey: queryKeys.admin.jobs(params),
@@ -262,10 +266,18 @@ export function useAIStatus(options?: { enabled?: boolean }) {
 }
 
 // Share token hooks
-export function useShareTokens(skip = 0, limit = 50, search?: string, status?: string) {
+export function useShareTokens(params: {
+  skip?: number;
+  limit?: number;
+  search?: string;
+  status?: string;
+  sort?: string;
+  order?: string;
+} = {}) {
+  const { skip = 0, limit = 50, search, status, sort, order } = params;
   return useQuery({
-    queryKey: queryKeys.admin.shareTokens(skip, limit, search, status),
-    queryFn: () => listShareTokens({ skip, limit, search, status }),
+    queryKey: queryKeys.admin.shareTokens(skip, limit, search, status, sort, order),
+    queryFn: () => listShareTokens({ skip, limit, search, status, sort, order }),
     placeholderData: keepPreviousData,
   });
 }

--- a/frontend/src/lib/__tests__/query-keys.test.ts
+++ b/frontend/src/lib/__tests__/query-keys.test.ts
@@ -191,6 +191,32 @@ describe('queryKeys factory', () => {
       );
     });
 
+    it('shareTokens includes skip, limit, search, status, sort, order', () => {
+      expect(queryKeys.admin.shareTokens(0, 50)).toEqual([
+        'admin', 'share-tokens', 0, 50, undefined, undefined, undefined, undefined,
+      ]);
+      expect(queryKeys.admin.shareTokens(0, 50, 'parcels', 'active')).toEqual([
+        'admin', 'share-tokens', 0, 50, 'parcels', 'active', undefined, undefined,
+      ]);
+      // Two orderings of the same page must not share a cache entry.
+      expect(
+        queryKeys.admin.shareTokens(0, 50, undefined, undefined, 'map_name', 'asc'),
+      ).not.toEqual(
+        queryKeys.admin.shareTokens(0, 50, undefined, undefined, 'map_name', 'desc'),
+      );
+    });
+
+    it('jobs and auditLogs separate two orderings of the same page', () => {
+      // Both take the whole params object, so sort/order ride along without a
+      // signature change — but only if the caller actually passes them.
+      expect(queryKeys.admin.jobs({ skip: 0, sort: 'status', order: 'asc' })).not.toEqual(
+        queryKeys.admin.jobs({ skip: 0, sort: 'status', order: 'desc' }),
+      );
+      expect(
+        queryKeys.admin.auditLogs({ skip: 0, sort: 'action', order: 'asc' }),
+      ).not.toEqual(queryKeys.admin.auditLogs({ skip: 0, sort: 'action', order: 'desc' }));
+    });
+
     it('aiStatus returns expected key', () => {
       expect(queryKeys.admin.aiStatus).toEqual(['admin', 'ai-status']);
     });

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -148,8 +148,18 @@ export const queryKeys = {
     publishedMapCount: ['admin', 'share-tokens', 'count'] as const,
     auditLogCount: ['admin', 'audit-logs', 'count'] as const,
     aiStatus: ['admin', 'ai-status'] as const,
-    shareTokens: (skip: number, limit: number, search?: string, status?: string) =>
-      ['admin', 'share-tokens', skip, limit, search, status] as const,
+    // sort/order belong in the key: two orderings of the same page are
+    // different responses, and sharing a key would serve one for the other.
+    // The jobs/auditLogs keys take the whole params object, so they carry
+    // sort/order without a signature change.
+    shareTokens: (
+      skip: number,
+      limit: number,
+      search?: string,
+      status?: string,
+      sort?: string,
+      order?: string,
+    ) => ['admin', 'share-tokens', skip, limit, search, status, sort, order] as const,
     allShareTokens: ['admin', 'share-tokens'] as const,
     embedTokens: (params: Record<string, unknown>) => ['admin', 'embed-tokens', params] as const,
     allEmbedTokens: ['admin', 'embed-tokens'] as const,

--- a/frontend/src/pages/admin/AdminSharedMapsPage.tsx
+++ b/frontend/src/pages/admin/AdminSharedMapsPage.tsx
@@ -31,10 +31,14 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { DataTablePagination } from '@/components/admin/DataTablePagination';
+import {
+  SortableColumnHeader,
+  type SortDirection,
+} from '@/components/admin/SortableColumnHeader';
 import { DataTableSearch } from '@/components/admin/DataTableSearch';
 import { DataTableSkeleton } from '@/components/admin/DataTableSkeleton';
 import { semanticBadgeColors } from '@/lib/status-colors';
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 import { Link2Off, ChevronDown, ChevronRight, Key, ShieldOff } from 'lucide-react';
 import { toast } from 'sonner';
 import type { AdminShareTokenResponse, AdminEmbedTokenResponse } from '@/types/api';
@@ -43,6 +47,31 @@ import { paginationRange } from '@/lib/pagination';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 
 const PAGE_SIZE = 50;
+
+/** Mirrors the ShareTokenSortField allowlist on GET /admin/share-tokens/.
+ *  Link status is absent by design: it is derived in Python from is_active
+ *  plus expires_at against now(), so the database has no column to order by.
+ *  A header for it would sort only the visible page, which looks correct and
+ *  is not. */
+const SORTABLE_FIELDS = [
+  'map_name',
+  'embed_token_count',
+  'expires_at',
+  'created_at',
+  'creator',
+] as const;
+type SortField = (typeof SORTABLE_FIELDS)[number];
+
+const DEFAULT_SORT: SortField = 'created_at';
+const DEFAULT_ORDER: SortDirection = 'desc';
+
+function parseSortField(raw: string | null): SortField {
+  return SORTABLE_FIELDS.includes(raw as SortField) ? (raw as SortField) : DEFAULT_SORT;
+}
+
+function parseSortOrder(raw: string | null): SortDirection {
+  return raw === 'desc' || raw === 'asc' ? raw : DEFAULT_ORDER;
+}
 
 type EmbedTokenStatus = 'active' | 'expiring_soon' | 'expired' | 'revoked';
 
@@ -228,8 +257,44 @@ export function AdminSharedMapsPage() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('');
+  // Sort lives in the URL so a sorted view is shareable. Sort clicks REPLACE
+  // the history entry rather than pushing — deliberately, per the #1200
+  // review: pushing would make five header clicks cost five Back presses to
+  // leave the page, and it matches JobList's replace-on-refinement pattern
+  // (#1185). The trade is that Back leaves the page instead of stepping
+  // through orderings. An unrecognised ?sort= falls back to the default
+  // rather than erroring the page; the API refuses it independently.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sortField = parseSortField(searchParams.get('sort'));
+  const sortOrder = parseSortOrder(searchParams.get('order'));
+
+  function handleSort(field: string) {
+    // Compare against the EFFECTIVE field, not the raw param: with no ?sort=
+    // the Created column already renders as the active descending sort, so
+    // clicking it must flip to ascending rather than re-assert descending.
+    const next = sortField === field && sortOrder === 'asc' ? 'desc' : 'asc';
+    setSearchParams(
+      (params) => {
+        params.set('sort', field);
+        params.set('order', next);
+        return params;
+      },
+      { replace: true },
+    );
+    // A new ordering renumbers every page, so page 3 of the old sort names
+    // different rows under the new one.
+    setPage(0);
+  }
+
   const skip = page * PAGE_SIZE;
-  const { data, isLoading, isError } = useShareTokens(skip, PAGE_SIZE, search || undefined, statusFilter || undefined);
+  const { data, isLoading, isError } = useShareTokens({
+    skip,
+    limit: PAGE_SIZE,
+    search: search || undefined,
+    status: statusFilter || undefined,
+    sort: sortField,
+    order: sortOrder,
+  });
   const revoke = useAdminRevokeShareToken();
 
   const total = data?.total ?? 0;
@@ -283,13 +348,46 @@ export function AdminSharedMapsPage() {
           <Table aria-label={t('sharedMaps.title')}>
             <TableHeader>
               <TableRow>
+                {/* The disclosure column has no data to order by. */}
                 <TableHead className="w-10" />
-                <TableHead>{t('sharedMaps.mapName')}</TableHead>
+                <SortableColumnHeader
+                  label={t('sharedMaps.mapName')}
+                  field="map_name"
+                  activeField={sortField}
+                  direction={sortOrder}
+                  onSort={handleSort}
+                />
+                {/* Link status is intentionally not sortable — see
+                    SORTABLE_FIELDS. */}
                 <TableHead>{t('sharedMaps.linkStatus')}</TableHead>
-                <TableHead>{t('sharedMaps.embedTokens')}</TableHead>
-                <TableHead>{t('sharedMaps.expires')}</TableHead>
-                <TableHead>{t('sharedMaps.created')}</TableHead>
-                <TableHead>{t('sharedMaps.creator')}</TableHead>
+                <SortableColumnHeader
+                  label={t('sharedMaps.embedTokens')}
+                  field="embed_token_count"
+                  activeField={sortField}
+                  direction={sortOrder}
+                  onSort={handleSort}
+                />
+                <SortableColumnHeader
+                  label={t('sharedMaps.expires')}
+                  field="expires_at"
+                  activeField={sortField}
+                  direction={sortOrder}
+                  onSort={handleSort}
+                />
+                <SortableColumnHeader
+                  label={t('sharedMaps.created')}
+                  field="created_at"
+                  activeField={sortField}
+                  direction={sortOrder}
+                  onSort={handleSort}
+                />
+                <SortableColumnHeader
+                  label={t('sharedMaps.creator')}
+                  field="creator"
+                  activeField={sortField}
+                  direction={sortOrder}
+                  onSort={handleSort}
+                />
                 <TableHead className="text-end">{t('sharedMaps.actions')}</TableHead>
               </TableRow>
             </TableHeader>

--- a/frontend/src/pages/admin/__tests__/AdminSharedMapsPage.sorting.test.tsx
+++ b/frontend/src/pages/admin/__tests__/AdminSharedMapsPage.sorting.test.tsx
@@ -1,0 +1,195 @@
+import { render, screen, within } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { useLocation } from 'react-router';
+import { AdminSharedMapsPage } from '../AdminSharedMapsPage';
+
+// fix(#1204): the Published Maps list is server-paginated, so ordering had to
+// go through the API — sorting only the current page would leave page 1 sorted
+// and page 2 unrelated, which looks correct in the UI and is not. These tests
+// pin the URL-owned sort state, the accessibility contract, and the link-status
+// column that deliberately has no sort control.
+
+const { mockUseShareTokens } = vi.hoisted(() => ({ mockUseShareTokens: vi.fn() }));
+
+vi.mock('@/hooks/use-admin', () => ({
+  useShareTokens: (...args: unknown[]) => mockUseShareTokens(...args),
+  useAdminRevokeShareToken: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useAdminEmbedTokens: () => ({ data: undefined, isLoading: false }),
+  useBulkRevokeEmbedTokens: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/hooks/use-document-title', () => ({ useDocumentTitle: vi.fn() }));
+
+/** Surfaces the live URL so state->URL can be asserted, not just URL->state. */
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{location.search}</output>;
+}
+
+function lastCall() {
+  return mockUseShareTokens.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+}
+
+const TOKEN = {
+  id: '44444444-4444-4444-8444-444444444444',
+  map_id: '55555555-5555-4555-8555-555555555555',
+  map_name: 'Parcels',
+  token: 'abcd1234',
+  is_active: true,
+  expires_at: null,
+  created_at: '2026-01-01T00:00:00Z',
+  created_by: 'alice',
+  embed_token_count: 0,
+};
+
+function renderPage(route = '/admin/shared-maps', total = 1) {
+  mockUseShareTokens.mockReturnValue({
+    data: { tokens: [TOKEN], total },
+    isLoading: false,
+    isError: false,
+  });
+  return render(
+    <>
+      <AdminSharedMapsPage />
+      <LocationProbe />
+    </>,
+    { route },
+  );
+}
+
+beforeEach(() => {
+  mockUseShareTokens.mockReset();
+});
+
+describe('AdminSharedMapsPage sorting', () => {
+  it('requests the historical created_at descending order by default', () => {
+    renderPage();
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'desc' });
+  });
+
+  it('names the sortable header with its visible label plus the next action', () => {
+    renderPage();
+
+    // The accessible name must CONTAIN the visible label (WCAG 2.5.3) — an
+    // aria-label would have replaced it.
+    expect(
+      screen.getByRole('button', { name: 'Map, sort ascending' }),
+    ).toBeInTheDocument();
+  });
+
+  it('marks sort state with aria-sort on the th, not on the button', () => {
+    renderPage('/admin/shared-maps?sort=map_name&order=desc');
+
+    expect(screen.getByRole('columnheader', { name: /Map/ })).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+    expect(screen.getByRole('columnheader', { name: /Creator/ })).toHaveAttribute(
+      'aria-sort',
+      'none',
+    );
+    // The active header now offers the opposite direction.
+    expect(
+      screen.getByRole('button', { name: 'Map, sort ascending' }),
+    ).toBeInTheDocument();
+  });
+
+  it('sorts ascending on first activation and flips on the second', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^Map,/ }));
+    expect(lastCall()).toMatchObject({ sort: 'map_name', order: 'asc' });
+
+    await user.click(screen.getByRole('button', { name: /^Map,/ }));
+    expect(lastCall()).toMatchObject({ sort: 'map_name', order: 'desc' });
+  });
+
+  it('flips the default column to ascending on first activation', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // Created is already the active DESCENDING sort, so activating it must
+    // reverse rather than re-assert descending.
+    await user.click(screen.getByRole('button', { name: /^Created/ }));
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'asc' });
+  });
+
+  it('sorts by the embed count, which the API orders as 0 not NULL', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^Embeds/ }));
+
+    expect(lastCall()).toMatchObject({ sort: 'embed_token_count', order: 'asc' });
+  });
+
+  it('is operable from the keyboard', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const header = screen.getByRole('button', { name: /^Expires/ });
+    header.focus();
+    await user.keyboard('{Enter}');
+
+    expect(lastCall()).toMatchObject({ sort: 'expires_at', order: 'asc' });
+  });
+
+  it('owns sort state in the URL', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^Creator/ }));
+
+    const search = screen.getByTestId('location').textContent ?? '';
+    expect(new URLSearchParams(search).get('sort')).toBe('creator');
+    expect(new URLSearchParams(search).get('order')).toBe('asc');
+  });
+
+  it('reads sort state back out of the URL', () => {
+    renderPage('/admin/shared-maps?sort=expires_at&order=asc');
+
+    expect(lastCall()).toMatchObject({ sort: 'expires_at', order: 'asc' });
+  });
+
+  it('falls back to the default for a sort field the API would refuse', () => {
+    // link_status is the trap: it IS a visible column, but it is derived in
+    // Python from is_active plus expires_at, so the API refuses it.
+    renderPage('/admin/shared-maps?sort=link_status&order=sideways');
+
+    expect(lastCall()).toMatchObject({ sort: 'created_at', order: 'desc' });
+  });
+
+  it('composes sort with the status filter instead of replacing it', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Active' }));
+    await user.click(screen.getByRole('button', { name: /^Map,/ }));
+
+    expect(lastCall()).toMatchObject({ status: 'active', sort: 'map_name' });
+  });
+
+  it('returns to the first page when the ordering changes', async () => {
+    const user = userEvent.setup();
+    renderPage('/admin/shared-maps', 200);
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    expect(lastCall()).toMatchObject({ skip: 50 });
+
+    await user.click(screen.getByRole('button', { name: /^Map,/ }));
+    // Page 3 of the old ordering names different rows under the new one.
+    expect(lastCall()).toMatchObject({ skip: 0, sort: 'map_name' });
+  });
+
+  it('offers no sort control for the link-status column', () => {
+    renderPage();
+
+    // "Status" here is the derived link status, not a database column.
+    const header = screen.getByRole('columnheader', { name: 'Status' });
+    expect(within(header).queryByRole('button')).toBeNull();
+    expect(header).not.toHaveAttribute('aria-sort');
+  });
+});

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -103,7 +103,10 @@ export interface paths {
         };
         /**
          * List Audit Logs
-         * @description Query audit logs with optional filters (admin only).
+         * @description Query audit logs with optional filters and sort (admin only).
+         *
+         *     `sort` and `order` are closed enums, so an unrecognised value is refused
+         *     with a 422 and never reaches the query.
          */
         get: operations["list_audit_logs_admin_audit_logs__get"];
         put?: never;
@@ -123,7 +126,7 @@ export interface paths {
         };
         /**
          * Download audit records
-         * @description Export up to 100,000 audit log rows as CSV or JSON.
+         * @description Export up to 100,000 audit log rows as CSV or JSON, newest first.
          */
         get: operations["export_audit_logs_admin_audit_logs_export__format__get"];
         put?: never;
@@ -246,7 +249,10 @@ export interface paths {
         };
         /**
          * List Admin Jobs
-         * @description List all ingestion jobs with optional status/user/search filters (admin only).
+         * @description List all ingestion jobs with optional status/user/search/sort filters (admin only).
+         *
+         *     `sort` and `order` are closed enums, so an unrecognised value is refused
+         *     with a 422 and never reaches the query.
          */
         get: operations["list_admin_jobs_admin_jobs__get"];
         put?: never;
@@ -267,6 +273,9 @@ export interface paths {
         /**
          * List Share Tokens Endpoint
          * @description List basic share-token inventory with map info; no quotas or domain controls (admin only).
+         *
+         *     `sort` and `order` are closed enums, so an unrecognised value is refused
+         *     with a 422 and never reaches the query.
          */
         get: operations["list_share_tokens_endpoint_admin_share_tokens__get"];
         put?: never;
@@ -13404,6 +13413,10 @@ export interface operations {
                 search?: string | null;
                 skip?: number;
                 limit?: number;
+                /** @description Column to order by. Resource name is not sortable: it is resolved per page after the query, so the database cannot order by it. */
+                sort?: "created_at" | "action" | "resource_type" | "ip_address" | "username";
+                /** @description Sort direction. */
+                order?: "asc" | "desc";
             };
             header?: never;
             path?: never;
@@ -14099,6 +14112,10 @@ export interface operations {
                 search?: string | null;
                 skip?: number;
                 limit?: number;
+                /** @description Column to order by. Duration orders by the completed_at - started_at interval, so unfinished jobs sort last either way. */
+                sort?: "created_at" | "source_filename" | "status" | "username" | "duration";
+                /** @description Sort direction. */
+                order?: "asc" | "desc";
             };
             header?: never;
             path?: never;
@@ -14198,6 +14215,10 @@ export interface operations {
                 limit?: number;
                 search?: string | null;
                 status?: string | null;
+                /** @description Column to order by. Link status is not sortable: it is derived from is_active and expires_at after the query returns. */
+                sort?: "map_name" | "created_at" | "creator" | "expires_at" | "embed_token_count";
+                /** @description Sort direction. */
+                order?: "asc" | "desc";
             };
             header?: never;
             path?: never;

--- a/sdks/python/geolens/api/admin/export_audit_logs_admin_audit_logs_export_format_get.py
+++ b/sdks/python/geolens/api/admin/export_audit_logs_admin_audit_logs_export_format_get.py
@@ -180,7 +180,7 @@ def sync_detailed(
 ) -> Response[Any | ProblemDetail]:
     """Download audit records
 
-     Export up to 100,000 audit log rows as CSV or JSON.
+     Export up to 100,000 audit log rows as CSV or JSON, newest first.
 
     Args:
         format_ (str):
@@ -235,7 +235,7 @@ def sync(
 ) -> Any | ProblemDetail | None:
     """Download audit records
 
-     Export up to 100,000 audit log rows as CSV or JSON.
+     Export up to 100,000 audit log rows as CSV or JSON, newest first.
 
     Args:
         format_ (str):
@@ -285,7 +285,7 @@ async def asyncio_detailed(
 ) -> Response[Any | ProblemDetail]:
     """Download audit records
 
-     Export up to 100,000 audit log rows as CSV or JSON.
+     Export up to 100,000 audit log rows as CSV or JSON, newest first.
 
     Args:
         format_ (str):
@@ -338,7 +338,7 @@ async def asyncio(
 ) -> Any | ProblemDetail | None:
     """Download audit records
 
-     Export up to 100,000 audit log rows as CSV or JSON.
+     Export up to 100,000 audit log rows as CSV or JSON, newest first.
 
     Args:
         format_ (str):

--- a/sdks/python/geolens/api/admin/list_admin_jobs_admin_jobs_get.py
+++ b/sdks/python/geolens/api/admin/list_admin_jobs_admin_jobs_get.py
@@ -8,6 +8,10 @@ from ...types import Response, UNSET
 from ... import errors
 
 from ...models.admin_job_list_response import AdminJobListResponse
+from ...models.list_admin_jobs_admin_jobs_get_order import (
+    ListAdminJobsAdminJobsGetOrder,
+)
+from ...models.list_admin_jobs_admin_jobs_get_sort import ListAdminJobsAdminJobsGetSort
 from ...models.problem_detail import ProblemDetail
 from ...types import Unset
 from uuid import UUID
@@ -20,6 +24,8 @@ def _get_kwargs(
     search: None | str | Unset = UNSET,
     skip: int | Unset = 0,
     limit: int | Unset = 50,
+    sort: ListAdminJobsAdminJobsGetSort | Unset = "created_at",
+    order: ListAdminJobsAdminJobsGetOrder | Unset = "desc",
 ) -> dict[str, Any]:
 
     params: dict[str, Any] = {}
@@ -50,6 +56,18 @@ def _get_kwargs(
     params["skip"] = skip
 
     params["limit"] = limit
+
+    json_sort: str | Unset = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort
+
+    params["sort"] = json_sort
+
+    json_order: str | Unset = UNSET
+    if not isinstance(order, Unset):
+        json_order = order
+
+    params["order"] = json_order
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -135,10 +153,15 @@ def sync_detailed(
     search: None | str | Unset = UNSET,
     skip: int | Unset = 0,
     limit: int | Unset = 50,
+    sort: ListAdminJobsAdminJobsGetSort | Unset = "created_at",
+    order: ListAdminJobsAdminJobsGetOrder | Unset = "desc",
 ) -> Response[AdminJobListResponse | ProblemDetail]:
     """List Admin Jobs
 
-     List all ingestion jobs with optional status/user/search filters (admin only).
+     List all ingestion jobs with optional status/user/search/sort filters (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         status (None | str | Unset):
@@ -146,6 +169,10 @@ def sync_detailed(
         search (None | str | Unset):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
+        sort (ListAdminJobsAdminJobsGetSort | Unset): Column to order by. Duration orders by the
+            completed_at - started_at interval, so unfinished jobs sort last either way. Default:
+            'created_at'.
+        order (ListAdminJobsAdminJobsGetOrder | Unset): Sort direction. Default: 'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -161,6 +188,8 @@ def sync_detailed(
         search=search,
         skip=skip,
         limit=limit,
+        sort=sort,
+        order=order,
     )
 
     response = client.get_httpx_client().request(
@@ -178,10 +207,15 @@ def sync(
     search: None | str | Unset = UNSET,
     skip: int | Unset = 0,
     limit: int | Unset = 50,
+    sort: ListAdminJobsAdminJobsGetSort | Unset = "created_at",
+    order: ListAdminJobsAdminJobsGetOrder | Unset = "desc",
 ) -> AdminJobListResponse | ProblemDetail | None:
     """List Admin Jobs
 
-     List all ingestion jobs with optional status/user/search filters (admin only).
+     List all ingestion jobs with optional status/user/search/sort filters (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         status (None | str | Unset):
@@ -189,6 +223,10 @@ def sync(
         search (None | str | Unset):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
+        sort (ListAdminJobsAdminJobsGetSort | Unset): Column to order by. Duration orders by the
+            completed_at - started_at interval, so unfinished jobs sort last either way. Default:
+            'created_at'.
+        order (ListAdminJobsAdminJobsGetOrder | Unset): Sort direction. Default: 'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -205,6 +243,8 @@ def sync(
         search=search,
         skip=skip,
         limit=limit,
+        sort=sort,
+        order=order,
     ).parsed
 
 
@@ -216,10 +256,15 @@ async def asyncio_detailed(
     search: None | str | Unset = UNSET,
     skip: int | Unset = 0,
     limit: int | Unset = 50,
+    sort: ListAdminJobsAdminJobsGetSort | Unset = "created_at",
+    order: ListAdminJobsAdminJobsGetOrder | Unset = "desc",
 ) -> Response[AdminJobListResponse | ProblemDetail]:
     """List Admin Jobs
 
-     List all ingestion jobs with optional status/user/search filters (admin only).
+     List all ingestion jobs with optional status/user/search/sort filters (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         status (None | str | Unset):
@@ -227,6 +272,10 @@ async def asyncio_detailed(
         search (None | str | Unset):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
+        sort (ListAdminJobsAdminJobsGetSort | Unset): Column to order by. Duration orders by the
+            completed_at - started_at interval, so unfinished jobs sort last either way. Default:
+            'created_at'.
+        order (ListAdminJobsAdminJobsGetOrder | Unset): Sort direction. Default: 'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -242,6 +291,8 @@ async def asyncio_detailed(
         search=search,
         skip=skip,
         limit=limit,
+        sort=sort,
+        order=order,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -257,10 +308,15 @@ async def asyncio(
     search: None | str | Unset = UNSET,
     skip: int | Unset = 0,
     limit: int | Unset = 50,
+    sort: ListAdminJobsAdminJobsGetSort | Unset = "created_at",
+    order: ListAdminJobsAdminJobsGetOrder | Unset = "desc",
 ) -> AdminJobListResponse | ProblemDetail | None:
     """List Admin Jobs
 
-     List all ingestion jobs with optional status/user/search filters (admin only).
+     List all ingestion jobs with optional status/user/search/sort filters (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         status (None | str | Unset):
@@ -268,6 +324,10 @@ async def asyncio(
         search (None | str | Unset):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
+        sort (ListAdminJobsAdminJobsGetSort | Unset): Column to order by. Duration orders by the
+            completed_at - started_at interval, so unfinished jobs sort last either way. Default:
+            'created_at'.
+        order (ListAdminJobsAdminJobsGetOrder | Unset): Sort direction. Default: 'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -285,5 +345,7 @@ async def asyncio(
             search=search,
             skip=skip,
             limit=limit,
+            sort=sort,
+            order=order,
         )
     ).parsed

--- a/sdks/python/geolens/api/admin/list_audit_logs_admin_audit_logs_get.py
+++ b/sdks/python/geolens/api/admin/list_audit_logs_admin_audit_logs_get.py
@@ -8,6 +8,12 @@ from ...types import Response, UNSET
 from ... import errors
 
 from ...models.audit_log_list_response import AuditLogListResponse
+from ...models.list_audit_logs_admin_audit_logs_get_order import (
+    ListAuditLogsAdminAuditLogsGetOrder,
+)
+from ...models.list_audit_logs_admin_audit_logs_get_sort import (
+    ListAuditLogsAdminAuditLogsGetSort,
+)
 from ...models.problem_detail import ProblemDetail
 from ...types import Unset
 from uuid import UUID
@@ -25,6 +31,8 @@ def _get_kwargs(
     search: None | str | Unset = UNSET,
     skip: int | Unset = 0,
     limit: int | Unset = 50,
+    sort: ListAuditLogsAdminAuditLogsGetSort | Unset = "created_at",
+    order: ListAuditLogsAdminAuditLogsGetOrder | Unset = "desc",
 ) -> dict[str, Any]:
 
     params: dict[str, Any] = {}
@@ -89,6 +97,18 @@ def _get_kwargs(
     params["skip"] = skip
 
     params["limit"] = limit
+
+    json_sort: str | Unset = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort
+
+    params["sort"] = json_sort
+
+    json_order: str | Unset = UNSET
+    if not isinstance(order, Unset):
+        json_order = order
+
+    params["order"] = json_order
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -178,10 +198,15 @@ def sync_detailed(
     search: None | str | Unset = UNSET,
     skip: int | Unset = 0,
     limit: int | Unset = 50,
+    sort: ListAuditLogsAdminAuditLogsGetSort | Unset = "created_at",
+    order: ListAuditLogsAdminAuditLogsGetOrder | Unset = "desc",
 ) -> Response[AuditLogListResponse | ProblemDetail]:
     """List Audit Logs
 
-     Query audit logs with optional filters (admin only).
+     Query audit logs with optional filters and sort (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         user_id (None | Unset | UUID):
@@ -193,6 +218,10 @@ def sync_detailed(
         search (None | str | Unset):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
+        sort (ListAuditLogsAdminAuditLogsGetSort | Unset): Column to order by. Resource name is
+            not sortable: it is resolved per page after the query, so the database cannot order by it.
+            Default: 'created_at'.
+        order (ListAuditLogsAdminAuditLogsGetOrder | Unset): Sort direction. Default: 'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -212,6 +241,8 @@ def sync_detailed(
         search=search,
         skip=skip,
         limit=limit,
+        sort=sort,
+        order=order,
     )
 
     response = client.get_httpx_client().request(
@@ -233,10 +264,15 @@ def sync(
     search: None | str | Unset = UNSET,
     skip: int | Unset = 0,
     limit: int | Unset = 50,
+    sort: ListAuditLogsAdminAuditLogsGetSort | Unset = "created_at",
+    order: ListAuditLogsAdminAuditLogsGetOrder | Unset = "desc",
 ) -> AuditLogListResponse | ProblemDetail | None:
     """List Audit Logs
 
-     Query audit logs with optional filters (admin only).
+     Query audit logs with optional filters and sort (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         user_id (None | Unset | UUID):
@@ -248,6 +284,10 @@ def sync(
         search (None | str | Unset):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
+        sort (ListAuditLogsAdminAuditLogsGetSort | Unset): Column to order by. Resource name is
+            not sortable: it is resolved per page after the query, so the database cannot order by it.
+            Default: 'created_at'.
+        order (ListAuditLogsAdminAuditLogsGetOrder | Unset): Sort direction. Default: 'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -268,6 +308,8 @@ def sync(
         search=search,
         skip=skip,
         limit=limit,
+        sort=sort,
+        order=order,
     ).parsed
 
 
@@ -283,10 +325,15 @@ async def asyncio_detailed(
     search: None | str | Unset = UNSET,
     skip: int | Unset = 0,
     limit: int | Unset = 50,
+    sort: ListAuditLogsAdminAuditLogsGetSort | Unset = "created_at",
+    order: ListAuditLogsAdminAuditLogsGetOrder | Unset = "desc",
 ) -> Response[AuditLogListResponse | ProblemDetail]:
     """List Audit Logs
 
-     Query audit logs with optional filters (admin only).
+     Query audit logs with optional filters and sort (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         user_id (None | Unset | UUID):
@@ -298,6 +345,10 @@ async def asyncio_detailed(
         search (None | str | Unset):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
+        sort (ListAuditLogsAdminAuditLogsGetSort | Unset): Column to order by. Resource name is
+            not sortable: it is resolved per page after the query, so the database cannot order by it.
+            Default: 'created_at'.
+        order (ListAuditLogsAdminAuditLogsGetOrder | Unset): Sort direction. Default: 'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -317,6 +368,8 @@ async def asyncio_detailed(
         search=search,
         skip=skip,
         limit=limit,
+        sort=sort,
+        order=order,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -336,10 +389,15 @@ async def asyncio(
     search: None | str | Unset = UNSET,
     skip: int | Unset = 0,
     limit: int | Unset = 50,
+    sort: ListAuditLogsAdminAuditLogsGetSort | Unset = "created_at",
+    order: ListAuditLogsAdminAuditLogsGetOrder | Unset = "desc",
 ) -> AuditLogListResponse | ProblemDetail | None:
     """List Audit Logs
 
-     Query audit logs with optional filters (admin only).
+     Query audit logs with optional filters and sort (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         user_id (None | Unset | UUID):
@@ -351,6 +409,10 @@ async def asyncio(
         search (None | str | Unset):
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
+        sort (ListAuditLogsAdminAuditLogsGetSort | Unset): Column to order by. Resource name is
+            not sortable: it is resolved per page after the query, so the database cannot order by it.
+            Default: 'created_at'.
+        order (ListAuditLogsAdminAuditLogsGetOrder | Unset): Sort direction. Default: 'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -372,5 +434,7 @@ async def asyncio(
             search=search,
             skip=skip,
             limit=limit,
+            sort=sort,
+            order=order,
         )
     ).parsed

--- a/sdks/python/geolens/api/admin/list_share_tokens_endpoint_admin_share_tokens_get.py
+++ b/sdks/python/geolens/api/admin/list_share_tokens_endpoint_admin_share_tokens_get.py
@@ -8,6 +8,12 @@ from ...types import Response, UNSET
 from ... import errors
 
 from ...models.admin_share_token_list_response import AdminShareTokenListResponse
+from ...models.list_share_tokens_endpoint_admin_share_tokens_get_order import (
+    ListShareTokensEndpointAdminShareTokensGetOrder,
+)
+from ...models.list_share_tokens_endpoint_admin_share_tokens_get_sort import (
+    ListShareTokensEndpointAdminShareTokensGetSort,
+)
 from ...models.problem_detail import ProblemDetail
 from ...types import Unset
 
@@ -18,6 +24,8 @@ def _get_kwargs(
     limit: int | Unset = 50,
     search: None | str | Unset = UNSET,
     status: None | str | Unset = UNSET,
+    sort: ListShareTokensEndpointAdminShareTokensGetSort | Unset = "created_at",
+    order: ListShareTokensEndpointAdminShareTokensGetOrder | Unset = "desc",
 ) -> dict[str, Any]:
 
     params: dict[str, Any] = {}
@@ -39,6 +47,18 @@ def _get_kwargs(
     else:
         json_status = status
     params["status"] = json_status
+
+    json_sort: str | Unset = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort
+
+    params["sort"] = json_sort
+
+    json_order: str | Unset = UNSET
+    if not isinstance(order, Unset):
+        json_order = order
+
+    params["order"] = json_order
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -123,16 +143,26 @@ def sync_detailed(
     limit: int | Unset = 50,
     search: None | str | Unset = UNSET,
     status: None | str | Unset = UNSET,
+    sort: ListShareTokensEndpointAdminShareTokensGetSort | Unset = "created_at",
+    order: ListShareTokensEndpointAdminShareTokensGetOrder | Unset = "desc",
 ) -> Response[AdminShareTokenListResponse | ProblemDetail]:
     """List Share Tokens Endpoint
 
      List basic share-token inventory with map info; no quotas or domain controls (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
         search (None | str | Unset):
         status (None | str | Unset):
+        sort (ListShareTokensEndpointAdminShareTokensGetSort | Unset): Column to order by. Link
+            status is not sortable: it is derived from is_active and expires_at after the query
+            returns. Default: 'created_at'.
+        order (ListShareTokensEndpointAdminShareTokensGetOrder | Unset): Sort direction. Default:
+            'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -147,6 +177,8 @@ def sync_detailed(
         limit=limit,
         search=search,
         status=status,
+        sort=sort,
+        order=order,
     )
 
     response = client.get_httpx_client().request(
@@ -163,16 +195,26 @@ def sync(
     limit: int | Unset = 50,
     search: None | str | Unset = UNSET,
     status: None | str | Unset = UNSET,
+    sort: ListShareTokensEndpointAdminShareTokensGetSort | Unset = "created_at",
+    order: ListShareTokensEndpointAdminShareTokensGetOrder | Unset = "desc",
 ) -> AdminShareTokenListResponse | ProblemDetail | None:
     """List Share Tokens Endpoint
 
      List basic share-token inventory with map info; no quotas or domain controls (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
         search (None | str | Unset):
         status (None | str | Unset):
+        sort (ListShareTokensEndpointAdminShareTokensGetSort | Unset): Column to order by. Link
+            status is not sortable: it is derived from is_active and expires_at after the query
+            returns. Default: 'created_at'.
+        order (ListShareTokensEndpointAdminShareTokensGetOrder | Unset): Sort direction. Default:
+            'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -188,6 +230,8 @@ def sync(
         limit=limit,
         search=search,
         status=status,
+        sort=sort,
+        order=order,
     ).parsed
 
 
@@ -198,16 +242,26 @@ async def asyncio_detailed(
     limit: int | Unset = 50,
     search: None | str | Unset = UNSET,
     status: None | str | Unset = UNSET,
+    sort: ListShareTokensEndpointAdminShareTokensGetSort | Unset = "created_at",
+    order: ListShareTokensEndpointAdminShareTokensGetOrder | Unset = "desc",
 ) -> Response[AdminShareTokenListResponse | ProblemDetail]:
     """List Share Tokens Endpoint
 
      List basic share-token inventory with map info; no quotas or domain controls (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
         search (None | str | Unset):
         status (None | str | Unset):
+        sort (ListShareTokensEndpointAdminShareTokensGetSort | Unset): Column to order by. Link
+            status is not sortable: it is derived from is_active and expires_at after the query
+            returns. Default: 'created_at'.
+        order (ListShareTokensEndpointAdminShareTokensGetOrder | Unset): Sort direction. Default:
+            'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -222,6 +276,8 @@ async def asyncio_detailed(
         limit=limit,
         search=search,
         status=status,
+        sort=sort,
+        order=order,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -236,16 +292,26 @@ async def asyncio(
     limit: int | Unset = 50,
     search: None | str | Unset = UNSET,
     status: None | str | Unset = UNSET,
+    sort: ListShareTokensEndpointAdminShareTokensGetSort | Unset = "created_at",
+    order: ListShareTokensEndpointAdminShareTokensGetOrder | Unset = "desc",
 ) -> AdminShareTokenListResponse | ProblemDetail | None:
     """List Share Tokens Endpoint
 
      List basic share-token inventory with map info; no quotas or domain controls (admin only).
+
+    `sort` and `order` are closed enums, so an unrecognised value is refused
+    with a 422 and never reaches the query.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 50.
         search (None | str | Unset):
         status (None | str | Unset):
+        sort (ListShareTokensEndpointAdminShareTokensGetSort | Unset): Column to order by. Link
+            status is not sortable: it is derived from is_active and expires_at after the query
+            returns. Default: 'created_at'.
+        order (ListShareTokensEndpointAdminShareTokensGetOrder | Unset): Sort direction. Default:
+            'desc'.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -262,5 +328,7 @@ async def asyncio(
             limit=limit,
             search=search,
             status=status,
+            sort=sort,
+            order=order,
         )
     ).parsed

--- a/sdks/python/geolens/models/__init__.py
+++ b/sdks/python/geolens/models/__init__.py
@@ -335,6 +335,14 @@ from .layer_info import LayerInfo
 from .layer_info_kind import LayerInfoKind
 from .layer_preview import LayerPreview
 from .lineage_draft_response import LineageDraftResponse
+from .list_admin_jobs_admin_jobs_get_order import ListAdminJobsAdminJobsGetOrder
+from .list_admin_jobs_admin_jobs_get_sort import ListAdminJobsAdminJobsGetSort
+from .list_audit_logs_admin_audit_logs_get_order import (
+    ListAuditLogsAdminAuditLogsGetOrder,
+)
+from .list_audit_logs_admin_audit_logs_get_sort import (
+    ListAuditLogsAdminAuditLogsGetSort,
+)
 from .list_features_datasets_dataset_id_features_get_geo_json_feature_collection import (
     ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollection,
 )
@@ -364,6 +372,12 @@ from .list_features_datasets_dataset_id_features_get_geo_json_feature_collection
 )
 from .list_maps_endpoint_maps_get_sort_by import ListMapsEndpointMapsGetSortBy
 from .list_maps_endpoint_maps_get_sort_dir import ListMapsEndpointMapsGetSortDir
+from .list_share_tokens_endpoint_admin_share_tokens_get_order import (
+    ListShareTokensEndpointAdminShareTokensGetOrder,
+)
+from .list_share_tokens_endpoint_admin_share_tokens_get_sort import (
+    ListShareTokensEndpointAdminShareTokensGetSort,
+)
 from .list_users_admin_users_get_order import ListUsersAdminUsersGetOrder
 from .list_users_admin_users_get_sort import ListUsersAdminUsersGetSort
 from .manifest_apply_entry_result import ManifestApplyEntryResult
@@ -979,6 +993,10 @@ __all__ = (
     "LayerInfoKind",
     "LayerPreview",
     "LineageDraftResponse",
+    "ListAdminJobsAdminJobsGetOrder",
+    "ListAdminJobsAdminJobsGetSort",
+    "ListAuditLogsAdminAuditLogsGetOrder",
+    "ListAuditLogsAdminAuditLogsGetSort",
     "ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollection",
     "ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeature",
     "ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometry",
@@ -990,6 +1008,8 @@ __all__ = (
     "ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionLink",
     "ListMapsEndpointMapsGetSortBy",
     "ListMapsEndpointMapsGetSortDir",
+    "ListShareTokensEndpointAdminShareTokensGetOrder",
+    "ListShareTokensEndpointAdminShareTokensGetSort",
     "ListUsersAdminUsersGetOrder",
     "ListUsersAdminUsersGetSort",
     "ManifestApplyEntryResult",

--- a/sdks/python/geolens/models/list_admin_jobs_admin_jobs_get_order.py
+++ b/sdks/python/geolens/models/list_admin_jobs_admin_jobs_get_order.py
@@ -1,0 +1,18 @@
+from typing import Literal, cast
+
+ListAdminJobsAdminJobsGetOrder = Literal["asc", "desc"]
+
+LIST_ADMIN_JOBS_ADMIN_JOBS_GET_ORDER_VALUES: set[ListAdminJobsAdminJobsGetOrder] = {
+    "asc",
+    "desc",
+}
+
+
+def check_list_admin_jobs_admin_jobs_get_order(
+    value: str,
+) -> ListAdminJobsAdminJobsGetOrder:
+    if value in LIST_ADMIN_JOBS_ADMIN_JOBS_GET_ORDER_VALUES:
+        return cast(ListAdminJobsAdminJobsGetOrder, value)
+    raise TypeError(
+        f"Unexpected value {value!r}. Expected one of {LIST_ADMIN_JOBS_ADMIN_JOBS_GET_ORDER_VALUES!r}"
+    )

--- a/sdks/python/geolens/models/list_admin_jobs_admin_jobs_get_sort.py
+++ b/sdks/python/geolens/models/list_admin_jobs_admin_jobs_get_sort.py
@@ -1,0 +1,23 @@
+from typing import Literal, cast
+
+ListAdminJobsAdminJobsGetSort = Literal[
+    "created_at", "duration", "source_filename", "status", "username"
+]
+
+LIST_ADMIN_JOBS_ADMIN_JOBS_GET_SORT_VALUES: set[ListAdminJobsAdminJobsGetSort] = {
+    "created_at",
+    "duration",
+    "source_filename",
+    "status",
+    "username",
+}
+
+
+def check_list_admin_jobs_admin_jobs_get_sort(
+    value: str,
+) -> ListAdminJobsAdminJobsGetSort:
+    if value in LIST_ADMIN_JOBS_ADMIN_JOBS_GET_SORT_VALUES:
+        return cast(ListAdminJobsAdminJobsGetSort, value)
+    raise TypeError(
+        f"Unexpected value {value!r}. Expected one of {LIST_ADMIN_JOBS_ADMIN_JOBS_GET_SORT_VALUES!r}"
+    )

--- a/sdks/python/geolens/models/list_audit_logs_admin_audit_logs_get_order.py
+++ b/sdks/python/geolens/models/list_audit_logs_admin_audit_logs_get_order.py
@@ -1,0 +1,20 @@
+from typing import Literal, cast
+
+ListAuditLogsAdminAuditLogsGetOrder = Literal["asc", "desc"]
+
+LIST_AUDIT_LOGS_ADMIN_AUDIT_LOGS_GET_ORDER_VALUES: set[
+    ListAuditLogsAdminAuditLogsGetOrder
+] = {
+    "asc",
+    "desc",
+}
+
+
+def check_list_audit_logs_admin_audit_logs_get_order(
+    value: str,
+) -> ListAuditLogsAdminAuditLogsGetOrder:
+    if value in LIST_AUDIT_LOGS_ADMIN_AUDIT_LOGS_GET_ORDER_VALUES:
+        return cast(ListAuditLogsAdminAuditLogsGetOrder, value)
+    raise TypeError(
+        f"Unexpected value {value!r}. Expected one of {LIST_AUDIT_LOGS_ADMIN_AUDIT_LOGS_GET_ORDER_VALUES!r}"
+    )

--- a/sdks/python/geolens/models/list_audit_logs_admin_audit_logs_get_sort.py
+++ b/sdks/python/geolens/models/list_audit_logs_admin_audit_logs_get_sort.py
@@ -1,0 +1,25 @@
+from typing import Literal, cast
+
+ListAuditLogsAdminAuditLogsGetSort = Literal[
+    "action", "created_at", "ip_address", "resource_type", "username"
+]
+
+LIST_AUDIT_LOGS_ADMIN_AUDIT_LOGS_GET_SORT_VALUES: set[
+    ListAuditLogsAdminAuditLogsGetSort
+] = {
+    "action",
+    "created_at",
+    "ip_address",
+    "resource_type",
+    "username",
+}
+
+
+def check_list_audit_logs_admin_audit_logs_get_sort(
+    value: str,
+) -> ListAuditLogsAdminAuditLogsGetSort:
+    if value in LIST_AUDIT_LOGS_ADMIN_AUDIT_LOGS_GET_SORT_VALUES:
+        return cast(ListAuditLogsAdminAuditLogsGetSort, value)
+    raise TypeError(
+        f"Unexpected value {value!r}. Expected one of {LIST_AUDIT_LOGS_ADMIN_AUDIT_LOGS_GET_SORT_VALUES!r}"
+    )

--- a/sdks/python/geolens/models/list_share_tokens_endpoint_admin_share_tokens_get_order.py
+++ b/sdks/python/geolens/models/list_share_tokens_endpoint_admin_share_tokens_get_order.py
@@ -1,0 +1,20 @@
+from typing import Literal, cast
+
+ListShareTokensEndpointAdminShareTokensGetOrder = Literal["asc", "desc"]
+
+LIST_SHARE_TOKENS_ENDPOINT_ADMIN_SHARE_TOKENS_GET_ORDER_VALUES: set[
+    ListShareTokensEndpointAdminShareTokensGetOrder
+] = {
+    "asc",
+    "desc",
+}
+
+
+def check_list_share_tokens_endpoint_admin_share_tokens_get_order(
+    value: str,
+) -> ListShareTokensEndpointAdminShareTokensGetOrder:
+    if value in LIST_SHARE_TOKENS_ENDPOINT_ADMIN_SHARE_TOKENS_GET_ORDER_VALUES:
+        return cast(ListShareTokensEndpointAdminShareTokensGetOrder, value)
+    raise TypeError(
+        f"Unexpected value {value!r}. Expected one of {LIST_SHARE_TOKENS_ENDPOINT_ADMIN_SHARE_TOKENS_GET_ORDER_VALUES!r}"
+    )

--- a/sdks/python/geolens/models/list_share_tokens_endpoint_admin_share_tokens_get_sort.py
+++ b/sdks/python/geolens/models/list_share_tokens_endpoint_admin_share_tokens_get_sort.py
@@ -1,0 +1,25 @@
+from typing import Literal, cast
+
+ListShareTokensEndpointAdminShareTokensGetSort = Literal[
+    "created_at", "creator", "embed_token_count", "expires_at", "map_name"
+]
+
+LIST_SHARE_TOKENS_ENDPOINT_ADMIN_SHARE_TOKENS_GET_SORT_VALUES: set[
+    ListShareTokensEndpointAdminShareTokensGetSort
+] = {
+    "created_at",
+    "creator",
+    "embed_token_count",
+    "expires_at",
+    "map_name",
+}
+
+
+def check_list_share_tokens_endpoint_admin_share_tokens_get_sort(
+    value: str,
+) -> ListShareTokensEndpointAdminShareTokensGetSort:
+    if value in LIST_SHARE_TOKENS_ENDPOINT_ADMIN_SHARE_TOKENS_GET_SORT_VALUES:
+        return cast(ListShareTokensEndpointAdminShareTokensGetSort, value)
+    raise TypeError(
+        f"Unexpected value {value!r}. Expected one of {LIST_SHARE_TOKENS_ENDPOINT_ADMIN_SHARE_TOKENS_GET_SORT_VALUES!r}"
+    )

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -133,7 +133,10 @@ export const revokeApiKeyAdminApiKeysKeyIdDelete = <ThrowOnError extends boolean
 /**
  * List Audit Logs
  *
- * Query audit logs with optional filters (admin only).
+ * Query audit logs with optional filters and sort (admin only).
+ *
+ * `sort` and `order` are closed enums, so an unrecognised value is refused
+ * with a 422 and never reaches the query.
  */
 export const listAuditLogsAdminAuditLogsGet = <ThrowOnError extends boolean = false>(options?: Options<ListAuditLogsAdminAuditLogsGetData, ThrowOnError>): RequestResult<ListAuditLogsAdminAuditLogsGetResponses, ListAuditLogsAdminAuditLogsGetErrors, ThrowOnError> => (options?.client ?? client).get<ListAuditLogsAdminAuditLogsGetResponses, ListAuditLogsAdminAuditLogsGetErrors, ThrowOnError>({
     security: [
@@ -152,7 +155,7 @@ export const listAuditLogsAdminAuditLogsGet = <ThrowOnError extends boolean = fa
 /**
  * Download audit records
  *
- * Export up to 100,000 audit log rows as CSV or JSON.
+ * Export up to 100,000 audit log rows as CSV or JSON, newest first.
  */
 export const exportAuditLogsAdminAuditLogsExportFormatGet = <ThrowOnError extends boolean = false>(options: Options<ExportAuditLogsAdminAuditLogsExportFormatGetData, ThrowOnError>): RequestResult<ExportAuditLogsAdminAuditLogsExportFormatGetResponses, ExportAuditLogsAdminAuditLogsExportFormatGetErrors, ThrowOnError> => (options.client ?? client).get<ExportAuditLogsAdminAuditLogsExportFormatGetResponses, ExportAuditLogsAdminAuditLogsExportFormatGetErrors, ThrowOnError>({
     security: [
@@ -273,7 +276,10 @@ export const getInfrastructureAdminInfrastructureGet = <ThrowOnError extends boo
 /**
  * List Admin Jobs
  *
- * List all ingestion jobs with optional status/user/search filters (admin only).
+ * List all ingestion jobs with optional status/user/search/sort filters (admin only).
+ *
+ * `sort` and `order` are closed enums, so an unrecognised value is refused
+ * with a 422 and never reaches the query.
  */
 export const listAdminJobsAdminJobsGet = <ThrowOnError extends boolean = false>(options?: Options<ListAdminJobsAdminJobsGetData, ThrowOnError>): RequestResult<ListAdminJobsAdminJobsGetResponses, ListAdminJobsAdminJobsGetErrors, ThrowOnError> => (options?.client ?? client).get<ListAdminJobsAdminJobsGetResponses, ListAdminJobsAdminJobsGetErrors, ThrowOnError>({
     security: [
@@ -293,6 +299,9 @@ export const listAdminJobsAdminJobsGet = <ThrowOnError extends boolean = false>(
  * List Share Tokens Endpoint
  *
  * List basic share-token inventory with map info; no quotas or domain controls (admin only).
+ *
+ * `sort` and `order` are closed enums, so an unrecognised value is refused
+ * with a 422 and never reaches the query.
  */
 export const listShareTokensEndpointAdminShareTokensGet = <ThrowOnError extends boolean = false>(options?: Options<ListShareTokensEndpointAdminShareTokensGetData, ThrowOnError>): RequestResult<ListShareTokensEndpointAdminShareTokensGetResponses, ListShareTokensEndpointAdminShareTokensGetErrors, ThrowOnError> => (options?.client ?? client).get<ListShareTokensEndpointAdminShareTokensGetResponses, ListShareTokensEndpointAdminShareTokensGetErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -10942,6 +10942,18 @@ export type ListAuditLogsAdminAuditLogsGetData = {
          * Limit
          */
         limit?: number;
+        /**
+         * Sort
+         *
+         * Column to order by. Resource name is not sortable: it is resolved per page after the query, so the database cannot order by it.
+         */
+        sort?: 'created_at' | 'action' | 'resource_type' | 'ip_address' | 'username';
+        /**
+         * Order
+         *
+         * Sort direction.
+         */
+        order?: 'asc' | 'desc';
     };
     url: '/admin/audit-logs/';
 };
@@ -11404,6 +11416,18 @@ export type ListAdminJobsAdminJobsGetData = {
          * Limit
          */
         limit?: number;
+        /**
+         * Sort
+         *
+         * Column to order by. Duration orders by the completed_at - started_at interval, so unfinished jobs sort last either way.
+         */
+        sort?: 'created_at' | 'source_filename' | 'status' | 'username' | 'duration';
+        /**
+         * Order
+         *
+         * Sort direction.
+         */
+        order?: 'asc' | 'desc';
     };
     url: '/admin/jobs/';
 };
@@ -11474,6 +11498,18 @@ export type ListShareTokensEndpointAdminShareTokensGetData = {
          * Status
          */
         status?: string | null;
+        /**
+         * Sort
+         *
+         * Column to order by. Link status is not sortable: it is derived from is_active and expires_at after the query returns.
+         */
+        sort?: 'map_name' | 'created_at' | 'creator' | 'expires_at' | 'embed_token_count';
+        /**
+         * Order
+         *
+         * Sort direction.
+         */
+        order?: 'asc' | 'desc';
     };
     url: '/admin/share-tokens/';
 };


### PR DESCRIPTION
## Problem

#1200 made the Users list sortable and shipped `SortableColumnHeader` as a shared component. The three sibling admin tables render the same paginated-table shape but each hardcoded a single ORDER BY. These lists are server-paginated, so client-side sorting would order only the visible page — which looks correct and is not. Each surface needed its own backend ordering param before the header could be wired up (#1204's scoping table).

## What each surface gained

- **Jobs** (`GET /admin/jobs/`): `created_at`, `source_filename`, `status`, joined `username`, and `duration` — derivable as `completed_at - started_at`, which is NULL for exactly the rows whose Duration cell renders "-", so ordering and display agree. The retry affordance stays unsortable (computed per page after the query).
- **Audit Log** (`GET /admin/audit-logs/`): `created_at`, `action`, `resource_type`, `ip_address`, joined `username` through a dedicated alias so the ORDER BY join cannot interact with the username sub-select the search filter builds (both compile identically today — measured; the alias is insurance against a future filter rewrite). `resource_name` stays unsortable: `resolve_resource_names()` runs after the query.
- **Published Maps** (`GET /admin/share-tokens/`): `map_name`, `created_at`, `creator`, `expires_at`, and the embed count, ordered by the same COALESCE'd expression the cell renders — the raw aggregate is NULL (not 0) for a map with no active embed token, and ordering by that would strand those rows in a band of their own. Link status stays unsortable (derived in Python from `is_active` + expiry).

Shared shape, copied from #1200 on every surface: closed `Literal` enums so bad input 422s at the boundary, a dict-lookup column allowlist that raises on an unmapped field rather than degrading to the default order, `NULLS LAST` pinned in both directions on every nullable sort column, a unique-id tiebreak so OFFSET paging cannot return a row twice, and unchanged default orderings.

**The audit CSV/JSON export deliberately takes no sort/order.** It streams through `stream_audit_logs`, a separate cursor-based generator with its own `created_at DESC`; an export is an archive the recipient reorders in their own tool, and adding a sort would change the row order of every existing consumer's file. Recorded at the handler and pinned by a test so the omission does not read as an oversight.

Frontend: `SortableColumnHeader` reused unchanged. Sort state lives in the URL on all three pages, sort clicks replace rather than push the history entry (per the #1200 review), `aria-sort` marks exactly one header, and an unrecognised `?sort=` falls back to the default silently. JobList's sort write takes the same self-write exemption as its status dropdown — without it the #1185 location-key effect would read the write as an external navigation and clear the user's search on every header click.

No new translation keys: the `sortable.*` strings landed with #1200 and every column label already existed.

## API impact

Three admin list endpoints gain optional `sort`/`order` query params (defaults preserve historical behavior). Full regen committed: `backend/openapi.json`, both SDKs, `frontend/src/types/api.generated.ts`.

## Verification

- New backend suites: `test_admin_job_sort.py` (21 passed), `test_admin_audit_sort.py` (23 passed), `test_admin_share_token_sort.py` (20 passed) — covering 422 on bogus params, NULLS LAST both directions, id tiebreak, unchanged defaults, and that the export takes no sort parameters
- Whole-tree after rebase onto the #1206 merge: backend `7136 passed, 88 skipped`; frontend `npm run lint` + `npm run typecheck` clean, `npm run test:coverage` — 379 files, 4656 tests passed; `npm run test:i18n` — 4 passed
- Regen verified by regenerating from the rebased source: zero drift (`make openapi` + `make sdks` + the frontend types generator all exit 0 with a clean tree)
- `pytest tests/test_layering.py -q` — 40 passed (two caps raised in the same commit with comments: `admin/router_operations.py` 296→316, `catalog/maps/service_public.py` 914→983)
- NULLS LAST on duration RED-checked (fired on DESC with the right assertion); the JobList self-write exemption RED-checked (removing it fails exactly the search-preservation test)

Closes #1204

https://claude.ai/code/session_01HWAxdeSdSJ5dS7bKUHFK98