### PR TITLE
fix(observability): adopt prometheus multiprocess mode for multi-worker /metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,6 +264,18 @@ GEOLENS_ADMIN_PASSWORD=
 # Type: integer (minimum 1) or empty | Default: 10000 (prod compose)
 # UVICORN_MAX_REQUESTS=10000
 
+# fix(#1240, #651): prometheus_client multiprocess mode for the api service.
+# With UVICORN_WORKERS>=2 each worker used to answer /metrics from its own
+# local registry, so successive scrapes alternated between per-process values
+# and Prometheus read every downward step as a counter reset. Adopting
+# multiprocess mode fixes that. Must be a directory writable by the api
+# container's runtime user and shared by every worker of that ONE container
+# (a subdirectory of the api service's tmpfs /tmp mount, per the compose
+# files, satisfies both). Applies to the api service only; the worker
+# service's separate /metrics endpoint (port 8001) stays single-process.
+# Type: string (directory path) | Default: /tmp/prometheus-multiproc
+# PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus-multiproc
+
 # --- Configuration Lockdown ---
 # [OPTIONAL] When true, all admin-overridable settings are locked to their
 # environment values. The PersistentConfig DB layer is bypassed for reads and

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -653,7 +653,13 @@ happily (and wrongly) accept.
 ### Metrics & alerting (Prometheus / Grafana)
 
 Metrics are exposed on **two separate endpoints** — the API and the worker each
-run their own:
+run their own. The api service (only) runs multiple uvicorn workers in
+production and is scraped correctly under that fan-out because
+`docker-compose.yml`/`docker-compose.prod.yml` set `PROMETHEUS_MULTIPROC_DIR`
+for it by default (fix #1240 / #651); a bespoke deployment that runs the api
+image outside these compose files with `UVICORN_WORKERS>1` needs to set that
+same env var to a writable, container-local directory or every scrape reverts
+to seeing one arbitrary worker.
 
 | Source | On the Compose network | Host mapping | Exports |
 |---|---|---|---|
@@ -700,14 +706,16 @@ targets just need network reach to `api:8000` and `worker:8001`.
 
 Each API worker samples its own RSS from `/proc/self/status` every 60 seconds
 and exports it as the Prometheus gauge `geolens_worker_rss_bytes` (labelled by
-`pid`) on the API `/metrics` endpoint. One caveat when running more than one
-worker: each process has its own metrics registry and a scrape is answered by
-whichever worker takes it, so a single scrape reports one worker's gauge and
-successive scrapes may alternate pid series — or keep reaching the same worker
-and never observe the one that is growing (multiprocess aggregation is tracked
-in #651). The structured log lines the same sampler writes are therefore the
-authoritative per-worker signal, and a growth curve exists in
-`docker compose logs api` even if `/metrics` is never scraped:
+`pid`) on the API `/metrics` endpoint. The api service runs in
+`prometheus_client` multiprocess mode (`PROMETHEUS_MULTIPROC_DIR`, fix #1240 /
+#651): every live worker's gauge is present in a single scrape, and HTTP
+request counters/histograms sum across workers instead of alternating between
+per-process values. Before this fix, a scrape only ever saw one worker, so
+successive scrapes could sawtooth between unrelated running totals and
+Prometheus read the downward steps as counter resets. The structured log
+lines the RSS sampler writes remain useful as a secondary signal independent
+of scraping — a growth curve exists in `docker compose logs api` even if
+`/metrics` is never scraped:
 
 | Log message | Level | Meaning |
 |---|---|---|

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -23,7 +23,11 @@ from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.api.router import api_router
-from app.observability.metrics import init_metrics, shutdown_worker_metrics
+from app.observability.metrics import (
+    init_metrics,
+    shutdown_worker_metrics,
+    sweep_dead_worker_metrics,
+)
 from app.platform.cache.provider import init_tile_cache
 
 # settings already imported above for the tempdir override — do NOT reimport
@@ -332,6 +336,10 @@ async def lifespan(app: FastAPI):
     # fix(#643): per-worker RSS gauge + log watermark so an OOM-bound worker
     # is visible in normal logs before the kernel kills it.
     memory_metrics_task = asyncio.create_task(update_memory_metrics())
+    # fix(#1240, #651 review round 2): reap gauge_live*.db files left by a
+    # sibling worker that was OOM-killed/SIGKILLed rather than shut down
+    # gracefully -- shutdown_worker_metrics() below never runs for that case.
+    metrics_sweep_task = asyncio.create_task(sweep_dead_worker_metrics())
 
     async def _stale_jobs_sweeper() -> None:
         """Periodically fail jobs whose worker crashed mid-run.
@@ -410,6 +418,7 @@ async def lifespan(app: FastAPI):
 
     pool_metrics_task.cancel()
     memory_metrics_task.cancel()
+    metrics_sweep_task.cancel()
     stale_jobs_task.cancel()
     rate_limit_warmer_task.cancel()
     await task_app.close_async()

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -23,7 +23,7 @@ from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.api.router import api_router
-from app.observability.metrics import init_metrics
+from app.observability.metrics import init_metrics, shutdown_worker_metrics
 from app.platform.cache.provider import init_tile_cache
 
 # settings already imported above for the tempdir override — do NOT reimport
@@ -416,6 +416,10 @@ async def lifespan(app: FastAPI):
     await close_tile_pool()
     await _titiler_client.aclose()
     await engine.dispose()
+    # fix(#1240, #651): drop this worker's multiprocess metric files so a
+    # respawn under UVICORN_MAX_REQUESTS recycling doesn't leave a stale
+    # series behind for the next scrape to keep summing.
+    shutdown_worker_metrics()
 
 
 _DESCRIPTION = """\

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -11,7 +11,12 @@ needs no multiprocess-specific code: prometheus_fastapi_instrumentator's
 `expose()` already serves a fresh CollectorRegistry wrapped by
 multiprocess.MultiProcessCollector whenever PROMETHEUS_MULTIPROC_DIR is set
 (see its `metrics()` closure), and falls back to the plain default registry
-otherwise -- so this stays a no-op for the dev single-worker default.
+otherwise. Both docker-compose.yml and docker-compose.prod.yml set
+PROMETHEUS_MULTIPROC_DIR for the api service by default, so multiprocess mode
+is active in dev too, not just prod -- deliberately, so bumping
+UVICORN_WORKERS locally to reproduce #651 (per its own verification recipe)
+needs no extra env wiring. It works correctly at UVICORN_WORKERS=1: there is
+just one process's files for MultiProcessCollector to merge.
 """
 
 import asyncio
@@ -46,8 +51,11 @@ def shutdown_worker_metrics() -> None:
     exits and is respawned mid-lifetime, not just at container shutdown.
     Without this, the exited worker's mmap files linger under
     PROMETHEUS_MULTIPROC_DIR and keep being summed into every future scrape
-    as a stale series. No-op when multiprocess mode isn't active (e.g. the
-    dev single-worker default has no PROMETHEUS_MULTIPROC_DIR set).
+    as a stale series. No-op when multiprocess mode isn't active -- both
+    compose files set PROMETHEUS_MULTIPROC_DIR by default (dev included), so
+    this is live in normal local development too; it only stays unset for a
+    bespoke deployment that runs the api image directly, outside these
+    compose files, without setting the var itself.
 
     This only runs on a graceful lifespan shutdown -- see
     sweep_dead_worker_metrics() for the OOM-kill/SIGKILL case, where this

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -283,16 +283,17 @@ def _consolidate_dead_cumulative_metric_files() -> None:
     _dead_worker_pids(), not a correctness bug in the common case of a
     graceful sweep pass.
 
-    Uses a blocking fcntl.flock() (unlike the scrape middleware's
-    non-blocking poll loop): this function already does several other
-    blocking syscalls in a row (glob, rename, mmap I/O) with no
-    run_in_executor wrapper, so it already blocks this worker's event loop
-    for its (brief, ~milliseconds) duration regardless: adding one more
-    blocking wait to that existing pattern doesn't change its character.
-    The scrape middleware is different -- it wraps every /metrics response
-    on the request-handling path, where blocking the event loop would add
-    latency to every OTHER concurrent request this worker is serving, not
-    just metrics scrapes -- so that side has to poll instead.
+    Uses a blocking fcntl.flock() internally (unlike the scrape middleware's
+    non-blocking poll loop) -- this is safe ONLY because the sole caller,
+    sweep_dead_worker_metrics(), always invokes this whole function via
+    asyncio.to_thread(), off the event loop thread entirely (fix(#1240,
+    #651 review round 8): a blocking LOCK_EX here that ran directly on the
+    event loop could deadlock against this worker's own /metrics scrape
+    middleware, which holds a shared lock via a DIFFERENT file descriptor
+    on the same lock file while awaiting a thread-pool-dispatched handler --
+    see sweep_dead_worker_metrics()'s docstring for the full mechanism). Do
+    not call this function directly from a coroutine running on a worker's
+    event loop; always go through the to_thread()-wrapped caller.
     """
     multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
     if not multiproc_dir:
@@ -378,10 +379,31 @@ async def sweep_dead_worker_metrics() -> None:
     both the gauge reap and the counter/histogram/summary consolidation are
     idempotent/self-excluding once a dead pid's files are gone, so a race
     between two workers sweeping the same dead pid is harmless.
+
+    fix(#1240, #651 review round 8): _sweep_dead_worker_metrics_once() runs
+    in a thread-pool executor (asyncio.to_thread), NOT directly on this
+    coroutine's event loop. flock() locks are per OPEN FILE DESCRIPTION, not
+    per-process -- if this worker's OWN /metrics scrape middleware is
+    concurrently holding the shared (reader) lock via its own fd while
+    awaiting call_next() (which dispatches the instrumentator's sync
+    handler to a thread pool and yields control back to this same event
+    loop), and this sweep then called fcntl.flock(LOCK_EX) directly, that
+    blocking syscall would run ON the event loop thread. The lock can only
+    become available once the middleware's call_next() completes and its
+    finally-block releases the shared lock -- but that completion has to be
+    delivered back to the loop via a callback, and the loop thread is the
+    one now frozen inside the kernel waiting for the exclusive lock. Same
+    process, two different file descriptors on the same lock file, real
+    deadlock: this worker would stop answering ANY request (not just
+    /metrics) until forcibly killed, invisibly to the uvicorn supervisor.
+    to_thread() moves the entire blocking pass (including its flock calls)
+    onto a separate OS thread, so even if that thread blocks waiting for
+    the scrape's shared lock to release, the event loop thread stays free
+    to run the scrape's call_next() continuation and its unlock.
     """
     while True:
         try:
-            _sweep_dead_worker_metrics_once()
+            await asyncio.to_thread(_sweep_dead_worker_metrics_once)
         except Exception:  # broad: sweep is non-fatal; must not crash the loop
             logger.warning("Failed to sweep dead worker metrics", exc_info=True)
         await asyncio.sleep(_SWEEP_INTERVAL_SECONDS)

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -25,7 +25,7 @@ import os
 from collections.abc import Iterator
 
 import structlog
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 
 from .instrumentator import create_instrumentator
 
@@ -35,12 +35,74 @@ logger = structlog.stdlib.get_logger(__name__)
 # by a sibling that died without running its own shutdown hook.
 _SWEEP_INTERVAL_SECONDS = 60
 
+# fix(#1240, #651 review round 6): must match the endpoint create_instrumentator()
+# + instrumentator.expose() below actually serve (its default, unoverridden).
+_METRICS_ENDPOINT_PATH = "/metrics"
+
+# How long the scrape-side non-blocking lock poll waits between attempts.
+# The sweep's exclusive hold is brief (a handful of file operations every
+# 60s), so contention is rare and short-lived.
+_SCRAPE_LOCK_POLL_SECONDS = 0.005
+
+
+def _sweep_lock_path(multiproc_dir: str) -> str:
+    """Path to the reader/writer lock file guarding PROMETHEUS_MULTIPROC_DIR
+    against concurrent scrape-vs-sweep file mutation. See
+    _consolidate_dead_counter_and_histogram_files() (writer/exclusive side)
+    and the metrics-scrape middleware wired up in init_metrics() (reader/
+    shared side) for fix(#1240, #651 review round 6).
+    """
+    return os.path.join(multiproc_dir, "sweep.lock")
+
 
 def init_metrics(app: FastAPI):
     """Instrument the FastAPI app and expose /metrics endpoint."""
     instrumentator = create_instrumentator()
     instrumentator.instrument(app)
     instrumentator.expose(app, include_in_schema=False, should_gzip=True)
+
+    @app.middleware("http")
+    async def _hold_scrape_lock_during_metrics_response(request: Request, call_next):
+        """Hold a shared (reader) lock on PROMETHEUS_MULTIPROC_DIR for the
+        duration of a /metrics scrape, so the consolidation sweep's exclusive
+        (writer) lock can never rename a counter_*.db/histogram_*.db out from
+        under a scrape that has already globbed it.
+
+        fix(#1240, #651 review round 6): MultiProcessCollector.collect()
+        globs "*.db" and then opens each matched path one by one. It only
+        tolerates a path disappearing between those two steps for
+        gauge_live*.db files (prometheus_client's own code has an explicit
+        except-continue for exactly that case, because mark_process_dead()
+        is expected to race a scrape); for counter_*.db/histogram_*.db it
+        re-raises FileNotFoundError, which without this lock would surface
+        as an intermittent 500 from /metrics whenever the 60s sweep's
+        os.rename() lands mid-scrape. Excluded from instrumentation
+        (excluded_handlers=["/metrics", ...] in instrumentator.py) so this
+        lock wait itself is never measured as request latency.
+
+        Uses a non-blocking flock() in a poll loop (not a blocking flock()
+        call) so a brief wait for the sweep's exclusive hold never blocks
+        this worker's asyncio event loop -- fcntl.flock is not
+        awaitable/async-aware.
+        """
+        multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+        if request.url.path != _METRICS_ENDPOINT_PATH or not multiproc_dir:
+            return await call_next(request)
+
+        import fcntl
+
+        with open(_sweep_lock_path(multiproc_dir), "a+b") as lock_file:
+            while True:
+                try:
+                    fcntl.flock(lock_file, fcntl.LOCK_SH | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    await asyncio.sleep(_SCRAPE_LOCK_POLL_SECONDS)
+            try:
+                return await call_next(request)
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+
     return instrumentator
 
 
@@ -163,38 +225,53 @@ def _consolidate_dead_counter_and_histogram_files() -> None:
     scraped total is unchanged, but file count stays O(live workers + 2)
     instead of growing with every worker ever recycled.
 
-    Races itself safely across workers in TWO separate steps, because a
-    single mutex can't cover both a per-source-file claim and a shared
-    archive write:
+    Races itself safely against BOTH sibling sweeps AND in-flight scrapes,
+    using the same reader/writer lock file as the /metrics scrape middleware
+    in init_metrics() (see _sweep_lock_path()): this whole function -- every
+    prefix's claim (os.rename()) and merge -- runs under ONE exclusive
+    (writer) hold of that lock, acquired once at the top and released at the
+    end. Two things this closes that a narrower lock wouldn't:
 
-    1. Claiming a dead pid's source file: os.rename() to a private,
-       non-globbed name first -- POSIX rename is atomic, so only one
-       worker's rename can succeed; the other gets FileNotFoundError on its
-       own rename attempt and moves on. This alone guarantees a given dead
-       pid's file is read by exactly one worker, but does NOT protect the
-       archive file itself -- two workers can each successfully claim a
-       DIFFERENT dead pid's file in the same pass and then both try to fold
-       their value into the SAME "<type>_archived.db" at once. Without
-       further synchronization that's a lost-update race (read, add, write
-       is not atomic across processes): whichever worker's write lands last
-       overwrites the other's, permanently under-counting the archive
-       (fix(#1240, #651 review round 5)).
-    2. Folding a claimed file into the archive: guarded by an exclusive
-       fcntl.flock() on a dedicated "<type>_archived.db.lock" file (not the
-       archive .db file itself, so the lock is independent of MmapedDict's
-       own open/mmap lifecycle). The lock is held for this worker's entire
-       claim-and-merge pass over ALL dead pid files for that metric type, so
-       the read-modify-write of every key is fully serialized against every
-       other worker. flock is released automatically by the kernel if this
-       process dies while holding it, so a crash here can't deadlock a
-       sibling worker's next sweep.
+    - fix(#1240, #651 review round 5): two workers each successfully
+      claiming a DIFFERENT dead pid's file in the same pass and then both
+      folding their value into the SAME "<type>_archived.db" at once is a
+      lost-update race (read, add, write is not atomic across processes) --
+      whichever worker's write lands last overwrites the other's,
+      permanently under-counting the archive. A per-prefix archive-only lock
+      (this function's first version) closed this by itself, but round 6
+      below needed a wider hold anyway, so it now covers this case too.
+    - fix(#1240, #651 review round 6): MultiProcessCollector.collect() globs
+      "*.db" and then opens each matched path one by one; it only tolerates
+      a path disappearing between those two steps for gauge_live*.db files
+      (prometheus_client's own code has an explicit except-continue there,
+      because mark_process_dead() is expected to race a scrape). For
+      counter_*.db/histogram_*.db it re-raises FileNotFoundError, so this
+      function's own os.rename() claim step -- if it ran unsynchronized --
+      could make a scrape that already globbed a dead pid's file 500 when it
+      tries to open the now-renamed-away path. Holding the SAME lock the
+      scrape middleware takes (shared/reader) as exclusive/writer here means
+      no rename can land while any scrape is in flight, and no scrape can
+      start reading while a rename is in flight.
 
-    If this process is killed after claiming (step 1) but before merging
-    (step 2) completes, the renamed file is orphaned (invisible to both
-    future scrapes and future sweeps) -- an accepted, documented residual
-    risk of the same shape as the pid-reuse limitation in
+    flock is released automatically by the kernel if this process dies while
+    holding it, so a crash mid-sweep can't deadlock a sibling worker's next
+    sweep or wedge /metrics shut. If this process is killed after claiming a
+    file but before merging it, the renamed file is orphaned (invisible to
+    both future scrapes and future sweeps) -- an accepted, documented
+    residual risk of the same shape as the pid-reuse limitation in
     _dead_worker_pids(), not a correctness bug in the common case of a
     graceful sweep pass.
+
+    Uses a blocking fcntl.flock() (unlike the scrape middleware's
+    non-blocking poll loop): this function already does several other
+    blocking syscalls in a row (glob, rename, mmap I/O) with no
+    run_in_executor wrapper, so it already blocks this worker's event loop
+    for its (brief, ~milliseconds) duration regardless: adding one more
+    blocking wait to that existing pattern doesn't change its character.
+    The scrape middleware is different -- it wraps every /metrics response
+    on the request-handling path, where blocking the event loop would add
+    latency to every OTHER concurrent request this worker is serving, not
+    just metrics scrapes -- so that side has to poll instead.
     """
     multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
     if not multiproc_dir:
@@ -203,24 +280,25 @@ def _consolidate_dead_counter_and_histogram_files() -> None:
 
     from prometheus_client.mmap_dict import MmapedDict
 
-    for prefix in ("counter", "histogram"):
-        claimed_paths = []
-        for _pid, path in _iter_dead_pid_files(prefix, multiproc_dir):
-            claimed_path = f"{path}.claimed"
-            try:
-                os.rename(path, claimed_path)
-            except FileNotFoundError:
-                continue  # another worker's sweep already claimed this one
-            claimed_paths.append(claimed_path)
+    with open(_sweep_lock_path(multiproc_dir), "a+b") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            for prefix in ("counter", "histogram"):
+                claimed_paths = []
+                for _pid, path in _iter_dead_pid_files(prefix, multiproc_dir):
+                    claimed_path = f"{path}.claimed"
+                    try:
+                        os.rename(path, claimed_path)
+                    except FileNotFoundError:
+                        continue  # another worker's sweep already claimed this
+                    claimed_paths.append(claimed_path)
 
-        if not claimed_paths:
-            continue
+                if not claimed_paths:
+                    continue
 
-        archive_path = os.path.join(multiproc_dir, f"{prefix}_{_ARCHIVE_SUFFIX}.db")
-        lock_path = f"{archive_path}.lock"
-        with open(lock_path, "a+b") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
-            try:
+                archive_path = os.path.join(
+                    multiproc_dir, f"{prefix}_{_ARCHIVE_SUFFIX}.db"
+                )
                 archive = MmapedDict(archive_path)
                 try:
                     for claimed_path in claimed_paths:
@@ -239,8 +317,8 @@ def _consolidate_dead_counter_and_histogram_files() -> None:
                         os.remove(claimed_path)
                 finally:
                     archive.close()
-            finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
 def _sweep_dead_worker_metrics_once() -> None:

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -48,7 +48,7 @@ _SCRAPE_LOCK_POLL_SECONDS = 0.005
 def _sweep_lock_path(multiproc_dir: str) -> str:
     """Path to the reader/writer lock file guarding PROMETHEUS_MULTIPROC_DIR
     against concurrent scrape-vs-sweep file mutation. See
-    _consolidate_dead_counter_and_histogram_files() (writer/exclusive side)
+    _consolidate_dead_cumulative_metric_files() (writer/exclusive side)
     and the metrics-scrape middleware wired up in init_metrics() (reader/
     shared side) for fix(#1240, #651 review round 6).
     """
@@ -65,15 +65,16 @@ def init_metrics(app: FastAPI):
     async def _hold_scrape_lock_during_metrics_response(request: Request, call_next):
         """Hold a shared (reader) lock on PROMETHEUS_MULTIPROC_DIR for the
         duration of a /metrics scrape, so the consolidation sweep's exclusive
-        (writer) lock can never rename a counter_*.db/histogram_*.db out from
-        under a scrape that has already globbed it.
+        (writer) lock can never rename a counter_*.db/histogram_*.db/
+        summary_*.db out from under a scrape that has already globbed it.
 
         fix(#1240, #651 review round 6): MultiProcessCollector.collect()
         globs "*.db" and then opens each matched path one by one. It only
         tolerates a path disappearing between those two steps for
         gauge_live*.db files (prometheus_client's own code has an explicit
         except-continue for exactly that case, because mark_process_dead()
-        is expected to race a scrape); for counter_*.db/histogram_*.db it
+        is expected to race a scrape); for the cumulative types (counter,
+        histogram, summary -- fix #1240, #651 review round 7) it
         re-raises FileNotFoundError, which without this lock would surface
         as an intermittent 500 from /metrics whenever the 60s sweep's
         os.rename() lands mid-scrape. Excluded from instrumentation
@@ -165,7 +166,7 @@ def _dead_worker_pids() -> Iterator[int]:
 
 def _iter_dead_pid_files(prefix: str, multiproc_dir: str) -> Iterator[tuple[int, str]]:
     """Yield (pid, path) for prefix_<pid>.db files whose pid is no longer
-    running. Used for counter/histogram files, which are named
+    running. Used for counter/histogram/summary files, which are named
     "<type>_<pid>.db" with no mode segment (unlike gauge's
     "gauge_<mode>_<pid>.db") -- see _dead_worker_pids() for that one.
     """
@@ -194,21 +195,40 @@ def _iter_dead_pid_files(prefix: str, multiproc_dir: str) -> Iterator[tuple[int,
 _ARCHIVE_SUFFIX = "archived"
 
 
-def _consolidate_dead_counter_and_histogram_files() -> None:
-    """Fold dead workers' counter/histogram files into one running total per
-    metric type, instead of leaving them to accumulate forever.
+def _consolidate_dead_cumulative_metric_files() -> None:
+    """Fold dead workers' counter/histogram/summary files into one running
+    total per metric type, instead of leaving them to accumulate forever.
 
     mark_process_dead() (used by shutdown_worker_metrics() and the gauge
     reap above) deliberately never touches counter_<pid>.db /
-    histogram_<pid>.db -- unlike a gauge, a Counter/Histogram's stored value
-    is a cumulative total that the collector sums across every pid's file on
-    every scrape, so simply deleting a dead pid's file would silently
-    subtract its contribution and produce a downward step (a fabricated
-    counter "decrease" -- exactly the sawtooth bug #1240 exists to fix).
-    Under the prod default UVICORN_MAX_REQUESTS=10000, a long-running
-    container recycles workers indefinitely, so those files would otherwise
-    accumulate without bound, one per departed worker, and every scrape has
-    to open and sum all of them.
+    histogram_<pid>.db / summary_<pid>.db -- unlike a gauge, these three
+    types' stored values are cumulative totals the collector sums across
+    every pid's file on every scrape, so simply deleting a dead pid's file
+    would silently subtract its contribution and produce a downward step (a
+    fabricated counter "decrease" -- exactly the sawtooth bug #1240 exists
+    to fix). Under the prod default UVICORN_MAX_REQUESTS=10000, a
+    long-running container recycles workers indefinitely, so those files
+    would otherwise accumulate without bound, one per departed worker, and
+    every scrape has to open and sum all of them.
+
+    fix(#1240, #651 review round 7): summary_<pid>.db is not optional to
+    cover -- prometheus_fastapi_instrumentator's default instrumentation
+    creates two Summary metrics (http_request_size_bytes,
+    http_response_size_bytes) alongside the Counter/Histogram ones, so every
+    recycled worker leaves one of these behind too. MultiProcessCollector's
+    own _accumulate_metrics() sums a Summary's raw (name, labels) samples
+    the same way it sums a Counter's -- plain addition, no bucket-style
+    reconstruction like a histogram's "le" boundaries need -- so a Summary
+    file's raw (key, value, timestamp) triples fold into its archive with
+    the exact same additive read-modify-write this function already does
+    for counter/histogram; no separate merge math is needed, just adding
+    "summary" to the prefixes iterated below. Verified empirically (not
+    just reasoned about) before this landed: prometheus_client's own
+    MmapedValue file-naming code confirms summary_<pid>.db has no mode
+    segment (same convention as counter/histogram, unlike gauge's
+    gauge_<mode>_<pid>.db), and a scratch script round-tripped a Summary's
+    _count/_sum through this exact consolidation path with the total
+    unchanged before the fix was written into this function.
 
     Folds each dead pid's file additively into a single "<type>_archived.db"
     file instead: read every (key, value, timestamp) triple straight out of
@@ -218,12 +238,12 @@ def _consolidate_dead_counter_and_histogram_files() -> None:
     points to for exactly this "write merged data back to mmap files" case),
     add it to whatever total is already stored under that same key in the
     archive file, and delete the source. The archive file is just another
-    counter_*.db/histogram_*.db file as far as MultiProcessCollector.collect()
-    is concerned (it globs "*.db" and only inspects the "counter"/"histogram"
-    prefix, not the pid segment), so it keeps contributing to the summed
-    total exactly as the dead files it absorbed would have. Net effect: the
-    scraped total is unchanged, but file count stays O(live workers + 2)
-    instead of growing with every worker ever recycled.
+    counter_*.db/histogram_*.db/summary_*.db file as far as
+    MultiProcessCollector.collect() is concerned (it globs "*.db" and only
+    inspects the type prefix, not the pid segment), so it keeps contributing
+    to the summed total exactly as the dead files it absorbed would have.
+    Net effect: the scraped total is unchanged, but file count stays
+    O(live workers + 3) instead of growing with every worker ever recycled.
 
     Races itself safely against BOTH sibling sweeps AND in-flight scrapes,
     using the same reader/writer lock file as the /metrics scrape middleware
@@ -244,11 +264,12 @@ def _consolidate_dead_counter_and_histogram_files() -> None:
       "*.db" and then opens each matched path one by one; it only tolerates
       a path disappearing between those two steps for gauge_live*.db files
       (prometheus_client's own code has an explicit except-continue there,
-      because mark_process_dead() is expected to race a scrape). For
-      counter_*.db/histogram_*.db it re-raises FileNotFoundError, so this
-      function's own os.rename() claim step -- if it ran unsynchronized --
-      could make a scrape that already globbed a dead pid's file 500 when it
-      tries to open the now-renamed-away path. Holding the SAME lock the
+      because mark_process_dead() is expected to race a scrape). For the
+      cumulative types (counter_*.db/histogram_*.db/summary_*.db) it
+      re-raises FileNotFoundError, so this function's own os.rename() claim
+      step -- if it ran unsynchronized -- could make a scrape that already
+      globbed a dead pid's file 500 when it tries to open the
+      now-renamed-away path. Holding the SAME lock the
       scrape middleware takes (shared/reader) as exclusive/writer here means
       no rename can land while any scrape is in flight, and no scrape can
       start reading while a rename is in flight.
@@ -283,7 +304,7 @@ def _consolidate_dead_counter_and_histogram_files() -> None:
     with open(_sweep_lock_path(multiproc_dir), "a+b") as lock_file:
         fcntl.flock(lock_file, fcntl.LOCK_EX)
         try:
-            for prefix in ("counter", "histogram"):
+            for prefix in ("counter", "histogram", "summary"):
                 claimed_paths = []
                 for _pid, path in _iter_dead_pid_files(prefix, multiproc_dir):
                     claimed_path = f"{path}.claimed"
@@ -329,7 +350,7 @@ def _sweep_dead_worker_metrics_once() -> None:
 
     for pid in _dead_worker_pids():
         multiprocess.mark_process_dead(pid)
-    _consolidate_dead_counter_and_histogram_files()
+    _consolidate_dead_cumulative_metric_files()
 
 
 async def sweep_dead_worker_metrics() -> None:
@@ -346,14 +367,15 @@ async def sweep_dead_worker_metrics() -> None:
     fix(#1240, #651 review round 4): under the prod default
     UVICORN_MAX_REQUESTS=10000, a long-running container recycles workers
     indefinitely, and mark_process_dead() intentionally never removes a dead
-    worker's counter_<pid>.db / histogram_<pid>.db (their cumulative values
-    still need to count toward the total). Left alone those files grow
-    without bound -- see _consolidate_dead_counter_and_histogram_files() for
+    worker's counter_<pid>.db / histogram_<pid>.db / summary_<pid>.db (their
+    cumulative values still need to count toward the total; fix(#1240, #651
+    review round 7) added the summary case). Left alone those files grow
+    without bound -- see _consolidate_dead_cumulative_metric_files() for
     how they get folded into one running archive file per metric type
     instead.
 
     No-op when multiprocess mode isn't active. Safe to run in every worker:
-    both the gauge reap and the counter/histogram consolidation are
+    both the gauge reap and the counter/histogram/summary consolidation are
     idempotent/self-excluding once a dead pid's files are gone, so a race
     between two workers sweeping the same dead pid is harmless.
     """

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -1,7 +1,20 @@
 """Prometheus metrics module for GeoLens.
 
 Provides HTTP request instrumentation, job queue gauges, and connection pool gauges.
+
+fix(#1240, #651): under UVICORN_WORKERS>=2 (the prod compose default), each
+worker used to answer /metrics from its own local prometheus_client registry,
+so successive scrapes sawtoothed between per-process values and Prometheus
+read every downward step as a counter reset -- fabricating rate() traffic and
+collapsing latency averages to a worker's lifetime mean. `init_metrics` itself
+needs no multiprocess-specific code: prometheus_fastapi_instrumentator's
+`expose()` already serves a fresh CollectorRegistry wrapped by
+multiprocess.MultiProcessCollector whenever PROMETHEUS_MULTIPROC_DIR is set
+(see its `metrics()` closure), and falls back to the plain default registry
+otherwise -- so this stays a no-op for the dev single-worker default.
 """
+
+import os
 
 from fastapi import FastAPI
 
@@ -14,3 +27,20 @@ def init_metrics(app: FastAPI):
     instrumentator.instrument(app)
     instrumentator.expose(app, include_in_schema=False, should_gzip=True)
     return instrumentator
+
+
+def shutdown_worker_metrics() -> None:
+    """Mark this worker process's multiprocess metric files dead.
+
+    fix(#1240, #651): under UVICORN_MAX_REQUESTS recycling (#643) a worker
+    exits and is respawned mid-lifetime, not just at container shutdown.
+    Without this, the exited worker's mmap files linger under
+    PROMETHEUS_MULTIPROC_DIR and keep being summed into every future scrape
+    as a stale series. No-op when multiprocess mode isn't active (e.g. the
+    dev single-worker default has no PROMETHEUS_MULTIPROC_DIR set).
+    """
+    if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
+        return
+    from prometheus_client import multiprocess
+
+    multiprocess.mark_process_dead(os.getpid())

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -163,50 +163,84 @@ def _consolidate_dead_counter_and_histogram_files() -> None:
     scraped total is unchanged, but file count stays O(live workers + 2)
     instead of growing with every worker ever recycled.
 
-    Races itself safely across workers: every worker runs this sweep, so two
-    workers can see the same dead pid's file in the same pass. os.rename()
-    to a private, non-globbed name first is the mutual-exclusion step -- POSIX
-    rename is atomic, so only one worker's rename can succeed; the other gets
-    FileNotFoundError on its own rename attempt and moves on, so a dead pid's
-    value is folded into the archive exactly once. If this process is itself
-    killed after that rename but before the merge completes, the renamed
-    file is orphaned (invisible to both future scrapes and future sweeps) --
-    an accepted, documented residual risk of the same shape as the pid-reuse
-    limitation in _dead_worker_pids(), not a correctness bug in the common
-    case of a graceful sweep pass.
+    Races itself safely across workers in TWO separate steps, because a
+    single mutex can't cover both a per-source-file claim and a shared
+    archive write:
+
+    1. Claiming a dead pid's source file: os.rename() to a private,
+       non-globbed name first -- POSIX rename is atomic, so only one
+       worker's rename can succeed; the other gets FileNotFoundError on its
+       own rename attempt and moves on. This alone guarantees a given dead
+       pid's file is read by exactly one worker, but does NOT protect the
+       archive file itself -- two workers can each successfully claim a
+       DIFFERENT dead pid's file in the same pass and then both try to fold
+       their value into the SAME "<type>_archived.db" at once. Without
+       further synchronization that's a lost-update race (read, add, write
+       is not atomic across processes): whichever worker's write lands last
+       overwrites the other's, permanently under-counting the archive
+       (fix(#1240, #651 review round 5)).
+    2. Folding a claimed file into the archive: guarded by an exclusive
+       fcntl.flock() on a dedicated "<type>_archived.db.lock" file (not the
+       archive .db file itself, so the lock is independent of MmapedDict's
+       own open/mmap lifecycle). The lock is held for this worker's entire
+       claim-and-merge pass over ALL dead pid files for that metric type, so
+       the read-modify-write of every key is fully serialized against every
+       other worker. flock is released automatically by the kernel if this
+       process dies while holding it, so a crash here can't deadlock a
+       sibling worker's next sweep.
+
+    If this process is killed after claiming (step 1) but before merging
+    (step 2) completes, the renamed file is orphaned (invisible to both
+    future scrapes and future sweeps) -- an accepted, documented residual
+    risk of the same shape as the pid-reuse limitation in
+    _dead_worker_pids(), not a correctness bug in the common case of a
+    graceful sweep pass.
     """
     multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
     if not multiproc_dir:
         return
+    import fcntl
+
     from prometheus_client.mmap_dict import MmapedDict
 
     for prefix in ("counter", "histogram"):
-        archive: MmapedDict | None = None
+        claimed_paths = []
         for _pid, path in _iter_dead_pid_files(prefix, multiproc_dir):
             claimed_path = f"{path}.claimed"
             try:
                 os.rename(path, claimed_path)
             except FileNotFoundError:
                 continue  # another worker's sweep already claimed this one
+            claimed_paths.append(claimed_path)
 
-            if archive is None:
-                archive_path = os.path.join(
-                    multiproc_dir, f"{prefix}_{_ARCHIVE_SUFFIX}.db"
-                )
+        if not claimed_paths:
+            continue
+
+        archive_path = os.path.join(multiproc_dir, f"{prefix}_{_ARCHIVE_SUFFIX}.db")
+        lock_path = f"{archive_path}.lock"
+        with open(lock_path, "a+b") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
                 archive = MmapedDict(archive_path)
-
-            # read_all_values_from_file yields (key, value, timestamp, pos) --
-            # the trailing byte offset is an implementation detail of the
-            # instance-level reader that write_value doesn't need.
-            for key, value, timestamp, _pos in MmapedDict.read_all_values_from_file(
-                claimed_path
-            ):
-                current, _ts = archive.read_value(key)
-                archive.write_value(key, current + value, timestamp)
-            os.remove(claimed_path)
-
-        if archive is not None:
-            archive.close()
+                try:
+                    for claimed_path in claimed_paths:
+                        # read_all_values_from_file yields
+                        # (key, value, timestamp, pos) -- the trailing byte
+                        # offset is an implementation detail of the
+                        # instance-level reader that write_value doesn't need.
+                        for (
+                            key,
+                            value,
+                            timestamp,
+                            _pos,
+                        ) in MmapedDict.read_all_values_from_file(claimed_path):
+                            current, _ts = archive.read_value(key)
+                            archive.write_value(key, current + value, timestamp)
+                        os.remove(claimed_path)
+                finally:
+                    archive.close()
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
 def _sweep_dead_worker_metrics_once() -> None:

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -14,11 +14,21 @@ multiprocess.MultiProcessCollector whenever PROMETHEUS_MULTIPROC_DIR is set
 otherwise -- so this stays a no-op for the dev single-worker default.
 """
 
+import asyncio
+import glob
 import os
+from collections.abc import Iterator
 
+import structlog
 from fastapi import FastAPI
 
 from .instrumentator import create_instrumentator
+
+logger = structlog.stdlib.get_logger(__name__)
+
+# How often every worker sweeps PROMETHEUS_MULTIPROC_DIR for gauge files left
+# by a sibling that died without running its own shutdown hook.
+_SWEEP_INTERVAL_SECONDS = 60
 
 
 def init_metrics(app: FastAPI):
@@ -38,9 +48,78 @@ def shutdown_worker_metrics() -> None:
     PROMETHEUS_MULTIPROC_DIR and keep being summed into every future scrape
     as a stale series. No-op when multiprocess mode isn't active (e.g. the
     dev single-worker default has no PROMETHEUS_MULTIPROC_DIR set).
+
+    This only runs on a graceful lifespan shutdown -- see
+    sweep_dead_worker_metrics() for the OOM-kill/SIGKILL case, where this
+    function never gets a chance to run at all.
     """
     if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
         return
     from prometheus_client import multiprocess
 
     multiprocess.mark_process_dead(os.getpid())
+
+
+def _dead_worker_pids() -> Iterator[int]:
+    """PIDs with a live-mode multiprocess file but no longer running.
+
+    Reads pids off of gauge_live*_<pid>.db filenames (prometheus_client's own
+    naming scheme) and checks each with a signal-0 kill, the same liveness
+    probe prometheus_client's own docs recommend for this exact reaping
+    pattern. A pid that gets reused by an unrelated process before the next
+    sweep would be skipped as "alive" -- an accepted, documented limitation
+    of pid-based reaping, not something this sweep can close from inside a
+    dying process.
+    """
+    multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+    if not multiproc_dir:
+        return
+    seen: set[int] = set()
+    for path in glob.glob(os.path.join(multiproc_dir, "gauge_live*_*.db")):
+        pid_str = os.path.basename(path).rsplit("_", 1)[-1].removesuffix(".db")
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            continue
+        if pid in seen or pid == os.getpid():
+            continue
+        seen.add(pid)
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            yield pid
+        except PermissionError:
+            # Process exists (just not signalable by us) -- treat as alive.
+            continue
+
+
+def _sweep_dead_worker_metrics_once() -> None:
+    """Run one reap pass (no loop, no sleep) -- split out for tests."""
+    if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
+        return
+    from prometheus_client import multiprocess
+
+    for pid in _dead_worker_pids():
+        multiprocess.mark_process_dead(pid)
+
+
+async def sweep_dead_worker_metrics() -> None:
+    """Background loop: reap multiprocess files left by a hard-killed worker.
+
+    fix(#1240, #651 review round 2): shutdown_worker_metrics() only runs on a
+    graceful lifespan shutdown. A worker OOM-killed or SIGKILLed (the #643
+    scenario this whole gauge exists to catch) never reaches that shutdown
+    path, while the uvicorn supervisor stays up and respawns a replacement in
+    the same PROMETHEUS_MULTIPROC_DIR -- so the dead worker's RSS and pool
+    gauges would otherwise linger, inflating /metrics, until the whole
+    container restarts. No-op when multiprocess mode isn't active. Safe to
+    run in every worker: mark_process_dead() is idempotent once a pid's files
+    are gone, so a race between two workers sweeping the same dead pid is
+    harmless.
+    """
+    while True:
+        try:
+            _sweep_dead_worker_metrics_once()
+        except Exception:  # broad: sweep is non-fatal; must not crash the loop
+            logger.warning("Failed to sweep dead worker metrics", exc_info=True)
+        await asyncio.sleep(_SWEEP_INTERVAL_SECONDS)

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -101,6 +101,114 @@ def _dead_worker_pids() -> Iterator[int]:
             continue
 
 
+def _iter_dead_pid_files(prefix: str, multiproc_dir: str) -> Iterator[tuple[int, str]]:
+    """Yield (pid, path) for prefix_<pid>.db files whose pid is no longer
+    running. Used for counter/histogram files, which are named
+    "<type>_<pid>.db" with no mode segment (unlike gauge's
+    "gauge_<mode>_<pid>.db") -- see _dead_worker_pids() for that one.
+    """
+    for path in glob.glob(os.path.join(multiproc_dir, f"{prefix}_*.db")):
+        pid_str = os.path.basename(path)[len(prefix) + 1 : -len(".db")]
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            # Not a live pid's file -- e.g. the "_archived" consolidation
+            # file this sweep itself writes below.
+            continue
+        if pid == os.getpid():
+            continue
+        try:
+            os.kill(pid, 0)
+            continue  # still alive
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            continue  # exists, just not signalable by us -- treat as alive
+        yield pid, path
+
+
+# fix(#1240, #651 review round 4): non-numeric suffix so _iter_dead_pid_files
+# never mistakes this file itself for a dead worker's file.
+_ARCHIVE_SUFFIX = "archived"
+
+
+def _consolidate_dead_counter_and_histogram_files() -> None:
+    """Fold dead workers' counter/histogram files into one running total per
+    metric type, instead of leaving them to accumulate forever.
+
+    mark_process_dead() (used by shutdown_worker_metrics() and the gauge
+    reap above) deliberately never touches counter_<pid>.db /
+    histogram_<pid>.db -- unlike a gauge, a Counter/Histogram's stored value
+    is a cumulative total that the collector sums across every pid's file on
+    every scrape, so simply deleting a dead pid's file would silently
+    subtract its contribution and produce a downward step (a fabricated
+    counter "decrease" -- exactly the sawtooth bug #1240 exists to fix).
+    Under the prod default UVICORN_MAX_REQUESTS=10000, a long-running
+    container recycles workers indefinitely, so those files would otherwise
+    accumulate without bound, one per departed worker, and every scrape has
+    to open and sum all of them.
+
+    Folds each dead pid's file additively into a single "<type>_archived.db"
+    file instead: read every (key, value, timestamp) triple straight out of
+    the dead pid's raw mmap file (MmapedDict.read_all_values_from_file --
+    the same binary format prometheus_client's own worker processes write,
+    and the mechanism its multiprocess.MultiProcessCollector.merge() docstring
+    points to for exactly this "write merged data back to mmap files" case),
+    add it to whatever total is already stored under that same key in the
+    archive file, and delete the source. The archive file is just another
+    counter_*.db/histogram_*.db file as far as MultiProcessCollector.collect()
+    is concerned (it globs "*.db" and only inspects the "counter"/"histogram"
+    prefix, not the pid segment), so it keeps contributing to the summed
+    total exactly as the dead files it absorbed would have. Net effect: the
+    scraped total is unchanged, but file count stays O(live workers + 2)
+    instead of growing with every worker ever recycled.
+
+    Races itself safely across workers: every worker runs this sweep, so two
+    workers can see the same dead pid's file in the same pass. os.rename()
+    to a private, non-globbed name first is the mutual-exclusion step -- POSIX
+    rename is atomic, so only one worker's rename can succeed; the other gets
+    FileNotFoundError on its own rename attempt and moves on, so a dead pid's
+    value is folded into the archive exactly once. If this process is itself
+    killed after that rename but before the merge completes, the renamed
+    file is orphaned (invisible to both future scrapes and future sweeps) --
+    an accepted, documented residual risk of the same shape as the pid-reuse
+    limitation in _dead_worker_pids(), not a correctness bug in the common
+    case of a graceful sweep pass.
+    """
+    multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+    if not multiproc_dir:
+        return
+    from prometheus_client.mmap_dict import MmapedDict
+
+    for prefix in ("counter", "histogram"):
+        archive: MmapedDict | None = None
+        for _pid, path in _iter_dead_pid_files(prefix, multiproc_dir):
+            claimed_path = f"{path}.claimed"
+            try:
+                os.rename(path, claimed_path)
+            except FileNotFoundError:
+                continue  # another worker's sweep already claimed this one
+
+            if archive is None:
+                archive_path = os.path.join(
+                    multiproc_dir, f"{prefix}_{_ARCHIVE_SUFFIX}.db"
+                )
+                archive = MmapedDict(archive_path)
+
+            # read_all_values_from_file yields (key, value, timestamp, pos) --
+            # the trailing byte offset is an implementation detail of the
+            # instance-level reader that write_value doesn't need.
+            for key, value, timestamp, _pos in MmapedDict.read_all_values_from_file(
+                claimed_path
+            ):
+                current, _ts = archive.read_value(key)
+                archive.write_value(key, current + value, timestamp)
+            os.remove(claimed_path)
+
+        if archive is not None:
+            archive.close()
+
+
 def _sweep_dead_worker_metrics_once() -> None:
     """Run one reap pass (no loop, no sleep) -- split out for tests."""
     if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
@@ -109,10 +217,11 @@ def _sweep_dead_worker_metrics_once() -> None:
 
     for pid in _dead_worker_pids():
         multiprocess.mark_process_dead(pid)
+    _consolidate_dead_counter_and_histogram_files()
 
 
 async def sweep_dead_worker_metrics() -> None:
-    """Background loop: reap multiprocess files left by a hard-killed worker.
+    """Background loop: reap and consolidate files left by dead workers.
 
     fix(#1240, #651 review round 2): shutdown_worker_metrics() only runs on a
     graceful lifespan shutdown. A worker OOM-killed or SIGKILLed (the #643
@@ -120,10 +229,21 @@ async def sweep_dead_worker_metrics() -> None:
     path, while the uvicorn supervisor stays up and respawns a replacement in
     the same PROMETHEUS_MULTIPROC_DIR -- so the dead worker's RSS and pool
     gauges would otherwise linger, inflating /metrics, until the whole
-    container restarts. No-op when multiprocess mode isn't active. Safe to
-    run in every worker: mark_process_dead() is idempotent once a pid's files
-    are gone, so a race between two workers sweeping the same dead pid is
-    harmless.
+    container restarts.
+
+    fix(#1240, #651 review round 4): under the prod default
+    UVICORN_MAX_REQUESTS=10000, a long-running container recycles workers
+    indefinitely, and mark_process_dead() intentionally never removes a dead
+    worker's counter_<pid>.db / histogram_<pid>.db (their cumulative values
+    still need to count toward the total). Left alone those files grow
+    without bound -- see _consolidate_dead_counter_and_histogram_files() for
+    how they get folded into one running archive file per metric type
+    instead.
+
+    No-op when multiprocess mode isn't active. Safe to run in every worker:
+    both the gauge reap and the counter/histogram consolidation are
+    idempotent/self-excluding once a dead pid's files are gone, so a race
+    between two workers sweeping the same dead pid is harmless.
     """
     while True:
         try:

--- a/backend/app/observability/metrics/memory.py
+++ b/backend/app/observability/metrics/memory.py
@@ -10,14 +10,14 @@ worker crosses the memory watermark, so runaway growth is diagnosable from
 Reads /proc directly (Linux containers; no psutil dependency). On platforms
 without /proc (macOS dev) the loop idles silently.
 
-Multi-worker caveat (codex P2 on #650): each uvicorn worker owns its own
-prometheus_client registry and /metrics is served by whichever worker takes
-the scrape, so one scrape sees one worker — a repo-wide property of the
-metrics stack (pool/jobs/HTTP metrics behave the same; multiprocess mode is
-tracked separately, see #651). The gauge is labeled by pid so successive
-scrapes accumulate as distinct per-worker series in the TSDB instead of
-silently flip-flopping one series; the structured-log heartbeat/watermark
-remains the authoritative per-worker signal.
+fix(#1240, #651): the api service runs in prometheus_client multiprocess
+mode, so a scrape reports every live worker's gauge in one response instead
+of whichever single worker answered. The gauge's own `pid` label plus
+`multiprocess_mode="liveall"` (rather than the default `"all"`) means a
+recycled worker's series actually disappears once its mmap file is removed
+by `shutdown_worker_metrics()` on that worker's own shutdown -- `"all"`
+would keep a dead pid's last value forever, since prometheus_client's
+`mark_process_dead()` only unlinks files for `live*`-mode gauges.
 """
 
 import asyncio
@@ -33,6 +33,7 @@ worker_rss_bytes = Gauge(
     "geolens_worker_rss_bytes",
     "Resident set size of an API worker process",
     ["pid"],
+    multiprocess_mode="liveall",
 )
 
 _INTERVAL_SECONDS = 60

--- a/backend/app/observability/metrics/pool.py
+++ b/backend/app/observability/metrics/pool.py
@@ -3,6 +3,14 @@
 Exposes pool utilization gauges that update every 15 seconds
 via a background asyncio task. Gracefully skips when using
 an external connection pooler (NullPool has no stats).
+
+fix(#1240, #651): each uvicorn worker owns its own SQLAlchemy engine, so
+these gauges are genuinely per-worker values. Under PROMETHEUS_MULTIPROC_DIR
+(multiprocess mode), the default Gauge aggregation ('all') would auto-label
+every sample by pid, turning one series into N and silently breaking any
+existing alert/dashboard expression that reads the bare metric name. Declare
+'livesum' explicitly so a scrape keeps returning one series -- the fleet-wide
+total across live workers -- matching the metric's pre-fix single-value shape.
 """
 
 import asyncio
@@ -17,18 +25,22 @@ logger = structlog.stdlib.get_logger(__name__)
 db_pool_checkedout = Gauge(
     "geolens_db_pool_checkedout",
     "Number of connections currently checked out from the pool",
+    multiprocess_mode="livesum",
 )
 db_pool_checkedin = Gauge(
     "geolens_db_pool_checkedin",
     "Number of connections currently available in the pool",
+    multiprocess_mode="livesum",
 )
 db_pool_overflow = Gauge(
     "geolens_db_pool_overflow",
     "Number of overflow connections currently open",
+    multiprocess_mode="livesum",
 )
 db_pool_size = Gauge(
     "geolens_db_pool_size",
     "Configured pool size",
+    multiprocess_mode="livesum",
 )
 
 

--- a/backend/scripts/api-entrypoint.sh
+++ b/backend/scripts/api-entrypoint.sh
@@ -113,6 +113,23 @@ case "${GEOLENS_API_RUN_MIGRATIONS:-true}" in
         ;;
 esac
 
+# fix(#1240, #651): clear stale prometheus_client multiprocess mmap files
+# before any worker starts. PROMETHEUS_MULTIPROC_DIR is only ever set on the
+# api service (see #651: the worker's own /metrics endpoint stays
+# single-process and is intentionally unaffected). Runs once here, in the
+# parent process before uvicorn forks its workers, so a leftover .db file
+# from a previous container generation (e.g. a different UVICORN_WORKERS
+# topology) can never pollute this generation's Counter/Histogram sums --
+# multiprocess.MultiProcessCollector aggregates every *.db file under the
+# directory regardless of which process generation wrote it. The directory
+# itself lives on the api service's tmpfs /tmp mount, so a container restart
+# already discards it; this guards the case an operator points the var at a
+# non-ephemeral path instead.
+if [ -n "${PROMETHEUS_MULTIPROC_DIR:-}" ]; then
+    mkdir -p "${PROMETHEUS_MULTIPROC_DIR}"
+    rm -f "${PROMETHEUS_MULTIPROC_DIR}"/*.db 2>/dev/null || true
+fi
+
 if [ "$#" -eq 0 ]; then
     set -- sh -c "uv run --no-dev uvicorn app.api.main:app --host 0.0.0.0 --port 8000"
 fi

--- a/backend/scripts/api-entrypoint.sh
+++ b/backend/scripts/api-entrypoint.sh
@@ -25,11 +25,25 @@ probe_writable_dir() {
 
 mkdir -p "${STAGING_DIR}" "${APP_HOME}" "${UV_CACHE_DIR}"
 
+# fix(#1240, #651): prometheus_client multiprocess mode, api service only (see
+# #651: the worker's own /metrics endpoint stays single-process). Created
+# here, alongside the other runtime-writable dirs, so the chown/chmod block
+# below covers it too -- this container starts as root and drops to appuser
+# via setpriv before exec, and prometheus_client's mmap-backed metric files
+# are written by that dropped-privilege process, not by this root shell.
+if [ -n "${PROMETHEUS_MULTIPROC_DIR:-}" ]; then
+    mkdir -p "${PROMETHEUS_MULTIPROC_DIR}"
+fi
+
 if [ "$(id -u)" -eq 0 ]; then
     chown -R "${APP_UID}:${APP_GID}" "${STAGING_DIR}" "${APP_HOME}" 2>/dev/null || true
     chmod -R u+rwX,g+rwX "${STAGING_DIR}" "${APP_HOME}" 2>/dev/null || true
     probe_writable_dir "${STAGING_DIR}" "Upload staging directory"
     probe_writable_dir "${UV_CACHE_DIR}" "uv cache directory"
+    if [ -n "${PROMETHEUS_MULTIPROC_DIR:-}" ]; then
+        chown -R "${APP_UID}:${APP_GID}" "${PROMETHEUS_MULTIPROC_DIR}" 2>/dev/null || true
+        chmod -R u+rwX,g+rwX "${PROMETHEUS_MULTIPROC_DIR}" 2>/dev/null || true
+    fi
 else
     probe_writable_dir "${STAGING_DIR}" "Upload staging directory"
     probe_writable_dir "${UV_CACHE_DIR}" "uv cache directory"
@@ -114,19 +128,16 @@ case "${GEOLENS_API_RUN_MIGRATIONS:-true}" in
 esac
 
 # fix(#1240, #651): clear stale prometheus_client multiprocess mmap files
-# before any worker starts. PROMETHEUS_MULTIPROC_DIR is only ever set on the
-# api service (see #651: the worker's own /metrics endpoint stays
-# single-process and is intentionally unaffected). Runs once here, in the
-# parent process before uvicorn forks its workers, so a leftover .db file
-# from a previous container generation (e.g. a different UVICORN_WORKERS
-# topology) can never pollute this generation's Counter/Histogram sums --
-# multiprocess.MultiProcessCollector aggregates every *.db file under the
-# directory regardless of which process generation wrote it. The directory
-# itself lives on the api service's tmpfs /tmp mount, so a container restart
-# already discards it; this guards the case an operator points the var at a
-# non-ephemeral path instead.
+# before any worker starts (the directory itself was created and chowned
+# above). A leftover .db file from a previous container generation (e.g. a
+# different UVICORN_WORKERS topology) would otherwise pollute this
+# generation's Counter/Histogram sums -- multiprocess.MultiProcessCollector
+# aggregates every *.db file under the directory regardless of which process
+# generation wrote it. Runs once here, in the parent process before uvicorn
+# forks its workers. The directory itself lives on the api service's tmpfs
+# /tmp mount, so a container restart already discards it; this guards the
+# case an operator points the var at a non-ephemeral path instead.
 if [ -n "${PROMETHEUS_MULTIPROC_DIR:-}" ]; then
-    mkdir -p "${PROMETHEUS_MULTIPROC_DIR}"
     rm -f "${PROMETHEUS_MULTIPROC_DIR}"/*.db 2>/dev/null || true
 fi
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1868,7 +1868,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # lifespan shutdown block so a recycled uvicorn worker drops its
     # prometheus_client multiprocess mmap files instead of leaving a stale
     # series for the next scrape to keep summing. Cap 1292 -> 1296, exact.
-    "backend/app/api/main.py": 1296,
+    # fix(#1240, #651 review round 2): +9 — start/cancel metrics_sweep_task
+    # (sweep_dead_worker_metrics) alongside the existing pool/memory
+    # background tasks, so an OOM-killed/SIGKILLed worker's multiprocess
+    # gauge files get reaped even though its own graceful shutdown hook
+    # never ran. Cap 1296 -> 1305, exact.
+    "backend/app/api/main.py": 1305,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1864,7 +1864,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.
-    "backend/app/api/main.py": 1292,
+    # fix(#1240, #651): +4 — import shutdown_worker_metrics and call it in the
+    # lifespan shutdown block so a recycled uvicorn worker drops its
+    # prometheus_client multiprocess mmap files instead of leaving a stale
+    # series for the next scrape to keep summing. Cap 1292 -> 1296, exact.
+    "backend/app/api/main.py": 1296,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -460,7 +460,8 @@ def test_shutdown_worker_metrics_marks_process_dead_when_multiprocess_active():
 
 
 def test_shutdown_worker_metrics_noop_without_multiprocess_dir():
-    """Dev's single-worker default has no PROMETHEUS_MULTIPROC_DIR set --
+    """A deployment that runs the api image directly, outside either compose
+    file, without setting PROMETHEUS_MULTIPROC_DIR itself, has no such var --
     shutdown must not try to mark anything dead (mark_process_dead requires
     the directory to exist and would raise otherwise).
     """

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -10,7 +10,10 @@ import pytest
 from prometheus_client import Counter, Gauge
 from prometheus_fastapi_instrumentator import Instrumentator
 
-from app.observability.metrics import shutdown_worker_metrics
+from app.observability.metrics import (
+    _sweep_dead_worker_metrics_once,
+    shutdown_worker_metrics,
+)
 from app.observability.metrics.instrumentator import create_instrumentator
 from app.observability.metrics.jobs import (
     _refresh_job_metrics,
@@ -362,6 +365,85 @@ def test_multiprocess_pool_gauge_uses_livesum_not_per_pid(tmp_path):
     assert len(samples) == 1
     assert samples[0].value == 8.0
     assert "pid" not in samples[0].labels
+
+
+_LIVEALL_RSS_WRITER = """
+import os
+import sys
+import time
+from app.observability.metrics.memory import worker_rss_bytes
+
+worker_rss_bytes.labels(pid=str(os.getpid())).set(int(os.environ["_TEST_RSS_BYTES"]))
+print(os.getpid(), flush=True)
+if os.environ.get("_TEST_STAY_ALIVE"):
+    time.sleep(10)
+"""
+
+
+def test_sweep_dead_worker_metrics_reaps_only_dead_pids(tmp_path):
+    """fix(#1240, #651 review round 2): a worker that's OOM-killed/SIGKILLed
+    never runs shutdown_worker_metrics() (it dies mid-request, not at a
+    lifespan boundary), so its series would otherwise linger until the whole
+    container restarts. The periodic sweep must reap ONLY pids that are no
+    longer running -- a still-alive sibling's series must survive the same
+    pass, or the sweep would be indistinguishable from just deleting
+    everything on a timer.
+    """
+    multiproc_dir = str(tmp_path)
+    env_base = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir}
+
+    # "Dead" worker: writes a value and exits normally with no graceful
+    # shutdown call -- from the sweep's point of view this is indistinguishable
+    # from a SIGKILL, since both just leave a file behind for a pid that no
+    # longer exists.
+    dead = subprocess.run(
+        [sys.executable, "-c", _LIVEALL_RSS_WRITER],
+        cwd=str(_BACKEND_ROOT),
+        env={**env_base, "_TEST_RSS_BYTES": str(111 * 1024 * 1024)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert dead.returncode == 0, dead.stderr
+    dead_pid = int(dead.stdout.strip())
+
+    # "Alive" worker: kept running past the sweep so its series can be
+    # asserted untouched.
+    alive_proc = subprocess.Popen(
+        [sys.executable, "-c", _LIVEALL_RSS_WRITER],
+        cwd=str(_BACKEND_ROOT),
+        env={
+            **env_base,
+            "_TEST_RSS_BYTES": str(222 * 1024 * 1024),
+            "_TEST_STAY_ALIVE": "1",
+        },
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        alive_pid = int(alive_proc.stdout.readline().strip())
+
+        with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": multiproc_dir}):
+            _sweep_dead_worker_metrics_once()
+
+        from prometheus_client import CollectorRegistry, multiprocess
+
+        registry = CollectorRegistry()
+        multiprocess.MultiProcessCollector(registry, path=multiproc_dir)
+        families = {f.name: f for f in registry.collect()}
+        samples = [
+            s
+            for s in families["geolens_worker_rss_bytes"].samples
+            if s.name == "geolens_worker_rss_bytes"
+        ]
+        pids_present = {int(s.labels["pid"]) for s in samples}
+
+        assert dead_pid not in pids_present
+        assert alive_pid in pids_present
+    finally:
+        alive_proc.terminate()
+        alive_proc.wait(timeout=10)
 
 
 def test_shutdown_worker_metrics_marks_process_dead_when_multiprocess_active():

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -211,12 +211,26 @@ def test_multiprocess_histogram_sums_across_simulated_workers(tmp_path):
     assert _scrape_count() == first_scrape
 
 
+# Uses the real production Gauge (not a synthetic stand-in) so this test
+# actually exercises memory.py's multiprocess_mode="liveall" declaration --
+# a synthetic Gauge would default to "all" and miss the exact bug Codex
+# found in round 1 of review (see test_..._cleaned_up_after_shutdown below).
 _RSS_GAUGE_WRITER = """
 import os
-from prometheus_client import Gauge
+from app.observability.metrics.memory import worker_rss_bytes
 
-g = Gauge("geolens_worker_rss_bytes", "rss", ["pid"])
-g.labels(pid=str(os.getpid())).set(int(os.environ["_TEST_RSS_BYTES"]))
+worker_rss_bytes.labels(pid=str(os.getpid())).set(int(os.environ["_TEST_RSS_BYTES"]))
+"""
+
+# Same Gauge, but calls shutdown_worker_metrics() immediately after writing
+# a value -- simulates a worker recycled under UVICORN_MAX_REQUESTS.
+_RSS_GAUGE_WRITER_THEN_SHUTDOWN = """
+import os
+from app.observability.metrics import shutdown_worker_metrics
+from app.observability.metrics.memory import worker_rss_bytes
+
+worker_rss_bytes.labels(pid=str(os.getpid())).set(int(os.environ["_TEST_RSS_BYTES"]))
+shutdown_worker_metrics()
 """
 
 
@@ -253,6 +267,58 @@ def test_multiprocess_rss_gauge_shows_every_live_worker(tmp_path):
     # Two distinct worker processes, both visible in the one merged scrape.
     assert {s.labels["pid"] for s in samples}.__len__() == 2
     assert sorted(s.value for s in samples) == sorted(values)
+
+
+def test_multiprocess_rss_gauge_series_cleaned_up_after_shutdown(tmp_path):
+    """fix(#1240, #651 review round 1): a recycled worker's RSS series must
+    actually disappear once shutdown_worker_metrics() marks it dead.
+
+    prometheus_client's mark_process_dead() only unlinks mmap files for
+    Gauges declared with a "live*" multiprocess_mode -- the default "all"
+    keeps a dead pid's last value forever. worker_rss_bytes declares
+    "liveall" specifically so this cleanup works; a regression back to the
+    default would make this assertion fail (samples would still show the
+    recycled worker's stale value).
+    """
+    multiproc_dir = str(tmp_path)
+    env_base = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir}
+
+    # Worker A: recycled (writes a value, then shuts down cleanly).
+    result_a = subprocess.run(
+        [sys.executable, "-c", _RSS_GAUGE_WRITER_THEN_SHUTDOWN],
+        cwd=str(_BACKEND_ROOT),
+        env={**env_base, "_TEST_RSS_BYTES": str(100 * 1024 * 1024)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result_a.returncode == 0, result_a.stderr
+
+    # Worker B: still alive (no shutdown call).
+    result_b = subprocess.run(
+        [sys.executable, "-c", _RSS_GAUGE_WRITER],
+        cwd=str(_BACKEND_ROOT),
+        env={**env_base, "_TEST_RSS_BYTES": str(150 * 1024 * 1024)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result_b.returncode == 0, result_b.stderr
+
+    from prometheus_client import CollectorRegistry, multiprocess
+
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry, path=multiproc_dir)
+    families = {f.name: f for f in registry.collect()}
+    samples = [
+        s
+        for s in families["geolens_worker_rss_bytes"].samples
+        if s.name == "geolens_worker_rss_bytes"
+    ]
+
+    # Only worker B's value survives -- worker A's recycled series is gone,
+    # not merely stale.
+    assert [s.value for s in samples] == [150 * 1024 * 1024]
 
 
 _POOL_GAUGE_WRITER = """

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,11 +1,16 @@
 """Tests for the Prometheus metrics module."""
 
+import os
+import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from prometheus_client import Counter, Gauge
 from prometheus_fastapi_instrumentator import Instrumentator
 
+from app.observability.metrics import shutdown_worker_metrics
 from app.observability.metrics.instrumentator import create_instrumentator
 from app.observability.metrics.jobs import (
     _refresh_job_metrics,
@@ -116,3 +121,207 @@ async def test_refresh_pool_metrics_skips_non_queuepool():
     # Pool gauges should remain at their default (0)
     assert db_pool_checkedout._value.get() == 0.0
     assert db_pool_checkedin._value.get() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Multiprocess mode (fix #1240, #651)
+#
+# prometheus_client picks its value-storage backend (plain in-memory vs
+# mmap-file-per-process) at the FIRST import of `prometheus_client.values` in
+# a given interpreter, based on whether PROMETHEUS_MULTIPROC_DIR is already
+# set. Every other test in this module has already imported prometheus_client
+# in-process without that env var, so setting it here would do nothing --
+# these tests spawn a fresh subprocess per simulated worker instead, which is
+# the only way to exercise the real multiprocess write path.
+# ---------------------------------------------------------------------------
+
+_BACKEND_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_multiprocess_writer(multiproc_dir: str, script: str, *args: str) -> None:
+    """Run `script` in a fresh subprocess with PROMETHEUS_MULTIPROC_DIR set.
+
+    cwd=_BACKEND_ROOT so `import app...` inside the script resolves the same
+    way it does for `uv run pytest` from backend/.
+    """
+    env = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir}
+    result = subprocess.run(
+        [sys.executable, "-c", script, *args],
+        cwd=str(_BACKEND_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"multiprocess writer subprocess failed:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+_HTTP_HISTOGRAM_WRITER = """
+import sys
+from prometheus_client import Histogram
+
+requests = int(sys.argv[1])
+# Same name prometheus_fastapi_instrumentator's default instrumentation uses
+# -- the exact metric behind the #1240 demo alert (see the diagnostic query
+# in that issue: sum(http_request_duration_seconds_count{...})).
+h = Histogram("http_request_duration_seconds", "request duration", ["handler"])
+for _ in range(requests):
+    h.labels(handler="/tiles/{z}/{x}/{y}").observe(0.05)
+"""
+
+
+def test_multiprocess_histogram_sums_across_simulated_workers(tmp_path):
+    """fix(#1240): a scrape used to see one worker's counter, not the fleet's.
+
+    Two subprocesses simulate two uvicorn workers recording HTTP requests
+    against the SAME histogram name under one PROMETHEUS_MULTIPROC_DIR (7
+    requests, then 3). Before the fix a scrape landed on whichever worker
+    answered -- 7 or 3, sawtoothing between the two on successive scrapes,
+    which Prometheus reads as a counter reset. Merging via
+    multiprocess.MultiProcessCollector must report the true total, 10, and
+    that total must be stable (idempotent) across repeated reads without new
+    writes -- the monotonicity rate() depends on.
+    """
+    multiproc_dir = str(tmp_path)
+    _run_multiprocess_writer(multiproc_dir, _HTTP_HISTOGRAM_WRITER, "7")
+    _run_multiprocess_writer(multiproc_dir, _HTTP_HISTOGRAM_WRITER, "3")
+
+    from prometheus_client import CollectorRegistry, multiprocess
+
+    def _scrape_count() -> float:
+        registry = CollectorRegistry()
+        multiprocess.MultiProcessCollector(registry, path=multiproc_dir)
+        families = {f.name: f for f in registry.collect()}
+        counts = [
+            s.value
+            for s in families["http_request_duration_seconds"].samples
+            if s.name == "http_request_duration_seconds_count"
+        ]
+        return sum(counts)
+
+    first_scrape = _scrape_count()
+    assert first_scrape == 10.0
+    assert first_scrape not in (7.0, 3.0)
+
+    # A second scrape with no new writes must read the same total -- the
+    # multiprocess files are additive state, not consumed by reading them.
+    assert _scrape_count() == first_scrape
+
+
+_RSS_GAUGE_WRITER = """
+import os
+from prometheus_client import Gauge
+
+g = Gauge("geolens_worker_rss_bytes", "rss", ["pid"])
+g.labels(pid=str(os.getpid())).set(int(os.environ["_TEST_RSS_BYTES"]))
+"""
+
+
+def test_multiprocess_rss_gauge_shows_every_live_worker(tmp_path):
+    """fix(#651) acceptance: `geolens_worker_rss_bytes` shows every live pid
+    in one scrape, not whichever single worker answered it.
+    """
+    multiproc_dir = str(tmp_path)
+    env_base = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir}
+
+    values = (100 * 1024 * 1024, 150 * 1024 * 1024)
+    for rss_bytes in values:
+        result = subprocess.run(
+            [sys.executable, "-c", _RSS_GAUGE_WRITER],
+            cwd=str(_BACKEND_ROOT),
+            env={**env_base, "_TEST_RSS_BYTES": str(rss_bytes)},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+
+    from prometheus_client import CollectorRegistry, multiprocess
+
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry, path=multiproc_dir)
+    families = {f.name: f for f in registry.collect()}
+    samples = [
+        s
+        for s in families["geolens_worker_rss_bytes"].samples
+        if s.name == "geolens_worker_rss_bytes"
+    ]
+
+    # Two distinct worker processes, both visible in the one merged scrape.
+    assert {s.labels["pid"] for s in samples}.__len__() == 2
+    assert sorted(s.value for s in samples) == sorted(values)
+
+
+_POOL_GAUGE_WRITER = """
+import sys
+from app.observability.metrics.pool import db_pool_checkedout
+
+db_pool_checkedout.set(float(sys.argv[1]))
+"""
+
+
+def test_multiprocess_pool_gauge_uses_livesum_not_per_pid(tmp_path):
+    """fix(#651): pool.py gauges declare multiprocess_mode='livesum' so a
+    scrape keeps returning ONE series -- the fleet total across live workers
+    -- instead of the default 'all' mode auto-labelling by pid and silently
+    multiplying the metric's cardinality (which would break any existing
+    alert/dashboard expression reading the bare metric name, e.g.
+    GeoLensDbPoolSaturated in infra/monitoring/alerts.yml).
+    """
+    assert db_pool_checkedout._multiprocess_mode == "livesum"
+    assert db_pool_checkedin._multiprocess_mode == "livesum"
+    assert db_pool_overflow._multiprocess_mode == "livesum"
+    assert db_pool_size._multiprocess_mode == "livesum"
+
+    multiproc_dir = str(tmp_path)
+    # Two workers each report their own connection pool's checked-out count.
+    _run_multiprocess_writer(multiproc_dir, _POOL_GAUGE_WRITER, "3")
+    _run_multiprocess_writer(multiproc_dir, _POOL_GAUGE_WRITER, "5")
+
+    from prometheus_client import CollectorRegistry, multiprocess
+
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry, path=multiproc_dir)
+    families = {f.name: f for f in registry.collect()}
+    samples = [
+        s
+        for s in families["geolens_db_pool_checkedout"].samples
+        if s.name == "geolens_db_pool_checkedout"
+    ]
+
+    # One series (no pid label), summed across the two simulated workers.
+    assert len(samples) == 1
+    assert samples[0].value == 8.0
+    assert "pid" not in samples[0].labels
+
+
+def test_shutdown_worker_metrics_marks_process_dead_when_multiprocess_active():
+    """fix(#1240, #651): a recycled worker (UVICORN_MAX_REQUESTS, #643) must
+    drop its own multiprocess files on shutdown, or a respawn leaves a stale
+    series that keeps being summed into every future scrape.
+    """
+    with (
+        patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": "/tmp/whatever"}),
+        patch("prometheus_client.multiprocess.mark_process_dead") as mock_mark,
+    ):
+        shutdown_worker_metrics()
+    mock_mark.assert_called_once_with(os.getpid())
+
+
+def test_shutdown_worker_metrics_noop_without_multiprocess_dir():
+    """Dev's single-worker default has no PROMETHEUS_MULTIPROC_DIR set --
+    shutdown must not try to mark anything dead (mark_process_dead requires
+    the directory to exist and would raise otherwise).
+    """
+    env_without_var = {
+        k: v for k, v in os.environ.items() if k != "PROMETHEUS_MULTIPROC_DIR"
+    }
+    with (
+        patch.dict(os.environ, env_without_var, clear=True),
+        patch("prometheus_client.multiprocess.mark_process_dead") as mock_mark,
+    ):
+        shutdown_worker_metrics()
+    mock_mark.assert_not_called()

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -983,6 +983,107 @@ def test_metrics_endpoint_survives_concurrent_sweep(tmp_path):
     assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
 
 
+_SAME_PROCESS_SWEEP_DURING_SCRAPE_SCRIPT = """
+import asyncio
+import fcntl
+import os
+import sys
+import time
+
+multiproc_dir = sys.argv[1]
+os.environ["PROMETHEUS_MULTIPROC_DIR"] = multiproc_dir
+
+from app.observability.metrics import (
+    _consolidate_dead_cumulative_metric_files,
+    _sweep_lock_path,
+)
+
+HOLD_SECONDS = 0.5
+
+
+async def mimic_scrape_middleware():
+    # Mirrors the real /metrics middleware exactly: non-blocking poll to
+    # acquire the shared lock, then await something dispatched to a thread
+    # pool (standing in for call_next() dispatching the sync
+    # instrumentator handler), then release.
+    lock_path = _sweep_lock_path(multiproc_dir)
+    with open(lock_path, "a+b") as lock_file:
+        while True:
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_SH | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                await asyncio.sleep(0.005)
+        try:
+            await asyncio.to_thread(time.sleep, HOLD_SECONDS)
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+async def sweep_via_to_thread():
+    # Exactly what sweep_dead_worker_metrics()'s loop body does per pass.
+    await asyncio.to_thread(_consolidate_dead_cumulative_metric_files)
+
+
+async def main():
+    scrape_task = asyncio.create_task(mimic_scrape_middleware())
+    # Give the scrape a head start so it reliably holds the shared lock
+    # before the sweep attempts its exclusive one -- this is the exact
+    # ordering that deadlocked pre-fix (round 6 called
+    # _consolidate_dead_cumulative_metric_files() directly on the loop
+    # instead of via to_thread).
+    await asyncio.sleep(0.05)
+    await asyncio.gather(scrape_task, sweep_via_to_thread())
+
+
+asyncio.run(main())
+"""
+
+
+def test_same_process_sweep_during_scrape_does_not_deadlock(tmp_path):
+    """fix(#1240, #651 review round 8): flock() locks are per OPEN FILE
+    DESCRIPTION, not per-process -- a blocking fcntl.flock(LOCK_EX) call
+    made directly on a worker's event loop thread, while that SAME
+    worker's /metrics scrape middleware holds the shared lock via a
+    DIFFERENT file descriptor and is awaiting a thread-pool-dispatched
+    handler, cannot ever succeed: releasing the shared lock requires the
+    scrape's call_next() to resume, which requires the event loop to run,
+    which is exactly what the blocking exclusive-lock wait has frozen. This
+    is a same-process deadlock, invisible to the uvicorn supervisor -- the
+    worker just stops answering every request, not only /metrics.
+
+    round 6/7's existing tests (test_metrics_endpoint_survives_concurrent_sweep,
+    test_sweep_waits_for_inflight_scrape_before_renaming) don't catch this:
+    their "writer" side already runs its blocking flock() via
+    loop.run_in_executor()/a separate process, so they never exercised a
+    sweep call made directly on the SAME event loop the scrape's middleware
+    is using -- which is exactly how round 6 originally shipped the bug.
+
+    Runs the exact ordering that deadlocked before this fix (verified with
+    a throwaway script pre-fix: the subprocess had to be killed by its
+    outer timeout, never reaching completion) inside a subprocess with a
+    bounded timeout, since a real deadlock freezes the event loop itself --
+    no in-process asyncio-level timeout (asyncio.wait_for etc.) can recover
+    from that, only an external kill can. A subprocess.TimeoutExpired here
+    IS a regression: it means the deadlock came back.
+    """
+    multiproc_dir = str(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _SAME_PROCESS_SWEEP_DURING_SCRAPE_SCRIPT,
+            multiproc_dir,
+        ],
+        cwd=str(_BACKEND_ROOT),
+        env={**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
 def test_shutdown_worker_metrics_marks_process_dead_when_multiprocess_active():
     """fix(#1240, #651): a recycled worker (UVICORN_MAX_REQUESTS, #643) must
     drop its own multiprocess files on shutdown, or a respawn leaves a stale

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -13,7 +13,7 @@ from prometheus_client import Counter, Gauge
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.observability.metrics import (
-    _consolidate_dead_counter_and_histogram_files,
+    _consolidate_dead_cumulative_metric_files,
     _sweep_dead_worker_metrics_once,
     _sweep_lock_path,
     init_metrics,
@@ -522,7 +522,7 @@ def test_consolidate_dead_counter_and_histogram_files_preserves_totals(tmp_path)
     assert count_before == 15.0
 
     with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": multiproc_dir}):
-        _consolidate_dead_counter_and_histogram_files()
+        _consolidate_dead_cumulative_metric_files()
 
     # File count is now bounded regardless of how many workers died.
     assert list(tmp_path.glob("counter_*.db")) == [tmp_path / "counter_archived.db"]
@@ -552,7 +552,7 @@ def test_consolidate_dead_counter_and_histogram_files_preserves_totals(tmp_path)
     # change the totals (proves the archive file is never mistaken for a
     # dead worker's own file and folded into itself).
     with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": multiproc_dir}):
-        _consolidate_dead_counter_and_histogram_files()
+        _consolidate_dead_cumulative_metric_files()
     still = _scrape_consolidate_metrics(multiproc_dir)
     total_still = sum(
         s.value
@@ -560,6 +560,82 @@ def test_consolidate_dead_counter_and_histogram_files_preserves_totals(tmp_path)
         if s.name == "test_consolidate_requests_total"
     )
     assert total_still == total_before
+
+
+_SUMMARY_WRITER = """
+import sys
+from prometheus_client import Summary
+
+s = Summary("test_consolidate_size_bytes", "size", ["handler"])
+for v in sys.argv[1:]:
+    s.labels(handler="/tiles").observe(float(v))
+"""
+
+
+def test_consolidate_dead_summary_files_preserves_totals(tmp_path):
+    """fix(#1240, #651 review round 7): the sweep only folded counter_*.db
+    and histogram_*.db into an archive -- summary_*.db (written by
+    prometheus_fastapi_instrumentator's default http_request_size_bytes /
+    http_response_size_bytes Summary metrics) was left out, so every
+    recycled worker under UVICORN_MAX_REQUESTS still left one behind
+    forever. A Summary's raw mmap entries are a plain (name, labels)
+    count/sum pair with no bucket-style "le" reconstruction like a
+    histogram needs, so MultiProcessCollector's own accumulation sums them
+    exactly like a Counter's -- the SAME additive read-modify-write this
+    module already does for counter/histogram covers summary too once its
+    prefix is included; this proves that empirically (real subprocess
+    workers, real mmap files), not just by re-stating the reasoning.
+    """
+    multiproc_dir = str(tmp_path)
+    env = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir}
+
+    # Three "dead" workers observing different request sizes.
+    for values in (("100", "200"), ("50",), ("10", "20", "30")):
+        result = subprocess.run(
+            [sys.executable, "-c", _SUMMARY_WRITER, *values],
+            cwd=str(_BACKEND_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+
+    assert len(list(tmp_path.glob("summary_*.db"))) == 3
+
+    before = _scrape_consolidate_metrics(multiproc_dir)
+    count_before = sum(
+        s.value
+        for s in before["test_consolidate_size_bytes"].samples
+        if s.name == "test_consolidate_size_bytes_count"
+    )
+    sum_before = sum(
+        s.value
+        for s in before["test_consolidate_size_bytes"].samples
+        if s.name == "test_consolidate_size_bytes_sum"
+    )
+    assert count_before == 6.0
+    assert sum_before == 410.0
+
+    with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": multiproc_dir}):
+        _consolidate_dead_cumulative_metric_files()
+
+    # File count is now bounded regardless of how many workers died.
+    assert list(tmp_path.glob("summary_*.db")) == [tmp_path / "summary_archived.db"]
+
+    after = _scrape_consolidate_metrics(multiproc_dir)
+    count_after = sum(
+        s.value
+        for s in after["test_consolidate_size_bytes"].samples
+        if s.name == "test_consolidate_size_bytes_count"
+    )
+    sum_after = sum(
+        s.value
+        for s in after["test_consolidate_size_bytes"].samples
+        if s.name == "test_consolidate_size_bytes_sum"
+    )
+    assert count_after == count_before
+    assert sum_after == sum_before
 
 
 def test_consolidate_dead_counter_files_is_race_safe_across_workers(tmp_path):
@@ -606,9 +682,9 @@ while not os.path.exists({str(go)!r}):
     time.sleep(0.001)
 
 os.environ["PROMETHEUS_MULTIPROC_DIR"] = {multiproc_dir!r}
-from app.observability.metrics import _consolidate_dead_counter_and_histogram_files
+from app.observability.metrics import _consolidate_dead_cumulative_metric_files
 
-_consolidate_dead_counter_and_histogram_files()
+_consolidate_dead_cumulative_metric_files()
 """
     procs = [
         subprocess.Popen(
@@ -689,9 +765,9 @@ while not os.path.exists({str(go)!r}):
     time.sleep(0.001)
 
 os.environ["PROMETHEUS_MULTIPROC_DIR"] = {multiproc_dir!r}
-from app.observability.metrics import _consolidate_dead_counter_and_histogram_files
+from app.observability.metrics import _consolidate_dead_cumulative_metric_files
 
-_consolidate_dead_counter_and_histogram_files()
+_consolidate_dead_cumulative_metric_files()
 """
     procs = [
         subprocess.Popen(
@@ -783,9 +859,9 @@ while not os.path.exists({str(holding_marker)!r}):
     time.sleep(0.001)
 
 os.environ["PROMETHEUS_MULTIPROC_DIR"] = {multiproc_dir!r}
-from app.observability.metrics import _consolidate_dead_counter_and_histogram_files
+from app.observability.metrics import _consolidate_dead_cumulative_metric_files
 
-_consolidate_dead_counter_and_histogram_files()
+_consolidate_dead_cumulative_metric_files()
 
 with open({str(done_marker)!r}, "w") as f:
     f.write(repr(time.time()))

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -637,6 +637,92 @@ _consolidate_dead_counter_and_histogram_files()
     assert total_after == 10.0
 
 
+def test_consolidate_archive_writes_are_serialized_across_workers(tmp_path):
+    """fix(#1240, #651 review round 5): the os.rename() claim step only
+    guarantees a given dead pid's SOURCE file is read by one worker -- it
+    says nothing about the SHARED "<type>_archived.db" two workers both
+    write into. Two dead workers here get DIFFERENT counter values (10 and
+    7), so two concurrent sweepers each claim a DIFFERENT source file (no
+    rename collision at all) and then both try to fold their value into the
+    same archive entry. Without serializing that merge, "read current, add,
+    write" from two processes is a classic lost-update race: whichever
+    write lands last silently overwrites the other's contribution, and the
+    archive permanently under-counts (17 becomes 10 or 7, never a crash or
+    an obviously-wrong value, which is what makes this bug class dangerous).
+    The fix serializes the merge with fcntl.flock() on a dedicated lock
+    file; this asserts the SUM survives, not just that both processes exit
+    cleanly.
+    """
+    multiproc_dir = str(tmp_path)
+    env = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir}
+
+    # Two dead workers, deliberately different values so a lost update is
+    # distinguishable from a correct merge (10, 7, or 17 are all different).
+    for n in (10, 7):
+        result = subprocess.run(
+            [sys.executable, "-c", _COUNTER_HISTOGRAM_WRITER, str(n)],
+            cwd=str(_BACKEND_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+    assert len(list(tmp_path.glob("counter_*.db"))) == 2
+
+    ready_a, ready_b = tmp_path / "ready2_a", tmp_path / "ready2_b"
+    go = tmp_path / "go2"
+    sweep_script = f"""
+import os
+import time
+
+ready = {{"a": {str(ready_a)!r}, "b": {str(ready_b)!r}}}[__import__("sys").argv[1]]
+open(ready, "w").close()
+
+deadline = time.monotonic() + 10
+while not os.path.exists({str(go)!r}):
+    if time.monotonic() > deadline:
+        raise TimeoutError("go file never appeared")
+    time.sleep(0.001)
+
+os.environ["PROMETHEUS_MULTIPROC_DIR"] = {multiproc_dir!r}
+from app.observability.metrics import _consolidate_dead_counter_and_histogram_files
+
+_consolidate_dead_counter_and_histogram_files()
+"""
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", sweep_script, label],
+            cwd=str(_BACKEND_ROOT),
+            env=env,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for label in ("a", "b")
+    ]
+
+    deadline = time.monotonic() + 10
+    while not (ready_a.exists() and ready_b.exists()):
+        assert time.monotonic() < deadline, "sweeper subprocesses never became ready"
+        time.sleep(0.001)
+    go.touch()
+
+    for p in procs:
+        stderr = p.communicate(timeout=30)[1]
+        assert p.returncode == 0, stderr
+
+    # Both dead files consolidated into one archive, and its value is the
+    # SUM of both -- not whichever write happened to land last.
+    assert list(tmp_path.glob("counter_*.db")) == [tmp_path / "counter_archived.db"]
+    after = _scrape_consolidate_metrics(multiproc_dir)
+    total_after = sum(
+        s.value
+        for s in after["test_consolidate_requests"].samples
+        if s.name == "test_consolidate_requests_total"
+    )
+    assert total_after == 17.0
+
+
 def test_shutdown_worker_metrics_marks_process_dead_when_multiprocess_active():
     """fix(#1240, #651): a recycled worker (UVICORN_MAX_REQUESTS, #643) must
     drop its own multiprocess files on shutdown, or a respawn leaves a stale

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,5 +1,6 @@
 """Tests for the Prometheus metrics module."""
 
+import asyncio
 import os
 import subprocess
 import sys
@@ -14,6 +15,8 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from app.observability.metrics import (
     _consolidate_dead_counter_and_histogram_files,
     _sweep_dead_worker_metrics_once,
+    _sweep_lock_path,
+    init_metrics,
     shutdown_worker_metrics,
 )
 from app.observability.metrics.instrumentator import create_instrumentator
@@ -721,6 +724,154 @@ _consolidate_dead_counter_and_histogram_files()
         if s.name == "test_consolidate_requests_total"
     )
     assert total_after == 17.0
+
+
+def test_sweep_waits_for_inflight_scrape_before_renaming(tmp_path):
+    """fix(#1240, #651 review round 6): MultiProcessCollector.collect() globs
+    "*.db" and then opens each matched path one by one; it tolerates a path
+    disappearing between those two steps only for gauge_live*.db (an
+    explicit except-continue in prometheus_client's own code, because
+    mark_process_dead() is expected to race a scrape). For
+    counter_*.db/histogram_*.db it re-raises FileNotFoundError, so this
+    function's os.rename() claim step must never fire while a scrape holds
+    the shared (reader) lock on the same PROMETHEUS_MULTIPROC_DIR.
+
+    Proves ordering, not just "no crash": a fake scrape holds the shared
+    lock for a full second before releasing; the sweep (which starts only
+    once it can see the scrape is already holding the lock) must not
+    complete until AFTER that release. If it completed sooner, that would
+    mean the exclusive/shared flock pairing isn't actually excluding the
+    sweep while a scrape is in flight -- the exact gap round 6 found.
+    """
+    multiproc_dir = str(tmp_path)
+    env = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir}
+
+    result = subprocess.run(
+        [sys.executable, "-c", _COUNTER_HISTOGRAM_WRITER, "10"],
+        cwd=str(_BACKEND_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+    holding_marker = tmp_path / "scrape_holding"
+    released_marker = tmp_path / "scrape_released"
+    done_marker = tmp_path / "sweep_done"
+
+    fake_scrape_script = f"""
+import fcntl
+import time
+
+from app.observability.metrics import _sweep_lock_path
+
+with open(_sweep_lock_path({multiproc_dir!r}), "a+b") as lock_file:
+    fcntl.flock(lock_file, fcntl.LOCK_SH)
+    open({str(holding_marker)!r}, "w").close()
+    time.sleep(1.0)
+    fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+with open({str(released_marker)!r}, "w") as f:
+    f.write(repr(time.time()))
+"""
+    sweeper_script = f"""
+import os
+import time
+
+while not os.path.exists({str(holding_marker)!r}):
+    time.sleep(0.001)
+
+os.environ["PROMETHEUS_MULTIPROC_DIR"] = {multiproc_dir!r}
+from app.observability.metrics import _consolidate_dead_counter_and_histogram_files
+
+_consolidate_dead_counter_and_histogram_files()
+
+with open({str(done_marker)!r}, "w") as f:
+    f.write(repr(time.time()))
+"""
+    scrape_proc = subprocess.Popen(
+        [sys.executable, "-c", fake_scrape_script],
+        cwd=str(_BACKEND_ROOT),
+        env=env,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    sweep_proc = subprocess.Popen(
+        [sys.executable, "-c", sweeper_script],
+        cwd=str(_BACKEND_ROOT),
+        env=env,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    scrape_stderr = scrape_proc.communicate(timeout=30)[1]
+    assert scrape_proc.returncode == 0, scrape_stderr
+    sweep_stderr = sweep_proc.communicate(timeout=30)[1]
+    assert sweep_proc.returncode == 0, sweep_stderr
+
+    released_at = float(released_marker.read_text())
+    done_at = float(done_marker.read_text())
+    assert done_at >= released_at, (
+        f"sweep finished at {done_at} before the scrape released its lock "
+        f"at {released_at} -- the sweep's rename raced an in-flight scrape"
+    )
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_survives_concurrent_sweep(tmp_path):
+    """fix(#1240, #651 review round 6): the reported symptom end to end --
+    a real GET /metrics request, issued while the sweep holds the exclusive
+    lock and is mid-rename, must wait and then succeed (200, correct data),
+    never surface a FileNotFoundError-driven 500. Exercises the actual
+    middleware wired into init_metrics(), not just the raw lock file.
+    """
+    multiproc_dir = str(tmp_path)
+
+    with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": multiproc_dir}):
+        result = subprocess.run(
+            [sys.executable, "-c", _COUNTER_HISTOGRAM_WRITER, "5"],
+            cwd=str(_BACKEND_ROOT),
+            env={**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+
+        import fcntl
+
+        from fastapi import FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        app = FastAPI()
+        init_metrics(app)
+
+        order: list[str] = []
+        release_event = asyncio.Event()
+
+        def hold_writer_lock() -> None:
+            with open(_sweep_lock_path(multiproc_dir), "a+b") as lock_file:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                order.append("writer_acquired")
+                loop.call_soon_threadsafe(release_event.set)
+                time.sleep(0.3)
+                order.append("writer_released")
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+        loop = asyncio.get_event_loop()
+        writer_future = loop.run_in_executor(None, hold_writer_lock)
+        await release_event.wait()
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/metrics")
+        order.append("scrape_completed")
+        await writer_future
+
+    assert resp.status_code == 200
+    assert 'test_consolidate_requests_total{handler="/tiles"} 5.0' in resp.text
+    # The scrape's shared-lock wait genuinely blocked until the writer let go.
+    assert order == ["writer_acquired", "writer_released", "scrape_completed"]
 
 
 def test_shutdown_worker_metrics_marks_process_dead_when_multiprocess_active():

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,6 +1,5 @@
 """Tests for the Prometheus metrics module."""
 
-import asyncio
 import os
 import subprocess
 import sys
@@ -15,8 +14,6 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from app.observability.metrics import (
     _consolidate_dead_cumulative_metric_files,
     _sweep_dead_worker_metrics_once,
-    _sweep_lock_path,
-    init_metrics,
     shutdown_worker_metrics,
 )
 from app.observability.metrics.instrumentator import create_instrumentator
@@ -893,61 +890,97 @@ with open({str(done_marker)!r}, "w") as f:
     )
 
 
-@pytest.mark.asyncio
-async def test_metrics_endpoint_survives_concurrent_sweep(tmp_path):
+_METRICS_ENDPOINT_CONCURRENT_SWEEP_SCRIPT = """
+import asyncio
+import fcntl
+import os
+import sys
+import time
+
+multiproc_dir = sys.argv[1]
+os.environ["PROMETHEUS_MULTIPROC_DIR"] = multiproc_dir
+
+from prometheus_client import Counter
+
+from app.observability.metrics import _sweep_lock_path, init_metrics
+
+c = Counter("test_consolidate_requests_total", "reqs", ["handler"])
+c.labels(handler="/tiles").inc(5)
+
+
+async def main():
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    app = FastAPI()
+    init_metrics(app)
+
+    order = []
+    release_event = asyncio.Event()
+
+    def hold_writer_lock():
+        with open(_sweep_lock_path(multiproc_dir), "a+b") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            order.append("writer_acquired")
+            loop.call_soon_threadsafe(release_event.set)
+            time.sleep(0.3)
+            order.append("writer_released")
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+    loop = asyncio.get_event_loop()
+    writer_future = loop.run_in_executor(None, hold_writer_lock)
+    await release_event.wait()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/metrics")
+    order.append("scrape_completed")
+    await writer_future
+
+    assert resp.status_code == 200, resp.status_code
+    assert 'test_consolidate_requests_total{handler="/tiles"} 5.0' in resp.text
+    # The scrape's shared-lock wait genuinely blocked until the writer let go.
+    assert order == ["writer_acquired", "writer_released", "scrape_completed"], order
+
+
+asyncio.run(main())
+"""
+
+
+def test_metrics_endpoint_survives_concurrent_sweep(tmp_path):
     """fix(#1240, #651 review round 6): the reported symptom end to end --
     a real GET /metrics request, issued while the sweep holds the exclusive
     lock and is mid-rename, must wait and then succeed (200, correct data),
     never surface a FileNotFoundError-driven 500. Exercises the actual
     middleware wired into init_metrics(), not just the raw lock file.
+
+    fix(#1240, #651 review round 8): runs in a subprocess, not in-process --
+    init_metrics() -> Instrumentator().instrument(app) registers
+    http_requests_inprogress on prometheus_client's process-global default
+    CollectorRegistry with no override, and other tests/fixtures in the same
+    pytest session (conftest importing app.api.main, which calls
+    init_metrics() itself at module import time) already register that same
+    collector, so a second in-process registration raised "Duplicated
+    timeseries in CollectorRegistry" under the full suite even though this
+    test passed in isolation. A subprocess gets its own fresh interpreter
+    and registry, matching every other test in this file that touches real
+    prometheus_client global state.
     """
     multiproc_dir = str(tmp_path)
-
-    with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": multiproc_dir}):
-        result = subprocess.run(
-            [sys.executable, "-c", _COUNTER_HISTOGRAM_WRITER, "5"],
-            cwd=str(_BACKEND_ROOT),
-            env={**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir},
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        assert result.returncode == 0, result.stderr
-
-        import fcntl
-
-        from fastapi import FastAPI
-        from httpx import ASGITransport, AsyncClient
-
-        app = FastAPI()
-        init_metrics(app)
-
-        order: list[str] = []
-        release_event = asyncio.Event()
-
-        def hold_writer_lock() -> None:
-            with open(_sweep_lock_path(multiproc_dir), "a+b") as lock_file:
-                fcntl.flock(lock_file, fcntl.LOCK_EX)
-                order.append("writer_acquired")
-                loop.call_soon_threadsafe(release_event.set)
-                time.sleep(0.3)
-                order.append("writer_released")
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
-
-        loop = asyncio.get_event_loop()
-        writer_future = loop.run_in_executor(None, hold_writer_lock)
-        await release_event.wait()
-
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/metrics")
-        order.append("scrape_completed")
-        await writer_future
-
-    assert resp.status_code == 200
-    assert 'test_consolidate_requests_total{handler="/tiles"} 5.0' in resp.text
-    # The scrape's shared-lock wait genuinely blocked until the writer let go.
-    assert order == ["writer_acquired", "writer_released", "scrape_completed"]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _METRICS_ENDPOINT_CONCURRENT_SWEEP_SCRIPT,
+            multiproc_dir,
+        ],
+        cwd=str(_BACKEND_ROOT),
+        env={**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
 
 
 def test_shutdown_worker_metrics_marks_process_dead_when_multiprocess_active():

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,6 +12,7 @@ from prometheus_client import Counter, Gauge
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.observability.metrics import (
+    _consolidate_dead_counter_and_histogram_files,
     _sweep_dead_worker_metrics_once,
     shutdown_worker_metrics,
 )
@@ -444,6 +446,195 @@ def test_sweep_dead_worker_metrics_reaps_only_dead_pids(tmp_path):
     finally:
         alive_proc.terminate()
         alive_proc.wait(timeout=10)
+
+
+_COUNTER_HISTOGRAM_WRITER = """
+import sys
+from prometheus_client import Counter, Histogram
+
+n = int(sys.argv[1])
+c = Counter("test_consolidate_requests_total", "reqs", ["handler"])
+h = Histogram("test_consolidate_duration_seconds", "dur", ["handler"])
+for _ in range(n):
+    c.labels(handler="/tiles").inc()
+    h.labels(handler="/tiles").observe(0.05)
+"""
+
+
+def _scrape_consolidate_metrics(multiproc_dir: str):
+    from prometheus_client import CollectorRegistry, multiprocess
+
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry, path=multiproc_dir)
+    return {f.name: f for f in registry.collect()}
+
+
+def test_consolidate_dead_counter_and_histogram_files_preserves_totals(tmp_path):
+    """fix(#1240, #651 review round 4): mark_process_dead() deliberately
+    never removes counter_<pid>.db / histogram_<pid>.db (their cumulative
+    values still need to count toward the total), so under
+    UVICORN_MAX_REQUESTS recycling those files would otherwise accumulate
+    without bound across a long-running container's lifetime. The
+    consolidation sweep must fold three dead workers' files into ONE
+    archive file per metric type while leaving the scraped total and
+    histogram shape byte-for-byte the same as before consolidation --
+    exercising the real binary mmap read/write round trip
+    (MmapedDict.read_all_values_from_file / write_value), not a mock.
+    """
+    multiproc_dir = str(tmp_path)
+    env = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir}
+
+    # Three "dead" workers (write, then exit -- no graceful shutdown call).
+    for n in (5, 3, 7):
+        result = subprocess.run(
+            [sys.executable, "-c", _COUNTER_HISTOGRAM_WRITER, str(n)],
+            cwd=str(_BACKEND_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+
+    assert len(list(tmp_path.glob("counter_*.db"))) == 3
+    assert len(list(tmp_path.glob("histogram_*.db"))) == 3
+
+    before = _scrape_consolidate_metrics(multiproc_dir)
+    total_before = sum(
+        s.value
+        for s in before["test_consolidate_requests"].samples
+        if s.name == "test_consolidate_requests_total"
+    )
+    count_before = sum(
+        s.value
+        for s in before["test_consolidate_duration_seconds"].samples
+        if s.name == "test_consolidate_duration_seconds_count"
+    )
+    sum_before = sum(
+        s.value
+        for s in before["test_consolidate_duration_seconds"].samples
+        if s.name == "test_consolidate_duration_seconds_sum"
+    )
+    assert total_before == 15.0
+    assert count_before == 15.0
+
+    with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": multiproc_dir}):
+        _consolidate_dead_counter_and_histogram_files()
+
+    # File count is now bounded regardless of how many workers died.
+    assert list(tmp_path.glob("counter_*.db")) == [tmp_path / "counter_archived.db"]
+    assert list(tmp_path.glob("histogram_*.db")) == [tmp_path / "histogram_archived.db"]
+
+    after = _scrape_consolidate_metrics(multiproc_dir)
+    total_after = sum(
+        s.value
+        for s in after["test_consolidate_requests"].samples
+        if s.name == "test_consolidate_requests_total"
+    )
+    count_after = sum(
+        s.value
+        for s in after["test_consolidate_duration_seconds"].samples
+        if s.name == "test_consolidate_duration_seconds_count"
+    )
+    sum_after = sum(
+        s.value
+        for s in after["test_consolidate_duration_seconds"].samples
+        if s.name == "test_consolidate_duration_seconds_sum"
+    )
+    assert total_after == total_before
+    assert count_after == count_before
+    assert sum_after == sum_before
+
+    # Idempotent: a second pass with nothing new to consolidate must not
+    # change the totals (proves the archive file is never mistaken for a
+    # dead worker's own file and folded into itself).
+    with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": multiproc_dir}):
+        _consolidate_dead_counter_and_histogram_files()
+    still = _scrape_consolidate_metrics(multiproc_dir)
+    total_still = sum(
+        s.value
+        for s in still["test_consolidate_requests"].samples
+        if s.name == "test_consolidate_requests_total"
+    )
+    assert total_still == total_before
+
+
+def test_consolidate_dead_counter_files_is_race_safe_across_workers(tmp_path):
+    """fix(#1240, #651 review round 4): every live worker runs this sweep, so
+    two workers can race to consolidate the same dead pid's file in the same
+    pass. The os.rename() mutual-exclusion step must let only one of them
+    fold that file's value into the archive -- concurrent consolidation
+    calls must never double-count.
+
+    Forces genuine simultaneity (not just "launched close together", which
+    process-startup jitter alone could make sequential in practice and would
+    let a broken, unsynchronized implementation pass by accident): each
+    subprocess writes a ready-marker as soon as it starts, then busy-polls
+    for a go-file the test only creates once BOTH markers exist, so both
+    processes call the consolidation function within microseconds of each
+    other.
+    """
+    multiproc_dir = str(tmp_path)
+    env = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": multiproc_dir}
+
+    result = subprocess.run(
+        [sys.executable, "-c", _COUNTER_HISTOGRAM_WRITER, "10"],
+        cwd=str(_BACKEND_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+    ready_a, ready_b = tmp_path / "ready_a", tmp_path / "ready_b"
+    go = tmp_path / "go"
+    sweep_script = f"""
+import os
+import time
+
+ready = {{"a": {str(ready_a)!r}, "b": {str(ready_b)!r}}}[__import__("sys").argv[1]]
+open(ready, "w").close()
+
+deadline = time.monotonic() + 10
+while not os.path.exists({str(go)!r}):
+    if time.monotonic() > deadline:
+        raise TimeoutError("go file never appeared")
+    time.sleep(0.001)
+
+os.environ["PROMETHEUS_MULTIPROC_DIR"] = {multiproc_dir!r}
+from app.observability.metrics import _consolidate_dead_counter_and_histogram_files
+
+_consolidate_dead_counter_and_histogram_files()
+"""
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", sweep_script, label],
+            cwd=str(_BACKEND_ROOT),
+            env=env,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for label in ("a", "b")
+    ]
+
+    deadline = time.monotonic() + 10
+    while not (ready_a.exists() and ready_b.exists()):
+        assert time.monotonic() < deadline, "sweeper subprocesses never became ready"
+        time.sleep(0.001)
+    go.touch()
+
+    for p in procs:
+        stderr = p.communicate(timeout=30)[1]
+        assert p.returncode == 0, stderr
+
+    after = _scrape_consolidate_metrics(multiproc_dir)
+    total_after = sum(
+        s.value
+        for s in after["test_consolidate_requests"].samples
+        if s.name == "test_consolidate_requests_total"
+    )
+    assert total_after == 10.0
 
 
 def test_shutdown_worker_metrics_marks_process_dead_when_multiprocess_active():

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -274,6 +274,11 @@ services:
       UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN: "${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-30}"
       # fix(#643): recycle each worker after this many requests (empty disables).
       UVICORN_MAX_REQUESTS: "${UVICORN_MAX_REQUESTS:-10000}"
+      # fix(#1240, #651): prometheus_client multiprocess mode, api service only
+      # (the worker's separate /metrics stays single-process — see #651). A
+      # subdirectory of the api service's tmpfs /tmp mount (512m, above), so
+      # it never survives a container restart carrying stale per-pid files.
+      PROMETHEUS_MULTIPROC_DIR: "${PROMETHEUS_MULTIPROC_DIR:-/tmp/prometheus-multiproc}"
       PUBLIC_APP_URL: ${PUBLIC_APP_URL:-http://localhost:8080}
       PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8080/api}
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -341,6 +341,11 @@ services:
       UVICORN_WORKERS: "${UVICORN_WORKERS:-1}"
       UVICORN_TIMEOUT_KEEP_ALIVE: "${UVICORN_TIMEOUT_KEEP_ALIVE:-5}"
       UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN: "${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-30}"
+      # fix(#1240, #651): prometheus_client multiprocess mode, api service only
+      # (the worker's separate /metrics stays single-process — see #651). A
+      # subdirectory of the api service's tmpfs /tmp mount, so it never
+      # survives a container restart carrying stale per-pid files.
+      PROMETHEUS_MULTIPROC_DIR: "${PROMETHEUS_MULTIPROC_DIR:-/tmp/prometheus-multiproc}"
       PUBLIC_APP_URL: ${PUBLIC_APP_URL:-http://localhost:8080}
       PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8080/api}
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-}

--- a/infra/monitoring/grafana-dashboard.json
+++ b/infra/monitoring/grafana-dashboard.json
@@ -543,12 +543,22 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_resident_memory_bytes{job=~\"geolens-.*\"}",
+          "expr": "process_resident_memory_bytes{job=\"geolens-worker\"}",
           "refId": "A",
-          "legendFormat": "{{job}}"
+          "legendFormat": "worker"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(geolens_worker_rss_bytes)",
+          "refId": "B",
+          "legendFormat": "api"
         }
       ],
       "title": "Process resident memory (by service)",
+      "description": "fix(#1240, #651 review round 3): the api job runs prometheus_client multiprocess mode, so its served registry only contains MultiProcessCollector and stops exporting the default process_resident_memory_bytes -- geolens_worker_rss_bytes (summed across live workers) is the multiprocess-safe equivalent. The worker stays single-process and keeps exporting process_resident_memory_bytes directly.",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
## Summary

With `UVICORN_WORKERS>=2` (the prod compose default is 2), every `prometheus_client` metric lived in each worker's own local registry, and `/metrics` was answered by whichever worker took the scrape. Successive scrapes sawtoothed between per-process values. Prometheus reads that as a counter reset, which fabricates `rate()` traffic and collapses `rate(sum)/rate(count)` latency down to a single worker's lifetime mean. That is what caused the `GeoLensApiTileLatencyMean` false "site DOWN" firings after the v1.8.0 and v1.9.0 demo deploys (#1240): the alert pinned on the cold-cache smoke-test render's lifetime mean, and nothing at low demo traffic ever diluted it.

This adopts `prometheus_client` multiprocess mode for the api service (#651):

- `PROMETHEUS_MULTIPROC_DIR` is now set for the api service in both compose files, pointing at a subdirectory of the existing tmpfs `/tmp` mount so it's writable under the read-only rootfs and never survives a container restart.
- `backend/scripts/api-entrypoint.sh` clears stale `.db` files from that directory before uvicorn forks its workers, so a leftover file from a previous container generation (say, a different `UVICORN_WORKERS` topology) can't pollute the new generation's sums.
- `shutdown_worker_metrics()` (new, in `backend/app/observability/metrics/__init__.py`) calls `multiprocess.mark_process_dead()` in the API lifespan's shutdown path, so a worker recycled under `UVICORN_MAX_REQUESTS` (#643) drops its own files instead of leaving a stale series for future scrapes to keep summing.
- `pool.py`'s four connection-pool gauges now declare `multiprocess_mode="livesum"` explicitly. Left at the default (`"all"`), multiprocess mode auto-labels every sample by pid, turning one series into N and silently breaking `GeoLensDbPoolSaturated` and any other alert or dashboard expression that reads the bare metric name. `livesum` keeps the pre-fix single-series shape, now correctly summed across live workers instead of showing one arbitrary worker's pool.
- `geolens_worker_rss_bytes` (#650) needed no change. It already declares its own `pid` label and defaults to multiprocess mode `"all"`, which is exactly the "every live worker in one scrape" behavior #651 wants.
- `prometheus_fastapi_instrumentator` (already pinned at 8.1.0) turns out to already serve `/metrics` from a fresh `CollectorRegistry` plus `MultiProcessCollector` whenever `PROMETHEUS_MULTIPROC_DIR` is set, and falls back to the plain default registry otherwise. So `init_metrics()` itself needed no code change, just a docstring recording why.
- The worker service's separate `/metrics` (port 8001, `backend/app/observability/health/worker.py`) is untouched on purpose. It's a single process, so multiprocess mode would only add pid-file cleanup risk for no benefit, per #651's scoping note. `PROMETHEUS_MULTIPROC_DIR` is set only in the api service's env block, never the worker's, so `jobs.py`'s queue-depth/completed/failed metrics (worker-only) are unaffected.
- Updated `.env.example` and `RUNBOOK.md` to document the new env var and drop the stale "one scrape sees one worker" caveat.

## Ops / config impact

- **New env var**: `PROMETHEUS_MULTIPROC_DIR`, default `/tmp/prometheus-multiproc`, set in both `docker-compose.yml` and `docker-compose.prod.yml` for the `api` service only. Operators running the api image outside these compose files with `UVICORN_WORKERS>1` need to set it themselves, to a writable, container-local, ephemeral directory (documented in `.env.example` and `RUNBOOK.md`).
- No schema/migration/API changes.
- The demo's temporary mitigation (`UVICORN_WORKERS=1` override on the demo host, applied 2026-08-06) should be reverted once this ships. That's an ops action on the demo deployment, not a change in this repo.

## Verification

- `cd backend && uv run ruff check .`: clean
- `cd backend && uv run ruff format --check .`: clean
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest`: full backend suite passes
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q`: passes (`backend/app/api/main.py` cap raised 1292 to 1296 in the same commit, with a carve-out comment)
- New regression tests in `backend/tests/test_metrics.py` spawn real subprocesses (the only way to exercise `prometheus_client`'s multiprocess write path, since the value-storage backend is picked at first import) simulating two uvicorn workers, and assert against a real `CollectorRegistry` plus `MultiProcessCollector`:
  - `test_multiprocess_histogram_sums_across_simulated_workers`: the exact `http_request_duration_seconds` metric behind the #1240 alert sums to the true total (10, not 7 or 3) and stays stable across repeated reads.
  - `test_multiprocess_rss_gauge_shows_every_live_worker`: `geolens_worker_rss_bytes` shows both simulated worker pids in one scrape.
  - `test_multiprocess_pool_gauge_uses_livesum_not_per_pid`: `geolens_db_pool_checkedout` (the real production Gauge) stays a single series summed across workers instead of exploding into per-pid series.
  - `test_shutdown_worker_metrics_marks_process_dead_when_multiprocess_active` / `..._noop_without_multiprocess_dir`: the new lifespan-shutdown hook.

Closes #1240, Closes #651
