### PR TITLE
ops(audit): convert RUNBOOK retention procedure to a tested script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,10 @@ jobs:
               - '.env.example'
               - '.dockerignore'
               - 'db/**'
+              # test_audit_retention_script.py runs this script for real against
+              # a throwaway database. Editing the script without re-running its
+              # only gate is exactly the regression it exists to catch.
+              - 'scripts/audit_retention.sh'
               # Frontend files that backend parity/drift tests read by literal
               # path (fe-sdk type drift, basemap/capability/paint-key drift,
               # nginx/CSP/Dockerfile regressions). Specific files only — NOT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,11 @@ jobs:
               - 'db/**'
               # test_audit_retention_script.py runs this script for real against
               # a throwaway database. Editing the script without re-running its
-              # only gate is exactly the regression it exists to catch.
+              # only gate is exactly the regression it exists to catch. The same
+              # test asserts audit-archives/ stays gitignored, so a
+              # .gitignore-only PR must run Backend Tests too.
               - 'scripts/audit_retention.sh'
+              - '.gitignore'
               # Frontend files that backend parity/drift tests read by literal
               # path (fe-sdk type drift, basemap/capability/paint-key drift,
               # nginx/CSP/Dockerfile regressions). Specific files only — NOT

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,13 @@ backups/
 restore/
 *.dump
 
+# Audit-log retention archives. RUNBOOK section 8 tells operators to point
+# `scripts/audit_retention.sh --archive-dir` outside the checkout, and this is
+# the second line of defence for anyone who takes the script's default of
+# ./audit-archives while sitting in the repo root. An archive is a verbatim
+# export of usernames, IP addresses and activity.
+audit-archives/
+
 # Playwright
 playwright/.auth/
 playwright-report/

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1456,14 +1456,34 @@ the other scripts here. On a managed or external Postgres (§3) there is no `db`
 container, so use either:
 
 ```bash
-# A libpq connection URL:
+# A libpq connection URL, with the password kept out of the command line:
+export PGPASSWORD=...
 ./scripts/audit_retention.sh --db-url "postgresql://user@host:5432/geolens" ...
+
+# ...or the whole URL in the environment, password included:
+export GEOLENS_RETENTION_DB_URL="postgresql://user:pw@host:5432/geolens"
+./scripts/audit_retention.sh ...
 
 # ...or the standard libpq environment variables (setting PGHOST or PGSERVICE
 # is what selects this mode):
 export PGHOST=... PGPORT=5432 PGUSER=... PGDATABASE=geolens PGPASSWORD=...
 ./scripts/audit_retention.sh ...
 ```
+
+**Do not put a password in `--db-url` if you can avoid it.** Command lines are
+world-readable on most systems (`ps`, `/proc/<pid>/cmdline`), so anything typed
+there is visible to every local account for as long as the process runs. The
+script keeps secrets out of the command lines it *controls* — the password is
+moved into the environment before `psql` is invoked, and the admin bearer token
+reaches `curl` through a `0600` header file rather than `-H` — but it cannot
+retract its own command line, so a password passed that way is exposed for the
+whole run and the script warns about it. `GEOLENS_RETENTION_DB_URL` and
+`PGPASSWORD` avoid that entirely.
+
+A password inside the URL must be percent-encoded, as libpq requires
+(`p@ss/word` becomes `p%40ss%2Fword`). The script decodes it before handing it
+over; if the encoding is malformed it stops and tells you to use `PGPASSWORD`
+instead, rather than guessing and connecting with a mangled password.
 
 A SQLAlchemy driver suffix is stripped for you: `postgresql+asyncpg://` and
 `postgresql+psycopg://` both become `postgresql://`, which is what libpq's URI

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1479,6 +1479,12 @@ retention pass, longer than any command it spawns. Nothing can retract it
 afterwards, so the password has to arrive by another route. The two above both
 work; the error message names them if you forget.
 
+That covers both places a libpq URL can carry one: `user:password@` and a
+`?password=` query parameter. Supplying it in both is refused as well, because
+libpq silently resolves that in favour of the query parameter and ignores the
+other — so changing the wrong half would connect with the credential you
+thought you had replaced.
+
 Secrets in the command lines the script *does* control are handled for you: a
 password from `GEOLENS_RETENTION_DB_URL` is moved into the environment before
 `psql` is invoked, and the admin bearer token reaches `curl` through a `0600`
@@ -1525,8 +1531,11 @@ at `--batch-size` rows per statement for that reason. Pass `--vacuum` if the run
 removed a large fraction of the table — routine autovacuum handles smaller,
 regular prunes on its own.
 
-Requires `psql`, `curl` and `jq` on the machine you run it from, plus `docker`
-for the bundled-container path.
+Requires `curl` and `jq` on the machine you run it from. Beyond that it depends
+on how you connect: the bundled path needs `docker` and nothing else, because it
+runs `psql` *inside* the db container, while the `--db-url`,
+`GEOLENS_RETENTION_DB_URL` and `PG*` paths need a `psql` client on the host. A
+Docker-only self-host does not need one installed.
 
 **What is actually lost:** the deleted rows, permanently, including the
 ability to answer "who did X on day Y" for anything older than the window.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1409,6 +1409,11 @@ Consecutive sub-windows share their boundary instant, so a row on a boundary is
 archived twice — harmless, and much safer than offsetting a bound by an epsilon,
 which would drop that row from every export instead.
 
+The one case that cannot be split is a single instant holding more rows than
+`--max-rows`, since no choice of bounds makes that window exportable; the run
+stops and names the timestamp. Raise `--max-rows` (up to 100000) or archive that
+instant by hand.
+
 If you want a CSV copy for human review, export it separately *after* a run has
 completed; never use CSV as the verification input.
 
@@ -1462,15 +1467,23 @@ A SQLAlchemy driver suffix is stripped for you: `postgresql+asyncpg://` and
 parser accepts.
 
 Whichever credential you use must be able to see and modify rows across every
-tenant — **not** the app's least-privilege runtime login. Boot refuses to start
-`GEOLENS_TENANCY_MODE=multi_tenant` with a runtime role that can bypass
-row-level security (`backend/app/core/db/rls.py`), by design, and
-`catalog.audit_logs` carries exactly that RLS policy (migration 0022): a session
-without `BYPASSRLS` and without `app.current_tenant` set only ever sees zero
-rows through it, so the counts and deletes would silently do nothing rather than
-the documented thing. Use the same privileged/migrator-class credential §2 calls
-out for schema changes, not the steady-state `DATABASE_URL_OVERRIDE` your running
-deployment authenticates with day to day.
+tenant — **not** the app's least-privilege runtime login. `catalog.audit_logs`
+carries the `tenant_isolation` row-level security policy (migration 0022), and a
+session without `BYPASSRLS` reads zero rows through it, so that credential would
+count nothing, delete nothing, and report success. Use the same
+privileged/migrator-class credential §2 calls out for schema changes, not the
+steady-state `DATABASE_URL_OVERRIDE` your deployment authenticates with day to
+day. Boot already refuses to start `GEOLENS_TENANCY_MODE=multi_tenant` with a
+runtime role that *can* bypass RLS (`backend/app/core/db/rls.py`), by design, so
+the two credentials really are different accounts.
+
+The script enforces this per query rather than trusting you to get it right:
+every statement it runs is preceded by `SET row_security = off`, which is a
+no-op for a session that can bypass RLS and an error — "query would be affected
+by row-level security policy" — for one that cannot. The run stops there. A
+connectivity check could not have caught it, because `SELECT ... LIMIT 0`
+succeeds for a login RLS reduces to nothing, which is exactly why the wrong
+credential used to look like an empty retention window.
 
 The export goes through the API, not a direct database connection, so this
 choice does not affect it.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1456,13 +1456,14 @@ the other scripts here. On a managed or external Postgres (§3) there is no `db`
 container, so use either:
 
 ```bash
-# A libpq connection URL, with the password kept out of the command line:
-export PGPASSWORD=...
-./scripts/audit_retention.sh --db-url "postgresql://user@host:5432/geolens" ...
-
-# ...or the whole URL in the environment, password included:
+# The whole URL in the environment, password included:
 export GEOLENS_RETENTION_DB_URL="postgresql://user:pw@host:5432/geolens"
 ./scripts/audit_retention.sh ...
+
+# ...or a password-free URL on the command line, with the password in the
+# environment beside it:
+export PGPASSWORD=...
+./scripts/audit_retention.sh --db-url "postgresql://user@host:5432/geolens" ...
 
 # ...or the standard libpq environment variables (setting PGHOST or PGSERVICE
 # is what selects this mode):
@@ -1470,17 +1471,20 @@ export PGHOST=... PGPORT=5432 PGUSER=... PGDATABASE=geolens PGPASSWORD=...
 ./scripts/audit_retention.sh ...
 ```
 
-**Do not put a password in `--db-url` if you can avoid it.** Command lines are
-world-readable on most systems (`ps`, `/proc/<pid>/cmdline`), so anything typed
-there is visible to every local account for as long as the process runs. The
-script keeps secrets out of the command lines it *controls* — the password is
-moved into the environment before `psql` is invoked, and the admin bearer token
-reaches `curl` through a `0600` header file rather than `-H` — but it cannot
-retract its own command line, so a password passed that way is exposed for the
-whole run and the script warns about it. `GEOLENS_RETENTION_DB_URL` and
-`PGPASSWORD` avoid that entirely.
+**`--db-url` will not accept a password, and refuses rather than warning.**
+Command lines are world-readable on most systems (`ps`,
+`/proc/<pid>/cmdline`), so anything typed there is visible to every local
+account for as long as the process runs — and this script runs for the whole
+retention pass, longer than any command it spawns. Nothing can retract it
+afterwards, so the password has to arrive by another route. The two above both
+work; the error message names them if you forget.
 
-A password inside the URL must be percent-encoded, as libpq requires
+Secrets in the command lines the script *does* control are handled for you: a
+password from `GEOLENS_RETENTION_DB_URL` is moved into the environment before
+`psql` is invoked, and the admin bearer token reaches `curl` through a `0600`
+header file instead of `-H`.
+
+A password inside either URL must be percent-encoded, as libpq requires
 (`p@ss/word` becomes `p%40ss%2Fword`). The script decodes it before handing it
 over; if the encoding is malformed it stops and tells you to use `PGPASSWORD`
 instead, rather than guessing and connecting with a mangled password.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1409,10 +1409,13 @@ Consecutive sub-windows share their boundary instant, so a row on a boundary is
 archived twice — harmless, and much safer than offsetting a bound by an epsilon,
 which would drop that row from every export instead.
 
-The one case that cannot be split is a single instant holding more rows than
-`--max-rows`, since no choice of bounds makes that window exportable; the run
-stops and names the timestamp. Raise `--max-rows` (up to 100000) or archive that
-instant by hand.
+Timestamps are not unique, so a split can land in the middle of a group of rows
+sharing one instant. When that happens the script backs off to the last distinct
+timestamp before the group and exports what precedes it, rather than treating
+the window as unsplittable. The only case it genuinely cannot split is a *single
+instant* holding more rows than `--max-rows`, because no choice of bounds makes
+that window exportable; the run stops and names the timestamp. Raise
+`--max-rows` (up to 100000) or archive that instant by hand.
 
 If you want a CSV copy for human review, export it separately *after* a run has
 completed; never use CSV as the verification input.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1369,9 +1369,15 @@ The script exits non-zero and deletes nothing if any of these fails:
   literal newlines that the CSV writer preserves inside a quoted field.
 - **The archive holds exactly as many rows as the database counts** for the
   identical window and scope, and no row whose timestamp falls outside that
-  window. The second check is what catches a right-sized archive holding the
-  wrong rows — the export is scoped by the host it is called against, so a
-  wrong `--api-url` can return somebody else's history.
+  window.
+- **The archive holds exactly the rows the delete would remove**, compared by
+  audit-log id. Size and time range are not enough on their own: the export is
+  scoped by the host it is called against, so pairing `--tenant-slug` with the
+  wrong tenant's `--api-url` returns that tenant's rows, and if both tenants
+  have the same number of rows in the window every other check passes while the
+  archive describes the wrong history. If your server predates this check it
+  will not send the id at all, and the script stops rather than guessing;
+  upgrade the deployment.
 - **After the delete**, no row at or before the cutoff remains in scope.
 
 Two structural properties sit behind those checks:
@@ -1389,6 +1395,12 @@ Archive filenames carry the scope, a UTC timestamp and the pid, and the script
 refuses to write over a file that already exists — two tenants archived on the
 same day, or the same tenant archived twice, cannot truncate each other's only
 copy.
+
+An archive is a verbatim dump of usernames, IP addresses and activity for the
+whole window, so the script runs under `umask 077`: archives are created 0600
+and an archive directory it creates is 0700. Under the usual 022 they would be
+world-readable by every local account on the host. A directory that already
+exists keeps whatever permissions you gave it, so check that one yourself.
 
 Windows holding more than `--max-rows` rows are split automatically. Narrowing
 `date_to` by hand does not work: the endpoint always returns the *newest* rows

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1333,14 +1333,24 @@ export ADMIN_TOKEN=<an admin bearer token>
 ./scripts/audit_retention.sh \
   --api-url https://<your-host>/api \
   --days 90 \
+  --archive-dir /var/backups/geolens/audit-archives \
   --confirm-single-tenant "yes, this deployment has no per-tenant host routing"
 
 # Per-tenant host routing: one run per tenant, against that tenant's host.
 ./scripts/audit_retention.sh \
   --api-url https://<tenant-host>/api \
   --days 90 \
+  --archive-dir /var/backups/geolens/audit-archives \
   --tenant-slug <your-tenant-slug>
 ```
+
+**Give `--archive-dir` a path outside the checkout**, alongside wherever §1
+puts your database backups. The archives belong with your backups rather than
+your source tree, and keeping them out of the working copy means no later
+`git add .` can stage an export of usernames, IP addresses and activity. The
+default is `./audit-archives`, which lands in the repository root when you run
+the script from there; `.gitignore` covers that directory as a second line of
+defence, but the directory you actually want is the one next to your backups.
 
 `--help` lists every flag. The ones worth knowing before the first run:
 
@@ -1349,7 +1359,7 @@ export ADMIN_TOKEN=<an admin bearer token>
 | `--days N` / `--cutoff TS` | The retention boundary. Exactly one is required; there is no default window. |
 | `--tenant-slug SLUG` / `--confirm-single-tenant PHRASE` | The scope. Exactly one is required. |
 | `--dry-run` | Export and verify, then stop without deleting. Use it for the first run on any deployment. |
-| `--archive-dir DIR` | Where archives land (default `./audit-archives`). |
+| `--archive-dir DIR` | Where archives land (default `./audit-archives`). Point it outside the checkout. |
 | `--db-url URL` | External/managed Postgres (below). |
 | `--batch-size N` | Rows per delete statement, default 5000. |
 | `--max-rows N` | Rows per export call, default 100000. |

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1296,11 +1296,12 @@ docstring, which already flags that the table can reach millions of rows on a
 busy instance). Community ships bounded CSV/JSON export
 (`GET /admin/audit-logs/export/{format}`, capped at 100,000 rows per request)
 but no automatic pruning — an operator who wants a retention window applies it
-manually. This section is that manual procedure, not an in-app feature: an
-in-app pruning endpoint means a new destructive-write surface (Rule 1 of the
-Security pre-commit checklist, plus RBAC and rate-limit review for a
-delete-many endpoint), and a manual SQL window is the smaller, auditable
-surface for a table whose entire purpose is being an audit trail.
+out of band, with `scripts/audit_retention.sh`. That is deliberately an
+operator-run script rather than an in-app feature: an in-app pruning endpoint
+means a new destructive-write surface (Rule 1 of the Security pre-commit
+checklist, plus RBAC and rate-limit review for a delete-many endpoint), and a
+script an operator invokes deliberately is the smaller, auditable surface for a
+table whose entire purpose is being an audit trail.
 
 ### Deciding on a window
 
@@ -1312,327 +1313,171 @@ mind:
   events. A shorter window for those and a longer one for account/security
   events (`user.login.*`, `user.logout`, `user.change_password`,
   `oauth_provider.*`) is a reasonable split if your regulatory requirement
-  distinguishes between them.
+  distinguishes between them. The script below has no per-action filter — it
+  applies one window to every action — so a split like that still has to be
+  done by hand.
 - The export endpoint is the archive step. Deleting rows you have not
   exported is not "retention", it's data loss — always export the window you
   are about to delete first.
 
 ### Archive-then-delete by age
 
-Fix the retention boundary to **one** timestamp and reuse it for every step
-below — the export and the delete must agree on the exact same cutoff, not
-two separately-evaluated `now() - interval '90 days'` calls (which drift
-against each other across the minutes the procedure takes to run, and again
-on every batched commit inside the delete loop):
+`scripts/audit_retention.sh` performs the whole procedure: it exports the
+window through the API, verifies the archive, and only then deletes exactly
+the rows it archived. Run it from the repository root.
 
 ```bash
-CUTOFF=$(date -u -d '-90 days' +%Y-%m-%dT%H:%M:%SZ)
+export ADMIN_TOKEN=<an admin bearer token>
+
+# Single-tenant deployment (see the confirmation note below):
+./scripts/audit_retention.sh \
+  --api-url https://<your-host>/api \
+  --days 90 \
+  --confirm-single-tenant "yes, this deployment has no per-tenant host routing"
+
+# Per-tenant host routing: one run per tenant, against that tenant's host.
+./scripts/audit_retention.sh \
+  --api-url https://<tenant-host>/api \
+  --days 90 \
+  --tenant-slug <your-tenant-slug>
 ```
 
-Every SQL step below runs through one `$PSQL` command array — set it once
-and every command that follows uses `"${PSQL[@]}"` instead of repeating a
-connection prefix that differs by deployment mode:
+`--help` lists every flag. The ones worth knowing before the first run:
+
+| Flag | Effect |
+| --- | --- |
+| `--days N` / `--cutoff TS` | The retention boundary. Exactly one is required; there is no default window. |
+| `--tenant-slug SLUG` / `--confirm-single-tenant PHRASE` | The scope. Exactly one is required. |
+| `--dry-run` | Export and verify, then stop without deleting. Use it for the first run on any deployment. |
+| `--archive-dir DIR` | Where archives land (default `./audit-archives`). |
+| `--db-url URL` | External/managed Postgres (below). |
+| `--batch-size N` | Rows per delete statement, default 5000. |
+| `--max-rows N` | Rows per export call, default 100000. |
+| `--vacuum` | `VACUUM (ANALYZE) catalog.audit_logs` after the delete. |
+
+#### What it verifies before deleting anything
+
+The script exits non-zero and deletes nothing if any of these fails:
+
+- **The export request itself.** curl runs with `--fail`, so an expired token,
+  a wrong host, or any 4xx/5xx aborts the run instead of saving the error body
+  (e.g. `{"detail":"Not authenticated"}`) as if it were the archive.
+- **The archive is a complete JSON array.** A 200 carrying a proxy error page,
+  or a truncated stream, fails here rather than reporting a plausible row
+  count. JSON is used rather than CSV because a CSV line count is not a row
+  count: `resource_name` comes from user-supplied titles, which may contain
+  literal newlines that the CSV writer preserves inside a quoted field.
+- **The archive holds exactly as many rows as the database counts** for the
+  identical window and scope, and no row whose timestamp falls outside that
+  window. The second check is what catches a right-sized archive holding the
+  wrong rows — the export is scoped by the host it is called against, so a
+  wrong `--api-url` can return somebody else's history.
+- **After the delete**, no row at or before the cutoff remains in scope.
+
+Two structural properties sit behind those checks:
+
+- The cutoff is evaluated **once**, in the database, and every later step reuses
+  that exact string. Nothing re-evaluates `now() - interval '90 days'`, so the
+  count, the export and the delete cannot drift apart over the minutes a large
+  run takes.
+- Both window bounds are inclusive everywhere (`created_at >= date_from AND
+  created_at <= date_to`), matching the export endpoint's own filters. There is
+  no way to ask that endpoint for an exclusive bound, and a delete using `<`
+  against an export using `<=` can discard a row that was never archived.
+
+Archive filenames carry the scope, a UTC timestamp and the pid, and the script
+refuses to write over a file that already exists — two tenants archived on the
+same day, or the same tenant archived twice, cannot truncate each other's only
+copy.
+
+Windows holding more than `--max-rows` rows are split automatically. Narrowing
+`date_to` by hand does not work: the endpoint always returns the *newest* rows
+in a range, so repeating the same call returns the same slice forever.
+Consecutive sub-windows share their boundary instant, so a row on a boundary is
+archived twice — harmless, and much safer than offsetting a bound by an epsilon,
+which would drop that row from every export instead.
+
+If you want a CSV copy for human review, export it separately *after* a run has
+completed; never use CSV as the verification input.
+
+#### Choosing a scope
+
+**The script does not detect your deployment's tenancy mode, and neither
+should you infer it.** An empty tenant slug is not evidence of a single-tenant
+deployment; a mistyped slug or a failed lookup is exactly what turns into an
+unscoped, cross-tenant delete. So the two scopes are separate flags with no
+fallback between them, and `--tenant-slug` aborts if the slug resolves to
+nothing.
+
+`--confirm-single-tenant` takes the phrase verbatim:
+
+```
+yes, this deployment has no per-tenant host routing
+```
+
+An earlier revision of this procedure read `GEOLENS_TENANCY_MODE` from `.env`
+instead. That value can be absent, injected by an orchestrator rather than
+persisted to a file, or simply not read from wherever the running deployment
+gets its configuration — any config-derived signal here can be missing, stale,
+or wrong in a way a shell script cannot detect. The phrase has to be typed by
+an operator who has personally confirmed it.
+
+Running the unscoped mode on a deployment that *does* have per-tenant host
+routing is the worst outcome available here, and the reason is the export, not
+the delete: the export is always scoped to whichever tenant's host you call it
+against, so an unscoped delete removes every other tenant's audit history that
+the export never captured — permanent loss with no archive.
+
+#### Connecting to the database
+
+By default the script talks to the bundled `db` container through
+`docker compose exec`, reading `POSTGRES_USER` / `POSTGRES_DB` from `.env` like
+the other scripts here. On a managed or external Postgres (§3) there is no `db`
+container, so use either:
 
 ```bash
-# Bundled Postgres (default):
-PSQL=(docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB")
+# A libpq connection URL:
+./scripts/audit_retention.sh --db-url "postgresql://user@host:5432/geolens" ...
 
-# Managed/external Postgres (§3): there is no `db` container to exec into.
-# Connect directly instead — uncomment ONE of these and comment out the
-# bundled line above:
-# PSQL=(psql -h <host> -p <port> -U "$POSTGRES_USER" -d "$POSTGRES_DB")
-#
-# On a deployment with per-tenant host routing, whichever credential you
-# use here must be able to see and modify rows across every tenant -- NOT
-# the app's own least-privilege runtime login. Boot refuses to start
-# GEOLENS_TENANCY_MODE=multi_tenant with a runtime role that can bypass
-# row-level security (backend/app/core/db/rls.py), by design, and
-# catalog.audit_logs carries exactly that RLS policy (migration 0022): a
-# session without BYPASSRLS and without `app.current_tenant` set only ever
-# sees zero rows through it, so the count/delete commands below would
-# silently do nothing rather than the documented thing. Use the SAME
-# privileged/migrator-class credential §2 calls out for schema changes
-# ("the least-privilege runtime login in .env is deliberately not allowed
-# to do any of this"), not the steady-state DATABASE_URL_OVERRIDE your
-# running deployment authenticates with day to day.
-#
-# If that privileged credential happens to be a postgresql+asyncpg:// or
-# postgresql+psycopg:// SQLAlchemy URL, strip the driver suffix first --
-# libpq's URI parser accepts only the postgresql:// and postgres://
-# schemes:
-# PG_URI=$(echo "<your-privileged-connection-url>" | sed -E 's#^postgresql\+[a-zA-Z0-9_]+://#postgresql://#')
-# PSQL=(psql "$PG_URI")
+# ...or the standard libpq environment variables (setting PGHOST or PGSERVICE
+# is what selects this mode):
+export PGHOST=... PGPORT=5432 PGUSER=... PGDATABASE=geolens PGPASSWORD=...
+./scripts/audit_retention.sh ...
 ```
 
-The HTTP export commands further down are unaffected by this choice either
-way — they go through the API, not a direct DB connection.
+A SQLAlchemy driver suffix is stripped for you: `postgresql+asyncpg://` and
+`postgresql+psycopg://` both become `postgresql://`, which is what libpq's URI
+parser accepts.
 
-**Choose a tenant-scoping mode below and follow only that branch through the
-count and delete steps.** Do not mix them, and do not treat an empty
-`$TENANT_ID` as "must mean single-tenant" — that assumption is exactly what
-lets a mistyped slug or a failed lookup silently escalate into an unscoped,
-cross-tenant delete. Each branch is a fully separate, explicit set of
-commands with no shared fallback between them.
+Whichever credential you use must be able to see and modify rows across every
+tenant — **not** the app's least-privilege runtime login. Boot refuses to start
+`GEOLENS_TENANCY_MODE=multi_tenant` with a runtime role that can bypass
+row-level security (`backend/app/core/db/rls.py`), by design, and
+`catalog.audit_logs` carries exactly that RLS policy (migration 0022): a session
+without `BYPASSRLS` and without `app.current_tenant` set only ever sees zero
+rows through it, so the counts and deletes would silently do nothing rather than
+the documented thing. Use the same privileged/migrator-class credential §2 calls
+out for schema changes, not the steady-state `DATABASE_URL_OVERRIDE` your running
+deployment authenticates with day to day.
 
-#### Per-tenant host routing (more than one row in `catalog.tenants`)
+The export goes through the API, not a direct database connection, so this
+choice does not affect it.
 
-The HTTP export below is already scoped to whichever tenant's host you call
-it against, but the SQL delete that follows connects directly as
-`$POSTGRES_USER` (bypassing RLS) and has no such scope by default — without
-this branch you would export one tenant's window and delete every tenant's
-history that predates it. Resolve the tenant's id from its slug and **stop
-if the lookup returns nothing**:
+#### Scheduling and running cost
 
-```bash
-TENANT_SLUG=<your-tenant-slug>
-TENANT_ID=$("${PSQL[@]}" -tAc "SELECT id FROM catalog.tenants WHERE slug = '$TENANT_SLUG'")
-if [ -z "$TENANT_ID" ]; then
-  echo "No tenant found for slug '$TENANT_SLUG' -- aborting rather than" \
-       "falling through to an unscoped, all-tenants run" >&2
-  exit 1
-fi
-ARCHIVE_TAG="${TENANT_SLUG}-$(date -u +%Y%m%dT%H%M%SZ)"
-```
+Run it from a low-traffic maintenance window. The table's only DELETE-supporting
+index is `ix_catalog_audit_logs_created_action_resource`
+(`created_at DESC, action, resource_type`), so an unbounded delete on a
+multi-million-row table can hold locks and bloat the table; the script batches
+at `--batch-size` rows per statement for that reason. Pass `--vacuum` if the run
+removed a large fraction of the table — routine autovacuum handles smaller,
+regular prunes on its own.
 
-#### Single-tenant deployments
-
-This branch is not a generic "run unscoped" option, and must not be used on
-a deployment with per-tenant host routing even if you intend to touch every
-tenant's rows. The reason is the export step, not the delete: the HTTP
-export is always scoped to whichever tenant's host you call it against
-(there is no cross-tenant export call), so running this branch's unscoped
-count/delete on a deployment with per-tenant routing enabled would remove
-every other tenant's audit history that the export never captured —
-permanent loss with no archive, not merely a scoping mistake.
-
-This procedure does **not** attempt to detect your deployment's tenancy mode
-for you. An earlier revision checked `GEOLENS_TENANCY_MODE` from `.env`, but
-that value can be absent, injected by an orchestrator instead of a persisted
-`.env` file, or simply not read from wherever the running deployment actually
-gets its configuration — any config-derived signal here can be missing,
-stale, or wrong in a way this shell script cannot detect. Instead, this
-branch requires you, the operator, to type an explicit confirmation with no
-default and no config lookup behind it. Edit the placeholder below to the
-exact phrase shown — copying this block unedited leaves the placeholder in
-place and the check refuses to run:
-
-```bash
-# This command is unscoped by explicit operator confirmation. Replace the
-# placeholder with the exact phrase on the right ONLY once you personally --
-# not a config file, not this script -- have confirmed this deployment has
-# no per-tenant host routing.
-CONFIRM_SINGLE_TENANT="<type-the-confirmation-phrase-here>"
-if [ "$CONFIRM_SINGLE_TENANT" != "yes, this deployment has no per-tenant host routing" ]; then
-  echo "Refusing: the commands below delete every row before \$CUTOFF with" \
-       "no tenant scoping. Set CONFIRM_SINGLE_TENANT to the exact phrase" \
-       "above, typed by you, before running them." >&2
-  exit 1
-fi
-```
-
-`catalog.audit_logs.tenant_id` is NULL on every row once that confirmation is
-given (single-tenant never stamps it), so there is nothing left to filter
-by. This branch never resolves or reads a `$TENANT_ID` — it is a separate
-set of commands below, not a fallback the per-tenant branch reaches by
-leaving a variable unset:
-
-```bash
-ARCHIVE_TAG="default-$(date -u +%Y%m%dT%H%M%SZ)"
-```
-
-Every archive filename in this procedure must be unique per tenant and per
-run — two tenants exported on the same day, or the same tenant exported
-twice, would otherwise both write the same filename, and the second
-`curl -o` silently truncates the first tenant's only copy (possibly after
-that tenant's rows are already deleted). `$ARCHIVE_TAG` above exists to
-prevent that; every export filename below reuses it.
-
-**Count before you export.** The export endpoint caps at 100,000 rows per
-call — silently. A window with more matching rows than that returns only the
-100,000 newest ones in it, and deleting the full window afterward would
-discard rows that were never in the archive. Check first, using the count
-command for the branch you chose above:
-
-```bash
-# Per-tenant host routing (uses the validated, non-empty $TENANT_ID above):
-"${PSQL[@]}" -tAc \
-  "SELECT count(*) FROM catalog.audit_logs
-   WHERE created_at <= '$CUTOFF' AND tenant_id = '$TENANT_ID'::uuid"
-```
-
-```bash
-# Single-tenant (no tenant predicate -- confirmed above, not the default):
-"${PSQL[@]}" -tAc \
-  "SELECT count(*) FROM catalog.audit_logs WHERE created_at <= '$CUTOFF'"
-```
-
-Use `<=`, not `<`, and use it consistently in every count/export/delete step below.
-The export endpoint's `date_to` filter is inclusive (`created_at <= date_to`,
-not exclusive) and there is no way to ask it for an exclusive bound. If the
-delete used `<` while the count/export used `<=`, and a row happened to land
-exactly on `$CUTOFF`, the two predicates would cover different sets: at the
-100,000-row cap that boundary row can displace an older in-range row out of
-the export while that older row still gets deleted — never archived, but
-gone. Matching the delete's boundary to the export's removes the mismatch
-outright rather than trying to work around it.
-
-Export as **JSON**, not CSV, for this procedure: the row count is then a
-plain array length, checkable with `jq length`. A CSV line count minus the
-header is not reliable here — `resource_name` values come from user-supplied
-dataset/map/collection titles, which permit literal newlines, and the CSV
-writer preserves those inside a quoted field. A raw `wc -l` can therefore
-undercount a complete archive (embedded newlines inflate the apparent row
-count) or, worse, appear to match a truncated download. If you want a CSV
-copy for human review, export it separately *after* the JSON archive has
-verified clean — never use it as the verification input.
-
-If that count is **at or under 100,000**, one export call covers the whole
-window:
-
-```bash
-curl -sS -f -H "Authorization: Bearer $ADMIN_TOKEN" \
-  "https://<your-host>/api/admin/audit-logs/export/json?date_to=$CUTOFF" \
-  -o "audit-archive-${ARCHIVE_TAG}.json" \
-  || { echo "export request failed -- aborting, do NOT delete" >&2; exit 1; }
-```
-
-`-f`/`--fail` is not optional here: without it, an expired token, a wrong
-host, or any other 4xx/5xx still exits 0 and writes the error body (e.g.
-`{"detail":"Not authenticated"}`) to the output file as if it were the
-archive. `--fail` makes curl exit non-zero and discard that body instead of
-saving it.
-
-Before trusting the row count, confirm the file is actually a JSON array —
-an auth failure or a proxy error page that slips past `--fail` (a 200 with
-an unexpected body) would otherwise report a `jq length` of 0 or 1, which
-can look like a real, if small, count rather than "the archive is garbage":
-
-```bash
-jq -e 'type == "array"' "audit-archive-${ARCHIVE_TAG}.json" >/dev/null \
-  || { echo "not a JSON array -- aborting, do NOT delete" >&2; exit 1; }
-```
-
-Only then verify the exported row count equals the count from the query
-above before proceeding to the delete. A mismatch means stop — do not
-delete:
-
-```bash
-jq length "audit-archive-${ARCHIVE_TAG}.json"
-```
-
-If the count is **over 100,000**, one call cannot capture the whole window,
-and narrowing `date_to` alone doesn't help — the export is always the
-*newest* rows in the range, so repeating the same call returns the same slice
-forever. Partition the range into disjoint `date_from`/`date_to` sub-windows
-instead (a week or a month at a time, whatever keeps each sub-window under
-100,000 rows given your write volume), export each one, and verify each
-sub-window's exported row count (`jq length`, same as above) against a COUNT
-query scoped to that same sub-window — for example:
-
-```bash
-# Repeat with adjacent date_from/date_to pairs that together cover the full
-# range up to $CUTOFF. Each pair's exported row count must match:
-# SELECT count(*) FROM catalog.audit_logs WHERE created_at >= date_from
-# AND created_at <= date_to AND (tenant scope as above) -- both bounds
-# inclusive, matching the export endpoint's own semantics (see the <=
-# note above the single-call case). Both bounds being inclusive means a
-# row landing exactly on a shared boundary appears in both adjacent
-# windows' exports; that duplicates an archive entry, which is harmless
-# (the delete below still removes it exactly once), but do not offset
-# date_from by an epsilon to "fix" it -- that would silently exclude the
-# boundary row from every export instead. <window-start> must also be
-# part of the filename -- distinct sub-windows of the SAME tenant/run
-# still need distinct files.
-curl -sS -f -H "Authorization: Bearer $ADMIN_TOKEN" \
-  "https://<your-host>/api/admin/audit-logs/export/json?date_from=<window-start>&date_to=<window-end>" \
-  -o "audit-archive-${ARCHIVE_TAG}-<window-start>.json" \
-  || { echo "export request failed -- aborting, do NOT delete" >&2; exit 1; }
-jq -e 'type == "array"' "audit-archive-${ARCHIVE_TAG}-<window-start>.json" >/dev/null \
-  || { echo "not a JSON array -- aborting, do NOT delete" >&2; exit 1; }
-```
-
-Only once every sub-window is exported, confirmed to be a real JSON array,
-and verified by count does the full window have a complete archive —
-proceed to the delete below.
-
-Then delete the archived window, using the identical `$CUTOFF` and the SAME
-branch (per-tenant or single-tenant) you used for the count above — run this
-from a low-traffic maintenance window: the table's only
-DELETE-supporting index is `ix_catalog_audit_logs_created_action_resource`
-(`created_at DESC, action, resource_type`), so an unbounded
-`DELETE ... WHERE created_at <= ...` on a multi-million-row table can hold
-locks and bloat the table for a while. Batch it.
-
-`psql`'s `-v`/`:name` substitution does not reach inside a `DO $$...$$` body —
-per the [psql docs](https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-VARIABLES),
-variable interpolation is skipped inside quoted SQL literals, and a
-dollar-quoted block is one. Pass `$CUTOFF` through a session GUC instead,
-which the PL/pgSQL body reads with `current_setting()` — that call happens at
-execution time, outside the literal, so it works. The two branches below are
-genuinely separate commands, not one command with a variable that happens to
-be empty — the per-tenant delete's `WHERE` clause hard-codes
-`tenant_id = tenant_uuid` with no `OR` fallback, so there is no path from a
-missing or malformed `$TENANT_ID` into an unscoped delete; that failure was
-already caught by the `exit 1` above, before this command is ever reached:
-
-```bash
-# Per-tenant host routing:
-"${PSQL[@]}" -v cutoff="'$CUTOFF'" -v tenant_id="'$TENANT_ID'" <<'SQL'
-SET geolens.retention_cutoff = :cutoff;
-SET geolens.retention_tenant = :tenant_id;
-DO $$
-DECLARE
-  deleted_count integer;
-  cutoff_ts timestamptz := current_setting('geolens.retention_cutoff')::timestamptz;
-  tenant_uuid uuid := current_setting('geolens.retention_tenant')::uuid;
-BEGIN
-  LOOP
-    DELETE FROM catalog.audit_logs
-    WHERE id IN (
-      SELECT id FROM catalog.audit_logs
-      WHERE created_at <= cutoff_ts
-        AND tenant_id = tenant_uuid
-      LIMIT 5000
-    );
-    GET DIAGNOSTICS deleted_count = ROW_COUNT;
-    EXIT WHEN deleted_count = 0;
-    COMMIT;
-  END LOOP;
-END $$;
-SQL
-```
-
-```bash
-# Single-tenant (no tenant predicate -- confirmed above, not the default):
-"${PSQL[@]}" -v cutoff="'$CUTOFF'" <<'SQL'
-SET geolens.retention_cutoff = :cutoff;
-DO $$
-DECLARE
-  deleted_count integer;
-  cutoff_ts timestamptz := current_setting('geolens.retention_cutoff')::timestamptz;
-BEGIN
-  LOOP
-    DELETE FROM catalog.audit_logs
-    WHERE id IN (
-      SELECT id FROM catalog.audit_logs
-      WHERE created_at <= cutoff_ts
-      LIMIT 5000
-    );
-    GET DIAGNOSTICS deleted_count = ROW_COUNT;
-    EXIT WHEN deleted_count = 0;
-    COMMIT;
-  END LOOP;
-END $$;
-SQL
-```
-
-Run `VACUUM (ANALYZE) catalog.audit_logs;` afterward if the delete removed a
-large fraction of the table — routine autovacuum handles smaller, regular
-prunes on its own.
+Requires `psql`, `curl` and `jq` on the machine you run it from, plus `docker`
+for the bundled-container path.
 
 **What is actually lost:** the deleted rows, permanently, including the
 ability to answer "who did X on day Y" for anything older than the window.
-That is the intended tradeoff of retention; keep the exported CSV/JSON
-archive (offsite, per §1's guidance on the primary backup) if you need to
-answer that question later without re-enabling unbounded storage in the live
-table.
+That is the intended tradeoff of retention; keep the exported archive (offsite,
+per §1's guidance on the primary backup) if you need to answer that question
+later without re-enabling unbounded storage in the live table.

--- a/backend/app/modules/audit/router.py
+++ b/backend/app/modules/audit/router.py
@@ -250,6 +250,13 @@ class _AuditExportStream:
                     if row_count >= self.max_rows:
                         break
                     row = {
+                        # fix(#1248): the row's own primary key, so an archive
+                        # can be checked against the rows a retention run is
+                        # about to delete. Without it two same-sized, same-era
+                        # slices from different tenants are indistinguishable,
+                        # and scripts/audit_retention.sh cannot tell that it
+                        # archived one tenant and is deleting another's.
+                        "id": str(log.id),
                         "timestamp": (
                             log.created_at.isoformat() if log.created_at else None
                         ),

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -543,6 +543,9 @@ async def test_export_completion_counts_rows_visible_when_stream_starts(monkeypa
     tenant_id = str(uuid.uuid4())
     streamed_rows = [
         SimpleNamespace(
+            # fix(#1248): the JSON export emits the row's own id, so a fake row
+            # must carry one -- AuditLog.id is the primary key and never absent.
+            id=uuid.uuid4(),
             created_at=datetime.now(timezone.utc),
             user=SimpleNamespace(username="admin"),
             action="first.action",
@@ -622,6 +625,9 @@ async def test_export_completion_counts_rows_visible_when_stream_starts(monkeypa
     # the fresh streaming SELECT establishes its MVCC statement snapshot.
     streamed_rows.append(
         SimpleNamespace(
+            # fix(#1248): the JSON export emits the row's own id, so a fake row
+            # must carry one -- AuditLog.id is the primary key and never absent.
+            id=uuid.uuid4(),
             created_at=datetime.now(timezone.utc),
             user=SimpleNamespace(username="admin"),
             action="concurrent.action",

--- a/backend/tests/test_audit_retention_script.py
+++ b/backend/tests/test_audit_retention_script.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -42,6 +43,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "audit_retention.sh"
 
 CONFIRM_PHRASE = "yes, this deployment has no per-tenant host routing"
+
+# Generous next to the ~2s a real run takes here; small enough that a
+# non-advancing split loop fails the suite rather than hanging it.
+_SCRIPT_TIMEOUT_SECONDS = 120
 
 _REQUIRED_TOOLS = ("psql", "jq")
 _MISSING_TOOLS = [tool for tool in _REQUIRED_TOOLS if shutil.which(tool) is None]
@@ -253,18 +258,32 @@ def _run_script(
     *args: str,
     shim_mode: str = "ok",
     shim_tenant: str = "",
+    env_overrides: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess:
     env = _pg_env(db)
     env["PATH"] = f"{curl_stub_dir}{os.pathsep}{env['PATH']}"
     env["ADMIN_TOKEN"] = "stub-token"
     env["RETENTION_SHIM_MODE"] = shim_mode
     env["RETENTION_SHIM_TENANT"] = shim_tenant
-    return subprocess.run(
-        ["bash", str(SCRIPT), "--api-url", "https://example.invalid/api", *args],
-        env=env,
-        capture_output=True,
-        text=True,
-    )
+    if env_overrides:
+        env.update(env_overrides)
+    try:
+        return subprocess.run(
+            ["bash", str(SCRIPT), "--api-url", "https://example.invalid/api", *args],
+            env=env,
+            capture_output=True,
+            text=True,
+            # The window-splitting loop advances by moving WINDOW_FROM forward;
+            # a regression that fails to advance re-exports the same rows
+            # forever. Bounding the run turns that into a test failure instead
+            # of a hung CI job.
+            timeout=_SCRIPT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise AssertionError(
+            f"{SCRIPT} did not finish within {_SCRIPT_TIMEOUT_SECONDS}s; the "
+            "window-splitting loop is most likely not advancing."
+        ) from exc
 
 
 def _archives(archive_dir: Path) -> list[Path]:
@@ -441,6 +460,77 @@ def test_window_over_the_export_cap_is_split_and_fully_archived(
     archived = {row["timestamp"] for row in _archived_rows(archive_dir)}
     assert len(archived) == 10
     assert _row_count(db) == 0
+
+
+def test_max_rows_one_splits_a_two_row_window(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """--max-rows 1 over two rows at distinct timestamps (#1260 review).
+
+    The first sub-window boundary is the oldest row's own timestamp, so the
+    window end equals the window start. That is a perfectly splittable window,
+    not the unsplittable case: only one row sits at that instant. The loop has
+    to export it and step to the next distinct timestamp.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200])
+    _seed_rows(db, days_ago=[150])
+    assert (
+        int(_psql("SELECT count(DISTINCT created_at) FROM catalog.audit_logs", db)) == 2
+    )
+
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+        "--max-rows",
+        "1",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert len(_archives(archive_dir)) == 2
+    assert len({row["id"] for row in _archived_rows(archive_dir)}) == 2
+    assert _row_count(db) == 0
+
+
+def test_more_rows_at_one_instant_than_max_rows_deletes_nothing(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """The genuinely unsplittable case still refuses.
+
+    No choice of bounds makes a window exportable when one instant holds more
+    rows than a single export call can return.
+    """
+    db = clean_audit_table
+    # One INSERT statement, so now() is evaluated once and both rows land on
+    # the identical timestamp.
+    _seed_rows(db, days_ago=[200, 200])
+    assert (
+        int(_psql("SELECT count(DISTINCT created_at) FROM catalog.audit_logs", db)) == 1
+    )
+
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        "--max-rows",
+        "1",
+    )
+
+    assert result.returncode != 0
+    assert "share the instant" in result.stderr
+    assert _row_count(db) == 2
 
 
 def test_repeated_runs_do_not_overwrite_an_earlier_archive(
@@ -708,6 +798,155 @@ def test_a_bad_export_deletes_nothing(
     assert result.returncode != 0
     assert expected_message in result.stderr
     assert _row_count(db) == 3
+
+
+# ---------------------------------------------------------------------------
+# Row-level security
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rls_db(curl_stub_dir):
+    """A database whose audit table is RLS-protected, plus a non-bypass login.
+
+    Its own database and its own role, both dropped afterwards, because the
+    shared Postgres at :5434 is cluster-global: enabling RLS or leaving a role
+    behind on the module-scoped scratch database would reach every other test.
+
+    The policy uses the two-argument ``current_setting(..., true)`` so a session
+    with no ``app.current_tenant`` gets NULL rather than an error. That is what
+    reproduces the *silent* failure: the credential reads the table, matches
+    nothing, and every count comes back 0.
+    """
+    admin_db = settings.postgres_db
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    suffix = uuid.uuid4().hex[:8]
+    name = f"geolens_auditrls_{worker}_{suffix}"
+    role = f"geolens_auditrls_role_{worker}_{suffix}"
+    password = "rls-test-password"
+
+    _psql(f'CREATE DATABASE "{name}"', admin_db)
+    _psql(f"CREATE ROLE \"{role}\" LOGIN PASSWORD '{password}'", admin_db)
+    try:
+        _psql(_SCRATCH_DDL, name)
+        _psql(
+            f"""
+            ALTER TABLE catalog.audit_logs ENABLE ROW LEVEL SECURITY;
+            CREATE POLICY tenant_isolation ON catalog.audit_logs
+                USING (tenant_id = current_setting('app.current_tenant', true)::uuid);
+            GRANT USAGE ON SCHEMA catalog TO "{role}";
+            GRANT SELECT, DELETE ON catalog.audit_logs TO "{role}";
+            GRANT SELECT ON catalog.tenants TO "{role}";
+            """,
+            name,
+        )
+        yield name, role, password
+    finally:
+        _psql(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)', admin_db, check=False)
+        _psql(f'DROP ROLE IF EXISTS "{role}"', admin_db, check=False)
+
+
+def test_credential_that_cannot_bypass_rls_fails_loudly(
+    rls_db, curl_stub_dir, tmp_path
+):
+    """A runtime login must not produce a silent, successful no-op (#1260 review).
+
+    catalog.audit_logs carries a tenant_isolation policy, so the app's own
+    least-privilege credential reads zero rows through it. The connectivity
+    preflight cannot catch that: a ``LIMIT 0`` succeeds for a session RLS would
+    filter to nothing. Without a per-query guard the run counts 0, reports
+    "Nothing to archive or delete" and exits 0 while the table is untouched and
+    growing.
+    """
+    db, role, password = rls_db
+    _seed_rows(db, days_ago=[200, 150, 120])
+
+    quoted = quote(password, safe="")
+    runtime_url = (
+        f"postgresql://{role}:{quoted}"
+        f"@{settings.postgres_host}:{settings.postgres_port}/{db}"
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        "--db-url",
+        runtime_url,
+    )
+
+    assert result.returncode != 0
+    assert "row-level security" in (result.stderr + result.stdout).lower()
+    assert "Nothing to archive or delete" not in result.stdout
+    assert _row_count(db) == 3
+
+
+def test_privileged_credential_still_works_against_the_same_rls_table(
+    rls_db, curl_stub_dir, tmp_path
+):
+    """The RLS guard is a no-op for a session that can bypass it.
+
+    Same database and same policy as the test above, so the credential is the
+    only variable. A guard that failed closed for everyone would be useless.
+    """
+    db, _role, _password = rls_db
+    _seed_rows(db, days_ago=[200, 150, 120])
+    _seed_rows(db, days_ago=[5])
+
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert len(_archived_rows(archive_dir)) == 3
+    assert _row_count(db) == 1
+
+
+def test_row_security_set_does_not_leak_into_parsed_values(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """`SET` must stay invisible under -tA, or every parsed value is corrupt.
+
+    psql prints a "SET" command tag that -q suppresses. If it ever reached
+    stdout it would be read as the first value of every query, so the cutoff
+    and every count would be garbage. This pins the observable consequence
+    rather than the flag.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150, 120, 100, 95])
+
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        "--dry-run",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Rows at or before the cutoff in scope: 5" in result.stdout
+    assert "SET" not in [line.strip() for line in result.stdout.splitlines()]
+    # A leaked tag would land in the cutoff string the run echoes back.
+    cutoff_line = next(
+        line for line in result.stdout.splitlines() if "Retention cutoff" in line
+    )
+    assert re.search(r": \d{4}-\d{2}-\d{2}T[\d:.]+Z$", cutoff_line), cutoff_line
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_audit_retention_script.py
+++ b/backend/tests/test_audit_retention_script.py
@@ -290,6 +290,35 @@ def _archives(archive_dir: Path) -> list[Path]:
     return sorted(archive_dir.glob("audit-archive-*.json"))
 
 
+def _assert_windows_within_cap(stdout: str, max_rows: int) -> None:
+    """No window the script asks the endpoint for may exceed the cap.
+
+    This reads the sizes off the script's own per-window log rather than off
+    the archives, and the difference matters. The real endpoint silently
+    returns only the newest ``max_rows`` rows of an over-cap range, and the
+    stub models that with a LIMIT -- so archive *lengths* can never exceed the
+    cap no matter how badly the splitter behaves, and asserting on them would
+    be vacuous. What can actually go wrong is the script sizing a window above
+    the cap in the first place, which this reads directly.
+
+    Measured caveat: in every scenario a faithful stub can produce, this is
+    SHADOWED by the script's own archive/database row-count check, which fires
+    first -- an over-cap window comes back truncated and the counts disagree.
+    So treat this as defence in depth that states the intended property, not as
+    the live gate. Verified by removing the over-cap handling entirely: the run
+    failed on "archive row count mismatch ... counts 5 ... holds 4" before this
+    assertion was reached.
+    """
+    sizes = [
+        int(n) for n in re.findall(r"window \d+: \S+ \.\. \S+ \((\d+) rows\)", stdout)
+    ]
+    assert sizes, f"no per-window log lines found in:\n{stdout}"
+    for size in sizes:
+        assert size <= max_rows, (
+            f"script requested a {size}-row window, above the {max_rows} cap"
+        )
+
+
 def _archived_rows(archive_dir: Path) -> list[dict]:
     rows: list[dict] = []
     for path in _archives(archive_dir):
@@ -459,6 +488,7 @@ def test_window_over_the_export_cap_is_split_and_fully_archived(
     # twice; what must never happen is a row archived zero times.
     archived = {row["timestamp"] for row in _archived_rows(archive_dir)}
     assert len(archived) == 10
+    _assert_windows_within_cap(result.stdout, 3)
     assert _row_count(db) == 0
 
 
@@ -496,6 +526,48 @@ def test_max_rows_one_splits_a_two_row_window(
     assert result.returncode == 0, result.stderr
     assert len(_archives(archive_dir)) == 2
     assert len({row["id"] for row in _archived_rows(archive_dir)}) == 2
+    _assert_windows_within_cap(result.stdout, 1)
+    assert _row_count(db) == 0
+
+
+def test_cap_cutting_through_a_timestamp_tie_backs_off(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """The export cap can land inside a group of rows sharing one instant.
+
+    Two rows at t1 and three at t2 with --max-rows 4: the 4th oldest row is at
+    t2, so the naive boundary [t1, t2] selects all five and looks unsplittable.
+    It is not. [t1, t1] holds two and [t2, t2] holds three, both under the cap,
+    so the split has to back off to the last distinct timestamp before the tie
+    rather than give up. Scaled-down form of the 2-at-t1 plus 99-at-t2 case
+    from the #1260 review.
+    """
+    db = clean_audit_table
+    # One INSERT per group, so now() is evaluated once per group and each group
+    # shares an instant.
+    _seed_rows(db, days_ago=[200, 200])
+    _seed_rows(db, days_ago=[150, 150, 150])
+    assert (
+        int(_psql("SELECT count(DISTINCT created_at) FROM catalog.audit_logs", db)) == 2
+    )
+
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+        "--max-rows",
+        "4",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert len({row["id"] for row in _archived_rows(archive_dir)}) == 5
+    _assert_windows_within_cap(result.stdout, 4)
     assert _row_count(db) == 0
 
 

--- a/backend/tests/test_audit_retention_script.py
+++ b/backend/tests/test_audit_retention_script.py
@@ -98,15 +98,35 @@ from urllib.parse import urlparse, parse_qs
 argv = sys.argv[1:]
 url = None
 out = None
+headers = []
 i = 0
 while i < len(argv):
     if argv[i] == "-o":
         out = argv[i + 1]
         i += 2
         continue
+    if argv[i] == "-H":
+        value = argv[i + 1]
+        # Real curl reads headers from a file when the value starts with '@'.
+        if value.startswith("@"):
+            with open(value[1:]) as fh:
+                headers.extend(line.rstrip("\n") for line in fh if line.strip())
+        else:
+            headers.append(value)
+        i += 2
+        continue
     if argv[i].startswith("http"):
         url = argv[i]
     i += 1
+
+_argv_log = os.environ.get("RETENTION_ARGV_LOG")
+if _argv_log:
+    with open(_argv_log, "a") as fh:
+        fh.write(json.dumps({"prog": "curl", "argv": argv}) + "\n")
+
+if not any(h.startswith("Authorization: Bearer ") for h in headers):
+    sys.stderr.write("curl stub: no Authorization header reached the request\n")
+    sys.exit(1)
 
 mode = os.environ.get("RETENTION_SHIM_MODE", "ok")
 if mode == "http_error":
@@ -141,10 +161,18 @@ SELECT coalesce(json_agg(t), '[]'::json) FROM (
     scope,
     int(params["max_rows"][0]),
 )
+# The script exports PGPASSWORD for its own psql when the URL carries a
+# password, and this stub inherits it. Harmless for real curl, fatal for a stub
+# that talks to Postgres, so the stub authenticates with credentials of its own
+# that the script never touches.
+_stub_env = os.environ.copy()
+_stub_env["PGUSER"] = os.environ["RETENTION_STUB_PGUSER"]
+_stub_env["PGPASSWORD"] = os.environ["RETENTION_STUB_PGPASSWORD"]
 proc = subprocess.run(
     ["psql", "-X", "-q", "-v", "ON_ERROR_STOP=1", "-tA", "-c", sql],
     capture_output=True,
     text=True,
+    env=_stub_env,
 )
 if proc.returncode != 0:
     sys.stderr.write(proc.stderr)
@@ -166,6 +194,34 @@ if mode == "drop_id":
 with open(out, "w") as fh:
     json.dump(rows, fh)
 '''
+
+
+# Records every psql command line, then hands off to the real binary. Used
+# only by the argv-inspection tests, from a directory those tests prepend to
+# PATH, so no other test pays for the extra hop.
+_PSQL_RECORDER = r"""#!/usr/bin/env python3
+import json
+import os
+import sys
+
+log = os.environ["RETENTION_ARGV_LOG"]
+with open(log, "a") as fh:
+    fh.write(
+        json.dumps(
+            {
+                "prog": "psql",
+                "argv": sys.argv[1:],
+                # The covert channel itself, so a test can prove the secret was
+                # delivered and not merely absent from argv.
+                "pgpassword": os.environ.get("PGPASSWORD"),
+            }
+        )
+        + "\n"
+    )
+
+real = os.environ["RETENTION_REAL_PSQL"]
+os.execv(real, [real] + sys.argv[1:])
+"""
 
 
 def _pg_env(dbname: str) -> dict[str, str]:
@@ -259,12 +315,17 @@ def _run_script(
     shim_mode: str = "ok",
     shim_tenant: str = "",
     env_overrides: dict[str, str] | None = None,
+    extra_path_dirs: list[Path] | None = None,
 ) -> subprocess.CompletedProcess:
     env = _pg_env(db)
     env["PATH"] = f"{curl_stub_dir}{os.pathsep}{env['PATH']}"
     env["ADMIN_TOKEN"] = "stub-token"
     env["RETENTION_SHIM_MODE"] = shim_mode
     env["RETENTION_SHIM_TENANT"] = shim_tenant
+    env["RETENTION_STUB_PGUSER"] = settings.postgres_user
+    env["RETENTION_STUB_PGPASSWORD"] = settings.postgres_password.get_secret_value()
+    for extra in reversed(extra_path_dirs or []):
+        env["PATH"] = f"{extra}{os.pathsep}{env['PATH']}"
     if env_overrides:
         env.update(env_overrides)
     try:
@@ -870,6 +931,267 @@ def test_a_bad_export_deletes_nothing(
     assert result.returncode != 0
     assert expected_message in result.stderr
     assert _row_count(db) == 3
+
+
+# ---------------------------------------------------------------------------
+# Secrets must not reach child command lines
+# ---------------------------------------------------------------------------
+
+# Deliberately awkward: every character here has to be percent-encoded in a URI,
+# and the literal '%' exercises the decoder's own escape.
+_NASTY_PASSWORD = "p@ss/w:rd%x"
+_NASTY_PASSWORD_ENCODED = "p%40ss%2Fw%3Ard%25x"
+
+
+@pytest.fixture
+def password_db():
+    """Own database and own login role whose password needs encoding."""
+    admin_db = settings.postgres_db
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    suffix = uuid.uuid4().hex[:8]
+    name = f"geolens_auditpw_{worker}_{suffix}"
+    role = f"geolens_auditpw_role_{worker}_{suffix}"
+
+    _psql(f'CREATE DATABASE "{name}"', admin_db)
+    _psql(f"CREATE ROLE \"{role}\" LOGIN PASSWORD '{_NASTY_PASSWORD}'", admin_db)
+    try:
+        _psql(_SCRATCH_DDL, name)
+        _psql(
+            f"""
+            GRANT USAGE ON SCHEMA catalog TO "{role}";
+            GRANT SELECT, DELETE ON catalog.audit_logs TO "{role}";
+            GRANT SELECT ON catalog.tenants TO "{role}";
+            """,
+            name,
+        )
+        yield name, role
+    finally:
+        _psql(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)', admin_db, check=False)
+        _psql(f'DROP ROLE IF EXISTS "{role}"', admin_db, check=False)
+
+
+@pytest.fixture
+def argv_recorder(tmp_path):
+    """A `psql` on PATH that logs its command line, then execs the real one."""
+    bindir = tmp_path / "recorder-bin"
+    bindir.mkdir()
+    shim = bindir / "psql"
+    shim.write_text(_PSQL_RECORDER)
+    shim.chmod(0o755)
+    log = tmp_path / "argv.log"
+    log.touch()
+    return bindir, log
+
+
+def _recorded(log: Path) -> list[dict]:
+    return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+def test_no_secret_reaches_a_child_command_line(
+    password_db, argv_recorder, curl_stub_dir, tmp_path
+):
+    """Passwords and bearer tokens must never appear in argv (#1260 review).
+
+    Command lines are world-readable through `ps` and /proc/<pid>/cmdline, so a
+    URI handed straight to psql, or `-H "Authorization: Bearer ..."` handed to
+    curl, publishes a BYPASSRLS credential and an admin token to every local
+    account. Environment and 0600 files are owner-only and carry them instead.
+
+    Absence alone would also be satisfied by dropping the secret entirely, so
+    this asserts delivery too: the run succeeds against a password-protected
+    role, and the recorded child environment carries the decoded password.
+    """
+    db, role = password_db
+    _seed_rows(db, days_ago=[200, 150])
+    recorder_dir, log = argv_recorder
+
+    db_url = (
+        f"postgresql://{role}:{_NASTY_PASSWORD_ENCODED}"
+        f"@{settings.postgres_host}:{settings.postgres_port}/{db}"
+    )
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+        "--db-url",
+        db_url,
+        extra_path_dirs=[recorder_dir],
+        env_overrides={
+            "RETENTION_ARGV_LOG": str(log),
+            "RETENTION_REAL_PSQL": shutil.which("psql"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = _recorded(log)
+    assert calls, "the recorder captured no child processes"
+    assert any(c["prog"] == "psql" for c in calls)
+    assert any(c["prog"] == "curl" for c in calls)
+
+    for call in calls:
+        flat = " ".join(call["argv"])
+        assert _NASTY_PASSWORD not in flat, f"password in {call['prog']} argv: {flat}"
+        assert _NASTY_PASSWORD_ENCODED not in flat, (
+            f"encoded password in {call['prog']} argv: {flat}"
+        )
+        assert "stub-token" not in flat, f"bearer token in {call['prog']} argv: {flat}"
+
+    # Delivery: the decoded password reached psql by the environment. Only the
+    # script's own psql calls are in scope -- the curl stub also runs psql, with
+    # credentials of its own that the script never sets.
+    script_psql = [
+        c
+        for c in calls
+        if c["prog"] == "psql" and any(a.startswith("postgresql://") for a in c["argv"])
+    ]
+    assert script_psql, "the script made no psql call carrying the connection URL"
+    assert all(c["pgpassword"] == _NASTY_PASSWORD for c in script_psql), [
+        c["pgpassword"] for c in script_psql
+    ]
+    # The non-secret remainder of the URL stays in argv, which keeps ps useful.
+    assert all(
+        any(a.startswith(f"postgresql://{role}@") for a in c["argv"])
+        for c in script_psql
+    )
+    assert _row_count(db) == 0
+
+
+def test_a_wrong_password_in_the_url_fails_to_connect(
+    password_db, curl_stub_dir, tmp_path
+):
+    """Negative control for the test above.
+
+    Without this, a server that did not enforce password authentication would
+    let the success there pass whether or not the password was ever delivered.
+    """
+    db, role = password_db
+    _seed_rows(db, days_ago=[200, 150])
+
+    db_url = (
+        f"postgresql://{role}:definitely-not-the-password"
+        f"@{settings.postgres_host}:{settings.postgres_port}/{db}"
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        "--db-url",
+        db_url,
+    )
+
+    assert result.returncode != 0
+    assert "password authentication failed" in result.stderr.lower()
+    assert _row_count(db) == 2
+
+
+def test_a_malformed_percent_encoded_password_is_refused(
+    password_db, curl_stub_dir, tmp_path
+):
+    """A stray '%' cannot be decoded, and guessing would mangle the password.
+
+    Refusing names the workaround instead, rather than silently connecting with
+    a wrong password or, worse, a half-decoded one.
+    """
+    db, role = password_db
+    _seed_rows(db, days_ago=[200, 150])
+
+    db_url = (
+        f"postgresql://{role}:not%valid"
+        f"@{settings.postgres_host}:{settings.postgres_port}/{db}"
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        "--db-url",
+        db_url,
+    )
+
+    assert result.returncode != 0
+    assert "not valid percent-encoding" in result.stderr
+    assert "PGPASSWORD" in result.stderr
+    assert _row_count(db) == 2
+
+
+def test_db_url_from_the_environment_avoids_the_scripts_own_argv(
+    password_db, curl_stub_dir, tmp_path
+):
+    """The half --db-url cannot fix: the script's own command line.
+
+    psql children are short-lived, but the script itself runs for the whole
+    retention pass with whatever was typed on its command line. The env var is
+    the way out, and passing a password through --db-url warns about it.
+    """
+    db, role = password_db
+    _seed_rows(db, days_ago=[200, 150])
+
+    db_url = (
+        f"postgresql://{role}:{_NASTY_PASSWORD_ENCODED}"
+        f"@{settings.postgres_host}:{settings.postgres_port}/{db}"
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        env_overrides={
+            "GEOLENS_RETENTION_DB_URL": db_url,
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Connecting via GEOLENS_RETENTION_DB_URL" in result.stdout
+    # No warning, because nothing secret was typed on a command line.
+    assert "visible in this script's own command line" not in result.stderr
+    assert _row_count(db) == 0
+
+
+def test_a_password_on_the_command_line_warns_about_it(
+    password_db, curl_stub_dir, tmp_path
+):
+    db, role = password_db
+    _seed_rows(db, days_ago=[200])
+
+    db_url = (
+        f"postgresql://{role}:{_NASTY_PASSWORD_ENCODED}"
+        f"@{settings.postgres_host}:{settings.postgres_port}/{db}"
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        "--db-url",
+        db_url,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "visible in this script's own command line" in result.stderr
+    assert "GEOLENS_RETENTION_DB_URL" in result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_audit_retention_script.py
+++ b/backend/tests/test_audit_retention_script.py
@@ -316,6 +316,7 @@ def _run_script(
     shim_tenant: str = "",
     env_overrides: dict[str, str] | None = None,
     extra_path_dirs: list[Path] | None = None,
+    path_override: str | None = None,
 ) -> subprocess.CompletedProcess:
     env = _pg_env(db)
     env["PATH"] = f"{curl_stub_dir}{os.pathsep}{env['PATH']}"
@@ -326,6 +327,8 @@ def _run_script(
     env["RETENTION_STUB_PGPASSWORD"] = settings.postgres_password.get_secret_value()
     for extra in reversed(extra_path_dirs or []):
         env["PATH"] = f"{extra}{os.pathsep}{env['PATH']}"
+    if path_override is not None:
+        env["PATH"] = path_override
     if env_overrides:
         env.update(env_overrides)
     try:
@@ -1198,6 +1201,304 @@ def test_a_password_on_the_command_line_is_refused(
     assert "GEOLENS_RETENTION_DB_URL" in result.stderr
     assert "PGPASSWORD" in result.stderr
     assert _row_count(db) == 1
+
+
+def test_a_query_string_password_on_the_command_line_is_refused(
+    password_db, curl_stub_dir, tmp_path
+):
+    """`?password=` is the second spelling of the same secret (#1260 review).
+
+    libpq's URI grammar lets any connection keyword ride in the query string,
+    `password` included, so a userinfo-only check leaves the refusal trivially
+    bypassable.
+    """
+    db, role = password_db
+
+    db_url = (
+        f"postgresql://{role}@{settings.postgres_host}:{settings.postgres_port}"
+        f"/{db}?password={_NASTY_PASSWORD_ENCODED}"
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        "--db-url",
+        db_url,
+    )
+
+    assert result.returncode != 0
+    assert "refusing a password in --db-url" in result.stderr
+    assert "?password=" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("keyword", "label"),
+    [
+        ("password", "plain"),
+        # libpq percent-decodes the keyword, so these are the same parameter.
+        ("%70assword", "leading byte encoded"),
+        ("passwor%64", "trailing byte encoded"),
+    ],
+)
+def test_a_query_string_password_is_extracted_and_delivered(
+    password_db, argv_recorder, curl_stub_dir, tmp_path, keyword, label
+):
+    """Through the env var, a query password is moved to PGPASSWORD and works.
+
+    Same delivery proof as the userinfo form: nothing secret in any child
+    command line, and the run authenticates, so the password demonstrably
+    arrived. The encoded spellings are here because matching "password=" as
+    literal text would miss them while libpq would not.
+    """
+    db, role = password_db
+    _seed_rows(db, days_ago=[200, 150])
+    recorder_dir, log = argv_recorder
+
+    db_url = (
+        f"postgresql://{role}@{settings.postgres_host}:{settings.postgres_port}"
+        f"/{db}?{keyword}={_NASTY_PASSWORD_ENCODED}"
+    )
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+        extra_path_dirs=[recorder_dir],
+        env_overrides={
+            "GEOLENS_RETENTION_DB_URL": db_url,
+            "RETENTION_ARGV_LOG": str(log),
+            "RETENTION_REAL_PSQL": shutil.which("psql"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = _recorded(log)
+    for call in calls:
+        flat = " ".join(call["argv"])
+        assert _NASTY_PASSWORD not in flat, f"password in {call['prog']} argv: {flat}"
+        assert _NASTY_PASSWORD_ENCODED not in flat, (
+            f"encoded password in {call['prog']} argv: {flat}"
+        )
+
+    script_psql = [
+        c
+        for c in calls
+        if c["prog"] == "psql" and any(a.startswith("postgresql://") for a in c["argv"])
+    ]
+    assert script_psql, "the script made no psql call carrying the connection URL"
+    assert all(c["pgpassword"] == _NASTY_PASSWORD for c in script_psql)
+    # The parameter is gone and, being the only one, took its "?" with it.
+    assert all(
+        not any("?" in a for a in c["argv"] if a.startswith("postgresql://"))
+        for c in script_psql
+    )
+    assert _row_count(db) == 0
+
+
+def test_a_wrong_query_string_password_fails_to_connect(
+    password_db, curl_stub_dir, tmp_path
+):
+    """Negative control for the extraction above."""
+    db, role = password_db
+    _seed_rows(db, days_ago=[200])
+
+    db_url = (
+        f"postgresql://{role}@{settings.postgres_host}:{settings.postgres_port}"
+        f"/{db}?password=definitely-not-the-password"
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        env_overrides={"GEOLENS_RETENTION_DB_URL": db_url},
+    )
+
+    assert result.returncode != 0
+    assert "password authentication failed" in result.stderr.lower()
+    assert _row_count(db) == 1
+
+
+def test_other_query_parameters_survive_the_extraction(
+    password_db, argv_recorder, curl_stub_dir, tmp_path
+):
+    """Removing a middle parameter must not corrupt the rest of the query."""
+    db, role = password_db
+    _seed_rows(db, days_ago=[200])
+    recorder_dir, log = argv_recorder
+
+    db_url = (
+        f"postgresql://{role}@{settings.postgres_host}:{settings.postgres_port}"
+        f"/{db}?application_name=retention"
+        f"&password={_NASTY_PASSWORD_ENCODED}&connect_timeout=10"
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        extra_path_dirs=[recorder_dir],
+        env_overrides={
+            "GEOLENS_RETENTION_DB_URL": db_url,
+            "RETENTION_ARGV_LOG": str(log),
+            "RETENTION_REAL_PSQL": shutil.which("psql"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    urls = [
+        a
+        for c in _recorded(log)
+        if c["prog"] == "psql"
+        for a in c["argv"]
+        if a.startswith("postgresql://")
+    ]
+    assert urls
+    for url in urls:
+        assert "password" not in url
+        assert url.endswith("?application_name=retention&connect_timeout=10"), url
+        assert "&&" not in url and "?&" not in url and not url.endswith("&")
+
+
+def test_a_password_in_both_places_is_refused(password_db, curl_stub_dir, tmp_path):
+    """Over-specified, and libpq resolves it in a surprising direction.
+
+    Measured against libpq 18: the query parameter wins and the userinfo one is
+    silently ignored, so an operator who changed the wrong half would connect
+    with a credential they thought they had replaced. Refused rather than
+    guessed at, and refused for both carriers.
+    """
+    db, role = password_db
+    _seed_rows(db, days_ago=[200])
+
+    db_url = (
+        f"postgresql://{role}:{_NASTY_PASSWORD_ENCODED}"
+        f"@{settings.postgres_host}:{settings.postgres_port}"
+        f"/{db}?password={_NASTY_PASSWORD_ENCODED}"
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        env_overrides={"GEOLENS_RETENTION_DB_URL": db_url},
+    )
+
+    assert result.returncode != 0
+    assert "carries a password twice" in result.stderr
+    assert _row_count(db) == 1
+
+
+# ---------------------------------------------------------------------------
+# Host tool requirements
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def path_without_psql(tmp_path, curl_stub_dir):
+    """A PATH holding what the script needs, minus psql and docker.
+
+    Symlinks rather than a copied PATH so the omission is explicit: anything
+    not listed here genuinely is not on the PATH the script sees.
+    """
+    bindir = tmp_path / "minimal-bin"
+    bindir.mkdir()
+    for tool in (
+        # bash runs the script; env/python3 back the curl stub's shebang.
+        "bash",
+        "env",
+        "python3",
+        "jq",
+        "grep",
+        "sed",
+        "cat",
+        "tr",
+        "date",
+        "mktemp",
+        "basename",
+        "dirname",
+        "sort",
+        "cmp",
+        "comm",
+        "wc",
+        "rm",
+    ):
+        found = shutil.which(tool)
+        if found:
+            (bindir / tool).symlink_to(found)
+    # curl comes from the stub directory, which also must not contain psql.
+    assert not (curl_stub_dir / "psql").exists()
+    return f"{curl_stub_dir}{os.pathsep}{bindir}"
+
+
+def test_bundled_branch_does_not_require_a_host_psql(
+    clean_audit_table, curl_stub_dir, tmp_path, path_without_psql
+):
+    """The documented default is Docker-only and never runs psql on the host.
+
+    It execs psql *inside* the db container, so requiring the binary here
+    aborted a correct install over something it does not use (#1260 review).
+    The run still fails, at docker, which is the requirement this branch really
+    has -- and failing there keeps the test from ever reaching a live stack.
+    """
+    result = _run_script(
+        clean_audit_table,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        path_override=path_without_psql,
+        # Unset so the bundled branch is selected rather than the PG* one.
+        env_overrides={"PGHOST": "", "PGSERVICE": ""},
+    )
+
+    assert "'psql' is required" not in result.stderr, result.stderr
+    assert "'docker' is required" in result.stderr
+
+
+def test_direct_connection_branch_still_requires_psql(
+    clean_audit_table, curl_stub_dir, tmp_path, path_without_psql
+):
+    """The other half of the same rule: the branches that do run psql say so."""
+    result = _run_script(
+        clean_audit_table,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        path_override=path_without_psql,
+    )
+
+    assert result.returncode != 0
+    assert "'psql' is required" in result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_audit_retention_script.py
+++ b/backend/tests/test_audit_retention_script.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import stat
 import subprocess
 import uuid
 from pathlib import Path
@@ -118,7 +119,8 @@ tenant = os.environ.get("RETENTION_SHIM_TENANT", "")
 scope = "TRUE" if not tenant else "tenant_id = '%s'::uuid" % tenant
 sql = """
 SELECT coalesce(json_agg(t), '[]'::json) FROM (
-  SELECT to_char(created_at AT TIME ZONE 'UTC',
+  SELECT id::text AS id,
+         to_char(created_at AT TIME ZONE 'UTC',
                  'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS timestamp,
          action, resource_type
   FROM catalog.audit_logs
@@ -152,6 +154,9 @@ if mode == "truncate" and rows:
     rows = rows[:-1]
 if mode == "outside_window" and rows:
     rows[0]["timestamp"] = "1999-01-01T00:00:00.000000+00:00"
+if mode == "drop_id":
+    for row in rows:
+        row.pop("id", None)
 
 with open(out, "w") as fh:
     json.dump(rows, fh)
@@ -502,6 +507,102 @@ def test_per_tenant_run_leaves_other_tenants_untouched(
     assert len(_archived_rows(archive_dir)) == 3
     assert _row_count(db, tenant_a) == 1
     assert _row_count(db, tenant_b) == 2
+
+
+def test_right_sized_slice_of_another_tenant_deletes_nothing(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """--tenant-slug alpha paired with tenant beta's API host (#1260 review).
+
+    Both tenants have three rows in the window, so the count check passes, and
+    beta's rows are genuinely inside the same time range, so the timestamp
+    check passes too. Without comparing row ids the script would archive
+    beta's history and permanently delete alpha's, unarchived. The export
+    schema carries no tenant id, so identity is the only signal available.
+    """
+    db = clean_audit_table
+    tenant_a = _seed_tenant(db, "alpha")
+    tenant_b = _seed_tenant(db, "beta")
+    _seed_rows(db, days_ago=[200, 150, 120], tenant_id=tenant_a)
+    _seed_rows(db, days_ago=[199, 149, 119], tenant_id=tenant_b)
+
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--tenant-slug",
+        "alpha",
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        # The stub is the wrong tenant's host, which is the whole scenario.
+        shim_tenant=tenant_b,
+    )
+
+    assert result.returncode != 0
+    assert "does not hold the rows this window would delete" in result.stderr
+    assert _row_count(db, tenant_a) == 3
+    assert _row_count(db, tenant_b) == 3
+
+
+def test_archive_without_row_ids_deletes_nothing(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """An export with no `id` field cannot be verified, so the run stops.
+
+    The script and the API version together in this repo, so a server that
+    does not send ids is an upgrade error, not a compatibility mode to fall
+    back through.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150])
+
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        shim_mode="drop_id",
+    )
+
+    assert result.returncode != 0
+    assert 'has a row with no "id"' in result.stderr
+    assert _row_count(db) == 2
+
+
+def test_archives_are_not_world_readable(clean_audit_table, curl_stub_dir, tmp_path):
+    """Archives hold usernames, IPs and activity for the whole window.
+
+    Under the usual umask 022 `curl -o` would create them 0644, readable by
+    every local account on the host.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150])
+
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+        "--dry-run",
+    )
+
+    assert result.returncode == 0, result.stderr
+    archives = _archives(archive_dir)
+    assert archives, "expected at least one archive"
+    for path in archives:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600, f"{path} is {oct(mode)}, expected 0o600"
+    assert stat.S_IMODE(archive_dir.stat().st_mode) == 0o700
 
 
 def test_unresolvable_tenant_slug_deletes_nothing(

--- a/backend/tests/test_audit_retention_script.py
+++ b/backend/tests/test_audit_retention_script.py
@@ -1412,6 +1412,141 @@ def test_a_password_in_both_places_is_refused(password_db, curl_stub_dir, tmp_pa
 
 
 # ---------------------------------------------------------------------------
+# The window has to be immutable
+# ---------------------------------------------------------------------------
+
+
+def test_a_future_cutoff_is_refused(clean_audit_table, curl_stub_dir, tmp_path):
+    """The whole procedure assumes the window cannot change while it runs.
+
+    Audit rows are written with created_at = now(), so a window ending in the
+    future keeps gaining rows between the count, the export and the delete, and
+    no count taken of it stays true. Exporting makes it concrete by writing its
+    own audit.export rows inside the window, which the endpoint excludes from
+    its output while a database-side query does not (#1260 review).
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150])
+
+    future = _psql(
+        "SELECT to_char((now() + interval '1 day') AT TIME ZONE 'UTC', "
+        '\'YYYY-MM-DD"T"HH24:MI:SS.US"Z"\')',
+        db,
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--cutoff",
+        future,
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+    )
+
+    assert result.returncode != 0
+    assert "is not in the past" in result.stderr
+    # The reason, not just the refusal: a reader has to learn why.
+    assert "created_at = now()" in result.stderr
+    assert _row_count(db) == 2
+
+
+def test_a_cutoff_just_barely_in_the_future_is_refused(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """The guard is `>= now()`, so far-future values are not all it catches.
+
+    The exact boundary -- a cutoff equal to the script's own now() at the
+    instant it checks -- cannot be reached from outside. Any timestamp captured
+    before the script starts is already in the past by the time the script
+    evaluates it, which is why the obvious version of this test passes for the
+    wrong reason: it exercises a *past* cutoff. The `>=` in the source pins the
+    boundary itself; this pins the region beside it, at a distance chosen to be
+    immune to timing rather than to look tight.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200])
+
+    soon = _psql(
+        "SELECT to_char((now() + interval '60 seconds') AT TIME ZONE 'UTC', "
+        '\'YYYY-MM-DD"T"HH24:MI:SS.US"Z"\')',
+        db,
+    )
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--cutoff",
+        soon,
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+    )
+
+    assert result.returncode != 0
+    assert "is not in the past" in result.stderr
+    assert _row_count(db) == 1
+
+
+def test_days_always_resolves_to_a_past_cutoff(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """--days N for N >= 1 cannot trip the guard, so it needs no second check.
+
+    This is the assertion that keeps that true rather than a second guard in
+    the --days branch.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200])
+
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "1",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        "--dry-run",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "is not in the past" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Archives must not be committable
+# ---------------------------------------------------------------------------
+
+
+def test_default_archive_directory_is_gitignored():
+    """Second line of defence behind the RUNBOOK's explicit --archive-dir.
+
+    The default is ./audit-archives and the RUNBOOK tells operators to run the
+    script from the repository root, so without this entry a later `git add .`
+    would stage an export of usernames, IPs and activity.
+    """
+
+    def ignored(path: str) -> bool:
+        return (
+            subprocess.run(
+                ["git", "check-ignore", "-q", path],
+                cwd=REPO_ROOT,
+                capture_output=True,
+            ).returncode
+            == 0
+        )
+
+    # Ask git rather than grep .gitignore: the property is that the path is
+    # ignored, and a matching line could still be overridden by a later
+    # negation. The second assertion is the positive control -- without it, a
+    # check-ignore that always returned 0 would look identical to a pass.
+    assert ignored("audit-archives/audit-archive-example.json")
+    assert not ignored("backend/tests/test_audit_retention_script.py")
+
+
+# ---------------------------------------------------------------------------
 # Host tool requirements
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_audit_retention_script.py
+++ b/backend/tests/test_audit_retention_script.py
@@ -450,9 +450,10 @@ def test_external_db_url_strips_the_sqlalchemy_driver_suffix(
     db = clean_audit_table
     _seed_rows(db, days_ago=[200, 150])
 
-    password = quote(settings.postgres_password.get_secret_value(), safe="")
+    # No password in the URL: --db-url refuses one outright. The ambient
+    # PGPASSWORD from _pg_env authenticates, which is the documented pairing.
     db_url = (
-        f"postgresql+asyncpg://{settings.postgres_user}:{password}"
+        f"postgresql+asyncpg://{settings.postgres_user}"
         f"@{settings.postgres_host}:{settings.postgres_port}/{db}"
     )
     archive_dir = tmp_path / "archives"
@@ -1019,10 +1020,9 @@ def test_no_secret_reaches_a_child_command_line(
         CONFIRM_PHRASE,
         "--archive-dir",
         str(archive_dir),
-        "--db-url",
-        db_url,
         extra_path_dirs=[recorder_dir],
         env_overrides={
+            "GEOLENS_RETENTION_DB_URL": db_url,
             "RETENTION_ARGV_LOG": str(log),
             "RETENTION_REAL_PSQL": shutil.which("psql"),
         },
@@ -1086,8 +1086,7 @@ def test_a_wrong_password_in_the_url_fails_to_connect(
         CONFIRM_PHRASE,
         "--archive-dir",
         str(tmp_path / "archives"),
-        "--db-url",
-        db_url,
+        env_overrides={"GEOLENS_RETENTION_DB_URL": db_url},
     )
 
     assert result.returncode != 0
@@ -1119,8 +1118,7 @@ def test_a_malformed_percent_encoded_password_is_refused(
         CONFIRM_PHRASE,
         "--archive-dir",
         str(tmp_path / "archives"),
-        "--db-url",
-        db_url,
+        env_overrides={"GEOLENS_RETENTION_DB_URL": db_url},
     )
 
     assert result.returncode != 0
@@ -1161,14 +1159,19 @@ def test_db_url_from_the_environment_avoids_the_scripts_own_argv(
 
     assert result.returncode == 0, result.stderr
     assert "Connecting via GEOLENS_RETENTION_DB_URL" in result.stdout
-    # No warning, because nothing secret was typed on a command line.
-    assert "visible in this script's own command line" not in result.stderr
     assert _row_count(db) == 0
 
 
-def test_a_password_on_the_command_line_warns_about_it(
+def test_a_password_on_the_command_line_is_refused(
     password_db, curl_stub_dir, tmp_path
 ):
+    """--db-url must not carry a password at all.
+
+    Moving it out of psql's command line achieves nothing while it sits in the
+    script's own, which is world-readable and outlives every psql child. There
+    is no way to retract that from inside, so the only fix is to decline the
+    input and name the two carriers that do work.
+    """
     db, role = password_db
     _seed_rows(db, days_ago=[200])
 
@@ -1189,9 +1192,12 @@ def test_a_password_on_the_command_line_warns_about_it(
         db_url,
     )
 
-    assert result.returncode == 0, result.stderr
-    assert "visible in this script's own command line" in result.stderr
+    assert result.returncode != 0
+    assert "refusing a password in --db-url" in result.stderr
+    # Both documented ways out are named, so the message is actionable alone.
     assert "GEOLENS_RETENTION_DB_URL" in result.stderr
+    assert "PGPASSWORD" in result.stderr
+    assert _row_count(db) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -1269,8 +1275,7 @@ def test_credential_that_cannot_bypass_rls_fails_loudly(
         CONFIRM_PHRASE,
         "--archive-dir",
         str(tmp_path / "archives"),
-        "--db-url",
-        runtime_url,
+        env_overrides={"GEOLENS_RETENTION_DB_URL": runtime_url},
     )
 
     assert result.returncode != 0

--- a/backend/tests/test_audit_retention_script.py
+++ b/backend/tests/test_audit_retention_script.py
@@ -1,0 +1,654 @@
+"""Functional guard for ``scripts/audit_retention.sh`` (#1248).
+
+The audit-log retention procedure used to live in ``RUNBOOK.md`` as prose
+bash+psql. Five review rounds found a real defect in that prose every round,
+and prose cannot be executed, so nothing caught the sixth. This module runs the
+script for real against a throwaway Postgres database with a stubbed export
+endpoint, and pins the properties those five rounds were about:
+
+* the export and the delete agree on one frozen cutoff, boundary row included;
+* a per-tenant run never touches another tenant's rows, and an unresolvable
+  slug aborts instead of falling through to an unscoped delete;
+* archive filenames are unique per run, so a second run cannot truncate the
+  first archive;
+* a failed, truncated, non-JSON, or out-of-window export blocks the delete
+  entirely — every one of those tests asserts the row count is *unchanged*, so
+  a regression that deletes un-archived rows fails here;
+* the external-Postgres connection path works, since an operator on a managed
+  database has no ``db`` container to exec into.
+
+The script talks to the database with ``psql`` and to the API with ``curl``.
+``curl`` is replaced by a stub on ``PATH`` that serves the export out of the
+same database, which is what makes the count/window verification meaningful
+rather than tautological.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+
+from app.core.config import settings
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "audit_retention.sh"
+
+CONFIRM_PHRASE = "yes, this deployment has no per-tenant host routing"
+
+_REQUIRED_TOOLS = ("psql", "jq")
+_MISSING_TOOLS = [tool for tool in _REQUIRED_TOOLS if shutil.which(tool) is None]
+
+# A silent skip here would make this the only gate on the script and have it
+# report green while asserting nothing, so CI is not allowed to skip: a missing
+# tool on a runner is a CI configuration bug and has to look like one.
+if _MISSING_TOOLS and os.environ.get("CI"):
+    raise RuntimeError(
+        f"{', '.join(_MISSING_TOOLS)} missing on a CI runner; "
+        "scripts/audit_retention.sh cannot be exercised without them."
+    )
+
+pytestmark = pytest.mark.skipif(
+    bool(_MISSING_TOOLS),
+    reason=f"requires {', '.join(_REQUIRED_TOOLS)} on PATH",
+)
+
+# Only the columns the script reads. test_scratch_schema_matches_the_models
+# pins these against the real ORM models, so a rename cannot leave this DDL
+# passing while the script breaks against a live database.
+_SCRATCH_DDL = """
+CREATE SCHEMA IF NOT EXISTS catalog;
+CREATE TABLE catalog.tenants (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    slug varchar(63) NOT NULL UNIQUE
+);
+CREATE TABLE catalog.audit_logs (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid,
+    action varchar(50) NOT NULL,
+    resource_type varchar(50) NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+"""
+
+# Stands in for `GET /admin/audit-logs/export/json`. It honours date_from,
+# date_to and max_rows, returns newest-first like the real streaming generator,
+# and is scoped to one tenant by RETENTION_SHIM_TENANT the way the real export
+# is scoped by the host it is called against. RETENTION_SHIM_MODE injects the
+# failure shapes the script must refuse to delete after.
+_CURL_STUB = r'''#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+from urllib.parse import urlparse, parse_qs
+
+argv = sys.argv[1:]
+url = None
+out = None
+i = 0
+while i < len(argv):
+    if argv[i] == "-o":
+        out = argv[i + 1]
+        i += 2
+        continue
+    if argv[i].startswith("http"):
+        url = argv[i]
+    i += 1
+
+mode = os.environ.get("RETENTION_SHIM_MODE", "ok")
+if mode == "http_error":
+    if "--fail" in argv or "-f" in argv:
+        sys.stderr.write("curl: (22) The requested URL returned error: 401\n")
+        sys.exit(22)
+    # Without --fail this is what real curl does: exit 0 and save the error
+    # body as if it were the archive.
+    with open(out, "w") as fh:
+        fh.write('{"detail":"Not authenticated"}')
+    sys.exit(0)
+
+params = parse_qs(urlparse(url).query)
+tenant = os.environ.get("RETENTION_SHIM_TENANT", "")
+scope = "TRUE" if not tenant else "tenant_id = '%s'::uuid" % tenant
+sql = """
+SELECT coalesce(json_agg(t), '[]'::json) FROM (
+  SELECT to_char(created_at AT TIME ZONE 'UTC',
+                 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS timestamp,
+         action, resource_type
+  FROM catalog.audit_logs
+  WHERE created_at >= '%s'::timestamptz
+    AND created_at <= '%s'::timestamptz
+    AND %s
+  ORDER BY created_at DESC
+  LIMIT %d
+) t
+""" % (
+    params["date_from"][0],
+    params["date_to"][0],
+    scope,
+    int(params["max_rows"][0]),
+)
+proc = subprocess.run(
+    ["psql", "-X", "-q", "-v", "ON_ERROR_STOP=1", "-tA", "-c", sql],
+    capture_output=True,
+    text=True,
+)
+if proc.returncode != 0:
+    sys.stderr.write(proc.stderr)
+    sys.exit(1)
+rows = json.loads(proc.stdout.strip())
+
+if mode == "not_array":
+    with open(out, "w") as fh:
+        fh.write('{"detail":"Not authenticated"}')
+    sys.exit(0)
+if mode == "truncate" and rows:
+    rows = rows[:-1]
+if mode == "outside_window" and rows:
+    rows[0]["timestamp"] = "1999-01-01T00:00:00.000000+00:00"
+
+with open(out, "w") as fh:
+    json.dump(rows, fh)
+'''
+
+
+def _pg_env(dbname: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "PGHOST": settings.postgres_host,
+            "PGPORT": str(settings.postgres_port),
+            "PGUSER": settings.postgres_user,
+            "PGPASSWORD": settings.postgres_password.get_secret_value(),
+            "PGDATABASE": dbname,
+        }
+    )
+    return env
+
+
+def _psql(sql: str, dbname: str, check: bool = True) -> str:
+    proc = subprocess.run(
+        ["psql", "-X", "-q", "-v", "ON_ERROR_STOP=1", "-tA", "-c", sql],
+        env=_pg_env(dbname),
+        capture_output=True,
+        text=True,
+    )
+    if check and proc.returncode != 0:
+        raise AssertionError(f"psql failed: {proc.stderr.strip()}\nSQL: {sql}")
+    return proc.stdout.strip()
+
+
+@pytest.fixture(scope="module")
+def scratch_db() -> str:
+    """A database of this module's own, never the shared per-worker one.
+
+    The single-tenant mode deletes every audit row before the cutoff. Pointed
+    at the per-worker test database that would silently destroy rows other
+    test files wrote, so the run gets a database nobody else can see.
+    """
+    admin_db = settings.postgres_db
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    name = f"geolens_auditret_{worker}_{uuid.uuid4().hex[:8]}"
+    _psql(f'CREATE DATABASE "{name}"', admin_db)
+    try:
+        _psql(_SCRATCH_DDL, name)
+        yield name
+    finally:
+        _psql(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)', admin_db, check=False)
+
+
+@pytest.fixture
+def clean_audit_table(scratch_db: str) -> str:
+    _psql("TRUNCATE catalog.audit_logs; TRUNCATE catalog.tenants CASCADE", scratch_db)
+    return scratch_db
+
+
+@pytest.fixture(scope="module")
+def curl_stub_dir(tmp_path_factory) -> Path:
+    bindir = tmp_path_factory.mktemp("stub-bin")
+    stub = bindir / "curl"
+    stub.write_text(_CURL_STUB)
+    stub.chmod(0o755)
+    return bindir
+
+
+def _seed_tenant(db: str, slug: str) -> str:
+    return _psql(
+        f"INSERT INTO catalog.tenants (slug) VALUES ('{slug}') RETURNING id", db
+    )
+
+
+def _seed_rows(db: str, *, days_ago: list[int], tenant_id: str | None = None) -> None:
+    tenant = "NULL" if tenant_id is None else f"'{tenant_id}'::uuid"
+    values = ",".join(
+        f"('audit.test', 'dataset', now() - interval '{d} days', {tenant})"
+        for d in days_ago
+    )
+    _psql(
+        "INSERT INTO catalog.audit_logs (action, resource_type, created_at, tenant_id) "
+        f"VALUES {values}",
+        db,
+    )
+
+
+def _row_count(db: str, tenant_id: str | None = None) -> int:
+    where = "" if tenant_id is None else f" WHERE tenant_id = '{tenant_id}'::uuid"
+    return int(_psql(f"SELECT count(*) FROM catalog.audit_logs{where}", db))
+
+
+def _run_script(
+    db: str,
+    curl_stub_dir: Path,
+    *args: str,
+    shim_mode: str = "ok",
+    shim_tenant: str = "",
+) -> subprocess.CompletedProcess:
+    env = _pg_env(db)
+    env["PATH"] = f"{curl_stub_dir}{os.pathsep}{env['PATH']}"
+    env["ADMIN_TOKEN"] = "stub-token"
+    env["RETENTION_SHIM_MODE"] = shim_mode
+    env["RETENTION_SHIM_TENANT"] = shim_tenant
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--api-url", "https://example.invalid/api", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _archives(archive_dir: Path) -> list[Path]:
+    return sorted(archive_dir.glob("audit-archive-*.json"))
+
+
+def _archived_rows(archive_dir: Path) -> list[dict]:
+    rows: list[dict] = []
+    for path in _archives(archive_dir):
+        rows.extend(json.loads(path.read_text()))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_archives_then_deletes_the_window(clean_audit_table, curl_stub_dir, tmp_path):
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150, 120, 100, 95])
+    _seed_rows(db, days_ago=[10, 5, 1])
+
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    # Proves the external-Postgres path was the one exercised, not a fallback.
+    assert "Connecting via PG* environment variables" in result.stdout
+    assert len(_archived_rows(archive_dir)) == 5
+    assert _row_count(db) == 3
+
+
+def test_dry_run_archives_without_deleting(clean_audit_table, curl_stub_dir, tmp_path):
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150, 120])
+
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+        "--dry-run",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert len(_archived_rows(archive_dir)) == 3
+    assert _row_count(db) == 3
+
+
+def test_external_db_url_strips_the_sqlalchemy_driver_suffix(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """A privileged credential copied out of app config carries +asyncpg.
+
+    libpq's URI parser accepts only postgresql:// and postgres://, so the
+    suffix has to be stripped or the operator on a managed database cannot run
+    the procedure at all.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150])
+
+    password = quote(settings.postgres_password.get_secret_value(), safe="")
+    db_url = (
+        f"postgresql+asyncpg://{settings.postgres_user}:{password}"
+        f"@{settings.postgres_host}:{settings.postgres_port}/{db}"
+    )
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+        "--db-url",
+        db_url,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Connecting via --db-url" in result.stdout
+    assert _row_count(db) == 0
+
+
+def test_boundary_row_at_the_cutoff_is_archived_and_deleted(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """The export's date_to is inclusive, so every step must use <=.
+
+    A row landing exactly on the cutoff must be in the archive and in the
+    delete. A delete using < would leave it; a count using < while the export
+    used <= could displace an older row out of the archive at the cap and
+    delete it anyway.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150])
+    _seed_rows(db, days_ago=[10])
+    boundary = _psql(
+        "INSERT INTO catalog.audit_logs (action, resource_type, created_at) "
+        "VALUES ('audit.boundary', 'dataset', now() - interval '120 days') "
+        "RETURNING to_char(created_at AT TIME ZONE 'UTC', "
+        '\'YYYY-MM-DD"T"HH24:MI:SS.US"Z"\')',
+        db,
+    )
+
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--cutoff",
+        boundary,
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    actions = [row["action"] for row in _archived_rows(archive_dir)]
+    assert "audit.boundary" in actions
+    # The 200-, 150- and 120-day rows are all at or before the cutoff; only the
+    # 10-day row survives.
+    assert _row_count(db) == 1
+    surviving = _psql("SELECT DISTINCT action FROM catalog.audit_logs", db)
+    assert surviving == "audit.test"
+
+
+def test_window_over_the_export_cap_is_split_and_fully_archived(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """One export call cannot return more than max_rows rows.
+
+    Narrowing date_to alone does not help — the endpoint always returns the
+    newest rows in the range — so the script has to partition the window. Every
+    row must end up in some archive before any of them is deleted.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=list(range(100, 110)))
+
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+        "--max-rows",
+        "3",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert len(_archives(archive_dir)) > 1
+    # Adjacent windows share their boundary instant, so a row can be archived
+    # twice; what must never happen is a row archived zero times.
+    archived = {row["timestamp"] for row in _archived_rows(archive_dir)}
+    assert len(archived) == 10
+    assert _row_count(db) == 0
+
+
+def test_repeated_runs_do_not_overwrite_an_earlier_archive(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """Two runs of the same scope on the same day must not share a filename.
+
+    The prose version wrote a name derived from the date alone, so the second
+    ``curl -o`` truncated the first archive — possibly after those rows were
+    already deleted.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150])
+    archive_dir = tmp_path / "archives"
+
+    common = (
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(archive_dir),
+        "--dry-run",
+    )
+    first = _run_script(db, curl_stub_dir, *common)
+    second = _run_script(db, curl_stub_dir, *common)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert len(_archives(archive_dir)) == 2
+    for path in _archives(archive_dir):
+        assert len(json.loads(path.read_text())) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tenant scoping
+# ---------------------------------------------------------------------------
+
+
+def test_per_tenant_run_leaves_other_tenants_untouched(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    db = clean_audit_table
+    tenant_a = _seed_tenant(db, "alpha")
+    tenant_b = _seed_tenant(db, "beta")
+    _seed_rows(db, days_ago=[200, 150, 120], tenant_id=tenant_a)
+    _seed_rows(db, days_ago=[5], tenant_id=tenant_a)
+    _seed_rows(db, days_ago=[200, 150], tenant_id=tenant_b)
+
+    archive_dir = tmp_path / "archives"
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--tenant-slug",
+        "alpha",
+        "--archive-dir",
+        str(archive_dir),
+        shim_tenant=tenant_a,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert len(_archived_rows(archive_dir)) == 3
+    assert _row_count(db, tenant_a) == 1
+    assert _row_count(db, tenant_b) == 2
+
+
+def test_unresolvable_tenant_slug_deletes_nothing(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150])
+
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--tenant-slug",
+        "no-such-tenant",
+        "--archive-dir",
+        str(tmp_path / "archives"),
+    )
+
+    assert result.returncode != 0
+    assert "no tenant found" in result.stderr
+    assert _row_count(db) == 2
+
+
+def test_no_scope_flag_is_refused(clean_audit_table, curl_stub_dir, tmp_path):
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150])
+
+    result = _run_script(
+        db, curl_stub_dir, "--days", "90", "--archive-dir", str(tmp_path / "archives")
+    )
+
+    assert result.returncode != 0
+    assert _row_count(db) == 2
+
+
+def test_wrong_single_tenant_confirmation_is_refused(
+    clean_audit_table, curl_stub_dir, tmp_path
+):
+    """The unscoped branch needs the exact phrase, typed by the operator.
+
+    Nothing reads GEOLENS_TENANCY_MODE: a config-derived signal can be absent,
+    stale, or injected by an orchestrator in a way the script cannot detect.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150])
+
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        "yes",
+        "--archive-dir",
+        str(tmp_path / "archives"),
+    )
+
+    assert result.returncode != 0
+    assert "refusing to run unscoped" in result.stderr
+    assert _row_count(db) == 2
+
+
+# ---------------------------------------------------------------------------
+# Export failures must block the delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("shim_mode", "expected_message"),
+    [
+        ("http_error", "export request failed"),
+        ("not_array", "is not a JSON array"),
+        ("truncate", "archive row count mismatch"),
+        ("outside_window", "contains a row outside"),
+    ],
+)
+def test_a_bad_export_deletes_nothing(
+    clean_audit_table, curl_stub_dir, tmp_path, shim_mode, expected_message
+):
+    """Each of these once produced a "successful" run that deleted live rows.
+
+    ``http_error`` is curl without --fail saving ``{"detail": ...}`` as the
+    archive; ``not_array`` is a 200 carrying a proxy error page; ``truncate``
+    is an export short of the window; ``outside_window`` is a right-sized
+    archive holding the wrong rows.
+    """
+    db = clean_audit_table
+    _seed_rows(db, days_ago=[200, 150, 120])
+
+    result = _run_script(
+        db,
+        curl_stub_dir,
+        "--days",
+        "90",
+        "--confirm-single-tenant",
+        CONFIRM_PHRASE,
+        "--archive-dir",
+        str(tmp_path / "archives"),
+        shim_mode=shim_mode,
+    )
+
+    assert result.returncode != 0
+    assert expected_message in result.stderr
+    assert _row_count(db) == 3
+
+
+# ---------------------------------------------------------------------------
+# Drift guard
+# ---------------------------------------------------------------------------
+
+
+def test_scratch_schema_matches_the_models():
+    """The stand-in DDL above must keep describing the real tables.
+
+    Renaming a column the script reads would otherwise leave this module green
+    while the script broke against a live database.
+    """
+    from app.modules.audit.models import AuditLog
+    from app.modules.tenancy.models import Tenant
+
+    assert AuditLog.__table__.schema == "catalog"
+    assert AuditLog.__tablename__ == "audit_logs"
+    assert {"id", "tenant_id", "created_at"} <= set(AuditLog.__table__.c.keys())
+
+    assert Tenant.__table__.schema == "catalog"
+    assert Tenant.__tablename__ == "tenants"
+    assert {"id", "slug"} <= set(Tenant.__table__.c.keys())
+
+
+def test_export_curl_invocation_keeps_fail():
+    """--fail on the export call, asserted directly rather than by behaviour.
+
+    The stub models curl faithfully: drop --fail and it exits 0 with the error
+    body on disk, which the JSON-array check then catches. That layering is
+    deliberate, and it also means no behavioural test goes red when --fail is
+    removed. This one does.
+    """
+    body = SCRIPT.read_text()
+    invocation = body.split("curl -sS", 1)
+    assert len(invocation) == 2, "expected a `curl -sS` export invocation"
+    # Up to the -o, i.e. the flags curl is actually called with.
+    flags = invocation[1].split("-o ", 1)[0]
+    assert "--fail" in flags
+
+
+def test_script_is_executable_and_syntactically_valid():
+    assert os.access(SCRIPT, os.X_OK), f"{SCRIPT} must be executable"
+    proc = subprocess.run(["bash", "-n", str(SCRIPT)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -78,6 +78,7 @@ separate post-step (headless browser capture + `PUT /maps/{id}/thumbnail/`).
 | `init-test-db.sh` | Initialize a host-accessible `geolens_test` database (extensions, schemas, roles) for local `psql` debugging. Not used by CI. CI and pytest each bootstrap their own test databases. |
 | `backup-entrypoint.sh` | Scheduled `pg_dump` backups with retention + optional S3 upload (the default Docker Compose backup service) |
 | `restore.sh` | Restore a database backup |
+| `audit_retention.sh` | Apply a retention window to `catalog.audit_logs`: export the window through the API, verify the archive, then delete exactly those rows (`RUNBOOK.md` §8) |
 | `run-baseline.sh` | Run performance baselines |
 | `analyze-query-plans.sh` | Analyze slow query plans |
 | `cleanup-test-pollution.sql` | Remove leftover test data (manual `psql`) |

--- a/scripts/audit_retention.sh
+++ b/scripts/audit_retention.sh
@@ -1,0 +1,539 @@
+#!/usr/bin/env bash
+# Archive-then-delete retention for catalog.audit_logs.
+#
+# RUNBOOK.md §8 is the operator-facing documentation. This script is the
+# procedure itself; the RUNBOOK no longer carries a copy of the SQL.
+#
+# The table has no built-in expiry and no in-app pruning endpoint, so a
+# retention window is applied out of band. Deleting rows that were never
+# exported is data loss rather than retention, so every step below is ordered
+# to make the archive provably complete BEFORE anything is deleted:
+#
+#   1. One cutoff timestamp is evaluated ONCE, in the database, and every later
+#      step reuses that frozen string. Nothing re-evaluates `now() - interval`,
+#      so the count, the export and the delete cannot drift apart across the
+#      minutes a large run takes.
+#   2. The tenant scope is chosen by an explicit flag, never inferred. There is
+#      no code path from an unset or empty tenant id into an unscoped delete:
+#      the scopes are separate values of $MODE, and the per-tenant one aborts
+#      before any other query if the slug does not resolve.
+#   3. Every archive filename carries the scope, a UTC timestamp and the pid,
+#      and the script refuses to write over a file that already exists -- two
+#      tenants, or two runs, on the same day cannot silently truncate each
+#      other's only copy.
+#   4. curl runs with --fail, so an auth failure or proxy error cannot land an
+#      error document on disk as if it were the archive. Each archive is then
+#      re-read: it must parse as a JSON array, hold exactly as many rows as the
+#      database counts for the identical window, and contain no row outside
+#      that window.
+#   5. The delete reuses the same predicate the count used -- one string, two
+#      uses -- and runs only after every window passed every check above.
+#
+# Connection: the bundled Postgres via `docker compose exec db` by default, or
+# any external/managed Postgres via --db-url or the standard PG* environment
+# variables. The credential must be able to see and modify rows across every
+# tenant; the app's least-privilege runtime login deliberately cannot. See
+# RUNBOOK.md §8.
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Timestamps are exchanged with both Postgres and the export API in one
+# canonical shape: UTC, microsecond precision, `Z` suffix. Postgres round-trips
+# it exactly (timestamptz resolution is microseconds) and Pydantic parses it,
+# so a window boundary means the same instant on both sides.
+TS_FORMAT='YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+
+# One definition: the help text, the comparison below, and RUNBOOK.md §8 all
+# have to agree, because an operator copy-pastes it.
+SINGLE_TENANT_PHRASE="yes, this deployment has no per-tenant host routing"
+
+say() { printf '%s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+need_command() {
+    command -v "$1" >/dev/null 2>&1 || die "'$1' is required but not installed."
+}
+
+usage() {
+    cat <<EOF
+Usage: $SCRIPT_NAME --api-url URL (--days N | --cutoff TS)
+                    (--tenant-slug SLUG | --confirm-single-tenant PHRASE) [options]
+
+Exports every catalog.audit_logs row at or before the cutoff, verifies the
+archive, then deletes exactly that window.
+
+Required:
+  --api-url URL     Base API URL for the export endpoint, e.g.
+                    https://geolens.example.com/api . On a deployment with
+                    per-tenant host routing this must be the host belonging to
+                    --tenant-slug: the export is scoped by host and there is no
+                    cross-tenant export call.
+  --days N          Cutoff is N days before now, evaluated once in the database.
+  --cutoff TS       Explicit cutoff instead of --days, as an ISO 8601 timestamp
+                    Postgres accepts (e.g. 2026-01-31T00:00:00Z).
+
+Scope -- choose exactly one. There is no default and no fallback between them:
+  --tenant-slug SLUG
+                    Per-tenant host routing. The slug is resolved to a tenant id
+                    and the run aborts if it resolves to nothing.
+  --confirm-single-tenant PHRASE
+                    Unscoped: touches every row before the cutoff regardless of
+                    tenant. PHRASE must be exactly
+                      $SINGLE_TENANT_PHRASE
+                    typed by an operator who has personally confirmed this
+                    deployment has no per-tenant host routing. No config value
+                    is consulted.
+
+Options:
+  --archive-dir DIR Where archives are written (default: ./audit-archives).
+  --db-url URL      Connect to an external/managed Postgres with this libpq URL
+                    instead of the bundled db container. A SQLAlchemy driver
+                    suffix (postgresql+asyncpg://) is stripped automatically.
+  --batch-size N    Rows per delete statement (default: 5000).
+  --max-rows N      Rows per export call (default: 100000, the endpoint's cap).
+                    Windows larger than this are split automatically.
+  --dry-run         Archive and verify, then stop without deleting.
+  --vacuum          Run VACUUM (ANALYZE) catalog.audit_logs after the delete.
+  -h, --help        Show this help.
+
+Environment:
+  ADMIN_TOKEN       Required. Bearer token for the export endpoint.
+  PGHOST PGPORT PGUSER PGDATABASE PGPASSWORD PGSERVICE
+                    Used when --db-url is not given; setting PGHOST or
+                    PGSERVICE is what selects the direct-connection mode.
+  POSTGRES_USER POSTGRES_DB
+                    Used for the bundled \`docker compose exec db\` path, read
+                    from .env like the other scripts in this directory.
+
+No row is deleted unless every archive for the window passed every check.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Arguments
+# ---------------------------------------------------------------------------
+
+API_URL=""
+DAYS=""
+CUTOFF_ARG=""
+TENANT_SLUG=""
+CONFIRM_PHRASE=""
+ARCHIVE_DIR="./audit-archives"
+DB_URL=""
+BATCH_SIZE=5000
+MAX_ROWS=100000
+DRY_RUN=0
+RUN_VACUUM=0
+
+# A flag whose value is missing must say so, not fall off the end of "$@" and
+# fail inside `shift 2` with an unrelated message.
+require_value() {
+    if [ "$2" -lt 2 ]; then
+        die "$1 requires a value."
+    fi
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --api-url) require_value "$1" $#; API_URL="$2"; shift 2 ;;
+        --days) require_value "$1" $#; DAYS="$2"; shift 2 ;;
+        --cutoff) require_value "$1" $#; CUTOFF_ARG="$2"; shift 2 ;;
+        --tenant-slug) require_value "$1" $#; TENANT_SLUG="$2"; shift 2 ;;
+        --confirm-single-tenant) require_value "$1" $#; CONFIRM_PHRASE="$2"; shift 2 ;;
+        --archive-dir) require_value "$1" $#; ARCHIVE_DIR="$2"; shift 2 ;;
+        --db-url) require_value "$1" $#; DB_URL="$2"; shift 2 ;;
+        --batch-size) require_value "$1" $#; BATCH_SIZE="$2"; shift 2 ;;
+        --max-rows) require_value "$1" $#; MAX_ROWS="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --vacuum) RUN_VACUUM=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage >&2; die "unknown argument: $1" ;;
+    esac
+done
+
+[ -n "$API_URL" ] || { usage >&2; die "--api-url is required."; }
+[ -n "${ADMIN_TOKEN:-}" ] || die "ADMIN_TOKEN is not set; the export endpoint needs a bearer token."
+
+if [ -n "$DAYS" ] && [ -n "$CUTOFF_ARG" ]; then
+    die "--days and --cutoff are mutually exclusive; pick one boundary."
+fi
+if [ -z "$DAYS" ] && [ -z "$CUTOFF_ARG" ]; then
+    usage >&2
+    die "one of --days or --cutoff is required."
+fi
+if [ -n "$DAYS" ]; then
+    case "$DAYS" in
+        ''|*[!0-9]*) die "--days must be a whole number of days, got '$DAYS'." ;;
+    esac
+    [ "$DAYS" -ge 1 ] || die "--days must be at least 1."
+fi
+case "$BATCH_SIZE" in ''|*[!0-9]*) die "--batch-size must be a positive integer." ;; esac
+[ "$BATCH_SIZE" -ge 1 ] || die "--batch-size must be at least 1."
+case "$MAX_ROWS" in ''|*[!0-9]*) die "--max-rows must be a positive integer." ;; esac
+if [ "$MAX_ROWS" -lt 1 ] || [ "$MAX_ROWS" -gt 100000 ]; then
+    die "--max-rows must be between 1 and 100000 (the export endpoint's own cap)."
+fi
+
+# The scope is a choice between two explicit modes. An empty --tenant-slug is
+# not "probably single-tenant": a mistyped slug or a failed lookup must never
+# fall through to an unscoped, cross-tenant delete, so neither branch can be
+# reached by leaving a variable unset.
+if [ -n "$TENANT_SLUG" ] && [ -n "$CONFIRM_PHRASE" ]; then
+    die "--tenant-slug and --confirm-single-tenant are mutually exclusive."
+fi
+if [ -n "$TENANT_SLUG" ]; then
+    MODE="tenant"
+elif [ -n "$CONFIRM_PHRASE" ]; then
+    MODE="single"
+    if [ "$CONFIRM_PHRASE" != "$SINGLE_TENANT_PHRASE" ]; then
+        die "refusing to run unscoped: --confirm-single-tenant must be exactly
+  $SINGLE_TENANT_PHRASE
+This mode deletes every row before the cutoff with no tenant scoping. On a
+deployment with per-tenant host routing that removes every other tenant's audit
+history, which the host-scoped export never captured -- permanent loss with no
+archive. The phrase is not read from any config file precisely because a
+config-derived signal can be absent, stale, or injected by an orchestrator in a
+way this script cannot detect."
+    fi
+else
+    usage >&2
+    die "one of --tenant-slug or --confirm-single-tenant is required; this script does not detect your deployment's tenancy mode."
+fi
+
+need_command psql
+need_command curl
+need_command jq
+
+# ---------------------------------------------------------------------------
+# Connection
+# ---------------------------------------------------------------------------
+#
+# Three paths, checked in order. The first two reach a managed or external
+# Postgres directly; only the last needs a local db container.
+if [ -n "$DB_URL" ]; then
+    # libpq's URI parser accepts only postgresql:// and postgres://. A
+    # privileged credential copied out of a SQLAlchemy config carries a driver
+    # suffix, which libpq rejects outright.
+    PG_URI="$(printf '%s' "$DB_URL" | sed -E 's#^postgresql\+[A-Za-z0-9_]+://#postgresql://#')"
+    PSQL=(psql "$PG_URI")
+    CONN_DESC="--db-url"
+elif [ -n "${PGHOST:-}" ] || [ -n "${PGSERVICE:-}" ]; then
+    PSQL=(psql)
+    CONN_DESC="PG* environment variables"
+else
+    need_command docker
+    if [ -f "$PROJECT_ROOT/.env" ]; then
+        set -a
+        # shellcheck source=/dev/null
+        . "$PROJECT_ROOT/.env"
+        set +a
+    fi
+    PSQL=(docker compose -f "$PROJECT_ROOT/${COMPOSE_FILE:-docker-compose.yml}" exec -T db
+          psql -U "${POSTGRES_USER:-geolens}" -d "${POSTGRES_DB:-geolens}")
+    CONN_DESC="bundled db container"
+fi
+
+# Every query goes through here. $1 is the SQL; anything after it is passed to
+# psql (in practice -v name=value bindings).
+#
+# The SQL arrives on stdin, NOT via -c. psql performs :name / :'name'
+# substitution only on input it lexes itself, which means files and stdin --
+# a -c string is handed to the server verbatim and every binding silently
+# survives into the query text as a syntax error at best. Passing it here, in
+# the one place every query goes through, is what keeps that from having to be
+# remembered at each call site.
+#
+# -X ignores ~/.psqlrc, whose output settings would otherwise break -tA
+# parsing; ON_ERROR_STOP turns a failed statement into a non-zero exit instead
+# of a silently empty result; -tA gives one bare value per line.
+psql_value() {
+    local sql="$1"
+    shift
+    printf '%s\n' "$sql" | "${PSQL[@]}" -X -q -v ON_ERROR_STOP=1 -tA "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Scope predicate: ONE definition, used by the count, the window search and the
+# delete. They cannot drift, because there is only one string.
+# ---------------------------------------------------------------------------
+if [ "$MODE" = "tenant" ]; then
+    SCOPE_SQL="tenant_id = :'tenant_id'::uuid"
+else
+    # Unscoped by explicit confirmation. Deliberately not `tenant_id IS NULL`:
+    # the export endpoint returns every row the host can see, so a narrower
+    # delete predicate here would leave behind rows the archive claims to cover.
+    SCOPE_SQL="TRUE"
+fi
+
+# Both bounds inclusive, matching the export endpoint's own filters
+# (created_at >= date_from AND created_at <= date_to). Using < anywhere would
+# let a row landing exactly on a boundary be counted by one step and missed by
+# another -- at the export cap, that boundary row can displace an older in-range
+# row out of the archive while the delete still removes it.
+#
+# Rows are only ever inserted with created_at = now(), so a window ending in the
+# past is immutable for the length of the run: nothing new can appear inside it
+# between the count and the delete. That is what lets a count taken now still
+# describe the rows deleted later.
+window_predicate() {
+    # $1 = lower-bound expression, or empty for no lower bound. $2 = upper bound.
+    if [ -n "$1" ]; then
+        printf 'created_at >= %s AND created_at <= %s AND %s' "$1" "$2" "$SCOPE_SQL"
+    else
+        printf 'created_at <= %s AND %s' "$2" "$SCOPE_SQL"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+say "Connecting via $CONN_DESC ..."
+psql_value "SELECT 1 FROM catalog.audit_logs LIMIT 0" >/dev/null \
+    || die "cannot read catalog.audit_logs through $CONN_DESC.
+Check the connection, and that the credential is a privileged/migrator-class
+login: catalog.audit_logs carries a row-level security policy, and a session
+without BYPASSRLS and without app.current_tenant set sees zero rows through it
+-- which would make every count and delete below silently do nothing."
+
+# The cutoff is evaluated once, here, and never again. Every later step is
+# handed this exact string.
+if [ -n "$CUTOFF_ARG" ]; then
+    CUTOFF="$(psql_value \
+        "SELECT to_char((:'c')::timestamptz AT TIME ZONE 'UTC', '$TS_FORMAT')" \
+        -v c="$CUTOFF_ARG")" \
+        || die "--cutoff '$CUTOFF_ARG' is not a timestamp Postgres accepts."
+else
+    CUTOFF="$(psql_value \
+        "SELECT to_char((now() - (:'d' || ' days')::interval) AT TIME ZONE 'UTC', '$TS_FORMAT')" \
+        -v d="$DAYS")"
+fi
+[ -n "$CUTOFF" ] || die "failed to resolve the retention cutoff."
+say "Retention cutoff (frozen for this run): $CUTOFF"
+
+# Resolve the tenant before anything else touches the table. A slug that
+# resolves to nothing ends the run here, so no later step can ever see an empty
+# tenant id.
+TENANT_ID=""
+if [ "$MODE" = "tenant" ]; then
+    TENANT_ID="$(psql_value \
+        "SELECT id FROM catalog.tenants WHERE slug = :'slug'" \
+        -v slug="$TENANT_SLUG")"
+    if [ -z "$TENANT_ID" ]; then
+        die "no tenant found for slug '$TENANT_SLUG' -- aborting rather than falling through to an unscoped, all-tenants run."
+    fi
+    # Belt and braces: the lookup can only return a uuid, but pinning the shape
+    # here means no future edit can reach the ::uuid cast with an empty or
+    # malformed value and get a cast error instead of this message.
+    _hex4='[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'
+    case "$TENANT_ID" in
+        ${_hex4}${_hex4}-${_hex4}-${_hex4}-${_hex4}-${_hex4}${_hex4}${_hex4}) ;;
+        *) die "tenant lookup for '$TENANT_SLUG' returned '$TENANT_ID', which is not a uuid." ;;
+    esac
+    say "Scope: tenant '$TENANT_SLUG' ($TENANT_ID)"
+    SCOPE_LABEL="$TENANT_SLUG"
+else
+    say "Scope: unscoped, by explicit operator confirmation (single-tenant deployment)"
+    SCOPE_LABEL="single-tenant"
+fi
+
+# psql refuses a query that references an unset variable, so both are always
+# bound; the single-tenant predicate simply never mentions :'tenant_id'.
+PSQL_VARS=(-v "cutoff=$CUTOFF" -v "tenant_id=$TENANT_ID")
+
+TOTAL_IN_WINDOW="$(psql_value \
+    "SELECT count(*) FROM catalog.audit_logs WHERE $(window_predicate '' ":'cutoff'::timestamptz")" \
+    "${PSQL_VARS[@]}")"
+say "Rows at or before the cutoff in scope: $TOTAL_IN_WINDOW"
+
+if [ "$TOTAL_IN_WINDOW" -eq 0 ]; then
+    say "Nothing to archive or delete. Done."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Archive
+# ---------------------------------------------------------------------------
+
+mkdir -p "$ARCHIVE_DIR"
+
+# Unique per scope AND per run. Two tenants archived on the same day, or the
+# same tenant archived twice, would otherwise write the same filename and the
+# second curl -o would truncate the first archive -- possibly after those rows
+# were already deleted. The refusal in export_window makes even a same-second
+# collision impossible rather than merely unlikely.
+SAFE_LABEL="$(printf '%s' "$SCOPE_LABEL" | tr -c 'A-Za-z0-9._-' '-')"
+ARCHIVE_TAG="${SAFE_LABEL}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+
+# Sum over every exported window. Adjacent windows share their boundary instant
+# (both bounds are inclusive), so a row on a boundary is archived twice and the
+# sum is >= the window total, never <. Duplicating an archive entry is harmless;
+# offsetting a bound by an epsilon to avoid it would silently drop the boundary
+# row from every export instead.
+ARCHIVED_TOTAL=0
+WINDOW_INDEX=0
+
+export_window() {
+    local window_from="$1"
+    local window_to="$2"
+    local expected="$3"
+    local stamp out got
+
+    WINDOW_INDEX=$((WINDOW_INDEX + 1))
+    stamp="$(printf '%s' "$window_from" | tr -c 'A-Za-z0-9' '-')"
+    out="${ARCHIVE_DIR}/audit-archive-${ARCHIVE_TAG}-$(printf '%03d' "$WINDOW_INDEX")-${stamp}.json"
+
+    if [ -e "$out" ]; then
+        die "refusing to overwrite an existing archive: $out"
+    fi
+
+    say "  window $WINDOW_INDEX: $window_from .. $window_to ($expected rows)"
+
+    # --fail is not optional. Without it an expired token, a wrong host, or any
+    # other 4xx/5xx still exits 0 and writes the error body (e.g.
+    # {"detail":"Not authenticated"}) to the output file as if it were the
+    # archive, and the delete would then run against a window that was never
+    # exported. --fail makes curl exit non-zero and discard that body.
+    curl -sS --fail \
+        -H "Authorization: Bearer $ADMIN_TOKEN" \
+        "${API_URL%/}/admin/audit-logs/export/json?date_from=${window_from}&date_to=${window_to}&max_rows=${MAX_ROWS}" \
+        -o "$out" \
+        || die "export request failed for $window_from .. $window_to -- nothing has been deleted."
+
+    # A 200 with an unexpected body (a proxy error page, a truncated stream)
+    # gets past --fail. jq has to parse the whole file to answer this, so a
+    # truncated download fails here instead of reporting a plausible count.
+    jq -e 'type == "array"' "$out" >/dev/null \
+        || die "$out is not a JSON array -- nothing has been deleted."
+
+    got="$(jq 'length' "$out")"
+    if [ "$got" != "$expected" ]; then
+        die "archive row count mismatch for $window_from .. $window_to: the database counts $expected, $out holds $got. Nothing has been deleted."
+    fi
+
+    # Catches an archive that is the right SIZE but holds the wrong ROWS. The
+    # export is scoped by host, so a wrong --api-url, or the wrong tenant's
+    # host, can return a same-sized slice of somebody else's history.
+    if [ "$got" -gt 0 ]; then
+        jq -e 'all(.[]; .timestamp != null and (.timestamp | test("(Z|\\+00:00)$")))' "$out" >/dev/null \
+            || die "$out contains a row whose timestamp is missing or is not UTC, so it cannot be checked against the window. Nothing has been deleted."
+        jq -e --arg lo "$window_from" --arg hi "$window_to" \
+            'all(.[]; .timestamp[0:19] >= $lo[0:19] and .timestamp[0:19] <= $hi[0:19])' "$out" >/dev/null \
+            || die "$out contains a row outside $window_from .. $window_to. Nothing has been deleted."
+    fi
+
+    ARCHIVED_TOTAL=$((ARCHIVED_TOTAL + got))
+    say "    archived $got rows -> $out"
+}
+
+say "Archiving to $ARCHIVE_DIR (tag $ARCHIVE_TAG) ..."
+
+WINDOW_FROM="$(psql_value \
+    "SELECT to_char(min(created_at) AT TIME ZONE 'UTC', '$TS_FORMAT')
+     FROM catalog.audit_logs WHERE $(window_predicate '' ":'cutoff'::timestamptz")" \
+    "${PSQL_VARS[@]}")"
+[ -n "$WINDOW_FROM" ] || die "could not determine the oldest row in the window."
+
+while :; do
+    remaining="$(psql_value \
+        "SELECT count(*) FROM catalog.audit_logs
+         WHERE $(window_predicate ":'wf'::timestamptz" ":'cutoff'::timestamptz")" \
+        "${PSQL_VARS[@]}" -v "wf=$WINDOW_FROM")"
+    if [ "$remaining" -eq 0 ]; then
+        break
+    fi
+
+    if [ "$remaining" -le "$MAX_ROWS" ]; then
+        export_window "$WINDOW_FROM" "$CUTOFF" "$remaining"
+        break
+    fi
+
+    # More rows than one export call can return. Narrowing date_to alone does
+    # not help: the endpoint always returns the NEWEST rows in the range, so
+    # repeating the same call returns the same slice forever. Split instead --
+    # take the timestamp of the MAX_ROWS-th oldest row and end this window
+    # there. The next window starts at that same instant, so consecutive windows
+    # overlap by one instant and cannot leave a gap between them.
+    sub_window_to="$(psql_value \
+        "SELECT to_char(max(created_at) AT TIME ZONE 'UTC', '$TS_FORMAT') FROM (
+             SELECT created_at FROM catalog.audit_logs
+             WHERE $(window_predicate ":'wf'::timestamptz" ":'cutoff'::timestamptz")
+             ORDER BY created_at LIMIT $MAX_ROWS) t" \
+        "${PSQL_VARS[@]}" -v "wf=$WINDOW_FROM")"
+    [ -n "$sub_window_to" ] || die "could not compute a sub-window boundary."
+
+    expected="$(psql_value \
+        "SELECT count(*) FROM catalog.audit_logs
+         WHERE $(window_predicate ":'wf'::timestamptz" ":'wt'::timestamptz")" \
+        "${PSQL_VARS[@]}" -v "wf=$WINDOW_FROM" -v "wt=$sub_window_to")"
+    if [ "$expected" -gt "$MAX_ROWS" ] || [ "$sub_window_to" = "$WINDOW_FROM" ]; then
+        die "more than $MAX_ROWS rows share the instant $sub_window_to, so the window cannot be split small enough for one export call. Raise --max-rows (up to 100000), or archive that instant by hand. Nothing has been deleted."
+    fi
+
+    export_window "$WINDOW_FROM" "$sub_window_to" "$expected"
+    WINDOW_FROM="$sub_window_to"
+done
+
+if [ "$ARCHIVED_TOTAL" -lt "$TOTAL_IN_WINDOW" ]; then
+    die "the archives hold $ARCHIVED_TOTAL rows but the window contains $TOTAL_IN_WINDOW. Nothing has been deleted."
+fi
+say "Archive verified: $ARCHIVED_TOTAL rows across $WINDOW_INDEX file(s) for a window of $TOTAL_IN_WINDOW."
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    say "--dry-run: stopping before the delete. The archives above are keepers."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+#
+# Batched: the only DELETE-supporting index is
+# ix_catalog_audit_logs_created_action_resource (created_at DESC, action,
+# resource_type), so an unbounded DELETE on a multi-million-row table holds
+# locks and bloats the table. Run this in a low-traffic maintenance window.
+#
+# The loop lives in the shell rather than in a PL/pgSQL DO block on purpose.
+# psql's :name substitution is skipped inside quoted SQL literals, and a
+# dollar-quoted $$...$$ body is one -- parameters passed that way silently never
+# reach the delete. Here every statement is a plain statement, psql binds and
+# quotes :'cutoff' and :'tenant_id' itself, and the predicate is the same string
+# the count above used.
+
+say "Deleting in batches of $BATCH_SIZE ..."
+DELETED_TOTAL=0
+while :; do
+    deleted="$(psql_value "
+        WITH doomed AS (
+            SELECT id FROM catalog.audit_logs
+            WHERE $(window_predicate '' ":'cutoff'::timestamptz")
+            ORDER BY created_at
+            LIMIT $BATCH_SIZE
+        ), removed AS (
+            DELETE FROM catalog.audit_logs a USING doomed d WHERE a.id = d.id
+            RETURNING 1
+        )
+        SELECT count(*) FROM removed" "${PSQL_VARS[@]}")"
+    [ -n "$deleted" ] || die "a delete batch returned no row count; stopping with $DELETED_TOTAL rows deleted so far."
+    if [ "$deleted" -eq 0 ]; then
+        break
+    fi
+    DELETED_TOTAL=$((DELETED_TOTAL + deleted))
+    say "  deleted $DELETED_TOTAL / $TOTAL_IN_WINDOW"
+done
+
+LEFTOVER="$(psql_value \
+    "SELECT count(*) FROM catalog.audit_logs WHERE $(window_predicate '' ":'cutoff'::timestamptz")" \
+    "${PSQL_VARS[@]}")"
+[ "$LEFTOVER" -eq 0 ] \
+    || die "$LEFTOVER rows at or before the cutoff remain in scope after the delete loop; investigate before re-running."
+
+say "Deleted $DELETED_TOTAL rows. The archives are in $ARCHIVE_DIR -- keep them offsite (RUNBOOK.md §1)."
+
+if [ "$RUN_VACUUM" -eq 1 ]; then
+    say "Running VACUUM (ANALYZE) catalog.audit_logs ..."
+    psql_value "VACUUM (ANALYZE) catalog.audit_logs" >/dev/null
+fi

--- a/scripts/audit_retention.sh
+++ b/scripts/audit_retention.sh
@@ -268,7 +268,26 @@ fi
 psql_value() {
     local sql="$1"
     shift
-    printf '%s\n' "$sql" | "${PSQL[@]}" -X -q -v ON_ERROR_STOP=1 -tA "$@"
+    # fix(#1248): `SET row_security = off` on EVERY connection, not once at
+    # startup -- each call here is its own psql process and its own session, so
+    # a one-time SET elsewhere would not survive to the query that matters.
+    #
+    # It is the RLS bypass check, expressed where it cannot be skipped. For a
+    # session that can bypass row-level security (superuser, BYPASSRLS, or the
+    # table owner without FORCE) it is a no-op. For anything else -- notably the
+    # app's own least-privilege runtime login -- any query touching an RLS table
+    # then fails with "query would be affected by row-level security policy",
+    # which ON_ERROR_STOP turns into a non-zero exit. Without it that credential
+    # reads through the tenant_isolation policy on catalog.audit_logs, sees zero
+    # rows, and the run reports "nothing to archive or delete" and exits 0: a
+    # silent no-op that looks exactly like a correctly-empty window.
+    #
+    # -q is load-bearing here and not cosmetic. SET emits a "SET" command tag on
+    # stdout, which under -tA would be parsed as the first value of every query;
+    # -q suppresses it. Measured: `-X -q -tA` returns "42\n" with or without the
+    # SET, while dropping -q returns "SET\n42\n".
+    printf 'SET row_security = off;\n%s\n' "$sql" \
+        | "${PSQL[@]}" -X -q -v ON_ERROR_STOP=1 -tA "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -308,12 +327,20 @@ window_predicate() {
 # ---------------------------------------------------------------------------
 
 say "Connecting via $CONN_DESC ..."
+# Connectivity and "does this table exist" only. The credential's ability to
+# see past row-level security is NOT established here -- a LIMIT 0 succeeds for
+# a session that RLS would filter to nothing. That check lives in psql_value,
+# on every query, so a credential that cannot bypass RLS fails loudly on the
+# first real statement instead of quietly counting zero rows.
 psql_value "SELECT 1 FROM catalog.audit_logs LIMIT 0" >/dev/null \
     || die "cannot read catalog.audit_logs through $CONN_DESC.
 Check the connection, and that the credential is a privileged/migrator-class
-login: catalog.audit_logs carries a row-level security policy, and a session
-without BYPASSRLS and without app.current_tenant set sees zero rows through it
--- which would make every count and delete below silently do nothing."
+login. If the failure mentions row-level security, that is this script
+refusing to run as a credential that RLS would filter: catalog.audit_logs
+carries the tenant_isolation policy (migration 0022), and reading through it
+would silently do nothing instead of the documented thing. Use the same
+privileged credential RUNBOOK.md §2 calls out for schema changes, not the
+steady-state runtime login your deployment authenticates with day to day."
 
 # The cutoff is evaluated once, here, and never again. Every later step is
 # handed this exact string.
@@ -510,12 +537,47 @@ while :; do
         "SELECT count(*) FROM catalog.audit_logs
          WHERE $(window_predicate ":'wf'::timestamptz" ":'wt'::timestamptz")" \
         "${PSQL_VARS[@]}" -v "wf=$WINDOW_FROM" -v "wt=$sub_window_to")"
-    if [ "$expected" -gt "$MAX_ROWS" ] || [ "$sub_window_to" = "$WINDOW_FROM" ]; then
+    # Genuinely unsplittable: one instant holds more rows than a single export
+    # call can return, so no choice of bounds makes this window exportable.
+    if [ "$expected" -gt "$MAX_ROWS" ]; then
         die "more than $MAX_ROWS rows share the instant $sub_window_to, so the window cannot be split small enough for one export call. Raise --max-rows (up to 100000), or archive that instant by hand. Nothing has been deleted."
     fi
 
     export_window "$WINDOW_FROM" "$sub_window_to" "$expected"
-    WINDOW_FROM="$sub_window_to"
+
+    # Loop variant: WINDOW_FROM strictly increases on every iteration, and the
+    # set of distinct created_at values at or before the cutoff is finite, so
+    # the loop terminates. Both branches below must preserve that -- nothing is
+    # deleted during the archive phase, so a WINDOW_FROM that merely stays put
+    # would spin forever re-exporting the same rows.
+    if [ "$sub_window_to" = "$WINDOW_FROM" ]; then
+        # The window just exported was a single instant. That is normal, not an
+        # error: with --max-rows 1 the first row IS the boundary, and one row at
+        # one timestamp splits perfectly well. Leaving WINDOW_FROM here would
+        # never advance, so step to the next distinct timestamp.
+        #
+        # This is the ONE place a strict `>` is correct, and it does not
+        # contradict the inclusive-bounds rule everywhere else: next_from is the
+        # SMALLEST created_at greater than the instant just archived, so by
+        # construction no row exists strictly between them and the two windows
+        # leave no gap. Widening this to `>=` would return WINDOW_FROM again and
+        # hang.
+        next_from="$(psql_value \
+            "SELECT to_char(min(created_at) AT TIME ZONE 'UTC', '$TS_FORMAT')
+             FROM catalog.audit_logs
+             WHERE created_at > :'wf'::timestamptz
+               AND created_at <= :'cutoff'::timestamptz
+               AND $SCOPE_SQL" \
+            "${PSQL_VARS[@]}" -v "wf=$WINDOW_FROM")"
+        [ -n "$next_from" ] || break
+        WINDOW_FROM="$next_from"
+    else
+        # sub_window_to is a max over rows at or after WINDOW_FROM and differs
+        # from it, so it is strictly greater. The next window starts on that
+        # same instant (inclusive), which duplicates the boundary row into two
+        # archives by design.
+        WINDOW_FROM="$sub_window_to"
+    fi
 done
 
 if [ "$ARCHIVED_TOTAL" -lt "$TOTAL_IN_WINDOW" ]; then

--- a/scripts/audit_retention.sh
+++ b/scripts/audit_retention.sh
@@ -67,7 +67,6 @@ WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 say() { printf '%s\n' "$*"; }
-warn() { printf 'WARNING: %s\n' "$*" >&2; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 need_command() {
@@ -109,9 +108,10 @@ Options:
   --db-url URL      Connect to an external/managed Postgres with this libpq URL
                     instead of the bundled db container. A SQLAlchemy driver
                     suffix (postgresql+asyncpg://) is stripped automatically.
-                    A password in the URL is moved out of psql's command line,
-                    but it is still visible in THIS script's own command line;
-                    prefer GEOLENS_RETENTION_DB_URL or PGPASSWORD.
+                    Must NOT contain a password: command lines are readable by
+                    every local account. Use GEOLENS_RETENTION_DB_URL for a URL
+                    with a password, or PGPASSWORD alongside a password-free
+                    --db-url. A password here is refused, not warned about.
   --batch-size N    Rows per delete statement (default: 5000).
   --max-rows N      Rows per export call (default: 100000, the endpoint's cap).
                     Windows larger than this are split automatically.
@@ -123,7 +123,8 @@ Environment:
   ADMIN_TOKEN       Required. Bearer token for the export endpoint.
   GEOLENS_RETENTION_DB_URL
                     Same as --db-url, but never appears in any command line.
-                    Prefer it when the URL carries a password.
+                    REQUIRED when the URL carries a password; --db-url refuses
+                    one.
   PGHOST PGPORT PGUSER PGDATABASE PGPASSWORD PGSERVICE
                     Used when no URL is given; setting PGHOST or PGSERVICE is
                     what selects the direct-connection mode.
@@ -274,6 +275,25 @@ if [ -n "$DB_URL" ] || [ -n "${GEOLENS_RETENTION_DB_URL:-}" ]; then
         *)   _uri_user="$_userinfo"; _pw_enc="" ;;
     esac
 
+    if [ -n "$_pw_enc" ] && [ "$CONN_DESC" = "--db-url" ]; then
+        # fix(#1248): refused, not warned. Moving the password out of psql's
+        # command line accomplishes nothing while it sits in THIS script's own
+        # command line, which is world-readable through `ps` and outlives every
+        # psql child it spawns -- making it the longest exposure of the three,
+        # not a lesser one. There is nothing to retract it with, so the only
+        # fix is not to accept it here.
+        die "refusing a password in --db-url: it is visible in this script's own command line, for the whole run, to every local account on this host.
+Use one of these instead, both of which keep it off every command line:
+
+  export GEOLENS_RETENTION_DB_URL='postgresql://user:password@host:5432/dbname'
+  $SCRIPT_NAME --api-url ... (no --db-url)
+
+or:
+
+  export PGPASSWORD='the-password'
+  $SCRIPT_NAME --db-url 'postgresql://user@host:5432/dbname' --api-url ..."
+    fi
+
     if [ -n "$_pw_enc" ]; then
         # The URI form percent-encodes; PGPASSWORD wants the raw bytes. Decode
         # by turning every %XX into \xXX and letting bash's printf %b do it.
@@ -303,14 +323,6 @@ Pass the URL without a password and put the password in PGPASSWORD instead."
             PG_URI="${_scheme}${_hostpart}${_uri_rest}"
         fi
 
-        if [ "$CONN_DESC" = "--db-url" ]; then
-            # Honest about the half this script cannot fix: its OWN argv still
-            # holds whatever was typed, for the whole run, which is longer than
-            # any psql child lives.
-            warn "the password given to --db-url is visible in this script's own command line for the duration of the run.
-It has been kept out of every psql command line, but to keep it out of \`ps\` entirely, pass the URL
-without a password and set PGPASSWORD, or put the whole URL in GEOLENS_RETENTION_DB_URL."
-        fi
     fi
 
     PSQL=(psql "$PG_URI")

--- a/scripts/audit_retention.sh
+++ b/scripts/audit_retention.sh
@@ -24,10 +24,13 @@
 #   4. curl runs with --fail, so an auth failure or proxy error cannot land an
 #      error document on disk as if it were the archive. Each archive is then
 #      re-read: it must parse as a JSON array, hold exactly as many rows as the
-#      database counts for the identical window, and contain no row outside
-#      that window.
+#      database counts for the identical window, contain no row outside that
+#      window, and carry exactly the row ids the delete is about to remove.
+#      That last check is the only one that separates a correct archive from a
+#      same-sized, same-era slice of another tenant's history.
 #   5. The delete reuses the same predicate the count used -- one string, two
 #      uses -- and runs only after every window passed every check above.
+#   6. Nothing this script writes is world-readable; see the umask below.
 #
 # Connection: the bundled Postgres via `docker compose exec db` by default, or
 # any external/managed Postgres via --db-url or the standard PG* environment
@@ -49,6 +52,19 @@ TS_FORMAT='YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
 # One definition: the help text, the comparison below, and RUNBOOK.md §8 all
 # have to agree, because an operator copy-pastes it.
 SINGLE_TENANT_PHRASE="yes, this deployment has no per-tenant host routing"
+
+# fix(#1248): an archive is a verbatim dump of usernames, IP addresses and
+# activity for a whole retention window, and the id lists below are audit-log
+# primary keys. Under the usual umask 022 `curl -o` creates its output 0644,
+# readable by every local account on the host. Setting the umask up here rather
+# than chmod-ing after the fact means no file this script writes is ever
+# world-readable, not even for the moment between creation and a chmod.
+umask 077
+
+# Scratch space for the archive/database id lists compared in export_window.
+# Removed on every exit path, including each `die`.
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
 
 say() { printf '%s\n' "$*"; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -358,6 +374,8 @@ fi
 # Archive
 # ---------------------------------------------------------------------------
 
+# 0700 when this script creates it; an existing directory keeps whatever the
+# operator gave it. See the umask near the top of the file.
 mkdir -p "$ARCHIVE_DIR"
 
 # Unique per scope AND per run. Two tenants archived on the same day, or the
@@ -380,7 +398,7 @@ export_window() {
     local window_from="$1"
     local window_to="$2"
     local expected="$3"
-    local stamp out got
+    local stamp out got archive_ids db_ids
 
     WINDOW_INDEX=$((WINDOW_INDEX + 1))
     stamp="$(printf '%s' "$window_from" | tr -c 'A-Za-z0-9' '-')"
@@ -423,6 +441,29 @@ export_window() {
         jq -e --arg lo "$window_from" --arg hi "$window_to" \
             'all(.[]; .timestamp[0:19] >= $lo[0:19] and .timestamp[0:19] <= $hi[0:19])' "$out" >/dev/null \
             || die "$out contains a row outside $window_from .. $window_to. Nothing has been deleted."
+
+        # fix(#1248): identity, not size. Pairing --tenant-slug with the wrong
+        # tenant's API host returns that tenant's rows, and when both tenants
+        # have the same number of rows in the window every check above passes:
+        # the count matches, and the other tenant's timestamps legitimately
+        # fall inside the same range. Comparing the archive's row ids against
+        # the ids the delete predicate selects is what separates "archived the
+        # rows I am about to delete" from "archived somebody else's".
+        jq -e 'all(.[]; (.id? // "") != "")' "$out" >/dev/null \
+            || die "$out has a row with no \"id\". This script requires an API that exports the audit-log id, which ships alongside it -- the server is older than the script, so upgrade the deployment rather than working around this. Nothing has been deleted."
+
+        archive_ids="$WORK_DIR/archive-ids"
+        db_ids="$WORK_DIR/db-ids"
+        jq -r '.[].id' "$out" | LC_ALL=C sort > "$archive_ids"
+        psql_value \
+            "SELECT id FROM catalog.audit_logs
+             WHERE $(window_predicate ":'wf'::timestamptz" ":'wt'::timestamptz")" \
+            "${PSQL_VARS[@]}" -v "wf=$window_from" -v "wt=$window_to" \
+            | LC_ALL=C sort > "$db_ids"
+        # cmp, not a count: this is multiset equality, so a duplicated id on
+        # one side and a missing one on the other cannot cancel out.
+        cmp -s "$archive_ids" "$db_ids" \
+            || die "$out does not hold the rows this window would delete: $(LC_ALL=C comm -13 "$archive_ids" "$db_ids" | wc -l | tr -d ' ') row(s) in the database are missing from the archive and $(LC_ALL=C comm -23 "$archive_ids" "$db_ids" | wc -l | tr -d ' ') row(s) in the archive are not in the window. Check that --api-url points at the host for this tenant. Nothing has been deleted."
     fi
 
     ARCHIVED_TOTAL=$((ARCHIVED_TOTAL + got))

--- a/scripts/audit_retention.sh
+++ b/scripts/audit_retention.sh
@@ -73,6 +73,18 @@ need_command() {
     command -v "$1" >/dev/null 2>&1 || die "'$1' is required but not installed."
 }
 
+# Percent-encoding appears in three places in a libpq URI -- the userinfo
+# password, and both the keyword and the value of every query parameter -- so
+# the decode lives in one place. It is only sound for well-formed input, hence
+# the separate check: a stray '%' would become a bogus \x escape and a literal
+# backslash would be interpreted rather than passed through.
+is_percent_safe() {
+    printf '%s' "$1" | grep -qE '^([^%\]|%[0-9A-Fa-f][0-9A-Fa-f])*$'
+}
+percent_decode() {
+    printf '%b' "${1//%/\\x}"
+}
+
 usage() {
     cat <<EOF
 Usage: $SCRIPT_NAME --api-url URL (--days N | --cutoff TS)
@@ -227,7 +239,10 @@ else
     die "one of --tenant-slug or --confirm-single-tenant is required; this script does not detect your deployment's tenancy mode."
 fi
 
-need_command psql
+# curl and jq are used by every branch. psql is NOT: the bundled path runs it
+# inside the db container, so requiring it on the host aborts a Docker-only
+# self-host -- the documented default -- over a binary it never invokes. Each
+# connection branch below declares what it actually needs.
 need_command curl
 need_command jq
 
@@ -275,6 +290,84 @@ if [ -n "$DB_URL" ] || [ -n "${GEOLENS_RETENTION_DB_URL:-}" ]; then
         *)   _uri_user="$_userinfo"; _pw_enc="" ;;
     esac
 
+    # fix(#1248): userinfo is not the only place a password rides in a
+    # connection URI. Per the libpq URI grammar
+    # (https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS)
+    # the query string carries arbitrary connection KEYWORDS, and `password` is
+    # one of them -- so `?password=secret` is a second spelling of the same
+    # secret. Measured against libpq 18, three things make a naive text search
+    # for "password=" wrong:
+    #
+    #   * the KEYWORD itself is percent-decoded, so `?%70assword=` and
+    #     `?passwor%64=` both connect. The keyword has to be decoded before it
+    #     is compared, not matched literally.
+    #   * keywords are case-SENSITIVE: `?PASSWORD=` is rejected by libpq
+    #     outright ("invalid URI query parameter"), so only lowercase counts.
+    #   * a query `password` OVERRIDES the userinfo one. Measured: a URL with
+    #     the wrong password in userinfo and the right one in the query
+    #     connects, and the reverse fails.
+    #
+    # Enumerating the rest of the grammar so a later round does not have to:
+    # `passfile=` names a path rather than holding a secret, so it is left
+    # working untouched, and no other documented URI parameter carries a
+    # credential. userinfo and query `password` are the whole space.
+    case "$_uri_rest" in
+        *\?*) _uri_path="${_uri_rest%%\?*}"; _query="${_uri_rest#*\?}" ;;
+        *)     _uri_path="$_uri_rest"; _query="" ;;
+    esac
+
+    _query_pw_enc=""
+    _kept_query=""
+    _rest_q="$_query"
+    while [ -n "$_rest_q" ]; do
+        case "$_rest_q" in
+            *\&*) _pair="${_rest_q%%&*}"; _rest_q="${_rest_q#*&}" ;;
+            *)     _pair="$_rest_q"; _rest_q="" ;;
+        esac
+        if [ -z "$_pair" ]; then
+            continue
+        fi
+        case "$_pair" in
+            *=*) _k_enc="${_pair%%=*}"; _v_enc="${_pair#*=}" ;;
+            *)   _k_enc="$_pair"; _v_enc="" ;;
+        esac
+        _k="$_k_enc"
+        if is_percent_safe "$_k_enc"; then
+            _k="$(percent_decode "$_k_enc")"
+        fi
+        # An empty value is not a secret, so it is left in place rather than
+        # extracted -- stripping it would change what libpq resolves.
+        if [ "$_k" = "password" ] && [ -n "$_v_enc" ]; then
+            _query_pw_enc="$_v_enc"
+        elif [ -n "$_kept_query" ]; then
+            _kept_query="${_kept_query}&${_pair}"
+        else
+            _kept_query="$_pair"
+        fi
+    done
+
+    # Rebuild the tail without the extracted parameter. Joining only between
+    # kept pairs is what keeps a removed middle parameter from leaving "&&" or
+    # a dangling separator, and an emptied query string drops its "?" entirely.
+    if [ -n "$_kept_query" ]; then
+        _uri_rest="${_uri_path}?${_kept_query}"
+    else
+        _uri_rest="$_uri_path"
+    fi
+
+    if [ -n "$_pw_enc" ] && [ -n "$_query_pw_enc" ]; then
+        # Over-specified. libpq resolves this silently in favour of the query
+        # parameter, which is exactly where an operator's intent and the actual
+        # behaviour part company, so it is refused rather than guessed at.
+        die "$CONN_DESC carries a password twice, once in the URL's user info and once as a ?password= parameter.
+libpq would silently use the query parameter and ignore the other, so this script refuses rather than pick for you.
+Remove one of them."
+    fi
+
+    if [ -z "$_pw_enc" ]; then
+        _pw_enc="$_query_pw_enc"
+    fi
+
     if [ -n "$_pw_enc" ] && [ "$CONN_DESC" = "--db-url" ]; then
         # fix(#1248): refused, not warned. Moving the password out of psql's
         # command line accomplishes nothing while it sits in THIS script's own
@@ -282,7 +375,7 @@ if [ -n "$DB_URL" ] || [ -n "${GEOLENS_RETENTION_DB_URL:-}" ]; then
         # psql child it spawns -- making it the longest exposure of the three,
         # not a lesser one. There is nothing to retract it with, so the only
         # fix is not to accept it here.
-        die "refusing a password in --db-url: it is visible in this script's own command line, for the whole run, to every local account on this host.
+        die "refusing a password in --db-url (whether as user:password@ or as a ?password= parameter): it is visible in this script's own command line, for the whole run, to every local account on this host.
 Use one of these instead, both of which keep it off every command line:
 
   export GEOLENS_RETENTION_DB_URL='postgresql://user:password@host:5432/dbname'
@@ -295,13 +388,8 @@ or:
     fi
 
     if [ -n "$_pw_enc" ]; then
-        # The URI form percent-encodes; PGPASSWORD wants the raw bytes. Decode
-        # by turning every %XX into \xXX and letting bash's printf %b do it.
-        # That is only sound for a well-formed encoding, so require one rather
-        # than silently mangling: a stray '%' would otherwise become a bogus
-        # \x escape, and a literal backslash would be interpreted rather than
-        # passed through.
-        if ! printf '%s' "$_pw_enc" | grep -qE '^([^%\]|%[0-9A-Fa-f][0-9A-Fa-f])*$'; then
+        # The URI form percent-encodes; PGPASSWORD wants the raw bytes.
+        if ! is_percent_safe "$_pw_enc"; then
             die "the password in $CONN_DESC is not valid percent-encoding, so it cannot be moved out of the psql command line safely.
 Pass the URL without a password and put the password in PGPASSWORD (raw, not percent-encoded) instead."
         fi
@@ -312,7 +400,7 @@ Pass the URL without a password and put the password in PGPASSWORD (raw, not per
             die "the password in $CONN_DESC contains an encoded NUL, newline or carriage return, which cannot be passed through the environment intact.
 Pass the URL without a password and put the password in PGPASSWORD instead."
         fi
-        PGPASSWORD="$(printf '%b' "${_pw_enc//%/\\x}")"
+        PGPASSWORD="$(percent_decode "$_pw_enc")"
         export PGPASSWORD
 
         # Rebuild without the password. Dropping the '@' too when there is no
@@ -325,8 +413,10 @@ Pass the URL without a password and put the password in PGPASSWORD instead."
 
     fi
 
+    need_command psql
     PSQL=(psql "$PG_URI")
 elif [ -n "${PGHOST:-}" ] || [ -n "${PGSERVICE:-}" ]; then
+    need_command psql
     PSQL=(psql)
     CONN_DESC="PG* environment variables"
 else

--- a/scripts/audit_retention.sh
+++ b/scripts/audit_retention.sh
@@ -521,10 +521,38 @@ while :; do
 
     # More rows than one export call can return. Narrowing date_to alone does
     # not help: the endpoint always returns the NEWEST rows in the range, so
-    # repeating the same call returns the same slice forever. Split instead --
-    # take the timestamp of the MAX_ROWS-th oldest row and end this window
-    # there. The next window starts at that same instant, so consecutive windows
-    # overlap by one instant and cannot leave a gap between them.
+    # repeating the same call returns the same slice forever. Split instead.
+    #
+    # Timestamps are not unique -- ties are ordinary on a busy instance -- so
+    # the MAX_ROWS-th oldest row can land in the MIDDLE of a group of rows
+    # sharing one instant. That is what makes this fiddly, and the four cases
+    # below are the whole space. Let `sub` be the timestamp of the MAX_ROWS-th
+    # oldest row in [wf, cutoff] and `expected` be count[wf, sub]:
+    #
+    #   (a) expected <= MAX_ROWS and sub > wf
+    #       The cap landed cleanly between instants. Export [wf, sub]; the next
+    #       window reopens at sub, duplicating that instant's rows into two
+    #       archives by design.
+    #   (b) expected <= MAX_ROWS and sub == wf
+    #       The whole window is one instant, which fits. Normal at --max-rows 1,
+    #       where the oldest row IS the boundary. Export [wf, wf] and step to
+    #       the next distinct timestamp.
+    #   (c) expected > MAX_ROWS and sub > wf
+    #       The cap cut through the tie AT sub, and rows exist before it. The
+    #       tie may well be exportable on its own, so back off to the last
+    #       distinct timestamp before sub and export what precedes it. That is
+    #       always <= MAX_ROWS: every row at or before the backed-off boundary
+    #       is strictly older than sub, so every one of them was already inside
+    #       the LIMIT that reached sub.
+    #   (d) expected > MAX_ROWS and sub == wf
+    #       One instant alone holds more rows than a single export call can
+    #       return. No choice of bounds fixes that, so this is the only die.
+    #
+    # Loop variant, over all of them: every path exports a window whose
+    # expected <= MAX_ROWS, then either strictly increases WINDOW_FROM or
+    # breaks. The set of distinct created_at values at or before the cutoff is
+    # finite, so the loop terminates. Nothing is deleted during the archive
+    # phase, so a WINDOW_FROM that merely stayed put would spin forever.
     sub_window_to="$(psql_value \
         "SELECT to_char(max(created_at) AT TIME ZONE 'UTC', '$TS_FORMAT') FROM (
              SELECT created_at FROM catalog.audit_logs
@@ -537,31 +565,51 @@ while :; do
         "SELECT count(*) FROM catalog.audit_logs
          WHERE $(window_predicate ":'wf'::timestamptz" ":'wt'::timestamptz")" \
         "${PSQL_VARS[@]}" -v "wf=$WINDOW_FROM" -v "wt=$sub_window_to")"
-    # Genuinely unsplittable: one instant holds more rows than a single export
-    # call can return, so no choice of bounds makes this window exportable.
+
     if [ "$expected" -gt "$MAX_ROWS" ]; then
-        die "more than $MAX_ROWS rows share the instant $sub_window_to, so the window cannot be split small enough for one export call. Raise --max-rows (up to 100000), or archive that instant by hand. Nothing has been deleted."
+        if [ "$sub_window_to" = "$WINDOW_FROM" ]; then
+            # Case (d).
+            die "more than $MAX_ROWS rows share the instant $sub_window_to, so the window cannot be split small enough for one export call. Raise --max-rows (up to 100000), or archive that instant by hand. Nothing has been deleted."
+        fi
+        # Case (c). The strict `<` finds the neighbouring distinct timestamp;
+        # it is not a window bound. Every bound this script exports or deletes
+        # on is inclusive, and the only strict comparisons in the whole script
+        # are this one and the `>` below, both of which locate an ADJACENT
+        # distinct timestamp rather than delimiting a window. Keeping that
+        # distinction is what stops either of them being "corrected" into an
+        # inclusive form later: with `<=` here the back-off would return
+        # sub_window_to unchanged and nothing would improve.
+        sub_window_to="$(psql_value \
+            "SELECT to_char(max(created_at) AT TIME ZONE 'UTC', '$TS_FORMAT')
+             FROM catalog.audit_logs
+             WHERE created_at >= :'wf'::timestamptz
+               AND created_at < :'sub'::timestamptz
+               AND $SCOPE_SQL" \
+            "${PSQL_VARS[@]}" -v "wf=$WINDOW_FROM" -v "sub=$sub_window_to")"
+        # WINDOW_FROM always names a real row (it is either the window's oldest
+        # created_at, a previous boundary, or a previous next_from), and
+        # sub > WINDOW_FROM here, so [wf, sub) is non-empty and this has a value.
+        [ -n "$sub_window_to" ] || die "could not back off from a tied sub-window boundary."
+        expected="$(psql_value \
+            "SELECT count(*) FROM catalog.audit_logs
+             WHERE $(window_predicate ":'wf'::timestamptz" ":'wt'::timestamptz")" \
+            "${PSQL_VARS[@]}" -v "wf=$WINDOW_FROM" -v "wt=$sub_window_to")"
+        # Unreachable given the argument in case (c) above; kept because the
+        # cost is one comparison and the alternative to a loud failure here is
+        # an export call silently truncated at the cap.
+        if [ "$expected" -gt "$MAX_ROWS" ]; then
+            die "internal error: backing off to $sub_window_to still selects $expected rows, above the $MAX_ROWS cap. Nothing has been deleted."
+        fi
     fi
 
     export_window "$WINDOW_FROM" "$sub_window_to" "$expected"
 
-    # Loop variant: WINDOW_FROM strictly increases on every iteration, and the
-    # set of distinct created_at values at or before the cutoff is finite, so
-    # the loop terminates. Both branches below must preserve that -- nothing is
-    # deleted during the archive phase, so a WINDOW_FROM that merely stays put
-    # would spin forever re-exporting the same rows.
     if [ "$sub_window_to" = "$WINDOW_FROM" ]; then
-        # The window just exported was a single instant. That is normal, not an
-        # error: with --max-rows 1 the first row IS the boundary, and one row at
-        # one timestamp splits perfectly well. Leaving WINDOW_FROM here would
-        # never advance, so step to the next distinct timestamp.
-        #
-        # This is the ONE place a strict `>` is correct, and it does not
-        # contradict the inclusive-bounds rule everywhere else: next_from is the
-        # SMALLEST created_at greater than the instant just archived, so by
-        # construction no row exists strictly between them and the two windows
-        # leave no gap. Widening this to `>=` would return WINDOW_FROM again and
-        # hang.
+        # Cases (b) and (c)-collapsed-to-one-instant. Leaving WINDOW_FROM here
+        # would never advance, so step to the next distinct timestamp. next_from
+        # is the SMALLEST created_at greater than the instant just archived, so
+        # no row exists between the two windows and they leave no gap. Widening
+        # this `>` to `>=` returns WINDOW_FROM again and hangs.
         next_from="$(psql_value \
             "SELECT to_char(min(created_at) AT TIME ZONE 'UTC', '$TS_FORMAT')
              FROM catalog.audit_logs
@@ -572,10 +620,8 @@ while :; do
         [ -n "$next_from" ] || break
         WINDOW_FROM="$next_from"
     else
-        # sub_window_to is a max over rows at or after WINDOW_FROM and differs
-        # from it, so it is strictly greater. The next window starts on that
-        # same instant (inclusive), which duplicates the boundary row into two
-        # archives by design.
+        # Case (a). sub_window_to is a max over rows at or after WINDOW_FROM and
+        # differs from it, so it is strictly greater.
         WINDOW_FROM="$sub_window_to"
     fi
 done

--- a/scripts/audit_retention.sh
+++ b/scripts/audit_retention.sh
@@ -535,6 +535,33 @@ else
         -v d="$DAYS")"
 fi
 [ -n "$CUTOFF" ] || die "failed to resolve the retention cutoff."
+
+# fix(#1248): the cutoff must lie strictly in the past, and this is a
+# correctness precondition rather than a nicety. Everything downstream rests on
+# the window being immutable for the length of the run -- rows are only ever
+# inserted with created_at = now(), so nothing new can appear inside a window
+# that ends in the past, which is what lets a count taken now still describe
+# the rows deleted later. A cutoff at or after now() breaks that premise
+# outright: ordinary activity keeps landing inside the window while the script
+# works, so no count it takes could be trusted.
+#
+# The export makes that concrete. Exporting writes its own audit.export request
+# and outcome rows, at now(), and the endpoint excludes them from its output
+# while a database-side query does not -- so a future window cannot even be
+# archived consistently. Refusing here fixes the cause; teaching the identity
+# check to ignore those rows would only paper over the symptom and leave a
+# mutable window in play.
+#
+# Checked against the frozen value rather than the raw argument, so what is
+# validated is exactly what every later step uses. --days N is always in the
+# past for N >= 1 (already enforced at parse time), so this can only ever fire
+# for --cutoff.
+if [ "$(psql_value "SELECT (:'cutoff'::timestamptz >= now())" -v "cutoff=$CUTOFF")" = "t" ]; then
+    die "the retention cutoff $CUTOFF is not in the past.
+This procedure only works on a window that cannot change while it runs: audit rows are written with created_at = now(), so a window ending now or later keeps gaining rows between the count, the export and the delete, and no count taken of it would still be true by the time anything were deleted. Exporting would also add its own audit.export rows inside the window.
+Pick a cutoff strictly in the past, or use --days N."
+fi
+
 say "Retention cutoff (frozen for this run): $CUTOFF"
 
 # Resolve the tenant before anything else touches the table. A slug that

--- a/scripts/audit_retention.sh
+++ b/scripts/audit_retention.sh
@@ -67,6 +67,7 @@ WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 say() { printf '%s\n' "$*"; }
+warn() { printf 'WARNING: %s\n' "$*" >&2; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 need_command() {
@@ -108,6 +109,9 @@ Options:
   --db-url URL      Connect to an external/managed Postgres with this libpq URL
                     instead of the bundled db container. A SQLAlchemy driver
                     suffix (postgresql+asyncpg://) is stripped automatically.
+                    A password in the URL is moved out of psql's command line,
+                    but it is still visible in THIS script's own command line;
+                    prefer GEOLENS_RETENTION_DB_URL or PGPASSWORD.
   --batch-size N    Rows per delete statement (default: 5000).
   --max-rows N      Rows per export call (default: 100000, the endpoint's cap).
                     Windows larger than this are split automatically.
@@ -117,9 +121,12 @@ Options:
 
 Environment:
   ADMIN_TOKEN       Required. Bearer token for the export endpoint.
+  GEOLENS_RETENTION_DB_URL
+                    Same as --db-url, but never appears in any command line.
+                    Prefer it when the URL carries a password.
   PGHOST PGPORT PGUSER PGDATABASE PGPASSWORD PGSERVICE
-                    Used when --db-url is not given; setting PGHOST or
-                    PGSERVICE is what selects the direct-connection mode.
+                    Used when no URL is given; setting PGHOST or PGSERVICE is
+                    what selects the direct-connection mode.
   POSTGRES_USER POSTGRES_DB
                     Used for the bundled \`docker compose exec db\` path, read
                     from .env like the other scripts in this directory.
@@ -229,13 +236,84 @@ need_command jq
 #
 # Three paths, checked in order. The first two reach a managed or external
 # Postgres directly; only the last needs a local db container.
-if [ -n "$DB_URL" ]; then
+if [ -n "$DB_URL" ] || [ -n "${GEOLENS_RETENTION_DB_URL:-}" ]; then
+    if [ -n "$DB_URL" ]; then
+        _url_in="$DB_URL"
+        CONN_DESC="--db-url"
+    else
+        _url_in="$GEOLENS_RETENTION_DB_URL"
+        CONN_DESC="GEOLENS_RETENTION_DB_URL"
+    fi
+
     # libpq's URI parser accepts only postgresql:// and postgres://. A
     # privileged credential copied out of a SQLAlchemy config carries a driver
     # suffix, which libpq rejects outright.
-    PG_URI="$(printf '%s' "$DB_URL" | sed -E 's#^postgresql\+[A-Za-z0-9_]+://#postgresql://#')"
+    PG_URI="$(printf '%s' "$_url_in" | sed -E 's#^postgresql\+[A-Za-z0-9_]+://#postgresql://#')"
+
+    # fix(#1248): a password in the URI must not reach psql's argv. Command
+    # lines are world-readable (`ps`, /proc/<pid>/cmdline), so a URI handed
+    # straight to psql publishes the BYPASSRLS credential to every local
+    # account for the life of each query. Environment is the carrier instead:
+    # /proc/<pid>/environ is owner-only. The rest of the URI stays in argv,
+    # which keeps `ps` useful for debugging and leaks nothing.
+    #
+    # Split scheme://[userinfo@]authority[/path][?params] by hand rather than
+    # with a regex, because the parts are positional: userinfo ends at the LAST
+    # '@' (a password may contain an encoded one), and the password starts at
+    # the FIRST ':' of the userinfo.
+    _scheme="${PG_URI%%://*}://"
+    _after_scheme="${PG_URI#*://}"
+    _authority="${_after_scheme%%[/?]*}"
+    _uri_rest="${_after_scheme:${#_authority}}"
+    case "$_authority" in
+        *@*) _userinfo="${_authority%@*}"; _hostpart="${_authority##*@}" ;;
+        *)   _userinfo=""; _hostpart="$_authority" ;;
+    esac
+    case "$_userinfo" in
+        *:*) _uri_user="${_userinfo%%:*}"; _pw_enc="${_userinfo#*:}" ;;
+        *)   _uri_user="$_userinfo"; _pw_enc="" ;;
+    esac
+
+    if [ -n "$_pw_enc" ]; then
+        # The URI form percent-encodes; PGPASSWORD wants the raw bytes. Decode
+        # by turning every %XX into \xXX and letting bash's printf %b do it.
+        # That is only sound for a well-formed encoding, so require one rather
+        # than silently mangling: a stray '%' would otherwise become a bogus
+        # \x escape, and a literal backslash would be interpreted rather than
+        # passed through.
+        if ! printf '%s' "$_pw_enc" | grep -qE '^([^%\]|%[0-9A-Fa-f][0-9A-Fa-f])*$'; then
+            die "the password in $CONN_DESC is not valid percent-encoding, so it cannot be moved out of the psql command line safely.
+Pass the URL without a password and put the password in PGPASSWORD (raw, not percent-encoded) instead."
+        fi
+        # A decoded NUL or newline cannot survive a shell variable or a psql
+        # invocation intact, and command substitution would silently eat a
+        # trailing newline. Refuse rather than hand over a truncated password.
+        if printf '%s' "$_pw_enc" | grep -qiE '%0[0ad]'; then
+            die "the password in $CONN_DESC contains an encoded NUL, newline or carriage return, which cannot be passed through the environment intact.
+Pass the URL without a password and put the password in PGPASSWORD instead."
+        fi
+        PGPASSWORD="$(printf '%b' "${_pw_enc//%/\\x}")"
+        export PGPASSWORD
+
+        # Rebuild without the password. Dropping the '@' too when there is no
+        # user keeps `postgresql://:pw@host/db` from becoming `postgresql://@host/db`.
+        if [ -n "$_uri_user" ]; then
+            PG_URI="${_scheme}${_uri_user}@${_hostpart}${_uri_rest}"
+        else
+            PG_URI="${_scheme}${_hostpart}${_uri_rest}"
+        fi
+
+        if [ "$CONN_DESC" = "--db-url" ]; then
+            # Honest about the half this script cannot fix: its OWN argv still
+            # holds whatever was typed, for the whole run, which is longer than
+            # any psql child lives.
+            warn "the password given to --db-url is visible in this script's own command line for the duration of the run.
+It has been kept out of every psql command line, but to keep it out of \`ps\` entirely, pass the URL
+without a password and set PGPASSWORD, or put the whole URL in GEOLENS_RETENTION_DB_URL."
+        fi
+    fi
+
     PSQL=(psql "$PG_URI")
-    CONN_DESC="--db-url"
 elif [ -n "${PGHOST:-}" ] || [ -n "${PGSERVICE:-}" ]; then
     PSQL=(psql)
     CONN_DESC="PG* environment variables"
@@ -413,6 +491,15 @@ mkdir -p "$ARCHIVE_DIR"
 SAFE_LABEL="$(printf '%s' "$SCOPE_LABEL" | tr -c 'A-Za-z0-9._-' '-')"
 ARCHIVE_TAG="${SAFE_LABEL}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 
+# fix(#1248): the bearer token goes to curl in a file, not on its command line.
+# `-H "Authorization: Bearer $ADMIN_TOKEN"` publishes an admin credential to
+# every local account via `ps` for as long as the export streams, which on a
+# 100,000-row window is not brief. curl's `-H @file` form reads headers from a
+# file instead; the umask at the top of this script makes it 0600 inside a 0700
+# directory, and the EXIT trap removes it.
+AUTH_HEADER_FILE="$WORK_DIR/auth-header"
+printf 'Authorization: Bearer %s\n' "$ADMIN_TOKEN" > "$AUTH_HEADER_FILE"
+
 # Sum over every exported window. Adjacent windows share their boundary instant
 # (both bounds are inclusive), so a row on a boundary is archived twice and the
 # sum is >= the window total, never <. Duplicating an archive entry is harmless;
@@ -443,7 +530,7 @@ export_window() {
     # archive, and the delete would then run against a window that was never
     # exported. --fail makes curl exit non-zero and discard that body.
     curl -sS --fail \
-        -H "Authorization: Bearer $ADMIN_TOKEN" \
+        -H "@$AUTH_HEADER_FILE" \
         "${API_URL%/}/admin/audit-logs/export/json?date_from=${window_from}&date_to=${window_to}&max_rows=${MAX_ROWS}" \
         -o "$out" \
         || die "export request failed for $window_from .. $window_to -- nothing has been deleted."


### PR DESCRIPTION
## Problem

RUNBOOK.md §8 carried the audit-log retention procedure as prose bash+psql. Five codex review rounds on #1244 found a real defect in that section every round (tenant scoping, psql substitution inside `DO $$…$$`, filename collisions, curl without `--fail`, boundary-predicate mismatch), and prose runs in no CI, so the sixth defect would have shipped silently.

## Fix

Replace the prose with `scripts/audit_retention.sh` plus a test that runs the script for real, closing each bug class structurally:

- **One frozen cutoff**, evaluated once in the database and reused by the count, the export, and the delete; both window bounds inclusive everywhere, matching the export endpoint's own filters. One `window_predicate()` string serves count and delete, so an unscoped delete under a scoped count is not expressible.
- **Explicit scope modes with no fallback**: `--tenant-slug` resolves and UUID-shape-validates before any query touches the table (a bad slug aborts the run); the unscoped mode requires a typed operator confirmation phrase, never a config lookup.
- **Collision-proof archives**: filenames carry scope + UTC timestamp + pid, and the script refuses to overwrite an existing file.
- **Verified exports before any delete**: `curl --fail`, archive must parse as a complete JSON array, hold exactly the row count the DB reports for the identical window+scope, and contain no row outside the window.
- **Parameters reach SQL via psql `:'name'` bindings on stdin** (one `psql_value()` helper); the batch-delete loop lives in the shell, so there is no dollar-quoted body for substitution to be silently skipped inside.
- **External-Postgres path**: `--db-url` (SQLAlchemy driver suffix stripped for libpq), then `PG*` env vars, then the bundled db container — managed/external Postgres operators finally have a supported path.

RUNBOOK §8 now documents invoking the script (flags, env, external-Postgres usage, what is verified before deleting) and keeps every operational caveat from the prose, including the one the script cannot satisfy (per-action retention windows still need a manual pass). `.github/workflows/ci.yml` adds the script to the backend paths filter so editing it re-runs its gate.

## Verification

- `backend/tests/test_audit_retention_script.py` runs the real script against a throwaway database with a curl stub serving the export from that same DB: 17 passed. Every failure-mode test asserts the row count is unchanged.
- Each guard was disabled in turn to prove the tests can fail for the right reason (cross-tenant delete, stranded boundary row, missing `--fail`, dropped row-count check).
- Whole-tree backend suite at this sha: 7303 passed, 89 skipped. `ruff check` and `ruff format --check` clean. `test_layering.py` 40 passed.

Closes #1248