### PR TITLE
fix(ingest): close post-expiry sweep orphan across timeout-lowering restart

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -109,7 +109,13 @@ class Settings(BaseSettings):
     upload_allowed_extensions: str = (
         ".zip,.gpkg,.geojson,.json,.csv,.tif,.tiff,.xlsx,.xls,.parquet"
     )
-    presigned_multipart_threshold_mb: int = Field(default=100, gt=0)
+    # fix(second-opinion review on #1236 review r3): capped at S3's own
+    # single-PUT hard limit (5GiB). Belt-and-suspenders — the invariant that
+    # actually matters is enforced in code, not config: see the clamp in
+    # `recheck_transfer_margin_seconds()` (platform/jobs/router.py), which
+    # a bound here cannot substitute for since that function must also stay
+    # safe against a value read before this bound ever applied.
+    presigned_multipart_threshold_mb: int = Field(default=100, gt=0, le=5120)
     # fix(#1234): a presigned job is abandoned after this long, and the part
     # URLs it hands out must not outlive it — the server was selling 7200s
     # URLs against a 3600s job lifetime. Lives here rather than in

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -52,6 +52,15 @@ KNOWN_BAD_JWT_SECRETS = frozenset(
 # Consumer: `require_signable_job_lifetime`.
 MIN_SIGNABLE_JOB_LIFETIME_SECONDS = 60
 
+# fix(#1236): the SigV4 ceiling. No presigned URL, issued under any past or
+# present value of `pending_job_timeout_seconds`, can outlive `created_at`
+# plus this many seconds — it is that field's own upper bound below. The
+# post-expiry sweep's re-check pass uses it as the age past which a
+# marked-reaped row is safe to consider settled for good, regardless of which
+# setting was in force when its URL was signed.
+# Consumer: `_sweep_expired_presigned_staging` in platform/jobs/router.py.
+MAX_PRESIGNED_URL_LIFETIME_SECONDS = 604800
+
 
 class Settings(BaseSettings):
     postgres_user: str = "geolens"
@@ -109,9 +118,10 @@ class Settings(BaseSettings):
     # would cycle.
     #
     # fix(#1235 review r5): bounded at the SigV4 ceiling. A presigned URL's
-    # X-Amz-Expires may not exceed 604800 seconds (7 days); above that boto
-    # still signs happily and S3 rejects every request, so an unbounded setting
-    # produced a deployment that booted clean and could not upload at all.
+    # X-Amz-Expires may not exceed MAX_PRESIGNED_URL_LIFETIME_SECONDS (7 days);
+    # above that boto still signs happily and S3 rejects every request, so an
+    # unbounded setting produced a deployment that booted clean and could not
+    # upload at all.
     #
     # fix(#1235 review r6): and floored past the dead zone at the other end.
     # `require_signable_job_lifetime` refuses to sign when fewer than
@@ -126,13 +136,17 @@ class Settings(BaseSettings):
     # measured from the job INSERT and a sufficiently slow request eats into
     # it at any setting.
     #
-    # Lowering it is safe at any time EXCEPT while presigned uploads are in
-    # flight: URLs already issued keep the old, longer life, while the
-    # post-expiry staging sweep immediately starts using the new, shorter
-    # window. Lower it during a quiet period, or wait out the previous value
-    # first. See `_sweep_expired_presigned_staging` in platform/jobs/router.py.
+    # Lowering it while presigned uploads are in flight is no longer a
+    # permanent leak: URLs already issued keep the old, longer life, and the
+    # post-expiry staging sweep starts using the new, shorter window
+    # immediately — but its re-check pass (fix #1236) revisits anything it
+    # marked reaped once MAX_PRESIGNED_URL_LIFETIME_SECONDS has passed since
+    # creation, which is the latest any such URL can still be live. See
+    # `_sweep_expired_presigned_staging` in platform/jobs/router.py.
     pending_job_timeout_seconds: int = Field(
-        default=3600, gt=MIN_SIGNABLE_JOB_LIFETIME_SECONDS, le=604800
+        default=3600,
+        gt=MIN_SIGNABLE_JOB_LIFETIME_SECONDS,
+        le=MAX_PRESIGNED_URL_LIFETIME_SECONDS,
     )
     procrastinate_schema: str = "catalog"
 

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -278,11 +278,34 @@ _STAGING_REAPED_FINAL_MARKER = "s3_key_reaped_final"
 # when an already-accepted PUT finishes transferring bytes — S3 validates the
 # signature at request start, not completion. A slow single-part upload begun
 # just under the ceiling can still be writing after it, so the re-check's
-# first delete attempt must not retire the row on the spot: only once this
-# margin has ALSO elapsed is a live transfer no longer credible. Reuses
-# `_COMMIT_HEADROOM_SECONDS`'s value under its own name — same "still
-# finishing past the nominal deadline" shape, different call site.
-_RECHECK_TRANSFER_MARGIN_SECONDS = _COMMIT_HEADROOM_SECONDS
+# first delete attempt must not retire the row on the spot: only once an
+# additional margin has ALSO elapsed is a live transfer no longer credible.
+#
+# fix(#1236 review r2, codex P1): that margin used to reuse
+# `_COMMIT_HEADROOM_SECONDS` — APPLICATION commit-round-trip headroom.
+# Presigned PUTs bypass the app entirely, so it never actually bounded
+# anything about them, and it does not scale if an operator raises the
+# setting below. The single-part object-key URL is the only recreation
+# vector (multipart needs a still-live upload id, consumed by
+# CompleteMultipartUpload), and `presigned_multipart_threshold_mb` is the
+# largest object it may legitimately carry — anything bigger is routed to
+# multipart at request time. Assuming no accepted transfer sustains less than
+# `_MIN_ASSUMED_UPLOAD_KBPS` derives a margin that scales with what an
+# operator actually configured, instead of a borrowed, unrelated constant.
+_MIN_ASSUMED_UPLOAD_KBPS = 32  # ~256kbit/s: slow, but a still-progressing PUT
+
+
+def recheck_transfer_margin_seconds() -> int:
+    """Longest a single-part PUT accepted just under the SigV4 ceiling could
+    still be writing, computed at call time so it tracks
+    ``presigned_multipart_threshold_mb`` if an operator raises it.
+
+    Floored at an hour: below the default 100MB threshold the throughput
+    assumption alone computes to less, and an hour is the minimum margin
+    worth enforcing regardless of how small the threshold is configured.
+    """
+    max_single_part_kb = settings.presigned_multipart_threshold_mb * 1024
+    return max(3600, max_single_part_kb // _MIN_ASSUMED_UPLOAD_KBPS)
 
 
 async def _sweep_expired_presigned_staging(
@@ -330,7 +353,7 @@ async def _sweep_expired_presigned_staging(
     attempt every pass once it crosses that age, which either recovers an
     object a stale marker was hiding or costs one no-op DeleteObject against a
     key that was never recreated — but does not finalize it until
-    `_RECHECK_TRANSFER_MARGIN_SECONDS` past that same age has ALSO elapsed
+    `recheck_transfer_margin_seconds()` past that same age has ALSO elapsed
     (codex P1 on this PR): SigV4 expiry stops new requests, not one already
     accepted, so a slow PUT begun just under the ceiling can still be writing
     after it. Only once no such transfer is credible does the final marker
@@ -340,7 +363,7 @@ async def _sweep_expired_presigned_staging(
     first_pass_cutoff = now - timedelta(seconds=post_expiry_sweep_after_seconds())
     recheck_cutoff = now - timedelta(seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS)
     recheck_final_cutoff = recheck_cutoff - timedelta(
-        seconds=_RECHECK_TRANSFER_MARGIN_SECONDS
+        seconds=recheck_transfer_margin_seconds()
     )
     not_yet_reaped = IngestJob.user_metadata[_STAGING_REAPED_MARKER].astext.is_(None)
     candidates = (
@@ -760,16 +783,26 @@ async def fail_stale_jobs(
         # because a re-PUT afterward recreates an object no row anywhere
         # references, and retention (unlike the sweep's own cutoff) is
         # commonly configured well under a week (1 day is an exercised
-        # value). Deferred exactly as long as the sweep's own re-check
-        # window: past MAX_PRESIGNED_URL_LIFETIME_SECONDS since creation no
-        # URL can be live under any setting the deployment ever ran, so
-        # purging is safe and `deleted_presigned_keys` below still reaps the
-        # object at that same moment — the row just doesn't need to survive
-        # to see it happen.
+        # value).
+        #
+        # fix(#1236 review r2, codex P1): deferred exactly as long as the
+        # sweep's own FINALIZATION window, not just its ceiling — an accepted
+        # PUT can still be transferring past MAX_PRESIGNED_URL_LIFETIME_SECONDS,
+        # which is why the sweep itself withholds its final marker for
+        # recheck_transfer_margin_seconds() longer. Purging on the bare
+        # ceiling reopened the exact race this row exists to close, just
+        # moved to the retention purge instead of the sweep. Past the
+        # combined window purging is safe and `deleted_presigned_keys` below
+        # still reaps the object at that same moment — the row just doesn't
+        # need to survive to see it happen.
         presigned_url_may_still_be_live = and_(
             IngestJob.user_metadata["s3_key"].astext.is_not(None),
             IngestJob.created_at
-            >= now - timedelta(seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS),
+            >= now
+            - timedelta(
+                seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS
+                + recheck_transfer_margin_seconds()
+            ),
         )
         # Single DELETE .. RETURNING re-applies every predicate atomically at
         # delete time — a SELECT-then-DELETE-by-id pair let /jobs/{id}/retry

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -284,28 +284,53 @@ _STAGING_REAPED_FINAL_MARKER = "s3_key_reaped_final"
 # fix(#1236 review r2, codex P1): that margin used to reuse
 # `_COMMIT_HEADROOM_SECONDS` — APPLICATION commit-round-trip headroom.
 # Presigned PUTs bypass the app entirely, so it never actually bounded
-# anything about them, and it does not scale if an operator raises the
-# setting below. The single-part object-key URL is the only recreation
-# vector (multipart needs a still-live upload id, consumed by
-# CompleteMultipartUpload), and `presigned_multipart_threshold_mb` is the
-# largest object it may legitimately carry — anything bigger is routed to
-# multipart at request time. Assuming no accepted transfer sustains less than
-# `_MIN_ASSUMED_UPLOAD_KBPS` derives a margin that scales with what an
-# operator actually configured, instead of a borrowed, unrelated constant.
+# anything about them. Replaced with a margin scaled by the largest object a
+# single-part URL (the only recreation vector; multipart needs a still-live
+# upload id, consumed by CompleteMultipartUpload) may legitimately carry,
+# assuming no accepted transfer sustains less than `_MIN_ASSUMED_UPLOAD_KBPS`.
+#
+# fix(#1236 review r3, codex P1): "may legitimately carry" is a property of
+# the JOB, fixed at the moment its URL was signed — not of whatever
+# `presigned_multipart_threshold_mb` reads as NOW. Lowering that setting
+# during a restart is exactly the #1236 class this whole PR exists to close:
+# a URL issued under the OLD, higher threshold can carry a transfer the
+# CURRENT setting no longer accounts for. Two call sites, two fixes for the
+# one root cause:
+#
+# - The SWEEP re-checks one already-fetched ROW at a time, so it passes
+#   THAT job's own persisted `expected_size` — declared when its URL was
+#   actually signed — instead of reading the current setting.
+# - The retention PURGE is one atomic bulk DELETE (kept that way to avoid
+#   reopening the SELECT-then-DELETE-by-id race #434/codex-P2-r10 already
+#   closed), so it cannot branch per row without a JSONB-to-numeric cast in
+#   the WHERE clause that could throw and fail the whole pass — the same
+#   shape of risk #1236's own known-gap writeup rejected for a timestamptz
+#   cast. It falls back to S3's own single-PUT ceiling instead, which no
+#   app setting can lower.
 _MIN_ASSUMED_UPLOAD_KBPS = 32  # ~256kbit/s: slow, but a still-progressing PUT
+_S3_SINGLE_PUT_MAX_BYTES = 5 * 1024 * 1024 * 1024  # AWS hard limit, 5GiB
 
 
-def recheck_transfer_margin_seconds() -> int:
-    """Longest a single-part PUT accepted just under the SigV4 ceiling could
-    still be writing, computed at call time so it tracks
-    ``presigned_multipart_threshold_mb`` if an operator raises it.
+def recheck_transfer_margin_seconds(expected_size_bytes: object = None) -> int:
+    """Longest a single-part PUT could still be writing past the SigV4
+    ceiling, at the assumed floor throughput.
 
-    Floored at an hour: below the default 100MB threshold the throughput
-    assumption alone computes to less, and an hour is the minimum margin
-    worth enforcing regardless of how small the threshold is configured.
+    Prefers ``expected_size_bytes`` — a job's own declared-at-signing-time
+    size — over any current setting, so a later config change cannot shrink
+    the margin out from under an upload already in flight. Falls back to
+    S3's own single-PUT ceiling (not the current
+    ``presigned_multipart_threshold_mb``, which is exactly the setting a
+    restart could have just lowered) when no per-job size is available: an
+    older row predating this field, a malformed value, or a caller — like
+    the retention purge — that cannot supply one per row.
+
+    Floored at an hour regardless of size.
     """
-    max_single_part_kb = settings.presigned_multipart_threshold_mb * 1024
-    return max(3600, max_single_part_kb // _MIN_ASSUMED_UPLOAD_KBPS)
+    try:
+        size_bytes = max(1, int(expected_size_bytes))
+    except (TypeError, ValueError):
+        size_bytes = _S3_SINGLE_PUT_MAX_BYTES
+    return max(3600, (size_bytes // 1024) // _MIN_ASSUMED_UPLOAD_KBPS)
 
 
 async def _sweep_expired_presigned_staging(
@@ -358,13 +383,15 @@ async def _sweep_expired_presigned_staging(
     accepted, so a slow PUT begun just under the ceiling can still be writing
     after it. Only once no such transfer is credible does the final marker
     retire the row for good.
+
+    fix(#1236 review r3, codex P1): that margin is computed PER ROW, from
+    each job's own persisted `expected_size`, inside the loop below — not
+    once up front from the current `presigned_multipart_threshold_mb`, which
+    an operator may have lowered since this particular job's URL was signed.
     """
     now = now or datetime.now(timezone.utc)
     first_pass_cutoff = now - timedelta(seconds=post_expiry_sweep_after_seconds())
     recheck_cutoff = now - timedelta(seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS)
-    recheck_final_cutoff = recheck_cutoff - timedelta(
-        seconds=recheck_transfer_margin_seconds()
-    )
     not_yet_reaped = IngestJob.user_metadata[_STAGING_REAPED_MARKER].astext.is_(None)
     candidates = (
         await db.execute(
@@ -413,8 +440,12 @@ async def _sweep_expired_presigned_staging(
         # loaded value — JSONB does not track mutation, so an in-place edit
         # would never flush.
         new_metadata = {**(metadata or {}), _STAGING_REAPED_MARKER: True}
-        if is_recheck_pass and created_at < recheck_final_cutoff:
-            new_metadata[_STAGING_REAPED_FINAL_MARKER] = True
+        if is_recheck_pass:
+            margin = recheck_transfer_margin_seconds(
+                (metadata or {}).get("expected_size")
+            )
+            if created_at < recheck_cutoff - timedelta(seconds=margin):
+                new_metadata[_STAGING_REAPED_FINAL_MARKER] = True
         await db.execute(
             update(IngestJob)
             .where(IngestJob.id == job_row_id)
@@ -795,6 +826,16 @@ async def fail_stale_jobs(
         # combined window purging is safe and `deleted_presigned_keys` below
         # still reaps the object at that same moment — the row just doesn't
         # need to survive to see it happen.
+        #
+        # fix(#1236 review r3, codex P1): called with no per-job size, so this
+        # always gets `recheck_transfer_margin_seconds()`'s S3-hard-limit
+        # fallback rather than the current `presigned_multipart_threshold_mb`
+        # — the ONE bulk DELETE cannot branch per row on each job's own
+        # `expected_size` without a JSONB-to-numeric cast that could throw
+        # and fail the whole pass (the sweep, which fetches rows individually,
+        # uses the per-job value instead — see that function's docstring).
+        # The fallback is config-immune by construction, so a lowered
+        # threshold during a restart cannot shrink this deferral either.
         presigned_url_may_still_be_live = and_(
             IngestJob.user_metadata["s3_key"].astext.is_not(None),
             IngestJob.created_at

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -324,10 +324,23 @@ def recheck_transfer_margin_seconds(expected_size_bytes: object = None) -> int:
     older row predating this field, a malformed value, or a caller — like
     the retention purge — that cannot supply one per row.
 
+    fix(second-opinion review on #1236 review r3): also CLAMPED at that same
+    ceiling, unconditionally. `presigned_multipart_threshold_mb` has no
+    configured upper bound, so a declared `expected_size` bigger than
+    `_S3_SINGLE_PUT_MAX_BYTES` was possible whenever an operator raised the
+    threshold past 5GiB — and the retention purge's fallback (this function
+    called with no size) always assumes 5GiB is the worst case. Without the
+    clamp the sweep could derive a bigger margin than the purge actually
+    waits out, reopening the #1236 orphan class through the purge path for
+    oversized single-part jobs: real exploitability is low (S3 itself
+    rejects a single PUT past 5GiB, so an honestly-reported `expected_size`
+    should never legitimately exceed it), but the invariant belongs in code
+    that does not trust configuration, not in an operator's Field bound.
+
     Floored at an hour regardless of size.
     """
     try:
-        size_bytes = max(1, int(expected_size_bytes))
+        size_bytes = min(max(1, int(expected_size_bytes)), _S3_SINGLE_PUT_MAX_BYTES)
     except (TypeError, ValueError):
         size_bytes = _S3_SINGLE_PUT_MAX_BYTES
     return max(3600, (size_bytes // 1024) // _MIN_ASSUMED_UPLOAD_KBPS)

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -8,10 +8,10 @@ from typing import Literal, cast, overload
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy import delete, func, not_, select, text, update
+from sqlalchemy import and_, delete, func, not_, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
+from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
 from app.core.dependencies import get_client_ip, get_db
 from app.core.identity import Identity
 from app.modules.auth.dependencies import (
@@ -262,8 +262,16 @@ def post_expiry_sweep_after_seconds() -> int:
     return settings.pending_job_timeout_seconds + _POST_EXPIRY_SWEEP_MARGIN_SECONDS
 
 
-# Set once the post-expiry sweep has run for a job, so it never runs twice.
+# Set on the post-expiry sweep's first pass over a job. Not permanent on its
+# own — see _STAGING_REAPED_FINAL_MARKER below (fix #1236).
 _STAGING_REAPED_MARKER = "s3_key_reaped"
+
+# fix(#1236): set once the sweep's RE-CHECK pass has run, which only happens
+# after MAX_PRESIGNED_URL_LIFETIME_SECONDS have elapsed since `created_at` —
+# the latest moment any URL for the job, signed under any setting the
+# deployment ever ran, can still be live. Only rows carrying this marker are
+# excluded from every future pass; _STAGING_REAPED_MARKER alone no longer is.
+_STAGING_REAPED_FINAL_MARKER = "s3_key_reaped_final"
 
 
 async def _sweep_expired_presigned_staging(
@@ -277,8 +285,12 @@ async def _sweep_expired_presigned_staging(
     successful job is the per-dataset latest-complete that the retention purge
     exempts forever. Those sweeps close the URL's past; this closes its future.
 
-    Runs exactly once per job, ever: the marker takes the row out of the query
-    below, so the exempt rows do not cost a storage call on every pass forever.
+    Runs up to twice per job, ever: an ordinary pass reaps once and sets
+    ``_STAGING_REAPED_MARKER``, which excludes the row from the ordinary
+    window from then on but not from the re-check window below. Only
+    ``_STAGING_REAPED_FINAL_MARKER`` — set once the re-check has actually run
+    — takes a row out of the query for good, so the steady-state cost stays
+    one excluded row per pass rather than one delete forever.
 
     Delete first, mark second — the opposite of ``_reap_committed_staged_paths``
     and for a different reason. That one must not destroy an artifact a
@@ -287,29 +299,44 @@ async def _sweep_expired_presigned_staging(
     leaks the object permanently. A crash between the two costs one redundant
     delete on the next pass instead, which is a no-op.
 
-    KNOWN GAP (#1235 review r5), bounded to one operator action: the window is
-    computed from the CURRENT setting, but a live URL was signed against the
-    setting in force when it was issued. Lower `pending_job_timeout_seconds`
-    and restart while presigned uploads are in flight, and this sweep runs
-    early against those older, longer-lived URLs — it reaps, sets the marker,
-    and a still-valid PUT afterwards recreates an object every later pass then
-    skips. Persisting the issued deadline per job would close it, but only for
-    jobs presigned after that ships, which is not the set at risk during the
-    upgrade that introduces it; and it costs a JSONB-to-timestamptz cast in the
-    candidate WHERE, where a single malformed value fails the whole sweep. The
-    setting's own comment carries the operator guidance instead: lower it while
-    nothing is in flight, or wait out the previous value.
+    fix(#1236): closes the #1235 review r5 known gap. The ordinary window is
+    computed from the CURRENT `pending_job_timeout_seconds`, but a live URL was
+    signed against whatever value was in force when it was issued. Lower the
+    setting and restart while presigned uploads are in flight, and the
+    ordinary pass ran early against those older, longer-lived URLs — it reaped
+    the object and set the first marker while a PUT could still recreate it,
+    and that marker used to exempt the row forever.
+
+    The fix does not need to know which deadline a given URL actually carries
+    — persisting that per job was rejected in #1235 for exactly that reason,
+    plus a JSONB-to-timestamptz cast in the candidate WHERE that could throw
+    and fail the whole bulk pass. Instead it uses the one bound every URL
+    obeys regardless of history: SigV4 rejects any `X-Amz-Expires` beyond
+    `MAX_PRESIGNED_URL_LIFETIME_SECONDS`, and `pending_job_timeout_seconds` has
+    always been capped at that same ceiling, so no URL for a job can still be
+    live past `created_at + MAX_PRESIGNED_URL_LIFETIME_SECONDS` no matter which
+    setting minted it. A row already carrying the first marker gets exactly
+    one more delete attempt once it crosses that age, which either recovers an
+    object a stale marker was hiding or costs one no-op DeleteObject against a
+    key that was never recreated — then the final marker retires it for good.
     """
-    cutoff = (now or datetime.now(timezone.utc)) - timedelta(
-        seconds=post_expiry_sweep_after_seconds()
-    )
+    now = now or datetime.now(timezone.utc)
+    first_pass_cutoff = now - timedelta(seconds=post_expiry_sweep_after_seconds())
+    recheck_cutoff = now - timedelta(seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS)
+    not_yet_reaped = IngestJob.user_metadata[_STAGING_REAPED_MARKER].astext.is_(None)
     candidates = (
         await db.execute(
             select(IngestJob.id, IngestJob.file_path, IngestJob.user_metadata).where(
                 IngestJob.status.not_in(("pending", "running")),
-                IngestJob.created_at < cutoff,
                 IngestJob.user_metadata["s3_key"].astext.is_not(None),
-                IngestJob.user_metadata[_STAGING_REAPED_MARKER].astext.is_(None),
+                IngestJob.user_metadata[_STAGING_REAPED_FINAL_MARKER].astext.is_(None),
+                or_(
+                    and_(not_yet_reaped, IngestJob.created_at < first_pass_cutoff),
+                    and_(
+                        not_(not_yet_reaped),
+                        IngestJob.created_at < recheck_cutoff,
+                    ),
+                ),
             )
         )
     ).all()
@@ -322,6 +349,7 @@ async def _sweep_expired_presigned_staging(
             # Not this job's key to delete — a fan-out child holding the
             # parent's inherited s3_key lands here, same rule as everywhere.
             continue
+        is_recheck_pass = (metadata or {}).get(_STAGING_REAPED_MARKER) is not None
         try:
             from app.platform.storage import get_storage
 
@@ -331,17 +359,19 @@ async def _sweep_expired_presigned_staging(
             log.warning(
                 "Failed to reap expired presigned staging object",
                 storage_key=staging_key,
+                recheck_pass=is_recheck_pass,
             )
             continue
         # A Core UPDATE with a fresh dict, not an in-place mutation of the
         # loaded value — JSONB does not track mutation, so an in-place edit
         # would never flush.
+        new_metadata = {**(metadata or {}), _STAGING_REAPED_MARKER: True}
+        if is_recheck_pass:
+            new_metadata[_STAGING_REAPED_FINAL_MARKER] = True
         await db.execute(
             update(IngestJob)
             .where(IngestJob.id == job_row_id)
-            .values(
-                user_metadata={**(metadata or {}), _STAGING_REAPED_MARKER: True},
-            )
+            .values(user_metadata=new_metadata)
         )
         reaped += 1
 

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -266,12 +266,23 @@ def post_expiry_sweep_after_seconds() -> int:
 # own — see _STAGING_REAPED_FINAL_MARKER below (fix #1236).
 _STAGING_REAPED_MARKER = "s3_key_reaped"
 
-# fix(#1236): set once the sweep's RE-CHECK pass has run, which only happens
-# after MAX_PRESIGNED_URL_LIFETIME_SECONDS have elapsed since `created_at` —
-# the latest moment any URL for the job, signed under any setting the
-# deployment ever ran, can still be live. Only rows carrying this marker are
-# excluded from every future pass; _STAGING_REAPED_MARKER alone no longer is.
+# fix(#1236): set once the sweep's RE-CHECK pass has run AND cleared the
+# transfer margin below, which only happens after
+# MAX_PRESIGNED_URL_LIFETIME_SECONDS have elapsed since `created_at` — the
+# latest moment any URL for the job, signed under any setting the deployment
+# ever ran, can still be live. Only rows carrying this marker are excluded
+# from every future pass; _STAGING_REAPED_MARKER alone no longer is.
 _STAGING_REAPED_FINAL_MARKER = "s3_key_reaped_final"
+
+# fix(#1236 review, codex P1): SigV4 bounds when a URL may be SIGNED for, not
+# when an already-accepted PUT finishes transferring bytes — S3 validates the
+# signature at request start, not completion. A slow single-part upload begun
+# just under the ceiling can still be writing after it, so the re-check's
+# first delete attempt must not retire the row on the spot: only once this
+# margin has ALSO elapsed is a live transfer no longer credible. Reuses
+# `_COMMIT_HEADROOM_SECONDS`'s value under its own name — same "still
+# finishing past the nominal deadline" shape, different call site.
+_RECHECK_TRANSFER_MARGIN_SECONDS = _COMMIT_HEADROOM_SECONDS
 
 
 async def _sweep_expired_presigned_staging(
@@ -315,18 +326,31 @@ async def _sweep_expired_presigned_staging(
     `MAX_PRESIGNED_URL_LIFETIME_SECONDS`, and `pending_job_timeout_seconds` has
     always been capped at that same ceiling, so no URL for a job can still be
     live past `created_at + MAX_PRESIGNED_URL_LIFETIME_SECONDS` no matter which
-    setting minted it. A row already carrying the first marker gets exactly
-    one more delete attempt once it crosses that age, which either recovers an
+    setting minted it. A row already carrying the first marker gets a delete
+    attempt every pass once it crosses that age, which either recovers an
     object a stale marker was hiding or costs one no-op DeleteObject against a
-    key that was never recreated — then the final marker retires it for good.
+    key that was never recreated — but does not finalize it until
+    `_RECHECK_TRANSFER_MARGIN_SECONDS` past that same age has ALSO elapsed
+    (codex P1 on this PR): SigV4 expiry stops new requests, not one already
+    accepted, so a slow PUT begun just under the ceiling can still be writing
+    after it. Only once no such transfer is credible does the final marker
+    retire the row for good.
     """
     now = now or datetime.now(timezone.utc)
     first_pass_cutoff = now - timedelta(seconds=post_expiry_sweep_after_seconds())
     recheck_cutoff = now - timedelta(seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS)
+    recheck_final_cutoff = recheck_cutoff - timedelta(
+        seconds=_RECHECK_TRANSFER_MARGIN_SECONDS
+    )
     not_yet_reaped = IngestJob.user_metadata[_STAGING_REAPED_MARKER].astext.is_(None)
     candidates = (
         await db.execute(
-            select(IngestJob.id, IngestJob.file_path, IngestJob.user_metadata).where(
+            select(
+                IngestJob.id,
+                IngestJob.file_path,
+                IngestJob.user_metadata,
+                IngestJob.created_at,
+            ).where(
                 IngestJob.status.not_in(("pending", "running")),
                 IngestJob.user_metadata["s3_key"].astext.is_not(None),
                 IngestJob.user_metadata[_STAGING_REAPED_FINAL_MARKER].astext.is_(None),
@@ -343,7 +367,7 @@ async def _sweep_expired_presigned_staging(
 
     reaped = 0
     failures = 0
-    for job_row_id, file_path, metadata in candidates:
+    for job_row_id, file_path, metadata, created_at in candidates:
         staging_key = owned_presigned_staging_key(job_row_id, metadata, file_path)
         if staging_key is None:
             # Not this job's key to delete — a fan-out child holding the
@@ -366,7 +390,7 @@ async def _sweep_expired_presigned_staging(
         # loaded value — JSONB does not track mutation, so an in-place edit
         # would never flush.
         new_metadata = {**(metadata or {}), _STAGING_REAPED_MARKER: True}
-        if is_recheck_pass:
+        if is_recheck_pass and created_at < recheck_final_cutoff:
             new_metadata[_STAGING_REAPED_FINAL_MARKER] = True
         await db.execute(
             update(IngestJob)
@@ -729,6 +753,24 @@ async def fail_stale_jobs(
                 IngestJob.created_at.desc(),
             )
         )
+        # fix(#1236 review, codex P1): a presigned job's ROW is the only place
+        # _sweep_expired_presigned_staging's markers live. Purging it before
+        # any URL issued for it can possibly still be live removes that
+        # tracking outright — worse than the marker gap this PR closes,
+        # because a re-PUT afterward recreates an object no row anywhere
+        # references, and retention (unlike the sweep's own cutoff) is
+        # commonly configured well under a week (1 day is an exercised
+        # value). Deferred exactly as long as the sweep's own re-check
+        # window: past MAX_PRESIGNED_URL_LIFETIME_SECONDS since creation no
+        # URL can be live under any setting the deployment ever ran, so
+        # purging is safe and `deleted_presigned_keys` below still reaps the
+        # object at that same moment — the row just doesn't need to survive
+        # to see it happen.
+        presigned_url_may_still_be_live = and_(
+            IngestJob.user_metadata["s3_key"].astext.is_not(None),
+            IngestJob.created_at
+            >= now - timedelta(seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS),
+        )
         # Single DELETE .. RETURNING re-applies every predicate atomically at
         # delete time — a SELECT-then-DELETE-by-id pair let /jobs/{id}/retry
         # flip a candidate back to pending between the two statements and
@@ -741,6 +783,7 @@ async def fail_stale_jobs(
                 < retention_cutoff,
                 IngestJob.id.not_in(latest_complete_ids),
                 IngestJob.id.not_in(latest_manifest_ids),
+                not_(presigned_url_may_still_be_live),
             )
             .returning(IngestJob.id, IngestJob.file_path, IngestJob.user_metadata)
         )

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -284,66 +284,29 @@ _STAGING_REAPED_FINAL_MARKER = "s3_key_reaped_final"
 # fix(#1236 review r2, codex P1): that margin used to reuse
 # `_COMMIT_HEADROOM_SECONDS` — APPLICATION commit-round-trip headroom.
 # Presigned PUTs bypass the app entirely, so it never actually bounded
-# anything about them. Replaced with a margin scaled by the largest object a
-# single-part URL (the only recreation vector; multipart needs a still-live
-# upload id, consumed by CompleteMultipartUpload) may legitimately carry,
-# assuming no accepted transfer sustains less than `_MIN_ASSUMED_UPLOAD_KBPS`.
+# anything about them.
 #
-# fix(#1236 review r3, codex P1): "may legitimately carry" is a property of
-# the JOB, fixed at the moment its URL was signed — not of whatever
-# `presigned_multipart_threshold_mb` reads as NOW. Lowering that setting
-# during a restart is exactly the #1236 class this whole PR exists to close:
-# a URL issued under the OLD, higher threshold can carry a transfer the
-# CURRENT setting no longer accounts for. Two call sites, two fixes for the
-# one root cause:
-#
-# - The SWEEP re-checks one already-fetched ROW at a time, so it passes
-#   THAT job's own persisted `expected_size` — declared when its URL was
-#   actually signed — instead of reading the current setting.
-# - The retention PURGE is one atomic bulk DELETE (kept that way to avoid
-#   reopening the SELECT-then-DELETE-by-id race #434/codex-P2-r10 already
-#   closed), so it cannot branch per row without a JSONB-to-numeric cast in
-#   the WHERE clause that could throw and fail the whole pass — the same
-#   shape of risk #1236's own known-gap writeup rejected for a timestamptz
-#   cast. It falls back to S3's own single-PUT ceiling instead, which no
-#   app setting can lower.
+# fix(#1236 review r3/second-opinion/r4, codex P1 x3): rounds r2-r3 then
+# scaled the margin from `presigned_multipart_threshold_mb` and, after that
+# proved config-fragile, from a job's own declared `expected_size` instead.
+# Round 4 found the actual root cause under BOTH attempts:
+# `generate_presigned_put_url` signs only `ContentType`, never a
+# content-length constraint, so nothing ever enforced `expected_size` —
+# a client can declare one byte and stream anything up to S3's real limit
+# regardless. A margin derived from an unenforced declaration was tighter
+# than the fixed ceiling, but never actually SAFE, which is worse than
+# simply being wide: fixed and correct beats tight and wrong. The margin is
+# now S3's own single-PUT ceiling, unconditionally, for every job — the one
+# bound nothing but S3 itself enforces, so no per-job data or setting can
+# ever undermine it. (Signing `Content-Length` into the URL so a mismatched
+# PUT gets rejected by S3, making a declared-size margin trustworthy, was
+# the other option; not worth the API-surface change for a low-frequency
+# finalization check.)
 _MIN_ASSUMED_UPLOAD_KBPS = 32  # ~256kbit/s: slow, but a still-progressing PUT
 _S3_SINGLE_PUT_MAX_BYTES = 5 * 1024 * 1024 * 1024  # AWS hard limit, 5GiB
-
-
-def recheck_transfer_margin_seconds(expected_size_bytes: object = None) -> int:
-    """Longest a single-part PUT could still be writing past the SigV4
-    ceiling, at the assumed floor throughput.
-
-    Prefers ``expected_size_bytes`` — a job's own declared-at-signing-time
-    size — over any current setting, so a later config change cannot shrink
-    the margin out from under an upload already in flight. Falls back to
-    S3's own single-PUT ceiling (not the current
-    ``presigned_multipart_threshold_mb``, which is exactly the setting a
-    restart could have just lowered) when no per-job size is available: an
-    older row predating this field, a malformed value, or a caller — like
-    the retention purge — that cannot supply one per row.
-
-    fix(second-opinion review on #1236 review r3): also CLAMPED at that same
-    ceiling, unconditionally. `presigned_multipart_threshold_mb` has no
-    configured upper bound, so a declared `expected_size` bigger than
-    `_S3_SINGLE_PUT_MAX_BYTES` was possible whenever an operator raised the
-    threshold past 5GiB — and the retention purge's fallback (this function
-    called with no size) always assumes 5GiB is the worst case. Without the
-    clamp the sweep could derive a bigger margin than the purge actually
-    waits out, reopening the #1236 orphan class through the purge path for
-    oversized single-part jobs: real exploitability is low (S3 itself
-    rejects a single PUT past 5GiB, so an honestly-reported `expected_size`
-    should never legitimately exceed it), but the invariant belongs in code
-    that does not trust configuration, not in an operator's Field bound.
-
-    Floored at an hour regardless of size.
-    """
-    try:
-        size_bytes = min(max(1, int(expected_size_bytes)), _S3_SINGLE_PUT_MAX_BYTES)
-    except (TypeError, ValueError):
-        size_bytes = _S3_SINGLE_PUT_MAX_BYTES
-    return max(3600, (size_bytes // 1024) // _MIN_ASSUMED_UPLOAD_KBPS)
+_RECHECK_TRANSFER_MARGIN_SECONDS = max(
+    3600, (_S3_SINGLE_PUT_MAX_BYTES // 1024) // _MIN_ASSUMED_UPLOAD_KBPS
+)
 
 
 async def _sweep_expired_presigned_staging(
@@ -391,20 +354,23 @@ async def _sweep_expired_presigned_staging(
     attempt every pass once it crosses that age, which either recovers an
     object a stale marker was hiding or costs one no-op DeleteObject against a
     key that was never recreated — but does not finalize it until
-    `recheck_transfer_margin_seconds()` past that same age has ALSO elapsed
+    `_RECHECK_TRANSFER_MARGIN_SECONDS` past that same age has ALSO elapsed
     (codex P1 on this PR): SigV4 expiry stops new requests, not one already
     accepted, so a slow PUT begun just under the ceiling can still be writing
     after it. Only once no such transfer is credible does the final marker
     retire the row for good.
 
-    fix(#1236 review r3, codex P1): that margin is computed PER ROW, from
-    each job's own persisted `expected_size`, inside the loop below — not
-    once up front from the current `presigned_multipart_threshold_mb`, which
-    an operator may have lowered since this particular job's URL was signed.
+    fix(#1236 review r4, codex P1): that margin is FIXED at S3's own
+    single-PUT ceiling for every job, not derived from anything a client
+    declared or an operator configured — see `_RECHECK_TRANSFER_MARGIN_SECONDS`
+    above for why rounds r2/r3 both proved unsafe.
     """
     now = now or datetime.now(timezone.utc)
     first_pass_cutoff = now - timedelta(seconds=post_expiry_sweep_after_seconds())
     recheck_cutoff = now - timedelta(seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS)
+    recheck_final_cutoff = recheck_cutoff - timedelta(
+        seconds=_RECHECK_TRANSFER_MARGIN_SECONDS
+    )
     not_yet_reaped = IngestJob.user_metadata[_STAGING_REAPED_MARKER].astext.is_(None)
     candidates = (
         await db.execute(
@@ -453,12 +419,8 @@ async def _sweep_expired_presigned_staging(
         # loaded value — JSONB does not track mutation, so an in-place edit
         # would never flush.
         new_metadata = {**(metadata or {}), _STAGING_REAPED_MARKER: True}
-        if is_recheck_pass:
-            margin = recheck_transfer_margin_seconds(
-                (metadata or {}).get("expected_size")
-            )
-            if created_at < recheck_cutoff - timedelta(seconds=margin):
-                new_metadata[_STAGING_REAPED_FINAL_MARKER] = True
+        if is_recheck_pass and created_at < recheck_final_cutoff:
+            new_metadata[_STAGING_REAPED_FINAL_MARKER] = True
         await db.execute(
             update(IngestJob)
             .where(IngestJob.id == job_row_id)
@@ -833,29 +795,24 @@ async def fail_stale_jobs(
         # sweep's own FINALIZATION window, not just its ceiling — an accepted
         # PUT can still be transferring past MAX_PRESIGNED_URL_LIFETIME_SECONDS,
         # which is why the sweep itself withholds its final marker for
-        # recheck_transfer_margin_seconds() longer. Purging on the bare
+        # _RECHECK_TRANSFER_MARGIN_SECONDS longer. Purging on the bare
         # ceiling reopened the exact race this row exists to close, just
         # moved to the retention purge instead of the sweep. Past the
         # combined window purging is safe and `deleted_presigned_keys` below
         # still reaps the object at that same moment — the row just doesn't
         # need to survive to see it happen.
         #
-        # fix(#1236 review r3, codex P1): called with no per-job size, so this
-        # always gets `recheck_transfer_margin_seconds()`'s S3-hard-limit
-        # fallback rather than the current `presigned_multipart_threshold_mb`
-        # — the ONE bulk DELETE cannot branch per row on each job's own
-        # `expected_size` without a JSONB-to-numeric cast that could throw
-        # and fail the whole pass (the sweep, which fetches rows individually,
-        # uses the per-job value instead — see that function's docstring).
-        # The fallback is config-immune by construction, so a lowered
-        # threshold during a restart cannot shrink this deferral either.
+        # fix(#1236 review r4, codex P1): that margin is now the SAME fixed
+        # constant the sweep uses (see its definition for why r3's per-job
+        # `expected_size` scaling proved unsafe) — no per-row data needed, so
+        # this bulk DELETE never has to branch per row on JSONB.
         presigned_url_may_still_be_live = and_(
             IngestJob.user_metadata["s3_key"].astext.is_not(None),
             IngestJob.created_at
             >= now
             - timedelta(
                 seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS
-                + recheck_transfer_margin_seconds()
+                + _RECHECK_TRANSFER_MARGIN_SECONDS
             ),
         )
         # Single DELETE .. RETURNING re-applies every predicate atomically at

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -806,8 +806,24 @@ async def fail_stale_jobs(
         # constant the sweep uses (see its definition for why r3's per-job
         # `expected_size` scaling proved unsafe) — no per-row data needed, so
         # this bulk DELETE never has to branch per row on JSONB.
+        #
+        # fix(#1236 review r5, codex P2): a non-null `s3_key` alone is not
+        # OWNERSHIP. `create_fan_out_jobs` clones the parent's `user_metadata`
+        # wholesale (processing/ingest/service.py), so every fan-out child
+        # carries the PARENT's `s3_key` too — the exact case
+        # `owned_presigned_staging_key` exists to reject, by requiring the
+        # key's prefix match the ROW'S OWN id. Without that same check here,
+        # every terminal fan-out child was exempted from retention for
+        # ~8.9 days regardless of how short `ingest_jobs_retention_days` was
+        # configured, since it can never be the row that legitimately reaps
+        # or finalizes that key. A `LIKE` prefix match is a safe string
+        # comparison — unlike a JSONB-to-numeric/timestamptz cast, it cannot
+        # throw and fail the whole bulk pass on a malformed value.
         presigned_url_may_still_be_live = and_(
             IngestJob.user_metadata["s3_key"].astext.is_not(None),
+            IngestJob.user_metadata["s3_key"].astext.like(
+                func.concat("staging/", IngestJob.id, "/%")
+            ),
             IngestJob.created_at
             >= now
             - timedelta(

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2120,7 +2120,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `recheck_transfer_margin_seconds()` function collapse back out. Ratchet
     # DOWN in the same commit, per the no-headroom rule. Cap 1588 -> 1545,
     # exact.
-    "backend/app/platform/jobs/router.py": 1545,
+    # fix(#1236 review r5, codex P2): +16 — a non-null `s3_key` was treated
+    # as ownership in the retention purge's deferral predicate, but
+    # `create_fan_out_jobs` clones the parent's `user_metadata` wholesale, so
+    # every fan-out child inherits the PARENT's `s3_key` too. The predicate
+    # now requires the key's prefix match the ROW'S OWN id (a LIKE string
+    # match, same ownership rule `owned_presigned_staging_key` already
+    # enforces), so a terminal child no longer rides along on the parent's
+    # ~8.9-day exemption. Cap 1545 -> 1561, exact.
+    "backend/app/platform/jobs/router.py": 1561,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2096,7 +2096,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # setting's max single-part size and an assumed floor throughput; the
     # retention purge's deferral now adds the same margin instead of stopping
     # at the bare SigV4 ceiling. Cap 1501 -> 1534, exact.
-    "backend/app/platform/jobs/router.py": 1534,
+    # fix(#1236 review r3, codex P1): +41 — that margin still read the
+    # CURRENT `presigned_multipart_threshold_mb`, so lowering it during a
+    # restart could shrink the margin under a transfer issued when it was
+    # higher — the #1236 class again, one level down. The sweep now derives
+    # each job's margin from its own persisted `expected_size` (computed per
+    # row, in the loop, since a bulk DELETE cannot); the retention purge,
+    # which cannot branch per row, falls back to S3's own single-PUT ceiling
+    # instead of the current setting. Cap 1534 -> 1575, exact.
+    "backend/app/platform/jobs/router.py": 1575,
     "backend/app/processing/ingest/tasks_vrt.py": 1071,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2080,6 +2080,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # line: that is the gap #958 was filed about. The next change to any of
     # them writes the first entry.
     "backend/app/platform/config_ops/service.py": 1201,
+    # fix(#1236): first entry — crossed the router-glob gate's default
+    # 1500-line cap. The lines bought a bounded re-check pass for
+    # `_sweep_expired_presigned_staging` (closes the #1235 review r5 known
+    # gap: a timeout-lowering restart could orphan a recreated staging
+    # object forever), a further-bounded finalization margin for a PUT still
+    # transferring past the SigV4 ceiling (codex P1), and deferring the
+    # terminal-job retention purge for presigned rows a live URL could still
+    # recreate (codex P1). Cap 1500 -> 1501, exact.
+    "backend/app/platform/jobs/router.py": 1501,
     "backend/app/processing/ingest/tasks_vrt.py": 1071,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2110,13 +2110,23 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # that. `recheck_transfer_margin_seconds()` now clamps unconditionally at
     # `_S3_SINGLE_PUT_MAX_BYTES` rather than trusting either the job's
     # declared size or the setting. Cap 1575 -> 1588, exact.
-    "backend/app/platform/jobs/router.py": 1588,
+    # fix(#1236 review r4, codex P1): -43 — rounds r2/r3 both scaled the
+    # margin from a client-declared size (a setting, then a job's own
+    # `expected_size`); r4 found neither was ever enforced —
+    # `generate_presigned_put_url` signs no content-length constraint, so a
+    # declaration bounds nothing. The margin is now a single fixed constant
+    # (S3's own single-PUT ceiling) for every job, which let the per-row
+    # `expected_size` branch in the sweep's loop and the whole
+    # `recheck_transfer_margin_seconds()` function collapse back out. Ratchet
+    # DOWN in the same commit, per the no-headroom rule. Cap 1588 -> 1545,
+    # exact.
+    "backend/app/platform/jobs/router.py": 1545,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side
-    # clamp in `recheck_transfer_margin_seconds()` is what actually closes
-    # the gap; this Field bound only stops a fresh boot from configuring
-    # past S3's own single-PUT ceiling in the first place).
+    # fixed margin in `_sweep_expired_presigned_staging` is what actually
+    # closes the gap; this Field bound only stops a fresh boot from
+    # configuring past S3's own single-PUT ceiling in the first place).
     "backend/app/core/config.py": 1004,
     "backend/app/processing/ingest/tasks_vrt.py": 1071,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2104,7 +2104,20 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # row, in the loop, since a bulk DELETE cannot); the retention purge,
     # which cannot branch per row, falls back to S3's own single-PUT ceiling
     # instead of the current setting. Cap 1534 -> 1575, exact.
-    "backend/app/platform/jobs/router.py": 1575,
+    # fix(second-opinion review on #1236 review r3): +13 — the setting has no
+    # configured upper bound, so a declared `expected_size` could exceed the
+    # purge fallback's 5GiB assumption whenever an operator raised it past
+    # that. `recheck_transfer_margin_seconds()` now clamps unconditionally at
+    # `_S3_SINGLE_PUT_MAX_BYTES` rather than trusting either the job's
+    # declared size or the setting. Cap 1575 -> 1588, exact.
+    "backend/app/platform/jobs/router.py": 1588,
+    # fix(second-opinion review on #1236 review r3): first entry — crossed
+    # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
+    # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side
+    # clamp in `recheck_transfer_margin_seconds()` is what actually closes
+    # the gap; this Field bound only stops a fresh boot from configuring
+    # past S3's own single-PUT ceiling in the first place).
+    "backend/app/core/config.py": 1004,
     "backend/app/processing/ingest/tasks_vrt.py": 1071,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2088,7 +2088,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # transferring past the SigV4 ceiling (codex P1), and deferring the
     # terminal-job retention purge for presigned rows a live URL could still
     # recreate (codex P1). Cap 1500 -> 1501, exact.
-    "backend/app/platform/jobs/router.py": 1501,
+    # fix(#1236 review r2, codex P1 x2): +33 — the finalization margin was
+    # reusing `_COMMIT_HEADROOM_SECONDS`, an APPLICATION commit-round-trip
+    # number that never bounded a presigned PUT (which bypasses the app
+    # entirely) and didn't scale with `presigned_multipart_threshold_mb`.
+    # Replaced with `recheck_transfer_margin_seconds()`, derived from that
+    # setting's max single-part size and an assumed floor throughput; the
+    # retention purge's deferral now adds the same margin instead of stopping
+    # at the bare SigV4 ceiling. Cap 1501 -> 1534, exact.
+    "backend/app/platform/jobs/router.py": 1534,
     "backend/app/processing/ingest/tasks_vrt.py": 1071,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -597,6 +597,109 @@ class TestPostExpirySweep:
         await test_db_session.refresh(refreshed)
         assert "s3_key_reaped" not in (refreshed.user_metadata or {})
 
+    async def test_a_timeout_lowering_restart_no_longer_orphans_the_recreated_object(
+        self, test_db_session, monkeypatch
+    ) -> None:
+        """#1236 repro. An operator lowers ``pending_job_timeout_seconds`` and
+        restarts while a PUT URL signed under the OLD, longer setting is still
+        live. The ordinary pass derives its window from the CURRENT setting,
+        so it reaps and marks the row early; a re-PUT through the still-valid
+        URL then recreates the object. Before this fix the marker exempted
+        the row from every later pass, orphaning the recreated object
+        forever. Reproduced across two "runs" against the same row —
+        ``pending_job_timeout_seconds`` changes between them, standing in for
+        the restart, and the second run's ``now=`` stands in for wall-clock
+        time actually passing — rather than an actual process restart.
+
+        Assertions key off this test's OWN ``staging_key`` and job row rather
+        than the aggregate ``StaleCleanupOutcome`` counts or an exact set of
+        every ``storage.delete`` call: per the isolation note above
+        ``test_db_session``, this file's test database is NOT rolled back
+        between tests, and the final ``now=`` jump is deliberately beyond
+        ``MAX_PRESIGNED_URL_LIFETIME_SECONDS`` — comfortably old enough to
+        also re-sweep unrelated already-reaped rows left behind by sibling
+        tests earlier in the same run.
+        """
+        from datetime import timedelta, timezone
+
+        from sqlalchemy import select
+
+        from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
+        from app.platform.jobs import router as jobs_router
+        from app.platform.jobs.models import IngestJob
+
+        # "Run 1": job created while pending_job_timeout_seconds was the
+        # 3600s default. A URL signed near creation is legitimately live
+        # until the job turns 3600s old.
+        job, staging_key = await self._make_job(test_db_session, age_seconds=1500)
+        storage = AsyncMock()
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+
+        async def _row() -> IngestJob:
+            return (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id == job.id)
+                )
+            ).scalar_one()
+
+        # "Run 2" / the restart: the operator lowers the setting to 120s.
+        # post_expiry_sweep_after_seconds() is now 120 + 900 = 1020, well
+        # under this job's age of 1500 — even though its URL, minted under
+        # the pre-restart 3600s setting, will not expire until age 3600.
+        with patch.object(settings, "pending_job_timeout_seconds", 120):
+            await jobs_router._sweep_expired_presigned_staging(
+                test_db_session, self._outcome()
+            )
+
+        assert staging_key in {c.args[0] for c in storage.delete.await_args_list}
+        reaped_row = await _row()
+        assert reaped_row.user_metadata["s3_key_reaped"] is True
+        assert "s3_key_reaped_final" not in reaped_row.user_metadata
+
+        # The client's still-valid pre-restart URL recreates the object.
+        storage.delete.reset_mock()
+
+        # A pass run shortly after must NOT re-check this row yet — the
+        # re-check cost is bounded to once, not paid on every pass.
+        await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome()
+        )
+        assert staging_key not in {c.args[0] for c in storage.delete.await_args_list}
+
+        # Once MAX_PRESIGNED_URL_LIFETIME_SECONDS have elapsed since
+        # creation — the latest moment ANY URL for this job, signed under
+        # ANY setting the deployment ever ran, can still be live — the
+        # re-check pass fires and sweeps the recreated object for good.
+        # `reaped_row.created_at` is read fresh from the row the ordinary
+        # pass backdated — `job` itself still holds the pre-backdate value
+        # from before `_make_job`'s follow-up UPDATE.
+        created_at = reaped_row.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        recheck_now = created_at + timedelta(
+            seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS + 1
+        )
+        storage.delete.reset_mock()
+        await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome(), now=recheck_now
+        )
+
+        assert staging_key in {c.args[0] for c in storage.delete.await_args_list}
+        final_row = await _row()
+        assert final_row.user_metadata["s3_key_reaped_final"] is True
+
+        # And it is now excluded for good — a later pass costs no further
+        # delete call against THIS key, however much more time passes.
+        storage.delete.reset_mock()
+        await jobs_router._sweep_expired_presigned_staging(
+            test_db_session,
+            self._outcome(),
+            now=recheck_now + timedelta(seconds=1),
+        )
+        assert staging_key not in {c.args[0] for c in storage.delete.await_args_list}
+
 
 class TestFailedSourceRetention:
     """fix(#1213 review r6): whether a FAILED job's source may be reaped is a

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -454,7 +454,14 @@ class TestPostExpirySweep:
         base.update(overrides)
         return StaleCleanupOutcome(**base)
 
-    async def _make_job(self, test_db_session, *, age_seconds: int, status="complete"):
+    async def _make_job(
+        self,
+        test_db_session,
+        *,
+        age_seconds: int,
+        status="complete",
+        expected_size: int | None = None,
+    ):
         from datetime import datetime, timedelta, timezone
 
         from sqlalchemy import select, update
@@ -476,6 +483,13 @@ class TestPostExpirySweep:
         await test_db_session.refresh(job)
 
         staging_key = f"staging/{job.id}/roads.geojson"
+        metadata = {"presigned": True, "s3_key": staging_key}
+        if expected_size is not None:
+            # Mirrors what the presign door persists at signing time
+            # (ingest/router.py) — the size declared for THIS job's URL,
+            # independent of whatever `presigned_multipart_threshold_mb`
+            # reads as later.
+            metadata["expected_size"] = expected_size
         # created_at is server-defaulted, so age it explicitly rather than
         # relying on wall-clock drift.
         await test_db_session.execute(
@@ -483,7 +497,7 @@ class TestPostExpirySweep:
             .where(IngestJob.id == job.id)
             .values(
                 file_path=f"staging/{job.id}/frozen/roads.geojson",
-                user_metadata={"presigned": True, "s3_key": staging_key},
+                user_metadata=metadata,
                 created_at=datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
             )
         )
@@ -736,6 +750,94 @@ class TestPostExpirySweep:
             now=final_now + timedelta(seconds=1),
         )
         assert staging_key not in {c.args[0] for c in storage.delete.await_args_list}
+
+    async def test_the_transfer_margin_survives_a_threshold_lowering_restart(
+        self, test_db_session, monkeypatch
+    ) -> None:
+        """codex P1 review r3: `recheck_transfer_margin_seconds()` must not
+        read the CURRENT `presigned_multipart_threshold_mb` for a job whose
+        URL was signed under the OLD, higher value — the #1236 class this PR
+        exists to close, one level down. A 500MB single-part PUT accepted
+        just under the SigV4 ceiling needs a margin computed for 500MB; if an
+        operator lowers the threshold during a restart, this job's own
+        persisted ``expected_size`` must still drive its margin, not the
+        smaller current setting.
+        """
+        from datetime import timedelta, timezone
+
+        from sqlalchemy import select
+
+        from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
+        from app.platform.jobs import router as jobs_router
+        from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.router import recheck_transfer_margin_seconds
+
+        five_hundred_mb = 500 * 1024 * 1024
+        # This job's URL was signed while presigned_multipart_threshold_mb
+        # allowed a 500MB single-part upload.
+        job, staging_key = await self._make_job(
+            test_db_session, age_seconds=10_000, expected_size=five_hundred_mb
+        )
+        storage = AsyncMock()
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+
+        async def _row() -> IngestJob:
+            return (
+                await test_db_session.execute(
+                    select(IngestJob).where(IngestJob.id == job.id)
+                )
+            ).scalar_one()
+
+        # Ordinary pass reaps and marks (not final) — unaffected by the
+        # margin logic, which only gates the LATER finalization.
+        await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome()
+        )
+        reaped_row = await _row()
+        created_at = reaped_row.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+
+        # The restart: an operator lowers the threshold to the 100MB
+        # default, well below the 500MB this job's URL actually carries.
+        monkeypatch.setattr(settings, "presigned_multipart_threshold_mb", 100)
+
+        five_hundred_mb_margin = recheck_transfer_margin_seconds(five_hundred_mb)
+        hundred_mb_margin = recheck_transfer_margin_seconds(100 * 1024 * 1024)
+        assert five_hundred_mb_margin > hundred_mb_margin, (
+            "test setup: the scenario needs the two margins to differ"
+        )
+
+        # Just past the ceiling plus the WRONG margin — what the CURRENT
+        # (lowered) setting would imply. If the sweep read that instead of
+        # this job's own declared size, it would wrongly finalize here.
+        wrongly_final_at = created_at + timedelta(
+            seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS + hundred_mb_margin + 1
+        )
+        storage.delete.reset_mock()
+        await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome(), now=wrongly_final_at
+        )
+        not_yet_final_row = await _row()
+        assert "s3_key_reaped_final" not in not_yet_final_row.user_metadata, (
+            "finalized off the CURRENT (lowered) threshold instead of this "
+            "job's own persisted 500MB expected_size"
+        )
+
+        # Past the ceiling plus the CORRECT margin — derived from this job's
+        # own persisted size — it finalizes.
+        correctly_final_at = created_at + timedelta(
+            seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS + five_hundred_mb_margin + 1
+        )
+        storage.delete.reset_mock()
+        await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome(), now=correctly_final_at
+        )
+        assert staging_key in {c.args[0] for c in storage.delete.await_args_list}
+        final_row = await _row()
+        assert final_row.user_metadata["s3_key_reaped_final"] is True
 
     async def test_retention_purge_defers_a_presigned_job_within_the_url_lifetime(
         self, test_db_session, monkeypatch

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -611,6 +611,12 @@ class TestPostExpirySweep:
         the restart, and the second run's ``now=`` stands in for wall-clock
         time actually passing — rather than an actual process restart.
 
+        Also covers the codex P1 follow-up: the re-check's first delete
+        attempt (right at the SigV4 ceiling) must not finalize the row on the
+        spot — a PUT accepted just under the ceiling can still be transferring
+        past it — so finalization needs `_RECHECK_TRANSFER_MARGIN_SECONDS`
+        MORE to elapse before the row is retired for good.
+
         Assertions key off this test's OWN ``staging_key`` and job row rather
         than the aggregate ``StaleCleanupOutcome`` counts or an exact set of
         every ``storage.delete`` call: per the isolation note above
@@ -627,6 +633,7 @@ class TestPostExpirySweep:
         from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
         from app.platform.jobs import router as jobs_router
         from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.router import _RECHECK_TRANSFER_MARGIN_SECONDS
 
         # "Run 1": job created while pending_job_timeout_seconds was the
         # 3600s default. A URL signed near creation is legitimately live
@@ -671,7 +678,10 @@ class TestPostExpirySweep:
         # Once MAX_PRESIGNED_URL_LIFETIME_SECONDS have elapsed since
         # creation — the latest moment ANY URL for this job, signed under
         # ANY setting the deployment ever ran, can still be live — the
-        # re-check pass fires and sweeps the recreated object for good.
+        # re-check pass fires and re-attempts the delete. It must NOT
+        # finalize yet: a PUT accepted a moment before the ceiling can still
+        # be uploading past it, so retiring the row here would risk the
+        # exact orphan this fix exists to close.
         # `reaped_row.created_at` is read fresh from the row the ordinary
         # pass backdated — `job` itself still holds the pre-backdate value
         # from before `_make_job`'s follow-up UPDATE.
@@ -687,6 +697,33 @@ class TestPostExpirySweep:
         )
 
         assert staging_key in {c.args[0] for c in storage.delete.await_args_list}
+        not_yet_final_row = await _row()
+        assert not_yet_final_row.user_metadata["s3_key_reaped"] is True
+        assert "s3_key_reaped_final" not in not_yet_final_row.user_metadata
+
+        # A pass run before the transfer margin has ALSO elapsed re-attempts
+        # the (now no-op) delete again but still does not finalize.
+        storage.delete.reset_mock()
+        await jobs_router._sweep_expired_presigned_staging(
+            test_db_session,
+            self._outcome(),
+            now=recheck_now + timedelta(seconds=1),
+        )
+        assert staging_key in {c.args[0] for c in storage.delete.await_args_list}
+        still_not_final_row = await _row()
+        assert "s3_key_reaped_final" not in still_not_final_row.user_metadata
+
+        # Only once _RECHECK_TRANSFER_MARGIN_SECONDS have ALSO passed beyond
+        # the ceiling is no such transfer credible any longer, and the row is
+        # retired for good.
+        final_now = recheck_now + timedelta(
+            seconds=_RECHECK_TRANSFER_MARGIN_SECONDS + 1
+        )
+        storage.delete.reset_mock()
+        await jobs_router._sweep_expired_presigned_staging(
+            test_db_session, self._outcome(), now=final_now
+        )
+        assert staging_key in {c.args[0] for c in storage.delete.await_args_list}
         final_row = await _row()
         assert final_row.user_metadata["s3_key_reaped_final"] is True
 
@@ -696,9 +733,62 @@ class TestPostExpirySweep:
         await jobs_router._sweep_expired_presigned_staging(
             test_db_session,
             self._outcome(),
-            now=recheck_now + timedelta(seconds=1),
+            now=final_now + timedelta(seconds=1),
         )
         assert staging_key not in {c.args[0] for c in storage.delete.await_args_list}
+
+    async def test_retention_purge_defers_a_presigned_job_within_the_url_lifetime(
+        self, test_db_session, monkeypatch
+    ) -> None:
+        """codex P1 on this PR: the retention purge in ``fail_stale_jobs`` is a
+        SEPARATE deletion path from ``_sweep_expired_presigned_staging`` and
+        runs before it. Left unguarded, a short ``ingest_jobs_retention_days``
+        (1 day is a supported, tested value elsewhere in this suite) could
+        delete a presigned job's ROW — the only place the sweep's markers
+        live — while a URL signed under a longer pre-restart setting is still
+        valid. A later PUT would then recreate an object no row anywhere
+        references: worse than the marker gap this PR closes, because
+        nothing could ever find it again.
+        """
+        from sqlalchemy import select
+
+        from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
+        from app.platform.jobs import router as jobs_router
+        from app.platform.jobs.models import IngestJob
+
+        # Past the 1-day retention cutoff but well under the 7-day SigV4
+        # ceiling — exactly the window a still-live pre-restart URL occupies.
+        still_tracked_job, _still_tracked_key = await self._make_job(
+            test_db_session, age_seconds=100_000
+        )
+        # Past the ceiling too — no URL for it can possibly still be live, so
+        # purging (and reaping its key immediately, same as the ordinary
+        # end-of-job sweeps) is safe.
+        safe_to_purge_job, safe_to_purge_key = await self._make_job(
+            test_db_session, age_seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS + 100
+        )
+        storage = AsyncMock()
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+        monkeypatch.setattr(settings, "ingest_jobs_retention_days", 1)
+
+        await jobs_router.fail_stale_jobs(test_db_session, detailed=True)
+
+        async def _exists(job_id) -> bool:
+            row = (
+                await test_db_session.execute(
+                    select(IngestJob.id).where(IngestJob.id == job_id)
+                )
+            ).scalar_one_or_none()
+            return row is not None
+
+        assert await _exists(still_tracked_job.id), (
+            "a presigned job within the URL lifetime must survive the "
+            "retention purge, or nothing can ever track its recreated object"
+        )
+        assert not await _exists(safe_to_purge_job.id)
+        assert safe_to_purge_key in {c.args[0] for c in storage.delete.await_args_list}
 
 
 class TestFailedSourceRetention:

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -426,6 +426,43 @@ async def test_validation_failure_still_sweeps_the_presigned_staging_object(
     )
 
 
+class TestRecheckTransferMarginSeconds:
+    """Second-opinion review on #1236 review r3: `presigned_multipart_threshold_mb`
+    has no upper bound (`gt=0` only, before this PR's `le=5120`), so a job's
+    declared `expected_size` could exceed S3's actual single-PUT hard limit
+    whenever an operator raised the threshold past 5GiB. The retention
+    purge's fallback (called with no per-job size) always assumes 5GiB is
+    the worst case; without a clamp, a bigger declared size would derive a
+    BIGGER sweep margin than that fallback, so the purge could delete a
+    job's row — the only place the sweep's markers live — before the
+    sweep's own longer margin considered a possible transfer finished.
+    Reopens the #1236 orphan class through the purge path for oversized
+    single-part jobs.
+    """
+
+    def test_an_oversized_declared_size_clamps_to_the_purge_fallback(self) -> None:
+        from app.platform.jobs.router import (
+            _S3_SINGLE_PUT_MAX_BYTES,
+            recheck_transfer_margin_seconds,
+        )
+
+        # What a threshold raised past 5120MB (bypassing the new Field bound
+        # via a pre-existing config value, or a caller that never validated
+        # it) could imply for a single-part job's declared size.
+        ten_gib = 10 * 1024 * 1024 * 1024
+        assert ten_gib > _S3_SINGLE_PUT_MAX_BYTES, "test setup: must exceed the ceiling"
+
+        oversized_margin = recheck_transfer_margin_seconds(ten_gib)
+        at_ceiling_margin = recheck_transfer_margin_seconds(_S3_SINGLE_PUT_MAX_BYTES)
+        purge_fallback_margin = recheck_transfer_margin_seconds()  # no per-job size
+
+        assert oversized_margin == at_ceiling_margin == purge_fallback_margin, (
+            "an oversized declared size must derive NO MORE margin than the "
+            "retention purge's own fallback assumes, or the purge could "
+            "delete a still-tracked row before the sweep considers it safe"
+        )
+
+
 class TestPostExpirySweep:
     """fix(#1202 review r8): the backstop that outlives the PUT URL.
 

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -913,6 +913,129 @@ class TestPostExpirySweep:
         assert not await _exists(safe_to_purge_job.id)
         assert safe_to_purge_key in {c.args[0] for c in storage.delete.await_args_list}
 
+    async def test_retention_purge_does_not_exempt_a_fan_out_child_for_a_key_it_does_not_own(
+        self, test_db_session, monkeypatch
+    ) -> None:
+        """codex P2 review r5: `create_fan_out_jobs` clones the parent's
+        ``user_metadata`` wholesale (processing/ingest/service.py), so every
+        fan-out child carries the PARENT's ``s3_key`` too —
+        ``owned_presigned_staging_key`` deliberately rejects that as
+        ownership (the key's prefix names the PARENT's id, not the child's).
+        The retention-purge deferral above must draw the same line: a
+        non-null ``s3_key`` alone is not ownership, and a child that can
+        never legitimately reap or finalize that key must not ride along on
+        the parent's ~8.9-day exemption. Left unguarded, a terminal fan-out
+        child would outlive a 1-day retention setting by roughly 9x.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from sqlalchemy import select, update
+
+        from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS
+        from app.modules.auth.models import User
+        from app.platform.jobs import router as jobs_router
+        from app.platform.jobs.models import IngestJob
+
+        admin = (
+            await test_db_session.execute(select(User).where(User.username == "admin"))
+        ).scalar_one()
+
+        # The parent: a genuine presigned upload, well past the 1-day
+        # retention cutoff but safely within the SigV4 ceiling — the row
+        # that legitimately still owns and needs `parent_staging_key`.
+        parent = IngestJob(
+            source_filename="roads.geojson",
+            created_by=admin.id,
+            status="complete",
+            user_metadata={"presigned": True},
+        )
+        test_db_session.add(parent)
+        await test_db_session.commit()
+        await test_db_session.refresh(parent)
+        parent_staging_key = f"staging/{parent.id}/roads.geojson"
+        await test_db_session.execute(
+            update(IngestJob)
+            .where(IngestJob.id == parent.id)
+            .values(
+                file_path=f"staging/{parent.id}/frozen/roads.geojson",
+                user_metadata={"presigned": True, "s3_key": parent_staging_key},
+                created_at=datetime.now(timezone.utc) - timedelta(seconds=100_000),
+            )
+        )
+
+        # A fan-out child: FAILED, same age, carrying the PARENT's s3_key
+        # (exactly what create_fan_out_jobs clones) plus fan_out_parent_id.
+        # This is the row a 1-day retention setting expects to be purged.
+        child = IngestJob(
+            source_filename="roads.geojson",
+            created_by=admin.id,
+            status="failed",
+            user_metadata={"presigned": True},
+        )
+        test_db_session.add(child)
+        await test_db_session.commit()
+        await test_db_session.refresh(child)
+        await test_db_session.execute(
+            update(IngestJob)
+            .where(IngestJob.id == child.id)
+            .values(
+                user_metadata={
+                    "presigned": True,
+                    "s3_key": parent_staging_key,  # inherited, not owned
+                    "fan_out_parent_id": str(parent.id),
+                },
+                created_at=datetime.now(timezone.utc) - timedelta(seconds=100_000),
+            )
+        )
+        await test_db_session.commit()
+
+        storage = AsyncMock()
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "ingest_jobs_retention_days", 1)
+
+        await jobs_router.fail_stale_jobs(test_db_session, detailed=True)
+
+        async def _exists(job_id) -> bool:
+            row = (
+                await test_db_session.execute(
+                    select(IngestJob.id).where(IngestJob.id == job_id)
+                )
+            ).scalar_one_or_none()
+            return row is not None
+
+        assert not await _exists(child.id), (
+            "a fan-out child inherits the parent's s3_key but not "
+            "ownership of it, and must not ride along on the parent's "
+            "~8.9-day exemption — it should purge on the configured "
+            "1-day retention like any other terminal row"
+        )
+        assert await _exists(parent.id), (
+            "test setup: the parent genuinely owns the key and IS within "
+            f"MAX_PRESIGNED_URL_LIFETIME_SECONDS ({MAX_PRESIGNED_URL_LIFETIME_SECONDS}s)"
+            " of it, so it must still be deferred"
+        )
+        # `fail_stale_jobs` also runs the ordinary post-expiry sweep in the
+        # same call, and the parent's own age legitimately crosses ITS
+        # cutoff too — so the key is deleted once, attributed to the
+        # parent's own sweep pass. What this fix prevents is the CHILD's
+        # purge independently reaping it a second time through the
+        # ownership bypass; `owned_presigned_staging_key` returning None for
+        # the child keeps it out of `deleted_presigned_keys` entirely, so
+        # the call count must not exceed the one legitimate reap.
+        delete_calls_for_key = [
+            c.args[0]
+            for c in storage.delete.await_args_list
+            if c.args[0] == parent_staging_key
+        ]
+        assert len(delete_calls_for_key) <= 1, (
+            "the key was reaped more than once — the child's purge reaped "
+            "a key it does not own, in addition to the parent's own sweep"
+        )
+
 
 class TestFailedSourceRetention:
     """fix(#1213 review r6): whether a FAILED job's source may be reaped is a

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -426,43 +426,6 @@ async def test_validation_failure_still_sweeps_the_presigned_staging_object(
     )
 
 
-class TestRecheckTransferMarginSeconds:
-    """Second-opinion review on #1236 review r3: `presigned_multipart_threshold_mb`
-    has no upper bound (`gt=0` only, before this PR's `le=5120`), so a job's
-    declared `expected_size` could exceed S3's actual single-PUT hard limit
-    whenever an operator raised the threshold past 5GiB. The retention
-    purge's fallback (called with no per-job size) always assumes 5GiB is
-    the worst case; without a clamp, a bigger declared size would derive a
-    BIGGER sweep margin than that fallback, so the purge could delete a
-    job's row — the only place the sweep's markers live — before the
-    sweep's own longer margin considered a possible transfer finished.
-    Reopens the #1236 orphan class through the purge path for oversized
-    single-part jobs.
-    """
-
-    def test_an_oversized_declared_size_clamps_to_the_purge_fallback(self) -> None:
-        from app.platform.jobs.router import (
-            _S3_SINGLE_PUT_MAX_BYTES,
-            recheck_transfer_margin_seconds,
-        )
-
-        # What a threshold raised past 5120MB (bypassing the new Field bound
-        # via a pre-existing config value, or a caller that never validated
-        # it) could imply for a single-part job's declared size.
-        ten_gib = 10 * 1024 * 1024 * 1024
-        assert ten_gib > _S3_SINGLE_PUT_MAX_BYTES, "test setup: must exceed the ceiling"
-
-        oversized_margin = recheck_transfer_margin_seconds(ten_gib)
-        at_ceiling_margin = recheck_transfer_margin_seconds(_S3_SINGLE_PUT_MAX_BYTES)
-        purge_fallback_margin = recheck_transfer_margin_seconds()  # no per-job size
-
-        assert oversized_margin == at_ceiling_margin == purge_fallback_margin, (
-            "an oversized declared size must derive NO MORE margin than the "
-            "retention purge's own fallback assumes, or the purge could "
-            "delete a still-tracked row before the sweep considers it safe"
-        )
-
-
 class TestPostExpirySweep:
     """fix(#1202 review r8): the backstop that outlives the PUT URL.
 
@@ -665,7 +628,7 @@ class TestPostExpirySweep:
         Also covers the codex P1 follow-up: the re-check's first delete
         attempt (right at the SigV4 ceiling) must not finalize the row on the
         spot — a PUT accepted just under the ceiling can still be transferring
-        past it — so finalization needs `recheck_transfer_margin_seconds()`
+        past it — so finalization needs `_RECHECK_TRANSFER_MARGIN_SECONDS`
         MORE to elapse before the row is retired for good.
 
         Assertions key off this test's OWN ``staging_key`` and job row rather
@@ -684,7 +647,7 @@ class TestPostExpirySweep:
         from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
         from app.platform.jobs import router as jobs_router
         from app.platform.jobs.models import IngestJob
-        from app.platform.jobs.router import recheck_transfer_margin_seconds
+        from app.platform.jobs.router import _RECHECK_TRANSFER_MARGIN_SECONDS
 
         # "Run 1": job created while pending_job_timeout_seconds was the
         # 3600s default. A URL signed near creation is legitimately live
@@ -764,11 +727,11 @@ class TestPostExpirySweep:
         still_not_final_row = await _row()
         assert "s3_key_reaped_final" not in still_not_final_row.user_metadata
 
-        # Only once recheck_transfer_margin_seconds() have ALSO passed beyond
+        # Only once _RECHECK_TRANSFER_MARGIN_SECONDS have ALSO passed beyond
         # the ceiling is no such transfer credible any longer, and the row is
         # retired for good.
         final_now = recheck_now + timedelta(
-            seconds=recheck_transfer_margin_seconds() + 1
+            seconds=_RECHECK_TRANSFER_MARGIN_SECONDS + 1
         )
         storage.delete.reset_mock()
         await jobs_router._sweep_expired_presigned_staging(
@@ -788,32 +751,33 @@ class TestPostExpirySweep:
         )
         assert staging_key not in {c.args[0] for c in storage.delete.await_args_list}
 
-    async def test_the_transfer_margin_survives_a_threshold_lowering_restart(
+    async def test_a_tiny_declared_size_still_gets_the_full_hard_limit_margin(
         self, test_db_session, monkeypatch
     ) -> None:
-        """codex P1 review r3: `recheck_transfer_margin_seconds()` must not
-        read the CURRENT `presigned_multipart_threshold_mb` for a job whose
-        URL was signed under the OLD, higher value — the #1236 class this PR
-        exists to close, one level down. A 500MB single-part PUT accepted
-        just under the SigV4 ceiling needs a margin computed for 500MB; if an
-        operator lowers the threshold during a restart, this job's own
-        persisted ``expected_size`` must still drive its margin, not the
-        smaller current setting.
+        """codex P1 review r4: rounds r2/r3 both derived the finalization
+        margin from a client-declared size — first the current
+        `presigned_multipart_threshold_mb`, then a job's own persisted
+        `expected_size`. Neither is enforced: `generate_presigned_put_url`
+        signs only `ContentType`, never a content-length constraint, so a
+        client can declare one byte and stream a multi-gigabyte object
+        anyway. A tiny declared `expected_size` must NOT shorten the
+        margin — finalization always waits out the full, fixed
+        `_RECHECK_TRANSFER_MARGIN_SECONDS`, regardless of what was declared.
         """
         from datetime import timedelta, timezone
 
         from sqlalchemy import select
 
-        from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
+        from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS
         from app.platform.jobs import router as jobs_router
         from app.platform.jobs.models import IngestJob
-        from app.platform.jobs.router import recheck_transfer_margin_seconds
+        from app.platform.jobs.router import _RECHECK_TRANSFER_MARGIN_SECONDS
 
-        five_hundred_mb = 500 * 1024 * 1024
-        # This job's URL was signed while presigned_multipart_threshold_mb
-        # allowed a 500MB single-part upload.
+        # This job's URL was signed against a ONE-BYTE declared size — the
+        # smallest a client could claim while actually streaming anything up
+        # to S3's real single-PUT limit, since nothing enforces the match.
         job, staging_key = await self._make_job(
-            test_db_session, age_seconds=10_000, expected_size=five_hundred_mb
+            test_db_session, age_seconds=10_000, expected_size=1
         )
         storage = AsyncMock()
         monkeypatch.setattr(
@@ -827,8 +791,7 @@ class TestPostExpirySweep:
                 )
             ).scalar_one()
 
-        # Ordinary pass reaps and marks (not final) — unaffected by the
-        # margin logic, which only gates the LATER finalization.
+        # Ordinary pass reaps and marks (not final).
         await jobs_router._sweep_expired_presigned_staging(
             test_db_session, self._outcome()
         )
@@ -837,40 +800,36 @@ class TestPostExpirySweep:
         if created_at.tzinfo is None:
             created_at = created_at.replace(tzinfo=timezone.utc)
 
-        # The restart: an operator lowers the threshold to the 100MB
-        # default, well below the 500MB this job's URL actually carries.
-        monkeypatch.setattr(settings, "presigned_multipart_threshold_mb", 100)
-
-        five_hundred_mb_margin = recheck_transfer_margin_seconds(five_hundred_mb)
-        hundred_mb_margin = recheck_transfer_margin_seconds(100 * 1024 * 1024)
-        assert five_hundred_mb_margin > hundred_mb_margin, (
-            "test setup: the scenario needs the two margins to differ"
+        # Just past the ceiling plus a SHORT margin (what a naive read of
+        # the one-byte declaration might imply) — must NOT finalize: a
+        # multi-gigabyte PUT accepted just under the ceiling could still be
+        # writing this far past it.
+        short_margin_seconds = 3600  # the absolute floor, and then some
+        assert short_margin_seconds < _RECHECK_TRANSFER_MARGIN_SECONDS, (
+            "test setup: the hard-limit margin must be the bigger one"
         )
-
-        # Just past the ceiling plus the WRONG margin — what the CURRENT
-        # (lowered) setting would imply. If the sweep read that instead of
-        # this job's own declared size, it would wrongly finalize here.
-        wrongly_final_at = created_at + timedelta(
-            seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS + hundred_mb_margin + 1
+        too_soon_at = created_at + timedelta(
+            seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS + short_margin_seconds + 1
         )
         storage.delete.reset_mock()
         await jobs_router._sweep_expired_presigned_staging(
-            test_db_session, self._outcome(), now=wrongly_final_at
+            test_db_session, self._outcome(), now=too_soon_at
         )
         not_yet_final_row = await _row()
         assert "s3_key_reaped_final" not in not_yet_final_row.user_metadata, (
-            "finalized off the CURRENT (lowered) threshold instead of this "
-            "job's own persisted 500MB expected_size"
+            "finalized off a size-scaled margin instead of the fixed, "
+            "unconditional S3 single-PUT hard-limit margin"
         )
 
-        # Past the ceiling plus the CORRECT margin — derived from this job's
-        # own persisted size — it finalizes.
-        correctly_final_at = created_at + timedelta(
-            seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS + five_hundred_mb_margin + 1
+        # Past the ceiling plus the FULL fixed margin, it finalizes.
+        final_now = created_at + timedelta(
+            seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS
+            + _RECHECK_TRANSFER_MARGIN_SECONDS
+            + 1
         )
         storage.delete.reset_mock()
         await jobs_router._sweep_expired_presigned_staging(
-            test_db_session, self._outcome(), now=correctly_final_at
+            test_db_session, self._outcome(), now=final_now
         )
         assert staging_key in {c.args[0] for c in storage.delete.await_args_list}
         final_row = await _row()
@@ -902,7 +861,7 @@ class TestPostExpirySweep:
         from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
         from app.platform.jobs import router as jobs_router
         from app.platform.jobs.models import IngestJob
-        from app.platform.jobs.router import recheck_transfer_margin_seconds
+        from app.platform.jobs.router import _RECHECK_TRANSFER_MARGIN_SECONDS
 
         # Past the 1-day retention cutoff but well under the 7-day SigV4
         # ceiling — exactly the window a still-live pre-restart URL occupies.
@@ -923,7 +882,7 @@ class TestPostExpirySweep:
             test_db_session,
             age_seconds=(
                 MAX_PRESIGNED_URL_LIFETIME_SECONDS
-                + recheck_transfer_margin_seconds()
+                + _RECHECK_TRANSFER_MARGIN_SECONDS
                 + 100
             ),
         )

--- a/backend/tests/test_presigned_staging_reap_1202.py
+++ b/backend/tests/test_presigned_staging_reap_1202.py
@@ -614,7 +614,7 @@ class TestPostExpirySweep:
         Also covers the codex P1 follow-up: the re-check's first delete
         attempt (right at the SigV4 ceiling) must not finalize the row on the
         spot — a PUT accepted just under the ceiling can still be transferring
-        past it — so finalization needs `_RECHECK_TRANSFER_MARGIN_SECONDS`
+        past it — so finalization needs `recheck_transfer_margin_seconds()`
         MORE to elapse before the row is retired for good.
 
         Assertions key off this test's OWN ``staging_key`` and job row rather
@@ -633,7 +633,7 @@ class TestPostExpirySweep:
         from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
         from app.platform.jobs import router as jobs_router
         from app.platform.jobs.models import IngestJob
-        from app.platform.jobs.router import _RECHECK_TRANSFER_MARGIN_SECONDS
+        from app.platform.jobs.router import recheck_transfer_margin_seconds
 
         # "Run 1": job created while pending_job_timeout_seconds was the
         # 3600s default. A URL signed near creation is legitimately live
@@ -713,11 +713,11 @@ class TestPostExpirySweep:
         still_not_final_row = await _row()
         assert "s3_key_reaped_final" not in still_not_final_row.user_metadata
 
-        # Only once _RECHECK_TRANSFER_MARGIN_SECONDS have ALSO passed beyond
+        # Only once recheck_transfer_margin_seconds() have ALSO passed beyond
         # the ceiling is no such transfer credible any longer, and the row is
         # retired for good.
         final_now = recheck_now + timedelta(
-            seconds=_RECHECK_TRANSFER_MARGIN_SECONDS + 1
+            seconds=recheck_transfer_margin_seconds() + 1
         )
         storage.delete.reset_mock()
         await jobs_router._sweep_expired_presigned_staging(
@@ -749,23 +749,44 @@ class TestPostExpirySweep:
         valid. A later PUT would then recreate an object no row anywhere
         references: worse than the marker gap this PR closes, because
         nothing could ever find it again.
+
+        codex P1 review r2: the deferral must extend through the SAME
+        transfer margin the sweep's own finalization waits out, not stop at
+        the bare SigV4 ceiling — a single-part PUT begun just before the
+        ceiling can still be transferring past it, and purging (which reaps
+        the key immediately, unconditionally) at the bare ceiling would
+        recreate the exact orphan this test's first case exists to prevent,
+        just via the purge path instead of the sweep's.
         """
         from sqlalchemy import select
 
         from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
         from app.platform.jobs import router as jobs_router
         from app.platform.jobs.models import IngestJob
+        from app.platform.jobs.router import recheck_transfer_margin_seconds
 
         # Past the 1-day retention cutoff but well under the 7-day SigV4
         # ceiling — exactly the window a still-live pre-restart URL occupies.
         still_tracked_job, _still_tracked_key = await self._make_job(
             test_db_session, age_seconds=100_000
         )
-        # Past the ceiling too — no URL for it can possibly still be live, so
-        # purging (and reaping its key immediately, same as the ordinary
-        # end-of-job sweeps) is safe.
-        safe_to_purge_job, safe_to_purge_key = await self._make_job(
+        # Past the ceiling but still within the transfer margin a PUT begun
+        # just under it may still need — must be deferred exactly like the
+        # first case, not purged just because the bare ceiling has passed.
+        within_margin_job, _within_margin_key = await self._make_job(
             test_db_session, age_seconds=MAX_PRESIGNED_URL_LIFETIME_SECONDS + 100
+        )
+        # Past the ceiling AND the margin — no URL for it, nor any transfer
+        # it could have accepted, can possibly still be live, so purging (and
+        # reaping its key immediately, same as the ordinary end-of-job
+        # sweeps) is safe.
+        safe_to_purge_job, safe_to_purge_key = await self._make_job(
+            test_db_session,
+            age_seconds=(
+                MAX_PRESIGNED_URL_LIFETIME_SECONDS
+                + recheck_transfer_margin_seconds()
+                + 100
+            ),
         )
         storage = AsyncMock()
         monkeypatch.setattr(
@@ -786,6 +807,10 @@ class TestPostExpirySweep:
         assert await _exists(still_tracked_job.id), (
             "a presigned job within the URL lifetime must survive the "
             "retention purge, or nothing can ever track its recreated object"
+        )
+        assert await _exists(within_margin_job.id), (
+            "a presigned job within the transfer margin past the ceiling "
+            "must also survive the purge — an accepted PUT can still land"
         )
         assert not await _exists(safe_to_purge_job.id)
         assert safe_to_purge_key in {c.args[0] for c in storage.delete.await_args_list}


### PR DESCRIPTION
## Summary

Closes #1236, a known gap left open at #1235 review r5.

The post-expiry sweep (`_sweep_expired_presigned_staging` in `backend/app/platform/jobs/router.py`) derives its reap window from the **current** `pending_job_timeout_seconds`, but a presigned PUT URL keeps whatever deadline was in force when it was signed. If an operator lowers the setting and restarts while presigned uploads are in flight, the sweep runs early against jobs whose URLs were signed under the old, longer setting: it deletes the staging object and sets the `s3_key_reaped` marker while the URL is still legitimately valid. A client's subsequent PUT recreates the object, and — before this fix — the marker exempted the row from every later pass, orphaning the recreated object permanently.

`#1235` rejected persisting the issued deadline per job (JSONB-to-timestamptz cast risk in the sweep's bulk WHERE, plus it wouldn't cover jobs presigned before the persistence change shipped) and left the gap documented for a follow-up. This PR takes the other fix direction it sketched: make the reaped marker non-permanent instead.

- `s3_key_reaped` still gates the *ordinary* pass (so a steady-state deployment costs no repeat storage calls).
- A new `s3_key_reaped_final` marker is the only one that excludes a row for good. It's set only after a **re-check pass**, which fires once `MAX_PRESIGNED_URL_LIFETIME_SECONDS` (604800s — the SigV4 ceiling, and also `pending_job_timeout_seconds`'s own upper bound) have elapsed since the job's `created_at`. That's the latest moment any URL for that job, signed under *any* setting the deployment ever ran, can still be live — so the re-check needs no knowledge of which deadline a given URL actually carries.
- A re-check that finds nothing costs one no-op `DeleteObject`; a re-check that finds a recreated object deletes it and closes the orphan.

`MAX_PRESIGNED_URL_LIFETIME_SECONDS` is a new named constant in `backend/app/core/config.py` (previously the SigV4 ceiling was an inline `604800` literal on the `pending_job_timeout_seconds` field bound).

## Race condition (repro)

1. Job created under the default `pending_job_timeout_seconds=3600`; a presigned PUT URL is signed near creation, valid until the job is 3600s old.
2. Operator lowers `pending_job_timeout_seconds` to e.g. 120s and restarts.
3. The ordinary sweep pass now computes its window from 120s (`post_expiry_sweep_after_seconds() = 120 + 900 = 1020`), so at job age 1500s it reaps the object and marks `s3_key_reaped` — even though the URL from step 1 is still valid until age 3600s.
4. The client's still-valid URL PUTs again, recreating the staging object.
5. Before this fix: every later sweep pass skips the row (marker present) — permanent orphan.
6. After this fix: once the job crosses `created_at + MAX_PRESIGNED_URL_LIFETIME_SECONDS`, the re-check pass fires, deletes the recreated object, and sets `s3_key_reaped_final`.

## Changes

- `backend/app/core/config.py`: new `MAX_PRESIGNED_URL_LIFETIME_SECONDS = 604800` constant; `pending_job_timeout_seconds`'s `le` bound now references it instead of a bare literal.
- `backend/app/platform/jobs/router.py`: `_sweep_expired_presigned_staging` now runs up to twice per job — the existing pass plus a bounded re-check pass — gated by a new `s3_key_reaped_final` marker.
- `backend/tests/test_presigned_staging_reap_1202.py`: new regression test `test_a_timeout_lowering_restart_no_longer_orphans_the_recreated_object`, reproducing the timeout-lowering restart across two sweep calls with different `pending_job_timeout_seconds` values against the same staging row (rather than an actual process restart), then jumping `now=` past the SigV4 ceiling to prove the re-check pass recovers the recreated object.

No schema change, no migration.

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest` — 7230 passed, 89 skipped, 0 failed (full suite, `-n 4`)
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q` — 40 passed (no module cap changes needed; `config.py` stayed under the 1000-line ratchet-inclusion threshold and `jobs/router.py` stayed under its 1500-line router cap)
- Targeted: `tests/test_presigned_staging_reap_1202.py`, `tests/test_jobs_router.py`, `tests/test_stale_pending_reaper.py`, `tests/test_config.py` — all passing

Closes #1236