### PR TITLE
fix(ingest): refuse manifest source keys under the staging/ prefix

### DIFF
--- a/backend/app/processing/ingest/manifest_sources.py
+++ b/backend/app/processing/ingest/manifest_sources.py
@@ -142,6 +142,19 @@ def _storage_uri_to_key(uri: str) -> str:
     key = parsed.path.lstrip("/")
     if not key:
         raise ManifestSourceError("s3:// manifest source must include an object key")
+    # fix(#1216): `staging/` is the discriminator for system-owned transient
+    # presigned-upload objects — the ingest tail reaps `staging/`-prefixed
+    # storage keys at terminal job status, and `resolve_file_path` routes
+    # them through the tenant resolver. An operator-declared manifest source
+    # under that prefix would be deleted at terminal status, so refuse it at
+    # declaration time instead of relying on the naming convention.
+    if key.startswith("staging/"):
+        raise ManifestSourceError(
+            "s3:// manifest source keys must not use the 'staging/' prefix: "
+            "staging/ is system-owned transient storage that is deleted when "
+            "ingest jobs reach terminal status. Move the object to a "
+            "different prefix."
+        )
     return key
 
 

--- a/backend/tests/test_manifest_apply_service.py
+++ b/backend/tests/test_manifest_apply_service.py
@@ -304,6 +304,43 @@ class TestManifestApplyHelpers:
         with pytest.raises(ManifestSourceError, match="private/internal"):
             await classify_manifest_source(source)
 
+    @pytest.mark.anyio
+    async def test_storage_seed_key_under_staging_prefix_is_rejected(self, monkeypatch):
+        """fix(#1216): `staging/` object keys are system-owned transient
+        presigned-upload storage — the ingest tail reaps them at terminal
+        job status, so an operator-declared manifest source under that
+        prefix would be deleted. Declaration must refuse the key."""
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "storage_provider", "s3")
+        monkeypatch.setattr(settings, "s3_bucket", "geolens-seed-bucket")
+        source = ManifestSource(
+            type="vector",
+            uri="s3://geolens-seed-bucket/staging/roads.geojson",
+        )
+
+        with pytest.raises(ManifestSourceError, match="staging/"):
+            await classify_manifest_source(source)
+
+    @pytest.mark.anyio
+    async def test_storage_seed_key_outside_staging_prefix_still_classifies(
+        self, monkeypatch
+    ):
+        """Control for #1216: an ordinary operator-owned key is unaffected."""
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "storage_provider", "s3")
+        monkeypatch.setattr(settings, "s3_bucket", "geolens-seed-bucket")
+        source = ManifestSource(
+            type="vector",
+            uri="s3://geolens-seed-bucket/operator/roads.geojson",
+        )
+
+        prepared = await classify_manifest_source(source)
+
+        assert prepared.kind == "storage"
+        assert prepared.file_path == "operator/roads.geojson"
+
     def test_dotdot_traversal_rejected_at_schema_layer(self):
         """Phase 268 H-29: ManifestSource must reject any URI containing
         a `..` path segment. The Pydantic validator catches it before any


### PR DESCRIPTION
Closes #1216.

After #1213, the ingest tail reaps any `staging/`-prefixed storage key at terminal job status — the prefix is the discriminator for system-owned transient presigned-upload objects. An operator who declares an `s3://` manifest source under a `staging/`-shaped key therefore loses the object after its first ingest, and `resolve_file_path` also mis-routes such keys through the tenant storage-key resolver.

This refuses the key at declaration time instead. The check lives in `_storage_uri_to_key`, the single funnel both the apply-create and apply-update/reupload paths pass through (`classify_manifest_source`), beside the existing scheme/bucket/empty-key contract checks. Local schemeless sources are unaffected: they resolve to absolute paths under `upload_staging_dir` and can never match the prefix.

No API or schema impact. The refusal raises `ManifestSourceError`, which surfaces as the existing per-entry `action="error"` in the apply response — the same shape as every neighboring source-contract violation. No Pydantic model changed, so no OpenAPI regeneration.

Tests were RED-verified against the pre-fix code: the rejection case failed with `DID NOT RAISE ManifestSourceError` before the check existed, with a control test proving an ordinary operator key (`operator/roads.geojson`) still classifies.

Verification:

```bash
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_manifest_apply_service.py tests/test_manifest_apply_roundtrip.py -q   # 46 passed
uv run pytest tests/test_layering.py -q
uv run ruff check . && uv run ruff format --check .
```

Whole-tree backend suite run green on the rebased head before this PR was opened.

https://claude.ai/code/session_01HWAxdeSdSJ5dS7bKUHFK98
