### PR TITLE
fix(audit): close coverage gaps for password logins, dataset.create, and action-registry drift

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1330,13 +1330,26 @@ tenant's window and delete every tenant's history that predates it. Resolve
 the tenant's id from its slug first:
 
 ```bash
+TENANT_SLUG=<your-tenant-slug>
 TENANT_ID=$(docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
-  "SELECT id FROM catalog.tenants WHERE slug = '<your-tenant-slug>'")
+  "SELECT id FROM catalog.tenants WHERE slug = '$TENANT_SLUG'")
 ```
 
 Single-tenant deployments: skip that step: `catalog.audit_logs.tenant_id` is
 NULL on every row (single-tenant never stamps it) and every SQL snippet
-below already tolerates an empty `$TENANT_ID`.
+below already tolerates an empty `$TENANT_ID`. Set `TENANT_SLUG=default` (or
+any fixed label) instead, so the archive filenames below still get a stable
+tag.
+
+Every archive filename in this procedure must be unique per tenant and per
+run — two tenants exported on the same day, or the same tenant exported
+twice, would otherwise both write `audit-archive-YYYYMMDD.csv`, and the
+second `curl -o` silently truncates the first tenant's only copy (possibly
+after that tenant's rows are already deleted). Build one tag and reuse it:
+
+```bash
+ARCHIVE_TAG="${TENANT_SLUG}-$(date -u +%Y%m%dT%H%M%SZ)"
+```
 
 **Count before you export.** The export endpoint caps at 100,000 rows per
 call — silently. A window with more matching rows than that returns only the
@@ -1352,18 +1365,31 @@ docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
 
 (`NULLIF('$TENANT_ID', '')` turns an empty `$TENANT_ID` into SQL `NULL` *before* the `::uuid` cast runs — casting the empty string itself, e.g. `''::uuid`, is invalid input and errors regardless of which side of the `OR` would end up mattering.)
 
+Export as **JSON**, not CSV, for this procedure: the row count is then a
+plain array length, checkable with `jq length`. A CSV line count minus the
+header is not reliable here — `resource_name` values come from user-supplied
+dataset/map/collection titles, which permit literal newlines, and the CSV
+writer preserves those inside a quoted field. A raw `wc -l` can therefore
+undercount a complete archive (embedded newlines inflate the apparent row
+count) or, worse, appear to match a truncated download. If you want a CSV
+copy for human review, export it separately *after* the JSON archive has
+verified clean — never use it as the verification input.
+
 If that count is **at or under 100,000**, one export call covers the whole
 window:
 
 ```bash
 curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
-  "https://<your-host>/api/admin/audit-logs/export/csv?date_to=$CUTOFF" \
-  -o audit-archive-$(date +%Y%m%d).csv
+  "https://<your-host>/api/admin/audit-logs/export/json?date_to=$CUTOFF" \
+  -o "audit-archive-${ARCHIVE_TAG}.json"
 ```
 
-Verify the row count you exported (CSV line count minus the header, or the
-JSON array length) equals the count from the query above before proceeding
-to the delete. A mismatch means stop — do not delete.
+Verify the exported row count equals the count from the query above before
+proceeding to the delete. A mismatch means stop — do not delete:
+
+```bash
+jq length "audit-archive-${ARCHIVE_TAG}.json"
+```
 
 If the count is **over 100,000**, one call cannot capture the whole window,
 and narrowing `date_to` alone doesn't help — the export is always the
@@ -1371,17 +1397,19 @@ and narrowing `date_to` alone doesn't help — the export is always the
 forever. Partition the range into disjoint `date_from`/`date_to` sub-windows
 instead (a week or a month at a time, whatever keeps each sub-window under
 100,000 rows given your write volume), export each one, and verify each
-sub-window's exported row count against a COUNT query scoped to that same
-sub-window — for example:
+sub-window's exported row count (`jq length`, same as above) against a COUNT
+query scoped to that same sub-window — for example:
 
 ```bash
 # Repeat with adjacent, non-overlapping date_from/date_to pairs that together
 # cover the full range up to $CUTOFF. Each pair's exported row count must
 # match: SELECT count(*) FROM catalog.audit_logs WHERE created_at >= date_from
-# AND created_at < date_to AND (tenant scope as above).
+# AND created_at < date_to AND (tenant scope as above). <window-start> must
+# also be part of the filename -- distinct sub-windows of the SAME tenant/run
+# still need distinct files.
 curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
-  "https://<your-host>/api/admin/audit-logs/export/csv?date_from=<window-start>&date_to=<window-end>" \
-  -o audit-archive-<window-start>.csv
+  "https://<your-host>/api/admin/audit-logs/export/json?date_from=<window-start>&date_to=<window-end>" \
+  -o "audit-archive-${ARCHIVE_TAG}-<window-start>.json"
 ```
 
 Only once every sub-window is exported and verified does the full window

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1321,6 +1321,16 @@ on every batched commit inside the delete loop):
 CUTOFF=$(date -u -d '-90 days' +%Y-%m-%dT%H:%M:%SZ)
 ```
 
+Every `docker compose exec -T db psql ...` command in this section assumes
+the bundled Postgres container. Managed/external Postgres
+([§3](#3-restore--managed--external-postgres-mode)): drop the
+`docker compose exec -T db` prefix and connect `psql` directly instead,
+passing your provider's `-h`, `-p`, and `-U` (the same substitution used in
+§2 and §6) — for example `psql -h <host> -p <port> -U "$POSTGRES_USER" -d
+"$POSTGRES_DB"`, or `psql "$DATABASE_URL_OVERRIDE"` if `.env` already has the
+migrator credential set. The HTTP export commands further down are
+unaffected either way — they go through the API, not a direct DB connection.
+
 If this deployment uses per-tenant host routing (more than one row in
 `catalog.tenants`), the HTTP export below is already scoped to whichever
 tenant's host you call it against, but the SQL delete that follows connects

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1334,11 +1334,25 @@ PSQL=(docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB")
 # bundled line above:
 # PSQL=(psql -h <host> -p <port> -U "$POSTGRES_USER" -d "$POSTGRES_DB")
 #
-# If reusing DATABASE_URL_OVERRIDE from .env, strip its SQLAlchemy driver
-# suffix first: libpq's URI parser accepts only the postgresql:// and
-# postgres:// schemes, and rejects the postgresql+asyncpg:// /
-# postgresql+psycopg:// forms .env.example documents for that variable.
-# PG_URI=$(echo "$DATABASE_URL_OVERRIDE" | sed -E 's#^postgresql\+[a-zA-Z0-9_]+://#postgresql://#')
+# On a deployment with per-tenant host routing, whichever credential you
+# use here must be able to see and modify rows across every tenant -- NOT
+# the app's own least-privilege runtime login. Boot refuses to start
+# GEOLENS_TENANCY_MODE=multi_tenant with a runtime role that can bypass
+# row-level security (backend/app/core/db/rls.py), by design, and
+# catalog.audit_logs carries exactly that RLS policy (migration 0022): a
+# session without BYPASSRLS and without `app.current_tenant` set only ever
+# sees zero rows through it, so the count/delete commands below would
+# silently do nothing rather than the documented thing. Use the SAME
+# privileged/migrator-class credential §2 calls out for schema changes
+# ("the least-privilege runtime login in .env is deliberately not allowed
+# to do any of this"), not the steady-state DATABASE_URL_OVERRIDE your
+# running deployment authenticates with day to day.
+#
+# If that privileged credential happens to be a postgresql+asyncpg:// or
+# postgresql+psycopg:// SQLAlchemy URL, strip the driver suffix first --
+# libpq's URI parser accepts only the postgresql:// and postgres://
+# schemes:
+# PG_URI=$(echo "<your-privileged-connection-url>" | sed -E 's#^postgresql\+[a-zA-Z0-9_]+://#postgresql://#')
 # PSQL=(psql "$PG_URI")
 ```
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1359,11 +1359,21 @@ discard rows that were never in the archive. Check first:
 ```bash
 docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
   "SELECT count(*) FROM catalog.audit_logs
-   WHERE created_at < '$CUTOFF'
+   WHERE created_at <= '$CUTOFF'
      AND (NULLIF('$TENANT_ID', '')::uuid IS NULL OR tenant_id = NULLIF('$TENANT_ID', '')::uuid)"
 ```
 
 (`NULLIF('$TENANT_ID', '')` turns an empty `$TENANT_ID` into SQL `NULL` *before* the `::uuid` cast runs — casting the empty string itself, e.g. `''::uuid`, is invalid input and errors regardless of which side of the `OR` would end up mattering.)
+
+Use `<=`, not `<`, and use it consistently in every count/export/delete step below.
+The export endpoint's `date_to` filter is inclusive (`created_at <= date_to`,
+not exclusive) and there is no way to ask it for an exclusive bound. If the
+delete used `<` while the count/export used `<=`, and a row happened to land
+exactly on `$CUTOFF`, the two predicates would cover different sets: at the
+100,000-row cap that boundary row can displace an older in-range row out of
+the export while that older row still gets deleted — never archived, but
+gone. Matching the delete's boundary to the export's removes the mismatch
+outright rather than trying to work around it.
 
 Export as **JSON**, not CSV, for this procedure: the row count is then a
 plain array length, checkable with `jq length`. A CSV line count minus the
@@ -1379,13 +1389,31 @@ If that count is **at or under 100,000**, one export call covers the whole
 window:
 
 ```bash
-curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+curl -sS -f -H "Authorization: Bearer $ADMIN_TOKEN" \
   "https://<your-host>/api/admin/audit-logs/export/json?date_to=$CUTOFF" \
-  -o "audit-archive-${ARCHIVE_TAG}.json"
+  -o "audit-archive-${ARCHIVE_TAG}.json" \
+  || { echo "export request failed -- aborting, do NOT delete" >&2; exit 1; }
 ```
 
-Verify the exported row count equals the count from the query above before
-proceeding to the delete. A mismatch means stop — do not delete:
+`-f`/`--fail` is not optional here: without it, an expired token, a wrong
+host, or any other 4xx/5xx still exits 0 and writes the error body (e.g.
+`{"detail":"Not authenticated"}`) to the output file as if it were the
+archive. `--fail` makes curl exit non-zero and discard that body instead of
+saving it.
+
+Before trusting the row count, confirm the file is actually a JSON array —
+an auth failure or a proxy error page that slips past `--fail` (a 200 with
+an unexpected body) would otherwise report a `jq length` of 0 or 1, which
+can look like a real, if small, count rather than "the archive is garbage":
+
+```bash
+jq -e 'type == "array"' "audit-archive-${ARCHIVE_TAG}.json" >/dev/null \
+  || { echo "not a JSON array -- aborting, do NOT delete" >&2; exit 1; }
+```
+
+Only then verify the exported row count equals the count from the query
+above before proceeding to the delete. A mismatch means stop — do not
+delete:
 
 ```bash
 jq length "audit-archive-${ARCHIVE_TAG}.json"
@@ -1401,25 +1429,36 @@ sub-window's exported row count (`jq length`, same as above) against a COUNT
 query scoped to that same sub-window — for example:
 
 ```bash
-# Repeat with adjacent, non-overlapping date_from/date_to pairs that together
-# cover the full range up to $CUTOFF. Each pair's exported row count must
-# match: SELECT count(*) FROM catalog.audit_logs WHERE created_at >= date_from
-# AND created_at < date_to AND (tenant scope as above). <window-start> must
-# also be part of the filename -- distinct sub-windows of the SAME tenant/run
+# Repeat with adjacent date_from/date_to pairs that together cover the full
+# range up to $CUTOFF. Each pair's exported row count must match:
+# SELECT count(*) FROM catalog.audit_logs WHERE created_at >= date_from
+# AND created_at <= date_to AND (tenant scope as above) -- both bounds
+# inclusive, matching the export endpoint's own semantics (see the <=
+# note above the single-call case). Both bounds being inclusive means a
+# row landing exactly on a shared boundary appears in both adjacent
+# windows' exports; that duplicates an archive entry, which is harmless
+# (the delete below still removes it exactly once), but do not offset
+# date_from by an epsilon to "fix" it -- that would silently exclude the
+# boundary row from every export instead. <window-start> must also be
+# part of the filename -- distinct sub-windows of the SAME tenant/run
 # still need distinct files.
-curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+curl -sS -f -H "Authorization: Bearer $ADMIN_TOKEN" \
   "https://<your-host>/api/admin/audit-logs/export/json?date_from=<window-start>&date_to=<window-end>" \
-  -o "audit-archive-${ARCHIVE_TAG}-<window-start>.json"
+  -o "audit-archive-${ARCHIVE_TAG}-<window-start>.json" \
+  || { echo "export request failed -- aborting, do NOT delete" >&2; exit 1; }
+jq -e 'type == "array"' "audit-archive-${ARCHIVE_TAG}-<window-start>.json" >/dev/null \
+  || { echo "not a JSON array -- aborting, do NOT delete" >&2; exit 1; }
 ```
 
-Only once every sub-window is exported and verified does the full window
-have a complete archive — proceed to the delete below.
+Only once every sub-window is exported, confirmed to be a real JSON array,
+and verified by count does the full window have a complete archive —
+proceed to the delete below.
 
 Then delete the archived window, using the identical `$CUTOFF` and tenant
 scope from above. Run this from a low-traffic maintenance window: the
 table's only DELETE-supporting index is
 `ix_catalog_audit_logs_created_action_resource` (`created_at DESC, action,
-resource_type`), so an unbounded `DELETE ... WHERE created_at < ...` on a
+resource_type`), so an unbounded `DELETE ... WHERE created_at <= ...` on a
 multi-million-row table can hold locks and bloat the table for a while.
 Batch it:
 
@@ -1445,7 +1484,7 @@ BEGIN
     DELETE FROM catalog.audit_logs
     WHERE id IN (
       SELECT id FROM catalog.audit_logs
-      WHERE created_at < cutoff_ts
+      WHERE created_at <= cutoff_ts
         AND (tenant_uuid IS NULL OR tenant_id = tenant_uuid)
       LIMIT 5000
     );

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1321,12 +1321,13 @@ on every batched commit inside the delete loop):
 CUTOFF=$(date -u -d '-90 days' +%Y-%m-%dT%H:%M:%SZ)
 ```
 
-If this is a **multi-tenant** deployment, the HTTP export below is already
-scoped to whichever tenant's host you call it against, but the SQL delete
-that follows connects directly as `$POSTGRES_USER` (bypassing RLS) and has no
-such scope by default — add the tenant filter shown below, or you will export
-one tenant's window and delete every tenant's history that predates it.
-Resolve the tenant's id from its slug first:
+If this deployment uses per-tenant host routing (more than one row in
+`catalog.tenants`), the HTTP export below is already scoped to whichever
+tenant's host you call it against, but the SQL delete that follows connects
+directly as `$POSTGRES_USER` (bypassing RLS) and has no such scope by
+default — add the tenant filter shown below, or you will export one
+tenant's window and delete every tenant's history that predates it. Resolve
+the tenant's id from its slug first:
 
 ```bash
 TENANT_ID=$(docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1321,59 +1321,87 @@ on every batched commit inside the delete loop):
 CUTOFF=$(date -u -d '-90 days' +%Y-%m-%dT%H:%M:%SZ)
 ```
 
-Every `docker compose exec -T db psql ...` command in this section assumes
-the bundled Postgres container. Managed/external Postgres
-([§3](#3-restore--managed--external-postgres-mode)): drop the
-`docker compose exec -T db` prefix and connect `psql` directly instead,
-passing your provider's `-h`, `-p`, and `-U` (the same substitution used in
-§2 and §6) — for example `psql -h <host> -p <port> -U "$POSTGRES_USER" -d
-"$POSTGRES_DB"`, or `psql "$DATABASE_URL_OVERRIDE"` if `.env` already has the
-migrator credential set. The HTTP export commands further down are
-unaffected either way — they go through the API, not a direct DB connection.
+Every SQL step below runs through one `$PSQL` command array — set it once
+and every command that follows uses `"${PSQL[@]}"` instead of repeating a
+connection prefix that differs by deployment mode:
 
-If this deployment uses per-tenant host routing (more than one row in
-`catalog.tenants`), the HTTP export below is already scoped to whichever
-tenant's host you call it against, but the SQL delete that follows connects
-directly as `$POSTGRES_USER` (bypassing RLS) and has no such scope by
-default — add the tenant filter shown below, or you will export one
-tenant's window and delete every tenant's history that predates it. Resolve
-the tenant's id from its slug first:
+```bash
+# Bundled Postgres (default):
+PSQL=(docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB")
+
+# Managed/external Postgres (§3): there is no `db` container to exec into.
+# Connect directly instead — uncomment ONE of these and comment out the
+# bundled line above:
+# PSQL=(psql -h <host> -p <port> -U "$POSTGRES_USER" -d "$POSTGRES_DB")
+# PSQL=(psql "$DATABASE_URL_OVERRIDE")   # if .env already has this set
+```
+
+The HTTP export commands further down are unaffected by this choice either
+way — they go through the API, not a direct DB connection.
+
+**Choose a tenant-scoping mode below and follow only that branch through the
+count and delete steps.** Do not mix them, and do not treat an empty
+`$TENANT_ID` as "must mean single-tenant" — that assumption is exactly what
+lets a mistyped slug or a failed lookup silently escalate into an unscoped,
+cross-tenant delete. Each branch is a fully separate, explicit set of
+commands with no shared fallback between them.
+
+#### Per-tenant host routing (more than one row in `catalog.tenants`)
+
+The HTTP export below is already scoped to whichever tenant's host you call
+it against, but the SQL delete that follows connects directly as
+`$POSTGRES_USER` (bypassing RLS) and has no such scope by default — without
+this branch you would export one tenant's window and delete every tenant's
+history that predates it. Resolve the tenant's id from its slug and **stop
+if the lookup returns nothing**:
 
 ```bash
 TENANT_SLUG=<your-tenant-slug>
-TENANT_ID=$(docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
-  "SELECT id FROM catalog.tenants WHERE slug = '$TENANT_SLUG'")
+TENANT_ID=$("${PSQL[@]}" -tAc "SELECT id FROM catalog.tenants WHERE slug = '$TENANT_SLUG'")
+if [ -z "$TENANT_ID" ]; then
+  echo "No tenant found for slug '$TENANT_SLUG' -- aborting rather than" \
+       "falling through to an unscoped, all-tenants run" >&2
+  exit 1
+fi
+ARCHIVE_TAG="${TENANT_SLUG}-$(date -u +%Y%m%dT%H%M%SZ)"
 ```
 
-Single-tenant deployments: skip that step: `catalog.audit_logs.tenant_id` is
-NULL on every row (single-tenant never stamps it) and every SQL snippet
-below already tolerates an empty `$TENANT_ID`. Set `TENANT_SLUG=default` (or
-any fixed label) instead, so the archive filenames below still get a stable
-tag.
+#### Single-tenant deployments (or a deliberately unscoped run)
+
+`catalog.audit_logs.tenant_id` is NULL on every row here (single-tenant never
+stamps it), so there is nothing to filter by. This branch never resolves or
+reads a `$TENANT_ID` at all — it is a separate set of commands below, not a
+fallback the per-tenant branch reaches by leaving a variable unset:
+
+```bash
+ARCHIVE_TAG="default-$(date -u +%Y%m%dT%H%M%SZ)"
+```
 
 Every archive filename in this procedure must be unique per tenant and per
 run — two tenants exported on the same day, or the same tenant exported
-twice, would otherwise both write `audit-archive-YYYYMMDD.csv`, and the
-second `curl -o` silently truncates the first tenant's only copy (possibly
-after that tenant's rows are already deleted). Build one tag and reuse it:
-
-```bash
-ARCHIVE_TAG="${TENANT_SLUG}-$(date -u +%Y%m%dT%H%M%SZ)"
-```
+twice, would otherwise both write the same filename, and the second
+`curl -o` silently truncates the first tenant's only copy (possibly after
+that tenant's rows are already deleted). `$ARCHIVE_TAG` above exists to
+prevent that; every export filename below reuses it.
 
 **Count before you export.** The export endpoint caps at 100,000 rows per
 call — silently. A window with more matching rows than that returns only the
 100,000 newest ones in it, and deleting the full window afterward would
-discard rows that were never in the archive. Check first:
+discard rows that were never in the archive. Check first, using the count
+command for the branch you chose above:
 
 ```bash
-docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+# Per-tenant host routing (uses the validated, non-empty $TENANT_ID above):
+"${PSQL[@]}" -tAc \
   "SELECT count(*) FROM catalog.audit_logs
-   WHERE created_at <= '$CUTOFF'
-     AND (NULLIF('$TENANT_ID', '')::uuid IS NULL OR tenant_id = NULLIF('$TENANT_ID', '')::uuid)"
+   WHERE created_at <= '$CUTOFF' AND tenant_id = '$TENANT_ID'::uuid"
 ```
 
-(`NULLIF('$TENANT_ID', '')` turns an empty `$TENANT_ID` into SQL `NULL` *before* the `::uuid` cast runs — casting the empty string itself, e.g. `''::uuid`, is invalid input and errors regardless of which side of the `OR` would end up mattering.)
+```bash
+# Single-tenant / deliberately unscoped (no tenant predicate at all):
+"${PSQL[@]}" -tAc \
+  "SELECT count(*) FROM catalog.audit_logs WHERE created_at <= '$CUTOFF'"
+```
 
 Use `<=`, not `<`, and use it consistently in every count/export/delete step below.
 The export endpoint's `date_to` filter is inclusive (`created_at <= date_to`,
@@ -1464,38 +1492,67 @@ Only once every sub-window is exported, confirmed to be a real JSON array,
 and verified by count does the full window have a complete archive —
 proceed to the delete below.
 
-Then delete the archived window, using the identical `$CUTOFF` and tenant
-scope from above. Run this from a low-traffic maintenance window: the
-table's only DELETE-supporting index is
-`ix_catalog_audit_logs_created_action_resource` (`created_at DESC, action,
-resource_type`), so an unbounded `DELETE ... WHERE created_at <= ...` on a
-multi-million-row table can hold locks and bloat the table for a while.
-Batch it:
+Then delete the archived window, using the identical `$CUTOFF` and the SAME
+branch (per-tenant or single-tenant/unscoped) you used for the count above —
+run this from a low-traffic maintenance window: the table's only
+DELETE-supporting index is `ix_catalog_audit_logs_created_action_resource`
+(`created_at DESC, action, resource_type`), so an unbounded
+`DELETE ... WHERE created_at <= ...` on a multi-million-row table can hold
+locks and bloat the table for a while. Batch it.
 
 `psql`'s `-v`/`:name` substitution does not reach inside a `DO $$...$$` body —
 per the [psql docs](https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-VARIABLES),
 variable interpolation is skipped inside quoted SQL literals, and a
-dollar-quoted block is one. Pass the values through session GUCs instead,
-which the PL/pgSQL body reads with `current_setting()` — that call happens
-at execution time, outside the literal, so it works:
+dollar-quoted block is one. Pass `$CUTOFF` through a session GUC instead,
+which the PL/pgSQL body reads with `current_setting()` — that call happens at
+execution time, outside the literal, so it works. The two branches below are
+genuinely separate commands, not one command with a variable that happens to
+be empty — the per-tenant delete's `WHERE` clause hard-codes
+`tenant_id = tenant_uuid` with no `OR` fallback, so there is no path from a
+missing or malformed `$TENANT_ID` into an unscoped delete; that failure was
+already caught by the `exit 1` above, before this command is ever reached:
 
 ```bash
-docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
-  -v cutoff="'$CUTOFF'" -v tenant_id="'$TENANT_ID'" <<'SQL'
+# Per-tenant host routing:
+"${PSQL[@]}" -v cutoff="'$CUTOFF'" -v tenant_id="'$TENANT_ID'" <<'SQL'
 SET geolens.retention_cutoff = :cutoff;
 SET geolens.retention_tenant = :tenant_id;
 DO $$
 DECLARE
   deleted_count integer;
   cutoff_ts timestamptz := current_setting('geolens.retention_cutoff')::timestamptz;
-  tenant_uuid uuid := NULLIF(current_setting('geolens.retention_tenant'), '')::uuid;
+  tenant_uuid uuid := current_setting('geolens.retention_tenant')::uuid;
 BEGIN
   LOOP
     DELETE FROM catalog.audit_logs
     WHERE id IN (
       SELECT id FROM catalog.audit_logs
       WHERE created_at <= cutoff_ts
-        AND (tenant_uuid IS NULL OR tenant_id = tenant_uuid)
+        AND tenant_id = tenant_uuid
+      LIMIT 5000
+    );
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    EXIT WHEN deleted_count = 0;
+    COMMIT;
+  END LOOP;
+END $$;
+SQL
+```
+
+```bash
+# Single-tenant / deliberately unscoped (no tenant predicate at all):
+"${PSQL[@]}" -v cutoff="'$CUTOFF'" <<'SQL'
+SET geolens.retention_cutoff = :cutoff;
+DO $$
+DECLARE
+  deleted_count integer;
+  cutoff_ts timestamptz := current_setting('geolens.retention_cutoff')::timestamptz;
+BEGIN
+  LOOP
+    DELETE FROM catalog.audit_logs
+    WHERE id IN (
+      SELECT id FROM catalog.audit_logs
+      WHERE created_at <= cutoff_ts
       LIMIT 5000
     );
     GET DIAGNOSTICS deleted_count = ROW_COUNT;

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1374,32 +1374,45 @@ ARCHIVE_TAG="${TENANT_SLUG}-$(date -u +%Y%m%dT%H%M%SZ)"
 
 #### Single-tenant deployments
 
-This branch is for confirmed single-tenant deployments **only** — it is not
-a generic "run unscoped" option, and must not be used on a deployment with
-per-tenant host routing even if you intend to touch every tenant's rows. The
-reason is the export step, not the delete: the HTTP export is always scoped
-to whichever tenant's host you call it against (there is no cross-tenant
-export call), so on a deployment with per-tenant routing enabled this
-branch's unscoped count/delete would remove every other tenant's audit
-history that the export never captured — permanent loss with no archive, not
-merely a scoping mistake. Verify the deployment is genuinely single-tenant
-before running anything below:
+This branch is not a generic "run unscoped" option, and must not be used on
+a deployment with per-tenant host routing even if you intend to touch every
+tenant's rows. The reason is the export step, not the delete: the HTTP
+export is always scoped to whichever tenant's host you call it against
+(there is no cross-tenant export call), so running this branch's unscoped
+count/delete on a deployment with per-tenant routing enabled would remove
+every other tenant's audit history that the export never captured —
+permanent loss with no archive, not merely a scoping mistake.
+
+This procedure does **not** attempt to detect your deployment's tenancy mode
+for you. An earlier revision checked `GEOLENS_TENANCY_MODE` from `.env`, but
+that value can be absent, injected by an orchestrator instead of a persisted
+`.env` file, or simply not read from wherever the running deployment actually
+gets its configuration — any config-derived signal here can be missing,
+stale, or wrong in a way this shell script cannot detect. Instead, this
+branch requires you, the operator, to type an explicit confirmation with no
+default and no config lookup behind it. Edit the placeholder below to the
+exact phrase shown — copying this block unedited leaves the placeholder in
+place and the check refuses to run:
 
 ```bash
-set -a; . ./.env; set +a   # if not already loaded in this shell
-if [ "${GEOLENS_TENANCY_MODE:-single_tenant}" = "multi_tenant" ]; then
-  echo "GEOLENS_TENANCY_MODE=multi_tenant -- this deployment has per-tenant" \
-       "routing. Use the per-tenant branch above for each tenant instead;" \
-       "aborting rather than running an unscoped delete here." >&2
+# This command is unscoped by explicit operator confirmation. Replace the
+# placeholder with the exact phrase on the right ONLY once you personally --
+# not a config file, not this script -- have confirmed this deployment has
+# no per-tenant host routing.
+CONFIRM_SINGLE_TENANT="<type-the-confirmation-phrase-here>"
+if [ "$CONFIRM_SINGLE_TENANT" != "yes, this deployment has no per-tenant host routing" ]; then
+  echo "Refusing: the commands below delete every row before \$CUTOFF with" \
+       "no tenant scoping. Set CONFIRM_SINGLE_TENANT to the exact phrase" \
+       "above, typed by you, before running them." >&2
   exit 1
 fi
 ```
 
-`catalog.audit_logs.tenant_id` is NULL on every row once that check passes
-(single-tenant never stamps it), so there is nothing left to filter by. This
-branch never resolves or reads a `$TENANT_ID` — it is a separate set of
-commands below, not a fallback the per-tenant branch reaches by leaving a
-variable unset:
+`catalog.audit_logs.tenant_id` is NULL on every row once that confirmation is
+given (single-tenant never stamps it), so there is nothing left to filter
+by. This branch never resolves or reads a `$TENANT_ID` — it is a separate
+set of commands below, not a fallback the per-tenant branch reaches by
+leaving a variable unset:
 
 ```bash
 ARCHIVE_TAG="default-$(date -u +%Y%m%dT%H%M%SZ)"

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -20,6 +20,7 @@ documentation.
 5. [Incident response — data loss](#5-incident-response--data-loss)
 6. [Major PostgreSQL version upgrade (17 → 18)](#6-major-postgresql-version-upgrade-17--18)
 7. [Schema rollback](#7-schema-rollback)
+8. [Audit log retention](#8-audit-log-retention)
 
 ---
 
@@ -1275,3 +1276,86 @@ Two further migrations refuse on downgrade for the same reason (blocking data
 exists that the older schema cannot represent safely): `0010` while GitHub
 OAuth providers exist, and `0005` while tenant-scoped data exists. Both print
 their own remediation in the error message; neither is auto-coerced.
+
+---
+
+## 8. Audit log retention
+
+`catalog.audit_logs` has no built-in expiry: every login, dataset mutation,
+share change, and export is a permanent row (see `AGENTS.md`'s Security
+pre-commit checklist and `backend/app/modules/audit/router.py`'s module
+docstring, which already flags that the table can reach millions of rows on a
+busy instance). Community ships bounded CSV/JSON export
+(`GET /admin/audit-logs/export/{format}`, capped at 100,000 rows per request)
+but no automatic pruning — an operator who wants a retention window applies it
+manually. This section is that manual procedure, not an in-app feature: an
+in-app pruning endpoint means a new destructive-write surface (Rule 1 of the
+Security pre-commit checklist, plus RBAC and rate-limit review for a
+delete-many endpoint), and a manual SQL window is the smaller, auditable
+surface for a table whose entire purpose is being an audit trail.
+
+### Deciding on a window
+
+There is no default; pick a retention period your compliance posture
+requires (30/90/365 days are common). Whatever you pick, keep two things in
+mind:
+- `dataset.download_cog`, `feature.*`, and `dataset.view` rows are usually the
+  bulk of the table on an active instance — high-frequency, low-value-per-row
+  events. A shorter window for those and a longer one for account/security
+  events (`user.login.*`, `user.logout`, `user.change_password`,
+  `oauth_provider.*`) is a reasonable split if your regulatory requirement
+  distinguishes between them.
+- The export endpoint is the archive step. Deleting rows you have not
+  exported is not "retention", it's data loss — always export the window you
+  are about to delete first.
+
+### Archive-then-delete by age
+
+Export first (adjust `date_to` to your retention boundary; the endpoint
+requires `manage_settings` and streams up to 100,000 rows per call, so a large
+window may need several date-bounded requests):
+
+```bash
+curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "https://<your-host>/api/admin/audit-logs/export/csv?date_to=$(date -u -d '-90 days' +%Y-%m-%dT%H:%M:%SZ)" \
+  -o audit-archive-$(date +%Y%m%d).csv
+```
+
+Then delete the exported window. Run this from a low-traffic maintenance
+window: the table's only DELETE-supporting index is
+`ix_catalog_audit_logs_created_action_resource` (`created_at DESC, action,
+resource_type`), so an unbounded `DELETE ... WHERE created_at < ...` on a
+multi-million-row table can hold locks and bloat the table for a while.
+Batch it:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+DO $$
+DECLARE
+  deleted_count integer;
+BEGIN
+  LOOP
+    DELETE FROM catalog.audit_logs
+    WHERE id IN (
+      SELECT id FROM catalog.audit_logs
+      WHERE created_at < now() - interval '90 days'
+      LIMIT 5000
+    );
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    EXIT WHEN deleted_count = 0;
+    COMMIT;
+  END LOOP;
+END $$;
+SQL
+```
+
+Substitute your chosen window for `interval '90 days'`. Run `VACUUM (ANALYZE)
+catalog.audit_logs;` afterward if the delete removed a large fraction of the
+table — routine autovacuum handles smaller, regular prunes on its own.
+
+**What is actually lost:** the deleted rows, permanently, including the
+ability to answer "who did X on day Y" for anything older than the window.
+That is the intended tradeoff of retention; keep the exported CSV/JSON
+archive (offsite, per §1's guidance on the primary backup) if you need to
+answer that question later without re-enabling unbounded storage in the live
+table.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1372,12 +1372,34 @@ fi
 ARCHIVE_TAG="${TENANT_SLUG}-$(date -u +%Y%m%dT%H%M%SZ)"
 ```
 
-#### Single-tenant deployments (or a deliberately unscoped run)
+#### Single-tenant deployments
 
-`catalog.audit_logs.tenant_id` is NULL on every row here (single-tenant never
-stamps it), so there is nothing to filter by. This branch never resolves or
-reads a `$TENANT_ID` at all — it is a separate set of commands below, not a
-fallback the per-tenant branch reaches by leaving a variable unset:
+This branch is for confirmed single-tenant deployments **only** — it is not
+a generic "run unscoped" option, and must not be used on a deployment with
+per-tenant host routing even if you intend to touch every tenant's rows. The
+reason is the export step, not the delete: the HTTP export is always scoped
+to whichever tenant's host you call it against (there is no cross-tenant
+export call), so on a deployment with per-tenant routing enabled this
+branch's unscoped count/delete would remove every other tenant's audit
+history that the export never captured — permanent loss with no archive, not
+merely a scoping mistake. Verify the deployment is genuinely single-tenant
+before running anything below:
+
+```bash
+set -a; . ./.env; set +a   # if not already loaded in this shell
+if [ "${GEOLENS_TENANCY_MODE:-single_tenant}" = "multi_tenant" ]; then
+  echo "GEOLENS_TENANCY_MODE=multi_tenant -- this deployment has per-tenant" \
+       "routing. Use the per-tenant branch above for each tenant instead;" \
+       "aborting rather than running an unscoped delete here." >&2
+  exit 1
+fi
+```
+
+`catalog.audit_logs.tenant_id` is NULL on every row once that check passes
+(single-tenant never stamps it), so there is nothing left to filter by. This
+branch never resolves or reads a `$TENANT_ID` — it is a separate set of
+commands below, not a fallback the per-tenant branch reaches by leaving a
+variable unset:
 
 ```bash
 ARCHIVE_TAG="default-$(date -u +%Y%m%dT%H%M%SZ)"
@@ -1404,7 +1426,7 @@ command for the branch you chose above:
 ```
 
 ```bash
-# Single-tenant / deliberately unscoped (no tenant predicate at all):
+# Single-tenant (no tenant predicate -- confirmed above, not the default):
 "${PSQL[@]}" -tAc \
   "SELECT count(*) FROM catalog.audit_logs WHERE created_at <= '$CUTOFF'"
 ```
@@ -1499,8 +1521,8 @@ and verified by count does the full window have a complete archive —
 proceed to the delete below.
 
 Then delete the archived window, using the identical `$CUTOFF` and the SAME
-branch (per-tenant or single-tenant/unscoped) you used for the count above —
-run this from a low-traffic maintenance window: the table's only
+branch (per-tenant or single-tenant) you used for the count above — run this
+from a low-traffic maintenance window: the table's only
 DELETE-supporting index is `ix_catalog_audit_logs_created_action_resource`
 (`created_at DESC, action, resource_type`), so an unbounded
 `DELETE ... WHERE created_at <= ...` on a multi-million-row table can hold
@@ -1546,7 +1568,7 @@ SQL
 ```
 
 ```bash
-# Single-tenant / deliberately unscoped (no tenant predicate at all):
+# Single-tenant (no tenant predicate -- confirmed above, not the default):
 "${PSQL[@]}" -v cutoff="'$CUTOFF'" <<'SQL'
 SET geolens.retention_cutoff = :cutoff;
 DO $$

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1347,8 +1347,10 @@ discard rows that were never in the archive. Check first:
 docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
   "SELECT count(*) FROM catalog.audit_logs
    WHERE created_at < '$CUTOFF'
-     AND ('$TENANT_ID' = '' OR tenant_id = '$TENANT_ID'::uuid)"
+     AND (NULLIF('$TENANT_ID', '')::uuid IS NULL OR tenant_id = NULLIF('$TENANT_ID', '')::uuid)"
 ```
+
+(`NULLIF('$TENANT_ID', '')` turns an empty `$TENANT_ID` into SQL `NULL` *before* the `::uuid` cast runs — casting the empty string itself, e.g. `''::uuid`, is invalid input and errors regardless of which side of the `OR` would end up mattering.)
 
 If that count is **at or under 100,000**, one export call covers the whole
 window:
@@ -1393,19 +1395,30 @@ resource_type`), so an unbounded `DELETE ... WHERE created_at < ...` on a
 multi-million-row table can hold locks and bloat the table for a while.
 Batch it:
 
+`psql`'s `-v`/`:name` substitution does not reach inside a `DO $$...$$` body —
+per the [psql docs](https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-VARIABLES),
+variable interpolation is skipped inside quoted SQL literals, and a
+dollar-quoted block is one. Pass the values through session GUCs instead,
+which the PL/pgSQL body reads with `current_setting()` — that call happens
+at execution time, outside the literal, so it works:
+
 ```bash
 docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
   -v cutoff="'$CUTOFF'" -v tenant_id="'$TENANT_ID'" <<'SQL'
+SET geolens.retention_cutoff = :cutoff;
+SET geolens.retention_tenant = :tenant_id;
 DO $$
 DECLARE
   deleted_count integer;
+  cutoff_ts timestamptz := current_setting('geolens.retention_cutoff')::timestamptz;
+  tenant_uuid uuid := NULLIF(current_setting('geolens.retention_tenant'), '')::uuid;
 BEGIN
   LOOP
     DELETE FROM catalog.audit_logs
     WHERE id IN (
       SELECT id FROM catalog.audit_logs
-      WHERE created_at < :cutoff::timestamptz
-        AND (:tenant_id = '' OR tenant_id = :tenant_id::uuid)
+      WHERE created_at < cutoff_ts
+        AND (tenant_uuid IS NULL OR tenant_id = tenant_uuid)
       LIMIT 5000
     );
     GET DIAGNOSTICS deleted_count = ROW_COUNT;

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1311,25 +1311,90 @@ mind:
 
 ### Archive-then-delete by age
 
-Export first (adjust `date_to` to your retention boundary; the endpoint
-requires `manage_settings` and streams up to 100,000 rows per call, so a large
-window may need several date-bounded requests):
+Fix the retention boundary to **one** timestamp and reuse it for every step
+below — the export and the delete must agree on the exact same cutoff, not
+two separately-evaluated `now() - interval '90 days'` calls (which drift
+against each other across the minutes the procedure takes to run, and again
+on every batched commit inside the delete loop):
+
+```bash
+CUTOFF=$(date -u -d '-90 days' +%Y-%m-%dT%H:%M:%SZ)
+```
+
+If this is a **multi-tenant** deployment, the HTTP export below is already
+scoped to whichever tenant's host you call it against, but the SQL delete
+that follows connects directly as `$POSTGRES_USER` (bypassing RLS) and has no
+such scope by default — add the tenant filter shown below, or you will export
+one tenant's window and delete every tenant's history that predates it.
+Resolve the tenant's id from its slug first:
+
+```bash
+TENANT_ID=$(docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+  "SELECT id FROM catalog.tenants WHERE slug = '<your-tenant-slug>'")
+```
+
+Single-tenant deployments: skip that step: `catalog.audit_logs.tenant_id` is
+NULL on every row (single-tenant never stamps it) and every SQL snippet
+below already tolerates an empty `$TENANT_ID`.
+
+**Count before you export.** The export endpoint caps at 100,000 rows per
+call — silently. A window with more matching rows than that returns only the
+100,000 newest ones in it, and deleting the full window afterward would
+discard rows that were never in the archive. Check first:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+  "SELECT count(*) FROM catalog.audit_logs
+   WHERE created_at < '$CUTOFF'
+     AND ('$TENANT_ID' = '' OR tenant_id = '$TENANT_ID'::uuid)"
+```
+
+If that count is **at or under 100,000**, one export call covers the whole
+window:
 
 ```bash
 curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
-  "https://<your-host>/api/admin/audit-logs/export/csv?date_to=$(date -u -d '-90 days' +%Y-%m-%dT%H:%M:%SZ)" \
+  "https://<your-host>/api/admin/audit-logs/export/csv?date_to=$CUTOFF" \
   -o audit-archive-$(date +%Y%m%d).csv
 ```
 
-Then delete the exported window. Run this from a low-traffic maintenance
-window: the table's only DELETE-supporting index is
+Verify the row count you exported (CSV line count minus the header, or the
+JSON array length) equals the count from the query above before proceeding
+to the delete. A mismatch means stop — do not delete.
+
+If the count is **over 100,000**, one call cannot capture the whole window,
+and narrowing `date_to` alone doesn't help — the export is always the
+*newest* rows in the range, so repeating the same call returns the same slice
+forever. Partition the range into disjoint `date_from`/`date_to` sub-windows
+instead (a week or a month at a time, whatever keeps each sub-window under
+100,000 rows given your write volume), export each one, and verify each
+sub-window's exported row count against a COUNT query scoped to that same
+sub-window — for example:
+
+```bash
+# Repeat with adjacent, non-overlapping date_from/date_to pairs that together
+# cover the full range up to $CUTOFF. Each pair's exported row count must
+# match: SELECT count(*) FROM catalog.audit_logs WHERE created_at >= date_from
+# AND created_at < date_to AND (tenant scope as above).
+curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "https://<your-host>/api/admin/audit-logs/export/csv?date_from=<window-start>&date_to=<window-end>" \
+  -o audit-archive-<window-start>.csv
+```
+
+Only once every sub-window is exported and verified does the full window
+have a complete archive — proceed to the delete below.
+
+Then delete the archived window, using the identical `$CUTOFF` and tenant
+scope from above. Run this from a low-traffic maintenance window: the
+table's only DELETE-supporting index is
 `ix_catalog_audit_logs_created_action_resource` (`created_at DESC, action,
 resource_type`), so an unbounded `DELETE ... WHERE created_at < ...` on a
 multi-million-row table can hold locks and bloat the table for a while.
 Batch it:
 
 ```bash
-docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -v cutoff="'$CUTOFF'" -v tenant_id="'$TENANT_ID'" <<'SQL'
 DO $$
 DECLARE
   deleted_count integer;
@@ -1338,7 +1403,8 @@ BEGIN
     DELETE FROM catalog.audit_logs
     WHERE id IN (
       SELECT id FROM catalog.audit_logs
-      WHERE created_at < now() - interval '90 days'
+      WHERE created_at < :cutoff::timestamptz
+        AND (:tenant_id = '' OR tenant_id = :tenant_id::uuid)
       LIMIT 5000
     );
     GET DIAGNOSTICS deleted_count = ROW_COUNT;
@@ -1349,9 +1415,9 @@ END $$;
 SQL
 ```
 
-Substitute your chosen window for `interval '90 days'`. Run `VACUUM (ANALYZE)
-catalog.audit_logs;` afterward if the delete removed a large fraction of the
-table — routine autovacuum handles smaller, regular prunes on its own.
+Run `VACUUM (ANALYZE) catalog.audit_logs;` afterward if the delete removed a
+large fraction of the table — routine autovacuum handles smaller, regular
+prunes on its own.
 
 **What is actually lost:** the deleted rows, permanently, including the
 ability to answer "who did X on day Y" for anything older than the window.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1333,7 +1333,13 @@ PSQL=(docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB")
 # Connect directly instead — uncomment ONE of these and comment out the
 # bundled line above:
 # PSQL=(psql -h <host> -p <port> -U "$POSTGRES_USER" -d "$POSTGRES_DB")
-# PSQL=(psql "$DATABASE_URL_OVERRIDE")   # if .env already has this set
+#
+# If reusing DATABASE_URL_OVERRIDE from .env, strip its SQLAlchemy driver
+# suffix first: libpq's URI parser accepts only the postgresql:// and
+# postgres:// schemes, and rejects the postgresql+asyncpg:// /
+# postgresql+psycopg:// forms .env.example documents for that variable.
+# PG_URI=$(echo "$DATABASE_URL_OVERRIDE" | sed -E 's#^postgresql\+[a-zA-Z0-9_]+://#postgresql://#')
+# PSQL=(psql "$PG_URI")
 ```
 
 The HTTP export commands further down are unaffected by this choice either

--- a/backend/app/modules/audit/actions.py
+++ b/backend/app/modules/audit/actions.py
@@ -1,0 +1,118 @@
+"""Canonical registry of ``AuditEvent.action`` string literals.
+
+#1230 ("action-registry drift"): the frontend's ``CURRENT_AUDIT_ACTIONS``
+(``frontend/src/components/admin/AuditLogViewer.tsx``) had drifted from what
+the backend actually emits — it listed four ``layer.*`` values nothing
+writes to ``audit_logs`` (builder layer edits go to map edit history
+instead) and was missing several real ones (``connector.discover``,
+``connector.ingest_dispatch``, and the password-login/``dataset.create``
+actions added by this same issue).
+
+This module is the backend half of the fix: every literal passed as
+``AuditEvent(action=...)`` anywhere in ``backend/app`` must be a member of
+``AUDIT_ACTIONS``. ``backend/tests/test_audit_action_registry.py`` walks the
+AST of ``backend/app`` and fails CI if an emit site uses a string this set
+does not contain — so a new action is a one-line addition here, made in the
+same commit that starts emitting it, rather than a silent drift for the next
+audit sweep to rediscover.
+
+This registry is NOT imported by emit sites (that would mean touching ~30
+call sites across a dozen modules for no behavioral gain); it is the
+independent source of truth the test checks emitted literals against. Keep
+it alphabetically sorted so a diff shows exactly what changed.
+"""
+
+from __future__ import annotations
+
+AUDIT_ACTIONS: frozenset[str] = frozenset(
+    {
+        "api_key.create",
+        "api_key.revoke",
+        "attribute.edit",
+        "attribute.reset",
+        "audit.export",
+        "collection.add_datasets",
+        "collection.create",
+        "collection.delete",
+        "collection.remove_dataset",
+        "collection.update",
+        "config_export",
+        "config_import",
+        "connector.discover",
+        "connector.ingest_dispatch",
+        # fix(#1230): previously no emit site existed anywhere. Emitted once,
+        # inside create_dataset() (service_create.py), the function every
+        # creation path (ingest registration, file-upload ingest,
+        # layer/table creation, the empty-dataset endpoint) funnels through.
+        "dataset.create",
+        "dataset.delete",
+        "dataset.download_cog",
+        "dataset.export",
+        "dataset.view",
+        "embed_token.bulk_revoke",
+        "embed_token.create",
+        "embed_token.revoke",
+        "embed_token.update",
+        "embedding.backfill",
+        "feature.delete",
+        "feature.insert",
+        "feature.replace",
+        "feature.update",
+        "job.cleanup_stale",
+        "job.retry",
+        "layer.add_column",
+        "layer.alter_column_type",
+        "layer.drop_column",
+        "layer.rename_column",
+        "map.add_layer",
+        "map.admin_share_revoke",
+        "map.bulk_remove_layers",
+        "map.create",
+        "map.delete",
+        "map.duplicate",
+        "map.import_style",
+        "map.patch_layers",
+        "map.remove_layer",
+        "map.revoke_share",
+        "map.share",
+        "map.update",
+        "map.update_share_token",
+        "metadata.edit",
+        "notification.test_sent",
+        "oauth.login.failure",
+        "oauth.login.init",
+        "oauth.login.success",
+        "oauth_provider.create",
+        "oauth_provider.delete",
+        "oauth_provider.update",
+        "preview_service_layer",
+        "probe_service",
+        # PersistentConfig.reset() — generic/unprefixed; resource_type="setting"
+        # plus details.setting_key already carry the specificity.
+        "reset",
+        "reupload.commit",
+        "stac_connect",
+        "stac_import",
+        # PersistentConfig.set() — generic/unprefixed, same rationale as "reset".
+        "update",
+        "user.approve",
+        "user.change_password",
+        "user.convert_saml_to_local",
+        "user.create",
+        "user.deactivate",
+        "user.delete",
+        "user.export",
+        # fix(#1230): password-login success/failure and logout were the
+        # other structural gap — only the OAuth path emitted login events.
+        # Named to mirror oauth.login.success/failure under the existing
+        # user.* prefix (user.change_password, user.register, ...) rather
+        # than introducing a separate "auth." prefix for one code path.
+        "user.login.failure",
+        "user.login.success",
+        "user.logout",
+        "user.register",
+        "user.reject",
+        "user.update",
+        "user.verify_email",
+    }
+)

--- a/backend/app/modules/auth/providers/local.py
+++ b/backend/app/modules/auth/providers/local.py
@@ -4,6 +4,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pwdlib import PasswordHash
+from pwdlib.exceptions import UnknownHashError
 from pwdlib.hashers.bcrypt import BcryptHasher
 
 from app.modules.auth.models import User
@@ -63,7 +64,27 @@ class LocalAuthProvider:
             password_hash.verify(password, DUMMY_HASH)
             raise AuthenticationError("Invalid credentials")
 
-        if not verify_password(password, user.password_hash or ""):
+        if user.password_hash is None:
+            # fix(#1230 codex r10): OAuth-only users have no local password
+            # hash (oauth/service.py never sets one) -- `user.password_hash
+            # or ""` used to hand pwdlib an empty string, which it cannot
+            # parse as any known hash format. That raised UnknownHashError
+            # uncaught here, 500ing the login request and skipping the
+            # user.login.failure audit emit entirely (the except clause in
+            # the router only catches AuthenticationError). Still run a
+            # real verify against the dummy hash for timing-attack parity
+            # with the "user not found" branch above, then always fail --
+            # there is no real password for this account to match.
+            password_hash.verify(password, DUMMY_HASH)
+            raise AuthenticationError("Invalid credentials")
+
+        try:
+            valid = verify_password(password, user.password_hash)
+        except UnknownHashError:
+            # Defense in depth: any other unparseable/corrupted stored hash
+            # is a login failure, not a 500.
+            valid = False
+        if not valid:
             raise AuthenticationError("Invalid credentials")
 
         return AuthenticatedIdentity(

--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -93,29 +93,42 @@ async def login(
         audit_emit,
     )  # LAZY — preserved per D-17
 
+    # fix(#1230 codex r1 P1): OAuth2PasswordRequestForm applies no length
+    # limit to username, so an unauthenticated caller could otherwise persist
+    # an unbounded string in JSONB on every failed attempt (storage
+    # exhaustion). Bound it to User.username's own column width (String(150))
+    # before it ever reaches an audit row.
+    attempted_username = form_data.username[:150]
+
+    async def _audit_login_failure(reason: str, *, user_id: uuid.UUID | None) -> None:
+        """fix(#1230 codex r1 P1): audit every denial path, not just bad
+        credentials — pending/deactivated accounts, a disallowed email
+        domain, and password-login-disabled are all login failures an
+        operator needs to see, especially attempts against deactivated
+        accounts. Never includes the submitted password."""
+        await audit_emit(
+            db,
+            AuditEvent(
+                user_id=user_id,
+                action="user.login.failure",
+                resource_type="user",
+                details={"username": attempted_username, "reason": reason},
+                ip_address=get_client_ip(request),
+            ),
+        )
+        await db.commit()
+
     provider = LocalAuthProvider(db)
     try:
         identity = await provider.authenticate(
             username=form_data.username, password=form_data.password
         )
     except AuthenticationError:
-        # fix(#1230): password-login failures were invisible in the audit
-        # trail — only the OAuth path emitted login events. user_id stays
-        # None because LocalAuthProvider deliberately does not disclose
-        # whether the username exists (the dummy-hash verify above this is
-        # a timing-attack guard, both branches raise here identically).
-        # Never log the submitted password.
-        await audit_emit(
-            db,
-            AuditEvent(
-                user_id=None,
-                action="user.login.failure",
-                resource_type="user",
-                details={"username": form_data.username},
-                ip_address=get_client_ip(request),
-            ),
-        )
-        await db.commit()
+        # user_id stays None: LocalAuthProvider deliberately does not
+        # disclose whether the username exists (the dummy-hash verify above
+        # this is a timing-attack guard, both branches raise here
+        # identically), and the audit row must not either.
+        await _audit_login_failure("invalid_credentials", user_id=None)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
@@ -127,11 +140,13 @@ async def login(
     user = result.scalar_one_or_none()
     if user is not None:
         if user.status == "pending":
+            await _audit_login_failure("pending_approval", user_id=user.id)
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Your account is awaiting approval",
             )
         if user.status != "active" or not user.is_active:
+            await _audit_login_failure("account_not_active", user_id=user.id)
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Account not active",
@@ -141,7 +156,11 @@ async def login(
     # skip, get_uncached cache-bypass, and the manage_settings break-glass all
     # live in the shared gate (fix(#836)).
     if user is not None:
-        await enforce_email_domain_gate(db, user.email, break_glass_user=user)
+        try:
+            await enforce_email_domain_gate(db, user.email, break_glass_user=user)
+        except HTTPException:
+            await _audit_login_failure("email_domain_not_allowed", user_id=user.id)
+            raise
 
     # SSO-01/SSO-02 (Phase 1236 Plan 02): when password_login_enabled is False,
     # reject password login for non-admins.  manage_settings holders are always
@@ -157,6 +176,7 @@ async def login(
 
         has_break_glass = await user_has_capability(db, user, MANAGE_SETTINGS)
         if not has_break_glass:
+            await _audit_login_failure("password_login_disabled", user_id=user.id)
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Password login is disabled; sign in with your SSO provider",

--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -88,12 +88,34 @@ async def login(
     db: AsyncSession = Depends(get_db),
 ) -> TokenResponse:
     """Authenticate with username and password, receive a JWT token."""
+    from app.modules.audit.service import (
+        AuditEvent,
+        audit_emit,
+    )  # LAZY — preserved per D-17
+
     provider = LocalAuthProvider(db)
     try:
         identity = await provider.authenticate(
             username=form_data.username, password=form_data.password
         )
     except AuthenticationError:
+        # fix(#1230): password-login failures were invisible in the audit
+        # trail — only the OAuth path emitted login events. user_id stays
+        # None because LocalAuthProvider deliberately does not disclose
+        # whether the username exists (the dummy-hash verify above this is
+        # a timing-attack guard, both branches raise here identically).
+        # Never log the submitted password.
+        await audit_emit(
+            db,
+            AuditEvent(
+                user_id=None,
+                action="user.login.failure",
+                resource_type="user",
+                details={"username": form_data.username},
+                ip_address=get_client_ip(request),
+            ),
+        )
+        await db.commit()
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
@@ -150,6 +172,17 @@ async def login(
     service = AuthService(db)
     token = await service.create_access_token(identity, expire_minutes=expire_minutes)
     refresh_token = service.create_refresh_token(user.id, expire_days=expire_days)
+
+    # fix(#1230): password-login success audit row, mirroring oauth.login.success.
+    await audit_emit(
+        db,
+        AuditEvent(
+            user_id=user.id,
+            action="user.login.success",
+            resource_type="user",
+            ip_address=get_client_ip(request),
+        ),
+    )
     await db.commit()
     return TokenResponse(
         access_token=token,
@@ -586,6 +619,7 @@ async def resend_verification(
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT, include_in_schema=False)
 @router.post("/logout/", status_code=status.HTTP_204_NO_CONTENT)
 async def logout(
+    request: Request,
     current_user: User = Depends(get_current_active_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
@@ -600,8 +634,26 @@ async def logout(
     outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
     must not revoke them. Security events (password change, role change) do.
     """
+    from app.modules.audit.service import (
+        AuditEvent,
+        audit_emit,
+    )  # LAZY — preserved per D-17
+
     service = AuthService(db)
-    await service.revoke_all_tokens(current_user.id)
+    # commit=False: fold the token revocation and the audit row into one
+    # transaction, mirroring change_password below (fix(#1230): logout was
+    # the third gap in the "wrong password, right password, logout" trail).
+    await service.revoke_all_tokens(current_user.id, commit=False)
+    await audit_emit(
+        db,
+        AuditEvent(
+            user_id=current_user.id,
+            action="user.logout",
+            resource_type="user",
+            ip_address=get_client_ip(request),
+        ),
+    )
+    await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/app/modules/catalog/datasets/domain/service_create.py
+++ b/backend/app/modules/catalog/datasets/domain/service_create.py
@@ -276,4 +276,29 @@ async def create_dataset(
     if ing.column_info:
         await auto_detect_relationships(session, dataset.id, record.id, ing.column_info)
 
+    # fix(#1230): dataset.create was invisible in the audit trail — emitted
+    # here, not per-router, so every creation path (ingest registration via
+    # register_existing_table, file-upload ingest via tasks_common, layer/
+    # table creation, and the empty-dataset endpoint via
+    # create_empty_dataset) is covered from the one place they all funnel
+    # through, instead of duplicating — and risking missing — the call at
+    # each call site. No ip_address here: this is a domain-layer function
+    # with no Request, matching the existing reupload.commit precedent
+    # (tasks_common.py) which also emits without one.
+    from app.modules.audit.service import (
+        AuditEvent,
+        audit_emit,
+    )  # LAZY — preserved per D-17
+
+    await audit_emit(
+        session,
+        AuditEvent(
+            user_id=created_by,
+            action="dataset.create",
+            resource_type="dataset",
+            resource_id=dataset.id,
+            details={"title": title, "source_format": ing.source_format},
+        ),
+    )
+
     return dataset

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -94,6 +94,45 @@ async def test_dataset_view_creates_audit_log(
 
 
 @pytest.mark.anyio
+async def test_create_empty_dataset_creates_audit_log(
+    client: AsyncClient,
+    admin_auth_header: dict,
+):
+    """fix(#1230): POST /datasets/create/ writes a dataset.create audit log entry.
+
+    create_empty_dataset() calls into create_dataset() (service_create.py),
+    the single function every dataset-creation path funnels through -- this
+    pins the emit for that shared function via its most direct caller.
+    """
+    resp = await client.post(
+        "/datasets/create/",
+        json={
+            "title": "Audit dataset.create target",
+            "columns": [{"name": "name", "type": "text"}],
+        },
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 201, resp.text
+    dataset_id = resp.json()["id"]
+
+    log_resp = await client.get(
+        "/admin/audit-logs/",
+        params={"action": "dataset.create"},
+        headers=admin_auth_header,
+    )
+    assert log_resp.status_code == 200
+    data = log_resp.json()
+    assert data["total"] >= 1
+
+    entries = [log for log in data["logs"] if log.get("resource_id") == dataset_id]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["action"] == "dataset.create"
+    assert entry["resource_type"] == "dataset"
+    assert entry["details"]["title"] == "Audit dataset.create target"
+
+
+@pytest.mark.anyio
 async def test_audit_log_resolves_dataset_resource_name(
     client: AsyncClient,
     admin_auth_header: dict,

--- a/backend/tests/test_audit_action_registry.py
+++ b/backend/tests/test_audit_action_registry.py
@@ -15,6 +15,7 @@ test_layering.py's other AST-walking guards.
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,12 @@ import pytest
 from app.modules.audit.actions import AUDIT_ACTIONS
 
 _BACKEND_APP = Path(__file__).resolve().parents[1] / "app"
+
+# backend/tests/.. -> backend/, backend/.. -> repo root.
+_FRONTEND_AUDIT_LOG_VIEWER = (
+    Path(__file__).resolve().parents[2]
+    / "frontend/src/components/admin/AuditLogViewer.tsx"
+)
 
 
 def _find_audit_event_actions() -> dict[str, list[str]]:
@@ -107,4 +114,62 @@ def test_registry_has_no_stale_actions() -> None:
             "These AUDIT_ACTIONS entries are not emitted by any "
             "AuditEvent(action=...) call site in backend/app — remove them "
             "or fix the emit site:\n" + "\n".join(sorted(stale))
+        )
+
+
+def _parse_frontend_audit_actions() -> set[str]:
+    """Extract the string literals inside AuditLogViewer.tsx's
+    ``CURRENT_AUDIT_ACTIONS`` array.
+
+    Regex, not a TS parser: the array is a flat list of single-quoted string
+    literals (`'action.name',`), and that shape is enforced by this same
+    test failing loudly the moment it stops holding.
+    """
+    text = _FRONTEND_AUDIT_LOG_VIEWER.read_text(encoding="utf-8")
+    match = re.search(
+        r"const CURRENT_AUDIT_ACTIONS = \[(.*?)\]\s*as const;", text, re.DOTALL
+    )
+    if match is None:
+        pytest.fail(
+            "Could not locate `const CURRENT_AUDIT_ACTIONS = [...] as const;` "
+            f"in {_FRONTEND_AUDIT_LOG_VIEWER} — the array shape changed and "
+            "this test's regex needs updating alongside it."
+        )
+    body = match.group(1)
+    literals = re.findall(r"'([^']+)'", body)
+    if not literals:
+        pytest.fail(
+            f"Parsed zero action strings out of CURRENT_AUDIT_ACTIONS in "
+            f"{_FRONTEND_AUDIT_LOG_VIEWER} — the extraction regex is broken."
+        )
+    return set(literals)
+
+
+@pytest.mark.architecture
+def test_frontend_action_list_matches_backend_registry() -> None:
+    """fix(#1230 codex r2 P2): a matching AUDIT_ACTIONS + emit-site pair added
+    together passes the two tests above without ever looking at
+    AuditLogViewer.tsx's CURRENT_AUDIT_ACTIONS — exactly the drift this
+    whole change exists to close. Parse the frontend array directly and
+    assert set equality against the backend registry, in both directions.
+    """
+    frontend_actions = _parse_frontend_audit_actions()
+    missing_from_frontend = AUDIT_ACTIONS - frontend_actions
+    extra_in_frontend = frontend_actions - AUDIT_ACTIONS
+    if missing_from_frontend or extra_in_frontend:
+        lines = []
+        if missing_from_frontend:
+            lines.append(
+                "  Backend emits these but CURRENT_AUDIT_ACTIONS is missing "
+                f"them: {sorted(missing_from_frontend)}"
+            )
+        if extra_in_frontend:
+            lines.append(
+                "  CURRENT_AUDIT_ACTIONS lists these but nothing in "
+                f"backend/app emits them: {sorted(extra_in_frontend)}"
+            )
+        pytest.fail(
+            "frontend/src/components/admin/AuditLogViewer.tsx's "
+            "CURRENT_AUDIT_ACTIONS has drifted from "
+            "app.modules.audit.actions.AUDIT_ACTIONS:\n" + "\n".join(lines)
         )

--- a/backend/tests/test_audit_action_registry.py
+++ b/backend/tests/test_audit_action_registry.py
@@ -39,6 +39,16 @@ def _find_audit_event_actions() -> dict[str, list[str]]:
     call shapes). A non-literal (e.g. a variable) is reported separately so a
     future dynamic action string does not silently pass unchecked — today
     there are none (verified below).
+
+    ``AuditEvent`` is a dataclass, so ``AuditEvent(user_id, "x", "dataset")``
+    (positional) is valid Python and would otherwise find no ``action=``
+    keyword and silently vanish from this scan — the registry/frontend-parity
+    checks would then pass while production emitted an action neither test
+    ever saw. Every real call site in the codebase already uses the keyword
+    form (this scan is itself the proof — see test_every_emitted_action_is_
+    registered's zero false negatives against grep), so a call with no
+    ``action=`` keyword is flagged the same way as a non-literal one rather
+    than silently skipped.
     """
     sites: dict[str, list[str]] = {}
     dynamic: list[str] = []
@@ -59,15 +69,18 @@ def _find_audit_event_actions() -> dict[str, list[str]]:
             )
             if fname != "AuditEvent":
                 continue
-            for kw in node.keywords:
-                if kw.arg != "action":
-                    continue
-                if isinstance(kw.value, ast.Constant) and isinstance(
-                    kw.value.value, str
-                ):
-                    sites.setdefault(kw.value.value, []).append(rel)
-                else:
-                    dynamic.append(f"{rel}:{node.lineno}")
+            action_kw = next((kw for kw in node.keywords if kw.arg == "action"), None)
+            if action_kw is None:
+                dynamic.append(
+                    f"{rel}:{node.lineno} (no action= keyword — positional or "
+                    "missing; use the keyword form)"
+                )
+            elif isinstance(action_kw.value, ast.Constant) and isinstance(
+                action_kw.value.value, str
+            ):
+                sites.setdefault(action_kw.value.value, []).append(rel)
+            else:
+                dynamic.append(f"{rel}:{node.lineno}")
     if dynamic:
         pytest.fail(
             "AuditEvent(action=...) called with a non-literal value — the "

--- a/backend/tests/test_audit_action_registry.py
+++ b/backend/tests/test_audit_action_registry.py
@@ -1,0 +1,110 @@
+"""#1230: the backend half of "one source of truth for action names".
+
+Walks the AST of every file under ``backend/app`` and collects the literal
+``action=`` value passed to every ``AuditEvent(...)`` call site. Any literal
+that is not a member of ``app.modules.audit.actions.AUDIT_ACTIONS`` fails the
+test — so an emit site introduced with a typo'd or unregistered action string
+fails CI immediately instead of silently drifting from the frontend's display
+registry (``frontend/src/components/admin/AuditLogViewer.tsx``), which is
+exactly the gap #1230's 2026-08-05 audit sweep found.
+
+Does not require a database: pure source-tree static analysis, same style as
+test_layering.py's other AST-walking guards.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from app.modules.audit.actions import AUDIT_ACTIONS
+
+_BACKEND_APP = Path(__file__).resolve().parents[1] / "app"
+
+
+def _find_audit_event_actions() -> dict[str, list[str]]:
+    """Return {action_literal: [file paths that emit it]} across backend/app.
+
+    Only literal string ``action=`` keywords on a call named ``AuditEvent``
+    are collected (matching either ``AuditEvent(...)`` or ``foo.AuditEvent(...)``
+    call shapes). A non-literal (e.g. a variable) is reported separately so a
+    future dynamic action string does not silently pass unchecked — today
+    there are none (verified below).
+    """
+    sites: dict[str, list[str]] = {}
+    dynamic: list[str] = []
+    for path in sorted(_BACKEND_APP.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        rel = f"backend/app/{path.relative_to(_BACKEND_APP).as_posix()}"
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            fname = (
+                func.id
+                if isinstance(func, ast.Name)
+                else (func.attr if isinstance(func, ast.Attribute) else None)
+            )
+            if fname != "AuditEvent":
+                continue
+            for kw in node.keywords:
+                if kw.arg != "action":
+                    continue
+                if isinstance(kw.value, ast.Constant) and isinstance(
+                    kw.value.value, str
+                ):
+                    sites.setdefault(kw.value.value, []).append(rel)
+                else:
+                    dynamic.append(f"{rel}:{node.lineno}")
+    if dynamic:
+        pytest.fail(
+            "AuditEvent(action=...) called with a non-literal value — the "
+            "static registry check cannot verify it. Use a literal string "
+            "(add it to AUDIT_ACTIONS) or update this test to handle the "
+            "dynamic case explicitly:\n" + "\n".join(dynamic)
+        )
+    return sites
+
+
+@pytest.mark.architecture
+def test_every_emitted_action_is_registered() -> None:
+    """Every action= literal passed to AuditEvent(...) is in AUDIT_ACTIONS."""
+    emitted = _find_audit_event_actions()
+    unregistered = {
+        action: files
+        for action, files in emitted.items()
+        if action not in AUDIT_ACTIONS
+    }
+    if unregistered:
+        lines = [
+            f"  {action!r} (emitted from {', '.join(files)})"
+            for action, files in sorted(unregistered.items())
+        ]
+        pytest.fail(
+            "These AuditEvent action strings are not in "
+            "app.modules.audit.actions.AUDIT_ACTIONS. Add each one there in "
+            "the same commit that starts emitting it:\n" + "\n".join(lines)
+        )
+
+
+@pytest.mark.architecture
+def test_registry_has_no_stale_actions() -> None:
+    """Every entry in AUDIT_ACTIONS is actually emitted somewhere.
+
+    Counterpart to test_every_emitted_action_is_registered: keeps the
+    registry from accumulating names nothing writes any more (the same kind
+    of drift #1230 found on the frontend side, just in the other direction).
+    """
+    emitted = set(_find_audit_event_actions())
+    stale = AUDIT_ACTIONS - emitted
+    if stale:
+        pytest.fail(
+            "These AUDIT_ACTIONS entries are not emitted by any "
+            "AuditEvent(action=...) call site in backend/app — remove them "
+            "or fix the emit site:\n" + "\n".join(sorted(stale))
+        )

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -267,6 +267,69 @@ class TestLoginAudit:
             (log["details"] or {}).get("username") == unique_username for log in logs
         )
 
+    async def test_login_deactivated_user_creates_audit_log(
+        self, client: AsyncClient, admin_auth_header: dict
+    ):
+        """fix(#1230 codex r1 P1): denial paths past credential-check are also
+        audited, not just AuthenticationError -- a deactivated account trying
+        to log in is exactly the kind of attempt an operator needs to see.
+        """
+        unique = uuid.uuid4().hex[:8]
+        username = f"deactaudit_{unique}"
+        user_data = await _create_user_via_admin(
+            client, admin_auth_header, username=username, password="TestPass1234!"
+        )
+        resp = await client.post(
+            f"/admin/users/{user_data['id']}/deactivate/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200
+
+        resp = await client.post(
+            "/auth/login",
+            data={"username": username, "password": "TestPass1234!"},
+        )
+        assert resp.status_code == 403
+
+        log_resp = await client.get(
+            "/admin/audit-logs/",
+            params={"action": "user.login.failure", "limit": 200},
+            headers=admin_auth_header,
+        )
+        assert log_resp.status_code == 200
+        logs = log_resp.json()["logs"]
+        entries = [log for log in logs if log["user_id"] == user_data["id"]]
+        assert len(entries) >= 1
+        assert entries[0]["details"]["reason"] == "account_not_active"
+
+    async def test_login_failure_truncates_long_username(
+        self, client: AsyncClient, admin_auth_header: dict
+    ):
+        """fix(#1230 codex r1 P1): OAuth2PasswordRequestForm applies no length
+        limit to username, so a failed login must not persist an unbounded
+        string in details -- bound it to User.username's own width (150).
+        """
+        oversized_username = "x" * 5000
+        resp = await client.post(
+            "/auth/login",
+            data={"username": oversized_username, "password": "anypass123"},
+        )
+        assert resp.status_code == 401
+
+        log_resp = await client.get(
+            "/admin/audit-logs/",
+            params={"action": "user.login.failure", "limit": 200},
+            headers=admin_auth_header,
+        )
+        assert log_resp.status_code == 200
+        logs = log_resp.json()["logs"]
+        matches = [
+            log
+            for log in logs
+            if (log["details"] or {}).get("username", "").startswith("xxxx")
+        ]
+        assert len(matches) >= 1
+        assert len(matches[0]["details"]["username"]) <= 150
+
     async def test_logout_creates_audit_log(
         self, client: AsyncClient, admin_auth_header: dict
     ):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -231,17 +231,25 @@ class TestLoginAudit:
         )
         assert resp.status_code == 401
 
+        # fix(#1230 second-opinion review): scope to rows for OUR attempted
+        # username rather than indexing logs[0] -- under pytest -n concurrent
+        # writes, a sibling test's own login.failure row can otherwise land
+        # "first" in this query's ordering.
         log_resp = await client.get(
             "/admin/audit-logs/",
-            params={"action": "user.login.failure"},
+            params={"action": "user.login.failure", "limit": 200},
             headers=admin_auth_header,
         )
         assert log_resp.status_code == 200
-        data = log_resp.json()
-        assert data["total"] >= 1
-        entry = data["logs"][0]
-        assert entry["user_id"] is None
-        assert "password" not in (entry["details"] or {})
+        matches = [
+            log
+            for log in log_resp.json()["logs"]
+            if (log["details"] or {}).get("username") == ADMIN_USER
+        ]
+        assert len(matches) >= 1
+        for entry in matches:
+            assert entry["user_id"] is None
+            assert "password" not in (entry["details"] or {})
 
     async def test_login_failure_nonexistent_user_creates_audit_log(
         self, client: AsyncClient, admin_auth_header: dict
@@ -300,6 +308,108 @@ class TestLoginAudit:
         entries = [log for log in logs if log["user_id"] == user_data["id"]]
         assert len(entries) >= 1
         assert entries[0]["details"]["reason"] == "account_not_active"
+
+    async def test_login_pending_user_creates_audit_log(
+        self, client: AsyncClient, admin_auth_header: dict, monkeypatch
+    ):
+        """fix(#1230 second-opinion review): the pending_approval denial path
+        had no test coverage -- mirrors test_login_deactivated_user_creates_
+        audit_log for the sibling denial branch.
+        """
+        monkeypatch.setattr(
+            REGISTRATION_ENABLED,
+            "get",
+            AsyncMock(return_value=True),
+        )
+        unique = uuid.uuid4().hex[:8]
+        username = f"pendaudit_{unique}"
+        password = "TestPass1234!"
+        reg_resp = await client.post(
+            "/auth/register/",
+            json={"username": username, "password": password},
+        )
+        assert reg_resp.status_code == 201
+
+        list_resp = await client.get(
+            "/admin/users/?status=pending",
+            headers=admin_auth_header,
+        )
+        assert list_resp.status_code == 200
+        pending_user = next(
+            u for u in list_resp.json()["users"] if u["username"] == username
+        )
+
+        resp = await client.post(
+            "/auth/login",
+            data={"username": username, "password": password},
+        )
+        assert resp.status_code == 403
+
+        log_resp = await client.get(
+            "/admin/audit-logs/",
+            params={"action": "user.login.failure", "limit": 200},
+            headers=admin_auth_header,
+        )
+        assert log_resp.status_code == 200
+        logs = log_resp.json()["logs"]
+        entries = [log for log in logs if log["user_id"] == pending_user["id"]]
+        assert len(entries) >= 1
+        assert entries[0]["details"]["reason"] == "pending_approval"
+
+    async def test_login_disallowed_domain_creates_audit_log(
+        self, client: AsyncClient, admin_auth_header: dict
+    ):
+        """fix(#1230 second-opinion review): the email_domain_not_allowed
+        denial path had no test coverage. Mirrors
+        test_domain_enforcement.py::test_disallowed_domain_login_rejected,
+        with an audit-log assertion added.
+        """
+        unique = uuid.uuid4().hex[:8]
+        username = f"domainaudit_{unique}"
+        password = "TestPass1234!"
+        disallowed_email = f"{username}@evil.example.net"
+        create_resp = await client.post(
+            "/admin/users/",
+            json={
+                "username": username,
+                "password": password,
+                "email": disallowed_email,
+                "role": "viewer",
+            },
+            headers=admin_auth_header,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        user_id = create_resp.json()["id"]
+
+        settings_resp = await client.put(
+            "/settings/",
+            json={"settings": {"allowed_email_domains": ["allowed.example.com"]}},
+            headers=admin_auth_header,
+        )
+        assert settings_resp.status_code == 200
+        try:
+            resp = await client.post(
+                "/auth/login",
+                data={"username": username, "password": password},
+            )
+            assert resp.status_code == 403
+
+            log_resp = await client.get(
+                "/admin/audit-logs/",
+                params={"action": "user.login.failure", "limit": 200},
+                headers=admin_auth_header,
+            )
+            assert log_resp.status_code == 200
+            logs = log_resp.json()["logs"]
+            entries = [log for log in logs if log["user_id"] == user_id]
+            assert len(entries) >= 1
+            assert entries[0]["details"]["reason"] == "email_domain_not_allowed"
+        finally:
+            await client.put(
+                "/settings/",
+                json={"settings": {"allowed_email_domains": []}},
+                headers=admin_auth_header,
+            )
 
     async def test_login_failure_truncates_long_username(
         self, client: AsyncClient, admin_auth_header: dict

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -188,6 +188,107 @@ class TestLogin:
 
 
 # ---------------------------------------------------------------------------
+# Login/logout audit tests (fix #1230)
+# ---------------------------------------------------------------------------
+
+
+class TestLoginAudit:
+    """Password login success/failure and logout were invisible in the audit
+    trail before #1230 -- only the OAuth path emitted login events."""
+
+    async def test_login_success_creates_audit_log(
+        self, client: AsyncClient, admin_auth_header: dict
+    ):
+        """A successful password login writes a user.login.success row."""
+        resp = await client.post(
+            "/auth/login",
+            data={"username": ADMIN_USER, "password": ADMIN_PASS},
+        )
+        assert resp.status_code == 200
+
+        log_resp = await client.get(
+            "/admin/audit-logs/",
+            params={"action": "user.login.success"},
+            headers=admin_auth_header,
+        )
+        assert log_resp.status_code == 200
+        data = log_resp.json()
+        assert data["total"] >= 1
+        assert any(log["username"] == ADMIN_USER for log in data["logs"])
+
+    async def test_login_failure_creates_audit_log(
+        self, client: AsyncClient, admin_auth_header: dict
+    ):
+        """A wrong password writes a user.login.failure row.
+
+        user_id must be None: LocalAuthProvider deliberately does not
+        disclose whether the username exists, and the audit row must not
+        either. The submitted password must never appear in details.
+        """
+        resp = await client.post(
+            "/auth/login",
+            data={"username": ADMIN_USER, "password": "definitely-the-wrong-password"},
+        )
+        assert resp.status_code == 401
+
+        log_resp = await client.get(
+            "/admin/audit-logs/",
+            params={"action": "user.login.failure"},
+            headers=admin_auth_header,
+        )
+        assert log_resp.status_code == 200
+        data = log_resp.json()
+        assert data["total"] >= 1
+        entry = data["logs"][0]
+        assert entry["user_id"] is None
+        assert "password" not in (entry["details"] or {})
+
+    async def test_login_failure_nonexistent_user_creates_audit_log(
+        self, client: AsyncClient, admin_auth_header: dict
+    ):
+        """A login attempt for a username that does not exist is also audited."""
+        unique_username = f"nonexistent_user_audit_{uuid.uuid4().hex[:8]}"
+        resp = await client.post(
+            "/auth/login",
+            data={"username": unique_username, "password": "anypass123"},
+        )
+        assert resp.status_code == 401
+
+        # search filters on action/resource_type/username-of-a-known-user, not
+        # JSONB details, so filter client-side on the attempted username.
+        log_resp = await client.get(
+            "/admin/audit-logs/",
+            params={"action": "user.login.failure", "limit": 200},
+            headers=admin_auth_header,
+        )
+        assert log_resp.status_code == 200
+        logs = log_resp.json()["logs"]
+        assert any(
+            (log["details"] or {}).get("username") == unique_username for log in logs
+        )
+
+    async def test_logout_creates_audit_log(
+        self, client: AsyncClient, admin_auth_header: dict
+    ):
+        """POST /auth/logout writes a user.logout row.
+
+        Logout revokes the token that authorized the call (SEC-S15), so the
+        follow-up admin query needs a freshly minted token.
+        """
+        resp = await client.post("/auth/logout", headers=admin_auth_header)
+        assert resp.status_code == 204
+
+        fresh_headers = await get_auth_header(client, ADMIN_USER, ADMIN_PASS)
+        log_resp = await client.get(
+            "/admin/audit-logs/",
+            params={"action": "user.logout"},
+            headers=fresh_headers,
+        )
+        assert log_resp.status_code == 200
+        assert log_resp.json()["total"] >= 1
+
+
+# ---------------------------------------------------------------------------
 # Token / me tests
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -411,6 +411,52 @@ class TestLoginAudit:
                 headers=admin_auth_header,
             )
 
+    async def test_login_oauth_only_user_creates_audit_log_not_500(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """fix(#1230 codex r10 P1): an OAuth-created user has password_hash=
+        None (oauth/service.py never sets one). Submitting the password form
+        for that username used to hand pwdlib an empty-string "hash" it
+        can't parse, raising UnknownHashError uncaught -- a 500 instead of
+        401, and no user.login.failure row (the router only catches
+        AuthenticationError). Must behave exactly like any other wrong-
+        password attempt: 401 + an audited failure with no user_id.
+        """
+        from app.modules.auth.models import User
+
+        unique = uuid.uuid4().hex[:8]
+        username = f"oauthonly_{unique}"
+        oauth_user = User(
+            username=username,
+            email=f"{username}@example.com",
+            password_hash=None,
+            auth_provider="oauth",
+            status="active",
+            is_active=True,
+        )
+        test_db_session.add(oauth_user)
+        await test_db_session.commit()
+
+        resp = await client.post(
+            "/auth/login",
+            data={"username": username, "password": "whatever-password-123"},
+        )
+        assert resp.status_code == 401, resp.text
+
+        log_resp = await client.get(
+            "/admin/audit-logs/",
+            params={"action": "user.login.failure", "limit": 200},
+            headers=admin_auth_header,
+        )
+        assert log_resp.status_code == 200
+        matches = [
+            log
+            for log in log_resp.json()["logs"]
+            if (log["details"] or {}).get("username") == username
+        ]
+        assert len(matches) >= 1
+        assert matches[0]["user_id"] is None
+
     async def test_login_failure_truncates_long_username(
         self, client: AsyncClient, admin_auth_header: dict
     ):

--- a/backend/tests/test_sso_login_mode.py
+++ b/backend/tests/test_sso_login_mode.py
@@ -172,6 +172,52 @@ class TestPasswordLoginEnabledGate:
             await _delete_provider(test_db_session, provider)
             await test_db_session.commit()
 
+    async def test_non_admin_login_creates_audit_log_when_flag_off(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ) -> None:
+        """fix(#1230 second-opinion review): the password_login_disabled
+        denial path had no test coverage. Mirrors
+        test_non_admin_login_rejected_when_flag_off, with an audit-log
+        assertion added.
+        """
+        username = _unique("sso_audit_viewer")
+        password = "TestPass1234!"
+        create_resp = await client.post(
+            "/admin/users/",
+            json={"username": username, "password": password, "role": "viewer"},
+            headers=admin_auth_header,
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        user_id = create_resp.json()["id"]
+
+        provider = await _make_enabled_oauth_provider(test_db_session)
+        await test_db_session.commit()
+        try:
+            await _set_password_login_enabled(client, admin_auth_header, False)
+            resp = await client.post(
+                "/auth/login",
+                data={"username": username, "password": password},
+            )
+            assert resp.status_code == 403
+
+            log_resp = await client.get(
+                "/admin/audit-logs/",
+                params={"action": "user.login.failure", "limit": 200},
+                headers=admin_auth_header,
+            )
+            assert log_resp.status_code == 200
+            logs = log_resp.json()["logs"]
+            entries = [log for log in logs if log["user_id"] == user_id]
+            assert len(entries) >= 1
+            assert entries[0]["details"]["reason"] == "password_login_disabled"
+        finally:
+            await _reset_password_login_enabled(client, admin_auth_header)
+            await _delete_provider(test_db_session, provider)
+            await test_db_session.commit()
+
     async def test_non_admin_login_succeeds_when_flag_on(
         self, client: AsyncClient, admin_auth_header: dict
     ) -> None:

--- a/frontend/src/components/admin/AuditLogViewer.tsx
+++ b/frontend/src/components/admin/AuditLogViewer.tsx
@@ -56,6 +56,13 @@ const RESOURCE_ROUTES: Record<string, string> = {
 // Canonical action strings currently emitted by audited application paths. Keep
 // the exact stored values visible so operators can correlate filters with API
 // responses and SIEM rules instead of relying on stale display-only aliases.
+//
+// fix(#1230): kept in sync by hand against the backend's authoritative
+// registry (backend/app/modules/audit/actions.py, enforced there by
+// test_audit_action_registry.py) — this array itself is not generated. The
+// four `layer.*` entries removed here (layer.add, layer.remove,
+// layer.reorder, layer.bulk_remove) were ghosts: builder layer edits write
+// to map edit history, not audit_logs, so nothing ever emitted them.
 const CURRENT_AUDIT_ACTIONS = [
   'api_key.create',
   'api_key.revoke',
@@ -69,6 +76,9 @@ const CURRENT_AUDIT_ACTIONS = [
   'collection.update',
   'config_export',
   'config_import',
+  'connector.discover',
+  'connector.ingest_dispatch',
+  'dataset.create',
   'dataset.delete',
   'dataset.download_cog',
   'dataset.export',
@@ -84,14 +94,10 @@ const CURRENT_AUDIT_ACTIONS = [
   'feature.update',
   'job.cleanup_stale',
   'job.retry',
-  'layer.add',
   'layer.add_column',
   'layer.alter_column_type',
-  'layer.bulk_remove',
   'layer.drop_column',
-  'layer.remove',
   'layer.rename_column',
-  'layer.reorder',
   'map.admin_share_revoke',
   'map.add_layer',
   'map.bulk_remove_layers',
@@ -127,6 +133,9 @@ const CURRENT_AUDIT_ACTIONS = [
   'user.deactivate',
   'user.delete',
   'user.export',
+  'user.login.failure',
+  'user.login.success',
+  'user.logout',
   'user.register',
   'user.reject',
   'user.update',

--- a/frontend/src/components/admin/__tests__/CardHeaderPatterns.test.tsx
+++ b/frontend/src/components/admin/__tests__/CardHeaderPatterns.test.tsx
@@ -163,7 +163,9 @@ describe('admin card header patterns', () => {
     expect(screen.getByRole('option', { name: 'audit.export' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'dataset.view' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'user.deactivate' })).toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: 'dataset.create' })).not.toBeInTheDocument();
+    // fix(#1230): dataset.create is now a real emitted action (create_dataset
+    // in service_create.py), so it belongs in the filter options.
+    expect(screen.getByRole('option', { name: 'dataset.create' })).toBeInTheDocument();
   });
 
   it('exposes admin overview card titles as h2s and puts refresh in CardAction', () => {


### PR DESCRIPTION
## Summary

Closes #1230. A 2026-08-05 audit sweep found four gaps in the audit trail:

- **Password login/logout not audited.** Only the OAuth path emitted login events (`oauth.login.success/failure`). The password form (`POST /auth/login`) and `POST /auth/logout` emitted nothing.
- **No `dataset.create` audit action existed anywhere**, despite the frontend (`ChangeHistory.tsx`) already carrying a display label for it.
- **Frontend action registry had drifted from reality.** `CURRENT_AUDIT_ACTIONS` in `AuditLogViewer.tsx` listed `layer.add`, `layer.remove`, `layer.reorder`, `layer.bulk_remove` — never written to `audit_logs` (builder layer edits go to map edit history instead) — and was missing `connector.discover` / `connector.ingest_dispatch`, which are real emit sites. There was no backend registry to check emit sites against at all.
- **No retention guidance** for `audit_logs`, which the router's own docstring already flags as reaching millions of rows.

## Changes

- `backend/app/modules/auth/router.py`: `POST /auth/login` now emits `user.login.success` on success and `user.login.failure` on bad credentials (no `user_id`, since `LocalAuthProvider` deliberately doesn't disclose whether a username exists; never logs the password). `POST /auth/logout` emits `user.logout`.
- `backend/app/modules/catalog/datasets/domain/service_create.py`: `create_dataset()` — the single function every dataset-creation path (ingest registration via `register_existing_table`, file-upload ingest via `tasks_common.py`, layer/table creation, the empty-dataset endpoint) funnels through — now emits `dataset.create`. One emit site instead of duplicating (and risking missing) the call at each router.
- `backend/app/modules/audit/actions.py` (new): canonical `AUDIT_ACTIONS` registry of every `AuditEvent.action` string literal actually emitted.
- `backend/tests/test_audit_action_registry.py` (new): AST-walks `backend/app` and fails if any `AuditEvent(action=...)` literal isn't registered, or if a registry entry is never emitted (both directions of drift).
- `frontend/src/components/admin/AuditLogViewer.tsx`: `CURRENT_AUDIT_ACTIONS` resynced by hand against the backend registry — the four `layer.*` ghosts removed, `connector.discover`, `connector.ingest_dispatch`, `dataset.create`, `user.login.success`, `user.login.failure`, `user.logout` added.
- `RUNBOOK.md`: new "Audit log retention" section — archive-then-delete SQL by age, batched delete to avoid long-held locks on a multi-million-row table. No in-app pruning endpoint: that's a new destructive-write surface (Rule 1 of AGENTS.md's Security pre-commit checklist) this issue didn't ask for; a documented manual SQL window is the smaller surface for a table whose whole purpose is being an audit trail.

## Schema / API / config impact

None. No migration — retention is operator SQL, not a new column or job. No new endpoints.

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- `uv run pytest` (full suite, host Postgres) — 7236 passed, 89 skipped, 0 failed
- `uv run pytest tests/test_layering.py -q` — 40 passed, no module cap changes needed (both touched files stayed well under their existing budgets)
- `uv run pytest tests/test_audit_action_registry.py tests/test_auth.py tests/test_audit.py -v` — new + updated tests pass
- `cd frontend && npm run build && npm run lint && npm run typecheck && npm run test:i18n && npm run test:coverage` — all clean (379 test files / 4656 tests passed)
- No migration added, so `make alembic-check` not applicable
- No Playwright run from this worktree (per AGENTS.md — the dev stack bind-mounts `main`, so worktree e2e results are meaningless)

## New regression tests

- `test_login_success_creates_audit_log`, `test_login_failure_creates_audit_log`, `test_login_failure_nonexistent_user_creates_audit_log`, `test_logout_creates_audit_log` (`backend/tests/test_auth.py`)
- `test_create_empty_dataset_creates_audit_log` (`backend/tests/test_audit.py`)
- `test_every_emitted_action_is_registered`, `test_registry_has_no_stale_actions` (`backend/tests/test_audit_action_registry.py`)
- `CardHeaderPatterns.test.tsx` updated: `dataset.create` now asserted present (was asserted absent) since it's a real emitted action.

https://claude.ai/code/session_01K1A5BGEoqmnS8X6D5s4UuL

## Suggested follow-up (not in this PR's scope)

Codex review found real bugs in the RUNBOOK retention section across three
consecutive rounds (archive/delete cutoff drift, tenant scoping, NULL-cast
handling, `DO $$...$$` variable substitution, per-tenant filename collisions,
CSV newline-unsafe row counting) — all fixed inline, but the pattern itself
is a signal. ~190 lines of prose bash+psql for a multi-step archive/verify/
delete procedure is exactly the shape that keeps producing this class of bug
one case at a time. Worth a follow-up issue to turn it into a tested script
(`scripts/` or similar) rather than continuing to patch prose.
