### PR TITLE
chore(release): v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-08-07
+
+### Security
+
+- **Password logins and dataset creation now write audit records, and the
+  action registry can no longer drift silently from what's actually logged.**
+  Failed and successful password-based logins, plus `dataset.create`, were
+  gaps in audit coverage; a new registry test walks every `AuditEvent` call
+  site (keyword or positional) and fails if it references an action that
+  isn't declared (#1230).
+
+### Fixed
+
+- **A sweep restart no longer strands a presigned upload mid-transfer.**
+  Lowering the presigned-URL timeout and restarting the sweep in the same
+  window could orphan a job whose upload was still in flight; the sweep and
+  the retry path now agree on the same margin, derived from S3's own
+  single-PUT size ceiling rather than a client-declared file size (#1236).
+- **A capped analysis preview now says so.** Previews that hit the row cap
+  used to render like a failed query; the map now shows the partial result
+  honestly, both in the preview list and as an on-map treatment, scoped to
+  the bbox actually queried (#727).
+
+### Changed
+
+- **`/metrics` no longer resets when a worker recycles.** Multi-worker
+  deployments (`UVICORN_WORKERS > 1`) previously served per-process counters
+  that could step backward on scrape whenever a worker restarted, which twice
+  produced false "site down" alerts in production. `/metrics` is now backed
+  by prometheus_client's multiprocess mode: a `PROMETHEUS_MULTIPROC_DIR`
+  tmpfs directory aggregates counters across workers, and a background sweep
+  reclaims a recycled worker's files without racing an in-flight scrape
+  (#1240, #651).
+- **`quality_score_numeric` removed.** The column was never wired to
+  anything; dropped via migration rather than carried forward unused (#1231).
+
+### Operations
+
+- **New required-for-multiprocess env var: `PROMETHEUS_MULTIPROC_DIR`.**
+  Set to a tmpfs-backed path in both the dev and prod Compose files. If you
+  run a custom deployment with `UVICORN_WORKERS > 1`, set this to a writable,
+  empty-on-boot directory or `/metrics` will serve single-process
+  (non-aggregated) counters again. Recreating the `api` container to pick up
+  this variable without also rebuilding the image will fail to boot: the
+  entrypoint script that prepares the directory ships in the image, not the
+  Compose file, so a deploy must rebuild/pull before it recreates.
+
 ## [1.9.0] - 2026-08-06
 
 ### Security
@@ -1782,7 +1829,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/geolens-io/geolens/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/geolens-io/geolens/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/geolens-io/geolens/compare/v1.7.1...v1.8.0
 [1.7.1]: https://github.com/geolens-io/geolens/compare/v1.7.0...v1.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and releases use semantic versioning.
   (#1240, #651).
 - **`quality_score_numeric` removed.** The column was never wired to
   anything; dropped via migration rather than carried forward unused (#1231).
+- **Python SDK: `AnalysisPreviewRequest`'s positional constructor argument
+  order shifted.** The new `bbox` field (#727) landed alphabetically before
+  `distance_meters` in the regenerated model, so code calling
+  `AnalysisPreviewRequest(operation, 500)` positionally now binds `500` to
+  `bbox` instead of `distance_meters` and gets a 422 on the next request.
+  Call with keyword arguments (`AnalysisPreviewRequest(operation=...,
+  distance_meters=500)`) to avoid this and any similar future reordering;
+  tracked for a permanent fix in #1257.
 
 ### Operations
 

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -603,7 +603,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.9.0"
+_FALLBACK_APP_VERSION = "1.10.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17846,7 +17846,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.9.0"
+    "version": "1.10.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.9.0"
+version = "1.10.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.9.0"
+version = "1.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.9.0"
+version = "1.10.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.9.0"
+version = "1.10.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.9.0"
+version = "1.10.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.9.0"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.9.0
+package_version_override: 1.10.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.9.0"
+version = "1.10.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
## Summary

Wave A release, per `docs-internal/handoff-next-round-20260806.md`. Five independent fixes merged into main (#1243-#1247), verified with a full whole-tree gate/smoke/probe pass post-merge, no version bump had gone out yet.

- **#1230** (audit): password logins and `dataset.create` now write audit records; a new registry test catches future action-declaration drift.
- **#1236** (ingest): closed the post-expiry sweep orphan across a timeout-lowering restart.
- **#727** (analysis): capped preview shows an honest partial-result state instead of reading as a failed query.
- **#1240 + #651** (observability): `/metrics` now runs prometheus_client's multiprocess mode, fixing the per-process counter reset that produced two false "site down" alerts in production. **New required env var for multi-worker deployments: `PROMETHEUS_MULTIPROC_DIR`.**
- **#1231** (catalog): dropped the unwired `quality_score_numeric` column via migration `0035`.

## Schema / API / config impact

- Migration `0035_drop_quality_score_numeric.py` (already merged with #1246, applied to main).
- New env var `PROMETHEUS_MULTIPROC_DIR` in both `docker-compose.yml` and `docker-compose.prod.yml`. **Deploy ordering matters**: recreating the `api` container to pick up this var without rebuilding the image will fail to boot, since the entrypoint script that prepares the tmpfs directory ships in the image, not the compose file. Standard "prune, then pull" redeploy order already handles this correctly.
- `backend/openapi.json` and typed SDK clients regenerated as part of the merged PRs (analysis preview response shape changed for #727).

## Verification

Full whole-tree pass on merged main (`a6385000d`), not just pre-merge per-PR CI:

- `make alembic-check`, `make openapi-check`, `make sdks-check`, `make cli-test`, `make version-check` — all pass.
- Backend pytest: 7290 passed, 83 skipped, 86.96% coverage (floor 80%). 2 failures under `-n 4` isolated to a pre-existing xdist test-isolation issue unrelated to any Wave A change (filed as #1251), confirmed passing 19/19 in isolation.
- `test_layering.py`: 40 passed.
- Frontend: build, lint, typecheck, `test:coverage` (380 files / 4669 tests) all pass.
- Playwright smoke: 67/69 pass. Both failures are pre-existing, unrelated to Wave A logic (filed as #1252, #1253) — confirmed the underlying product behavior is correct in both cases.
- Two targeted probes per the release runbook, both pass with positive evidence (not just "looked stable"):
  - Metrics: 20 scrapes under `UVICORN_WORKERS=2` with live traffic, 0 downward steps across 27 series; a negative control (same probe, var unset) reproduced the exact pre-fix bug signature.
  - Sweep: drove the real sweep function against real Postgres and a real on-disk object (not the merged test's mocked storage), 10/10 checks including recheck-reaps-recreated-orphan.

Two Makefile/infra papercuts found during verification, filed as #1254 and #1255 (not release-blocking).