### PR TITLE
chore(release): v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-08-06
+
+### Security
+
+- **The presigned reupload door enforces the same completion contract as the
+  upload door (#1207).** Dataset replacement via presigned upload now goes
+  through the shared one-shot completion guard: a job whose bytes are already
+  bound or whose status is terminal is refused with a clear restart hint
+  instead of being silently re-completable. The frozen-copy discriminator keys
+  off the `staging/` prefix, and a refused completion deletes both the frozen
+  snapshot and the client-writable key.
+
+### Fixed
+
+- **A failed import keeps its source, so retry works.** Transient failures
+  (an S3 blip during download, a mid-ingest error) no longer delete the
+  staging object that `/jobs/{id}/retry` needs; only dataset-replacement
+  jobs, which are never retryable, reap their source on failure. Terminal
+  cleanup also drains through cancellation, so an interrupted worker cannot
+  skip the sweep of a still-recreatable staging key (#1213).
+- **A dropped connection during multipart completion no longer destroys the
+  upload.** The assembled object is the record that assembly succeeded; it is
+  now kept when the request is cancelled, so the client's natural retry
+  completes instead of 502-looping until a full re-upload (#1233).
+- **The stale-job sweep no longer races a finishing completion.** A job that
+  bound its bytes moments before the sweep ran could be failed out from under
+  a request that had just returned success; bound and unbound jobs now age on
+  separate clocks, applied identically by the background sweep, the status
+  poll, and worker startup recovery (#1234).
+- **Presigned URLs expire exactly when their job does.** Part and PUT URLs
+  used to carry fixed lifetimes measured from whenever they were signed; every
+  URL is now signed against the job's deadline, computed inside the signing
+  thread, and the new `PENDING_JOB_TIMEOUT_SECONDS` setting (61..604800)
+  bounds both together (#1234, #1235).
+- **Manifest sources declared under a `staging/`-shaped key are refused at
+  declaration time** instead of being silently deleted after their first
+  ingest by the staging sweep (#1216).
+
+### Changed
+
+- **react-router upgraded 7.18 -> 8.3** and the last `js-audit` allowlist
+  entry removed — the advisory it waived (GHSA-qwww-vcr4-c8h2) no longer
+  applies at 8.3.0 (#1205).
+
+### Operations
+
+- **Bundled MinIO aborts abandoned multipart uploads after 24 hours**
+  (`MINIO_API_STALE_UPLOADS_EXPIRY`, operator-overridable), and RUNBOOK.md
+  documents the equivalent AWS S3 lifecycle rule. Note for MinIO operators:
+  S3 `AbortIncompleteMultipartUpload` lifecycle JSON is silently ignored by
+  MinIO (minio/minio#19115) — the server-side stale-uploads sweep is the
+  mechanism. If `PENDING_JOB_TIMEOUT_SECONDS` is raised past 24 hours, raise
+  the abort window to match (#1211).
+
 ## [1.8.0] - 2026-08-05
 
 ### Added
@@ -1727,7 +1781,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/geolens-io/geolens/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/geolens-io/geolens/compare/v1.7.1...v1.8.0
 [1.7.1]: https://github.com/geolens-io/geolens/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/geolens-io/geolens/compare/v1.6.1...v1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,9 @@ and releases use semantic versioning.
   documents the equivalent AWS S3 lifecycle rule. Note for MinIO operators:
   S3 `AbortIncompleteMultipartUpload` lifecycle JSON is silently ignored by
   MinIO (minio/minio#19115) — the server-side stale-uploads sweep is the
-  mechanism. If `PENDING_JOB_TIMEOUT_SECONDS` is raised past 24 hours, raise
-  the abort window to match (#1211).
+  mechanism. The abort window must exceed the configured upload lifetime with
+  headroom: if `PENDING_JOB_TIMEOUT_SECONDS` approaches or exceeds ~23 hours,
+  raise the abort window above it (#1211).
 
 ## [1.8.0] - 2026-08-05
 

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -590,7 +590,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.8.0"
+_FALLBACK_APP_VERSION = "1.9.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17831,7 +17831,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.8.0"
+    "version": "1.9.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.8.0"
+version = "1.9.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.8.0"
+version = "1.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.8.0"
+version = "1.9.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.9.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.8.0"
+version = "1.9.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.8.0
+package_version_override: 1.9.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.8.0"
+version = "1.9.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Release PR for v1.9.0. Version bump across all 19 sites via `make bump`, CHANGELOG promoted from Unreleased, OpenAPI snapshot and both SDKs regenerated at the new version (version-string deltas only).

What ships in 1.9.0:

- **#1207 / PR #1213** — the presigned reupload door enforces the upload door's completion contract: shared one-shot guard, `staging/`-prefix frozen-copy discriminator, dual-key deletion on refusal. Seven codex rounds.
- **#1233 / #1234 / PR #1235** — pre-tag lifecycle fixes from the adversarial state-interaction pass: cancelled multipart completion keeps the assembled object (the retry record), every pending-fail site shares one bound/unbound predicate boundary, presigned URLs signed against the job deadline inside the signing thread, and the new `PENDING_JOB_TIMEOUT_SECONDS` setting bounds the job and URL lifetimes together.
- **#1216 / PR #1232** — manifest sources under a `staging/`-shaped key refused at declaration time.
- **#1211 / PR #1237** — bundled MinIO aborts abandoned multipart uploads (server-side sweep; MinIO ignores S3 abort lifecycle JSON), RUNBOOK documents the AWS rule, abort window operator-overridable and coupled to the job lifetime.
- **#1205 / PR #1238** — react-router 8.3, js-audit allowlist now empty.

Verification: whole-tree backend suite green at every merged head; frontend build/lint/typecheck/vitest (4656) green; e2e smoke (core, builder, fixtures, reupload) green on the dev stack running this code; browser smoke green (catalog, maps, Matterhorn 3D render, admin sort URL-state, zero console errors); `make version-check`, `make openapi-check`, `make sdks-check`, and the env-doc drift gate all green at this commit.

Known accepted risks, documented in their issues: #1210 (raster frozen-source retention, deferred to #1217 decision 4) and #1236 (sweep window across a timeout-lowering restart).

https://claude.ai/code/session_01HWAxdeSdSJ5dS7bKUHFK98