### PR TITLE
chore(release): v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,79 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-05
+
+### Added
+
+- **All four admin lists are sortable.** The Users list gained server-side
+  sorting with clickable column headers (#1200), and Jobs, Audit Log, and
+  Published Maps adopt the same pattern (#1204): closed-enum sort parameters
+  (bad input is refused with a 422), NULLS LAST on nullable columns, and a
+  stable tiebreak so paging never repeats a row. Sort state lives in the URL,
+  so a sorted view can be bookmarked or shared.
+- **Analysis results can be chained.** A materialized analysis output can be
+  fed straight into another operation without leaving the builder (#1130).
+- **The ephemeral analysis preview appears as a row in the layer stack**, so
+  it can be toggled and inspected like any other layer while it exists (#1165).
+- **Analysis-derived datasets surface inherited keywords** from their source
+  datasets in catalog search and dataset detail (#1178).
+- **A TITILER_WORKERS knob** sizes the raster tile sidecar's worker pool for
+  larger deployments (#1197).
+
+### Security
+
+- **Presigned uploads get the same content validation as direct uploads
+  (#1202).** The completion endpoint used to accept whatever bytes sat at the
+  staging key; it now server-side copies the object to a frozen key no client
+  URL has ever pointed at, and judges the frozen copy — size, quota, and the
+  same content validation the direct door runs, returning the identical 422.
+  Freezing first closes the swap window a still-valid presigned PUT URL
+  otherwise has (upload clean bytes, complete, re-PUT garbage). Completion is
+  one-shot and serialized per job, a failed completion is retryable without
+  re-uploading, and staging objects are swept at job end plus once more after
+  the URL expires, so a dead URL cannot leave bytes behind. The dataset
+  **reupload** completion door has the same gaps and is NOT covered by this
+  release; it is tracked as #1207.
+- **URL credential redaction is bounded against quadratic backtracking
+  (#1118)**, refuses unparsable authorities (#1162), and no longer raises on a
+  malformed authority (#1131).
+- **The titiler sidecar pins its GDAL rawband environment (#1197)** and is
+  bumped 2.0.5 → 2.2.1 (#1198).
+- Dependency advisories patched: cryptography, undici, brace-expansion
+  (#1173), idna floors for CLI/SDK and cryptography 50 for MCP (#1179).
+- The backend image ships a third-party NOTICE file (#1189).
+
+### Fixed
+
+- **Presigned uploads stamp raster metadata (#1196).** On S3 deployments every
+  GeoTIFF uploaded through the browser fell through to the vector branch and
+  failed at preview. This release also makes that path the validated one — see
+  #1202 above.
+- **Manifests accept extension-defined record statuses (#1201).**
+  `record_status` is documented as extension-defined (#1194); the manifest
+  layer now validates intent against the live extension's status order instead
+  of a frozen four-value set, and the CLI schema follows.
+- **The admin Jobs badge counts failed jobs, not all jobs (#1195).**
+- **Keyword suggestions honor the counterfactual only for the record owner
+  (#1184).**
+- **The login page refreshes its provider list after admin OAuth/SAML changes
+  (#1163).**
+- **DEM terrain coverage is measured from the layer extent, not the token span
+  (#1129)**, and small-DEM viewport coverage works across the antimeridian
+  (#1124).
+- **`dataset_extent_bbox` is served in the RFC 7946 spec form (#1125).**
+- **Intersect carries JSON and XML overlay attributes through to the output
+  (#1123).**
+
+### Changed
+
+- **Operators: API worker memory recycling guidance** is in the runbook
+  (#1177) — the recommended mitigation for slow RSS growth under sustained
+  raster proxy load (the #643 investigation continues).
+- **The permission extension seam can answer who a record's audience is
+  (#1126)**, groundwork for overlay-aware visibility guards.
+- CI and local dev converge on Python 3.14 (#1168).
+
 ## [1.7.1] - 2026-08-02
 
 ### Fixed
@@ -1654,7 +1727,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.7.1...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/geolens-io/geolens/compare/v1.7.1...v1.8.0
 [1.7.1]: https://github.com/geolens-io/geolens/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/geolens-io/geolens/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/geolens-io/geolens/compare/v1.6.0...v1.6.1

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -590,7 +590,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.7.1"
+_FALLBACK_APP_VERSION = "1.8.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17831,7 +17831,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.7.1"
+    "version": "1.8.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.7.1"
+version = "1.8.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.7.1"
+version = "1.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.7.1"
+version = "1.8.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.8.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.7.1"
+version = "1.8.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.7.1"
+version = "1.8.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.7.1"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.7.1
+package_version_override: 1.8.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.7.1"
+version = "1.8.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Release bump for v1.8.0: `make bump VERSION=1.8.0` (all 19 version sites, atomic) plus the CHANGELOG section.

## What's in the release

Three-issue wave on top of the 1.7.x line:

- #1200/#1204 — all four admin lists sortable (server-side closed-enum sort, NULLS LAST, stable tiebreak, URL-owned state)
- #1201 — manifests validate intent against the live extension's status order
- #1202 (PR #1209) — presigned upload completion validates content on a frozen copy; one-shot, per-job serialized, retryable, with staging swept at job end and post-URL-expiry. The changelog entry is door-precise: the reupload door is NOT covered and is tracked as #1207.

Plus the already-merged 1.8.0-cycle items listed in the CHANGELOG section (analysis chaining, preview-in-stack, inherited keywords, TITILER_WORKERS, and the fix/security batch).

## Impacts

- No schema changes (`make alembic-check` clean), no API shape changes beyond the version string (`make openapi-check` clean before the bump; `backend/openapi.json` in this diff changes only its version field).
- CHANGELOG mechanics: `[1.8.0]` bottom compare link added AND `[Unreleased]` compare moved to `v1.8.0...HEAD`.

## Verification

- `make version-check` — all 19 sites agree on 1.8.0, CHANGELOG section present
- Whole-tree backend at the release base: 7168 passed, 89 skipped
- Frontend: build, lint, typecheck, coverage suite all green
- `make openapi-check` / `sdks-check` / `cli-test` / `alembic-check` — all exit 0
- Pre-tag browser smoke on the dev stack (Playwright): catalog search, 3D terrain (Matterhorn VRT DEM), vector map rendering, direct ingest end-to-end (job complete), all four admin sortable lists incl. invalid-sort fallback and deep-linking, dark mode round-trip — zero console errors

https://claude.ai/code/session_01HWAxdeSdSJ5dS7bKUHFK98
