### PR TITLE
feat(catalog): add source-state fields to Dataset

### DIFF
--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -175,6 +175,22 @@ def _quoted(values: Sequence[str]) -> str:
 # and the remainder becomes ``url``. WFS and OGC API Features address their
 # layer by typename/collection inside the request rather than by a path
 # suffix, so their whole URL is the base.
+#
+# fix(#1218 review r3): a WFS/OGC row's layer identity is its typename or
+# collection id, which lives on the ingest job rather than on the dataset.
+# It is recovered from ``catalog.ingest_jobs.source_layer`` because the
+# retention sweep in platform/jobs/router.py deliberately EXEMPTS each
+# dataset's most recent complete job ("the reupload source_layer hint"), so
+# that row survives regardless of age. Older jobs are purged, hence the
+# newest-first pick.
+#
+# datasets.source_filename is deliberately NOT used as a fallback. Service
+# imports set it to ``layer_title or layer_name`` (sources/router.py), so it
+# is often a human title, and nothing on the row says which of the two it
+# holds — writing it into layer_id would hand a refresh a display string to
+# use as a typename. A dataset whose job row is gone therefore keeps a ref
+# with no layer_id and needs its layer identified once before a first
+# refresh; an honest gap beats invented data.
 _SERVICE_BACKFILL = f"""
     UPDATE catalog.datasets AS d
     SET origin_uri = d.source_url,
@@ -192,6 +208,16 @@ _SERVICE_BACKFILL = f"""
                     WHEN d.source_format = 'arcgis_featureserver'
                          AND d.source_url ~ '/[0-9]+$'
                     THEN substring(d.source_url from '/([0-9]+)$')
+                    WHEN d.source_format IN ('wfs', 'ogcapi_features')
+                    THEN (
+                        SELECT j.source_layer
+                        FROM catalog.ingest_jobs AS j
+                        WHERE j.dataset_id = d.id
+                          AND j.status = 'complete'
+                          AND j.source_layer IS NOT NULL
+                        ORDER BY j.created_at DESC
+                        LIMIT 1
+                    )
                     ELSE NULL
                 END
             )

--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -351,8 +351,9 @@ _STAC_BACKFILL = f"""
 # composed from other datasets and has no origin of its own.
 #
 # RESOLUTION REQUIRES BOTH: exactly one physical relation carrying the name
-# (the HAVING count(*) = 1 above) AND exactly one catalog row claiming it (the
-# NOT EXISTS below). Ambiguity on either side leaves the row NULL.
+# (the HAVING count(*) = 1 above) AND no other catalog row of ANY origin
+# claiming that name (the NOT EXISTS below). Ambiguity on either side leaves
+# the row NULL.
 #
 # The two guards are NOT redundant and neither can be simplified away
 # (fix #1218 review rounds 1 and 2):
@@ -364,6 +365,14 @@ _STAC_BACKFILL = f"""
 #     the physical count is a clean 1 and BOTH catalog rows would otherwise
 #     bind to the surviving tenant's schema. One of them is an orphan holding
 #     a pointer into another tenant's data.
+#
+# fix(#1218 review r8): the claimant half counts datasets of ANY origin, not
+# only the ones this backfill targets. Uploads, service imports and created
+# datasets own physical tables with tenant-local names too, so tenant A's
+# dropped registered `roads` beside tenant B's surviving UPLOADED `roads` is
+# one physical relation with a claimant the narrow filter could not see —
+# and B's schema would be stamped onto A's orphan. The outer population is
+# unchanged; only the NOT EXISTS widened.
 #
 # The `IS NOT NULL` predicate also skips a catalog row whose physical table is
 # gone entirely, rather than building a pointer from a NULL schema.
@@ -383,11 +392,8 @@ _POSTGIS_BACKFILL = f"""
       AND NOT EXISTS (
           SELECT 1
           FROM catalog.datasets AS d2
-          JOIN catalog.records AS r2 ON r2.id = d2.record_id
           WHERE d2.table_name = d.table_name
             AND d2.id <> d.id
-            AND d2.source_format IS NULL
-            AND r2.record_type IN ('vector_dataset', 'table')
       )
 """
 
@@ -478,6 +484,23 @@ def downgrade() -> None:
 _URL_REF_KEYS = ("url", "asset_href", "item_href")
 
 
+def _is_unsafe(detector, url: str) -> bool:
+    """Run the credential detector, treating a raise as unsafe.
+
+    fix(#1218 review r8): ``has_url_credentials`` already converts the
+    ``ValueError`` it expects (a malformed authority) into ``True`` internally,
+    but this is a migration operating on arbitrary legacy strings, and an
+    unanticipated raise here would abort the whole upgrade rather than skip one
+    pointer. Failing closed keeps the asymmetry the detector itself documents:
+    refusing a URL nobody can parse costs one unrecovered pointer, admitting it
+    silently freezes a credential into a read-only column.
+    """
+    try:
+        return bool(detector(url))
+    except Exception:  # broad: a detector raise must never admit a URL
+        return True
+
+
 def purge_credential_bearing_pointers(bind) -> int:
     """Re-check every backfilled pointer with the REAL credential rule.
 
@@ -526,7 +549,7 @@ def purge_credential_bearing_pointers(bind) -> int:
                 for key in _URL_REF_KEYS
                 if isinstance(value := row.origin_ref.get(key), str)
             )
-        if any(has_url_credentials(candidate) for candidate in candidates):
+        if any(_is_unsafe(has_url_credentials, candidate) for candidate in candidates):
             offenders.append(row.id)
 
     if offenders:

--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -159,6 +159,10 @@ def upgrade() -> None:
     for statement in backfill_statements():
         op.execute(statement)
 
+    # The authority pass. See purge_credential_bearing_pointers: the SQL above
+    # is a pre-filter, this is what actually decides.
+    purge_credential_bearing_pointers(op.get_bind())
+
     # last_checked_at, source_health, source_health_detail and
     # schema_drift_status are left NULL on every row on purpose: GeoLens has
     # never contacted an origin, so any value here would be invented.
@@ -186,54 +190,33 @@ def _url_is_safe(expr: str) -> str:
     code here follows ``alembic/env.py``, which already imports
     ``app.core.config`` and ``app.core.db``.
 
-    fix(#1218 reviews r6 and r7): the name-normalization gap is closed as a
-    CLASS, not a spelling. Rounds 6 and 7 each reported one encoding of the
-    same idea (``?%74oken=``, then ``?+token+=``), so the arm below is derived
-    from the transforms themselves.
+    fix(#1218 review r7): this predicate is a PRE-FILTER, not the authority.
+    ``purge_credential_bearing_pointers`` runs the real ``has_url_credentials``
+    over everything the backfill populated and clears any offender it finds,
+    so completeness of the arms below is no longer a correctness requirement.
+    That restructure exists because three review rounds each reported one
+    spelling of the same class (``?token=``, ``?%74oken=``, ``?+token+=``):
+    a regex mirror has to be re-proven complete every time ``parse_qsl`` grows
+    a normalization, and nothing fails loudly when it stops being complete.
 
-    Every normalization the runtime pair applies to a query NAME before
-    judging it, read off ``parse_qsl`` and ``_is_sensitive_query_param``
-    (``app/core/url_redaction.py``) and MEASURED against this Python, not
-    recalled:
-
-    ==========================  ============  ==============================
-    transform                   example       how this predicate handles it
-    ==========================  ============  ==============================
-    pair split on ``&``         ``&token=``   anchored on ``[?&]``
-    pair split on ``;``         ``;token=``   NOT a separator in Python 3.14
-                                              (``parse_qsl('a=1;token=s')``
-                                              yields one pair), so nothing
-                                              to handle
-    percent-decode              ``%74oken``   refused by the name arm
-    plus-to-space               ``+token+``   refused by the name arm
-    ``.strip()`` whitespace     ``' token '`` refused by the name arm
-    ``.lower()`` case fold      ``TOKEN``     already matched, the
-                                              alternation runs case
-                                              insensitively (``!~*``)
-    empty name                  ``?=secret``  decodes to ``''``, never in
-                                              SENSITIVE_QUERY_PARAMS
-    ==========================  ============  ==============================
-
-    Case folding is the one transform NOT handled by refusal, deliberately:
-    refusing uppercase names would reject ``?SERVICE=WFS`` and every other
-    ordinary OGC parameter. Matching case-insensitively handles it exactly,
-    so there is nothing ambiguous left to refuse.
-
-    Everything else collapses to one rule: a NAME containing ``%``, ``+``, or
-    whitespace is refused outright, whatever it decodes to. Decoding in SQL
-    would be a second copy of ``parse_qsl`` that can drift from the first,
-    which is the thing binding SENSITIVE_QUERY_PARAMS above exists to prevent.
-    Names never legitimately carry those characters in a service or STAC URL,
-    so the refusal costs approximately no real pointers.
+    What the arms buy, now that they are not load-bearing, is cheapness: the
+    common shapes never reach the Python pass at all. They cover the literal
+    names, plus the two encodings that turn a harmless-looking name into a
+    sensitive one — percent-escapes and ``+`` (which ``parse_qsl`` decodes to a
+    space that ``_is_sensitive_query_param`` then strips). Whitespace rides
+    along in the same character class for free. Every other normalization,
+    and every shape a pattern cannot express — a fullwidth ``＠`` that NFKC
+    turns into a delimiter, a malformed authority ``urlsplit`` refuses — is
+    the authority pass's job.
 
     VALUES keep their encoding rights: the name segment is bounded by the
     FIRST ``=`` of its pair, so ``?typename=ns%3Aroads`` and ``?q=a+b`` both
     still backfill. That distinction is the whole reason for the ``[^=&#]*``
     classes rather than a bare character test.
 
-    To check this list is still complete, re-read those two functions: the
-    predicate is at least as strict as the Python rule on every shape it is
-    given.
+    Case is handled exactly rather than conservatively: the alternation runs
+    case-insensitively (``!~*``), so ``?TOKEN=`` matches without refusing the
+    ordinary uppercase parameters real OGC services use.
     """
     from app.core.url_redaction import SENSITIVE_QUERY_PARAMS
 
@@ -487,3 +470,71 @@ def downgrade() -> None:
         "origin_uri",
     ):
         op.drop_column("datasets", column, schema="catalog")
+
+
+# Keys in origin_ref whose value is a URL. Kept beside the pass that reads
+# them so a new URL-bearing key in ORIGIN_REF_KEYS is one edit away from being
+# checked rather than silently unchecked.
+_URL_REF_KEYS = ("url", "asset_href", "item_href")
+
+
+def purge_credential_bearing_pointers(bind) -> int:
+    """Re-check every backfilled pointer with the REAL credential rule.
+
+    fix(#1218 review r7): this is the authority, and the SQL predicate is a
+    pre-filter in front of it. Three review rounds each reported one spelling
+    of a single class (``?token=``, then ``?%74oken=``, then ``?+token+=``),
+    which is the signal that enumerating spellings in SQL is the wrong shape:
+    a regex mirror of ``has_url_credentials`` has to be re-proven complete
+    every time ``parse_qsl`` grows a normalization, and nothing fails loudly
+    when it stops being complete.
+
+    Running the real function closes the class by construction. Anything the
+    SQL misses is caught here, including shapes a regex cannot reasonably
+    express: ``has_url_credentials`` returns True when ``urlsplit`` REFUSES an
+    authority, so a fullwidth ``＠`` that NFKC turns into a delimiter, or a
+    malformed ``https://[::1``, are both credential-bearing to Python and
+    invisible to any ASCII pattern.
+
+    Both pointer columns are cleared together on an offender. Leaving a
+    half-populated ref would be the "wrong pointer is worse than none" failure
+    this migration avoids everywhere else; the origin still classifies from
+    ``source_format``, so only the pointer is lost.
+
+    Row counts make this ordinary: the scan touches datasets carrying an
+    origin at all, and only those with a URL-shaped field are inspected.
+    Returns the number of rows cleared, so a caller (and the test) can assert
+    on it rather than infer.
+    """
+    from app.core.url_redaction import has_url_credentials
+
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, origin_uri, origin_ref FROM catalog.datasets "
+            "WHERE origin_uri IS NOT NULL OR origin_ref IS NOT NULL"
+        )
+    ).all()
+
+    offenders = []
+    for row in rows:
+        candidates = []
+        if isinstance(row.origin_uri, str):
+            candidates.append(row.origin_uri)
+        if isinstance(row.origin_ref, dict):
+            candidates.extend(
+                value
+                for key in _URL_REF_KEYS
+                if isinstance(value := row.origin_ref.get(key), str)
+            )
+        if any(has_url_credentials(candidate) for candidate in candidates):
+            offenders.append(row.id)
+
+    if offenders:
+        bind.execute(
+            sa.text(
+                "UPDATE catalog.datasets "
+                "SET origin_uri = NULL, origin_ref = NULL "
+                "WHERE id = ANY(:ids)"
+            ).bindparams(sa.bindparam("ids", value=offenders))
+        )
+    return len(offenders)

--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -186,12 +186,25 @@ def _url_is_safe(expr: str) -> str:
     code here follows ``alembic/env.py``, which already imports
     ``app.core.config`` and ``app.core.db``.
 
-    Known narrower than the Python original, in the safe direction for
-    everything except one case: ``parse_qsl`` percent-decodes a parameter NAME
-    before judging it, so ``?%74oken=`` reads as ``token`` there and not here.
-    Matching that in SQL needs a decoder Postgres does not provide. The
-    residual is a legacy URL with a percent-encoded credential parameter name;
-    every other shape this misses is a shape the Python rule also admits.
+    fix(#1218 review r6): the encoded-name gap is CLOSED, by refusing the
+    ambiguous class rather than adjudicating it. ``parse_qsl`` percent-decodes
+    a parameter NAME before judging it, so ``?%74oken=`` reads as ``token`` in
+    Python; the name alternation below sees the literal ``%74oken`` and would
+    have admitted it. Rather than reimplement percent-decoding in SQL — a
+    second copy of ``parse_qsl`` that can drift from the first, which is the
+    thing binding SENSITIVE_QUERY_PARAMS above exists to prevent — the last
+    arm refuses ANY url whose query encodes a parameter NAME at all,
+    regardless of what it decodes to. Parameter names are never legitimately
+    percent-encoded in a service or STAC URL, so this costs approximately no
+    real pointers.
+
+    VALUES keep their encoding rights: the name segment is bounded by the
+    FIRST ``=`` of its pair, so ``?typename=ns%3Aroads`` still backfills. That
+    distinction is the whole reason for the ``[^=&#]*`` classes rather than a
+    bare ``%``.
+
+    The predicate is now at least as strict as the Python rule on every shape
+    it is given.
     """
     from app.core.url_redaction import SENSITIVE_QUERY_PARAMS
 
@@ -201,6 +214,7 @@ def _url_is_safe(expr: str) -> str:
         {expr} ~* '^https?://'
         AND {expr} !~ '^[a-zA-Z][a-zA-Z0-9+.-]*://[^/?#]*@'
         AND {expr} !~* '[?&]({alternation})='
+        AND {expr} !~ '[?&][^=&#]*%[0-9A-Fa-f][0-9A-Fa-f][^=&#]*='
     )"""
 
 

--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -230,8 +230,23 @@ _STAC_BACKFILL = """
 # file), and the record_type predicate is still what keeps them out: a VRT is
 # composed from other datasets and has no origin of its own.
 #
-# The final predicate skips a catalog row whose physical table is gone,
-# rather than giving it a pointer built from a NULL schema.
+# RESOLUTION REQUIRES BOTH: exactly one physical relation carrying the name
+# (the HAVING count(*) = 1 above) AND exactly one catalog row claiming it (the
+# NOT EXISTS below). Ambiguity on either side leaves the row NULL.
+#
+# The two guards are NOT redundant and neither can be simplified away
+# (fix #1218 review rounds 1 and 2):
+#
+#   - Two physical relations, one claimant: the round-1 finding. The catalog
+#     side sees nothing wrong; only the physical count catches it.
+#   - One physical relation, two claimants: the round-2 finding. Two tenants
+#     both registered `parcels` and one tenant's table was later dropped, so
+#     the physical count is a clean 1 and BOTH catalog rows would otherwise
+#     bind to the surviving tenant's schema. One of them is an orphan holding
+#     a pointer into another tenant's data.
+#
+# The `IS NOT NULL` predicate also skips a catalog row whose physical table is
+# gone entirely, rather than building a pointer from a NULL schema.
 _POSTGIS_BACKFILL = f"""
     UPDATE catalog.datasets AS d
     SET origin_uri = 'postgis://' || ({_DATA_SCHEMA_SQL})
@@ -245,6 +260,15 @@ _POSTGIS_BACKFILL = f"""
       AND d.source_format IS NULL
       AND r.record_type IN ('vector_dataset', 'table')
       AND ({_DATA_SCHEMA_SQL}) IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1
+          FROM catalog.datasets AS d2
+          JOIN catalog.records AS r2 ON r2.id = d2.record_id
+          WHERE d2.table_name = d.table_name
+            AND d2.id <> d.id
+            AND d2.source_format IS NULL
+            AND r2.record_type IN ('vector_dataset', 'table')
+      )
 """
 
 # Uploaded files have no remote origin, so origin_uri stays NULL. The hash

--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -62,16 +62,39 @@ _UPLOAD_FORMATS = (
 # wrong pointer is worse than none, since NULL at least reads as "unknown".
 # A dropped table yields NULL here, which correctly leaves origin_uri NULL.
 #
+# Unambiguous-or-NULL (fix #1218 review, P1). Table names are unique per
+# tenant but NOT across tenants (uq_datasets_table_name_tenant is partial on
+# tenant_id), so in a multi-tenant install two tenants can both own a
+# `parcels` table. An unconstrained LIMIT 1 would hand one tenant's dataset a
+# pointer into the OTHER tenant's schema, permanently and silently.
+#
+# `HAVING count(*) = 1` makes that inexpressible: the aggregate yields a row
+# only when exactly one candidate schema holds a matching relation, and a
+# scalar subquery over zero rows is NULL, which the `IS NOT NULL` predicate
+# below then skips. Ambiguous rows keep a NULL pointer and read as "unknown".
+#
+# Ambiguity is per table NAME, not per row: this subquery can see only
+# `d.table_name`, so it cannot tell the two colliding datasets apart, and
+# BOTH stay NULL. Resolving them would mean trusting `tenant_id`, which is
+# the thing the comment above establishes we cannot trust. NULL for both is
+# the only answer that cannot be wrong. A dropped table (count = 0) lands in
+# the same branch, which is the behaviour this had before.
+#
+# relkind is filtered because count(*) is now load-bearing: an index or
+# sequence sharing the table's name in another data schema would otherwise
+# push the count to 2 and null out a row that resolves perfectly well.
+#
 # A correlated scalar subquery rather than a LATERAL join: PostgreSQL does not
 # expose an UPDATE's target table to LATERAL items in its FROM clause, but it
 # does to a correlated subquery in SET and WHERE.
 _DATA_SCHEMA_SQL = r"""
-    (SELECT n.nspname
+    (SELECT min(n.nspname)
      FROM pg_class c
      JOIN pg_namespace n ON n.oid = c.relnamespace
      WHERE c.relname = d.table_name
+       AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
        AND (n.nspname = 'data' OR n.nspname LIKE 'data\_t\_%')
-     LIMIT 1)
+     HAVING count(*) = 1)
 """
 
 

--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -186,25 +186,54 @@ def _url_is_safe(expr: str) -> str:
     code here follows ``alembic/env.py``, which already imports
     ``app.core.config`` and ``app.core.db``.
 
-    fix(#1218 review r6): the encoded-name gap is CLOSED, by refusing the
-    ambiguous class rather than adjudicating it. ``parse_qsl`` percent-decodes
-    a parameter NAME before judging it, so ``?%74oken=`` reads as ``token`` in
-    Python; the name alternation below sees the literal ``%74oken`` and would
-    have admitted it. Rather than reimplement percent-decoding in SQL — a
-    second copy of ``parse_qsl`` that can drift from the first, which is the
-    thing binding SENSITIVE_QUERY_PARAMS above exists to prevent — the last
-    arm refuses ANY url whose query encodes a parameter NAME at all,
-    regardless of what it decodes to. Parameter names are never legitimately
-    percent-encoded in a service or STAC URL, so this costs approximately no
-    real pointers.
+    fix(#1218 reviews r6 and r7): the name-normalization gap is closed as a
+    CLASS, not a spelling. Rounds 6 and 7 each reported one encoding of the
+    same idea (``?%74oken=``, then ``?+token+=``), so the arm below is derived
+    from the transforms themselves.
+
+    Every normalization the runtime pair applies to a query NAME before
+    judging it, read off ``parse_qsl`` and ``_is_sensitive_query_param``
+    (``app/core/url_redaction.py``) and MEASURED against this Python, not
+    recalled:
+
+    ==========================  ============  ==============================
+    transform                   example       how this predicate handles it
+    ==========================  ============  ==============================
+    pair split on ``&``         ``&token=``   anchored on ``[?&]``
+    pair split on ``;``         ``;token=``   NOT a separator in Python 3.14
+                                              (``parse_qsl('a=1;token=s')``
+                                              yields one pair), so nothing
+                                              to handle
+    percent-decode              ``%74oken``   refused by the name arm
+    plus-to-space               ``+token+``   refused by the name arm
+    ``.strip()`` whitespace     ``' token '`` refused by the name arm
+    ``.lower()`` case fold      ``TOKEN``     already matched, the
+                                              alternation runs case
+                                              insensitively (``!~*``)
+    empty name                  ``?=secret``  decodes to ``''``, never in
+                                              SENSITIVE_QUERY_PARAMS
+    ==========================  ============  ==============================
+
+    Case folding is the one transform NOT handled by refusal, deliberately:
+    refusing uppercase names would reject ``?SERVICE=WFS`` and every other
+    ordinary OGC parameter. Matching case-insensitively handles it exactly,
+    so there is nothing ambiguous left to refuse.
+
+    Everything else collapses to one rule: a NAME containing ``%``, ``+``, or
+    whitespace is refused outright, whatever it decodes to. Decoding in SQL
+    would be a second copy of ``parse_qsl`` that can drift from the first,
+    which is the thing binding SENSITIVE_QUERY_PARAMS above exists to prevent.
+    Names never legitimately carry those characters in a service or STAC URL,
+    so the refusal costs approximately no real pointers.
 
     VALUES keep their encoding rights: the name segment is bounded by the
-    FIRST ``=`` of its pair, so ``?typename=ns%3Aroads`` still backfills. That
-    distinction is the whole reason for the ``[^=&#]*`` classes rather than a
-    bare ``%``.
+    FIRST ``=`` of its pair, so ``?typename=ns%3Aroads`` and ``?q=a+b`` both
+    still backfill. That distinction is the whole reason for the ``[^=&#]*``
+    classes rather than a bare character test.
 
-    The predicate is now at least as strict as the Python rule on every shape
-    it is given.
+    To check this list is still complete, re-read those two functions: the
+    predicate is at least as strict as the Python rule on every shape it is
+    given.
     """
     from app.core.url_redaction import SENSITIVE_QUERY_PARAMS
 
@@ -214,7 +243,7 @@ def _url_is_safe(expr: str) -> str:
         {expr} ~* '^https?://'
         AND {expr} !~ '^[a-zA-Z][a-zA-Z0-9+.-]*://[^/?#]*@'
         AND {expr} !~* '[?&]({alternation})='
-        AND {expr} !~ '[?&][^=&#]*%[0-9A-Fa-f][0-9A-Fa-f][^=&#]*='
+        AND {expr} !~ '[?&][^=&#]*[%+[:space:]][^=&#]*='
     )"""
 
 

--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -191,6 +191,41 @@ def _quoted(values: Sequence[str]) -> str:
 # use as a typename. A dataset whose job row is gone therefore keeps a ref
 # with no layer_id and needs its layer identified once before a first
 # refresh; an honest gap beats invented data.
+#
+# THE INVARIANT (fix #1218 review r4): `origin_ref.url` is the service BASE for
+# every service_type, `layer_id` is the service-native layer identifier, and
+# the url NEVER embeds the layer.
+#
+# `datasets.source_url` cannot supply that base directly. The probe puts the
+# layer NAME in layer_id for WFS and OGC API (sources/probe.py:73), and ingest
+# persists `<base>/<layer_id>` onto the dataset (tasks_vector.py:997-999), so
+# the stored column is enriched and reading it would have produced
+# url=<base>/topp:roads beside layer_id=topp:roads. The runtime write site is
+# already correct — it stores the un-enriched ingest argument
+# (tasks_vector.py:1037) — so this was a backfill-only divergence and the two
+# now agree.
+#
+# The base is therefore RECOVERED from the ingest job's own source_url, which
+# is the normalized value the operator submitted (sources/router.py:548), not
+# reconstructed by string surgery. ArcGIS keeps a derivation as fallback
+# because its suffix is provably numeric. For WFS/OGC API with no surviving
+# job the base is NOT derivable: stripping needs the layer name, which is the
+# thing that went missing. Those rows get NEITHER url nor layer_id rather than
+# a wrong base, which would violate the invariant above. `origin_uri` still
+# holds the full enriched URL, so an operator can re-identify the layer from
+# it by hand.
+
+# The latest complete ingest job for this dataset. Both columns below are read
+# from THIS row, with an id tiebreaker so two separate scalar subqueries can
+# never resolve to different jobs on identical created_at values.
+_LATEST_JOB = """
+    FROM catalog.ingest_jobs AS j
+    WHERE j.dataset_id = d.id
+      AND j.status = 'complete'
+    ORDER BY j.created_at DESC, j.id DESC
+    LIMIT 1
+"""
+
 _SERVICE_BACKFILL = f"""
     UPDATE catalog.datasets AS d
     SET origin_uri = d.source_url,
@@ -198,26 +233,23 @@ _SERVICE_BACKFILL = f"""
             jsonb_build_object(
                 'kind', 'service',
                 'service_type', d.source_format,
-                'url', CASE
-                    WHEN d.source_format = 'arcgis_featureserver'
-                         AND d.source_url ~ '/[0-9]+$'
-                    THEN regexp_replace(d.source_url, '/[0-9]+$', '')
-                    ELSE d.source_url
-                END,
+                'url', COALESCE(
+                    (SELECT j.source_url {_LATEST_JOB}),
+                    CASE
+                        WHEN d.source_format = 'arcgis_featureserver'
+                             AND d.source_url ~ '/[0-9]+$'
+                        THEN regexp_replace(d.source_url, '/[0-9]+$', '')
+                        WHEN d.source_format = 'arcgis_featureserver'
+                        THEN d.source_url
+                        ELSE NULL
+                    END
+                ),
                 'layer_id', CASE
                     WHEN d.source_format = 'arcgis_featureserver'
                          AND d.source_url ~ '/[0-9]+$'
                     THEN substring(d.source_url from '/([0-9]+)$')
                     WHEN d.source_format IN ('wfs', 'ogcapi_features')
-                    THEN (
-                        SELECT j.source_layer
-                        FROM catalog.ingest_jobs AS j
-                        WHERE j.dataset_id = d.id
-                          AND j.status = 'complete'
-                          AND j.source_layer IS NOT NULL
-                        ORDER BY j.created_at DESC
-                        LIMIT 1
-                    )
+                    THEN (SELECT j.source_layer {_LATEST_JOB})
                     ELSE NULL
                 END
             )

--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -1,0 +1,295 @@
+"""Add source-origin and refresh-state columns to catalog.datasets.
+
+feat(#1218) / ADR-002 Decision 3. Seven nullable columns, two CHECK
+constraints, and one partial index, plus a best-effort per-origin backfill.
+
+NULL is the only stored spelling of "never determined": the CHECK sets
+deliberately exclude an 'unknown' literal, and the API projects NULL to
+"unknown" at the response boundary. That keeps this migration cheap (no
+full-table rewrite of health/drift) and removes a way to be wrong — with
+both spellings legal, every query would have to handle two forever.
+
+Revision ID: 0036_dataset_source_state
+Revises: 0035_drop_quality_score_numeric
+Create Date: 2026-08-07
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0036_dataset_source_state"
+down_revision: Union[str, None] = "0035_drop_quality_score_numeric"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Formats that were fetched from a remote OGC/Esri service. Their source_url
+# was machine-written at ingest, so it is a usable pointer — but only when it
+# still parses as a URL. A user may have PATCHed it to prose before this
+# migration ran (source_url is in _DATASET_FIELD_MAP), and a pointer that does
+# not parse must stay NULL rather than be backfilled into a broken refresh.
+_SERVICE_FORMATS = ("wfs", "arcgis_featureserver", "ogcapi_features")
+
+# Everything in chk_datasets_source_format that is neither a service format,
+# nor 'stac', nor 'created'. These datasets hold a copy of uploaded bytes.
+_UPLOAD_FORMATS = (
+    "geojson",
+    "shapefile",
+    "shp",
+    "gpkg",
+    "csv",
+    "kml",
+    "gml",
+    "fgdb",
+    "geotiff",
+    "parquet",
+    "json",
+    "xlsx",
+    "xls",
+)
+
+# The data schema a dataset row's table lives in.
+#
+# Asked of the catalog rather than computed from tenant_id, because those two
+# can disagree: `tenant_data_schema` returns the shared `data` schema in
+# single-tenant mode whatever tenant_id holds, and tenant_id is a dormant
+# column that gets stamped independently of where ingest actually put the
+# table. Deriving `data_t_<uuid>` from a stamped id on a single-tenant
+# instance would write a pointer at a schema that does not exist — and a
+# wrong pointer is worse than none, since NULL at least reads as "unknown".
+# A dropped table yields NULL here, which correctly leaves origin_uri NULL.
+#
+# A correlated scalar subquery rather than a LATERAL join: PostgreSQL does not
+# expose an UPDATE's target table to LATERAL items in its FROM clause, but it
+# does to a correlated subquery in SET and WHERE.
+_DATA_SCHEMA_SQL = r"""
+    (SELECT n.nspname
+     FROM pg_class c
+     JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.relname = d.table_name
+       AND (n.nspname = 'data' OR n.nspname LIKE 'data\_t\_%')
+     LIMIT 1)
+"""
+
+
+def upgrade() -> None:
+    op.add_column(
+        "datasets",
+        sa.Column("origin_uri", sa.String(length=2000), nullable=True),
+        schema="catalog",
+    )
+    op.add_column(
+        "datasets",
+        sa.Column("origin_ref", postgresql.JSONB(), nullable=True),
+        schema="catalog",
+    )
+    op.add_column(
+        "datasets",
+        sa.Column("last_refreshed_at", sa.DateTime(timezone=True), nullable=True),
+        schema="catalog",
+    )
+    op.add_column(
+        "datasets",
+        sa.Column("last_checked_at", sa.DateTime(timezone=True), nullable=True),
+        schema="catalog",
+    )
+    op.add_column(
+        "datasets",
+        sa.Column("source_health", sa.String(length=20), nullable=True),
+        schema="catalog",
+    )
+    op.add_column(
+        "datasets",
+        sa.Column("source_health_detail", sa.Text(), nullable=True),
+        schema="catalog",
+    )
+    op.add_column(
+        "datasets",
+        sa.Column("schema_drift_status", sa.String(length=20), nullable=True),
+        schema="catalog",
+    )
+
+    op.create_check_constraint(
+        "chk_datasets_source_health",
+        "datasets",
+        "source_health IS NULL OR source_health IN "
+        "('healthy', 'missing', 'inaccessible')",
+        schema="catalog",
+    )
+    op.create_check_constraint(
+        "chk_datasets_schema_drift_status",
+        "datasets",
+        "schema_drift_status IS NULL OR schema_drift_status IN ('none', 'drifted')",
+        schema="catalog",
+    )
+    op.create_index(
+        "ix_datasets_origin_uri",
+        "datasets",
+        ["origin_uri"],
+        schema="catalog",
+        postgresql_where=sa.text("origin_uri IS NOT NULL"),
+    )
+
+    for statement in backfill_statements():
+        op.execute(statement)
+
+    # last_checked_at, source_health, source_health_detail and
+    # schema_drift_status are left NULL on every row on purpose: GeoLens has
+    # never contacted an origin, so any value here would be invented.
+
+
+def _quoted(values: Sequence[str]) -> str:
+    """SQL literal list. Every value is a hard-coded constant in this file."""
+    return ", ".join(f"'{value}'" for value in values)
+
+
+# Service datasets: source_url is the enriched URL ingest composed.
+# ``tasks_vector`` stores ``<base>/<layer_id>`` for ArcGIS FeatureServer
+# layers, so the trailing numeric segment splits back out into ``layer_id``
+# and the remainder becomes ``url``. WFS and OGC API Features address their
+# layer by typename/collection inside the request rather than by a path
+# suffix, so their whole URL is the base.
+_SERVICE_BACKFILL = f"""
+    UPDATE catalog.datasets AS d
+    SET origin_uri = d.source_url,
+        origin_ref = jsonb_strip_nulls(
+            jsonb_build_object(
+                'kind', 'service',
+                'service_type', d.source_format,
+                'url', CASE
+                    WHEN d.source_format = 'arcgis_featureserver'
+                         AND d.source_url ~ '/[0-9]+$'
+                    THEN regexp_replace(d.source_url, '/[0-9]+$', '')
+                    ELSE d.source_url
+                END,
+                'layer_id', CASE
+                    WHEN d.source_format = 'arcgis_featureserver'
+                         AND d.source_url ~ '/[0-9]+$'
+                    THEN substring(d.source_url from '/([0-9]+)$')
+                    ELSE NULL
+                END
+            )
+        )
+    WHERE d.source_format IN ({_quoted(_SERVICE_FORMATS)})
+      AND d.source_url ~* '^https?://'
+"""
+
+# STAC datasets point at the referenced asset. ``stac_router`` stores the
+# item's data-asset href in source_url and never captures the item's own
+# href, so ``asset_href`` is what this can honestly record. It is also the
+# value the duplicate-source guard keys on today, so re-keying that guard to
+# origin_uri (ADR-002 Decision 6) leaves its behaviour unchanged on
+# existing rows.
+_STAC_BACKFILL = """
+    UPDATE catalog.datasets AS d
+    SET origin_uri = d.source_url,
+        origin_ref = jsonb_build_object(
+            'kind', 'stac', 'asset_href', d.source_url
+        )
+    WHERE d.source_format = 'stac'
+      AND d.source_url ~* '^https?://'
+"""
+
+# Registered PostGIS tables: no source_format, referenced in place. VRT
+# datasets also store a null source_format (they have no single source file),
+# so the record_type predicate is what keeps them out — a VRT is composed
+# from other datasets and has no origin of its own.
+# The final predicate skips a catalog row whose physical table is gone,
+# rather than giving it a pointer built from a NULL schema.
+_POSTGIS_BACKFILL = f"""
+    UPDATE catalog.datasets AS d
+    SET origin_uri = 'postgis://' || ({_DATA_SCHEMA_SQL})
+                     || '.' || d.table_name,
+        origin_ref = jsonb_build_object(
+            'kind', 'postgis',
+            'table_name', ({_DATA_SCHEMA_SQL}) || '.' || d.table_name
+        )
+    FROM catalog.records AS r
+    WHERE r.id = d.record_id
+      AND d.source_format IS NULL
+      AND r.record_type = 'vector_dataset'
+      AND ({_DATA_SCHEMA_SQL}) IS NOT NULL
+"""
+
+# Uploaded files have no remote origin, so origin_uri stays NULL. The hash
+# comes from the newest DatasetVersion that has one; rows ingested before
+# hashing existed simply omit the key.
+_UPLOAD_BACKFILL = f"""
+    UPDATE catalog.datasets AS d
+    SET origin_ref = jsonb_strip_nulls(
+            jsonb_build_object(
+                'kind', 'upload',
+                'filename', d.source_filename,
+                'file_hash', (
+                    SELECT dv.file_hash
+                    FROM catalog.dataset_versions AS dv
+                    WHERE dv.dataset_id = d.id
+                      AND dv.file_hash IS NOT NULL
+                    ORDER BY dv.version_number DESC
+                    LIMIT 1
+                )
+            )
+        )
+    WHERE d.source_format IN ({_quoted(_UPLOAD_FORMATS)})
+"""
+
+# Newest version upload where the dataset has version history, else creation.
+# A re-uploaded dataset was genuinely refreshed after its import, so the
+# version table is the better answer wherever it has rows; records.created_at
+# is the floor for datasets that were never re-uploaded.
+_LAST_REFRESHED_BACKFILL = """
+    UPDATE catalog.datasets AS d
+    SET last_refreshed_at = COALESCE(
+        (
+            SELECT max(dv.uploaded_at)
+            FROM catalog.dataset_versions AS dv
+            WHERE dv.dataset_id = d.id
+        ),
+        r.created_at
+    )
+    FROM catalog.records AS r
+    WHERE r.id = d.record_id
+"""
+
+
+def backfill_statements() -> list[sa.TextClause]:
+    """The backfill, in order, as executable statements.
+
+    Exposed rather than inlined into ``upgrade()`` so
+    ``tests/test_dataset_source_state.py`` can run the REAL statements against
+    pre-migration-shaped rows. A test that re-copied the SQL would prove only
+    that the copy works.
+    """
+    return [
+        sa.text(_SERVICE_BACKFILL),
+        sa.text(_STAC_BACKFILL),
+        sa.text(_POSTGIS_BACKFILL),
+        sa.text(_UPLOAD_BACKFILL),
+        sa.text(_LAST_REFRESHED_BACKFILL),
+    ]
+
+
+def downgrade() -> None:
+    op.drop_index("ix_datasets_origin_uri", table_name="datasets", schema="catalog")
+    op.drop_constraint(
+        "chk_datasets_schema_drift_status",
+        "datasets",
+        schema="catalog",
+        type_="check",
+    )
+    op.drop_constraint(
+        "chk_datasets_source_health", "datasets", schema="catalog", type_="check"
+    )
+    for column in (
+        "schema_drift_status",
+        "source_health_detail",
+        "source_health",
+        "last_checked_at",
+        "last_refreshed_at",
+        "origin_ref",
+        "origin_uri",
+    ):
+        op.drop_column("datasets", column, schema="catalog")

--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -193,10 +193,20 @@ _STAC_BACKFILL = """
       AND d.source_url ~* '^https?://'
 """
 
-# Registered PostGIS tables: no source_format, referenced in place. VRT
-# datasets also store a null source_format (they have no single source file),
-# so the record_type predicate is what keeps them out — a VRT is composed
-# from other datasets and has no origin of its own.
+# Registered PostGIS tables: no source_format, referenced in place.
+#
+# Both record types registration can produce are covered. `create_dataset`
+# assigns 'table' when the source has no geometry and 'vector_dataset'
+# otherwise, and `register_existing_table` stamps the origin either way, so
+# restricting this to 'vector_dataset' would leave registered non-spatial
+# tables as the only rows whose pointer depends on whether they were
+# registered before or after this migration. ADR-002's predicate names the
+# common case rather than an exclusion (widened deliberately, #1218 review).
+#
+# VRT datasets also store a null source_format (they have no single source
+# file), and the record_type predicate is still what keeps them out: a VRT is
+# composed from other datasets and has no origin of its own.
+#
 # The final predicate skips a catalog row whose physical table is gone,
 # rather than giving it a pointer built from a NULL schema.
 _POSTGIS_BACKFILL = f"""
@@ -210,7 +220,7 @@ _POSTGIS_BACKFILL = f"""
     FROM catalog.records AS r
     WHERE r.id = d.record_id
       AND d.source_format IS NULL
-      AND r.record_type = 'vector_dataset'
+      AND r.record_type IN ('vector_dataset', 'table')
       AND ({_DATA_SCHEMA_SQL}) IS NOT NULL
 """
 

--- a/backend/alembic/versions/0036_dataset_source_state.py
+++ b/backend/alembic/versions/0036_dataset_source_state.py
@@ -169,6 +169,41 @@ def _quoted(values: Sequence[str]) -> str:
     return ", ".join(f"'{value}'" for value in values)
 
 
+def _url_is_safe(expr: str) -> str:
+    """SQL predicate mirroring ``has_url_credentials`` for one URL column.
+
+    fix(#1218 review r5): a legacy service URL can carry ``user:pass@`` or a
+    ``?token=`` parameter. Those predate the submission-time gate
+    (``_validate_service_url`` in ``modules/catalog/sources/schemas.py:91``,
+    which refuses both on ``ProbeRequest`` and ``ServicePreviewRequest``), so a
+    NEW ingest cannot persist one, but an OLD row can still hold it. Copying it
+    into ``origin_uri``/``origin_ref`` would be strictly worse than leaving it
+    in ``source_url``: those two columns are read-only on ``DatasetResponse``,
+    so an operator who spots the secret cannot edit it away.
+
+    The parameter names come from ``SENSITIVE_QUERY_PARAMS`` itself rather than
+    a transcription, so this cannot drift from the runtime rule. Importing app
+    code here follows ``alembic/env.py``, which already imports
+    ``app.core.config`` and ``app.core.db``.
+
+    Known narrower than the Python original, in the safe direction for
+    everything except one case: ``parse_qsl`` percent-decodes a parameter NAME
+    before judging it, so ``?%74oken=`` reads as ``token`` there and not here.
+    Matching that in SQL needs a decoder Postgres does not provide. The
+    residual is a legacy URL with a percent-encoded credential parameter name;
+    every other shape this misses is a shape the Python rule also admits.
+    """
+    from app.core.url_redaction import SENSITIVE_QUERY_PARAMS
+
+    # Every name is [a-z0-9_-], so no regex metacharacter needs escaping.
+    alternation = "|".join(sorted(SENSITIVE_QUERY_PARAMS))
+    return f"""(
+        {expr} ~* '^https?://'
+        AND {expr} !~ '^[a-zA-Z][a-zA-Z0-9+.-]*://[^/?#]*@'
+        AND {expr} !~* '[?&]({alternation})='
+    )"""
+
+
 # Service datasets: source_url is the enriched URL ingest composed.
 # ``tasks_vector`` stores ``<base>/<layer_id>`` for ArcGIS FeatureServer
 # layers, so the trailing numeric segment splits back out into ``layer_id``
@@ -234,7 +269,8 @@ _SERVICE_BACKFILL = f"""
                 'kind', 'service',
                 'service_type', d.source_format,
                 'url', COALESCE(
-                    (SELECT j.source_url {_LATEST_JOB}),
+                    (SELECT CASE WHEN {_url_is_safe("j.source_url")}
+                                 THEN j.source_url END {_LATEST_JOB}),
                     CASE
                         WHEN d.source_format = 'arcgis_featureserver'
                              AND d.source_url ~ '/[0-9]+$'
@@ -255,7 +291,7 @@ _SERVICE_BACKFILL = f"""
             )
         )
     WHERE d.source_format IN ({_quoted(_SERVICE_FORMATS)})
-      AND d.source_url ~* '^https?://'
+      AND {_url_is_safe("d.source_url")}
 """
 
 # STAC datasets point at the referenced asset. ``stac_router`` stores the
@@ -264,14 +300,14 @@ _SERVICE_BACKFILL = f"""
 # value the duplicate-source guard keys on today, so re-keying that guard to
 # origin_uri (ADR-002 Decision 6) leaves its behaviour unchanged on
 # existing rows.
-_STAC_BACKFILL = """
+_STAC_BACKFILL = f"""
     UPDATE catalog.datasets AS d
     SET origin_uri = d.source_url,
         origin_ref = jsonb_build_object(
             'kind', 'stac', 'asset_href', d.source_url
         )
     WHERE d.source_format = 'stac'
-      AND d.source_url ~* '^https?://'
+      AND {_url_is_safe("d.source_url")}
 """
 
 # Registered PostGIS tables: no source_format, referenced in place.

--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -21,6 +21,7 @@ from app.modules.catalog.sources.provenance import (
     resolve_actor,
 )
 from app.core.geo import extent_to_bbox, wkt_is_geographic
+from app.platform.dataset_origin import classify_origin, project_unknown
 
 
 async def _load_actor_identities(
@@ -203,6 +204,21 @@ def dataset_to_response(
         original_srid=dataset.original_srid,
         current_version=dataset.current_version,
         source_url=dataset.source_url,
+        # feat(#1218): origin is COMPUTED here, not stored — it is fully
+        # determined by source_format and record_type, and a third persisted
+        # value could only ever disagree with the two it derives from. Serving
+        # it retires the frontend's duplicate rule in OriginBadge.tsx and gives
+        # the CLI, MCP server, and SDKs the same answer.
+        origin=classify_origin(dataset.source_format, record_type),
+        origin_uri=dataset.origin_uri,
+        origin_ref=dataset.origin_ref,
+        last_refreshed_at=dataset.last_refreshed_at,
+        last_checked_at=dataset.last_checked_at,
+        # NULL is the stored spelling of "never determined"; "unknown" is the
+        # wire spelling. Only one of the two is ever storable.
+        source_health=project_unknown(dataset.source_health),
+        source_health_detail=dataset.source_health_detail,
+        schema_drift_status=project_unknown(dataset.schema_drift_status),
         quality_statement=dataset.quality_statement,
         visibility=record.visibility,
         created_by=record.created_by,

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -393,6 +393,29 @@ class Dataset(Base):
             "original_srid IS NULL OR original_srid > 0",
             name="chk_datasets_original_srid_positive",
         ),
+        # feat(#1218): NULL is the only spelling of "never determined" — an
+        # 'unknown' literal is deliberately OUT of both value sets, so no
+        # query ever has to handle two spellings of one state. The API
+        # projects NULL to "unknown" at the response boundary instead.
+        # Migration 0036_dataset_source_state is the source of truth.
+        CheckConstraint(
+            "source_health IS NULL OR source_health IN "
+            "('healthy', 'missing', 'inaccessible')",
+            name="chk_datasets_source_health",
+        ),
+        CheckConstraint(
+            "schema_drift_status IS NULL OR schema_drift_status IN ('none', 'drifted')",
+            name="chk_datasets_schema_drift_status",
+        ),
+        # feat(#1218): backs the duplicate-source guard, which ADR-002
+        # Decision 6 re-keys from the user-PATCHable source_url to the
+        # system-managed origin_uri. Partial: upload and created datasets
+        # have no remote origin to point at, so most rows are NULL.
+        Index(
+            "ix_datasets_origin_uri",
+            "origin_uri",
+            postgresql_where=text("origin_uri IS NOT NULL"),
+        ),
         Index(
             "uq_datasets_table_name_global",
             "table_name",
@@ -445,6 +468,42 @@ class Dataset(Base):
     source_filename: Mapped[str | None] = mapped_column(String(500), nullable=True)
     original_srid: Mapped[int | None] = mapped_column(Integer, nullable=True)
     source_url: Mapped[str | None] = mapped_column(String(2000), nullable=True)
+
+    # Source origin & refresh state (ADR-002, #1218). System-managed: none of
+    # these is in _DATASET_FIELD_MAP, so the metadata PATCH cannot reach them.
+    # source_url stays user-editable descriptive prose beside origin_uri, the
+    # machine pointer — two URL-ish fields, bounded by tests rather than by
+    # removing the one DCAT export depends on.
+    #
+    # origin_ref carries a `kind` discriminator plus a per-kind payload; every
+    # write goes through the key allowlist in
+    # app/platform/dataset_origin.py, which is what keeps a credential out of
+    # the binding and keeps external PostGIS federation out of v1.
+    origin_uri: Mapped[str | None] = mapped_column(String(2000), nullable=True)
+    origin_ref: Mapped[dict | None] = mapped_column(
+        MutableDict.as_mutable(JSONB), nullable=True
+    )
+    # Last committed successful swap, NOT last attempt. last_checked_at is the
+    # "we contacted the origin at all" timestamp — probe or refresh, success or
+    # failure. There is deliberately no last_verified_at: v1 has no
+    # verification layer, and a column named for one would be a lie in the
+    # schema (ADR-002 Decision 3 / invariant 9).
+    last_refreshed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_checked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Vocabulary reused from the VRT member probe (router_vrt.py) so one legend
+    # renders across VRT members and standalone origins.
+    source_health: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # Short, redacted reason. Never a raw exception, a URL carrying
+    # query-string credentials, or a GDAL command line.
+    source_health_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Persisted rather than derived — unlike origin classification and
+    # staleness — because the pre-refresh schema is gone once the swap
+    # commits, so drift has no live inputs to recompute from.
+    schema_drift_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
 
     # TSEAM-01 (Phase 1207): dormant tenant_id — nullable, no FK enforcement.
     tenant_id: Mapped[uuid.UUID | None] = mapped_column(

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -323,6 +323,62 @@ class DatasetResponse(BaseModel):
         max_length=2000,
         description="URL the data was originally fetched from",
     )
+    # feat(#1218): read-only source-origin & refresh state. Every field below
+    # is system-managed — none is accepted by PATCH /datasets/{id}/metadata.
+    origin: str | None = Field(
+        default=None,
+        description=(
+            "How the data entered the catalog: upload, postgis, service, "
+            "stac, or created. Computed from source_format and record_type, "
+            "not stored; null for collections and VRTs, which have no origin "
+            "of their own."
+        ),
+    )
+    origin_uri: str | None = Field(
+        default=None,
+        max_length=2000,
+        description=(
+            "Machine-readable pointer back to the origin, written only by "
+            "ingest and refresh. Distinct from source_url, which is editable "
+            "descriptive metadata. Null for uploads and created datasets."
+        ),
+    )
+    origin_ref: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Typed per-origin payload with a `kind` discriminator, e.g. "
+            '{"kind": "service", "service_type": "wfs", "url": "...", '
+            '"layer_id": "0"}. Never contains credentials.'
+        ),
+    )
+    last_refreshed_at: datetime | None = Field(
+        default=None,
+        description="Last committed successful refresh — not the last attempt",
+    )
+    last_checked_at: datetime | None = Field(
+        default=None,
+        description=(
+            "Last time GeoLens contacted the origin at all, whether the "
+            "attempt succeeded or failed"
+        ),
+    )
+    source_health: str = Field(
+        default="unknown",
+        description=(
+            "healthy, missing, inaccessible, or unknown. 'unknown' means "
+            "never probed, or an origin kind with nothing to probe."
+        ),
+    )
+    source_health_detail: str | None = Field(
+        default=None, description="Short redacted reason for a non-healthy state"
+    )
+    schema_drift_status: str = Field(
+        default="unknown",
+        description=(
+            "none, drifted, or unknown. Set at refresh commit from the "
+            "schema diff; 'unknown' until a refresh has run."
+        ),
+    )
     quality_statement: str | None = None
     visibility: str = Field(
         description="Access level: private, restricted, internal, public"

--- a/backend/app/modules/catalog/datasets/domain/service_create.py
+++ b/backend/app/modules/catalog/datasets/domain/service_create.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -233,6 +234,19 @@ async def create_dataset(
     dataset = Dataset(
         record_id=record.id,
         table_name=table_name,
+        # fix(#1218 review): first ingest IS the first successful
+        # materialization, so stamp it here rather than leaving every
+        # post-migration dataset reporting null forever. This mirrors the
+        # floor migration 0036's backfill uses (records.created_at), so a
+        # dataset created before the migration and one created after report
+        # the same kind of thing.
+        #
+        # A Python datetime, NOT func.now(): a SQL expression leaves the
+        # attribute EXPIRED after flush, so the next read of
+        # dataset.last_refreshed_at issues a lazy SELECT — which explodes once
+        # the session is closed, exactly where dataset_to_response reads it.
+        # Every stamping site uses a Python value for that reason.
+        last_refreshed_at=datetime.now(timezone.utc),
         srid=ing.srid,
         geometry_type=ing.geometry_type,
         feature_count=ing.feature_count,

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -6,7 +6,7 @@ search items, and import selected items as raster datasets.
 
 import asyncio
 import uuid
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Literal
 
 import structlog
@@ -578,6 +578,12 @@ async def stac_import(
                     source_url=item.data_asset_href,
                     source_filename=item.id,
                     srid=item.epsg,
+                    # fix(#1218 review): stamped like every other creation
+                    # path, so post-migration imports do not report null while
+                    # backfilled ones carry a timestamp. Python value, not
+                    # func.now(): a SQL expression leaves the attribute
+                    # expired and the next read lazy-loads.
+                    last_refreshed_at=datetime.now(timezone.utc),
                 )
                 # feat(#1218): system-managed origin pointer. The asset href is
                 # also what the duplicate-source guard keys on, so pointing

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -28,6 +28,7 @@ from app.modules.catalog.datasets.domain.models import (
     RecordKeyword,
 )
 from app.core.dependencies import get_db
+from app.platform.dataset_origin import set_dataset_origin
 from app.platform.extensions import get_catalog_port
 from app.modules.catalog.sources.adapters.stac import (
     connect_stac_api,
@@ -577,6 +578,17 @@ async def stac_import(
                     source_url=item.data_asset_href,
                     source_filename=item.id,
                     srid=item.epsg,
+                )
+                # feat(#1218): system-managed origin pointer. The asset href is
+                # also what the duplicate-source guard keys on, so pointing
+                # origin_uri at it keeps that guard identical when ADR-002
+                # Decision 6 re-keys it off the PATCHable source_url.
+                set_dataset_origin(
+                    dataset,
+                    "stac",
+                    uri=item.data_asset_href,
+                    asset_href=item.data_asset_href,
+                    collection_id=item.collection,
                 )
                 db.add(dataset)
                 await db.flush()

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -1,0 +1,193 @@
+"""Dataset origin vocabulary: classification, pointer, and typed payload.
+
+feat(#1218): one home for three things that must agree across the catalog
+domain, the ingest tasks, and the API response boundary (ADR-002).
+
+- ``classify_origin`` is the derivation ADR-002 Decision 2 deliberately keeps
+  *derived*: origin is a pure function of ``source_format`` and
+  ``record_type``, so no third column can disagree with the two it comes
+  from. It moves server-side here so the CLI, MCP server, and SDKs stop
+  needing a second implementation of the rule (the frontend's
+  ``datasetOrigin()`` in ``OriginBadge.tsx`` becomes a consumer of the
+  computed ``origin`` response field).
+- ``build_origin_ref`` is the per-kind key allowlist that is the ONLY door
+  into ``datasets.origin_ref``. Two ADR-002 guarantees are structural here
+  rather than conventional: invariant 4 (the source binding holds no
+  plaintext secret) holds because a key the kind does not declare raises, so
+  ``token``/``password``/``authorization`` cannot land even by accident; and
+  gate 2 (no external PostGIS federation in v1) holds because ``postgis``
+  accepts ``table_name`` and nothing else — no host, port, DSN, or
+  credential. Widening a JSON blob at a later PR's convenience is therefore
+  not enough to add federation; it needs a new kind here.
+- ``project_unknown`` is the NULL-means-unknown projection. NULL is the only
+  stored spelling of "never determined" (the CHECK sets exclude ``unknown``),
+  and the API renders it as the string at the boundary.
+
+This lives under ``platform/`` rather than in the datasets domain because
+both ``app.modules.catalog`` and ``app.processing.ingest`` write origins, and
+processing/ may not import catalog (``test_no_processing_imports_catalog``).
+It imports nothing from either side: the write helper is duck-typed on the
+Dataset ORM instance.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+# Formats whose rows were pulled from a remote OGC/Esri service. Mirrors
+# SERVICE_FORMATS in frontend/src/components/dataset/OriginBadge.tsx.
+SERVICE_SOURCE_FORMATS: frozenset[str] = frozenset(
+    {"wfs", "arcgis_featureserver", "ogcapi_features"}
+)
+
+# Record types with no dataset origin of their own: a collection has no
+# dataset row at all, and a VRT is composed from other datasets rather than
+# fetched from anywhere. Both classify as None so the type badge speaks alone.
+_ORIGINLESS_RECORD_TYPES: frozenset[str] = frozenset({"collection", "vrt_dataset"})
+
+ORIGIN_KINDS: frozenset[str] = frozenset(
+    {"upload", "postgis", "service", "stac", "created"}
+)
+
+# The response-boundary spelling of "never determined". Deliberately absent
+# from chk_datasets_source_health / chk_datasets_schema_drift_status: with
+# both NULL and 'unknown' storable, every query would have to handle two
+# spellings of one state forever.
+UNKNOWN: str = "unknown"
+
+# Stored value sets, matching the two CHECK constraints on catalog.datasets.
+SOURCE_HEALTH_VALUES: tuple[str, ...] = ("healthy", "missing", "inaccessible")
+SCHEMA_DRIFT_STATUS_VALUES: tuple[str, ...] = ("none", "drifted")
+
+# Keys each origin kind may carry in origin_ref, beside the `kind`
+# discriminator itself. Adding a key here widens what can be persisted about
+# an origin, so treat it as a schema change.
+ORIGIN_REF_KEYS: dict[str, frozenset[str]] = {
+    "service": frozenset({"service_type", "url", "layer_id"}),
+    # `asset_href` is additive to ADR-002's declared stac shape. The STAC
+    # import request carries the item id, the collection id, and the chosen
+    # data-asset href — never the item's own href — so writing that asset URL
+    # into a key named `item_href` would be a lie in the payload. The key is
+    # reserved and stays unwritten until the import request carries it
+    # (#1222 owns the STAC health probe that will want it).
+    "stac": frozenset({"item_href", "asset_href", "collection_id", "asset_key"}),
+    "upload": frozenset({"filename", "file_hash"}),
+    # Gate 2: GeoLens-internal table only. No host/port/DSN/credential key.
+    "postgis": frozenset({"table_name"}),
+    # A dataset drawn in the app came from nowhere; it carries no payload.
+    "created": frozenset(),
+}
+
+
+def classify_origin(
+    source_format: str | None, record_type: str | None = None
+) -> str | None:
+    """How the data entered the catalog, derived from the two stored columns.
+
+    Registering an existing PostGIS table stores no ``source_format`` (see
+    ``register_existing_table``), so a null format means "referenced in
+    place" rather than "unknown".
+    """
+    resolved_type = record_type or "vector_dataset"
+    if resolved_type in _ORIGINLESS_RECORD_TYPES:
+        return None
+    if not source_format:
+        return "postgis"
+    if source_format == "created":
+        return "created"
+    if source_format == "stac":
+        return "stac"
+    if source_format in SERVICE_SOURCE_FORMATS:
+        return "service"
+    return "upload"
+
+
+def data_schema_for(tenant_id: uuid.UUID | str | None) -> str:
+    """Data-schema name for a dataset row, for use in a ``postgis://`` URI.
+
+    Mirrors ``tenant_data_schema`` but treats a null tenant as the shared
+    ``data`` schema in either tenancy mode, because a dataset row with a null
+    ``tenant_id`` lives there regardless of how the instance is configured.
+
+    Correct here because ingest places the table through the same resolver.
+    Migration 0036 deliberately does NOT reuse this rule: backfilling an
+    existing row means asking where its table actually is, so it reads
+    pg_class instead of trusting a tenant_id stamped independently of ingest.
+    """
+    if tenant_id is None:
+        return "data"
+    from app.core.db.tenant_schema import tenant_data_schema
+
+    return tenant_data_schema(str(tenant_id))
+
+
+def set_postgis_origin(
+    dataset: Any, table_name: str, tenant_id: uuid.UUID | str | None
+) -> None:
+    """Stamp a registered PostGIS table's origin.
+
+    Separate from the generic writer because the pointer and the ref's
+    ``table_name`` are two spellings of one fact and have to agree. Composing
+    them at the call site is how they drift, so the qualified name is built
+    once here and the URI is derived from it.
+    """
+    qualified = f"{data_schema_for(tenant_id)}.{table_name}"
+    set_dataset_origin(
+        dataset, "postgis", uri=f"postgis://{qualified}", table_name=qualified
+    )
+
+
+def build_origin_ref(kind: str, **fields: Any) -> dict[str, Any] | None:
+    """Validated ``origin_ref`` payload for one origin kind.
+
+    Raises on any key the kind does not declare rather than dropping it: a
+    silent drop would make a mis-keyed write indistinguishable from a
+    correct one, and this allowlist is the enforcement point for ADR-002
+    invariant 4 and gate 2. ``None``-valued fields are omitted, so an absent
+    file hash simply leaves the key out.
+
+    Returns ``None`` for a kind with no payload (``created``).
+    """
+    try:
+        allowed = ORIGIN_REF_KEYS[kind]
+    except KeyError:
+        raise ValueError(
+            f"unknown origin kind {kind!r}; expected one of {sorted(ORIGIN_KINDS)}"
+        ) from None
+
+    rejected = sorted(set(fields) - allowed)
+    if rejected:
+        raise ValueError(
+            f"origin_ref[{kind}] rejects key(s) {rejected}; "
+            f"allowed keys are {sorted(allowed)}"
+        )
+
+    payload = {
+        key: fields[key] for key in sorted(allowed) if fields.get(key) is not None
+    }
+    if not payload and not allowed:
+        return None
+    return {"kind": kind, **payload}
+
+
+def set_dataset_origin(
+    dataset: Any, kind: str, *, uri: str | None = None, **ref_fields: Any
+) -> None:
+    """Write the system-managed origin pointer onto a Dataset ORM instance.
+
+    The only supported way to populate ``origin_uri``/``origin_ref``. Neither
+    column appears in ``_DATASET_FIELD_MAP``, so nothing reaches them through
+    the metadata PATCH; ingest and refresh paths come through here.
+    """
+    if kind not in ORIGIN_KINDS:
+        raise ValueError(
+            f"unknown origin kind {kind!r}; expected one of {sorted(ORIGIN_KINDS)}"
+        )
+    dataset.origin_uri = uri
+    dataset.origin_ref = build_origin_ref(kind, **ref_fields)
+
+
+def project_unknown(value: str | None) -> str:
+    """Render a never-determined source-state column at the API boundary."""
+    return UNKNOWN if value is None else value

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -63,6 +63,20 @@ SCHEMA_DRIFT_STATUS_VALUES: tuple[str, ...] = ("none", "drifted")
 # discriminator itself. Adding a key here widens what can be persisted about
 # an origin, so treat it as a schema change.
 ORIGIN_REF_KEYS: dict[str, frozenset[str]] = {
+    # `layer_id` is the SERVICE-NATIVE layer identifier, and which field that
+    # is depends on service_type (fix #1218 review r3). `build_gdal_source` in
+    # catalog/sources/preview.py is the authority:
+    #
+    #   arcgis_featureserver -> the numeric layer id. Required; the layer NAME
+    #                           is ignored, the id becomes a URL path segment.
+    #   wfs                  -> the typename, passed to GDAL as the layer name.
+    #                           layer_id is ignored.
+    #   ogcapi_features      -> the collection id, same handling as wfs.
+    #
+    # Exactly one of the two identifies the layer for a given service, so they
+    # cannot disagree, and one key is enough for a refresh to re-address the
+    # layer. Do NOT add a second key for the name: that would create two fields
+    # with overlapping meaning and leave a refresh to guess which one applies.
     "service": frozenset({"service_type", "url", "layer_id"}),
     # `asset_href` is additive to ADR-002's declared stac shape. The STAC
     # import request carries the item id, the collection id, and the chosen
@@ -125,6 +139,26 @@ def set_postgis_origin(dataset: Any, table_name: str, *, schema: str) -> None:
     set_dataset_origin(
         dataset, "postgis", uri=f"postgis://{qualified}", table_name=qualified
     )
+
+
+def service_layer_identity(
+    service_type: str, *, layer_id: Any, layer_name: str | None
+) -> str | None:
+    """The service-native layer identifier for a service ``origin_ref``.
+
+    Which field addresses a layer depends on the service, and
+    ``build_gdal_source`` in ``catalog/sources/preview.py`` is the authority:
+    its ArcGIS branch requires the numeric ``layer_id`` and discards the layer
+    name, while its WFS and OGC API branches pass the layer NAME to GDAL and
+    never read ``layer_id``. Exactly one applies per service, so they cannot
+    disagree and one stored key is enough.
+
+    Lives here rather than at the two ingest call sites so both spell the rule
+    the same way and a change has one place to happen (fix #1218 review r3).
+    """
+    if service_type == "arcgis_featureserver":
+        return None if layer_id is None else str(layer_id)
+    return layer_name
 
 
 def build_origin_ref(kind: str, **fields: Any) -> dict[str, Any] | None:

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -32,7 +32,6 @@ Dataset ORM instance.
 
 from __future__ import annotations
 
-import uuid
 from typing import Any
 
 # Formats whose rows were pulled from a remote OGC/Esri service. Mirrors
@@ -103,36 +102,26 @@ def classify_origin(
     return "upload"
 
 
-def data_schema_for(tenant_id: uuid.UUID | str | None) -> str:
-    """Data-schema name for a dataset row, for use in a ``postgis://`` URI.
-
-    Mirrors ``tenant_data_schema`` but treats a null tenant as the shared
-    ``data`` schema in either tenancy mode, because a dataset row with a null
-    ``tenant_id`` lives there regardless of how the instance is configured.
-
-    Correct here because ingest places the table through the same resolver.
-    Migration 0036 deliberately does NOT reuse this rule: backfilling an
-    existing row means asking where its table actually is, so it reads
-    pg_class instead of trusting a tenant_id stamped independently of ingest.
-    """
-    if tenant_id is None:
-        return "data"
-    from app.core.db.tenant_schema import tenant_data_schema
-
-    return tenant_data_schema(str(tenant_id))
-
-
-def set_postgis_origin(
-    dataset: Any, table_name: str, tenant_id: uuid.UUID | str | None
-) -> None:
+def set_postgis_origin(dataset: Any, table_name: str, *, schema: str) -> None:
     """Stamp a registered PostGIS table's origin.
 
     Separate from the generic writer because the pointer and the ref's
     ``table_name`` are two spellings of one fact and have to agree. Composing
     them at the call site is how they drift, so the qualified name is built
     once here and the URI is derived from it.
+
+    ``schema`` is passed in rather than derived, and specifically NOT derived
+    from ``dataset.tenant_id`` (fix #1218 review round 2). In multi-tenant
+    mode the INSERT sends ``tenant_id`` as NULL and the
+    ``trg_stamp_current_tenant_on_insert`` trigger fills it from the
+    ``app.current_tenant`` GUC, so the real value exists only in the database
+    and the ORM attribute stays None — every multi-tenant registration would
+    have been pointed at ``data.<table>`` for a table living in
+    ``data_t_<tenant>``. Callers pass the schema they actually created,
+    granted, and read the table in, which makes the pointer agree with
+    physical placement by construction rather than by a parallel derivation.
     """
-    qualified = f"{data_schema_for(tenant_id)}.{table_name}"
+    qualified = f"{schema}.{table_name}"
     set_dataset_origin(
         dataset, "postgis", uri=f"postgis://{qualified}", table_name=qualified
     )

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -77,6 +77,13 @@ ORIGIN_REF_KEYS: dict[str, frozenset[str]] = {
     # cannot disagree, and one key is enough for a refresh to re-address the
     # layer. Do NOT add a second key for the name: that would create two fields
     # with overlapping meaning and leave a refresh to guess which one applies.
+    #
+    # THE INVARIANT (fix #1218 review r4): `url` is the service BASE for every
+    # service_type, `layer_id` is the service-native layer identifier, and the
+    # url NEVER embeds the layer. A refresh composes the two per service; it
+    # must never have to strip a layer back out of the url. Note this is why
+    # `url` is not the same value as `datasets.origin_uri`, which deliberately
+    # keeps the enriched form ingest composed, as provenance.
     "service": frozenset({"service_type", "url", "layer_id"}),
     # `asset_href` is additive to ADR-002's declared stac shape. The STAC
     # import request carries the item id, the collection id, and the chosen

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -666,7 +666,15 @@ async def register_existing_table(
     # so the origin IS that table. Gate 2 (no external PostGIS federation in
     # v1) is why the ref carries a schema-qualified name and no connection
     # detail — the allowlist accepts no host, port, DSN, or credential key.
-    set_postgis_origin(dataset, table_name, dataset.tenant_id)
+    #
+    # fix(#1218 review r2): pass the SAME _schema this function verified,
+    # granted, and extracted metadata in. Reading dataset.tenant_id instead
+    # pointed every multi-tenant registration at `data.<table>`: the INSERT
+    # sends tenant_id NULL and the trg_stamp_current_tenant_on_insert trigger
+    # fills it in the database, so the ORM attribute never sees the real
+    # value. _schema comes from the active tenant context and already fails
+    # closed in multi-tenant mode when that context is missing.
+    set_postgis_origin(dataset, table_name, schema=_schema)
 
     return dataset
 

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -22,6 +22,7 @@ from app.core.async_io import run_in_thread_draining
 from app.core.identity import Identity
 from app.core.config import settings
 from app.core.db.tenant_session import defer_async_with_tenant
+from app.platform.dataset_origin import set_postgis_origin
 from app.platform.extensions import get_processing_port
 from app.processing.ingest.metadata import (
     add_4326_column,
@@ -660,6 +661,12 @@ async def register_existing_table(
         visibility=request.visibility,
         ingestion=ingestion,
     )
+
+    # feat(#1218): registration copies no data and serves from the live table,
+    # so the origin IS that table. Gate 2 (no external PostGIS federation in
+    # v1) is why the ref carries a schema-qualified name and no connection
+    # detail — the allowlist accepts no host, port, DSN, or credential key.
+    set_postgis_origin(dataset, table_name, dataset.tenant_id)
 
     return dataset
 

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1622,8 +1622,16 @@ async def _apply_reupload_swap(
     original_srid: int | None,
     source_url: str | None = None,
     file_hash: str | None = None,
+    origin_ref: dict[str, Any] | None = None,
 ) -> None:
-    """Apply shared atomic swap + version invariants for all reupload sources."""
+    """Apply shared atomic swap + version invariants for all reupload sources.
+
+    ``origin_ref`` carries the typed per-origin payload for the bytes this
+    swap installs, minus the ``kind`` discriminator (derived from
+    ``source_format``). Same contract as ``IngestContext.origin_ref``: keys go
+    through the per-kind allowlist, and callers supply their own rather than
+    one being inferred here.
+    """
     from app.modules.audit.service import (
         AuditEvent,
         audit_emit,
@@ -1776,6 +1784,32 @@ async def _apply_reupload_swap(
     dataset.record.updated_by = actor_id
     if source_url is not None:
         dataset.source_url = source_url
+
+    # fix(#1218 review): restamp the binding, which must describe where the
+    # CURRENT bytes came from. Without this a file reupload of a
+    # registered-postgis or service dataset leaves the old pointer in place,
+    # so the API serves a computed origin of `upload` beside a stored ref
+    # still claiming `postgis` — and a later refresh would follow the stale
+    # pointer. The kind is derived from the NEW source_format exactly as first
+    # ingest derives it, so a service reupload stays a service origin instead
+    # of being flattened to an upload, and a file reupload correctly clears
+    # origin_uri (an upload has no remote pointer) while leaving the
+    # user-editable source_url alone.
+    #
+    # #1220's shared refresh executor takes over both writes below for
+    # server-side refresh; until it lands, this path owns them.
+    set_dataset_origin(
+        dataset,
+        classify_origin(source_format),
+        uri=source_url,
+        **(origin_ref or {}),
+    )
+    # The swap commit time, which is what migration 0036's backfill reads off
+    # max(dataset_versions.uploaded_at) for a pre-existing dataset. A Python
+    # datetime rather than func.now(): a SQL expression leaves the attribute
+    # expired after flush, and the next read of dataset.last_refreshed_at then
+    # lazy-loads against a session that may already be closed.
+    dataset.last_refreshed_at = datetime.now(timezone.utc)
 
     quality_score = await compute_quality_score(
         session,

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -22,6 +22,7 @@ from app.core.async_io import await_draining
 from procrastinate import App, PsycopgConnector
 
 from app.platform.cache.tiles import invalidate_catalog_cache
+from app.platform.dataset_origin import classify_origin, set_dataset_origin
 from app.core.config import settings
 from app.processing.embeddings.helpers import defer_embedding
 from app.platform.storage import get_storage
@@ -208,6 +209,14 @@ class IngestContext:
     user_metadata: dict[str, Any]
     source_url: str | None = None
     attempt_id: uuid.UUID | None = None
+    # feat(#1218): typed origin_ref payload for the dataset the finalize
+    # pipeline creates, minus the `kind` discriminator (derived from
+    # source_format). Keys are validated against the per-kind allowlist in
+    # app/platform/dataset_origin.py, so nothing unexpected — a credential
+    # most of all — can reach the column. Callers pass their own payload
+    # rather than one being inferred here: an incomplete ref is visible in
+    # the stored JSON, whereas a plausible default would not be.
+    origin_ref: dict[str, Any] | None = None
 
 
 @dataclass
@@ -1368,6 +1377,17 @@ async def _finalize_ingest(ctx: IngestContext):
     dataset.record.record_status = final_status
     if final_status != "published":
         dataset.record.published_at = None
+
+    # feat(#1218): system-managed origin pointer, in the same transaction that
+    # creates the dataset. Service ingest supplies the enriched URL through
+    # ctx.source_url; an uploaded file has no remote origin to point at, so
+    # its origin_uri stays NULL and only the ref carries the filename.
+    set_dataset_origin(
+        dataset,
+        classify_origin(ctx.source_format),
+        uri=ctx.source_url,
+        **(ctx.origin_ref or {}),
+    )
 
     # Compute quality score (requires Dataset to exist for metadata checks)
     quality_score = await compute_quality_score(

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1810,6 +1810,13 @@ async def _apply_reupload_swap(
     # expired after flush, and the next read of dataset.last_refreshed_at then
     # lazy-loads against a session that may already be closed.
     dataset.last_refreshed_at = datetime.now(timezone.utc)
+    # fix(#1218 review r9): a service re-pull just contacted the remote origin,
+    # and last_checked_at is defined as the last origin contact of any kind —
+    # so a successful service refresh must move it with last_refreshed_at, in
+    # the same transaction. A file reupload contacts no origin and leaves it
+    # alone.
+    if classify_origin(source_format) == "service":
+        dataset.last_checked_at = dataset.last_refreshed_at
 
     quality_score = await compute_quality_score(
         session,

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1810,13 +1810,6 @@ async def _apply_reupload_swap(
     # expired after flush, and the next read of dataset.last_refreshed_at then
     # lazy-loads against a session that may already be closed.
     dataset.last_refreshed_at = datetime.now(timezone.utc)
-    # fix(#1218 review r9): a service re-pull just contacted the remote origin,
-    # and last_checked_at is defined as the last origin contact of any kind —
-    # so a successful service refresh must move it with last_refreshed_at, in
-    # the same transaction. A file reupload contacts no origin and leaves it
-    # alone.
-    if classify_origin(source_format) == "service":
-        dataset.last_checked_at = dataset.last_refreshed_at
 
     quality_score = await compute_quality_score(
         session,

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -163,6 +163,11 @@ async def create_raster_dataset(
         source_format="geotiff",
         source_filename=source_filename,
         srid=meta.get("epsg"),
+        # fix(#1218 review): see create_dataset — every creation path stamps
+        # this, or post-migration rows report null while backfilled ones do
+        # not. Python value, not func.now(): a SQL expression leaves the
+        # attribute expired and the next read lazy-loads.
+        last_refreshed_at=datetime.now(timezone.utc),
     )
     # feat(#1218): a raster dataset IS the COG; the pre-conversion upload is a
     # transient input, so the origin is the uploaded file and there is no

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -9,6 +9,7 @@ import structlog
 from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.core.tenancy import is_multi_tenant
 from app.platform.cache.tiles import invalidate_catalog_cache
+from app.platform.dataset_origin import set_dataset_origin
 from app.platform.jobs.heartbeat import (
     claim_job_attempt_and_start_heartbeat,
     require_ingest_job_update,
@@ -163,6 +164,10 @@ async def create_raster_dataset(
         source_filename=source_filename,
         srid=meta.get("epsg"),
     )
+    # feat(#1218): a raster dataset IS the COG; the pre-conversion upload is a
+    # transient input, so the origin is the uploaded file and there is no
+    # remote URI to point at (ADR-002 Decision 7).
+    set_dataset_origin(dataset, "upload", filename=source_filename)
     session.add(dataset)
     await session.flush()
 

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 
 from app.core.db.tenant_session import tenant_task
 from app.platform.cache.tiles import invalidate_catalog_cache
+from app.platform.dataset_origin import service_layer_identity
 from app.platform.jobs.heartbeat import (
     attempt_scoped_staging_table,
     claim_job_attempt_and_start_heartbeat,
@@ -765,13 +766,22 @@ async def reupload_service(
                 source_format=source_format,
                 original_srid=metadata.get("srid"),
                 source_url=reupload_source_url,
-                # fix(#1218 review): base URL and layer id stay separate, as
-                # on the first-ingest path, so a refresh can re-address the
-                # layer without re-parsing the enriched pointer.
+                # fix(#1218 review): base URL and layer identifier stay
+                # separate, as on the first-ingest path, so a refresh can
+                # re-address the layer without re-parsing the enriched pointer.
+                # fix(#1218 review r3): layer_id is the SERVICE-NATIVE
+                # identifier — the numeric id for ArcGIS, the typename or
+                # collection id otherwise. See the matching comment in
+                # tasks_vector.ingest_service for why build_gdal_source makes
+                # these mutually exclusive per service type.
                 origin_ref={
                     "service_type": source_format,
                     "url": source_url_value,
-                    "layer_id": None if layer_id is None else str(layer_id),
+                    "layer_id": service_layer_identity(
+                        source_format,
+                        layer_id=layer_id,
+                        layer_name=source_layer_value,
+                    ),
                 },
             )
             # Captured pre-commit: the ORM attribute may be expired after commit.

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -382,6 +382,10 @@ async def reupload_file(
                 source_format=source_format,
                 original_srid=srid,
                 file_hash=file_hash,
+                # fix(#1218 review): the new bytes came from a file, so the
+                # binding says upload — even when the dataset was originally
+                # a registered table or a service import.
+                origin_ref={"filename": source_filename, "file_hash": file_hash},
             )
             # Captured pre-commit: the ORM attribute may be expired after commit.
             live_table_name = dataset.table_name
@@ -761,6 +765,14 @@ async def reupload_service(
                 source_format=source_format,
                 original_srid=metadata.get("srid"),
                 source_url=reupload_source_url,
+                # fix(#1218 review): base URL and layer id stay separate, as
+                # on the first-ingest path, so a refresh can re-address the
+                # layer without re-parsing the enriched pointer.
+                origin_ref={
+                    "service_type": source_format,
+                    "url": source_url_value,
+                    "layer_id": None if layer_id is None else str(layer_id),
+                },
             )
             # Captured pre-commit: the ORM attribute may be expired after commit.
             live_table_name = dataset.table_name

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -584,6 +584,9 @@ async def ingest_file(
                     original_srid=srid,
                     user_metadata=um,
                     attempt_id=attempt_uuid,
+                    # feat(#1218): no file_hash — it is computed on the
+                    # re-upload path only, and the allowlist omits absent keys.
+                    origin_ref={"filename": source_filename},
                 )
             )
 
@@ -1014,6 +1017,14 @@ async def ingest_service(
                     user_metadata=um,
                     source_url=dataset_source_url,
                     attempt_id=attempt_uuid,
+                    # feat(#1218): the base URL and layer id stay separate here
+                    # so a refresh can re-address the layer without re-parsing
+                    # the enriched URI. No token: it is per-call and transient.
+                    origin_ref={
+                        "service_type": source_format,
+                        "url": source_url,
+                        "layer_id": None if layer_id is None else str(layer_id),
+                    },
                 )
             )
 

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -10,6 +10,7 @@ import structlog
 from sqlalchemy import text
 
 from app.core.db.tenant_session import tenant_task
+from app.platform.dataset_origin import service_layer_identity
 from app.platform.jobs.heartbeat import (
     attempt_scoped_staging_table,
     claim_job_attempt_and_start_heartbeat,
@@ -1017,13 +1018,28 @@ async def ingest_service(
                     user_metadata=um,
                     source_url=dataset_source_url,
                     attempt_id=attempt_uuid,
-                    # feat(#1218): the base URL and layer id stay separate here
-                    # so a refresh can re-address the layer without re-parsing
-                    # the enriched URI. No token: it is per-call and transient.
+                    # feat(#1218): the base URL and layer identifier stay
+                    # separate here so a refresh can re-address the layer
+                    # without re-parsing the enriched URI. No token: it is
+                    # per-call and transient.
+                    #
+                    # fix(#1218 review r3): layer_id carries the SERVICE-NATIVE
+                    # identifier, which is a different field per service type.
+                    # build_gdal_source is the authority: its ArcGIS branch
+                    # requires layer_id and ignores the layer name, while its
+                    # WFS and OGC API branches pass the layer NAME through and
+                    # ignore layer_id. So exactly one of the two identifies the
+                    # layer for any given service, and they cannot disagree.
+                    # Storing only the numeric id left WFS/OGC refs with no way
+                    # to name the layer at all once the ingest job aged out.
                     origin_ref={
                         "service_type": source_format,
                         "url": source_url,
-                        "layer_id": None if layer_id is None else str(layer_id),
+                        "layer_id": service_layer_identity(
+                            source_format,
+                            layer_id=layer_id,
+                            layer_name=source_layer,
+                        ),
                     },
                 )
             )

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -132,6 +132,13 @@ async def create_vrt_dataset(
         source_format=None,  # VRT datasets have no source_format (avoids chk constraint)
         source_filename=source_filename,
         srid=meta.get("epsg"),
+        # fix(#1218 review): stamped like every other creation path. A VRT has
+        # no origin (it is composed from other datasets), but assembling it IS
+        # a successful materialization, and migration 0036 backfills a
+        # timestamp onto pre-existing VRTs the same way. Python value, not
+        # func.now(): a SQL expression leaves the attribute expired and the
+        # next read lazy-loads.
+        last_refreshed_at=datetime.now(timezone.utc),
     )
     session.add(dataset)
     await session.flush()

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5284,6 +5284,19 @@
             "description": "ISO 639-1 language code, e.g. en, fr",
             "title": "Language"
           },
+          "last_checked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last time GeoLens contacted the origin at all, whether the attempt succeeded or failed",
+            "title": "Last Checked At"
+          },
           "last_edited_at": {
             "anyOf": [
               {
@@ -5306,6 +5319,19 @@
               }
             ],
             "title": "Last Edited By Display"
+          },
+          "last_refreshed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last committed successful refresh \u2014 not the last attempt",
+            "title": "Last Refreshed At"
           },
           "license": {
             "anyOf": [
@@ -5356,6 +5382,44 @@
             ],
             "description": "Number of coordinate dimensions (2, 3, or 4)",
             "title": "N Dims"
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "How the data entered the catalog: upload, postgis, service, stac, or created. Computed from source_format and record_type, not stored; null for collections and VRTs, which have no origin of their own.",
+            "title": "Origin"
+          },
+          "origin_ref": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Typed per-origin payload with a `kind` discriminator, e.g. {\"kind\": \"service\", \"service_type\": \"wfs\", \"url\": \"...\", \"layer_id\": \"0\"}. Never contains credentials.",
+            "title": "Origin Ref"
+          },
+          "origin_uri": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.",
+            "title": "Origin Uri"
           },
           "original_srid": {
             "anyOf": [
@@ -5444,6 +5508,12 @@
             "title": "Record Type",
             "type": "string"
           },
+          "schema_drift_status": {
+            "default": "unknown",
+            "description": "none, drifted, or unknown. Set at refresh commit from the schema diff; 'unknown' until a refresh has run.",
+            "title": "Schema Drift Status",
+            "type": "string"
+          },
           "sensitivity_classification": {
             "anyOf": [
               {
@@ -5478,6 +5548,24 @@
             ],
             "description": "Original file format, e.g. GPKG, SHP",
             "title": "Source Format"
+          },
+          "source_health": {
+            "default": "unknown",
+            "description": "healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an origin kind with nothing to probe.",
+            "title": "Source Health",
+            "type": "string"
+          },
+          "source_health_detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Short redacted reason for a non-healthy state",
+            "title": "Source Health Detail"
           },
           "source_organization": {
             "anyOf": [

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -679,6 +679,13 @@ class TestBackfill:
             )
             for statement in module.backfill_statements():
                 await test_db_session.execute(statement)
+            # upgrade() runs the authority pass right after the SQL, so every
+            # backfill test runs it too or it asserts on a half-built state.
+            await test_db_session.run_sync(
+                lambda sync_session: module.purge_credential_bearing_pointers(
+                    sync_session.connection()
+                )
+            )
 
             rows = {
                 row.id: row
@@ -834,6 +841,13 @@ class TestBackfill:
         try:
             for statement in module.backfill_statements():
                 await test_db_session.execute(statement)
+            # upgrade() runs the authority pass right after the SQL, so every
+            # backfill test runs it too or it asserts on a half-built state.
+            await test_db_session.run_sync(
+                lambda sync_session: module.purge_credential_bearing_pointers(
+                    sync_session.connection()
+                )
+            )
             row = (
                 await test_db_session.execute(
                     sa.text(
@@ -872,6 +886,13 @@ class TestBackfill:
         try:
             for statement in module.backfill_statements():
                 await test_db_session.execute(statement)
+            # upgrade() runs the authority pass right after the SQL, so every
+            # backfill test runs it too or it asserts on a half-built state.
+            await test_db_session.run_sync(
+                lambda sync_session: module.purge_credential_bearing_pointers(
+                    sync_session.connection()
+                )
+            )
             row = (
                 await test_db_session.execute(
                     sa.text(
@@ -947,6 +968,13 @@ class TestBackfill:
             )
             for statement in module.backfill_statements():
                 await test_db_session.execute(statement)
+            # upgrade() runs the authority pass right after the SQL, so every
+            # backfill test runs it too or it asserts on a half-built state.
+            await test_db_session.run_sync(
+                lambda sync_session: module.purge_credential_bearing_pointers(
+                    sync_session.connection()
+                )
+            )
 
             rows = (
                 await test_db_session.execute(
@@ -1016,6 +1044,13 @@ class TestBackfill:
             )
             for statement in module.backfill_statements():
                 await test_db_session.execute(statement)
+            # upgrade() runs the authority pass right after the SQL, so every
+            # backfill test runs it too or it asserts on a half-built state.
+            await test_db_session.run_sync(
+                lambda sync_session: module.purge_credential_bearing_pointers(
+                    sync_session.connection()
+                )
+            )
 
             rows = (
                 await test_db_session.execute(
@@ -1178,6 +1213,26 @@ class TestBackfill:
             )
         )
 
+        # fix(#1218 review r7): shapes the SQL pre-filter CANNOT express, so
+        # the Python authority pass is the only thing that catches them.
+        # has_url_credentials returns True whenever urlsplit REFUSES an
+        # authority, and both of these make it refuse.
+        fullwidth_at = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Fullwidth At",
+            source_format="wfs",
+        )
+        fullwidth_at.source_url = "https://bob:hunter2＠gis.test/geoserver/wfs"
+
+        malformed_authority = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Malformed Authority",
+            source_format="stac",
+        )
+        malformed_authority.source_url = "https://[::1/scene.tif"
+
         stac_cred = await _pre_migration_dataset(
             test_db_session,
             created_by=admin_id,
@@ -1191,6 +1246,13 @@ class TestBackfill:
         try:
             for statement in module.backfill_statements():
                 await test_db_session.execute(statement)
+            # upgrade() runs the authority pass right after the SQL, so every
+            # backfill test runs it too or it asserts on a half-built state.
+            await test_db_session.run_sync(
+                lambda sync_session: module.purge_credential_bearing_pointers(
+                    sync_session.connection()
+                )
+            )
             rows = {
                 r.id: r
                 for r in (
@@ -1213,6 +1275,8 @@ class TestBackfill:
                                     plus_name.id,
                                     plus_name_stac.id,
                                     space_name.id,
+                                    fullwidth_at.id,
+                                    malformed_authority.id,
                                 ],
                             )
                         )
@@ -1229,6 +1293,8 @@ class TestBackfill:
                 plus_name,
                 plus_name_stac,
                 space_name,
+                fullwidth_at,
+                malformed_authority,
             ):
                 row = rows[unsafe.id]
                 assert row.origin_uri is None, f"{row.source_url} was frozen in"

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -123,10 +123,19 @@ class TestClassifyOrigin:
         assert classify_origin("stac", "raster_dataset") == "stac"
         assert classify_origin("created", "vector_dataset") == "created"
 
-    def test_absent_source_format_means_referenced_in_place(self) -> None:
-        """Registration stores no source_format — null is postgis, not unknown."""
-        assert classify_origin(None, "vector_dataset") == "postgis"
-        assert classify_origin("", "vector_dataset") == "postgis"
+    @pytest.mark.parametrize("record_type", ["vector_dataset", "table"])
+    def test_absent_source_format_means_referenced_in_place(
+        self, record_type: str
+    ) -> None:
+        """Registration stores no source_format — null is postgis, not unknown.
+
+        Both record types registration can produce are covered: create_dataset
+        assigns 'table' when the source has no geometry and 'vector_dataset'
+        otherwise, and register_existing_table stamps a postgis origin either
+        way. Asserted rather than assumed (#1218 review).
+        """
+        assert classify_origin(None, record_type) == "postgis"
+        assert classify_origin("", record_type) == "postgis"
 
     def test_record_type_defaults_to_vector_dataset(self) -> None:
         assert classify_origin("gpkg") == "upload"
@@ -456,6 +465,34 @@ class TestResponseExposure:
         # Computed, not stored — the column does not exist.
         assert body["origin"] == "upload"
 
+    @pytest.mark.parametrize("record_type", ["vector_dataset", "table"])
+    async def test_registered_table_reports_postgis_origin(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        record_type: str,
+    ) -> None:
+        """A registered table serves origin=postgis whether or not it has geometry.
+
+        The non-spatial half is the one worth pinning: create_dataset gives a
+        geometry-less registration record_type='table', and nothing else in
+        the suite would notice if that started classifying as an upload.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name=f"Registered {record_type}",
+            source_format=None,
+        )
+        ds.record.record_type = record_type
+        await test_db_session.commit()
+
+        resp = await client.get(f"/datasets/{ds.id}", headers=admin_auth_header)
+        assert resp.status_code == 200
+        assert resp.json()["origin"] == "postgis"
+
     async def test_stored_state_reaches_the_response(
         self,
         client: AsyncClient,
@@ -556,6 +593,20 @@ class TestBackfill:
             table_name="backfill_registered_tbl",
         )
 
+        # A geometry-less registration: create_dataset gives it
+        # record_type='table'. Covered because register_existing_table stamps
+        # the origin either way, so a backfill restricted to 'vector_dataset'
+        # would leave these permanently different from post-migration
+        # registrations (#1218 review).
+        nonspatial = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill Registered Nonspatial",
+            source_format=None,
+            table_name="backfill_nonspatial_tbl",
+        )
+        nonspatial.record.record_type = "table"
+
         upload = await _pre_migration_dataset(
             test_db_session,
             created_by=admin_id,
@@ -592,6 +643,9 @@ class TestBackfill:
             await test_db_session.execute(
                 sa.text("CREATE TABLE data.backfill_registered_tbl (id integer)")
             )
+            await test_db_session.execute(
+                sa.text("CREATE TABLE data.backfill_nonspatial_tbl (id integer)")
+            )
             for statement in module.backfill_statements():
                 await test_db_session.execute(statement)
 
@@ -611,6 +665,7 @@ class TestBackfill:
                                     prose.id,
                                     stac.id,
                                     registered.id,
+                                    nonspatial.id,
                                     upload.id,
                                     created.id,
                                     orphan.id,
@@ -657,6 +712,15 @@ class TestBackfill:
             assert registered_row.origin_ref == {
                 "kind": "postgis",
                 "table_name": "data.backfill_registered_tbl",
+            }
+
+            nonspatial_row = rows[nonspatial.id]
+            assert nonspatial_row.origin_uri == (
+                "postgis://data.backfill_nonspatial_tbl"
+            )
+            assert nonspatial_row.origin_ref == {
+                "kind": "postgis",
+                "table_name": "data.backfill_nonspatial_tbl",
             }
 
             upload_row = rows[upload.id]

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -1,0 +1,770 @@
+"""Source-origin and refresh-state fields on Dataset (#1218, ADR-002).
+
+Four properties this suite exists to hold:
+
+1. The origin-pointer columns are CLOSED to the metadata PATCH. Two URL-ish
+   fields now live on `datasets` — user-editable `source_url` and
+   system-managed `origin_uri` — and the whole design rests on the second
+   being unreachable from a request body.
+2. `origin_ref` can only ever hold the keys its kind declares, which is what
+   keeps a credential out of the binding (ADR-002 invariant 4) and external
+   PostGIS federation out of v1 (gate 2).
+3. NULL is the only stored spelling of "never determined"; "unknown" exists
+   only on the wire.
+4. The migration's backfill produces the documented shapes. The DB test runs
+   the migration's OWN statements rather than a copy of them.
+
+Each refusal is paired with an admission: a guard that starts rejecting valid
+input fails silently otherwise, because nothing in a refusal assertion notices
+it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from httpx import AsyncClient
+
+import app.modules.catalog.datasets.domain.models  # noqa: F401
+from app.core.db import Base
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.dataset_origin import (
+    ORIGIN_KINDS,
+    ORIGIN_REF_KEYS,
+    SCHEMA_DRIFT_STATUS_VALUES,
+    SERVICE_SOURCE_FORMATS,
+    SOURCE_HEALTH_VALUES,
+    UNKNOWN,
+    build_origin_ref,
+    classify_origin,
+    project_unknown,
+    set_dataset_origin,
+    set_postgis_origin,
+)
+from tests.factories import create_dataset as _create_dataset, get_user_id
+
+# Formats that are neither service, nor stac, nor created — every one of them
+# means "GeoLens holds a copy of bytes somebody uploaded".
+_UPLOAD_FORMATS = (
+    "geojson",
+    "shapefile",
+    "shp",
+    "gpkg",
+    "csv",
+    "kml",
+    "gml",
+    "fgdb",
+    "geotiff",
+    "parquet",
+    "json",
+    "xlsx",
+    "xls",
+)
+
+# Key names an attacker or a careless caller would most plausibly try to smuggle
+# through. None appears in any kind's allowlist, so all of them must raise.
+_SECRET_SHAPED_KEYS = (
+    "token",
+    "password",
+    "authorization",
+    "api_key",
+    "secret",
+    "access_key",
+    "credentials",
+)
+
+# The seven columns this issue adds. Named once so the PATCH test cannot
+# quietly cover fewer fields than it claims.
+_SOURCE_STATE_COLUMNS = (
+    "origin_uri",
+    "origin_ref",
+    "last_refreshed_at",
+    "last_checked_at",
+    "source_health",
+    "source_health_detail",
+    "schema_drift_status",
+)
+
+
+def _load_migration():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "0036_dataset_source_state.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0036", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Origin classification — derived, never stored
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyOrigin:
+    @pytest.mark.parametrize("source_format", sorted(SERVICE_SOURCE_FORMATS))
+    def test_service_formats_classify_as_service(self, source_format: str) -> None:
+        assert classify_origin(source_format, "vector_dataset") == "service"
+
+    @pytest.mark.parametrize("source_format", _UPLOAD_FORMATS)
+    def test_upload_formats_classify_as_upload(self, source_format: str) -> None:
+        assert classify_origin(source_format, "vector_dataset") == "upload"
+
+    def test_stac_and_created_keep_their_own_names(self) -> None:
+        assert classify_origin("stac", "raster_dataset") == "stac"
+        assert classify_origin("created", "vector_dataset") == "created"
+
+    def test_absent_source_format_means_referenced_in_place(self) -> None:
+        """Registration stores no source_format — null is postgis, not unknown."""
+        assert classify_origin(None, "vector_dataset") == "postgis"
+        assert classify_origin("", "vector_dataset") == "postgis"
+
+    def test_record_type_defaults_to_vector_dataset(self) -> None:
+        assert classify_origin("gpkg") == "upload"
+
+    @pytest.mark.parametrize("record_type", ["collection", "vrt_dataset"])
+    def test_composed_and_container_types_have_no_origin(
+        self, record_type: str
+    ) -> None:
+        """A VRT is built from other datasets; a collection has no dataset row."""
+        assert classify_origin(None, record_type) is None
+        assert classify_origin("geotiff", record_type) is None
+
+    def test_raster_record_type_does_not_suppress_its_origin(self) -> None:
+        """The other direction: only collection/vrt are origin-less."""
+        assert classify_origin("geotiff", "raster_dataset") == "upload"
+        assert classify_origin("gpkg", "table") == "upload"
+
+    def test_every_classification_is_a_declared_kind(self) -> None:
+        formats = [None, "created", "stac", *SERVICE_SOURCE_FORMATS, *_UPLOAD_FORMATS]
+        for source_format in formats:
+            assert classify_origin(source_format, "vector_dataset") in ORIGIN_KINDS
+
+
+# ---------------------------------------------------------------------------
+# origin_ref allowlist — invariant 4 and gate 2
+# ---------------------------------------------------------------------------
+
+
+class TestOriginRefAllowlist:
+    @pytest.mark.parametrize("kind", sorted(ORIGIN_REF_KEYS))
+    @pytest.mark.parametrize("key", _SECRET_SHAPED_KEYS)
+    def test_secret_shaped_keys_are_rejected_for_every_kind(
+        self, kind: str, key: str
+    ) -> None:
+        with pytest.raises(ValueError, match="rejects key"):
+            build_origin_ref(kind, **{key: "hunter2"})
+
+    @pytest.mark.parametrize("kind", sorted(ORIGIN_REF_KEYS))
+    def test_declared_keys_are_still_accepted(self, kind: str) -> None:
+        """The admission half: a rejection rule that over-fires is silent."""
+        fields = {key: f"value-{key}" for key in ORIGIN_REF_KEYS[kind]}
+        ref = build_origin_ref(kind, **fields)
+        if not fields:
+            # `created` declares no keys and therefore has no payload at all.
+            assert ref is None
+            return
+        assert ref is not None
+        assert ref["kind"] == kind
+        assert set(ref) == {"kind", *fields}
+
+    @pytest.mark.parametrize(
+        "key", ["host", "port", "dsn", "username", "connection_string", "database"]
+    )
+    def test_postgis_ref_admits_no_connection_detail(self, key: str) -> None:
+        """Gate 2: federation needs a new origin kind, not a wider blob."""
+        with pytest.raises(ValueError, match="rejects key"):
+            build_origin_ref("postgis", **{key: "db.internal"})
+
+    def test_postgis_ref_holds_only_the_table_name(self) -> None:
+        assert ORIGIN_REF_KEYS["postgis"] == frozenset({"table_name"})
+        assert build_origin_ref("postgis", table_name="data.parcels") == {
+            "kind": "postgis",
+            "table_name": "data.parcels",
+        }
+
+    def test_absent_values_are_omitted_not_stored_as_null(self) -> None:
+        """A file ingested before hashing existed simply has no file_hash key."""
+        assert build_origin_ref("upload", filename="parcels.gpkg", file_hash=None) == {
+            "kind": "upload",
+            "filename": "parcels.gpkg",
+        }
+
+    def test_created_carries_no_payload(self) -> None:
+        assert build_origin_ref("created") is None
+
+    def test_unknown_kind_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown origin kind"):
+            build_origin_ref("federated_postgis", table_name="x")
+
+    def test_service_ref_keeps_url_and_layer_id_separate(self) -> None:
+        ref = build_origin_ref(
+            "service",
+            service_type="arcgis_featureserver",
+            url="https://example.test/arcgis/rest/services/Parcels/FeatureServer",
+            layer_id="0",
+        )
+        assert ref == {
+            "kind": "service",
+            "layer_id": "0",
+            "service_type": "arcgis_featureserver",
+            "url": "https://example.test/arcgis/rest/services/Parcels/FeatureServer",
+        }
+
+
+class TestSetDatasetOrigin:
+    def test_writes_both_columns(self) -> None:
+        dataset = Dataset(record_id=uuid.uuid4(), table_name="ds_x")
+        set_dataset_origin(
+            dataset, "stac", uri="https://example.test/a.tif", asset_href="https://e/a"
+        )
+        assert dataset.origin_uri == "https://example.test/a.tif"
+        assert dataset.origin_ref == {"kind": "stac", "asset_href": "https://e/a"}
+
+    def test_upload_has_no_uri(self) -> None:
+        dataset = Dataset(record_id=uuid.uuid4(), table_name="ds_x")
+        set_dataset_origin(dataset, "upload", filename="parcels.gpkg")
+        assert dataset.origin_uri is None
+        assert dataset.origin_ref == {"kind": "upload", "filename": "parcels.gpkg"}
+
+    def test_unknown_kind_raises_before_touching_the_row(self) -> None:
+        dataset = Dataset(record_id=uuid.uuid4(), table_name="ds_x")
+        with pytest.raises(ValueError, match="unknown origin kind"):
+            set_dataset_origin(dataset, "sftp", uri="sftp://host/x")
+        assert dataset.origin_uri is None
+        assert dataset.origin_ref is None
+
+    def test_postgis_pointer_and_ref_name_the_same_table(self) -> None:
+        """Two spellings of one fact; set_postgis_origin owns keeping them equal."""
+        dataset = Dataset(record_id=uuid.uuid4(), table_name="parcels")
+        set_postgis_origin(dataset, "parcels", None)
+        assert dataset.origin_uri == "postgis://data.parcels"
+        assert dataset.origin_ref == {"kind": "postgis", "table_name": "data.parcels"}
+        assert dataset.origin_uri == f"postgis://{dataset.origin_ref['table_name']}"
+
+    def test_postgis_origin_follows_the_ingest_schema_resolver(
+        self, monkeypatch
+    ) -> None:
+        """A tenant's table lives in its own schema and the pointer must say so.
+
+        Single-tenant is the default here, and `tenant_data_schema` returns
+        the shared `data` schema in that mode whatever tenant_id holds, so
+        asserting only the default would never exercise the tenant branch.
+        """
+        monkeypatch.setattr("app.core.tenancy.is_multi_tenant", lambda: True)
+        tenant = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        dataset = Dataset(record_id=uuid.uuid4(), table_name="parcels")
+        set_postgis_origin(dataset, "parcels", tenant)
+        assert dataset.origin_uri == (
+            "postgis://data_t_aaaaaaaa_bbbb_cccc_dddd_eeeeeeeeeeee.parcels"
+        )
+        assert dataset.origin_ref["table_name"] == (
+            "data_t_aaaaaaaa_bbbb_cccc_dddd_eeeeeeeeeeee.parcels"
+        )
+
+
+# ---------------------------------------------------------------------------
+# NULL is the only stored spelling of "never determined"
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownProjection:
+    def test_unknown_is_not_storable(self) -> None:
+        assert UNKNOWN not in SOURCE_HEALTH_VALUES
+        assert UNKNOWN not in SCHEMA_DRIFT_STATUS_VALUES
+
+    def test_check_constraints_exclude_unknown(self) -> None:
+        table = Base.metadata.tables["catalog.datasets"]
+        constraints = {
+            c.name: str(c.sqltext)
+            for c in table.constraints
+            if isinstance(c, sa.CheckConstraint) and c.name
+        }
+        for name in ("chk_datasets_source_health", "chk_datasets_schema_drift_status"):
+            assert f"'{UNKNOWN}'" not in constraints[name]
+
+    def test_null_projects_to_unknown_and_values_pass_through(self) -> None:
+        assert project_unknown(None) == UNKNOWN
+        for value in (*SOURCE_HEALTH_VALUES, *SCHEMA_DRIFT_STATUS_VALUES):
+            assert project_unknown(value) == value
+
+
+# ---------------------------------------------------------------------------
+# ORM shape and migration structure — no database required
+# ---------------------------------------------------------------------------
+
+
+class TestOrmAndMigrationShape:
+    def test_orm_declares_every_source_state_column_as_nullable(self) -> None:
+        table = Base.metadata.tables["catalog.datasets"]
+        for name in _SOURCE_STATE_COLUMNS:
+            assert name in table.columns, f"missing column {name}"
+            assert table.columns[name].nullable is True
+
+    def test_health_and_drift_check_constraints_match_the_adr(self) -> None:
+        table = Base.metadata.tables["catalog.datasets"]
+        constraints = {
+            c.name: " ".join(str(c.sqltext).split())
+            for c in table.constraints
+            if isinstance(c, sa.CheckConstraint) and c.name
+        }
+        assert constraints["chk_datasets_source_health"] == (
+            "source_health IS NULL OR source_health IN "
+            "('healthy', 'missing', 'inaccessible')"
+        )
+        assert constraints["chk_datasets_schema_drift_status"] == (
+            "schema_drift_status IS NULL OR schema_drift_status IN ('none', 'drifted')"
+        )
+
+    def test_origin_uri_partial_index_exists(self) -> None:
+        table = Base.metadata.tables["catalog.datasets"]
+        matches = [i for i in table.indexes if i.name == "ix_datasets_origin_uri"]
+        assert len(matches) == 1
+        index = matches[0]
+        assert [c.name for c in index.columns] == ["origin_uri"]
+        predicate = index.dialect_options["postgresql"]["where"]
+        assert str(predicate) == "origin_uri IS NOT NULL"
+
+    def test_migration_chains_onto_the_quality_score_drop(self) -> None:
+        module = _load_migration()
+        assert module.revision == "0036_dataset_source_state"
+        assert module.down_revision == "0035_drop_quality_score_numeric"
+
+    def test_downgrade_drops_every_column_the_upgrade_adds(self) -> None:
+        module = _load_migration()
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "alembic"
+            / "versions"
+            / "0036_dataset_source_state.py"
+        ).read_text(encoding="utf-8")
+        for name in _SOURCE_STATE_COLUMNS:
+            assert f'sa.Column("{name}"' in source, f"upgrade never adds {name}"
+            assert f'"{name}",' in source, f"downgrade never drops {name}"
+        assert len(module.backfill_statements()) == 5
+
+
+# ---------------------------------------------------------------------------
+# The PATCH write path stays closed
+# ---------------------------------------------------------------------------
+
+
+_SENTINEL_STATE = {
+    "origin_uri": "https://origin.test/services/Parcels/FeatureServer/0",
+    "origin_ref": {"kind": "service", "service_type": "wfs", "url": "https://o.test"},
+    "last_refreshed_at": datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+    "last_checked_at": datetime(2026, 1, 2, 3, 4, 6, tzinfo=timezone.utc),
+    "source_health": "healthy",
+    "source_health_detail": "probe ok",
+    "schema_drift_status": "none",
+}
+
+_ATTACKER_BODY = {
+    "origin_uri": "https://attacker.test/evil",
+    "origin_ref": {"kind": "service", "token": "leaked"},
+    "last_refreshed_at": "2030-01-01T00:00:00Z",
+    "last_checked_at": "2030-01-01T00:00:00Z",
+    "source_health": "missing",
+    "source_health_detail": "attacker supplied",
+    "schema_drift_status": "drifted",
+    "origin": "postgis",
+}
+
+
+class TestPatchCannotReachSourceState:
+    async def test_patch_ignores_every_source_state_field(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        """Refusal AND admission in one request: the editable field must land."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Origin PATCH Guard",
+            source_format="wfs",
+        )
+        for attr, value in _SENTINEL_STATE.items():
+            setattr(ds, attr, value)
+        ds.source_url = "https://origin.test/describe"
+        await test_db_session.commit()
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={
+                **_ATTACKER_BODY,
+                # The control: a field that IS in _DATASET_FIELD_MAP. Without
+                # it, a PATCH rejected wholesale would pass this test.
+                "source_url": "https://edited.test/describe",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["source_url"] == "https://edited.test/describe"
+
+        await test_db_session.refresh(ds)
+        for attr, value in _SENTINEL_STATE.items():
+            assert getattr(ds, attr) == value, f"PATCH mutated {attr}"
+
+    async def test_dataset_meta_schema_declares_no_source_state_field(self) -> None:
+        """Structural half: the fields are absent from the request model too.
+
+        The runtime test above proves today's handler ignores them. This one
+        keeps a future field from being added to DatasetMeta and silently
+        wired through _apply_simple_field_assignments.
+        """
+        from app.modules.catalog.datasets.domain.schemas import DatasetMeta
+
+        for name in (*_SOURCE_STATE_COLUMNS, "origin"):
+            assert name not in DatasetMeta.model_fields
+
+
+class TestResponseExposure:
+    async def test_never_probed_dataset_reports_unknown(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Never Probed",
+            source_format="gpkg",
+        )
+        await test_db_session.commit()
+
+        resp = await client.get(f"/datasets/{ds.id}", headers=admin_auth_header)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["source_health"] == UNKNOWN
+        assert body["schema_drift_status"] == UNKNOWN
+        assert body["last_refreshed_at"] is None
+        assert body["origin_uri"] is None
+        # Computed, not stored — the column does not exist.
+        assert body["origin"] == "upload"
+
+    async def test_stored_state_reaches_the_response(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Probed Service",
+            source_format="arcgis_featureserver",
+        )
+        for attr, value in _SENTINEL_STATE.items():
+            setattr(ds, attr, value)
+        await test_db_session.commit()
+
+        resp = await client.get(f"/datasets/{ds.id}", headers=admin_auth_header)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["origin"] == "service"
+        assert body["origin_uri"] == _SENTINEL_STATE["origin_uri"]
+        assert body["origin_ref"] == _SENTINEL_STATE["origin_ref"]
+        assert body["source_health"] == "healthy"
+        assert body["schema_drift_status"] == "none"
+        assert body["source_health_detail"] == "probe ok"
+        assert body["last_refreshed_at"].startswith("2026-01-02T03:04:05")
+
+
+# ---------------------------------------------------------------------------
+# Backfill, against pre-migration-shaped rows
+# ---------------------------------------------------------------------------
+
+
+async def _pre_migration_dataset(session, *, created_by, **kwargs) -> Dataset:
+    """A dataset row as it looked before 0036 ran: source columns, no origin."""
+    ds = await _create_dataset(session, created_by=created_by, **kwargs)
+    for name in _SOURCE_STATE_COLUMNS:
+        setattr(ds, name, None)
+    await session.flush()
+    return ds
+
+
+class TestBackfill:
+    async def test_backfill_derives_each_origin_shape(self, test_db_session) -> None:
+        """Runs migration 0036's OWN statements, then rolls them back.
+
+        The statements are unscoped UPDATEs over catalog.datasets — that is
+        what a migration is — so they run inside a savepoint that is discarded.
+        Leaving them committed would rewrite every other test's rows on this
+        shared per-worker database.
+        """
+        module = _load_migration()
+        admin_id = await get_user_id(test_db_session, "admin")
+
+        arcgis = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill ArcGIS",
+            source_format="arcgis_featureserver",
+        )
+        arcgis.source_url = (
+            "https://gis.test/arcgis/rest/services/Parcels/FeatureServer/7"
+        )
+
+        wfs = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill WFS",
+            source_format="wfs",
+        )
+        wfs.source_url = "https://gis.test/geoserver/wfs"
+
+        # A user PATCHed source_url to prose before the migration ran. A
+        # pointer that does not parse must stay NULL rather than be
+        # backfilled into a refresh that can never work.
+        prose = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill Prose",
+            source_format="wfs",
+        )
+        prose.source_url = "Downloaded from the county GIS portal in March"
+
+        stac = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill STAC",
+            source_format="stac",
+        )
+        stac.source_url = "https://stac.test/items/abc/asset.tif"
+
+        registered = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill Registered",
+            source_format=None,
+            table_name="backfill_registered_tbl",
+        )
+
+        upload = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill Upload",
+            source_format="gpkg",
+            source_filename="parcels.gpkg",
+        )
+
+        created = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill Created",
+            source_format="created",
+        )
+
+        # Registered-shaped catalog row whose physical table is gone. A
+        # pointer at a table that does not exist is worse than none, because
+        # NULL at least reads as "unknown".
+        orphan = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill Orphan",
+            source_format=None,
+            table_name="backfill_orphan_tbl_absent",
+        )
+        await test_db_session.flush()
+
+        savepoint = await test_db_session.begin_nested()
+        try:
+            # The postgis backfill reads the physical table's schema out of
+            # pg_class rather than computing one from tenant_id, so the table
+            # has to exist. DDL is transactional, so the savepoint rollback
+            # takes it away again.
+            await test_db_session.execute(
+                sa.text("CREATE TABLE data.backfill_registered_tbl (id integer)")
+            )
+            for statement in module.backfill_statements():
+                await test_db_session.execute(statement)
+
+            rows = {
+                row.id: row
+                for row in (
+                    await test_db_session.execute(
+                        sa.text(
+                            "SELECT id, origin_uri, origin_ref, last_refreshed_at "
+                            "FROM catalog.datasets WHERE id = ANY(:ids)"
+                        ).bindparams(
+                            sa.bindparam(
+                                "ids",
+                                value=[
+                                    arcgis.id,
+                                    wfs.id,
+                                    prose.id,
+                                    stac.id,
+                                    registered.id,
+                                    upload.id,
+                                    created.id,
+                                    orphan.id,
+                                ],
+                            )
+                        )
+                    )
+                ).all()
+            }
+
+            arcgis_row = rows[arcgis.id]
+            assert arcgis_row.origin_uri == arcgis.source_url
+            assert arcgis_row.origin_ref == {
+                "kind": "service",
+                "service_type": "arcgis_featureserver",
+                "url": "https://gis.test/arcgis/rest/services/Parcels/FeatureServer",
+                "layer_id": "7",
+            }
+
+            wfs_row = rows[wfs.id]
+            assert wfs_row.origin_uri == wfs.source_url
+            assert wfs_row.origin_ref == {
+                "kind": "service",
+                "service_type": "wfs",
+                "url": "https://gis.test/geoserver/wfs",
+            }
+            assert "layer_id" not in wfs_row.origin_ref
+
+            prose_row = rows[prose.id]
+            assert prose_row.origin_uri is None
+            assert prose_row.origin_ref is None
+
+            stac_row = rows[stac.id]
+            assert stac_row.origin_uri == stac.source_url
+            assert stac_row.origin_ref == {
+                "kind": "stac",
+                "asset_href": "https://stac.test/items/abc/asset.tif",
+            }
+
+            registered_row = rows[registered.id]
+            assert registered_row.origin_uri == (
+                "postgis://data.backfill_registered_tbl"
+            )
+            assert registered_row.origin_ref == {
+                "kind": "postgis",
+                "table_name": "data.backfill_registered_tbl",
+            }
+
+            upload_row = rows[upload.id]
+            assert upload_row.origin_uri is None, "an upload has no remote origin"
+            assert upload_row.origin_ref == {
+                "kind": "upload",
+                "filename": "parcels.gpkg",
+            }
+
+            created_row = rows[created.id]
+            assert created_row.origin_uri is None
+            assert created_row.origin_ref is None
+
+            orphan_row = rows[orphan.id]
+            assert orphan_row.origin_uri is None
+            assert orphan_row.origin_ref is None
+
+            # Every row gets a last_refreshed_at floor from its record.
+            for row in rows.values():
+                assert row.last_refreshed_at is not None
+        finally:
+            await savepoint.rollback()
+
+    async def test_backfill_prefers_the_newest_version_upload(
+        self, test_db_session
+    ) -> None:
+        """Version history beats records.created_at — a re-upload IS a refresh."""
+        from app.modules.catalog.collections.models import DatasetVersion
+
+        module = _load_migration()
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill Versioned",
+            source_format="gpkg",
+            source_filename="v.gpkg",
+        )
+        newest = datetime.now(timezone.utc) + timedelta(days=1)
+        test_db_session.add_all(
+            [
+                DatasetVersion(
+                    dataset_id=ds.id,
+                    version_number=1,
+                    uploaded_at=newest - timedelta(days=2),
+                    file_hash="older-hash",
+                ),
+                DatasetVersion(
+                    dataset_id=ds.id,
+                    version_number=2,
+                    uploaded_at=newest,
+                    file_hash="newest-hash",
+                ),
+            ]
+        )
+        await test_db_session.flush()
+
+        savepoint = await test_db_session.begin_nested()
+        try:
+            for statement in module.backfill_statements():
+                await test_db_session.execute(statement)
+            row = (
+                await test_db_session.execute(
+                    sa.text(
+                        "SELECT origin_ref, last_refreshed_at "
+                        "FROM catalog.datasets WHERE id = :id"
+                    ).bindparams(sa.bindparam("id", value=ds.id))
+                )
+            ).one()
+            assert row.origin_ref["file_hash"] == "newest-hash"
+            assert row.last_refreshed_at == newest
+        finally:
+            await savepoint.rollback()
+
+    async def test_backfill_leaves_vrt_datasets_alone(self, test_db_session) -> None:
+        """A VRT stores a null source_format too; record_type is what excludes it."""
+        module = _load_migration()
+        admin_id = await get_user_id(test_db_session, "admin")
+        record = Record(
+            title="Backfill VRT",
+            record_type="vrt_dataset",
+            visibility="private",
+            record_status="published",
+            created_by=admin_id,
+        )
+        test_db_session.add(record)
+        await test_db_session.flush()
+        vrt = Dataset(
+            record_id=record.id,
+            table_name=f"vrt_{uuid.uuid4().hex[:12]}",
+            source_format=None,
+        )
+        test_db_session.add(vrt)
+        await test_db_session.flush()
+
+        savepoint = await test_db_session.begin_nested()
+        try:
+            for statement in module.backfill_statements():
+                await test_db_session.execute(statement)
+            row = (
+                await test_db_session.execute(
+                    sa.text(
+                        "SELECT origin_uri, origin_ref FROM catalog.datasets "
+                        "WHERE id = :id"
+                    ).bindparams(sa.bindparam("id", value=vrt.id))
+                )
+            ).one()
+            assert row.origin_uri is None
+            assert row.origin_ref is None
+        finally:
+            await savepoint.rollback()

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -1516,6 +1516,9 @@ class TestReuploadRestampsTheBinding:
         # The user-editable prose field is NOT collateral damage.
         assert ds.source_url == "https://descriptive.test/about-this-layer"
         assert ds.last_refreshed_at is not None and ds.last_refreshed_at > stale
+        # fix(#1218 review r9): a file reupload contacts no origin, so the
+        # last-origin-contact stamp must NOT move.
+        assert ds.last_checked_at is None
 
     async def test_service_reupload_stays_a_service_origin(
         self, test_db_session
@@ -1560,6 +1563,12 @@ class TestReuploadRestampsTheBinding:
             "url": "https://gis.test/geoserver/wfs",
         }
         assert ds.origin_uri == "https://gis.test/geoserver/wfs"
+        # fix(#1218 review r9): the re-pull just contacted the remote origin,
+        # and last_checked_at is the last origin contact of any kind — a
+        # successful service refresh moves it with last_refreshed_at, in the
+        # same transaction.
+        assert ds.last_checked_at is not None
+        assert ds.last_checked_at == ds.last_refreshed_at
 
     async def test_reupload_ref_still_goes_through_the_allowlist(
         self, test_db_session

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -1516,9 +1516,6 @@ class TestReuploadRestampsTheBinding:
         # The user-editable prose field is NOT collateral damage.
         assert ds.source_url == "https://descriptive.test/about-this-layer"
         assert ds.last_refreshed_at is not None and ds.last_refreshed_at > stale
-        # fix(#1218 review r9): a file reupload contacts no origin, so the
-        # last-origin-contact stamp must NOT move.
-        assert ds.last_checked_at is None
 
     async def test_service_reupload_stays_a_service_origin(
         self, test_db_session
@@ -1563,12 +1560,6 @@ class TestReuploadRestampsTheBinding:
             "url": "https://gis.test/geoserver/wfs",
         }
         assert ds.origin_uri == "https://gis.test/geoserver/wfs"
-        # fix(#1218 review r9): the re-pull just contacted the remote origin,
-        # and last_checked_at is the last origin contact of any kind — a
-        # successful service refresh moves it with last_refreshed_at, in the
-        # same transaction.
-        assert ds.last_checked_at is not None
-        assert ds.last_checked_at == ds.last_refreshed_at
 
     async def test_reupload_ref_still_goes_through_the_allowlist(
         self, test_db_session

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -1035,6 +1035,135 @@ class TestBackfill:
         finally:
             await savepoint.rollback()
 
+    async def test_credential_bearing_urls_are_never_frozen_into_the_pointer(
+        self, test_db_session
+    ) -> None:
+        """A legacy secret must not be copied into a read-only column.
+
+        fix(#1218 review r5): source_url is PATCHable, so an operator who
+        spots a credential in it can edit it away. origin_uri and origin_ref
+        are read-only on DatasetResponse, so a secret copied there is stuck.
+        New ingests cannot produce one — _validate_service_url refuses both
+        shapes at submission (sources/schemas.py:91) — but rows predating that
+        gate still hold them.
+        """
+        module = _load_migration()
+        admin_id = await get_user_id(test_db_session, "admin")
+
+        userinfo = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Userinfo",
+            source_format="wfs",
+        )
+        userinfo.source_url = "https://bob:hunter2@gis.test/geoserver/wfs"
+
+        token_param = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Token Param",
+            source_format="arcgis_featureserver",
+        )
+        token_param.source_url = (
+            "https://gis.test/rest/services/P/FeatureServer/3?token=hunter2"
+        )
+
+        # The admission half: a benign query param must still backfill, or the
+        # guard has quietly stopped every legacy service row from resolving.
+        benign = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Benign Query",
+            source_format="wfs",
+        )
+        benign.source_url = "https://gis.test/geoserver/wfs?service=WFS&version=2.0.0"
+        test_db_session.add(
+            IngestJob(
+                dataset_id=benign.id,
+                status="complete",
+                source_url="https://gis.test/geoserver/wfs?service=WFS&version=2.0.0",
+                source_layer="topp:benign",
+                created_by=admin_id,
+            )
+        )
+
+        # A clean dataset URL whose recovered JOB url carries the secret: the
+        # guard has to cover that second source too, not just the first.
+        dirty_job = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Dirty Job",
+            source_format="wfs",
+        )
+        dirty_job.source_url = "https://gis.test/geoserver/wfs/topp:secret"
+        test_db_session.add(
+            IngestJob(
+                dataset_id=dirty_job.id,
+                status="complete",
+                source_url="https://svc:pw@gis.test/geoserver/wfs",
+                source_layer="topp:secret",
+                created_by=admin_id,
+            )
+        )
+
+        stac_cred = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred STAC Presigned",
+            source_format="stac",
+        )
+        stac_cred.source_url = "https://bucket.test/scene.tif?X-Amz-Signature=deadbeef"
+        await test_db_session.flush()
+
+        savepoint = await test_db_session.begin_nested()
+        try:
+            for statement in module.backfill_statements():
+                await test_db_session.execute(statement)
+            rows = {
+                r.id: r
+                for r in (
+                    await test_db_session.execute(
+                        sa.text(
+                            "SELECT id, source_url, origin_uri, origin_ref "
+                            "FROM catalog.datasets WHERE id = ANY(:ids)"
+                        ).bindparams(
+                            sa.bindparam(
+                                "ids",
+                                value=[
+                                    userinfo.id,
+                                    token_param.id,
+                                    benign.id,
+                                    dirty_job.id,
+                                    stac_cred.id,
+                                ],
+                            )
+                        )
+                    )
+                ).all()
+            }
+
+            for unsafe in (userinfo, token_param, stac_cred):
+                row = rows[unsafe.id]
+                assert row.origin_uri is None, f"{row.source_url} was frozen in"
+                assert row.origin_ref is None
+                # The secret stays only where the operator can still edit it.
+                assert row.source_url == unsafe.source_url
+
+            benign_row = rows[benign.id]
+            assert benign_row.origin_uri == benign.source_url, (
+                "the guard must not refuse an ordinary WFS query string"
+            )
+            assert benign_row.origin_ref["layer_id"] == "topp:benign"
+
+            dirty_job_row = rows[dirty_job.id]
+            assert "svc:pw@" not in (dirty_job_row.origin_uri or "")
+            assert "svc:pw@" not in str(dirty_job_row.origin_ref)
+            # The job's layer survives; only its credential-bearing url is dropped.
+            assert dirty_job_row.origin_ref["layer_id"] == "topp:secret"
+            assert "url" not in dirty_job_row.origin_ref
+        finally:
+            await savepoint.rollback()
+
 
 # ---------------------------------------------------------------------------
 # The binding follows the current bytes

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -832,3 +832,351 @@ class TestBackfill:
             assert row.origin_ref is None
         finally:
             await savepoint.rollback()
+
+    async def test_same_table_name_in_two_tenant_schemas_stays_null(
+        self, test_db_session
+    ) -> None:
+        """Cross-tenant collisions resolve to NULL, never to the wrong tenant.
+
+        fix(#1218 review, P1): table names are unique per tenant but not
+        across tenants, so two tenants can both own a `parcels` table. The
+        schema lookup keys on `d.table_name` alone and cannot tell the two
+        catalog rows apart, so per-row resolution is not expressible here —
+        both rows staying NULL is the only answer that cannot be wrong. An
+        unconstrained LIMIT 1 would instead hand one dataset a pointer into
+        the other tenant's schema, permanently and silently.
+        """
+        module = _load_migration()
+        admin_id = await get_user_id(test_db_session, "admin")
+        shared_name = f"collide_{uuid.uuid4().hex[:10]}"
+        # The shared-schema row keeps tenant_id NULL; the tenant row carries
+        # one. That is what makes the name collision legal in the first place:
+        # uq_datasets_table_name_global is partial on tenant_id IS NULL, and
+        # uq_datasets_table_name_tenant keys on (tenant_id, table_name).
+        tenant_id = uuid.uuid4()
+        tenant_schema = f"data_t_{str(tenant_id).replace('-', '_')}"
+
+        first = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Collision Shared Schema",
+            source_format=None,
+            table_name=shared_name,
+        )
+        # Built directly rather than through the factory: tenant_id has to be
+        # set at INSERT time, or the partial unique index on tenant_id IS NULL
+        # rejects the row before it can become the tenant-owned twin.
+        tenant_record = Record(
+            title="Collision Tenant Schema",
+            record_type="vector_dataset",
+            visibility="private",
+            record_status="published",
+            created_by=admin_id,
+        )
+        test_db_session.add(tenant_record)
+        await test_db_session.flush()
+        second = Dataset(
+            record_id=tenant_record.id,
+            table_name=shared_name,
+            source_format=None,
+            tenant_id=tenant_id,
+        )
+        test_db_session.add(second)
+        await test_db_session.flush()
+
+        savepoint = await test_db_session.begin_nested()
+        try:
+            await test_db_session.execute(sa.text(f'CREATE SCHEMA "{tenant_schema}"'))
+            await test_db_session.execute(
+                sa.text(f"CREATE TABLE data.{shared_name} (id integer)")
+            )
+            await test_db_session.execute(
+                sa.text(f'CREATE TABLE "{tenant_schema}".{shared_name} (id integer)')
+            )
+            for statement in module.backfill_statements():
+                await test_db_session.execute(statement)
+
+            rows = (
+                await test_db_session.execute(
+                    sa.text(
+                        "SELECT id, origin_uri, origin_ref FROM catalog.datasets "
+                        "WHERE id = ANY(:ids)"
+                    ).bindparams(sa.bindparam("ids", value=[first.id, second.id]))
+                )
+            ).all()
+            assert len(rows) == 2
+            for row in rows:
+                assert row.origin_uri is None, "ambiguous schema must not resolve"
+                assert row.origin_ref is None
+        finally:
+            await savepoint.rollback()
+
+
+# ---------------------------------------------------------------------------
+# The binding follows the current bytes
+# ---------------------------------------------------------------------------
+
+
+_SWAP_METADATA = {
+    "srid": 4326,
+    "geometry_type": "POINT",
+    "feature_count": 3,
+    "extent_wkt": "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+    "column_info": [
+        {"name": "name", "type": "character varying", "ordinal_position": 1},
+    ],
+}
+
+
+async def _run_reupload_swap(session, dataset, *, admin_id, **kwargs) -> None:
+    """Drive _apply_reupload_swap against a real staging table."""
+    from unittest.mock import AsyncMock, patch
+
+    from app.processing.ingest.tasks import _apply_reupload_swap
+
+    staging_table = f"{dataset.table_name}_staging"
+    await session.execute(
+        sa.text(
+            f"CREATE TABLE data.{staging_table} ("
+            "gid SERIAL PRIMARY KEY, "
+            "geom geometry(Point, 4326), "
+            "geom_4326 geometry(Geometry, 4326), "
+            "name TEXT)"
+        )
+    )
+    with (
+        patch(
+            "app.processing.ingest.metadata.refresh_attribute_metadata",
+            new_callable=AsyncMock,
+        ) as mock_refresh,
+        patch(
+            "app.processing.ingest.metadata.compute_quality_score",
+            new_callable=AsyncMock,
+        ) as mock_quality,
+    ):
+        mock_refresh.return_value = None
+        # A COMPLETE QualityDetail. These tests commit, and the row outlives
+        # them on the shared per-worker database, so a partial dict here does
+        # not just fail this test — it makes every later GET /datasets/ that
+        # includes the row raise a 500 on response validation. Costed 9
+        # failures across test_datasets.py before it was caught.
+        mock_quality.return_value = {
+            "overall": 90.0,
+            "metadata_completeness": 90.0,
+            "geometry_validity": 100.0,
+            "attribute_completeness": 90.0,
+            "crs_defined": 100.0,
+        }
+        await _apply_reupload_swap(
+            session,
+            dataset=dataset,
+            staging_table=staging_table,
+            metadata=_SWAP_METADATA,
+            sample_values={"name": ["A"]},
+            user_id=str(admin_id),
+            original_srid=4326,
+            **kwargs,
+        )
+
+
+class TestReuploadRestampsTheBinding:
+    async def test_file_reupload_of_a_postgis_dataset_becomes_an_upload(
+        self, test_db_session
+    ) -> None:
+        """The binding must describe where the CURRENT bytes came from.
+
+        Without the restamp the API serves a computed origin of `upload`
+        (source_format is now a file suffix) beside a stored ref still
+        claiming `postgis`, and a later refresh would follow the stale
+        pointer at a table these bytes no longer came from.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Reupload Was Postgis",
+            # Private: these rows outlive the test on the shared
+            # per-worker DB, so keep them out of public-list assertions.
+            visibility="private",
+            source_format=None,
+        )
+        set_postgis_origin(ds, ds.table_name, None)
+        ds.source_url = "https://descriptive.test/about-this-layer"
+        stale = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        ds.last_refreshed_at = stale
+        await test_db_session.commit()
+        assert ds.origin_ref["kind"] == "postgis"
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            source_filename="parcels.geojson",
+            source_format="geojson",
+            file_hash="sha256:abc123",
+            origin_ref={"filename": "parcels.geojson", "file_hash": "sha256:abc123"},
+        )
+        await test_db_session.commit()
+        await test_db_session.refresh(ds)
+
+        assert ds.origin_ref == {
+            "kind": "upload",
+            "filename": "parcels.geojson",
+            "file_hash": "sha256:abc123",
+        }
+        assert ds.origin_uri is None, "an upload has no remote pointer"
+        assert classify_origin(ds.source_format) == "upload"
+        # The user-editable prose field is NOT collateral damage.
+        assert ds.source_url == "https://descriptive.test/about-this-layer"
+        assert ds.last_refreshed_at is not None and ds.last_refreshed_at > stale
+
+    async def test_service_reupload_stays_a_service_origin(
+        self, test_db_session
+    ) -> None:
+        """Kind is derived, not hardcoded to upload.
+
+        _apply_reupload_swap serves the service re-pull path too, so stamping
+        `upload` unconditionally would flatten a service dataset's binding and
+        drop the pointer a refresh needs.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Reupload Service",
+            # Private: these rows outlive the test on the shared
+            # per-worker DB, so keep them out of public-list assertions.
+            visibility="private",
+            source_format="wfs",
+        )
+        await test_db_session.commit()
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            source_filename="parcels",
+            source_format="wfs",
+            source_url="https://gis.test/geoserver/wfs",
+            origin_ref={
+                "service_type": "wfs",
+                "url": "https://gis.test/geoserver/wfs",
+                "layer_id": None,
+            },
+        )
+        await test_db_session.commit()
+        await test_db_session.refresh(ds)
+
+        assert ds.origin_ref == {
+            "kind": "service",
+            "service_type": "wfs",
+            "url": "https://gis.test/geoserver/wfs",
+        }
+        assert ds.origin_uri == "https://gis.test/geoserver/wfs"
+
+    async def test_reupload_ref_still_goes_through_the_allowlist(
+        self, test_db_session
+    ) -> None:
+        """The reupload path is not a side door around the key allowlist."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Reupload Allowlist",
+            # Private: these rows outlive the test on the shared
+            # per-worker DB, so keep them out of public-list assertions.
+            visibility="private",
+            source_format="geojson",
+        )
+        await test_db_session.commit()
+
+        with pytest.raises(ValueError, match="rejects key"):
+            await _run_reupload_swap(
+                test_db_session,
+                ds,
+                admin_id=admin_id,
+                source_filename="parcels.geojson",
+                source_format="geojson",
+                origin_ref={"filename": "parcels.geojson", "token": "leaked"},
+            )
+        await test_db_session.rollback()
+
+
+class TestFirstIngestStampsLastRefreshed:
+    async def test_created_dataset_carries_its_creation_instant(
+        self, test_db_session
+    ) -> None:
+        """Runtime and backfill must agree on the floor.
+
+        Migration 0036 gives a pre-existing dataset records.created_at when it
+        has no version history; a dataset created after the migration must
+        land on effectively the same instant rather than reporting null
+        forever.
+
+        Compared with a tolerance rather than for equality: the stamp is a
+        Python datetime while records.created_at comes from the database's own
+        server_default, so the two clocks agree to well within a second but
+        not to the microsecond. A SQL func.now() would make them identical and
+        is deliberately not used — it leaves the attribute expired after
+        flush, so dataset_to_response's read of it lazy-loads against a closed
+        session (9 suite failures before that was tracked down).
+        """
+        from app.modules.catalog.datasets.domain.service import create_dataset
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            f"lr_{uuid.uuid4().hex[:12]}",
+            "Last Refreshed At Creation",
+            admin_id,
+            source_format="geojson",
+            source_filename="x.geojson",
+            geometry_type="Point",
+            srid=4326,
+        )
+        # Captured pre-commit: attributes expire on commit, and a bare attribute
+        # read would then lazy-load outside the greenlet context.
+        dataset_id = dataset.id
+        await test_db_session.commit()
+
+        row = (
+            await test_db_session.execute(
+                sa.text(
+                    "SELECT d.last_refreshed_at, r.created_at "
+                    "FROM catalog.datasets d "
+                    "JOIN catalog.records r ON r.id = d.record_id "
+                    "WHERE d.id = :id"
+                ).bindparams(sa.bindparam("id", value=dataset_id))
+            )
+        ).one()
+
+        assert row.last_refreshed_at is not None
+        assert abs(row.last_refreshed_at - row.created_at) < timedelta(seconds=30)
+
+    async def test_creation_endpoint_serializes_without_a_lazy_load(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+    ) -> None:
+        """The freshly-created row must serialize on the spot.
+
+        POST /datasets/create/ builds a DatasetResponse from the instance it
+        just made. Stamping last_refreshed_at with a SQL expression leaves the
+        attribute expired, so dataset_to_response's read of it fires a lazy
+        SELECT and the endpoint 500s. That regression showed up only in
+        unrelated files (test_audit, test_features_crud), so it is pinned here
+        where the field lives.
+        """
+        resp = await client.post(
+            "/datasets/create/",
+            json={
+                "title": f"Lazy Load Guard {uuid.uuid4().hex[:8]}",
+                "columns": [{"name": "label", "type": "text"}],
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["last_refreshed_at"] is not None
+        assert body["origin"] == "created"
+        assert body["source_health"] == UNKNOWN

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -255,30 +255,30 @@ class TestSetDatasetOrigin:
     def test_postgis_pointer_and_ref_name_the_same_table(self) -> None:
         """Two spellings of one fact; set_postgis_origin owns keeping them equal."""
         dataset = Dataset(record_id=uuid.uuid4(), table_name="parcels")
-        set_postgis_origin(dataset, "parcels", None)
+        set_postgis_origin(dataset, "parcels", schema="data")
         assert dataset.origin_uri == "postgis://data.parcels"
         assert dataset.origin_ref == {"kind": "postgis", "table_name": "data.parcels"}
         assert dataset.origin_uri == f"postgis://{dataset.origin_ref['table_name']}"
 
-    def test_postgis_origin_follows_the_ingest_schema_resolver(
-        self, monkeypatch
-    ) -> None:
+    def test_postgis_origin_names_the_schema_it_is_given(self) -> None:
         """A tenant's table lives in its own schema and the pointer must say so.
 
-        Single-tenant is the default here, and `tenant_data_schema` returns
-        the shared `data` schema in that mode whatever tenant_id holds, so
-        asserting only the default would never exercise the tenant branch.
+        The schema is a required keyword rather than something derived from
+        the dataset row, because dataset.tenant_id is NULL on the ORM instance
+        in multi-tenant mode: the insert trigger fills it in the database
+        (#1218 review r2). Callers hand over the schema they actually used.
         """
-        monkeypatch.setattr("app.core.tenancy.is_multi_tenant", lambda: True)
-        tenant = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        tenant_schema = "data_t_aaaaaaaa_bbbb_cccc_dddd_eeeeeeeeeeee"
         dataset = Dataset(record_id=uuid.uuid4(), table_name="parcels")
-        set_postgis_origin(dataset, "parcels", tenant)
-        assert dataset.origin_uri == (
-            "postgis://data_t_aaaaaaaa_bbbb_cccc_dddd_eeeeeeeeeeee.parcels"
-        )
-        assert dataset.origin_ref["table_name"] == (
-            "data_t_aaaaaaaa_bbbb_cccc_dddd_eeeeeeeeeeee.parcels"
-        )
+        set_postgis_origin(dataset, "parcels", schema=tenant_schema)
+        assert dataset.origin_uri == f"postgis://{tenant_schema}.parcels"
+        assert dataset.origin_ref["table_name"] == f"{tenant_schema}.parcels"
+
+    def test_postgis_origin_cannot_be_stamped_without_a_schema(self) -> None:
+        """Keyword-only and required: no positional tenant_id can slip back in."""
+        dataset = Dataset(record_id=uuid.uuid4(), table_name="parcels")
+        with pytest.raises(TypeError):
+            set_postgis_origin(dataset, "parcels")  # type: ignore[call-arg]
 
 
 # ---------------------------------------------------------------------------
@@ -911,6 +911,78 @@ class TestBackfill:
         finally:
             await savepoint.rollback()
 
+    async def test_two_claimants_on_one_surviving_table_stay_null(
+        self, test_db_session
+    ) -> None:
+        """The catalog half of the ambiguity guard (#1218 review r2).
+
+        Two tenants both registered `parcels` and one tenant's physical table
+        was later dropped. The physical count is then a clean 1, so the
+        relation guard is satisfied and BOTH catalog rows would bind to the
+        surviving tenant's schema — leaving one of them an orphan pointing
+        into another tenant's data.
+
+        Resolution requires exactly one physical relation AND exactly one
+        catalog claimant. This pins the second half; the sibling test above
+        pins the first, and neither subsumes the other.
+        """
+        module = _load_migration()
+        admin_id = await get_user_id(test_db_session, "admin")
+        shared_name = f"orphan_{uuid.uuid4().hex[:10]}"
+        tenant_id = uuid.uuid4()
+
+        survivor = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Claimant With Table",
+            source_format=None,
+            table_name=shared_name,
+        )
+        orphan_record = Record(
+            title="Claimant Whose Table Was Dropped",
+            record_type="vector_dataset",
+            visibility="private",
+            record_status="published",
+            created_by=admin_id,
+        )
+        test_db_session.add(orphan_record)
+        await test_db_session.flush()
+        orphaned = Dataset(
+            record_id=orphan_record.id,
+            table_name=shared_name,
+            source_format=None,
+            tenant_id=tenant_id,
+        )
+        test_db_session.add(orphaned)
+        await test_db_session.flush()
+
+        savepoint = await test_db_session.begin_nested()
+        try:
+            # Exactly ONE physical relation: the other tenant's table is gone.
+            await test_db_session.execute(
+                sa.text(f"CREATE TABLE data.{shared_name} (id integer)")
+            )
+            for statement in module.backfill_statements():
+                await test_db_session.execute(statement)
+
+            rows = (
+                await test_db_session.execute(
+                    sa.text(
+                        "SELECT id, origin_uri, origin_ref FROM catalog.datasets "
+                        "WHERE id = ANY(:ids)"
+                    ).bindparams(sa.bindparam("ids", value=[survivor.id, orphaned.id]))
+                )
+            ).all()
+            assert len(rows) == 2
+            for row in rows:
+                assert row.origin_uri is None, (
+                    "one physical table with two catalog claimants must not "
+                    "resolve for either of them"
+                )
+                assert row.origin_ref is None
+        finally:
+            await savepoint.rollback()
+
 
 # ---------------------------------------------------------------------------
 # The binding follows the current bytes
@@ -1000,7 +1072,7 @@ class TestReuploadRestampsTheBinding:
             visibility="private",
             source_format=None,
         )
-        set_postgis_origin(ds, ds.table_name, None)
+        set_postgis_origin(ds, ds.table_name, schema="data")
         ds.source_url = "https://descriptive.test/about-this-layer"
         stale = datetime(2020, 1, 1, tzinfo=timezone.utc)
         ds.last_refreshed_at = stale

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -566,14 +566,19 @@ class TestBackfill:
             name="Backfill WFS",
             source_format="wfs",
         )
-        wfs.source_url = "https://gis.test/geoserver/wfs"
+        # fix(#1218 review r4): the ENRICHED form ingest actually persists.
+        # The probe puts the layer name in layer_id for WFS, so
+        # tasks_vector composes <base>/<typename> into datasets.source_url.
+        wfs.source_url = "https://gis.test/geoserver/wfs/topp:parcels"
         # fix(#1218 review r3): a WFS layer is identified by its typename,
         # which lives on the ingest job. The retention sweep exempts each
-        # dataset's newest complete job precisely so this hint survives.
+        # dataset's newest complete job precisely so this hint survives, and
+        # r4 takes the un-enriched base from the same row.
         test_db_session.add(
             IngestJob(
                 dataset_id=wfs.id,
                 status="complete",
+                source_url="https://gis.test/geoserver/wfs",
                 source_filename="Parcels (2024)",
                 source_layer="topp:parcels",
                 created_by=admin_id,
@@ -590,7 +595,7 @@ class TestBackfill:
             source_format="wfs",
             source_filename="Human Readable Title",
         )
-        wfs_orphan.source_url = "https://gis.test/geoserver/wfs2"
+        wfs_orphan.source_url = "https://gis.test/geoserver/wfs2/Human Readable Title"
 
         # A user PATCHed source_url to prose before the migration ran. A
         # pointer that does not parse must stay NULL rather than be
@@ -713,21 +718,33 @@ class TestBackfill:
             }
 
             wfs_row = rows[wfs.id]
-            assert wfs_row.origin_uri == wfs.source_url
+            # origin_uri keeps the enriched form as provenance...
+            assert wfs_row.origin_uri == "https://gis.test/geoserver/wfs/topp:parcels"
+            # ...while the ref carries the BASE plus the layer separately.
             assert wfs_row.origin_ref == {
                 "kind": "service",
                 "service_type": "wfs",
                 "url": "https://gis.test/geoserver/wfs",
                 "layer_id": "topp:parcels",
             }
+            assert not wfs_row.origin_ref["url"].endswith("topp:parcels"), (
+                "the invariant: origin_ref.url is the base and never embeds "
+                "the layer, or a refresh addresses the wrong endpoint"
+            )
 
             orphan_wfs_row = rows[wfs_orphan.id]
+            # No surviving job, so neither the base nor the layer is
+            # derivable. A wrong base would break the invariant, so the ref
+            # carries neither and origin_uri keeps the full URL for a human.
             assert orphan_wfs_row.origin_ref == {
                 "kind": "service",
                 "service_type": "wfs",
-                "url": "https://gis.test/geoserver/wfs2",
             }, "a human title must never be backfilled as the layer identifier"
             assert "layer_id" not in orphan_wfs_row.origin_ref
+            assert "url" not in orphan_wfs_row.origin_ref
+            assert orphan_wfs_row.origin_uri == (
+                "https://gis.test/geoserver/wfs2/Human Readable Title"
+            )
 
             prose_row = rows[prose.id]
             assert prose_row.origin_uri is None

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -1106,6 +1106,49 @@ class TestBackfill:
             )
         )
 
+        # fix(#1218 review r6): parse_qsl decodes a parameter NAME before
+        # judging it, so this reads as ?token= in Python. The SQL refuses any
+        # encoded NAME outright rather than decoding, closing the class.
+        encoded_name = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Encoded Name",
+            source_format="wfs",
+        )
+        encoded_name.source_url = "https://gis.test/geoserver/wfs?%74oken=hunter2"
+
+        encoded_name_stac = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Encoded Name STAC",
+            source_format="stac",
+        )
+        encoded_name_stac.source_url = "https://bucket.test/s.tif?%73ig=deadbeef"
+
+        # The admission half for r6: a percent-encoded VALUE is ordinary in a
+        # WFS typename and must still backfill. The name segment ends at the
+        # first '=' of its pair, which is what keeps these apart.
+        encoded_value = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Encoded Value",
+            source_format="wfs",
+        )
+        encoded_value.source_url = (
+            "https://gis.test/geoserver/wfs?service=WFS&typename=ns%3Aroads"
+        )
+        test_db_session.add(
+            IngestJob(
+                dataset_id=encoded_value.id,
+                status="complete",
+                source_url=(
+                    "https://gis.test/geoserver/wfs?service=WFS&typename=ns%3Aroads"
+                ),
+                source_layer="ns:roads",
+                created_by=admin_id,
+            )
+        )
+
         stac_cred = await _pre_migration_dataset(
             test_db_session,
             created_by=admin_id,
@@ -1135,6 +1178,9 @@ class TestBackfill:
                                     benign.id,
                                     dirty_job.id,
                                     stac_cred.id,
+                                    encoded_name.id,
+                                    encoded_name_stac.id,
+                                    encoded_value.id,
                                 ],
                             )
                         )
@@ -1142,12 +1188,24 @@ class TestBackfill:
                 ).all()
             }
 
-            for unsafe in (userinfo, token_param, stac_cred):
+            for unsafe in (
+                userinfo,
+                token_param,
+                stac_cred,
+                encoded_name,
+                encoded_name_stac,
+            ):
                 row = rows[unsafe.id]
                 assert row.origin_uri is None, f"{row.source_url} was frozen in"
                 assert row.origin_ref is None
                 # The secret stays only where the operator can still edit it.
                 assert row.source_url == unsafe.source_url
+
+            encoded_value_row = rows[encoded_value.id]
+            assert encoded_value_row.origin_uri == encoded_value.source_url, (
+                "an encoded VALUE is ordinary; only encoded NAMES are refused"
+            )
+            assert encoded_value_row.origin_ref["layer_id"] == "ns:roads"
 
             benign_row = rows[benign.id]
             assert benign_row.origin_uri == benign.source_url, (

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -1125,6 +1125,35 @@ class TestBackfill:
         )
         encoded_name_stac.source_url = "https://bucket.test/s.tif?%73ig=deadbeef"
 
+        # fix(#1218 review r7): parse_qsl decodes + to a space and
+        # _is_sensitive_query_param strips whitespace, so this reads as
+        # ?token= in Python. Same class as the encoded name above, third
+        # spelling; the guard is derived from the transforms, not the
+        # spellings, so literal whitespace is covered by the same arm.
+        plus_name = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Plus Name",
+            source_format="wfs",
+        )
+        plus_name.source_url = "https://gis.test/geoserver/wfs?+token+=hunter2"
+
+        plus_name_stac = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Plus Name STAC",
+            source_format="stac",
+        )
+        plus_name_stac.source_url = "https://bucket.test/s.tif?+sig+=deadbeef"
+
+        space_name = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Cred Space Name",
+            source_format="wfs",
+        )
+        space_name.source_url = "https://gis.test/geoserver/wfs? token =hunter2"
+
         # The admission half for r6: a percent-encoded VALUE is ordinary in a
         # WFS typename and must still backfill. The name segment ends at the
         # first '=' of its pair, which is what keeps these apart.
@@ -1134,16 +1163,16 @@ class TestBackfill:
             name="Cred Encoded Value",
             source_format="wfs",
         )
+        # r7 admission: a + in a VALUE is ordinary too and must not trip the
+        # name arm, so this URL carries both an encoded value and a plus one.
         encoded_value.source_url = (
-            "https://gis.test/geoserver/wfs?service=WFS&typename=ns%3Aroads"
+            "https://gis.test/geoserver/wfs?typename=ns%3Aroads&q=a+b"
         )
         test_db_session.add(
             IngestJob(
                 dataset_id=encoded_value.id,
                 status="complete",
-                source_url=(
-                    "https://gis.test/geoserver/wfs?service=WFS&typename=ns%3Aroads"
-                ),
+                source_url=("https://gis.test/geoserver/wfs?typename=ns%3Aroads&q=a+b"),
                 source_layer="ns:roads",
                 created_by=admin_id,
             )
@@ -1181,6 +1210,9 @@ class TestBackfill:
                                     encoded_name.id,
                                     encoded_name_stac.id,
                                     encoded_value.id,
+                                    plus_name.id,
+                                    plus_name_stac.id,
+                                    space_name.id,
                                 ],
                             )
                         )
@@ -1194,6 +1226,9 @@ class TestBackfill:
                 stac_cred,
                 encoded_name,
                 encoded_name_stac,
+                plus_name,
+                plus_name_stac,
+                space_name,
             ):
                 row = rows[unsafe.id]
                 assert row.origin_uri is None, f"{row.source_url} was frozen in"
@@ -1203,7 +1238,8 @@ class TestBackfill:
 
             encoded_value_row = rows[encoded_value.id]
             assert encoded_value_row.origin_uri == encoded_value.source_url, (
-                "an encoded VALUE is ordinary; only encoded NAMES are refused"
+                "an encoded or plus-bearing VALUE is ordinary; only NAMES "
+                "carrying %, + or whitespace are refused"
             )
             assert encoded_value_row.origin_ref["layer_id"] == "ns:roads"
 

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -1324,6 +1324,80 @@ class TestBackfill:
         finally:
             await savepoint.rollback()
 
+    async def test_an_upload_claiming_the_name_blocks_resolution(
+        self, test_db_session
+    ) -> None:
+        """A claimant of ANY origin counts, not just registered ones.
+
+        fix(#1218 review r8): the claimant guard used to look only at rows
+        this backfill targets (null source_format, vector_dataset/table).
+        Uploads, service imports and created datasets own physical tables with
+        tenant-local names too, so tenant A's dropped registered `roads`
+        beside tenant B's surviving UPLOADED `roads` is one physical relation
+        with a claimant the narrow filter could not see, and B's schema would
+        have been stamped onto A's orphan.
+        """
+        module = _load_migration()
+        admin_id = await get_user_id(test_db_session, "admin")
+        shared_name = f"anyclaim_{uuid.uuid4().hex[:10]}"
+
+        # The registered row whose own physical table is gone.
+        orphan = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Registered Orphan",
+            source_format=None,
+            table_name=shared_name,
+        )
+        # A different tenant's UPLOAD owning the same table name. Outside the
+        # backfill population, so the narrow filter did not see it at all.
+        upload_claimant_record = Record(
+            title="Uploaded Same Name",
+            record_type="vector_dataset",
+            visibility="private",
+            record_status="published",
+            created_by=admin_id,
+        )
+        test_db_session.add(upload_claimant_record)
+        await test_db_session.flush()
+        upload_claimant = Dataset(
+            record_id=upload_claimant_record.id,
+            table_name=shared_name,
+            source_format="gpkg",
+            source_filename="roads.gpkg",
+            tenant_id=uuid.uuid4(),
+        )
+        test_db_session.add(upload_claimant)
+        await test_db_session.flush()
+
+        savepoint = await test_db_session.begin_nested()
+        try:
+            # Exactly ONE physical relation, owned by the upload.
+            await test_db_session.execute(
+                sa.text(f"CREATE TABLE data.{shared_name} (id integer)")
+            )
+            for statement in module.backfill_statements():
+                await test_db_session.execute(statement)
+            await test_db_session.run_sync(
+                lambda sync_session: module.purge_credential_bearing_pointers(
+                    sync_session.connection()
+                )
+            )
+            row = (
+                await test_db_session.execute(
+                    sa.text(
+                        "SELECT origin_uri, origin_ref FROM catalog.datasets "
+                        "WHERE id = :id"
+                    ).bindparams(sa.bindparam("id", value=orphan.id))
+                )
+            ).one()
+            assert row.origin_uri is None, (
+                "a same-named dataset of any origin must block resolution"
+            )
+            assert row.origin_ref is None
+        finally:
+            await savepoint.rollback()
+
 
 # ---------------------------------------------------------------------------
 # The binding follows the current bytes

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -33,6 +33,7 @@ from httpx import AsyncClient
 import app.modules.catalog.datasets.domain.models  # noqa: F401
 from app.core.db import Base
 from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.jobs.models import IngestJob
 from app.platform.dataset_origin import (
     ORIGIN_KINDS,
     ORIGIN_REF_KEYS,
@@ -43,6 +44,7 @@ from app.platform.dataset_origin import (
     build_origin_ref,
     classify_origin,
     project_unknown,
+    service_layer_identity,
     set_dataset_origin,
     set_postgis_origin,
 )
@@ -565,6 +567,30 @@ class TestBackfill:
             source_format="wfs",
         )
         wfs.source_url = "https://gis.test/geoserver/wfs"
+        # fix(#1218 review r3): a WFS layer is identified by its typename,
+        # which lives on the ingest job. The retention sweep exempts each
+        # dataset's newest complete job precisely so this hint survives.
+        test_db_session.add(
+            IngestJob(
+                dataset_id=wfs.id,
+                status="complete",
+                source_filename="Parcels (2024)",
+                source_layer="topp:parcels",
+                created_by=admin_id,
+            )
+        )
+
+        # Same shape, no surviving job row: the layer identity is simply gone.
+        # source_filename holds `layer_title or layer_name` and nothing says
+        # which, so it must NOT be used as a fallback.
+        wfs_orphan = await _pre_migration_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Backfill WFS No Job",
+            source_format="wfs",
+            source_filename="Human Readable Title",
+        )
+        wfs_orphan.source_url = "https://gis.test/geoserver/wfs2"
 
         # A user PATCHed source_url to prose before the migration ran. A
         # pointer that does not parse must stay NULL rather than be
@@ -662,6 +688,7 @@ class TestBackfill:
                                 value=[
                                     arcgis.id,
                                     wfs.id,
+                                    wfs_orphan.id,
                                     prose.id,
                                     stac.id,
                                     registered.id,
@@ -691,8 +718,16 @@ class TestBackfill:
                 "kind": "service",
                 "service_type": "wfs",
                 "url": "https://gis.test/geoserver/wfs",
+                "layer_id": "topp:parcels",
             }
-            assert "layer_id" not in wfs_row.origin_ref
+
+            orphan_wfs_row = rows[wfs_orphan.id]
+            assert orphan_wfs_row.origin_ref == {
+                "kind": "service",
+                "service_type": "wfs",
+                "url": "https://gis.test/geoserver/wfs2",
+            }, "a human title must never be backfilled as the layer identifier"
+            assert "layer_id" not in orphan_wfs_row.origin_ref
 
             prose_row = rows[prose.id]
             assert prose_row.origin_uri is None
@@ -1252,3 +1287,105 @@ class TestFirstIngestStampsLastRefreshed:
         assert body["last_refreshed_at"] is not None
         assert body["origin"] == "created"
         assert body["source_health"] == UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# The service binding names the layer, per service type
+# ---------------------------------------------------------------------------
+
+
+class TestServiceLayerIdentity:
+    """`layer_id` holds whichever field the service actually addresses by.
+
+    `build_gdal_source` (catalog/sources/preview.py) is the authority and it
+    makes the two mutually exclusive: its ArcGIS branch requires the numeric
+    layer id and returns an EMPTY layer name, while its WFS and OGC API
+    branches pass the layer name through and never look at layer_id. So one
+    key can carry the identity for all three without ambiguity, which is why
+    the allowlist is not widened with a second name field (#1218 review r3).
+    """
+
+    @pytest.mark.parametrize(
+        ("service_type", "gdal_prefix"),
+        [("wfs", "WFS"), ("ogcapi_features", "OGC API")],
+    )
+    def test_name_addressed_services_carry_the_layer_name(
+        self, service_type: str, gdal_prefix: str
+    ) -> None:
+        """Pin the premise itself: these drivers address by NAME, not id."""
+        from app.modules.catalog.sources.preview import build_gdal_source
+
+        _source, layer = build_gdal_source(
+            gdal_prefix, "https://gis.test/svc", "topp:parcels", layer_id=None
+        )
+        assert layer == "topp:parcels", "driver addresses the layer by name"
+
+        ref = build_origin_ref(
+            "service",
+            service_type=service_type,
+            url="https://gis.test/svc",
+            layer_id="topp:parcels",
+        )
+        assert ref == {
+            "kind": "service",
+            "service_type": service_type,
+            "url": "https://gis.test/svc",
+            "layer_id": "topp:parcels",
+        }
+
+    def test_arcgis_addresses_by_numeric_id_and_ignores_the_name(self) -> None:
+        """The other half of the premise, which is why one key suffices."""
+        from app.modules.catalog.sources.preview import build_gdal_source
+
+        source, layer = build_gdal_source(
+            "ArcGIS FeatureServer",
+            "https://gis.test/rest/services/Parcels/FeatureServer",
+            "a human layer name",
+            layer_id=7,
+        )
+        assert layer == "", "the layer name is discarded for ArcGIS"
+        assert "/7/query?" in source, "the numeric id addresses the layer"
+
+        with pytest.raises(ValueError, match="requires a layer ID"):
+            build_gdal_source("ArcGIS FeatureServer", "https://x", "name", None)
+
+    @pytest.mark.parametrize("service_type", ["wfs", "ogcapi_features"])
+    def test_write_sites_record_the_layer_name_for_name_addressed_services(
+        self, service_type: str
+    ) -> None:
+        """The rule both ingest write sites actually call.
+
+        Covers the write-site half: previously they stored only layer_id,
+        which is None for these services, so the ref named no layer at all and
+        a refresh had nothing to fetch once the ingest job aged out.
+        """
+        assert (
+            service_layer_identity(
+                service_type, layer_id=None, layer_name="topp:parcels"
+            )
+            == "topp:parcels"
+        )
+
+    def test_write_sites_record_the_numeric_id_for_arcgis(self) -> None:
+        """ArcGIS keeps the id and discards the name, matching the driver."""
+        assert (
+            service_layer_identity(
+                "arcgis_featureserver", layer_id=7, layer_name="a display name"
+            )
+            == "7"
+        )
+        assert (
+            service_layer_identity(
+                "arcgis_featureserver", layer_id=None, layer_name="a display name"
+            )
+            is None
+        ), "no id means no identity; a display name is not a substitute"
+
+    def test_a_second_name_key_is_still_refused(self) -> None:
+        """Unification means one key; the allowlist must not have grown."""
+        assert ORIGIN_REF_KEYS["service"] == frozenset(
+            {"service_type", "url", "layer_id"}
+        )
+        for key in ("layer_name", "source_layer", "typename", "collection_id"):
+            with pytest.raises(ValueError, match="rejects key"):
+                build_origin_ref("service", **{key: "topp:parcels"})

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2109,7 +2109,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reupload caller reaps on failure) plus draining both terminal reapers so
     # a cancellation cannot skip the sweep that follows. Most of it is the
     # docstring correcting r4's claim, which cited the wrong authority.
-    "backend/app/processing/ingest/tasks_common.py": 1796,
+    # feat(#1218): +20 — IngestContext gains origin_ref (the typed per-origin
+    # payload the finalize pipeline writes) and _finalize_ingest stamps the
+    # system-managed origin pointer in the same transaction that creates the
+    # dataset. Most of it is the field's comment recording why the caller
+    # supplies the payload rather than this module inferring one.
+    # Cap 1796 -> 1816, exact.
+    "backend/app/processing/ingest/tasks_common.py": 1816,
     # --- entered by the inclusion rule, fix(#958) -------------------------
     # These five were the ungated modules at or above _RATCHET_INCLUSION_LOC
     # when the rule was written. They arrive at their measured size with no
@@ -2190,7 +2196,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1213 review r4): -1 — the now-dead file_path argument dropped from
     # the call. Ratchet DOWN in the same commit.
     # fix(#1213 review r6): +4 — the caller states its retry semantics.
-    "backend/app/processing/ingest/tasks_vector.py": 1063,
+    # feat(#1218): +11 — both finalize call sites now pass their origin_ref.
+    # The service one keeps the base URL and layer id as separate keys so a
+    # refresh can re-address the layer without re-parsing the enriched URI.
+    # Cap 1063 -> 1074, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1074,
     "backend/app/modules/auth/oauth/service.py": 1031,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the
@@ -2199,7 +2209,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1114): +12 — register_existing_table docstring records the
     # registered-table linear-geometry contract (linearize once at
     # registration, no post-registration policing). Cap 1032 -> 1044.
-    "backend/app/processing/ingest/service.py": 1044,
+    # feat(#1218): +7 — register_existing_table stamps the postgis origin
+    # pointer (schema-qualified table, no connection detail: gate 2 keeps
+    # external federation out of v1). The URI and the ref's table_name are two
+    # spellings of one fact, so set_postgis_origin composes both and this call
+    # site stays one line. Cap 1044 -> 1051, exact.
+    "backend/app/processing/ingest/service.py": 1051,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.
@@ -2257,7 +2272,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # geometry preview runs, unlike select_by_location's separate uncapped
     # count query) now that the intersect branch actually receives bbox.
     # 1209 -> 1215.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1215,
+    # feat(#1218): +56 — the eight read-only source-state fields on
+    # DatasetResponse. Seven mirror the new columns; `origin` is computed at
+    # the boundary rather than stored, so its description has to say so or a
+    # reader will go looking for the column. source_health and
+    # schema_drift_status carry the NULL -> "unknown" projection, which is
+    # only discoverable from the description. Cap 1215 -> 1271, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1271,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2212,7 +2212,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # The service one keeps the base URL and layer id as separate keys so a
     # refresh can re-address the layer without re-parsing the enriched URI.
     # Cap 1063 -> 1074, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1074,
+    # fix(#1218 review r3): +16 — the service ref records the SERVICE-NATIVE
+    # layer identifier via service_layer_identity, so WFS/OGC rows name their
+    # typename instead of storing nothing. Most of it is the comment recording
+    # that build_gdal_source makes id and name mutually exclusive per service,
+    # which is why one key suffices. Cap 1074 -> 1090, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1090,
     "backend/app/modules/auth/oauth/service.py": 1031,
     # fix(#1113 review): +15 — register_existing_table linearizes a
     # pre-existing geom_4326 (savepoint + error contract mirroring the

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2115,7 +2115,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # dataset. Most of it is the field's comment recording why the caller
     # supplies the payload rather than this module inferring one.
     # Cap 1796 -> 1816, exact.
-    "backend/app/processing/ingest/tasks_common.py": 1816,
+    # fix(#1218 review): +32 — _apply_reupload_swap restamps the origin
+    # binding and last_refreshed_at, so the stored ref keeps describing where
+    # the CURRENT bytes came from after a reupload changes the origin kind.
+    # Most of it is the comment explaining why the kind is derived rather than
+    # hardcoded to upload (a service reupload must stay a service origin) and
+    # that #1220's executor takes both writes over, and why the timestamp is a
+    # Python datetime rather than func.now() (a SQL expression leaves the
+    # attribute expired, so the next read lazy-loads). Cap 1816 -> 1850, exact.
+    "backend/app/processing/ingest/tasks_common.py": 1850,
     # --- entered by the inclusion rule, fix(#958) -------------------------
     # These five were the ungated modules at or above _RATCHET_INCLUSION_LOC
     # when the rule was written. They arrive at their measured size with no
@@ -2179,7 +2187,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # closes the gap; this Field bound only stops a fresh boot from
     # configuring past S3's own single-PUT ceiling in the first place).
     "backend/app/core/config.py": 1004,
-    "backend/app/processing/ingest/tasks_vrt.py": 1071,
+    # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
+    # other creation path, so a post-migration VRT does not report null while
+    # a backfilled one carries a timestamp, with a note on why it is a Python
+    # datetime and not func.now(). Cap 1071 -> 1078, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1078,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2226,7 +2226,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # external federation out of v1). The URI and the ref's table_name are two
     # spellings of one fact, so set_postgis_origin composes both and this call
     # site stays one line. Cap 1044 -> 1051, exact.
-    "backend/app/processing/ingest/service.py": 1051,
+    # fix(#1218 review r2): +8 — the call site passes the _schema it resolved
+    # from the active tenant context instead of dataset.tenant_id, which is
+    # NULL on the ORM instance because the insert trigger fills that column in
+    # the database. The comment records why, so nobody "simplifies" it back to
+    # reading the row. Cap 1051 -> 1059, exact.
+    "backend/app/processing/ingest/service.py": 1059,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2123,7 +2123,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # that #1220's executor takes both writes over, and why the timestamp is a
     # Python datetime rather than func.now() (a SQL expression leaves the
     # attribute expired, so the next read lazy-loads). Cap 1816 -> 1850, exact.
-    "backend/app/processing/ingest/tasks_common.py": 1850,
+    # fix(#1218 review r9): +7 — a successful service re-pull moves
+    # last_checked_at with last_refreshed_at, since last_checked_at is defined
+    # as the last origin contact of any kind and a re-pull just made one. A
+    # file reupload contacts no origin and leaves it alone, which is what the
+    # classify_origin branch and its comment buy. Cap 1850 -> 1857, exact.
+    "backend/app/processing/ingest/tasks_common.py": 1857,
     # --- entered by the inclusion rule, fix(#958) -------------------------
     # These five were the ungated modules at or above _RATCHET_INCLUSION_LOC
     # when the rule was written. They arrive at their measured size with no

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2123,12 +2123,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # that #1220's executor takes both writes over, and why the timestamp is a
     # Python datetime rather than func.now() (a SQL expression leaves the
     # attribute expired, so the next read lazy-loads). Cap 1816 -> 1850, exact.
-    # fix(#1218 review r9): +7 — a successful service re-pull moves
-    # last_checked_at with last_refreshed_at, since last_checked_at is defined
-    # as the last origin contact of any kind and a re-pull just made one. A
-    # file reupload contacts no origin and leaves it alone, which is what the
-    # classify_origin branch and its comment buy. Cap 1850 -> 1857, exact.
-    "backend/app/processing/ingest/tasks_common.py": 1857,
+    "backend/app/processing/ingest/tasks_common.py": 1850,
     # --- entered by the inclusion rule, fix(#958) -------------------------
     # These five were the ungated modules at or above _RATCHET_INCLUSION_LOC
     # when the rule was written. They arrive at their measured size with no

--- a/backend/tests/test_tenant_attribution_materialize.py
+++ b/backend/tests/test_tenant_attribution_materialize.py
@@ -368,7 +368,11 @@ async def _stamped_tenant_ids(db_url: str, dataset_id) -> tuple:
             sa.text(
                 "SELECT d.tenant_id AS dataset_tenant_id,"
                 "       r.tenant_id AS record_tenant_id,"
-                "       d.table_name AS table_name"
+                "       d.table_name AS table_name,"
+                # fix(#1218 review r2): the origin pointer rides along so the
+                # test below can check it against the same row's real tenant.
+                "       d.origin_uri AS origin_uri,"
+                "       d.origin_ref AS origin_ref"
                 " FROM catalog.datasets d"
                 " JOIN catalog.records r ON r.id = d.record_id"
                 " WHERE d.id = :dataset_id"
@@ -416,6 +420,57 @@ class TestMaterializeStampsTenantAttribution:
             "insert in create_dataset ran without the tenant GUC.\n"
             f"  stored={row.record_tenant_id!r} expected={env.tenant_a!r}"
         )
+
+    async def test_registered_origin_pointer_names_the_tenant_schema(
+        self, tenant_analysis
+    ):
+        """fix(#1218 review r2): the origin pointer follows physical placement.
+
+        ``register_existing_table`` derived the pointer from
+        ``dataset.tenant_id``, which is NULL on the ORM instance at that
+        moment — the INSERT sends NULL and
+        ``trg_stamp_current_tenant_on_insert`` fills the column inside the
+        database. So every multi-tenant registration recorded
+        ``postgis://data.<table>`` for a table that actually lives in
+        ``data_t_<tenant>``: a system-managed pointer aimed at the wrong
+        tenant's schema, which #1220's refresh would then follow.
+
+        The fix passes the schema the function itself resolved from the active
+        tenant context and used to verify, grant, and read the table, so the
+        pointer cannot disagree with where the data is.
+        """
+        env = tenant_analysis
+        src = await _seed_source_dataset(env, env.tenant_a)
+        job_id = await _create_job(env, env.tenant_a)
+
+        from app.processing.analysis.tasks import materialize_analysis
+
+        await materialize_analysis(
+            tenant_id=env.tenant_a,
+            job_id=str(job_id),
+            dataset_id=str(src.id),
+            user_id=str(env.user_a_id),
+            operation="centroid",
+            title=f"Origin Pointer {uuid.uuid4().hex[:6]}",
+        )
+
+        job = await _job_row(env.db_url, job_id)
+        assert job.status == "complete", job.error_message
+        assert job.dataset_id is not None
+
+        row = await _stamped_tenant_ids(env.db_url, job.dataset_id)
+        expected_schema = f"data_t_{env.tenant_a.replace('-', '_')}"
+        qualified = f"{expected_schema}.{row.table_name}"
+
+        assert row.origin_uri == f"postgis://{qualified}", (
+            "origin_uri does not name the tenant schema the table lives in.\n"
+            f"  stored={row.origin_uri!r} expected='postgis://{qualified}'"
+        )
+        assert row.origin_ref == {"kind": "postgis", "table_name": qualified}
+        # The pointer and the ref are two spellings of one fact.
+        assert row.origin_uri == f"postgis://{row.origin_ref['table_name']}"
+        # And the shared schema must not appear anywhere in it.
+        assert not row.origin_uri.startswith("postgis://data.")
 
     async def test_stamp_is_lost_when_the_guc_is_absent_at_registration(
         self, tenant_analysis, monkeypatch

--- a/backend/tests/test_vrt_catalog_175.py
+++ b/backend/tests/test_vrt_catalog_175.py
@@ -71,6 +71,16 @@ def _make_mock_dataset(record_type: str, title: str = "Test Dataset") -> MagicMo
     ds.current_version = 1
     ds.source_url = None
     ds.quality_statement = None
+    # feat(#1218): source-origin & refresh state. A bare MagicMock returns a
+    # MagicMock for any attribute never set, which DatasetResponse rejects, so
+    # every new dataset column has to be pinned here explicitly.
+    ds.origin_uri = None
+    ds.origin_ref = None
+    ds.last_refreshed_at = None
+    ds.last_checked_at = None
+    ds.source_health = None
+    ds.source_health_detail = None
+    ds.schema_drift_status = None
 
     ds.record = MagicMock()
     ds.record.record_type = record_type

--- a/frontend/src/components/dataset/OriginBadge.tsx
+++ b/frontend/src/components/dataset/OriginBadge.tsx
@@ -2,13 +2,12 @@ import { Database, Globe, Satellite, SquarePen, Upload, type LucideIcon } from '
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import type { DatasetOrigin } from '@/types/api';
 
-/**
- * Dataset origin — how the data entered the catalog. Distinct from
- * `record_type` (what the data is): a vector dataset can be an uploaded
- * file, a registered PostGIS table, or a mirrored remote service.
- */
-export type DatasetOrigin = 'upload' | 'postgis' | 'service' | 'stac' | 'created';
+// feat(#1218): the union moved to types/api.ts, where the backend now serves it
+// as the computed `origin` field. Re-exported here so existing importers keep
+// working and the vocabulary keeps one definition.
+export type { DatasetOrigin };
 
 const SERVICE_FORMATS = new Set(['wfs', 'arcgis_featureserver', 'ogcapi_features']);
 

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7287,10 +7287,20 @@ export interface components {
              * @description ISO 639-1 language code, e.g. en, fr
              */
             language?: string | null;
+            /**
+             * Last Checked At
+             * @description Last time GeoLens contacted the origin at all, whether the attempt succeeded or failed
+             */
+            last_checked_at?: string | null;
             /** Last Edited At */
             last_edited_at?: string | null;
             /** Last Edited By Display */
             last_edited_by_display?: string | null;
+            /**
+             * Last Refreshed At
+             * @description Last committed successful refresh — not the last attempt
+             */
+            last_refreshed_at?: string | null;
             /** License */
             license?: string | null;
             /**
@@ -7308,6 +7318,23 @@ export interface components {
              * @description Number of coordinate dimensions (2, 3, or 4)
              */
             n_dims?: number | null;
+            /**
+             * Origin
+             * @description How the data entered the catalog: upload, postgis, service, stac, or created. Computed from source_format and record_type, not stored; null for collections and VRTs, which have no origin of their own.
+             */
+            origin?: string | null;
+            /**
+             * Origin Ref
+             * @description Typed per-origin payload with a `kind` discriminator, e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials.
+             */
+            origin_ref?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Origin Uri
+             * @description Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.
+             */
+            origin_uri?: string | null;
             /**
              * Original Srid
              * @description EPSG SRID of the uploaded source file
@@ -7345,6 +7372,12 @@ export interface components {
              */
             record_type: string;
             /**
+             * Schema Drift Status
+             * @description none, drifted, or unknown. Set at refresh commit from the schema diff; 'unknown' until a refresh has run.
+             * @default unknown
+             */
+            schema_drift_status: string;
+            /**
              * Sensitivity Classification
              * @description e.g. public, confidential, restricted
              */
@@ -7356,6 +7389,17 @@ export interface components {
              * @description Original file format, e.g. GPKG, SHP
              */
             source_format?: string | null;
+            /**
+             * Source Health
+             * @description healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an origin kind with nothing to probe.
+             * @default unknown
+             */
+            source_health: string;
+            /**
+             * Source Health Detail
+             * @description Short redacted reason for a non-healthy state
+             */
+            source_health_detail?: string | null;
             /** Source Organization */
             source_organization?: string | null;
             /**

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -180,6 +180,18 @@ export type DatasetVisibility = 'public' | 'internal' | 'restricted' | 'private'
 export type RecordStatus = string;
 export type DistributionType = 'download' | 'ogc_features' | 'vector_tiles';
 
+/** feat(#1218): how the data entered the catalog. Distinct from `record_type`
+ *  (what the data is): a vector dataset can be an uploaded file, a registered
+ *  PostGIS table, or a copy pulled from a remote service. The backend computes
+ *  this from source_format + record_type and serves it as `origin`; OriginBadge
+ *  re-exports the type so the rule has one name across the app. */
+export type DatasetOrigin = 'upload' | 'postgis' | 'service' | 'stac' | 'created';
+/** Reuses the VRT member-probe vocabulary so one legend covers both. NULL in the
+ *  database is projected to 'unknown' on the wire — the column stores no such
+ *  literal, so there is exactly one way to spell "never determined". */
+export type SourceHealth = 'healthy' | 'missing' | 'inaccessible' | 'unknown';
+export type SchemaDriftStatus = 'none' | 'drifted' | 'unknown';
+
 /** Response returned by dataset publication-status mutation endpoints. */
 export type StatusUpdateResponse = components['schemas']['StatusUpdateResponse'];
 
@@ -243,6 +255,30 @@ export interface DatasetResponse {
   updated_by: string | null;
   current_version: number;
   source_url: string | null;
+  /** feat(#1218): read-only source-origin & refresh state. All system-managed —
+   * none of these is accepted by PATCH /datasets/{id}/metadata, unlike the
+   * editable `source_url` above.
+   *
+   * `origin` is computed server-side from source_format and record_type. It is
+   * the same rule `datasetOrigin()` in OriginBadge.tsx implements locally; that
+   * local copy is the fallback for endpoints that do not serve this field yet.
+   * Null for collections and VRTs, which have no origin of their own. */
+  origin?: DatasetOrigin | null;
+  /** Machine-readable pointer back to the origin. Null for uploads and created
+   * datasets, which have no remote origin. Distinct from `source_url`. */
+  origin_uri?: string | null;
+  /** Typed per-origin payload, discriminated by `kind`. Never holds credentials. */
+  origin_ref?: Record<string, unknown> | null;
+  /** Last committed successful refresh — not the last attempt. */
+  last_refreshed_at?: string | null;
+  /** Last contact with the origin at all, whether it succeeded or failed. */
+  last_checked_at?: string | null;
+  /** 'unknown' means never probed, or an origin kind with nothing to probe. */
+  source_health?: SourceHealth;
+  /** Short redacted reason for a non-healthy state. */
+  source_health_detail?: string | null;
+  /** 'unknown' until a refresh has run. */
+  schema_drift_status?: SchemaDriftStatus;
   quality_statement: string | null;
   collections: Array<{ id: string; name: string }> | null;
   quality_detail?: {

--- a/sdks/python/geolens/models/__init__.py
+++ b/sdks/python/geolens/models/__init__.py
@@ -202,6 +202,7 @@ from .dataset_relationship_create import DatasetRelationshipCreate
 from .dataset_relationship_list_response import DatasetRelationshipListResponse
 from .dataset_relationship_response import DatasetRelationshipResponse
 from .dataset_response import DatasetResponse
+from .dataset_response_origin_ref_type_0 import DatasetResponseOriginRefType0
 from .dataset_response_stac_assets_type_0 import DatasetResponseStacAssetsType0
 from .dataset_rows_response import DatasetRowsResponse
 from .dataset_rows_response_rows_item import DatasetRowsResponseRowsItem
@@ -900,6 +901,7 @@ __all__ = (
     "DatasetRelationshipListResponse",
     "DatasetRelationshipResponse",
     "DatasetResponse",
+    "DatasetResponseOriginRefType0",
     "DatasetResponseStacAssetsType0",
     "DatasetRowsResponse",
     "DatasetRowsResponseRowsItem",

--- a/sdks/python/geolens/models/dataset_response.py
+++ b/sdks/python/geolens/models/dataset_response.py
@@ -16,6 +16,9 @@ import datetime
 if TYPE_CHECKING:
     from ..models.collection_ref import CollectionRef
     from ..models.column_info import ColumnInfo
+    from ..models.dataset_response_origin_ref_type_0 import (
+        DatasetResponseOriginRefType0,
+    )
     from ..models.dataset_response_stac_assets_type_0 import (
         DatasetResponseStacAssetsType0,
     )
@@ -60,14 +63,25 @@ class DatasetResponse:
             Computed on the detail endpoint only (fix #430 codex r18); list endpoints always report false. Default: False.
         is_3d (bool | None | Unset): True if geometry has Z dimension
         language (None | str | Unset): ISO 639-1 language code, e.g. en, fr
+        last_checked_at (datetime.datetime | None | Unset): Last time GeoLens contacted the origin at all, whether the
+            attempt succeeded or failed
         last_edited_at (datetime.datetime | None | Unset):
         last_edited_by_display (None | str | Unset):
+        last_refreshed_at (datetime.datetime | None | Unset): Last committed successful refresh — not the last attempt
         license_ (None | str | Unset):
         lineage_summary (None | str | Unset): Free-text provenance / lineage statement
         metadata_warnings (list[str] | None | Unset): Advisory warnings produced by a metadata update — e.g. a
             visibility or status change exposing keywords inherited from an analysis source the new audience cannot open
             (feat #1070). Only ever set on the PATCH response; the change has already applied.
         n_dims (int | None | Unset): Number of coordinate dimensions (2, 3, or 4)
+        origin (None | str | Unset): How the data entered the catalog: upload, postgis, service, stac, or created.
+            Computed from source_format and record_type, not stored; null for collections and VRTs, which have no origin of
+            their own.
+        origin_ref (DatasetResponseOriginRefType0 | None | Unset): Typed per-origin payload with a `kind` discriminator,
+            e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials.
+        origin_uri (None | str | Unset): Machine-readable pointer back to the origin, written only by ingest and
+            refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created
+            datasets.
         original_srid (int | None | Unset): EPSG SRID of the uploaded source file
         owner_org (None | str | Unset): Owning organization name
         published_at (datetime.datetime | None | Unset):
@@ -80,8 +94,13 @@ class DatasetResponse:
         record_type (str | Unset): Record type: 'vector_dataset' (spatial features), 'raster_dataset' (single COG),
             'vrt_dataset' (VRT mosaic), 'table' (non-spatial tabular), 'map' (saved map), 'service' (catalogued remote
             service), 'collection' (flat dataset group). Default: 'vector_dataset'.
+        schema_drift_status (str | Unset): none, drifted, or unknown. Set at refresh commit from the schema diff;
+            'unknown' until a refresh has run. Default: 'unknown'.
         sensitivity_classification (None | str | Unset): e.g. public, confidential, restricted
         source_format (None | str | Unset): Original file format, e.g. GPKG, SHP
+        source_health (str | Unset): healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an
+            origin kind with nothing to probe. Default: 'unknown'.
+        source_health_detail (None | str | Unset): Short redacted reason for a non-healthy state
         source_organization (None | str | Unset):
         source_url (None | str | Unset): URL the data was originally fetched from
         srid (int | None | Unset): Current EPSG SRID of stored geometry
@@ -121,12 +140,17 @@ class DatasetResponse:
     has_generic_geometry: bool | Unset = False
     is_3d: bool | None | Unset = UNSET
     language: None | str | Unset = UNSET
+    last_checked_at: datetime.datetime | None | Unset = UNSET
     last_edited_at: datetime.datetime | None | Unset = UNSET
     last_edited_by_display: None | str | Unset = UNSET
+    last_refreshed_at: datetime.datetime | None | Unset = UNSET
     license_: None | str | Unset = UNSET
     lineage_summary: None | str | Unset = UNSET
     metadata_warnings: list[str] | None | Unset = UNSET
     n_dims: int | None | Unset = UNSET
+    origin: None | str | Unset = UNSET
+    origin_ref: DatasetResponseOriginRefType0 | None | Unset = UNSET
+    origin_uri: None | str | Unset = UNSET
     original_srid: int | None | Unset = UNSET
     owner_org: None | str | Unset = UNSET
     published_at: datetime.datetime | None | Unset = UNSET
@@ -135,8 +159,11 @@ class DatasetResponse:
     raster: None | RasterMetadata | Unset = UNSET
     record_status: str | Unset = "draft"
     record_type: str | Unset = "vector_dataset"
+    schema_drift_status: str | Unset = "unknown"
     sensitivity_classification: None | str | Unset = UNSET
     source_format: None | str | Unset = UNSET
+    source_health: str | Unset = "unknown"
+    source_health_detail: None | str | Unset = UNSET
     source_organization: None | str | Unset = UNSET
     source_url: None | str | Unset = UNSET
     srid: int | None | Unset = UNSET
@@ -152,6 +179,9 @@ class DatasetResponse:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.dataset_response_origin_ref_type_0 import (
+            DatasetResponseOriginRefType0,
+        )
         from ..models.dataset_response_stac_assets_type_0 import (
             DatasetResponseStacAssetsType0,
         )
@@ -275,6 +305,14 @@ class DatasetResponse:
         else:
             language = self.language
 
+        last_checked_at: None | str | Unset
+        if isinstance(self.last_checked_at, Unset):
+            last_checked_at = UNSET
+        elif isinstance(self.last_checked_at, datetime.datetime):
+            last_checked_at = self.last_checked_at.isoformat()
+        else:
+            last_checked_at = self.last_checked_at
+
         last_edited_at: None | str | Unset
         if isinstance(self.last_edited_at, Unset):
             last_edited_at = UNSET
@@ -288,6 +326,14 @@ class DatasetResponse:
             last_edited_by_display = UNSET
         else:
             last_edited_by_display = self.last_edited_by_display
+
+        last_refreshed_at: None | str | Unset
+        if isinstance(self.last_refreshed_at, Unset):
+            last_refreshed_at = UNSET
+        elif isinstance(self.last_refreshed_at, datetime.datetime):
+            last_refreshed_at = self.last_refreshed_at.isoformat()
+        else:
+            last_refreshed_at = self.last_refreshed_at
 
         license_: None | str | Unset
         if isinstance(self.license_, Unset):
@@ -315,6 +361,26 @@ class DatasetResponse:
             n_dims = UNSET
         else:
             n_dims = self.n_dims
+
+        origin: None | str | Unset
+        if isinstance(self.origin, Unset):
+            origin = UNSET
+        else:
+            origin = self.origin
+
+        origin_ref: dict[str, Any] | None | Unset
+        if isinstance(self.origin_ref, Unset):
+            origin_ref = UNSET
+        elif isinstance(self.origin_ref, DatasetResponseOriginRefType0):
+            origin_ref = self.origin_ref.to_dict()
+        else:
+            origin_ref = self.origin_ref
+
+        origin_uri: None | str | Unset
+        if isinstance(self.origin_uri, Unset):
+            origin_uri = UNSET
+        else:
+            origin_uri = self.origin_uri
 
         original_srid: int | None | Unset
         if isinstance(self.original_srid, Unset):
@@ -362,6 +428,8 @@ class DatasetResponse:
 
         record_type = self.record_type
 
+        schema_drift_status = self.schema_drift_status
+
         sensitivity_classification: None | str | Unset
         if isinstance(self.sensitivity_classification, Unset):
             sensitivity_classification = UNSET
@@ -373,6 +441,14 @@ class DatasetResponse:
             source_format = UNSET
         else:
             source_format = self.source_format
+
+        source_health = self.source_health
+
+        source_health_detail: None | str | Unset
+        if isinstance(self.source_health_detail, Unset):
+            source_health_detail = UNSET
+        else:
+            source_health_detail = self.source_health_detail
 
         source_organization: None | str | Unset
         if isinstance(self.source_organization, Unset):
@@ -501,10 +577,14 @@ class DatasetResponse:
             field_dict["is_3d"] = is_3d
         if language is not UNSET:
             field_dict["language"] = language
+        if last_checked_at is not UNSET:
+            field_dict["last_checked_at"] = last_checked_at
         if last_edited_at is not UNSET:
             field_dict["last_edited_at"] = last_edited_at
         if last_edited_by_display is not UNSET:
             field_dict["last_edited_by_display"] = last_edited_by_display
+        if last_refreshed_at is not UNSET:
+            field_dict["last_refreshed_at"] = last_refreshed_at
         if license_ is not UNSET:
             field_dict["license"] = license_
         if lineage_summary is not UNSET:
@@ -513,6 +593,12 @@ class DatasetResponse:
             field_dict["metadata_warnings"] = metadata_warnings
         if n_dims is not UNSET:
             field_dict["n_dims"] = n_dims
+        if origin is not UNSET:
+            field_dict["origin"] = origin
+        if origin_ref is not UNSET:
+            field_dict["origin_ref"] = origin_ref
+        if origin_uri is not UNSET:
+            field_dict["origin_uri"] = origin_uri
         if original_srid is not UNSET:
             field_dict["original_srid"] = original_srid
         if owner_org is not UNSET:
@@ -529,10 +615,16 @@ class DatasetResponse:
             field_dict["record_status"] = record_status
         if record_type is not UNSET:
             field_dict["record_type"] = record_type
+        if schema_drift_status is not UNSET:
+            field_dict["schema_drift_status"] = schema_drift_status
         if sensitivity_classification is not UNSET:
             field_dict["sensitivity_classification"] = sensitivity_classification
         if source_format is not UNSET:
             field_dict["source_format"] = source_format
+        if source_health is not UNSET:
+            field_dict["source_health"] = source_health
+        if source_health_detail is not UNSET:
+            field_dict["source_health_detail"] = source_health_detail
         if source_organization is not UNSET:
             field_dict["source_organization"] = source_organization
         if source_url is not UNSET:
@@ -564,6 +656,9 @@ class DatasetResponse:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.collection_ref import CollectionRef
         from ..models.column_info import ColumnInfo
+        from ..models.dataset_response_origin_ref_type_0 import (
+            DatasetResponseOriginRefType0,
+        )
         from ..models.dataset_response_stac_assets_type_0 import (
             DatasetResponseStacAssetsType0,
         )
@@ -784,6 +879,23 @@ class DatasetResponse:
 
         language = _parse_language(d.pop("language", UNSET))
 
+        def _parse_last_checked_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                last_checked_at_type_0 = isoparse(data)
+
+                return last_checked_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        last_checked_at = _parse_last_checked_at(d.pop("last_checked_at", UNSET))
+
         def _parse_last_edited_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
                 return data
@@ -811,6 +923,23 @@ class DatasetResponse:
         last_edited_by_display = _parse_last_edited_by_display(
             d.pop("last_edited_by_display", UNSET)
         )
+
+        def _parse_last_refreshed_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                last_refreshed_at_type_0 = isoparse(data)
+
+                return last_refreshed_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        last_refreshed_at = _parse_last_refreshed_at(d.pop("last_refreshed_at", UNSET))
 
         def _parse_license_(data: object) -> None | str | Unset:
             if data is None:
@@ -855,6 +984,43 @@ class DatasetResponse:
             return cast(int | None | Unset, data)
 
         n_dims = _parse_n_dims(d.pop("n_dims", UNSET))
+
+        def _parse_origin(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        origin = _parse_origin(d.pop("origin", UNSET))
+
+        def _parse_origin_ref(
+            data: object,
+        ) -> DatasetResponseOriginRefType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                origin_ref_type_0 = DatasetResponseOriginRefType0.from_dict(data)
+
+                return origin_ref_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(DatasetResponseOriginRefType0 | None | Unset, data)
+
+        origin_ref = _parse_origin_ref(d.pop("origin_ref", UNSET))
+
+        def _parse_origin_uri(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        origin_uri = _parse_origin_uri(d.pop("origin_uri", UNSET))
 
         def _parse_original_srid(data: object) -> int | None | Unset:
             if data is None:
@@ -938,6 +1104,8 @@ class DatasetResponse:
 
         record_type = d.pop("record_type", UNSET)
 
+        schema_drift_status = d.pop("schema_drift_status", UNSET)
+
         def _parse_sensitivity_classification(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -957,6 +1125,19 @@ class DatasetResponse:
             return cast(None | str | Unset, data)
 
         source_format = _parse_source_format(d.pop("source_format", UNSET))
+
+        source_health = d.pop("source_health", UNSET)
+
+        def _parse_source_health_detail(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        source_health_detail = _parse_source_health_detail(
+            d.pop("source_health_detail", UNSET)
+        )
 
         def _parse_source_organization(data: object) -> None | str | Unset:
             if data is None:
@@ -1135,12 +1316,17 @@ class DatasetResponse:
             has_generic_geometry=has_generic_geometry,
             is_3d=is_3d,
             language=language,
+            last_checked_at=last_checked_at,
             last_edited_at=last_edited_at,
             last_edited_by_display=last_edited_by_display,
+            last_refreshed_at=last_refreshed_at,
             license_=license_,
             lineage_summary=lineage_summary,
             metadata_warnings=metadata_warnings,
             n_dims=n_dims,
+            origin=origin,
+            origin_ref=origin_ref,
+            origin_uri=origin_uri,
             original_srid=original_srid,
             owner_org=owner_org,
             published_at=published_at,
@@ -1149,8 +1335,11 @@ class DatasetResponse:
             raster=raster,
             record_status=record_status,
             record_type=record_type,
+            schema_drift_status=schema_drift_status,
             sensitivity_classification=sensitivity_classification,
             source_format=source_format,
+            source_health=source_health,
+            source_health_detail=source_health_detail,
             source_organization=source_organization,
             source_url=source_url,
             srid=srid,

--- a/sdks/python/geolens/models/dataset_response_origin_ref_type_0.py
+++ b/sdks/python/geolens/models/dataset_response_origin_ref_type_0.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+
+T = TypeVar("T", bound="DatasetResponseOriginRefType0")
+
+
+@_attrs_define
+class DatasetResponseOriginRefType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        dataset_response_origin_ref_type_0 = cls()
+
+        dataset_response_origin_ref_type_0.additional_properties = d
+        return dataset_response_origin_ref_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3120,6 +3120,12 @@ export type DatasetResponse = {
      */
     language?: string | null;
     /**
+     * Last Checked At
+     *
+     * Last time GeoLens contacted the origin at all, whether the attempt succeeded or failed
+     */
+    last_checked_at?: string | null;
+    /**
      * Last Edited At
      */
     last_edited_at?: string | null;
@@ -3127,6 +3133,12 @@ export type DatasetResponse = {
      * Last Edited By Display
      */
     last_edited_by_display?: string | null;
+    /**
+     * Last Refreshed At
+     *
+     * Last committed successful refresh — not the last attempt
+     */
+    last_refreshed_at?: string | null;
     /**
      * License
      */
@@ -3149,6 +3161,26 @@ export type DatasetResponse = {
      * Number of coordinate dimensions (2, 3, or 4)
      */
     n_dims?: number | null;
+    /**
+     * Origin
+     *
+     * How the data entered the catalog: upload, postgis, service, stac, or created. Computed from source_format and record_type, not stored; null for collections and VRTs, which have no origin of their own.
+     */
+    origin?: string | null;
+    /**
+     * Origin Ref
+     *
+     * Typed per-origin payload with a `kind` discriminator, e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials.
+     */
+    origin_ref?: {
+        [key: string]: unknown;
+    } | null;
+    /**
+     * Origin Uri
+     *
+     * Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.
+     */
+    origin_uri?: string | null;
     /**
      * Original Srid
      *
@@ -3196,6 +3228,12 @@ export type DatasetResponse = {
      */
     record_type?: string;
     /**
+     * Schema Drift Status
+     *
+     * none, drifted, or unknown. Set at refresh commit from the schema diff; 'unknown' until a refresh has run.
+     */
+    schema_drift_status?: string;
+    /**
      * Sensitivity Classification
      *
      * e.g. public, confidential, restricted
@@ -3211,6 +3249,18 @@ export type DatasetResponse = {
      * Original file format, e.g. GPKG, SHP
      */
     source_format?: string | null;
+    /**
+     * Source Health
+     *
+     * healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an origin kind with nothing to probe.
+     */
+    source_health?: string;
+    /**
+     * Source Health Detail
+     *
+     * Short redacted reason for a non-healthy state
+     */
+    source_health_detail?: string | null;
     /**
      * Source Organization
      */


### PR DESCRIPTION
## Problem

Datasets carry only descriptive source info (`source_format`, `source_filename`, `original_srid`, user-editable `source_url`) — no machine-readable pointer back to where the data came from, and no freshness, health, or drift state anywhere in the schema. ADR-002 Decision 3 (signed off on #1217) specifies the columns; this is the milestone's foundation PR.

## Change

**Schema** (migration `0036_dataset_source_state`, additive, all nullable): `origin_uri`, `origin_ref` (JSONB with a `kind` discriminator), `last_refreshed_at`, `last_checked_at`, `source_health`, `source_health_detail`, `schema_drift_status` on `catalog.datasets`; CHECK constraints bounding the health and drift value sets ('unknown' deliberately excluded — NULL is the only stored spelling of "never determined", projected to "unknown" at the response boundary); a partial index on `origin_uri` backing Decision 6's duplicate-source re-key.

**Backfill**, per origin kind, gated on `source_url` still parsing as a URL (it is PATCHable prose): service URLs split ArcGIS layer ids back out, and WFS/OGC-API rows recover their layer identity (typename / collection id) from the dataset's newest complete ingest job — a row the retention sweep exempts by design; STAC rows point at their data asset; registered PostGIS tables resolve their schema from `pg_class` — a row backfills only when exactly ONE physical relation matches AND exactly one catalog row claims the name (either-side ambiguity leaves NULL, so a cross-tenant misassignment is inexpressible); uploads record filename + newest version hash; `last_refreshed_at` = newest version upload, else record creation. Health/drift stay NULL everywhere — GeoLens has never contacted an origin, so any value would be invented.

**Write path is closed, and stays current.** None of the new fields is PATCHable (`_DATASET_FIELD_MAP` and `DatasetMeta` untouched, both pinned by tests). `origin_uri`/`origin_ref` are written only through a per-kind key allowlist in the new `app/platform/dataset_origin.py` (platform/, because both catalog and processing write origins and processing may not import catalog). An undeclared key raises — so a credential cannot land in the binding even by accident (ADR invariant 4), and the `postgis` kind accepts `table_name` only, keeping external federation out of v1 (gate 2). Ingest stamps the pointer in the same transaction that creates the dataset (file/service ingest, STAC import, raster, VRT, and PostGIS registration — the postgis pointer takes the SAME schema the registration verified and created in, never a derivation from the trigger-stamped `tenant_id`), reuploads RE-stamp the binding for what the current bytes actually are, and every creation path plus the reupload swap writes `last_refreshed_at`.

**`layer_id` is the service-native layer identifier**: the numeric ArcGIS layer for `arcgis_featureserver`, the WFS typename, or the OGC API Features collection id. The GDAL source builder consults exactly one of id/name per service type, so one key suffices and a refresh reads one place.

**API**: `DatasetResponse` gains the seven fields read-only plus a server-computed `origin` (Decision 2 keeps classification derived — it is a pure function of `source_format` and `record_type`; serving it retires the frontend's duplicate rule and gives CLI/MCP/SDKs one answer). openapi.json, both SDKs, and the frontend type mirrors regenerated and committed (88 insertions, 0 deletions — purely additive).

## Two deliberate deviations from ADR-002's literal text

- **stac allowlist carries `asset_href`**: the STAC import request stores the chosen data-asset href and never the item's own href, so writing that URL into a key named `item_href` would be a lie in the payload. `item_href` stays reserved and unwritten until #1222 captures it.
- **postgis backfill covers `record_type IN ('vector_dataset', 'table')`**: the runtime writer stamps every registered table including non-spatial ones, so the ADR-literal `vector_dataset`-only predicate would make pre-migration registrations permanently diverge from post-migration ones — the exact inconsistency a backfill exists to prevent.

## Known residual

A pre-existing WFS or OGC API Features dataset whose ingest job row is gone (purged as a non-latest job, or predating the job table) keeps a service ref with neither `url` nor `layer_id` (`origin_uri` retains the original enriched URL as provenance) and needs its layer identified once before a first refresh. `source_filename` is deliberately NOT used as a fallback — it may hold a human display title with nothing on the row saying which, and a refresh handed a display string as a typename fails worse than one that asks. ArcGIS rows are unaffected (id recoverable from the URL path).

## Verification

- `tests/test_dataset_source_state.py`: 112 tests — PATCH-immunity (runtime + structural, with an admission control proving `source_url` still changes), secret-shaped-key rejection per kind paired with admission tests, backfill against pre-migration-shaped rows for all origin kinds (running the migration's REAL exported statements) plus VRT-exclusion, missing-table, colliding-schema, and orphaned-claimant cases, served-`origin` API assertions for spatial and non-spatial registered tables, multi-tenant registration pointer correctness, reupload restamp, layer-identity persistence for all three service types (with the GDAL-builder premise itself pinned), and a lazy-load serialization regression guard.
- Full backend suite: 7400 passed, 88 skipped. Frontend typecheck/lint/vitest (4669 tests) clean.
- Clean-DB `alembic upgrade head` → `alembic check` → "No new upgrade operations detected"; downgrade/upgrade round-trip verified. Containerized `make alembic-check`: clean.
- `make openapi-check`, `make sdks-check`, `types:check` all exit 0 at HEAD.

Closes #1218