### PR TITLE
chore(catalog): drop unused quality_score_numeric column

### DIFF
--- a/backend/alembic/versions/0035_drop_quality_score_numeric.py
+++ b/backend/alembic/versions/0035_drop_quality_score_numeric.py
@@ -1,0 +1,46 @@
+"""Drop the unused datasets.quality_score_numeric column.
+
+fix(#1231): quality_score_numeric was written nowhere, read nowhere, and
+absent from openapi.json — a scalar that would only ever be a derived
+roll-up of quality_detail (JSONB, written at ingest in tasks_common.py).
+Persisting a derived value separately is a second source of truth that
+goes stale, so ADR-002 Decision 8 calls for dropping it rather than wiring
+it up. This decision is not gated on the rest of ADR-002 / Milestone 5.
+
+Revision ID: 0035_drop_quality_score_numeric
+Revises: 0034_linearize_geom_4326
+Create Date: 2026-08-06
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0035_drop_quality_score_numeric"
+down_revision: Union[str, None] = "0034_linearize_geom_4326"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "chk_quality_score_range", "datasets", schema="catalog", type_="check"
+    )
+    op.drop_column("datasets", "quality_score_numeric", schema="catalog")
+
+
+def downgrade() -> None:
+    # Column had no writers in production, so there is no data to restore.
+    op.add_column(
+        "datasets",
+        sa.Column("quality_score_numeric", sa.Float(), nullable=True),
+        schema="catalog",
+    )
+    op.create_check_constraint(
+        "chk_quality_score_range",
+        "datasets",
+        "quality_score_numeric IS NULL OR "
+        "(quality_score_numeric >= 0 AND quality_score_numeric <= 1)",
+        schema="catalog",
+    )

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -366,11 +366,6 @@ class Dataset(Base):
     __tablename__ = "datasets"
     __table_args__ = (
         CheckConstraint(
-            "quality_score_numeric IS NULL OR "
-            "(quality_score_numeric >= 0 AND quality_score_numeric <= 1)",
-            name="chk_quality_score_range",
-        ),
-        CheckConstraint(
             # fix(#430 codex r5): 'GEOMETRY' = generic mixed-geometry sentinel
             # stored by create_empty_dataset (fix #430 BA-32). Migration
             # 0011_allow_generic_geometry_type is the source of truth.
@@ -439,7 +434,6 @@ class Dataset(Base):
         MutableDict.as_mutable(JSONB), nullable=True
     )
     quality_statement: Mapped[str | None] = mapped_column(Text, nullable=True)
-    quality_score_numeric: Mapped[float | None] = mapped_column(Float, nullable=True)
     is_3d: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     n_dims: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
     z_min: Mapped[float | None] = mapped_column(Float, nullable=True)


### PR DESCRIPTION
## Summary

**Schema change — this migration drops a column and its CHECK constraint. Destructive; no downtime concern since the column carries no data (confirmed dead below), but flagging per convention.**

`datasets.quality_score_numeric` was written nowhere, read nowhere, and absent from `openapi.json`. Per ADR-002 Decision 8 (`docs-internal/decisions/adr-002-sources-refresh-v1.md`), the decision is to drop it rather than wire it up — a numeric quality roll-up is a pure function of `quality_detail` (JSONB, written at ingest) and belongs at read time if ever needed; persisting a derived value separately is a second source of truth that goes stale. This decision is explicitly called out in the ADR as **not gated** on the rest of ADR-002 / Milestone 5, so it ships as a standalone change.

Changes:
- `backend/app/modules/catalog/datasets/domain/models.py`: remove the `quality_score_numeric` column and the `chk_quality_score_range` CHECK constraint from the `Dataset` model.
- `backend/alembic/versions/0035_drop_quality_score_numeric.py`: new migration (`0034_linearize_geom_4326` → `0035_drop_quality_score_numeric`) drops the CHECK constraint then the column. `downgrade()` re-adds the nullable column and CHECK — no data restoration since there was none to lose.

Re-confirmed dead via `git grep -n "quality_score_numeric" -- backend/ frontend/ cli/ sdks/ mcp/`: only hits were `domain/models.py` (now removed) and the immutable baseline migration `0001_baseline.py` (expected — migration history doesn't change). `backend/openapi.json` has 0 references, so no SDK/CLI/openapi regen is needed.

Closes #1231

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- `uv run pytest` (full suite, host, against Postgres :5434) — 7229 passed, 89 skipped, 14 deselected
- `uv run pytest tests/test_layering.py -q` — 40 passed
- `alembic upgrade heads` + `alembic check` against a dedicated scratch database built from this worktree's models/migrations — `No new upgrade operations detected.`
- Pre-commit hooks (ruff, SSRF/visibility structural gates, secret detection) — all passed on commit