### PR TITLE
chore(deps): react-router 8.3, drop the js-audit waiver

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,7 +35,7 @@
         "react-dom": "^19.2.8",
         "react-dropzone": "^19.1.1",
         "react-i18next": "^17.0.11",
-        "react-router": "^7.18.1",
+        "react-router": "^8.3.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.3",
@@ -4656,18 +4656,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7884,20 +7877,19 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -8160,12 +8152,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
     "react-dom": "^19.2.8",
     "react-dropzone": "^19.1.1",
     "react-i18next": "^17.0.11",
-    "react-router": "^7.18.1",
+    "react-router": "^8.3.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM, { type Root } from 'react-dom/client';
-import { createBrowserRouter, createRoutesFromElements, RouterProvider } from 'react-router';
+import { createBrowserRouter, createRoutesFromElements } from 'react-router';
+import { RouterProvider } from 'react-router/dom';
 import {
   MutationCache,
   QueryCache,

--- a/scripts/js-audit-gate.mjs
+++ b/scripts/js-audit-gate.mjs
@@ -6,20 +6,7 @@
 // an expired entry stops suppressing, forcing a revisit.
 import { execFileSync } from 'node:child_process';
 
-const ALLOWLIST = [
-  {
-    id: 'GHSA-qwww-vcr4-c8h2', // react-router RSC-mode CSRF (high)
-    reason:
-      'Fixed in the installed version: react-router 7.18.2 backports the RSC ' +
-      'CSRF hardening (remix-run/react-router#15353), but the advisory range ' +
-      'still says <8.3.0, so npm audit flags it anyway. Defense in depth: the ' +
-      'frontend is a Vite SPA using library-mode <BrowserRouter> ' +
-      '(frontend/src/main.tsx) — no RSC entry point exists, so the vulnerable ' +
-      'code never executed even before the backport. Drop this entry when the ' +
-      'advisory range is corrected upstream or the router moves to >=8.3.0.',
-    expires: '2026-09-01',
-  },
-];
+const ALLOWLIST = [];
 
 let raw;
 try {


### PR DESCRIPTION
Closes #1205.

Upgrades react-router 7.18.2 -> 8.3.0 and deletes the last js-audit allowlist entry (GHSA-qwww-vcr4-c8h2), which would have expired 2026-09-01 and started blocking every PR.

The migration surface was verified, not assumed: zero `react-router-dom` imports and zero subpath imports anywhere in `frontend/` (100 imports all use plain `'react-router'`), and `RouterProvider` is used only in `main.tsx`. The only code change v8 requires here is importing `RouterProvider` from `'react-router/dom'` — the rest of the v8 breaking list is framework-mode or server-side and does not apply to this Vite SPA.

With 8.3.0 installed, npm audit is genuinely clean (`found 0 vulnerabilities` at install; the audit gate passes in all three matrix directories with the allowlist now empty), so the advisory is resolved rather than suppressed. The lockfile delta is confined to react-router's own subtree (its `cookie`/`set-cookie-parser` deps replaced by `cookie-es`).

Engines note: 8.3.0 declares `node >=22.22.0`. CI's `node-version: 22` resolves above that, and the build image is node 26.

Dependency and config impact only; no API or schema changes.

Verification (all run at the rebased head):

```bash
cd frontend && npm ci && npm run build && npm run lint && npm run typecheck && npx vitest run
node scripts/js-audit-gate.mjs   # repo root, frontend/, sdks/typescript
```

Build ✓, eslint clean, `tsc -b --noEmit` clean, 4656 vitest tests passed, audit gate clean in all directories. Backend whole-tree suite also green at the rebased head (7229 passed). A dev-stack Playwright pass over router-dependent surfaces follows the merge.

https://claude.ai/code/session_01HWAxdeSdSJ5dS7bKUHFK98
