### PR TITLE
sec(ingest): validate content at presigned upload completion

### DIFF
--- a/backend/app/platform/jobs/models.py
+++ b/backend/app/platform/jobs/models.py
@@ -20,6 +20,34 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.core.db import Base
 
 
+def owned_presigned_staging_key(
+    job_id: uuid.UUID | str,
+    user_metadata: dict[str, Any] | None,
+    file_path: str | None,
+) -> str | None:
+    """Return the presigned staging key this job alone is responsible for.
+
+    fix(#1202 review r5): a completed presigned upload points ``file_path`` at
+    a frozen copy, which leaves ``user_metadata["s3_key"]`` as the only
+    reference to the client-writable staging key. That URL stays valid until
+    expiry, so the client can recreate the object after completion. Reapers
+    use this to sweep it alongside ``file_path``.
+
+    Ownership is decided by the key's OWN prefix, not by "differs from
+    file_path". ``create_fan_out_jobs`` clones the parent's ``user_metadata``
+    wholesale, so every fan-out child carries the PARENT's ``s3_key``:
+    sweeping on difference alone would delete the shared original out from
+    under siblings that still need it — the same breakage the
+    ``is_fan_out_child`` default-true guard exists to prevent. A staging key
+    is namespaced by the job that presigned it, so the prefix settles
+    ownership outright and needs no survivor query.
+    """
+    key = (user_metadata or {}).get("s3_key")
+    if not isinstance(key, str) or not key or key == file_path:
+        return None
+    return key if key.startswith(f"staging/{job_id}/") else None
+
+
 class IngestJob(Base):
     __tablename__ = "ingest_jobs"
     __table_args__ = (

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -136,6 +136,108 @@ class StaleCleanupOutcome:
         }
 
 
+# fix(#1202 review r8): how long a presigned PUT URL can still recreate the
+# staging object after the event-triggered sweeps have already run.
+#
+# Grounded in the provider default rather than assumed: S3StorageProvider
+# .generate_presigned_put_url takes `expiration: int = 3600`, and neither call
+# site — the ingest and reupload presign requests — passes one, so 3600 is
+# always the value. No setting exposes it; if one is ever added, derive this
+# from that instead of the literal.
+#
+# Part URLs default to 7200 but cannot recreate an OBJECT: they need a live
+# upload id, and CompleteMultipartUpload consumes it (an abort kills it). Only
+# the single-part object-key URL is a recreation vector, so 3600 bounds it.
+#
+# `created_at` is a sound conservative anchor because the row is inserted
+# BEFORE any URL for it is minted, so no URL can outlive created_at + TTL.
+_PRESIGNED_PUT_URL_TTL_SECONDS = 3600
+_POST_EXPIRY_SWEEP_MARGIN_SECONDS = 900
+_POST_EXPIRY_SWEEP_AFTER_SECONDS = (
+    _PRESIGNED_PUT_URL_TTL_SECONDS + _POST_EXPIRY_SWEEP_MARGIN_SECONDS
+)
+# Set once the post-expiry sweep has run for a job, so it never runs twice.
+_STAGING_REAPED_MARKER = "s3_key_reaped"
+
+
+async def _sweep_expired_presigned_staging(
+    db: AsyncSession, outcome: StaleCleanupOutcome, *, now: datetime | None = None
+) -> StaleCleanupOutcome:
+    """Sweep staging objects a now-dead PUT URL may have recreated.
+
+    The other two sweeps are EVENT-triggered — one at completion, one at job
+    end — and a fast ingest fires both while the client's URL is still valid.
+    A re-PUT after them recreates an object nothing later reaps, because a
+    successful job is the per-dataset latest-complete that the retention purge
+    exempts forever. Those sweeps close the URL's past; this closes its future.
+
+    Runs exactly once per job, ever: the marker takes the row out of the query
+    below, so the exempt rows do not cost a storage call on every pass forever.
+
+    Delete first, mark second — the opposite of ``_reap_committed_staged_paths``
+    and for a different reason. That one must not destroy an artifact a
+    rolled-back row DELETE might still need. Here the row survives either way,
+    so the only asymmetric outcome is marking a FAILED delete as done, which
+    leaks the object permanently. A crash between the two costs one redundant
+    delete on the next pass instead, which is a no-op.
+    """
+    cutoff = (now or datetime.now(timezone.utc)) - timedelta(
+        seconds=_POST_EXPIRY_SWEEP_AFTER_SECONDS
+    )
+    candidates = (
+        await db.execute(
+            select(IngestJob.id, IngestJob.file_path, IngestJob.user_metadata).where(
+                IngestJob.status.not_in(("pending", "running")),
+                IngestJob.created_at < cutoff,
+                IngestJob.user_metadata["s3_key"].astext.is_not(None),
+                IngestJob.user_metadata[_STAGING_REAPED_MARKER].astext.is_(None),
+            )
+        )
+    ).all()
+
+    reaped = 0
+    failures = 0
+    for job_row_id, file_path, metadata in candidates:
+        staging_key = owned_presigned_staging_key(job_row_id, metadata, file_path)
+        if staging_key is None:
+            # Not this job's key to delete — a fan-out child holding the
+            # parent's inherited s3_key lands here, same rule as everywhere.
+            continue
+        try:
+            from app.platform.storage import get_storage
+
+            await get_storage().delete(resolve_current_storage_key(staging_key))
+        except Exception:  # broad: best-effort staging cleanup
+            failures += 1
+            log.warning(
+                "Failed to reap expired presigned staging object",
+                storage_key=staging_key,
+            )
+            continue
+        # A Core UPDATE with a fresh dict, not an in-place mutation of the
+        # loaded value — JSONB does not track mutation, so an in-place edit
+        # would never flush.
+        await db.execute(
+            update(IngestJob)
+            .where(IngestJob.id == job_row_id)
+            .values(
+                user_metadata={**(metadata or {}), _STAGING_REAPED_MARKER: True},
+            )
+        )
+        reaped += 1
+
+    if reaped:
+        await db.commit()
+
+    if not (reaped or failures):
+        return outcome
+    return replace(
+        outcome,
+        storage_objects_reaped=outcome.storage_objects_reaped + reaped,
+        staged_cleanup_failures=outcome.staged_cleanup_failures + failures,
+    )
+
+
 async def _reap_committed_staged_paths(
     outcome: StaleCleanupOutcome,
 ) -> StaleCleanupOutcome:
@@ -527,6 +629,7 @@ async def fail_stale_jobs(
         # cannot restore a job row whose only retry input has been destroyed.
         await db.commit()
         outcome = await _reap_committed_staged_paths(outcome)
+        outcome = await _sweep_expired_presigned_staging(db, outcome, now=now)
     if detailed:
         return outcome
     return outcome.pending_failed, outcome.running_failed
@@ -655,6 +758,7 @@ async def cleanup_stale_jobs(
             details = database_details
         else:
             outcome = await _reap_committed_staged_paths(outcome)
+            outcome = await _sweep_expired_presigned_staging(db, outcome)
             details = outcome.as_dict()
     except Exception as exc:  # broad: cleanup spans DB and artifact deletion
         await db.rollback()

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -23,7 +23,7 @@ from app.processing.ingest.schemas import UploadResponse
 from app.processing.ingest.service import queue_ingest_job
 from app.platform.extensions import get_permission_extension
 from app.platform.jobs.heartbeat import ANALYSIS_MATERIALIZE_LEASE_SECONDS
-from app.platform.jobs.models import IngestJob
+from app.platform.jobs.models import IngestJob, owned_presigned_staging_key
 from app.platform.jobs.schemas import (
     DbfTruncationCollisionWarning,
     JobStatusResponse,
@@ -94,6 +94,12 @@ class StaleCleanupOutcome:
     staged_paths_skipped: int
     staged_cleanup_failures: int
     _staged_paths: tuple[str, ...] = field(default=(), repr=False, compare=False)
+    # fix(#1202 review r5): presigned staging keys of the purged rows. Kept
+    # separate from _staged_paths because they need no survivor query — a
+    # staging key is namespaced by the job that presigned it.
+    _staged_presigned_keys: tuple[str, ...] = field(
+        default=(), repr=False, compare=False
+    )
 
     @property
     def total_cleaned(self) -> int:
@@ -175,6 +181,26 @@ async def _reap_committed_staged_paths(
             log.warning(
                 "Failed to reap staged file for purged jobs",
                 file_path=file_path,
+            )
+
+    # fix(#1202 review r5): the presigned staging keys. A completed presigned
+    # job points `file_path` at its frozen copy, so the loop above never
+    # reaches the key the client still holds a PUT URL for — and a
+    # post-completion re-PUT recreates an object that escapes size and quota
+    # accounting. These are always provider keys (never local paths) and are
+    # namespaced by the job that presigned them, which is what makes deleting
+    # them safe without a survivor query.
+    for staging_key in outcome._staged_presigned_keys:
+        try:
+            from app.platform.storage import get_storage
+
+            await get_storage().delete(resolve_current_storage_key(staging_key))
+            storage_objects_reaped += 1
+        except Exception:  # broad: best-effort staging cleanup
+            staged_cleanup_failures += 1
+            log.warning(
+                "Failed to reap presigned staging object for purged jobs",
+                storage_key=staging_key,
             )
 
     return replace(
@@ -380,6 +406,7 @@ async def fail_stale_jobs(
     staged_paths_skipped = 0
     staged_cleanup_failures = 0
     deleted_paths: set[str] = set()
+    deleted_presigned_keys: set[str] = set()
 
     # fix(#434): purge terminal jobs past retention so the admin Jobs page
     # doesn't accumulate history forever. Cutoff is on finished-at
@@ -440,11 +467,18 @@ async def fail_stale_jobs(
                 IngestJob.id.not_in(latest_complete_ids),
                 IngestJob.id.not_in(latest_manifest_ids),
             )
-            .returning(IngestJob.file_path)
+            .returning(IngestJob.id, IngestJob.file_path, IngestJob.user_metadata)
         )
         deleted_rows = deleted.all()
         terminal_jobs_purged = len(deleted_rows)
-        deleted_paths = {fp for (fp,) in deleted_rows if fp}
+        deleted_paths = {fp for (_id, fp, _um) in deleted_rows if fp}
+        # fix(#1202 review r5): a purged presigned job's staging key is the one
+        # reference left to an object the client's PUT URL can still recreate.
+        deleted_presigned_keys = {
+            key
+            for (job_row_id, fp, um) in deleted_rows
+            if (key := owned_presigned_staging_key(job_row_id, um, fp))
+        }
         if deleted_rows:
             log.info(
                 "Purged ingest jobs past retention",
@@ -485,6 +519,7 @@ async def fail_stale_jobs(
         staged_paths_skipped=staged_paths_skipped,
         staged_cleanup_failures=staged_cleanup_failures,
         _staged_paths=tuple(sorted(deleted_paths)),
+        _staged_presigned_keys=tuple(sorted(deleted_presigned_keys)),
     )
     if commit:
         # Never remove an external artifact for a DELETE that may still roll

--- a/backend/app/platform/storage/azure.py
+++ b/backend/app/platform/storage/azure.py
@@ -85,6 +85,19 @@ class AzureBlobStorageProvider:
 
         return await asyncio.to_thread(_get)
 
+    async def get_range(self, key: str, start: int, length: int) -> bytes:
+        """Read at most ``length`` bytes from byte offset ``start``."""
+
+        def _get_range() -> bytes:
+            blob = self._client.get_blob_client(container=self.container, blob=key)
+            try:
+                return blob.download_blob(offset=start, length=length).readall()
+            except ResourceNotFoundError as e:
+                # fix(#430 BA-24): normalize missing-object to FileNotFoundError across providers.
+                raise FileNotFoundError(key) from e
+
+        return await asyncio.to_thread(_get_range)
+
     async def get_stream(self, key: str) -> AsyncIterator[bytes]:
         """Azure streaming is served via SAS redirect; this method should never be reached.
 

--- a/backend/app/platform/storage/azure.py
+++ b/backend/app/platform/storage/azure.py
@@ -85,6 +85,31 @@ class AzureBlobStorageProvider:
 
         return await asyncio.to_thread(_get)
 
+    async def copy(self, src_key: str, dst_key: str) -> None:
+        """Service-side copy within the container.
+
+        ``requires_sync`` makes the service finish the copy before returning,
+        so callers that read the destination immediately see the bytes. Azure
+        bounds a synchronous copy's source size, and same-account URL copies
+        depend on the destination credential authorizing the source — neither
+        is exercised today, because presigned uploads (the only caller) refuse
+        anything but the S3 backend at request time. This exists for protocol
+        completeness; verify it against a live account before relying on it.
+        """
+
+        def _copy() -> None:
+            source = self._client.get_blob_client(
+                container=self.container, blob=src_key
+            )
+            dest = self._client.get_blob_client(container=self.container, blob=dst_key)
+            try:
+                dest.start_copy_from_url(source.url, requires_sync=True)
+            except ResourceNotFoundError as e:
+                # fix(#430 BA-24): normalize missing-object to FileNotFoundError across providers.
+                raise FileNotFoundError(src_key) from e
+
+        await asyncio.to_thread(_copy)
+
     async def get_range(self, key: str, start: int, length: int) -> bytes:
         """Read at most ``length`` bytes from byte offset ``start``."""
 

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -82,6 +82,17 @@ class LocalStorageProvider:
         path = self._resolve_contained(key)
         return await asyncio.to_thread(path.read_bytes)
 
+    async def copy(self, src_key: str, dst_key: str) -> None:
+        """Copy within the staging root, creating the destination's parents."""
+        src = self._resolve_contained(src_key)
+        dst = self._resolve_contained(dst_key)
+
+        def _copy() -> None:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+
+        await asyncio.to_thread(_copy)
+
     async def get_range(self, key: str, start: int, length: int) -> bytes:
         """Read at most ``length`` bytes from byte offset ``start``."""
         path = self._resolve_contained(key)

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -82,6 +82,17 @@ class LocalStorageProvider:
         path = self._resolve_contained(key)
         return await asyncio.to_thread(path.read_bytes)
 
+    async def get_range(self, key: str, start: int, length: int) -> bytes:
+        """Read at most ``length`` bytes from byte offset ``start``."""
+        path = self._resolve_contained(key)
+
+        def _read() -> bytes:
+            with path.open("rb") as fh:
+                fh.seek(start)
+                return fh.read(length)
+
+        return await asyncio.to_thread(_read)
+
     async def get_stream(self, key: str) -> AsyncIterator[bytes]:
         """Stream key bytes in 1 MiB chunks (ING-03 / P2-03).
 

--- a/backend/app/platform/storage/provider.py
+++ b/backend/app/platform/storage/provider.py
@@ -19,6 +19,16 @@ class StorageProvider(Protocol):
         """
         ...
 
+    async def copy(self, src_key: str, dst_key: str) -> None:
+        """Copy an object within this backend, overwriting ``dst_key``.
+
+        Server-side wherever the provider supports it — the bytes must not
+        round-trip through this process, because callers use this to snapshot
+        multi-GB uploads. Raises FileNotFoundError if ``src_key`` does not
+        exist (BA-24).
+        """
+        ...
+
     async def get_range(self, key: str, start: int, length: int) -> bytes:
         """Retrieve at most ``length`` bytes starting at byte offset ``start``.
 

--- a/backend/app/platform/storage/provider.py
+++ b/backend/app/platform/storage/provider.py
@@ -19,6 +19,19 @@ class StorageProvider(Protocol):
         """
         ...
 
+    async def get_range(self, key: str, start: int, length: int) -> bytes:
+        """Retrieve at most ``length`` bytes starting at byte offset ``start``.
+
+        For checks that only inspect a bounded window of a large object (the
+        presigned-completion content check reads a header and, for Parquet,
+        the trailing magic) so the whole object never has to be downloaded.
+
+        ``length`` must be positive. Returns fewer bytes than requested when
+        the window runs past the end of the object. Raises FileNotFoundError
+        if the key does not exist (BA-24).
+        """
+        ...
+
     def get_stream(self, key: str) -> AsyncIterator[bytes]:
         """Stream key bytes as an async iterator.
 

--- a/backend/app/platform/storage/s3.py
+++ b/backend/app/platform/storage/s3.py
@@ -101,6 +101,30 @@ class S3StorageProvider:
 
         return await asyncio.to_thread(_get)
 
+    async def copy(self, src_key: str, dst_key: str) -> None:
+        """Server-side copy within the bucket.
+
+        Uses the managed ``client.copy`` transfer rather than ``copy_object``:
+        the single-request CopyObject API caps at 5 GB, and presigned uploads
+        exist precisely for objects that can exceed it. The managed API falls
+        back to multipart copy above that ceiling on its own.
+        """
+
+        def _copy() -> None:
+            try:
+                self.client.copy(
+                    CopySource={"Bucket": self.bucket, "Key": src_key},
+                    Bucket=self.bucket,
+                    Key=dst_key,
+                )
+            except ClientError as e:
+                # fix(#430 BA-24): normalize missing-object to FileNotFoundError across providers.
+                if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+                    raise FileNotFoundError(src_key) from e
+                raise
+
+        await asyncio.to_thread(_copy)
+
     async def get_range(self, key: str, start: int, length: int) -> bytes:
         """Read at most ``length`` bytes from byte offset ``start``."""
 

--- a/backend/app/platform/storage/s3.py
+++ b/backend/app/platform/storage/s3.py
@@ -101,6 +101,30 @@ class S3StorageProvider:
 
         return await asyncio.to_thread(_get)
 
+    async def get_range(self, key: str, start: int, length: int) -> bytes:
+        """Read at most ``length`` bytes from byte offset ``start``."""
+
+        def _get_range() -> bytes:
+            try:
+                response = self.client.get_object(
+                    Bucket=self.bucket,
+                    Key=key,
+                    Range=f"bytes={start}-{start + length - 1}",
+                )
+                return response["Body"].read()
+            except ClientError as e:
+                code = e.response.get("Error", {}).get("Code")
+                # fix(#430 BA-24): normalize missing-object to FileNotFoundError across providers.
+                if code in ("404", "NoSuchKey"):
+                    raise FileNotFoundError(key) from e
+                # A window that starts at or past the end of the object is an
+                # empty read, not an error — matches local/POSIX seek+read.
+                if code in ("416", "InvalidRange", "RequestedRangeNotSatisfiable"):
+                    return b""
+                raise
+
+        return await asyncio.to_thread(_get_range)
+
     async def get_stream(self, key: str) -> AsyncIterator[bytes]:
         """S3 streaming is served via presigned GET redirect; never reached.
 

--- a/backend/app/processing/ingest/presigned.py
+++ b/backend/app/processing/ingest/presigned.py
@@ -51,6 +51,23 @@ async def abort_presigned_multipart_upload(
         )
 
 
+def raise_if_over_max_upload_size(actual_size: int, max_size_mb: int) -> None:
+    """Raise the canonical oversize 422 for a completed presigned upload.
+
+    Extracted so the pre-copy fast path in the ingest router and the
+    authoritative post-copy check below cannot drift apart: a client that
+    trips either one has to see the same status and the same wording.
+    """
+    if actual_size > max_size_mb * 1024 * 1024:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Uploaded file size ({actual_size / (1024 * 1024):.1f} MB) exceeds "
+                f"the maximum allowed ({max_size_mb} MB)."
+            ),
+        )
+
+
 async def verify_completed_presigned_upload(
     *,
     db: AsyncSession,
@@ -64,17 +81,12 @@ async def verify_completed_presigned_upload(
     """Verify a completed direct-to-object-storage upload before accepting it."""
     actual_size = await storage.size(key)
     max_size_mb = await UPLOAD_MAX_SIZE_MB.get(db)
-    max_size_bytes = max_size_mb * 1024 * 1024
 
-    if actual_size > max_size_bytes:
+    try:
+        raise_if_over_max_upload_size(actual_size, max_size_mb)
+    except HTTPException:
         await _cleanup_presigned_object(storage, key, job_id)
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=(
-                f"Uploaded file size ({actual_size / (1024 * 1024):.1f} MB) exceeds "
-                f"the maximum allowed ({max_size_mb} MB)."
-            ),
-        )
+        raise
 
     if expected_size is not None:
         try:

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -567,12 +567,17 @@ async def complete_presigned_upload(
     #
     # Past this line the staging object has served its purpose. A delete
     # failure here, or a late re-PUT through the still-valid URL, leaves an
-    # orphan that nothing reads. Both staging reapers sweep it at job end via
-    # `user_metadata["s3_key"]` (tasks_vector.py's post-ingest cleanup and
-    # jobs/router.py's stale-job purge, both through
-    # `owned_presigned_staging_key`), so the residual window is completion to
-    # reap, not forever. S3 cannot revoke an individual presigned URL, so
-    # reaping is the only real remedy.
+    # orphan that nothing reads.
+    #
+    # It is swept at job end by whichever terminal reaper owns the job. Every
+    # one of them resolves the key through `owned_presigned_staging_key`, so
+    # grep that name for the current set rather than trusting a list here —
+    # this comment has already gone stale once by naming them. The stale-job
+    # purge is a backstop, not a guarantee: it exempts the newest complete job
+    # per dataset, which is exactly what a successful ingest leaves behind, so
+    # a path with no task-level reaper would keep its orphan indefinitely.
+    # S3 cannot revoke an individual presigned URL, so reaping is the only
+    # real remedy.
     await _cleanup_saved_upload(s3_key, str(job.id))
 
     return UploadResponse(

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -409,39 +409,81 @@ async def complete_presigned_upload(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="File not found in S3 after upload",
         )
-    actual_size = await verify_completed_presigned_upload(
-        db=db,
-        storage=storage,
-        key=physical_s3_key,
-        expected_size=um.get("expected_size"),
-        user_id=user.id,
-        request=http_request,
-        job_id=job.id,
-    )
+    frozen_key = _frozen_staging_key(s3_key)
+    physical_frozen_key = resolve_current_storage_key(frozen_key)
 
-    # fix(#1202): both ingest doors enforce the same content contract. A
-    # deliberate rejection drops the object, matching the direct path's
-    # rollback — completion is the last point that exclusively owns it. Only
-    # HTTPException, deliberately: a transient storage error here leaves the
-    # object for the client to retry completion against, rather than forcing a
-    # multi-GB re-upload over a hiccup.
+    # fix(#1202 review): FREEZE FIRST, then judge the frozen copy. The client
+    # still holds a presigned PUT URL for the staging key — those stay valid
+    # until expiry, and a PUT to an existing key replaces the object — so
+    # anything checked at the staging key can be swapped afterwards: upload
+    # clean bytes, complete, re-PUT garbage, and preview hands GDAL a file
+    # nothing ever validated. Snapshotting to a key no presign endpoint has
+    # ever issued a URL for is what makes the checks below mean something.
+    #
+    # The ORDER is the fix, not the copy. Verifying or validating before the
+    # copy re-opens the same race between check and freeze, one step earlier,
+    # and size/quota have to judge the immutable bytes too — otherwise the
+    # client declares 1 KB, completes, and swells the staging object to 5 GB
+    # before we snapshot it.
     try:
+        await storage.copy(physical_s3_key, physical_frozen_key)
+    except Exception as exc:  # broad: S3/MinIO server-side copy can throw varied SDK errors; map to 502
+        await _cleanup_saved_upload(frozen_key, str(job.id))
+        logger.exception(
+            "presigned_upload_freeze_failed",
+            job_id=str(job.id),
+            s3_key=s3_key,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Upload completion failed — the upload session may have expired. Please try again.",
+        ) from exc
+
+    try:
+        actual_size = await verify_completed_presigned_upload(
+            db=db,
+            storage=storage,
+            key=physical_frozen_key,
+            expected_size=um.get("expected_size"),
+            user_id=user.id,
+            request=http_request,
+            job_id=job.id,
+        )
+        # fix(#1202): both ingest doors enforce the same content contract.
         await _validate_presigned_content(
             storage,
-            key=physical_s3_key,
+            key=physical_frozen_key,
             filename=job.source_filename or "",
             size=actual_size,
         )
     except HTTPException:
+        # A deliberate rejection drops BOTH objects, matching the direct
+        # path's rollback — leaving the staging object would hand the client
+        # bytes we just refused, still addressable by its PUT URL.
+        await _cleanup_saved_upload(frozen_key, str(job.id))
         await _cleanup_saved_upload(s3_key, str(job.id))
         raise
+    except BaseException:
+        # N4: this clause must stay AFTER the HTTPException one. A transient
+        # storage failure drops only the copy we just made; the staging object
+        # survives so a retry costs one more completion call rather than a
+        # multi-GB re-upload.
+        await _cleanup_saved_upload(frozen_key, str(job.id))
+        raise
 
-    job.file_path = s3_key
+    job.file_path = frozen_key
     # fix(#1186): the presigned path never stamped file_type, and on an S3
     # deployment the frontend always uploads through it — so every GeoTIFF
     # fell through to the vector branch: 422 at preview, a vector commit body
     # after that, and an ogr2ogr dispatch after that.
     _stamp_raster_metadata(job, job.source_filename)
+    # The staging object has served its purpose. A late re-PUT through the
+    # still-valid URL recreates it as an orphan that nothing reads — no
+    # sweeper covers it either, because every staging reaper here keys off
+    # `job.file_path` (tasks_vector.py's post-ingest delete, jobs/router.py's
+    # stale-job purge), which now points at the frozen key. That is a storage
+    # -consumption nuisance, not a validation bypass.
+    await _cleanup_saved_upload(s3_key, str(job.id))
     await db.commit()
 
     return UploadResponse(
@@ -502,6 +544,26 @@ def _stamp_raster_metadata(job: "IngestJob", filename: str | None) -> None:
 
 # Trailing PAR1 magic that validate_parquet_file seeks to from the end.
 _PARQUET_MAGIC_BYTES = 4
+
+# Path segment separating the frozen snapshot from the client-writable
+# staging key. The presign endpoints only ever mint URLs for
+# `staging/{job_id}/{filename}`, so nothing under here is client-writable.
+_FROZEN_SEGMENT = "frozen"
+
+
+def _frozen_staging_key(s3_key: str) -> str:
+    """Derive the immutable snapshot key for a staging upload key.
+
+    Inserts a segment before the filename rather than appending a suffix:
+    the extension is load-bearing all the way down (content sniffing, the
+    raster/vector branch, ogr2ogr driver selection), so the filename has to
+    survive as the last segment. The result still starts with `staging/`,
+    which is what every existing staging reaper keys off.
+    """
+    parent, separator, name = s3_key.rpartition("/")
+    if not separator:
+        return f"{_FROZEN_SEGMENT}/{s3_key}"
+    return f"{parent}/{_FROZEN_SEGMENT}/{name}"
 
 
 async def _validate_presigned_content(

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -91,6 +91,7 @@ from app.processing.ingest.service import (
 )
 from app.processing.ingest.presigned import (
     abort_presigned_multipart_upload,
+    raise_if_over_max_upload_size,
     verify_completed_presigned_upload,
 )
 from app.processing.ingest.tasks import regenerate_vrt
@@ -360,6 +361,21 @@ async def complete_presigned_upload(
             detail="Job is not a presigned upload",
         )
 
+    # fix(#1202 review): completion is ONE-SHOT, keyed off resolved state.
+    # `file_path` is created empty and set only by a completion that made it
+    # all the way through, so its presence is the fact "these bytes were
+    # accepted" — no metadata flag to rotate and no window to race. Without
+    # this, a second call re-copies the staging key (still writable through
+    # the client's PUT URL) over the frozen bytes the first 200 accepted, or
+    # rejects and deletes both objects out from under a job that already
+    # points at them. Same class as the TOCTOU: client-writable state
+    # re-entering after acceptance.
+    if job.file_path:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Upload already completed for this job",
+        )
+
     storage = get_storage()
     s3_key = um["s3_key"]
     physical_s3_key = resolve_current_storage_key(s3_key)
@@ -409,6 +425,21 @@ async def complete_presigned_upload(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="File not found in S3 after upload",
         )
+    # fix(#1202 review): resource-waste fast path, NOT the security boundary.
+    # Presigned PUT URLs do not bind Content-Length, so the object on disk can
+    # be any size regardless of what the client declared at request time —
+    # without this, an oversize upload gets fully copied just to be rejected a
+    # moment later. This gate is advisory ONLY: the client can swell the object
+    # after the measurement and before the copy, which is exactly why the
+    # post-copy check on the frozen bytes below stays and stays authoritative.
+    # Do not remove that one on the strength of this one.
+    staging_size = await storage.size(physical_s3_key)
+    try:
+        raise_if_over_max_upload_size(staging_size, await UPLOAD_MAX_SIZE_MB.get(db))
+    except HTTPException:
+        await _cleanup_saved_upload(s3_key, str(job.id))
+        raise
+
     frozen_key = _frozen_staging_key(s3_key)
     physical_frozen_key = resolve_current_storage_key(frozen_key)
 
@@ -425,10 +456,24 @@ async def complete_presigned_upload(
     # and size/quota have to judge the immutable bytes too — otherwise the
     # client declares 1 KB, completes, and swells the staging object to 5 GB
     # before we snapshot it.
+    #
+    # Drained, because the copy runs in an SDK thread that a client disconnect
+    # cannot stop: returning early would leave it writing a frozen object no
+    # job row references. `_await_provider_call_draining` waits the thread out
+    # and then re-raises the cancellation, so by the time we clean up, there is
+    # a whole object to delete rather than one still being written.
     try:
-        await storage.copy(physical_s3_key, physical_frozen_key)
-    except Exception as exc:  # broad: S3/MinIO server-side copy can throw varied SDK errors; map to 502
+        await _await_provider_call_draining(
+            storage.copy(physical_s3_key, physical_frozen_key)
+        )
+    except BaseException as exc:
+        # ONE cleanup path for every way the freeze can fail — an SDK error or
+        # a drained cancellation, which `except Exception` cannot see at all.
+        # The staging object is never touched here, so a retry costs one more
+        # completion call rather than a multi-GB re-upload.
         await _cleanup_saved_upload(frozen_key, str(job.id))
+        if isinstance(exc, asyncio.CancelledError):
+            raise
         logger.exception(
             "presigned_upload_freeze_failed",
             job_id=str(job.id),

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -352,31 +352,8 @@ async def complete_presigned_upload(
     db: AsyncSession = Depends(get_db),
 ) -> UploadResponse:
     """Notify that direct-to-S3 upload is complete."""
-    # Runtime import: the module-scope one is TYPE_CHECKING-only.
-    from app.platform.jobs.models import IngestJob
-
     job = await get_job_or_404(db, job_id, user)
-
-    # fix(#1202 review r5): re-fetch under a row lock before reading anything
-    # the one-shot guard depends on. That guard was an UNLOCKED read: two
-    # overlapping completions both saw an empty `file_path` and proceeded, and
-    # because the frozen key is derived deterministically they raced over the
-    # same object — the loser's refusal path deletes BOTH objects while the
-    # winner commits `file_path` pointing at one of them, binding the job to
-    # nothing. Bad bytes still never got bound, but a refusal was destroying
-    # state a concurrent accept depended on.
-    #
-    # The lock is held until this handler's commit or rollback, so the second
-    # request blocks and then reads the committed `file_path` and takes the
-    # 400 below. It locks one row, so completions of DIFFERENT jobs are
-    # untouched. `get_job_or_404` stays unlocked — its other callers are reads
-    # that must not serialize behind a completion.
-    job = await db.get(IngestJob, job_id, with_for_update=True)
-    if job is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Job not found",
-        )
+    job = await lock_presigned_job(db, job_id)
     um = job.user_metadata or {}
 
     if not um.get("presigned"):
@@ -634,6 +611,43 @@ def _stamp_raster_metadata(job: "IngestJob", filename: str | None) -> None:
         return
 
     job.user_metadata = {**(job.user_metadata or {}), "file_type": "raster"}
+
+
+async def lock_presigned_job(db: AsyncSession, job_id: uuid.UUID) -> "IngestJob":
+    """Re-fetch a job under a row lock, with attributes reloaded from the row.
+
+    fix(#1202 review r5, r9): the one-shot guard reads `file_path`, and the
+    property it needs is TWO-PART. Both halves are load-bearing and each was
+    got wrong once:
+
+    1. The SELECT must LOCK. Without `with_for_update` two overlapping
+       completions both saw an empty `file_path` and proceeded, racing over
+       the same deterministically-derived frozen key: the loser's refusal
+       deletes both objects while the winner commits a binding to one of them.
+
+    2. The read must be FRESH. `with_for_update` alone serializes without
+       informing — SQLAlchemy keeps the already-loaded attributes on the
+       identity-map instance, and the caller's authz fetch loaded this row
+       BEFORE the competing request committed. Measured, not inferred: without
+       `populate_existing` the re-fetch returns the stale empty `file_path`
+       and the guard passes on a job that was already completed. The r5 test
+       pinned only half of this (that a FOR UPDATE statement reached the
+       driver), which is why the second half survived four review rounds.
+
+    The lock is held to the caller's commit or rollback, and it is one row, so
+    completions of different jobs never serialize against each other.
+    `get_job_or_404` deliberately stays unlocked — its other callers are reads
+    that must not queue behind a completion.
+    """
+    from app.platform.jobs.models import IngestJob
+
+    job = await db.get(IngestJob, job_id, with_for_update=True, populate_existing=True)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job not found",
+        )
+    return job
 
 
 # Trailing PAR1 magic that validate_parquet_file seeks to from the end.

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -352,7 +352,31 @@ async def complete_presigned_upload(
     db: AsyncSession = Depends(get_db),
 ) -> UploadResponse:
     """Notify that direct-to-S3 upload is complete."""
+    # Runtime import: the module-scope one is TYPE_CHECKING-only.
+    from app.platform.jobs.models import IngestJob
+
     job = await get_job_or_404(db, job_id, user)
+
+    # fix(#1202 review r5): re-fetch under a row lock before reading anything
+    # the one-shot guard depends on. That guard was an UNLOCKED read: two
+    # overlapping completions both saw an empty `file_path` and proceeded, and
+    # because the frozen key is derived deterministically they raced over the
+    # same object — the loser's refusal path deletes BOTH objects while the
+    # winner commits `file_path` pointing at one of them, binding the job to
+    # nothing. Bad bytes still never got bound, but a refusal was destroying
+    # state a concurrent accept depended on.
+    #
+    # The lock is held until this handler's commit or rollback, so the second
+    # request blocks and then reads the committed `file_path` and takes the
+    # 400 below. It locks one row, so completions of DIFFERENT jobs are
+    # untouched. `get_job_or_404` stays unlocked — its other callers are reads
+    # that must not serialize behind a completion.
+    job = await db.get(IngestJob, job_id, with_for_update=True)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job not found",
+        )
     um = job.user_metadata or {}
 
     if not um.get("presigned"):
@@ -543,10 +567,12 @@ async def complete_presigned_upload(
     #
     # Past this line the staging object has served its purpose. A delete
     # failure here, or a late re-PUT through the still-valid URL, leaves an
-    # orphan that nothing reads — and nothing sweeps either, because every
-    # staging reaper keys off `job.file_path` (tasks_vector.py's post-ingest
-    # delete, jobs/router.py's stale-job purge), which now points at the
-    # frozen key. Storage-consumption nuisance, not a validation bypass.
+    # orphan that nothing reads. Both staging reapers sweep it at job end via
+    # `user_metadata["s3_key"]` (tasks_vector.py's post-ingest cleanup and
+    # jobs/router.py's stale-job purge, both through
+    # `owned_presigned_staging_key`), so the residual window is completion to
+    # reap, not forever. S3 cannot revoke an individual presigned URL, so
+    # reaping is the only real remedy.
     await _cleanup_saved_upload(s3_key, str(job.id))
 
     return UploadResponse(

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import math
+import tempfile
 import uuid
 from datetime import datetime, timezone
 
@@ -93,7 +94,7 @@ from app.processing.ingest.presigned import (
     verify_completed_presigned_upload,
 )
 from app.processing.ingest.tasks import regenerate_vrt
-from app.processing.ingest.validation import validate_file_content
+from app.processing.ingest.validation import HEADER_READ_SIZE, validate_file_content
 from app.platform.jobs.defer_guard import defer_with_orphan_guard
 from app.core.persistent_config import (
     UPLOAD_ALLOWED_EXTENSIONS,
@@ -102,7 +103,7 @@ from app.core.persistent_config import (
 )
 from app.modules.quota.service import check_upload_quota, get_user_quota_usage
 from app.processing.raster.validation import validate_sources
-from app.platform.storage import get_storage
+from app.platform.storage import StorageProvider, get_storage
 from app.platform.storage.titiler_url import resolve_current_storage_key
 from app.standards.ogc.errors import (
     BAD_GATEWAY_RESPONSE,
@@ -408,7 +409,7 @@ async def complete_presigned_upload(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="File not found in S3 after upload",
         )
-    await verify_completed_presigned_upload(
+    actual_size = await verify_completed_presigned_upload(
         db=db,
         storage=storage,
         key=physical_s3_key,
@@ -417,6 +418,23 @@ async def complete_presigned_upload(
         request=http_request,
         job_id=job.id,
     )
+
+    # fix(#1202): both ingest doors enforce the same content contract. A
+    # deliberate rejection drops the object, matching the direct path's
+    # rollback — completion is the last point that exclusively owns it. Only
+    # HTTPException, deliberately: a transient storage error here leaves the
+    # object for the client to retry completion against, rather than forcing a
+    # multi-GB re-upload over a hiccup.
+    try:
+        await _validate_presigned_content(
+            storage,
+            key=physical_s3_key,
+            filename=job.source_filename or "",
+            size=actual_size,
+        )
+    except HTTPException:
+        await _cleanup_saved_upload(s3_key, str(job.id))
+        raise
 
     job.file_path = s3_key
     # fix(#1186): the presigned path never stamped file_type, and on an S3
@@ -480,6 +498,62 @@ def _stamp_raster_metadata(job: "IngestJob", filename: str | None) -> None:
         return
 
     job.user_metadata = {**(job.user_metadata or {}), "file_type": "raster"}
+
+
+# Trailing PAR1 magic that validate_parquet_file seeks to from the end.
+_PARQUET_MAGIC_BYTES = 4
+
+
+async def _validate_presigned_content(
+    storage: StorageProvider,
+    *,
+    key: str,
+    filename: str,
+    size: int,
+) -> None:
+    """Run the direct path's content check against an object in storage.
+
+    fix(#1202): ``upload_file`` calls ``validate_file_content`` on the staged
+    bytes, and the presigned completion path did not — so the two ingest doors
+    accepted different files, and a presigned upload reached preview (which
+    hands the file to GDAL) with no content check behind it.
+
+    ``validate_file_content`` wants a path, and presigned uploads exist for the
+    multi-GB case, so instead of downloading the object this builds a probe
+    file out of the only bytes the checks read:
+
+    - the first ``HEADER_READ_SIZE`` bytes, which is exactly what the
+      magic-byte branch reads;
+    - for ``.parquet``, the trailing ``PAR1`` magic, which
+      ``validate_parquet_file`` seeks to from the end. Only appended when the
+      object is larger than the header window — below that the header IS the
+      whole object, so the probe is byte-identical to it.
+
+    The ``.vrt`` branch reads the whole body and is never reached here:
+    ``_reject_standalone_vrt`` refuses a ``.vrt`` filename at presign-request
+    time, before any object exists.
+
+    Raises HTTPException 422 carrying ``str(exc)``, the same class, status and
+    body the direct path raises at its ``validate_file_content`` call.
+    """
+    head = await storage.get_range(key, 0, HEADER_READ_SIZE)
+
+    tail = b""
+    if Path(filename).suffix.lower() == ".parquet" and size > len(head):
+        tail = await storage.get_range(
+            key, size - _PARQUET_MAGIC_BYTES, _PARQUET_MAGIC_BYTES
+        )
+
+    with tempfile.NamedTemporaryFile(suffix=".probe") as probe:
+        probe.write(head + tail)
+        probe.flush()
+        try:
+            validate_file_content(probe.name, filename)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=str(exc),
+            ) from exc
 
 
 @router.post(

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -380,7 +380,17 @@ async def complete_presigned_upload(
     s3_key = um["s3_key"]
     physical_s3_key = resolve_current_storage_key(s3_key)
 
-    if um.get("multipart"):
+    # fix(#1202 review r3): skip assembly when it already happened. For an S3
+    # multipart upload the staging object exists IF AND ONLY IF
+    # CompleteMultipartUpload succeeded — uploaded parts are invisible as an
+    # object until then — so the object's presence is a sound record that this
+    # step is done, with no metadata to keep in sync. Without this, a
+    # completion that got past assembly and then failed (at the freeze, say)
+    # left the job unbound and the upload id SPENT: the retry this endpoint's
+    # 502 advertises re-entered the branch, called complete with a consumed id,
+    # and could never succeed. The parts-required 400 is skipped along with it,
+    # deliberately — a retrying client has nothing left to resend.
+    if um.get("multipart") and not await storage.exists(physical_s3_key):
         if not request.parts:
             await abort_presigned_multipart_upload(
                 storage,
@@ -522,14 +532,22 @@ async def complete_presigned_upload(
     # fell through to the vector branch: 422 at preview, a vector commit body
     # after that, and an ogr2ogr dispatch after that.
     _stamp_raster_metadata(job, job.source_filename)
-    # The staging object has served its purpose. A late re-PUT through the
-    # still-valid URL recreates it as an orphan that nothing reads — no
-    # sweeper covers it either, because every staging reaper here keys off
-    # `job.file_path` (tasks_vector.py's post-ingest delete, jobs/router.py's
-    # stale-job purge), which now points at the frozen key. That is a storage
-    # -consumption nuisance, not a validation bypass.
-    await _cleanup_saved_upload(s3_key, str(job.id))
     await db.commit()
+
+    # fix(#1202 review r3): AFTER the commit, never before. Deleting first
+    # meant a failed commit rolled `file_path` back with the staging object
+    # already gone — the retry then hit "File not found in S3 after upload"
+    # and the frozen copy orphaned with nothing pointing at it. Now a failed
+    # commit leaves both objects, so the retry re-copies over the frozen key
+    # and proceeds.
+    #
+    # Past this line the staging object has served its purpose. A delete
+    # failure here, or a late re-PUT through the still-valid URL, leaves an
+    # orphan that nothing reads — and nothing sweeps either, because every
+    # staging reaper keys off `job.file_path` (tasks_vector.py's post-ingest
+    # delete, jobs/router.py's stale-job purge), which now points at the
+    # frozen key. Storage-consumption nuisance, not a validation bypass.
+    await _cleanup_saved_upload(s3_key, str(job.id))
 
     return UploadResponse(
         job_id=job.id,

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -463,6 +463,38 @@ def check_missing_crs(
     )
 
 
+async def reap_presigned_staging_object(
+    job_id: str, owned_staging_key: str | None
+) -> None:
+    """Best-effort delete of a job's OWN presigned staging object.
+
+    fix(#1202 review r5): a completed presigned upload points ``file_path`` at
+    the frozen copy, so every reaper that keys off ``file_path`` misses the
+    staging key — the one the client's PUT URL can still recreate, outside
+    size and quota accounting. Each terminal task tail calls this.
+
+    Pass the result of ``owned_presigned_staging_key``, which is what decides
+    there is anything to delete: it declines a fan-out child's inherited
+    parent key, so a child can never reap the original its siblings read.
+
+    Never raises. A failed sweep leaves an orphan, which is strictly better
+    than failing a job whose work is already done and committed.
+    """
+    if not owned_staging_key:
+        return
+    try:
+        from app.platform.storage import get_storage
+        from app.platform.storage.titiler_url import resolve_current_storage_key
+
+        await get_storage().delete(resolve_current_storage_key(owned_staging_key))
+    except Exception:  # broad: best-effort staging cleanup; never fail the task
+        structlog.get_logger().warning(
+            "Failed to delete presigned staging object",
+            job_id=job_id,
+            storage_key=owned_staging_key,
+        )
+
+
 async def _validate_upload_file_safety(
     session,
     *,

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -26,12 +26,14 @@ from app.processing.raster.cog import (
 )
 from app.processing.raster.quicklook import generate_quicklook
 
+from app.platform.jobs.models import owned_presigned_staging_key
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
     _emit_billing_event,
     _job_phase_session,
     _parse_temporal_fields,
     _validate_upload_file_safety,
+    reap_presigned_staging_object,
     task_app,
 )
 
@@ -362,6 +364,8 @@ async def ingest_raster(
     tmp_dir: str | None = None
     original_file_path = file_path
     final_status: str = "pending"
+    # fix(#1202 review r5): captured in phase 1, swept in the finally.
+    owned_staging_key: str | None = None
     # GAP-017: storage keys written BEFORE the terminal DB commit. base_key
     # embeds dataset.id, a flushed-but-uncommitted UUID — if the commit (or any
     # step after the puts) fails the dataset row is rolled back, so delete_dataset
@@ -447,6 +451,9 @@ async def ingest_raster(
             # Snapshot job attributes needed in phase 2 (after CPU work).
             # These plain Python values do not require an attached ORM session.
             um: dict = job.user_metadata or {}
+            owned_staging_key = owned_presigned_staging_key(
+                job.id, job.user_metadata, job.file_path
+            )
             source_filename: str | None = job.source_filename
             _reject_raw_vrt_job(source_filename)
             is_manifest_vrt = _is_manifest_vrt_job(job)
@@ -856,3 +863,12 @@ async def ingest_raster(
             _Path(file_path).unlink(missing_ok=True)
         elif file_path != original_file_path:
             _Path(file_path).unlink(missing_ok=True)
+        # fix(#1202 review r5): sweep the presigned staging key. Raster has no
+        # equivalent of the vector tail's #430 BA-09 block, so before this
+        # nothing on this path ever deleted a storage object the client could
+        # still overwrite — and the stale-job purge is not a backstop here,
+        # because it exempts the newest complete job per dataset, which is
+        # exactly what a successful ingest produces. Shared with the vector
+        # tail so the two cannot drift.
+        if final_status in ("complete", "failed"):
+            await reap_presigned_staging_object(job_id, owned_staging_key)

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -388,6 +388,21 @@ async def ingest_raster(
             if job is None:
                 return
 
+            # fix(#1202 review r7): captured HERE, first thing after the row is
+            # in hand, so no exit from this block can precede it. It used to sit
+            # with the phase-2 snapshot below, past three exits — the
+            # heartbeat-claim bail, a `resolve_file_path` download failure, and
+            # the validation `return` — each of which reached the terminal
+            # `finally` with the key still None and left the staging object
+            # behind. The validation path is the reachable one: lowering
+            # UPLOAD_MAX_SIZE_MB between completion and worker pickup fails a
+            # job whose bytes are already in the bucket. Reads the DB column,
+            # not the local `file_path` that step 2 rebinds, so moving it
+            # earlier changes the timing and nothing else.
+            owned_staging_key = owned_presigned_staging_key(
+                job.id, job.user_metadata, job.file_path
+            )
+
             # 1. Mark running.
             # REMED-02 / ingest-audit P2-07: the fresh "validating" stamp rides
             # the claim commit (see the helper). Raster ingests are the prime
@@ -451,9 +466,6 @@ async def ingest_raster(
             # Snapshot job attributes needed in phase 2 (after CPU work).
             # These plain Python values do not require an attached ORM session.
             um: dict = job.user_metadata or {}
-            owned_staging_key = owned_presigned_staging_key(
-                job.id, job.user_metadata, job.file_path
-            )
             source_filename: str | None = job.source_filename
             _reject_raw_vrt_job(source_filename)
             is_manifest_vrt = _is_manifest_vrt_job(job)

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -21,6 +21,7 @@ from app.platform.jobs.heartbeat import (
 from app.processing.ingest.metadata import _qtable
 from app.processing.ingest.tasks_common import (
     IngestContext,
+    reap_presigned_staging_object,
     _append_job_warning,
     _archive_original_file,
     _bind_task_log_context,
@@ -730,26 +731,13 @@ async def ingest_file(
                     storage_key=original_file_path,
                 )
 
-        # fix(#1202 review r5): sweep the presigned staging key too. After a
-        # presigned completion the job points at the frozen copy, so the block
-        # above never touches the key the client still holds a PUT URL for —
-        # and a post-completion re-PUT recreates an object that escapes size
-        # and quota accounting. `owned_presigned_staging_key` returns it only
-        # when this job is the one that presigned it, so a fan-out child (which
-        # inherits the parent's metadata) cannot delete the shared original.
-        if final_status in ("complete", "failed") and owned_staging_key:
-            try:
-                from app.platform.storage import get_storage
-
-                await get_storage().delete(
-                    resolve_current_storage_key(owned_staging_key)
-                )
-            except Exception:  # broad: best-effort staging cleanup; never fail the task
-                structlog.get_logger().warning(
-                    "Failed to delete presigned staging object",
-                    job_id=job_id,
-                    storage_key=owned_staging_key,
-                )
+        # fix(#1202 review r5): sweep the presigned staging key too. The block
+        # above only reaps `original_file_path`, which after a presigned
+        # completion is the FROZEN copy — so the key the client still holds a
+        # PUT URL for was never touched. Shared with the raster tail so the
+        # two cannot drift.
+        if final_status in ("complete", "failed"):
+            await reap_presigned_staging_object(job_id, owned_staging_key)
 
 
 @task_app.task(queue="ingest", retry=0, aliases=["app.ingest.tasks.ingest_service"])

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -36,6 +36,7 @@ from app.processing.ingest.tasks_common import (
     resolve_service_type,
     task_app,
 )
+from app.platform.jobs.models import owned_presigned_staging_key
 from app.platform.storage.titiler_url import resolve_current_storage_key
 
 
@@ -672,6 +673,8 @@ async def ingest_file(
         # (retry=0). Cost of the fail-safe: an orphaned staging object the
         # retention policy reaps later.
         is_fan_out_child = True
+        # fix(#1202 review r5): the presigned staging key, swept below.
+        owned_staging_key: str | None = None
         try:
             # REMED-03 / P2-05: route through _job_phase_session. The helper
             # yields the IngestJob row directly, so we just check user_metadata.
@@ -684,6 +687,11 @@ async def ingest_file(
                 if _check_job is not None:
                     is_fan_out_child = bool(
                         (_check_job.user_metadata or {}).get("fan_out_parent_id")
+                    )
+                    owned_staging_key = owned_presigned_staging_key(
+                        _check_job.id,
+                        _check_job.user_metadata,
+                        _check_job.file_path,
                     )
         except Exception:  # broad: cleanup decision is best-effort, never block completion on this query
             is_fan_out_child = True
@@ -720,6 +728,27 @@ async def ingest_file(
                     "Failed to delete staging source object",
                     job_id=job_id,
                     storage_key=original_file_path,
+                )
+
+        # fix(#1202 review r5): sweep the presigned staging key too. After a
+        # presigned completion the job points at the frozen copy, so the block
+        # above never touches the key the client still holds a PUT URL for —
+        # and a post-completion re-PUT recreates an object that escapes size
+        # and quota accounting. `owned_presigned_staging_key` returns it only
+        # when this job is the one that presigned it, so a fan-out child (which
+        # inherits the parent's metadata) cannot delete the shared original.
+        if final_status in ("complete", "failed") and owned_staging_key:
+            try:
+                from app.platform.storage import get_storage
+
+                await get_storage().delete(
+                    resolve_current_storage_key(owned_staging_key)
+                )
+            except Exception:  # broad: best-effort staging cleanup; never fail the task
+                structlog.get_logger().warning(
+                    "Failed to delete presigned staging object",
+                    job_id=job_id,
+                    storage_key=owned_staging_key,
                 )
 
 

--- a/backend/tests/test_jobs_router.py
+++ b/backend/tests/test_jobs_router.py
@@ -1181,6 +1181,13 @@ class TestCleanupStaleJobs:
         monkeypatch.setattr(audit_service, "audit_emit_durable", record_durable)
         monkeypatch.setattr(jobs_router, "fail_stale_jobs", cleanup)
         monkeypatch.setattr(jobs_router, "_reap_committed_staged_paths", reap)
+        # fix(#1202 review r8): the post-expiry staging sweep runs beside the
+        # reaper on this path; stub it out so the fake session is not queried.
+        monkeypatch.setattr(
+            jobs_router,
+            "_sweep_expired_presigned_staging",
+            AsyncMock(return_value=outcome),
+        )
         error_logs = []
         monkeypatch.setattr(
             jobs_router.log,
@@ -1263,6 +1270,13 @@ class TestCleanupStaleJobs:
         monkeypatch.setattr(audit_service, "audit_emit_durable", fail_durable)
         monkeypatch.setattr(jobs_router, "fail_stale_jobs", cleanup)
         monkeypatch.setattr(jobs_router, "_reap_committed_staged_paths", reap)
+        # fix(#1202 review r8): the post-expiry staging sweep runs beside the
+        # reaper on this path; stub it out so the fake session is not queried.
+        monkeypatch.setattr(
+            jobs_router,
+            "_sweep_expired_presigned_staging",
+            AsyncMock(return_value=outcome),
+        )
         error_logs = []
         monkeypatch.setattr(
             jobs_router.log,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1972,7 +1972,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # The comments carry which of the three is the security boundary (only
     # the post-copy verify) — deleting the wrong one reads as a cleanup.
     # Cap 1609 -> 1654, exact.
-    "backend/app/processing/ingest/router.py": 1654,
+    # fix(#1202 review r3): +18 — both findings were "the failure path leaves
+    # state the retry path cannot proceed from". Multipart assembly is skipped
+    # when the staging object already exists (for S3 that is an iff for
+    # CompleteMultipartUpload having succeeded, so a retry no longer presents a
+    # spent upload id), and the staging delete moved after the commit so a
+    # rolled-back commit does not strand the retry with the bytes gone. Both
+    # comments carry the invariant, not the mechanic. Cap 1654 -> 1672, exact.
+    "backend/app/processing/ingest/router.py": 1672,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1955,7 +1955,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # trailing PAR1 magic for .parquet. That reasoning is the load-bearing
     # part — a check added to validate_file_content that reads the middle of a
     # file would pass vacuously here. Cap 1473 -> 1547, exact.
-    "backend/app/processing/ingest/router.py": 1547,
+    # fix(#1202 review): +62 — freeze-first. Validating the staging key was a
+    # TOCTOU: the client keeps a working presigned PUT URL for it until expiry,
+    # so checked bytes could be swapped for garbage before preview read them.
+    # Completion now snapshots to a key no presign endpoint ever issued a URL
+    # for and judges THAT (_frozen_staging_key plus the copy/verify/validate
+    # ordering). The lines are mostly the two comments recording why the ORDER
+    # is the fix and which object each failure branch may delete — get either
+    # wrong and the race is back with the guard still apparently in place.
+    # Cap 1547 -> 1609, exact.
+    "backend/app/processing/ingest/router.py": 1609,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1948,7 +1948,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # complete_presigned_upload from calling it at all. `crs_missing` is
     # derived in ingest_raster now, from metadata that task already reads.
     # Cap 1493 -> 1473, still exact.
-    "backend/app/processing/ingest/router.py": 1473,
+    # fix(#1202): +74 — _validate_presigned_content, so the presigned door
+    # enforces the same content contract as the direct one. Most of it is the
+    # docstring recording WHICH bytes the probe carries and why that is
+    # faithful: the header window the magic-byte branch reads, plus the
+    # trailing PAR1 magic for .parquet. That reasoning is the load-bearing
+    # part — a check added to validate_file_content that reads the middle of a
+    # file would pass vacuously here. Cap 1473 -> 1547, exact.
+    "backend/app/processing/ingest/router.py": 1547,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1979,7 +1979,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # spent upload id), and the staging delete moved after the commit so a
     # rolled-back commit does not strand the retry with the bytes gone. Both
     # comments carry the invariant, not the mechanic. Cap 1654 -> 1672, exact.
-    "backend/app/processing/ingest/router.py": 1672,
+    # fix(#1202 review r5): +26 — the one-shot guard was an UNLOCKED read, so
+    # two overlapping completions both passed it and raced over the same
+    # deterministic frozen key, letting the loser's refusal delete state the
+    # winner had already accepted. Completion now re-fetches the row FOR
+    # UPDATE before reading anything the guard depends on. The rest is the
+    # comment explaining why get_job_or_404 deliberately stays unlocked.
+    # Cap 1672 -> 1698, exact.
+    "backend/app/processing/ingest/router.py": 1698,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
@@ -2004,7 +2011,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # them writes the first entry.
     "backend/app/platform/config_ops/service.py": 1201,
     "backend/app/processing/ingest/tasks_vrt.py": 1071,
-    "backend/app/processing/ingest/tasks_vector.py": 1058,
+    # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
+    # A completed presigned job points file_path at its frozen copy, so this
+    # reaper never touched the key the client's PUT URL can still recreate.
+    # Ownership comes from owned_presigned_staging_key, which refuses a
+    # fan-out child's inherited parent key. Cap 1058 -> 1087, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1087,
     "backend/app/modules/auth/oauth/service.py": 1031,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1986,7 +1986,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # UPDATE before reading anything the guard depends on. The rest is the
     # comment explaining why get_job_or_404 deliberately stays unlocked.
     # Cap 1672 -> 1698, exact.
-    "backend/app/processing/ingest/router.py": 1698,
+    # fix(#1202 review r5b): +5 — the sweep comment named its reapers and went
+    # stale the moment the raster tail was added. It now points at
+    # `owned_presigned_staging_key` as the grep-able registry and records that
+    # the stale purge is a backstop only (it exempts the newest complete job
+    # per dataset). Cap 1698 -> 1703, exact.
+    "backend/app/processing/ingest/router.py": 1703,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
@@ -2002,7 +2007,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # correction fixes `_run_staging_pipeline`'s own docstring, which claimed
     # `_ingest_vector_into_staging` was the "new ingests" caller.
     # Ratchet stays exact.
-    "backend/app/processing/ingest/tasks_common.py": 1671,
+    # fix(#1202 review r5b): +32 — `reap_presigned_staging_object`, the shared
+    # sweep. The vector tail had it inline; raster needed the same block, and
+    # two copies of a best-effort delete in a PR about doors that drifted
+    # would have been the same mistake one level down. Cap 1671 -> 1703, exact.
+    "backend/app/processing/ingest/tasks_common.py": 1703,
     # --- entered by the inclusion rule, fix(#958) -------------------------
     # These five were the ungated modules at or above _RATCHET_INCLUSION_LOC
     # when the rule was written. They arrive at their measured size with no
@@ -2016,7 +2025,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reaper never touched the key the client's PUT URL can still recreate.
     # Ownership comes from owned_presigned_staging_key, which refuses a
     # fan-out child's inherited parent key. Cap 1058 -> 1087, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1087,
+    # fix(#1202 review r5b): -12 — that block moved to
+    # `tasks_common.reap_presigned_staging_object` so the raster tail could
+    # share it. Ratchet DOWN in the same commit, per the no-headroom rule.
+    # Cap 1087 -> 1075, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1075,
     "backend/app/modules/auth/oauth/service.py": 1031,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1991,7 +1991,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `owned_presigned_staging_key` as the grep-able registry and records that
     # the stale purge is a backstop only (it exempts the newest complete job
     # per dataset). Cap 1698 -> 1703, exact.
-    "backend/app/processing/ingest/router.py": 1703,
+    # fix(#1202 review r9): +14 — the locked re-fetch became
+    # `lock_presigned_job`, whose docstring records that the property is
+    # TWO-part: the SELECT must lock AND the read must be fresh. Without
+    # populate_existing the lock serialized without informing, and the r5 test
+    # pinned only the first half, which is why the second survived four
+    # rounds. Extracting it also stops a test reimplementing the call and
+    # passing while the handler diverges. Cap 1703 -> 1717, exact.
+    "backend/app/processing/ingest/router.py": 1717,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1964,7 +1964,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # is the fix and which object each failure branch may delete — get either
     # wrong and the race is back with the guard still apparently in place.
     # Cap 1547 -> 1609, exact.
-    "backend/app/processing/ingest/router.py": 1609,
+    # fix(#1202 review r2): +45 — three findings, all the same shape as the
+    # first two rounds (client-writable state re-entering after a check).
+    # One-shot completion keyed off `file_path`; a pre-copy size fast path so
+    # an oversize object is not copied just to be rejected; and draining the
+    # freeze copy so a disconnect cannot abandon the SDK thread mid-write.
+    # The comments carry which of the three is the security boundary (only
+    # the post-copy verify) — deleting the wrong one reads as a cleanup.
+    # Cap 1609 -> 1654, exact.
+    "backend/app/processing/ingest/router.py": 1654,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901

--- a/backend/tests/test_presigned_content_validation_1202.py
+++ b/backend/tests/test_presigned_content_validation_1202.py
@@ -30,15 +30,15 @@ pytestmark = pytest.mark.anyio
 _GIF_PAYLOAD = b"GIF89a" + b"\x00" * 512
 _VALID_GEOJSON = b'{"type":"FeatureCollection","features":[]}'
 
-# Parquet carries its magic at BOTH ends. Sized past the header window on
-# purpose: the completion path reads the first 8192 bytes, so the trailing
-# magic can only come from a second, separately ranged read.
 # Same LENGTH as the valid GeoJSON, deliberately. A replay payload of a
 # different size is caught by the declared-size check, which masks the swap
 # this file is trying to observe and makes the one-shot test pass for a
 # reason that is not the guard. Do not "simplify" this to a different payload.
 _SAME_SIZE_GARBAGE = b"X" * len(_VALID_GEOJSON)
 
+# Parquet carries its magic at BOTH ends. Sized past the header window on
+# purpose: the completion path reads the first 8192 bytes, so the trailing
+# magic can only come from a second, separately ranged read.
 _PARQUET_FILLER = b"\x00" * 20_000
 _VALID_PARQUET = b"PAR1" + _PARQUET_FILLER + b"PAR1"
 _TRUNCATED_PARQUET = b"PAR1" + _PARQUET_FILLER + b"\x00\x00\x00\x00"
@@ -57,9 +57,38 @@ class _FakeS3Storage:
         self.range_reads: list[tuple[str, int, int]] = []
         self.whole_object_reads: list[str] = []
         self.copies: list[tuple[str, str]] = []
+        # Multipart state, modelled the way S3 actually behaves: uploaded
+        # parts are NOT visible as an object, and the upload id is spent by a
+        # successful completion. The retry guard keys off exactly that.
+        self.live_upload_ids: dict[str, str] = {}
+        self.pending_parts: dict[str, bytes] = {}
+        self.multipart_completions: list[tuple[str, str]] = []
 
     def generate_presigned_put_url(self, key: str, content_type: str) -> str:
         return f"https://s3.invalid/{key}?signed=1"
+
+    def initiate_multipart_upload(
+        self, key: str, content_type: str = "application/octet-stream"
+    ) -> str:
+        upload_id = f"upload-{len(self.live_upload_ids) + 1}"
+        self.live_upload_ids[key] = upload_id
+        return upload_id
+
+    def generate_presigned_part_url(
+        self, key: str, upload_id: str, part_number: int, expiration: int = 7200
+    ) -> str:
+        return f"https://s3.invalid/{key}?part={part_number}&upload={upload_id}"
+
+    def complete_multipart_upload(self, key: str, upload_id: str, parts: list) -> None:
+        self.multipart_completions.append((key, upload_id))
+        if self.live_upload_ids.get(key) != upload_id:
+            raise RuntimeError(f"NoSuchUpload: {upload_id} is spent or unknown")
+        del self.live_upload_ids[key]
+        self.objects[key] = self.pending_parts.pop(key)
+
+    def abort_multipart_upload(self, key: str, upload_id: str) -> None:
+        self.live_upload_ids.pop(key, None)
+        self.pending_parts.pop(key, None)
 
     async def exists(self, key: str) -> bool:
         return key in self.objects
@@ -464,3 +493,147 @@ async def test_an_oversize_object_is_refused_without_being_copied(
     assert "exceeds the maximum allowed" in completion.json()["detail"]
     assert both_doors.copies == [], both_doors.copies
     assert both_doors.objects == {}, both_doors.objects
+
+
+# Big enough to cross the multipart threshold the fixture lowers to 1 MB, and
+# still plain text so content validation passes on its first 8192 bytes.
+_LARGE_GEOJSON = _VALID_GEOJSON + b" " * (2 * 1024 * 1024)
+
+
+async def _request_multipart_presign(client, headers, filename: str, payload: bytes):
+    resp = await client.post(
+        "/ingest/upload/presigned",
+        json={
+            "filename": filename,
+            "file_size": len(payload),
+            "content_type": "application/octet-stream",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["upload_id"], "expected a multipart presign, got a single PUT"
+    return body
+
+
+async def test_multipart_retry_after_a_failed_freeze_does_not_reuse_a_spent_upload_id(
+    client, admin_auth_header, test_db_session, both_doors, monkeypatch
+) -> None:
+    """The retry this endpoint's 502 promises has to actually work for multipart.
+
+    CompleteMultipartUpload consumes the upload id and materializes the
+    object. A completion that got past assembly and then died at the freeze
+    left the job unbound with the id already spent, so every retry called
+    complete again and was refused by the provider. The fake models both
+    facts, so a regression here fails rather than passing quietly.
+    """
+    monkeypatch.setattr(settings, "presigned_multipart_threshold_mb", 1)
+
+    body = await _request_multipart_presign(
+        client, admin_auth_header, "roads.geojson", _LARGE_GEOJSON
+    )
+    # The client uploads its parts: present, but not yet an object.
+    both_doors.pending_parts[body["s3_key"]] = _LARGE_GEOJSON
+    assert body["s3_key"] not in both_doors.objects
+
+    real_copy = both_doors.copy
+    freeze_calls = {"n": 0}
+
+    async def _fail_first_freeze(src_key: str, dst_key: str) -> None:
+        freeze_calls["n"] += 1
+        if freeze_calls["n"] == 1:
+            raise RuntimeError("storage hiccup during freeze")
+        await real_copy(src_key, dst_key)
+
+    parts = [{"etag": "etag-1", "part_number": 1}]
+    with patch.object(both_doors, "copy", _fail_first_freeze):
+        failed = await client.post(
+            f"/ingest/upload/presigned/{body['job_id']}/complete",
+            json={"parts": parts},
+            headers=admin_auth_header,
+        )
+    assert failed.status_code == 502, failed.text
+    # Assembly succeeded before the freeze died, so the object is there.
+    assert body["s3_key"] in both_doors.objects
+
+    # The retry sends no parts — it has nothing left to resend.
+    retried = await client.post(
+        f"/ingest/upload/presigned/{body['job_id']}/complete",
+        json={},
+        headers=admin_auth_header,
+    )
+
+    assert retried.status_code == 200, retried.text
+    assert len(both_doors.multipart_completions) == 1, both_doors.multipart_completions
+    file_path = await _job_file_path(test_db_session, body["job_id"])
+    assert file_path.endswith("/frozen/roads.geojson")
+    assert both_doors.objects[file_path] == _LARGE_GEOJSON
+
+
+async def test_a_failed_commit_leaves_both_objects_so_the_retry_can_proceed(
+    client, admin_auth_header, test_db_session, both_doors
+) -> None:
+    """Deleting staging before the commit stranded the client.
+
+    A rolled-back commit unsets file_path, so the job still needs the staging
+    object — but it had already been deleted, and the retry could only report
+    "File not found in S3 after upload" while the frozen copy orphaned.
+    """
+    from fastapi import HTTPException
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    resp = await client.post(
+        "/ingest/upload/presigned",
+        json={
+            "filename": "roads.geojson",
+            "file_size": len(_VALID_GEOJSON),
+            "content_type": "application/octet-stream",
+        },
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    both_doors.objects[body["s3_key"]] = _VALID_GEOJSON
+
+    real_commit = AsyncSession.commit
+    commits = {"n": 0}
+
+    async def _fail_first_commit(self) -> None:
+        commits["n"] += 1
+        if commits["n"] == 1:
+            await self.rollback()
+            # HTTPException rather than a raw error ONLY to keep the test
+            # fast: an unhandled exception here sends the middleware stack
+            # into rendering a full traceback with locals, which costs 44
+            # seconds per run. What this test asserts is the ORDERING — that
+            # an exception at the commit leaves the staging object alone —
+            # and that is identical whichever exception type unwinds it.
+            raise HTTPException(status_code=503, detail="commit failed")
+        await real_commit(self)
+
+    with patch.object(AsyncSession, "commit", _fail_first_commit):
+        failed = await client.post(
+            f"/ingest/upload/presigned/{body['job_id']}/complete",
+            json={},
+            headers=admin_auth_header,
+        )
+
+    assert failed.status_code == 503, failed.text
+    # It really was the handler's commit that failed, not an earlier one.
+    assert commits["n"] == 1
+    # Both objects survive: the retry needs the staging bytes to re-freeze,
+    # and the frozen copy proves the run got all the way past the freeze.
+    assert body["s3_key"] in both_doors.objects
+    assert any(dst in both_doors.objects for _src, dst in both_doors.copies)
+    assert await _job_file_path(test_db_session, body["job_id"]) in ("", None)
+
+    retried = await client.post(
+        f"/ingest/upload/presigned/{body['job_id']}/complete",
+        json={},
+        headers=admin_auth_header,
+    )
+
+    assert retried.status_code == 200, retried.text
+    file_path = await _job_file_path(test_db_session, body["job_id"])
+    assert both_doors.objects[file_path] == _VALID_GEOJSON
+    assert body["s3_key"] not in both_doors.objects

--- a/backend/tests/test_presigned_content_validation_1202.py
+++ b/backend/tests/test_presigned_content_validation_1202.py
@@ -1,0 +1,263 @@
+"""Regression coverage for #1202: both ingest doors enforce one content contract.
+
+``POST /ingest/upload`` content-validates the bytes it stages. The presigned
+completion endpoint did not — it stamped metadata and committed — so a client
+that presigned could land a file the direct door refuses, and preview handed
+that unvalidated file to GDAL seconds later.
+
+Every test here drives BOTH doors with the same payload and compares the
+outcome, because the bug was never "one door is wrong" but "the two doors
+disagree". The refusal cases and the admission cases are both pinned: a fix
+that only tightens refusals lets the false-positive half regress silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.config import settings
+
+
+pytestmark = pytest.mark.anyio
+
+
+# A GIF header is binary (null bytes, so the text-content escape hatch does not
+# apply) and puremagic names it exactly, which makes the rejection message a
+# concrete string both doors must produce character for character.
+_GIF_PAYLOAD = b"GIF89a" + b"\x00" * 512
+_VALID_GEOJSON = b'{"type":"FeatureCollection","features":[]}'
+
+# Parquet carries its magic at BOTH ends. Sized past the header window on
+# purpose: the completion path reads the first 8192 bytes, so the trailing
+# magic can only come from a second, separately ranged read.
+_PARQUET_FILLER = b"\x00" * 20_000
+_VALID_PARQUET = b"PAR1" + _PARQUET_FILLER + b"PAR1"
+_TRUNCATED_PARQUET = b"PAR1" + _PARQUET_FILLER + b"\x00\x00\x00\x00"
+
+
+class _FakeS3Storage:
+    """In-memory stand-in for the S3 provider, keyed like the real one.
+
+    Records every read so a test can assert what the completion path touched
+    — the point of the fix is that it validates without downloading the
+    object, and only a recording fake can tell those two apart.
+    """
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.range_reads: list[tuple[str, int, int]] = []
+        self.whole_object_reads: list[str] = []
+
+    def generate_presigned_put_url(self, key: str, content_type: str) -> str:
+        return f"https://s3.invalid/{key}?signed=1"
+
+    async def exists(self, key: str) -> bool:
+        return key in self.objects
+
+    async def size(self, key: str) -> int:
+        return len(self.objects[key])
+
+    async def get_range(self, key: str, start: int, length: int) -> bytes:
+        self.range_reads.append((key, start, length))
+        return self.objects[key][start : start + length]
+
+    async def get(self, key: str) -> bytes:
+        self.whole_object_reads.append(key)
+        return self.objects[key]
+
+    async def get_to_file(self, key: str, dest: Path) -> Path:
+        self.whole_object_reads.append(key)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(self.objects[key])
+        return dest
+
+    async def delete(self, key: str) -> None:
+        self.objects.pop(key, None)
+
+
+@pytest.fixture
+def both_doors(monkeypatch, tmp_path):
+    """Make both upload doors drivable in one test against one fake bucket.
+
+    The direct door's ``save_upload_file`` writes to ``tmp_path`` (mirroring
+    ``test_ingest.py``) so validation sees a real local file; the presigned
+    door reads from the in-memory bucket. The allowed-extension list is fixed
+    here rather than read from persistent config: the shared per-worker
+    database carries whatever earlier tests stored, and these tests are about
+    content, not configuration.
+    """
+    from app.processing.ingest import router
+
+    storage = _FakeS3Storage()
+    monkeypatch.setattr(settings, "storage_provider", "s3")
+    monkeypatch.setattr(router, "get_storage", lambda: storage, raising=True)
+    monkeypatch.setattr(
+        "app.platform.storage.get_storage", lambda: storage, raising=True
+    )
+    monkeypatch.setattr(
+        router,
+        "_get_allowed_extensions_safely",
+        AsyncMock(return_value=[".geojson", ".json", ".parquet", ".tif"]),
+    )
+
+    async def _save_to_temp(file, job_id: str, **_) -> Path:
+        dest = tmp_path / f"{job_id}_{file.filename}"
+        dest.write_bytes(await file.read())
+        await file.seek(0)
+        return dest
+
+    with patch.object(router, "save_upload_file", AsyncMock(side_effect=_save_to_temp)):
+        yield storage
+
+
+async def _direct_upload(client, headers, filename: str, payload: bytes):
+    """Drive ``POST /ingest/upload`` — the door that always validated."""
+    return await client.post(
+        "/ingest/upload",
+        files={"file": (filename, payload, "application/octet-stream")},
+        headers=headers,
+    )
+
+
+async def _presigned_upload(
+    client, headers, storage: _FakeS3Storage, filename: str, payload: bytes
+):
+    """Drive request-presigned → (client PUTs to S3) → complete."""
+    resp = await client.post(
+        "/ingest/upload/presigned",
+        json={
+            "filename": filename,
+            "file_size": len(payload),
+            "content_type": "application/octet-stream",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+
+    # Stand in for the browser's direct PUT to the presigned URL.
+    storage.objects[body["s3_key"]] = payload
+
+    completion = await client.post(
+        f"/ingest/upload/presigned/{body['job_id']}/complete",
+        json={},
+        headers=headers,
+    )
+    return completion, body["s3_key"]
+
+
+async def test_both_doors_reject_a_mislabeled_payload_identically(
+    client, admin_auth_header, both_doors
+) -> None:
+    """The bug: a GIF named .geojson was refused at one door and accepted at the other.
+
+    Asserting the details are EQUAL, not merely both-4xx, is the taxonomy
+    requirement — a client sees one contract regardless of which door it used.
+    """
+    direct = await _direct_upload(
+        client, admin_auth_header, "roads.geojson", _GIF_PAYLOAD
+    )
+    presigned, _ = await _presigned_upload(
+        client, admin_auth_header, both_doors, "roads.geojson", _GIF_PAYLOAD
+    )
+
+    assert direct.status_code == 422, direct.text
+    assert presigned.status_code == direct.status_code, presigned.text
+    assert presigned.json()["detail"] == direct.json()["detail"]
+    assert "'.gif'" in direct.json()["detail"]
+
+
+async def test_both_doors_accept_a_legitimate_payload(
+    client, admin_auth_header, both_doors
+) -> None:
+    """The other direction. A refusal test alone cannot see over-rejection."""
+    direct = await _direct_upload(
+        client, admin_auth_header, "roads.geojson", _VALID_GEOJSON
+    )
+    presigned, _ = await _presigned_upload(
+        client, admin_auth_header, both_doors, "roads.geojson", _VALID_GEOJSON
+    )
+
+    assert direct.status_code == 201, direct.text
+    assert presigned.status_code == 200, presigned.text
+
+
+async def test_both_doors_reject_a_truncated_parquet_identically(
+    client, admin_auth_header, both_doors
+) -> None:
+    """Parquet's footer magic lives past the header window.
+
+    A completion check that only read a prefix would accept this file while
+    the direct door refuses it — the asymmetry in miniature, one layer down.
+    """
+    direct = await _direct_upload(
+        client, admin_auth_header, "cells.parquet", _TRUNCATED_PARQUET
+    )
+    presigned, _ = await _presigned_upload(
+        client, admin_auth_header, both_doors, "cells.parquet", _TRUNCATED_PARQUET
+    )
+
+    assert direct.status_code == 422, direct.text
+    assert presigned.status_code == direct.status_code, presigned.text
+    assert presigned.json()["detail"] == direct.json()["detail"]
+    assert "PAR1" in direct.json()["detail"]
+
+    # The footer can only have come from a read anchored to the end.
+    size = len(_TRUNCATED_PARQUET)
+    assert any(start == size - 4 for _key, start, _length in both_doors.range_reads), (
+        both_doors.range_reads
+    )
+
+
+async def test_both_doors_accept_a_valid_parquet_larger_than_the_header_window(
+    client, admin_auth_header, both_doors
+) -> None:
+    """The admission half of the parquet rule, at a size that needs the tail read."""
+    direct = await _direct_upload(
+        client, admin_auth_header, "cells.parquet", _VALID_PARQUET
+    )
+    presigned, _ = await _presigned_upload(
+        client, admin_auth_header, both_doors, "cells.parquet", _VALID_PARQUET
+    )
+
+    assert direct.status_code == 201, direct.text
+    assert presigned.status_code == 200, presigned.text
+
+
+async def test_rejected_presigned_object_is_removed_from_storage(
+    client, admin_auth_header, both_doors
+) -> None:
+    """A refused upload must not leave the bytes sitting in the bucket.
+
+    The direct door deletes its staged file on a content failure; completion
+    is the last point that exclusively owns the object, so it has to as well.
+    """
+    presigned, s3_key = await _presigned_upload(
+        client, admin_auth_header, both_doors, "roads.geojson", _GIF_PAYLOAD
+    )
+
+    assert presigned.status_code == 422, presigned.text
+    assert s3_key not in both_doors.objects
+
+
+async def test_completion_validates_without_downloading_the_object(
+    client, admin_auth_header, both_doors
+) -> None:
+    """Presigned uploads exist for the multi-GB case.
+
+    #1186 removed a whole-object download from this endpoint for exactly that
+    reason; re-adding the content check must not put one back. Pinning the
+    read WIDTH is what keeps the fix affordable — a future edit that reaches
+    for ``get()`` would still pass every assertion above.
+    """
+    presigned, _ = await _presigned_upload(
+        client, admin_auth_header, both_doors, "cells.parquet", _VALID_PARQUET
+    )
+
+    assert presigned.status_code == 200, presigned.text
+    assert both_doors.whole_object_reads == []
+    total_bytes = sum(length for _key, _start, length in both_doors.range_reads)
+    assert total_bytes <= 8192 + 4, both_doors.range_reads

--- a/backend/tests/test_presigned_content_validation_1202.py
+++ b/backend/tests/test_presigned_content_validation_1202.py
@@ -33,6 +33,12 @@ _VALID_GEOJSON = b'{"type":"FeatureCollection","features":[]}'
 # Parquet carries its magic at BOTH ends. Sized past the header window on
 # purpose: the completion path reads the first 8192 bytes, so the trailing
 # magic can only come from a second, separately ranged read.
+# Same LENGTH as the valid GeoJSON, deliberately. A replay payload of a
+# different size is caught by the declared-size check, which masks the swap
+# this file is trying to observe and makes the one-shot test pass for a
+# reason that is not the guard. Do not "simplify" this to a different payload.
+_SAME_SIZE_GARBAGE = b"X" * len(_VALID_GEOJSON)
+
 _PARQUET_FILLER = b"\x00" * 20_000
 _VALID_PARQUET = b"PAR1" + _PARQUET_FILLER + b"PAR1"
 _TRUNCATED_PARQUET = b"PAR1" + _PARQUET_FILLER + b"\x00\x00\x00\x00"
@@ -336,3 +342,125 @@ async def test_a_late_reput_to_the_staging_key_cannot_swap_validated_bytes(
     both_doors.objects[staging_key] = _GIF_PAYLOAD
 
     assert both_doors.objects[file_path] == _VALID_GEOJSON
+
+
+async def test_a_second_completion_is_refused_and_cannot_replace_the_bytes(
+    client, admin_auth_header, test_db_session, both_doors
+) -> None:
+    """Completion is one-shot.
+
+    The re-PUT above is only harmless while nothing re-runs the freeze. A
+    second ``/complete`` would copy the staging key — which the client can
+    still write — straight over the bytes the first call accepted. Refusing
+    it is the guard; the byte assertion is what the guard is FOR.
+
+    The replay payload matches the original's LENGTH so the declared-size
+    check cannot reject it first. With a different size this test passes
+    against a build that has no guard at all.
+    """
+    presigned, job_id, staging_key = await _presigned_upload(
+        client, admin_auth_header, both_doors, "roads.geojson", _VALID_GEOJSON
+    )
+    assert presigned.status_code == 200, presigned.text
+    file_path = await _job_file_path(test_db_session, job_id)
+
+    # Re-PUT garbage, then try to get the server to re-freeze it.
+    both_doors.objects[staging_key] = _SAME_SIZE_GARBAGE
+    replay = await client.post(
+        f"/ingest/upload/presigned/{job_id}/complete",
+        json={},
+        headers=admin_auth_header,
+    )
+
+    assert replay.status_code == 400, replay.text
+    assert "already completed" in replay.json()["detail"].lower()
+    assert both_doors.objects[file_path] == _VALID_GEOJSON
+    assert both_doors.copies == [(staging_key, file_path)]
+
+
+async def test_completion_can_still_be_retried_after_a_transient_failure(
+    client, admin_auth_header, test_db_session, both_doors
+) -> None:
+    """The other direction of the one-shot rule, and the reason it keys off
+    ``file_path`` rather than a "completion attempted" flag.
+
+    A completion that died in the storage layer leaves the job unbound, and
+    the client must be able to retry without re-uploading. Pinning this is
+    what stops the guard from being tightened into a rule that strands
+    every interrupted upload.
+    """
+    resp = await client.post(
+        "/ingest/upload/presigned",
+        json={
+            "filename": "roads.geojson",
+            "file_size": len(_VALID_GEOJSON),
+            "content_type": "application/octet-stream",
+        },
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    both_doors.objects[body["s3_key"]] = _VALID_GEOJSON
+
+    async def _boom(src_key: str, dst_key: str) -> None:
+        raise RuntimeError("storage hiccup during freeze")
+
+    with patch.object(both_doors, "copy", _boom):
+        failed = await client.post(
+            f"/ingest/upload/presigned/{body['job_id']}/complete",
+            json={},
+            headers=admin_auth_header,
+        )
+    assert failed.status_code == 502, failed.text
+    # The staging object survives a transient failure — that is the whole
+    # point of not deleting it there.
+    assert body["s3_key"] in both_doors.objects
+
+    retried = await client.post(
+        f"/ingest/upload/presigned/{body['job_id']}/complete",
+        json={},
+        headers=admin_auth_header,
+    )
+
+    assert retried.status_code == 200, retried.text
+    file_path = await _job_file_path(test_db_session, body["job_id"])
+    assert both_doors.objects[file_path] == _VALID_GEOJSON
+
+
+async def test_an_oversize_object_is_refused_without_being_copied(
+    client, admin_auth_header, both_doors
+) -> None:
+    """The pre-copy fast path: do not move gigabytes just to reject them.
+
+    Presigned PUT URLs do not bind Content-Length, so the object can exceed
+    the declared size. Asserting NO copy was recorded is the whole test —
+    a rejection alone would pass with the wasteful copy still happening.
+    """
+    from app.processing.ingest import router
+
+    resp = await client.post(
+        "/ingest/upload/presigned",
+        json={
+            "filename": "roads.geojson",
+            "file_size": len(_VALID_GEOJSON),
+            "content_type": "application/octet-stream",
+        },
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+
+    # The client PUTs far more than it declared. 1 MB against a 0-MB cap.
+    both_doors.objects[body["s3_key"]] = b"\x00" * (1024 * 1024)
+
+    with patch.object(router.UPLOAD_MAX_SIZE_MB, "get", AsyncMock(return_value=0)):
+        completion = await client.post(
+            f"/ingest/upload/presigned/{body['job_id']}/complete",
+            json={},
+            headers=admin_auth_header,
+        )
+
+    assert completion.status_code == 422, completion.text
+    assert "exceeds the maximum allowed" in completion.json()["detail"]
+    assert both_doors.copies == [], both_doors.copies
+    assert both_doors.objects == {}, both_doors.objects

--- a/backend/tests/test_presigned_content_validation_1202.py
+++ b/backend/tests/test_presigned_content_validation_1202.py
@@ -637,3 +637,45 @@ async def test_a_failed_commit_leaves_both_objects_so_the_retry_can_proceed(
     file_path = await _job_file_path(test_db_session, body["job_id"])
     assert both_doors.objects[file_path] == _VALID_GEOJSON
     assert body["s3_key"] not in both_doors.objects
+
+
+async def test_completion_locks_the_job_row_before_reading_file_path(
+    client, admin_auth_header, both_doors
+) -> None:
+    """Pin the serialization mechanism, since the race itself is not
+    deterministically testable through the ASGI client.
+
+    The one-shot guard was an unlocked read: two overlapping completions both
+    saw an empty ``file_path``, derived the SAME frozen key, and raced — the
+    loser's refusal path deletes both objects while the winner commits a
+    ``file_path`` pointing at one of them. What makes that impossible is the
+    row lock, so this asserts the lock reaches the DATABASE rather than that
+    the call was written with the right keyword. A `db.get` on an object
+    already in the identity map can return the cached instance without
+    emitting SQL at all, and that failure mode is invisible to a spy on the
+    call arguments.
+    """
+    from sqlalchemy import event
+    from sqlalchemy.engine import Engine
+
+    statements: list[str] = []
+
+    def _record(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    event.listen(Engine, "before_cursor_execute", _record)
+    try:
+        presigned, _job_id, _staging = await _presigned_upload(
+            client, admin_auth_header, both_doors, "roads.geojson", _VALID_GEOJSON
+        )
+    finally:
+        event.remove(Engine, "before_cursor_execute", _record)
+
+    assert presigned.status_code == 200, presigned.text
+    locking = [s for s in statements if "FOR UPDATE" in s.upper()]
+    assert locking, (
+        "completion issued no FOR UPDATE; the one-shot guard is an unlocked "
+        f"read again. ingest_jobs statements seen: "
+        f"{[s for s in statements if 'ingest_jobs' in s][:5]}"
+    )
+    assert any("ingest_jobs" in s for s in locking), locking

--- a/backend/tests/test_presigned_content_validation_1202.py
+++ b/backend/tests/test_presigned_content_validation_1202.py
@@ -679,3 +679,73 @@ async def test_completion_locks_the_job_row_before_reading_file_path(
         f"{[s for s in statements if 'ingest_jobs' in s][:5]}"
     )
     assert any("ingest_jobs" in s for s in locking), locking
+
+
+async def test_the_locked_refetch_reads_the_committed_file_path(
+    test_db_session,
+) -> None:
+    """fix(#1202 review r9): the lock must INFORM, not just serialize.
+
+    The r5 pin proves a `FOR UPDATE` statement reaches the database. It does
+    NOT prove the handler then reads the committed value: SQLAlchemy does not
+    overwrite already-loaded attributes on an identity-map instance unless
+    told to, and the handler's authz fetch loads the row BEFORE the competing
+    request commits. If the locked re-fetch returned the cached `file_path`,
+    the one-shot guard would pass on a job that was already completed — the
+    lock would serialize and race identically.
+
+    Two sessions, no interleaving needed: session 1 loads the row (the authz
+    fetch), a separate session commits a binding (the winning request), then
+    session 1 does exactly what the handler does and we read the attribute.
+    """
+    from sqlalchemy import select, update
+
+    from app.core import db as db_module
+    from app.modules.auth.models import User
+    from app.platform.jobs.models import IngestJob
+    from app.processing.ingest.router import lock_presigned_job
+
+    admin = (
+        await test_db_session.execute(select(User).where(User.username == "admin"))
+    ).scalar_one()
+    job = IngestJob(
+        source_filename="roads.geojson",
+        created_by=admin.id,
+        status="pending",
+        file_path="",
+        user_metadata={"presigned": True},
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+    await test_db_session.refresh(job)
+    job_id = job.id
+    bound_path = f"staging/{job_id}/frozen/roads.geojson"
+
+    async with db_module.async_session() as request_session:
+        # The unlocked authz fetch, exactly as get_job_or_404 does it.
+        loaded = (
+            await request_session.execute(
+                select(IngestJob).where(IngestJob.id == job_id)
+            )
+        ).scalar_one()
+        assert loaded.file_path == "", "precondition: unbound when first read"
+
+        # The winning request commits its binding on another connection.
+        async with db_module.async_session() as other_session:
+            await other_session.execute(
+                update(IngestJob)
+                .where(IngestJob.id == job_id)
+                .values(file_path=bound_path)
+            )
+            await other_session.commit()
+
+        # The handler's OWN helper, not a copy of it — a local
+        # reimplementation would keep passing if the handler dropped
+        # populate_existing, which is exactly the regression this guards.
+        relocked = await lock_presigned_job(request_session, job_id)
+
+    assert relocked.file_path == bound_path, (
+        "the locked re-fetch returned a STALE file_path — the one-shot guard "
+        "would pass on an already-completed job, so the lock serializes "
+        "without informing"
+    )

--- a/backend/tests/test_presigned_content_validation_1202.py
+++ b/backend/tests/test_presigned_content_validation_1202.py
@@ -50,6 +50,7 @@ class _FakeS3Storage:
         self.objects: dict[str, bytes] = {}
         self.range_reads: list[tuple[str, int, int]] = []
         self.whole_object_reads: list[str] = []
+        self.copies: list[tuple[str, str]] = []
 
     def generate_presigned_put_url(self, key: str, content_type: str) -> str:
         return f"https://s3.invalid/{key}?signed=1"
@@ -59,6 +60,12 @@ class _FakeS3Storage:
 
     async def size(self, key: str) -> int:
         return len(self.objects[key])
+
+    async def copy(self, src_key: str, dst_key: str) -> None:
+        # Server-side on the real provider: the bytes never enter this
+        # process, which is why this does not touch whole_object_reads.
+        self.copies.append((src_key, dst_key))
+        self.objects[dst_key] = self.objects[src_key]
 
     async def get_range(self, key: str, start: int, length: int) -> bytes:
         self.range_reads.append((key, start, length))
@@ -125,7 +132,12 @@ async def _direct_upload(client, headers, filename: str, payload: bytes):
 async def _presigned_upload(
     client, headers, storage: _FakeS3Storage, filename: str, payload: bytes
 ):
-    """Drive request-presigned → (client PUTs to S3) → complete."""
+    """Drive request-presigned → (client PUTs to S3) → complete.
+
+    Returns the completion response, the job id, and the staging key the
+    client holds a PUT URL for. Tests run single-tenant, so logical and
+    physical keys are identical and either may be used against the fake.
+    """
     resp = await client.post(
         "/ingest/upload/presigned",
         json={
@@ -146,7 +158,19 @@ async def _presigned_upload(
         json={},
         headers=headers,
     )
-    return completion, body["s3_key"]
+    return completion, body["job_id"], body["s3_key"]
+
+
+async def _job_file_path(test_db_session, job_id: str) -> str:
+    from sqlalchemy import select
+
+    from app.platform.jobs.models import IngestJob
+
+    job = (
+        await test_db_session.execute(select(IngestJob).where(IngestJob.id == job_id))
+    ).scalar_one()
+    await test_db_session.refresh(job)
+    return job.file_path
 
 
 async def test_both_doors_reject_a_mislabeled_payload_identically(
@@ -160,7 +184,7 @@ async def test_both_doors_reject_a_mislabeled_payload_identically(
     direct = await _direct_upload(
         client, admin_auth_header, "roads.geojson", _GIF_PAYLOAD
     )
-    presigned, _ = await _presigned_upload(
+    presigned, _job_id, _staging = await _presigned_upload(
         client, admin_auth_header, both_doors, "roads.geojson", _GIF_PAYLOAD
     )
 
@@ -177,7 +201,7 @@ async def test_both_doors_accept_a_legitimate_payload(
     direct = await _direct_upload(
         client, admin_auth_header, "roads.geojson", _VALID_GEOJSON
     )
-    presigned, _ = await _presigned_upload(
+    presigned, _job_id, _staging = await _presigned_upload(
         client, admin_auth_header, both_doors, "roads.geojson", _VALID_GEOJSON
     )
 
@@ -196,7 +220,7 @@ async def test_both_doors_reject_a_truncated_parquet_identically(
     direct = await _direct_upload(
         client, admin_auth_header, "cells.parquet", _TRUNCATED_PARQUET
     )
-    presigned, _ = await _presigned_upload(
+    presigned, _job_id, _staging = await _presigned_upload(
         client, admin_auth_header, both_doors, "cells.parquet", _TRUNCATED_PARQUET
     )
 
@@ -219,7 +243,7 @@ async def test_both_doors_accept_a_valid_parquet_larger_than_the_header_window(
     direct = await _direct_upload(
         client, admin_auth_header, "cells.parquet", _VALID_PARQUET
     )
-    presigned, _ = await _presigned_upload(
+    presigned, _job_id, _staging = await _presigned_upload(
         client, admin_auth_header, both_doors, "cells.parquet", _VALID_PARQUET
     )
 
@@ -227,20 +251,22 @@ async def test_both_doors_accept_a_valid_parquet_larger_than_the_header_window(
     assert presigned.status_code == 200, presigned.text
 
 
-async def test_rejected_presigned_object_is_removed_from_storage(
+async def test_rejected_presigned_upload_removes_both_objects(
     client, admin_auth_header, both_doors
 ) -> None:
     """A refused upload must not leave the bytes sitting in the bucket.
 
-    The direct door deletes its staged file on a content failure; completion
-    is the last point that exclusively owns the object, so it has to as well.
+    BOTH objects, because there are two after the freeze. Leaving the staging
+    one would hand the client back exactly the bytes we just refused, still
+    addressable through the PUT URL it holds.
     """
-    presigned, s3_key = await _presigned_upload(
+    presigned, _job_id, staging_key = await _presigned_upload(
         client, admin_auth_header, both_doors, "roads.geojson", _GIF_PAYLOAD
     )
 
     assert presigned.status_code == 422, presigned.text
-    assert s3_key not in both_doors.objects
+    assert both_doors.objects == {}, both_doors.objects
+    assert staging_key not in both_doors.objects
 
 
 async def test_completion_validates_without_downloading_the_object(
@@ -253,7 +279,7 @@ async def test_completion_validates_without_downloading_the_object(
     read WIDTH is what keeps the fix affordable — a future edit that reaches
     for ``get()`` would still pass every assertion above.
     """
-    presigned, _ = await _presigned_upload(
+    presigned, _job_id, _staging = await _presigned_upload(
         client, admin_auth_header, both_doors, "cells.parquet", _VALID_PARQUET
     )
 
@@ -261,3 +287,52 @@ async def test_completion_validates_without_downloading_the_object(
     assert both_doors.whole_object_reads == []
     total_bytes = sum(length for _key, _start, length in both_doors.range_reads)
     assert total_bytes <= 8192 + 4, both_doors.range_reads
+
+
+async def test_completion_binds_the_job_to_a_frozen_key_and_drops_staging(
+    client, admin_auth_header, test_db_session, both_doors
+) -> None:
+    """The key layout the TOCTOU fix rests on.
+
+    The job's source must be a key no presign endpoint ever minted a URL for,
+    and it must still live under ``staging/`` — every staging reaper in the
+    codebase keys off that prefix, so a frozen copy outside it would leak.
+    """
+    presigned, job_id, staging_key = await _presigned_upload(
+        client, admin_auth_header, both_doors, "roads.geojson", _VALID_GEOJSON
+    )
+    assert presigned.status_code == 200, presigned.text
+
+    file_path = await _job_file_path(test_db_session, job_id)
+
+    assert file_path != staging_key
+    assert file_path.startswith("staging/")
+    assert file_path.endswith("/roads.geojson")
+    assert both_doors.copies == [(staging_key, file_path)]
+    assert file_path in both_doors.objects
+    assert staging_key not in both_doors.objects
+
+
+async def test_a_late_reput_to_the_staging_key_cannot_swap_validated_bytes(
+    client, admin_auth_header, test_db_session, both_doors
+) -> None:
+    """The P1: presigned PUT URLs outlive completion.
+
+    They stay valid until expiry (an hour by default) and a PUT to an existing
+    key REPLACES the object, so validating the key the client can still write
+    to proves nothing about what preview later hands to GDAL. Completion
+    snapshots the bytes first and binds the job to the snapshot, so the
+    re-PUT below lands somewhere nothing reads.
+    """
+    presigned, job_id, staging_key = await _presigned_upload(
+        client, admin_auth_header, both_doors, "roads.geojson", _VALID_GEOJSON
+    )
+    assert presigned.status_code == 200, presigned.text
+
+    file_path = await _job_file_path(test_db_session, job_id)
+
+    # The client re-PUTs garbage through the URL it still holds, after the
+    # completion call has already returned 200.
+    both_doors.objects[staging_key] = _GIF_PAYLOAD
+
+    assert both_doors.objects[file_path] == _VALID_GEOJSON

--- a/backend/tests/test_presigned_raster_stamp_1186.py
+++ b/backend/tests/test_presigned_raster_stamp_1186.py
@@ -80,6 +80,10 @@ class _FakeS3Storage:
     async def size(self, key: str) -> int:
         return len(self.objects[key])
 
+    async def get_range(self, key: str, start: int, length: int) -> bytes:
+        # fix(#1202): completion content-validates from a bounded window.
+        return self.objects[key][start : start + length]
+
     async def delete(self, key: str) -> None:
         self.objects.pop(key, None)
 

--- a/backend/tests/test_presigned_raster_stamp_1186.py
+++ b/backend/tests/test_presigned_raster_stamp_1186.py
@@ -84,6 +84,10 @@ class _FakeS3Storage:
         # fix(#1202): completion content-validates from a bounded window.
         return self.objects[key][start : start + length]
 
+    async def copy(self, src_key: str, dst_key: str) -> None:
+        # fix(#1202 review): completion freezes the upload before judging it.
+        self.objects[dst_key] = self.objects[src_key]
+
     async def delete(self, key: str) -> None:
         self.objects.pop(key, None)
 

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -1,0 +1,157 @@
+"""#1202 review r5: the presigned staging key must be swept at job end.
+
+A completed presigned upload points ``file_path`` at a frozen copy, which
+leaves ``user_metadata["s3_key"]`` as the only reference to the key the
+client can still write through its unexpired PUT URL. Both staging reapers
+now sweep it, and this file pins the decision policy plus the reaper that is
+directly callable.
+
+The decision policy is tested as a pure helper rather than by driving
+ogr2ogr, matching ``test_ingest_staging_cleanup_gap018.py`` — the sibling
+file that pins ``_should_unlink_staging`` for the same reason.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.platform.jobs.models import owned_presigned_staging_key
+
+
+pytestmark = pytest.mark.anyio
+
+
+class TestOwnedPresignedStagingKey:
+    """Which staging key a reaping job is allowed to delete."""
+
+    def test_a_completed_presigned_job_owns_its_staging_key(self):
+        job_id = uuid.uuid4()
+        assert (
+            owned_presigned_staging_key(
+                job_id,
+                {"presigned": True, "s3_key": f"staging/{job_id}/roads.geojson"},
+                f"staging/{job_id}/frozen/roads.geojson",
+            )
+            == f"staging/{job_id}/roads.geojson"
+        )
+
+    def test_a_fan_out_child_does_not_own_the_inherited_parent_key(self):
+        """The case that decided the design.
+
+        ``create_fan_out_jobs`` clones the parent's ``user_metadata``
+        wholesale, so every child carries the PARENT's ``s3_key``. Sweeping on
+        "differs from file_path" alone would delete the shared original out
+        from under siblings that still need it — the breakage the
+        ``is_fan_out_child`` default-true guard exists to prevent. Ownership
+        is the key's own prefix, so a child declines it.
+        """
+        parent_id = uuid.uuid4()
+        child_id = uuid.uuid4()
+        assert (
+            owned_presigned_staging_key(
+                child_id,
+                {
+                    "s3_key": f"staging/{parent_id}/multi.gpkg",
+                    "fan_out_parent_id": str(parent_id),
+                },
+                f"staging/{parent_id}/multi.gpkg",
+            )
+            is None
+        )
+
+    def test_the_still_bound_staging_key_is_not_swept(self):
+        """A job whose file_path IS the staging key still needs it."""
+        job_id = uuid.uuid4()
+        key = f"staging/{job_id}/roads.geojson"
+        assert owned_presigned_staging_key(job_id, {"s3_key": key}, key) is None
+
+    def test_a_job_with_no_presigned_metadata_sweeps_nothing(self):
+        job_id = uuid.uuid4()
+        assert owned_presigned_staging_key(job_id, None, "/local/path.geojson") is None
+        assert owned_presigned_staging_key(job_id, {}, "/local/path.geojson") is None
+
+    def test_a_non_string_key_is_refused_rather_than_formatted(self):
+        """Metadata is user-influenced JSONB; a non-string must not reach the
+        provider as a stringified value."""
+        job_id = uuid.uuid4()
+        assert owned_presigned_staging_key(job_id, {"s3_key": 17}, None) is None
+        assert owned_presigned_staging_key(job_id, {"s3_key": None}, None) is None
+
+    def test_an_arbitrary_same_bucket_key_is_refused(self):
+        """Manifest sources can put arbitrary keys in this column. Only a key
+        under THIS job's staging prefix is ours to delete."""
+        job_id = uuid.uuid4()
+        assert (
+            owned_presigned_staging_key(
+                job_id, {"s3_key": "customer-data/quarterly.gpkg"}, None
+            )
+            is None
+        )
+
+
+async def test_stale_purge_reaps_the_presigned_staging_object():
+    """The jobs/router reaper, run for real.
+
+    The purge deletes ``file_path`` for every purged row; the staging key it
+    never reached is what a post-completion re-PUT recreates.
+    """
+    from app.platform.jobs import router as jobs_router
+
+    job_id = uuid.uuid4()
+    staging_key = f"staging/{job_id}/roads.geojson"
+    frozen_key = f"staging/{job_id}/frozen/roads.geojson"
+
+    storage = AsyncMock()
+    outcome = jobs_router.StaleCleanupOutcome(
+        pending_failed=0,
+        running_failed=0,
+        vrt_assets_recovered=0,
+        vrt_generations_failed=0,
+        terminal_jobs_purged=1,
+        staged_paths_considered=1,
+        local_files_reaped=0,
+        storage_objects_reaped=0,
+        staged_paths_skipped=0,
+        staged_cleanup_failures=0,
+        _staged_paths=(frozen_key,),
+        _staged_presigned_keys=(staging_key,),
+    )
+
+    with patch("app.platform.storage.get_storage", return_value=storage):
+        reaped = await jobs_router._reap_committed_staged_paths(outcome)
+
+    deleted = {call.args[0] for call in storage.delete.await_args_list}
+    assert deleted == {frozen_key, staging_key}, deleted
+    assert reaped.storage_objects_reaped == 2
+    assert reaped.staged_cleanup_failures == 0
+
+
+async def test_a_failed_staging_sweep_is_counted_not_raised():
+    """Same error posture as the existing cleanup: never raise, just count."""
+    from app.platform.jobs import router as jobs_router
+
+    job_id = uuid.uuid4()
+    storage = AsyncMock()
+    storage.delete.side_effect = RuntimeError("provider down")
+    outcome = jobs_router.StaleCleanupOutcome(
+        pending_failed=0,
+        running_failed=0,
+        vrt_assets_recovered=0,
+        vrt_generations_failed=0,
+        terminal_jobs_purged=1,
+        staged_paths_considered=0,
+        local_files_reaped=0,
+        storage_objects_reaped=0,
+        staged_paths_skipped=0,
+        staged_cleanup_failures=0,
+        _staged_presigned_keys=(f"staging/{job_id}/roads.geojson",),
+    )
+
+    with patch("app.platform.storage.get_storage", return_value=storage):
+        reaped = await jobs_router._reap_committed_staged_paths(outcome)
+
+    assert reaped.staged_cleanup_failures == 1
+    assert reaped.storage_objects_reaped == 0

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -17,6 +17,7 @@ import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from rasterio.crs import CRS
 
 from app.platform.jobs.models import owned_presigned_staging_key
 
@@ -331,4 +332,74 @@ async def test_failed_raster_ingest_sweeps_its_presigned_staging_object(
     assert not await storage.exists(staging_key), (
         "a failed raster ingest left its presigned staging object behind; "
         "nothing else reaps it (the stale purge exempts latest-complete)"
+    )
+
+
+async def test_validation_failure_still_sweeps_the_presigned_staging_object(
+    test_db_session, tmp_path, monkeypatch
+) -> None:
+    """fix(#1202 review r7): the early return, not the happy path.
+
+    ``_validate_upload_file_safety`` failing returns from the phase-1 session
+    block before the phase-2 snapshot. The staging-key capture used to live in
+    that snapshot, so this path reached the terminal ``finally`` with the key
+    still None and left the object behind. Reachable without any attacker:
+    lowering the size limit between completion and worker pickup fails a job
+    whose bytes are already in the bucket.
+    """
+    from sqlalchemy import select
+
+    from app.core.persistent_config import UPLOAD_MAX_SIZE_MB
+    from app.modules.auth.models import User
+    from app.platform.jobs.models import IngestJob
+    from app.platform.storage.local import LocalStorageProvider
+    from app.processing.ingest.tasks_raster import ingest_raster
+
+    bucket = tmp_path / "bucket"
+    bucket.mkdir()
+    storage = LocalStorageProvider(str(bucket))
+    monkeypatch.setattr(
+        "app.platform.storage.get_storage", lambda: storage, raising=True
+    )
+
+    raster = tmp_path / "dem.tif"
+    raster.write_bytes(_geotiff_bytes(crs=CRS.from_epsg(4326)))
+
+    admin = (
+        await test_db_session.execute(select(User).where(User.username == "admin"))
+    ).scalar_one()
+
+    job = IngestJob(
+        source_filename="dem.tif",
+        file_path=str(raster),
+        created_by=admin.id,
+        status="pending",
+        user_metadata={"file_type": "raster", "presigned": True},
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+    await test_db_session.refresh(job)
+
+    staging_key = f"staging/{job.id}/dem.tif"
+    job.user_metadata = {**job.user_metadata, "s3_key": staging_key}
+    await test_db_session.commit()
+
+    await storage.put(staging_key, b"the-client-uploaded-bytes")
+    assert await storage.exists(staging_key), "precondition: staging object present"
+
+    # The operator lowered the cap after this job's bytes landed. Validation
+    # now fails on size, taking the early return out of the phase-1 block.
+    with patch.object(UPLOAD_MAX_SIZE_MB, "get", AsyncMock(return_value=0)):
+        await ingest_raster.func(
+            job_id=str(job.id),
+            file_path=str(raster),
+            user_id=str(admin.id),
+            attempt_id=str(job.attempt_id),
+        )
+
+    await test_db_session.refresh(job)
+    assert job.status == "failed", "precondition: took the validation-failure path"
+    assert "exceeds the maximum" in (job.error_message or "")
+    assert not await storage.exists(staging_key), (
+        "the validation-failure early return skipped the staging sweep"
     )

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -155,3 +155,180 @@ async def test_a_failed_staging_sweep_is_counted_not_raised():
 
     assert reaped.staged_cleanup_failures == 1
     assert reaped.storage_objects_reaped == 0
+
+
+class TestReapPresignedStagingObject:
+    """The shared sweep both task tails call.
+
+    Exercised against a real ``LocalStorageProvider`` rather than by driving
+    ogr2ogr/GDAL, matching ``test_raster_ingest_orphan_cleanup_gap017.py`` —
+    the sibling file that tests the other cleanup in the same ``finally``.
+    """
+
+    async def test_the_owned_key_is_deleted(self, tmp_path, monkeypatch):
+        from app.platform.storage.local import LocalStorageProvider
+        from app.processing.ingest.tasks_common import reap_presigned_staging_object
+
+        storage = LocalStorageProvider(str(tmp_path))
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+        job_id = uuid.uuid4()
+        key = f"staging/{job_id}/roads.geojson"
+        await storage.put(key, b"staged-bytes")
+        assert await storage.exists(key), "precondition: object staged"
+
+        await reap_presigned_staging_object(str(job_id), key)
+
+        assert not await storage.exists(key)
+
+    async def test_none_is_a_no_op_rather_than_a_delete(self, tmp_path, monkeypatch):
+        """A job with nothing of its own to sweep must not reach the provider.
+
+        This is the fan-out child's path: ``owned_presigned_staging_key``
+        returns None for the inherited parent key, and that None must stay a
+        no-op all the way down.
+        """
+        from app.processing.ingest.tasks_common import reap_presigned_staging_object
+
+        storage = AsyncMock()
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+
+        await reap_presigned_staging_object("job-1", None)
+
+        storage.delete.assert_not_awaited()
+
+    async def test_a_provider_failure_never_escapes(self, monkeypatch):
+        """The tail runs in a `finally` after the job is committed. Raising
+        here would turn a completed ingest into a task failure."""
+        from app.processing.ingest.tasks_common import reap_presigned_staging_object
+
+        storage = AsyncMock()
+        storage.delete.side_effect = RuntimeError("provider down")
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+
+        await reap_presigned_staging_object("job-1", "staging/job-1/roads.geojson")
+
+        storage.delete.assert_awaited_once()
+
+
+def test_both_task_tails_sweep_through_the_shared_helper():
+    """Neither ingest path may grow its own copy of the sweep.
+
+    The raster tail was added a round after the vector one precisely because
+    the two had drifted; this catches a third path arriving without the sweep,
+    or either call being deleted outright.
+
+    KNOWN BLIND SPOT, stated so nobody mistakes this for reachability: it
+    greps the module source, so a call that is PRESENT but UNREACHABLE passes.
+    Measured — disabling the raster sweep with `if False:` left this test
+    green. ``test_failed_raster_ingest_sweeps_its_presigned_staging_object``
+    is the one that fails in that case, and it is the one to trust.
+    """
+    import inspect
+
+    from app.processing.ingest import tasks_raster, tasks_vector
+
+    for module in (tasks_vector, tasks_raster):
+        source = inspect.getsource(module)
+        assert "reap_presigned_staging_object(" in source, (
+            f"{module.__name__} does not sweep the presigned staging key"
+        )
+        assert "owned_presigned_staging_key(" in source, (
+            f"{module.__name__} does not resolve staging-key ownership"
+        )
+
+
+def _geotiff_bytes(*, crs=None) -> bytes:
+    """Minimal in-memory GeoTIFF. Mirrors the copy in test_raster_ingest.py."""
+    import io
+
+    import numpy as np
+    from rasterio.io import MemoryFile
+    from rasterio.transform import from_bounds
+
+    profile = {
+        "driver": "GTiff",
+        "dtype": "uint8",
+        "width": 32,
+        "height": 32,
+        "count": 1,
+        "transform": from_bounds(-180, -90, 180, 90, 32, 32),
+    }
+    if crs is not None:
+        profile["crs"] = crs
+    buf = io.BytesIO()
+    with MemoryFile() as mem:
+        with mem.open(**profile) as ds:
+            ds.write(np.zeros((32, 32), dtype="uint8"), 1)
+        buf.write(mem.read())
+    return buf.getvalue()
+
+
+async def test_failed_raster_ingest_sweeps_its_presigned_staging_object(
+    test_db_session, tmp_path, monkeypatch
+) -> None:
+    """The raster tail, driven for real rather than asserted structurally.
+
+    A structural "does the module mention the helper" check cannot fail when
+    the call is present but unreachable — disabling the sweep left it green.
+    This runs ``ingest_raster`` to its terminal ``finally`` (via the CRS
+    failure, the cheapest deterministic one) and asserts the object is gone.
+    """
+    from sqlalchemy import select
+
+    from app.modules.auth.models import User
+    from app.platform.jobs.models import IngestJob
+    from app.platform.storage.local import LocalStorageProvider
+    from app.processing.ingest.tasks_raster import ingest_raster
+
+    bucket = tmp_path / "bucket"
+    bucket.mkdir()
+    storage = LocalStorageProvider(str(bucket))
+    monkeypatch.setattr(
+        "app.platform.storage.get_storage", lambda: storage, raising=True
+    )
+
+    raster = tmp_path / "dem.tif"
+    raster.write_bytes(_geotiff_bytes(crs=None))
+
+    admin = (
+        await test_db_session.execute(select(User).where(User.username == "admin"))
+    ).scalar_one()
+
+    job = IngestJob(
+        source_filename="dem.tif",
+        # What a presigned completion leaves: bound to the FROZEN copy, with
+        # the client-writable staging key surviving only in metadata.
+        file_path=str(raster),
+        created_by=admin.id,
+        status="pending",
+        user_metadata={"file_type": "raster", "presigned": True},
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+    await test_db_session.refresh(job)
+
+    staging_key = f"staging/{job.id}/dem.tif"
+    job.user_metadata = {**job.user_metadata, "s3_key": staging_key}
+    await test_db_session.commit()
+
+    await storage.put(staging_key, b"the-client-uploaded-bytes")
+    assert await storage.exists(staging_key), "precondition: staging object present"
+
+    with pytest.raises(ValueError, match="Provide a CRS override"):
+        await ingest_raster.func(
+            job_id=str(job.id),
+            file_path=str(raster),
+            user_id=str(admin.id),
+            attempt_id=str(job.attempt_id),
+        )
+
+    assert not await storage.exists(staging_key), (
+        "a failed raster ingest left its presigned staging object behind; "
+        "nothing else reaps it (the stale purge exempts latest-complete)"
+    )

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -403,3 +403,175 @@ async def test_validation_failure_still_sweeps_the_presigned_staging_object(
     assert not await storage.exists(staging_key), (
         "the validation-failure early return skipped the staging sweep"
     )
+
+
+class TestPostExpirySweep:
+    """fix(#1202 review r8): the backstop that outlives the PUT URL.
+
+    Both other sweeps are event-triggered and a fast ingest fires both while
+    the URL is still valid, so a re-PUT after them recreates an object nothing
+    later reaps — the successful job is latest-complete-exempt from the purge
+    forever. This pass runs once per job, after the URL can no longer be used.
+    """
+
+    @staticmethod
+    def _outcome(**overrides):
+        from app.platform.jobs.router import StaleCleanupOutcome
+
+        base = dict(
+            pending_failed=0,
+            running_failed=0,
+            vrt_assets_recovered=0,
+            vrt_generations_failed=0,
+            terminal_jobs_purged=0,
+            staged_paths_considered=0,
+            local_files_reaped=0,
+            storage_objects_reaped=0,
+            staged_paths_skipped=0,
+            staged_cleanup_failures=0,
+        )
+        base.update(overrides)
+        return StaleCleanupOutcome(**base)
+
+    async def _make_job(self, test_db_session, *, age_seconds: int, status="complete"):
+        from datetime import datetime, timedelta, timezone
+
+        from sqlalchemy import select, update
+
+        from app.modules.auth.models import User
+        from app.platform.jobs.models import IngestJob
+
+        admin = (
+            await test_db_session.execute(select(User).where(User.username == "admin"))
+        ).scalar_one()
+        job = IngestJob(
+            source_filename="roads.geojson",
+            created_by=admin.id,
+            status=status,
+            user_metadata={"presigned": True},
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+
+        staging_key = f"staging/{job.id}/roads.geojson"
+        # created_at is server-defaulted, so age it explicitly rather than
+        # relying on wall-clock drift.
+        await test_db_session.execute(
+            update(IngestJob)
+            .where(IngestJob.id == job.id)
+            .values(
+                file_path=f"staging/{job.id}/frozen/roads.geojson",
+                user_metadata={"presigned": True, "s3_key": staging_key},
+                created_at=datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
+            )
+        )
+        await test_db_session.commit()
+        return job, staging_key
+
+    async def test_a_recreated_object_past_the_deadline_is_swept_once(
+        self, test_db_session, monkeypatch
+    ) -> None:
+        from sqlalchemy import select
+
+        from app.platform.jobs import router as jobs_router
+        from app.platform.jobs.models import IngestJob
+
+        job, staging_key = await self._make_job(test_db_session, age_seconds=10_000)
+        storage = AsyncMock()
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+
+        first = await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome()
+        )
+
+        assert {c.args[0] for c in storage.delete.await_args_list} == {staging_key}
+        assert first.storage_objects_reaped == 1
+        refreshed = (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.id == job.id)
+            )
+        ).scalar_one()
+        await test_db_session.refresh(refreshed)
+        assert refreshed.user_metadata["s3_key_reaped"] is True
+        # The key itself survives in metadata — the marker is what stops the
+        # re-sweep, not deleting the record of which key it was.
+        assert refreshed.user_metadata["s3_key"] == staging_key
+
+    async def test_a_second_pass_costs_no_storage_call(
+        self, test_db_session, monkeypatch
+    ) -> None:
+        """Without the marker, latest-complete rows would cost a delete on
+        every purge run for the rest of the deployment's life."""
+        from app.platform.jobs import router as jobs_router
+
+        await self._make_job(test_db_session, age_seconds=10_000)
+        storage = AsyncMock()
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+
+        await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome()
+        )
+        storage.delete.reset_mock()
+
+        second = await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome()
+        )
+
+        storage.delete.assert_not_awaited()
+        assert second.storage_objects_reaped == 0
+
+    async def test_a_job_inside_the_url_window_is_left_alone(
+        self, test_db_session, monkeypatch
+    ) -> None:
+        """The URL may still be in legitimate use; sweeping here would delete
+        bytes a retry needs."""
+        from app.platform.jobs import router as jobs_router
+
+        await self._make_job(test_db_session, age_seconds=60)
+        storage = AsyncMock()
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+
+        await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome()
+        )
+
+        storage.delete.assert_not_awaited()
+
+    async def test_a_failed_delete_is_not_marked_done(
+        self, test_db_session, monkeypatch
+    ) -> None:
+        """Marking a failed delete as done is the one outcome that leaks the
+        object permanently, so the marker is withheld and a later pass retries.
+        """
+        from sqlalchemy import select
+
+        from app.platform.jobs import router as jobs_router
+        from app.platform.jobs.models import IngestJob
+
+        job, _key = await self._make_job(test_db_session, age_seconds=10_000)
+        storage = AsyncMock()
+        storage.delete.side_effect = RuntimeError("provider down")
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+
+        result = await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome()
+        )
+
+        assert result.staged_cleanup_failures == 1
+        assert result.storage_objects_reaped == 0
+        refreshed = (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.id == job.id)
+            )
+        ).scalar_one()
+        await test_db_session.refresh(refreshed)
+        assert "s3_key_reaped" not in (refreshed.user_metadata or {})

--- a/backend/tests/test_tenant_staging_storage_keys.py
+++ b/backend/tests/test_tenant_staging_storage_keys.py
@@ -212,6 +212,11 @@ async def test_presigned_completion_reads_physical_and_keeps_logical_job_path(
         },
     )
     db = AsyncMock()
+    # fix(#1202 review r5): completion re-fetches the row FOR UPDATE before
+    # reading file_path, so the locked fetch has to yield the SAME job the
+    # test configured — a bare AsyncMock returns a fresh mock whose truthy
+    # file_path trips the one-shot guard.
+    db.get = AsyncMock(return_value=job)
     storage = AsyncMock()
     storage.exists.return_value = True
     # fix(#1202): completion content-validates from a ranged read of the
@@ -353,7 +358,11 @@ async def test_cleanup_and_retention_reaper_delete_only_tenant_key(
     for result in empty_scalars:
         result.scalars.return_value = []
     deleted = MagicMock()
-    deleted.all.return_value = [(logical,)]
+    # fix(#1202 review r5): the purge's RETURNING is (id, file_path,
+    # user_metadata) now — it also reaps the presigned staging key, which
+    # needs the row's own id to decide ownership. No s3_key here, so this
+    # row still contributes exactly one delete.
+    deleted.all.return_value = [(uuid.uuid4(), logical, None)]
     survivors = MagicMock()
     survivors.scalars.return_value = []
     db = AsyncMock()

--- a/backend/tests/test_tenant_staging_storage_keys.py
+++ b/backend/tests/test_tenant_staging_storage_keys.py
@@ -200,6 +200,10 @@ async def test_presigned_completion_reads_physical_and_keeps_logical_job_path(
     job = MagicMock(
         id=uuid.uuid4(),
         source_filename="roads.geojson",
+        # fix(#1202 review): completion is one-shot and keys off file_path, so
+        # the mock has to start where create_ingest_job leaves a presigned job
+        # — empty — rather than with MagicMock's truthy auto-attribute.
+        file_path="",
         user_metadata={
             "presigned": True,
             "s3_key": logical,
@@ -213,12 +217,16 @@ async def test_presigned_completion_reads_physical_and_keeps_logical_job_path(
     # fix(#1202): completion content-validates from a ranged read of the
     # physical key, so the fake has to serve bytes rather than a sentinel.
     storage.get_range.return_value = b"{}"
+    # The pre-copy size fast path measures the staging object before the
+    # freeze, so the fake needs a real integer here.
+    storage.size.return_value = 2
     verify = AsyncMock(return_value=2)
 
     with (
         patch.object(router, "get_job_or_404", AsyncMock(return_value=job)),
         patch.object(router, "get_storage", return_value=storage),
         patch.object(router, "verify_completed_presigned_upload", verify),
+        patch.object(router.UPLOAD_MAX_SIZE_MB, "get", AsyncMock(return_value=10)),
         _tenant_mode(monkeypatch, "multi_tenant", TENANT_A),
     ):
         await router.complete_presigned_upload(

--- a/backend/tests/test_tenant_staging_storage_keys.py
+++ b/backend/tests/test_tenant_staging_storage_keys.py
@@ -193,6 +193,10 @@ async def test_presigned_completion_reads_physical_and_keeps_logical_job_path(
 
     logical = "staging/job-a/roads.geojson"
     physical = f"tenants/{TENANT_A}/{logical}"
+    # fix(#1202 review): completion freezes the upload to an unwritable key
+    # first and judges THAT, so the tenant prefix has to survive the derivation.
+    frozen_logical = "staging/job-a/frozen/roads.geojson"
+    frozen_physical = f"tenants/{TENANT_A}/{frozen_logical}"
     job = MagicMock(
         id=uuid.uuid4(),
         source_filename="roads.geojson",
@@ -226,9 +230,14 @@ async def test_presigned_completion_reads_physical_and_keeps_logical_job_path(
         )
 
     storage.exists.assert_awaited_once_with(physical)
-    assert verify.await_args.kwargs["key"] == physical
-    assert storage.get_range.await_args.args[0] == physical
-    assert job.file_path == logical
+    # The snapshot is taken from the physical staging key to the physical
+    # frozen key; everything downstream then judges the frozen one.
+    assert storage.copy.await_args.args == (physical, frozen_physical)
+    assert verify.await_args.kwargs["key"] == frozen_physical
+    assert storage.get_range.await_args.args[0] == frozen_physical
+    assert job.file_path == frozen_logical
+    # The staging object is dropped once the frozen copy is the job's source.
+    assert storage.delete.await_args.args == (physical,)
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_tenant_staging_storage_keys.py
+++ b/backend/tests/test_tenant_staging_storage_keys.py
@@ -195,6 +195,7 @@ async def test_presigned_completion_reads_physical_and_keeps_logical_job_path(
     physical = f"tenants/{TENANT_A}/{logical}"
     job = MagicMock(
         id=uuid.uuid4(),
+        source_filename="roads.geojson",
         user_metadata={
             "presigned": True,
             "s3_key": logical,
@@ -205,6 +206,9 @@ async def test_presigned_completion_reads_physical_and_keeps_logical_job_path(
     db = AsyncMock()
     storage = AsyncMock()
     storage.exists.return_value = True
+    # fix(#1202): completion content-validates from a ranged read of the
+    # physical key, so the fake has to serve bytes rather than a sentinel.
+    storage.get_range.return_value = b"{}"
     verify = AsyncMock(return_value=2)
 
     with (
@@ -223,6 +227,7 @@ async def test_presigned_completion_reads_physical_and_keeps_logical_job_path(
 
     storage.exists.assert_awaited_once_with(physical)
     assert verify.await_args.kwargs["key"] == physical
+    assert storage.get_range.await_args.args[0] == physical
     assert job.file_path == logical
 
 

--- a/backend/tests/test_tenant_staging_storage_keys.py
+++ b/backend/tests/test_tenant_staging_storage_keys.py
@@ -365,8 +365,13 @@ async def test_cleanup_and_retention_reaper_delete_only_tenant_key(
     deleted.all.return_value = [(uuid.uuid4(), logical, None)]
     survivors = MagicMock()
     survivors.scalars.return_value = []
+    # fix(#1202 review r8): one more SELECT for the post-expiry staging sweep.
+    post_expiry = MagicMock()
+    post_expiry.all.return_value = []
     db = AsyncMock()
-    db.execute = AsyncMock(side_effect=[*empty_scalars, deleted, survivors])
+    db.execute = AsyncMock(
+        side_effect=[*empty_scalars, deleted, survivors, post_expiry]
+    )
 
     with _tenant_mode(monkeypatch, "multi_tenant", TENANT_A):
         await fail_stale_jobs(db)

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -148,6 +148,13 @@ def _make_mock_db_for_fail_stale(
         survivors_result.scalars.return_value = surviving_paths or []
         results.append(survivors_result)
 
+    # fix(#1202 review r8): the post-expiry presigned-staging sweep issues one
+    # more SELECT after the purge. No candidates in these fixtures, so an empty
+    # .all() keeps each test stating only what it cares about.
+    post_expiry_result = MagicMock()
+    post_expiry_result.all.return_value = []
+    results.append(post_expiry_result)
+
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock(side_effect=results)
     mock_db.commit = AsyncMock()
@@ -356,7 +363,9 @@ async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
     mock_db = _make_mock_db_for_fail_stale(purge_candidates=[(None,)])
     await fail_stale_jobs(mock_db)
 
-    assert mock_db.execute.await_count == 5
+    # 4 sweeps + the purge DELETE + the post-expiry staging SELECT
+    # (fix(#1202 review r8)). The purge is still index 4.
+    assert mock_db.execute.await_count == 6
     purge_stmt = mock_db.execute.await_args_list[4].args[0]
     assert isinstance(purge_stmt, Delete)
     where_sql = str(purge_stmt.compile(compile_kwargs={"literal_binds": True}))
@@ -518,7 +527,9 @@ async def test_fail_stale_jobs_retention_zero_disables_purge(monkeypatch):
     mock_db = _make_mock_db_for_fail_stale()
     await fail_stale_jobs(mock_db)
 
-    assert mock_db.execute.await_count == 4
+    # 4 sweeps and no purge DELETE, plus the post-expiry staging SELECT, which
+    # is independent of retention being disabled (fix(#1202 review r8)).
+    assert mock_db.execute.await_count == 5
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -9,6 +9,7 @@ RED → GREEN: fails pre-fix (no sweep exists), passes post-fix.
 """
 
 from datetime import datetime, timedelta, timezone
+import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -115,8 +116,12 @@ def _make_mock_db_for_fail_stale(
       2. stale running IngestJobs → scalars() returns list
       3. stale VrtGeneration UPDATE → scalars() returns generation ids
       4. stale regenerating RasterAsset UPDATE → scalars() returns dataset ids
-      5. purge DELETE .. RETURNING file_path (fix #434) → .all() returns
-         (file_path,) one-tuples
+      5. purge DELETE .. RETURNING (id, file_path, user_metadata) → .all()
+         returns those three-tuples. fix(#1202 review r5) widened the
+         RETURNING so the purge can also reap a completed presigned job's
+         staging key. Callers may still pass (file_path,) one-tuples; they
+         are normalized below so each test keeps stating only what it cares
+         about.
       6. optional surviving-path SELECT when a deleted row had a file_path
     """
     results = []
@@ -130,11 +135,15 @@ def _make_mock_db_for_fail_stale(
         mock_result.scalars.return_value = returned_ids
         results.append(mock_result)
 
+    normalized_candidates = [
+        row if len(row) == 3 else (uuid.uuid4(), row[0], None)
+        for row in (purge_candidates or [])
+    ]
     delete_result = MagicMock()
-    delete_result.all.return_value = purge_candidates or []
+    delete_result.all.return_value = normalized_candidates
     results.append(delete_result)
 
-    if any(file_path for (file_path,) in (purge_candidates or [])):
+    if any(file_path for (_id, file_path, _um) in normalized_candidates):
         survivors_result = MagicMock()
         survivors_result.scalars.return_value = surviving_paths or []
         results.append(survivors_result)


### PR DESCRIPTION
## Problem

The direct upload path runs `validate_file_content` on the bytes it stages (`router.py`, the `upload_file` handler). `complete_presigned_upload` did not: it stamped metadata and committed. So the two ingest doors enforced different contracts, and a client that presigned could land a file the direct door refuses. Preview then hands that file to GDAL before the worker's own content check ever runs. #1196 (this release) made the presigned path the default browser path on S3 deployments, which is why this rides in v1.8.0.

## Fix

Completion freezes the object, then judges the frozen copy:

1. **Freeze first.** The object is server-side copied to `staging/{job_id}/frozen/{filename}`, a key no presign endpoint has ever minted a URL for. The client's presigned PUT URL stays valid until expiry (an hour by default) and a PUT to an existing key replaces the object, so anything checked at the staging key can be swapped after the check: upload clean bytes, complete, re-PUT garbage. The order is the fix. Verifying or validating before the copy re-opens the same race one step earlier.
2. **Verify and validate the frozen bytes.** `verify_completed_presigned_upload` (size/quota, which must judge the immutable bytes too, or a 1 KB declaration can swell past quota before the snapshot) and then the same `validate_file_content` the direct door runs, returning the identical 422 with the identical detail string. The check reads only the bytes the validator inspects instead of downloading the object: the first `HEADER_READ_SIZE` (8192) bytes, plus the trailing `PAR1` magic for `.parquet` (appended only when the object exceeds the header window). The `.vrt` branch (whole-body read) is unreachable: `_reject_standalone_vrt` refuses the filename at presign-request time.
3. **Bind and clean up.** `job.file_path` points at the frozen key. Every staging reaper keys off `job.file_path`, so post-ingest deletion and stale-job purges reach it unchanged. The staging object is dropped only after the commit succeeds.

Review hardening on top of the freeze, all the same class (client-writable state re-entering after acceptance, or a failure path leaving state the retry cannot proceed from):

- **One-shot completion.** A job with `file_path` set refuses further completions with a 400. Without it, a second completion re-judged whatever sat at the staging key, and the still-valid PUT URL controls that.
- **Size gate before the copy.** The declared-vs-actual size check runs against the staging object before the freeze, so an oversize upload is refused without paying for a server-side copy of it.
- **Drained freeze.** The copy runs through `_await_provider_call_draining`; cancellation deletes the partial snapshot and re-raises instead of leaving a half-frozen object.
- **Multipart retry works.** Assembly is skipped when the staging object already exists. For S3 that is an iff: uploaded parts are invisible as an object until `CompleteMultipartUpload` succeeds, so the object's presence is a sound record that assembly is done. Without this, a completion that got past assembly and then failed at the freeze left the upload id spent, and the retry the 502 advertises could never succeed.
- **Staging outlives a failed commit.** The staging delete moved after `db.commit()`. Deleting first meant a rolled-back commit stranded the retry: `file_path` unset, bytes gone, frozen copy orphaned.
- **Completion is serialized per job.** The one-shot guard was an unlocked read: two overlapping completions both saw an empty `file_path`, raced over the same deterministic frozen key, and a concurrent refusal could delete the object a concurrent accept then committed a binding to. The handler now re-fetches the job (`lock_presigned_job`) `with_for_update` AND `populate_existing` — the lock alone serializes without informing: SQLAlchemy keeps the already-loaded attributes on the identity-map instance, so the guard would read the pre-commit value and pass on an already-completed job. Both halves are pinned by tests: a driver-level assertion that a `FOR UPDATE` statement is emitted, and a two-session test that the re-fetch reflects a commit made in between. One row locked; completions of different jobs are unaffected.
- **The staging key is reaped at job end.** After completion, `user_metadata["s3_key"]` is the only reference to the client-writable staging key, and the still-valid PUT URL can recreate the object there — S3 cannot revoke an individual presigned URL. The vector and raster task tails both sweep it at terminal status through a shared `reap_presigned_staging_object` helper (extracted so the two cannot drift; raster previously had NO storage sweep at all), and the stale-job purge sweeps it when it deletes a job row. The raster capture happens before any exit from the job-phase block — the sweep's coverage is exactly the exits the capture dominates, which is not visible from the call site. The two event sweeps are backed by a once-per-job post-expiry pass in the periodic purge, keyed off the presign TTL (`created_at` anchors it soundly: the row exists before any URL is minted): a re-PUT after both event sweeps have fired is reaped once the URL is dead, and a `user_metadata` marker takes the job out of the query so permanent latest-complete rows never cost a storage call per pass. That backstop is what makes "nothing can recreate it afterwards" true rather than "we delete it when we notice". The purge is a backstop, not a guarantee: it exempts the newest complete job per dataset — exactly what a successful ingest leaves — which is why the task-level sweeps have to exist.
- **Sweep ownership is decided by the key's own `staging/{job_id}/` prefix, NOT by "differs from `file_path`".** This is the rule a future change will trip over: fan-out children clone the parent's `user_metadata` wholesale, so every child carries the parent's `s3_key`, and a difference-based sweep would delete the shared staging original out from under siblings. The prefix settles ownership outright (`owned_presigned_staging_key`).

`StorageProvider` gains `get_range(key, start, length)` and `copy(src, dst)` with local/S3/Azure implementations on the existing clients (S3: `Range` reads with 416 normalized to empty to match POSIX seek; managed `client.copy` for the >5 GB case `copy_object` caps out on; missing keys normalize to `FileNotFoundError`).

## Failure points, and what a retry sees

Every exit from `complete_presigned_upload`, top to bottom. State is (`file_path`, staging object, frozen object).

| # | Exit | State left behind | The retry |
|---|------|-------------------|-----------|
| 1 | job not found, 404 | untouched | same 404, terminal |
| 2 | not a presigned job, 400 | untouched | terminal |
| 3 | one-shot 400, already completed | untouched | terminal by design: `file_path` set means the bytes were accepted |
| 4 | multipart with no parts, 400 | upload id aborted | must re-presign (pre-existing abort semantics, unchanged) |
| 5 | multipart complete fails, 502 | upload id aborted | must re-presign (pre-existing) |
| 6 | multipart complete cancelled | object deleted, cancel re-raised | must re-presign |
| 7 | staging object missing, 400 | unset / absent / absent | client re-PUTs or re-presigns |
| 8 | pre-copy size check, 422 | staging deleted | hits case 7; the object was refused |
| 9 | freeze copy fails, 502 | unset / present / absent | re-enters, skips assembly, re-copies, proceeds (the multipart-retry fix) |
| 10 | freeze copy cancelled | unset / present / absent | same as 9 |
| 11 | verify 422 (size or quota) | both objects deleted | hits case 7; refused |
| 12 | content validation 422 | both objects deleted | hits case 7; refused |
| 13 | verify/validate transient error | unset / present / absent | same as 9 |
| 14 | `db.commit()` fails | unset / present / present | re-enters, skips assembly, re-copies over the frozen key, re-verifies, binds, commits (the delete-ordering fix) |
| 15 | staging delete fails after commit | bound / present / present | 200 already returned; job bound to frozen. The orphan is swept at job end by whichever terminal reaper owns the job (vector and raster tails) with the stale purge as backstop, so the residual window is completion-to-reap rather than forever |

The invariant that falls out: **staging is deleted only when the upload was refused (8, 11, 12), when the job is durably bound to the frozen copy (15), or when the job reaches its end and the reapers sweep it. Every transient failure keeps it, and per-job row locking means a concurrent refusal can never delete what a concurrent accept has bound.** That is the property that makes "please try again" true.

## Scope note

`complete_presigned_reupload` (the dataset reupload surface) has every gap this PR closes: no content validation, no freeze, no one-shot guard (and so no row lock on it), no size gate, no drained copy, no multipart-retry guard — **and no staging reaper of any kind**: `reupload_file` unlinks the local file only, and the stale purge exempts the newest complete job per dataset, which is exactly what a successful reupload produces, so its staging objects are currently never swept. It is deliberately not fixed here: it sits behind `get_catalog_port()` and needs the completion sequence extracted into shared helpers (`lock_presigned_job`, `should_assemble_multipart`, `finalize_presigned_object` with a postcondition contract), not a single check hoisted into `verify_completed_presigned_upload` — that boundary now runs on the frozen object and owns only one of the six completion steps. Tracked as #1207, which depends on this PR's helpers and uses the enumeration above as its spec.

## Verification

- `backend/tests/test_presigned_content_validation_1202.py` (14 tests): both doors driven with the same payloads, details asserted EQUAL both directions; the rejected completion removes both objects; a read-width pin so a future whole-object download fails; the job binds to a frozen key under `staging/` with the staging object gone; a TOCTOU regression (a re-PUT to the staging key after successful completion cannot change the bytes the job points at); a one-shot replay refusal with a same-length garbage payload so the size check cannot mask the guard; a multipart retry after a failed freeze that succeeds with `complete_multipart_upload` called exactly once; a failed commit that leaves both objects for a successful retry; and a row-lock pin that listens at the driver level and requires a `FOR UPDATE` statement against `ingest_jobs` (a call-level spy would pass on an identity-map hit that never locked anything)
- `backend/tests/test_presigned_staging_reap_1202.py` (13 cases): the ownership predicate including a fan-out child declining the parent's inherited key; both task tails and the stale purge sweeping through the shared helper; sweep failures counted not raised; and a real `ingest_raster` run to its terminal `finally` asserting the staged object is gone
- RED checks, each read for cause: guard disabled → the three refusal tests fail on `assert 200 == 422`; freeze reverted → the TOCTOU test fails with the job's content equal to the attacker's payload; multipart guard reverted → the retry is refused with the parts-required 400 before it reaches the spent-id path; delete moved back before the commit → the bucket holds only the frozen key with `file_path` rolled back, the stranded retry exactly; row lock dropped → the pin fails and dumps the four `ingest_jobs` statements it saw, none carrying `FOR UPDATE`; sweep disabled → the staging key survives in the bucket
- Whole-tree backend suite run on every review round's tree (latest full-tree pass `7141 passed, 89 skipped`); ingest/storage/jobs, reupload/raster/structural/contract, and every purge/reaper consumer (enumerated by grep, not by memory) green on the branch tip; order-varied reruns green
- `tests/test_layering.py` caps updated in the same commits with comments (router.py 1703, tasks_common.py 1703, tasks_vector.py 1075 — the last ratcheted down when the sweep was extracted; all exact)
- `make openapi-check` no drift; `uv run ruff check .` / `format --check` clean

Closes #1202

https://claude.ai/code/session_01HWAxdeSdSJ5dS7bKUHFK98
