### PR TITLE
chore(deps): bump js-yaml lockfile pins to 4.3.1 for GHSA advisory

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6520,9 +6520,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -436,9 +436,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Problem

A newly published js-yaml advisory (affects >=4.0.0 <4.3.1) turns the `JS audit (frontend)` and `JS audit (sdks/typescript)` gates red on every open PR. Dependabot's security update for /sdks/typescript failed outright (run 31175599595 — the advisory ships no patched-version metadata), and its /frontend PR #1258 red-crossed on the sdks/typescript gate, so neither directory could land alone.

## Fix

Lockfile-only bumps of js-yaml 4.3.0 -> 4.3.1 in `frontend/package-lock.json` and `sdks/typescript/package-lock.json`. Both directories pin ranges that admit 4.3.1 (frontend directly; sdks/typescript via the direct pin and the transitive `@hey-api/json-schema-ref-parser` requirement), so no manifest changes are needed.

## Verification

- `cd frontend && npm audit` → 0 vulnerabilities
- `cd sdks/typescript && npm audit` → 0 vulnerabilities
- `cd sdks/typescript && npm run build` → clean (tsc + fix-esm-extensions)

Supersedes #1258 (frontend half of the same advisory).