### PR TITLE
fix(sdks): preserve schema property order for stable SDK constructors

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -23,18 +23,6 @@
             "title": "Configured",
             "type": "boolean"
           },
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Short sanitized failure reason. Never contains the key or raw provider error bodies.",
-            "title": "Error"
-          },
           "ok": {
             "anyOf": [
               {
@@ -58,6 +46,18 @@
             ],
             "description": "HTTP status returned by the provider on failure, when available.",
             "title": "Status"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Short sanitized failure reason. Never contains the key or raw provider error bodies.",
+            "title": "Error"
           }
         },
         "required": [
@@ -85,21 +85,17 @@
       },
       "AIStatusResponse": {
         "properties": {
-          "configured": {
-            "description": "Whether an API key is configured. AI features require both 'enabled' and 'configured'.",
-            "title": "Configured",
-            "type": "boolean"
-          },
-          "enabled": {
-            "description": "Whether AI features are enabled for this instance.",
-            "title": "Enabled",
-            "type": "boolean"
-          },
-          "has_embeddings": {
-            "default": false,
-            "description": "Whether at least one record has embeddings stored.",
-            "title": "Has Embeddings",
-            "type": "boolean"
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Active AI provider name (e.g. 'anthropic', 'openai').",
+            "title": "Provider"
           },
           "model": {
             "anyOf": [
@@ -113,6 +109,28 @@
             "description": "Active model name (e.g. 'claude-sonnet-4-20250514').",
             "title": "Model"
           },
+          "enabled": {
+            "description": "Whether AI features are enabled for this instance.",
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "configured": {
+            "description": "Whether an API key is configured. AI features require both 'enabled' and 'configured'.",
+            "title": "Configured",
+            "type": "boolean"
+          },
+          "semantic_search_enabled": {
+            "default": false,
+            "description": "Whether pgvector-backed semantic search is enabled.",
+            "title": "Semantic Search Enabled",
+            "type": "boolean"
+          },
+          "has_embeddings": {
+            "default": false,
+            "description": "Whether at least one record has embeddings stored.",
+            "title": "Has Embeddings",
+            "type": "boolean"
+          },
           "probe": {
             "anyOf": [
               {
@@ -123,24 +141,6 @@
               }
             ],
             "description": "Live provider probe results. Only present when the request opted in via ?probe=true."
-          },
-          "provider": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Active AI provider name (e.g. 'anthropic', 'openai').",
-            "title": "Provider"
-          },
-          "semantic_search_enabled": {
-            "default": false,
-            "description": "Whether pgvector-backed semantic search is enabled.",
-            "title": "Semantic Search Enabled",
-            "type": "boolean"
           }
         },
         "required": [
@@ -193,6 +193,19 @@
       },
       "AdminApiKeyCreateRequest": {
         "properties": {
+          "user_id": {
+            "description": "ID of the user the new API key will belong to.",
+            "format": "uuid",
+            "title": "User Id",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human-readable label for the API key (e.g. 'CI pipeline', 'QGIS desktop').",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
           "expires_at": {
             "anyOf": [
               {
@@ -206,13 +219,6 @@
             "description": "Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.",
             "title": "Expires At"
           },
-          "name": {
-            "description": "Human-readable label for the API key (e.g. 'CI pipeline', 'QGIS desktop').",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
-          },
           "scope": {
             "default": "full",
             "description": "Privilege scope (#875). 'full' impersonates the owner completely, the pre-existing behavior. 'read_only' authenticates GET, HEAD and OPTIONS requests only; any other method is refused with 403. A service-account key minted for an application is the usual case for 'read_only'.",
@@ -221,12 +227,6 @@
               "read_only"
             ],
             "title": "Scope",
-            "type": "string"
-          },
-          "user_id": {
-            "description": "ID of the user the new API key will belong to.",
-            "format": "uuid",
-            "title": "User Id",
             "type": "string"
           }
         },
@@ -239,11 +239,39 @@
       },
       "AdminApiKeyListItem": {
         "properties": {
-          "created_at": {
-            "description": "Timestamp when the key was created.",
-            "format": "date-time",
-            "title": "Created At",
+          "id": {
+            "description": "Unique API key identifier.",
+            "format": "uuid",
+            "title": "Id",
             "type": "string"
+          },
+          "user_id": {
+            "description": "Owning user's ID.",
+            "format": "uuid",
+            "title": "User Id",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human-readable label.",
+            "title": "Name",
+            "type": "string"
+          },
+          "fingerprint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Non-secret key identifier; null for legacy keys.",
+            "title": "Fingerprint"
+          },
+          "is_active": {
+            "description": "Whether the key is active. Inactive keys cannot authenticate.",
+            "title": "Is Active",
+            "type": "boolean"
           },
           "expires_at": {
             "anyOf": [
@@ -258,28 +286,16 @@
             "description": "Expiry timestamp; null means the key does not expire.",
             "title": "Expires At"
           },
-          "fingerprint": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Non-secret key identifier; null for legacy keys.",
-            "title": "Fingerprint"
-          },
-          "id": {
-            "description": "Unique API key identifier.",
-            "format": "uuid",
-            "title": "Id",
+          "scope": {
+            "description": "Privilege scope: 'full' or 'read_only' (#875).",
+            "title": "Scope",
             "type": "string"
           },
-          "is_active": {
-            "description": "Whether the key is active. Inactive keys cannot authenticate.",
-            "title": "Is Active",
-            "type": "boolean"
+          "created_at": {
+            "description": "Timestamp when the key was created.",
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           },
           "last_used_at": {
             "anyOf": [
@@ -293,22 +309,6 @@
             ],
             "description": "Timestamp of the most recent successful authentication using this key.",
             "title": "Last Used At"
-          },
-          "name": {
-            "description": "Human-readable label.",
-            "title": "Name",
-            "type": "string"
-          },
-          "scope": {
-            "description": "Privilege scope: 'full' or 'read_only' (#875).",
-            "title": "Scope",
-            "type": "string"
-          },
-          "user_id": {
-            "description": "Owning user's ID.",
-            "format": "uuid",
-            "title": "User Id",
-            "type": "string"
           }
         },
         "required": [
@@ -370,6 +370,38 @@
       },
       "AdminEmbedTokenResponse": {
         "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "map_id": {
+            "format": "uuid",
+            "title": "Map Id",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "token_hint": {
+            "title": "Token Hint",
+            "type": "string"
+          },
+          "scoped_dataset_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Scoped Dataset Ids",
+            "type": "array"
+          },
           "allowed_origins": {
             "anyOf": [
               {
@@ -384,35 +416,19 @@
             ],
             "title": "Allowed Origins"
           },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "creator_username": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Creator Username"
-          },
           "expires_at": {
             "format": "date-time",
             "title": "Expires At",
             "type": "string"
           },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
           "is_active": {
             "title": "Is Active",
             "type": "boolean"
+          },
+          "use_count": {
+            "default": 0,
+            "title": "Use Count",
+            "type": "integer"
           },
           "last_used_at": {
             "anyOf": [
@@ -426,9 +442,9 @@
             ],
             "title": "Last Used At"
           },
-          "map_id": {
-            "format": "uuid",
-            "title": "Map Id",
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
             "type": "string"
           },
           "map_name": {
@@ -442,7 +458,7 @@
             ],
             "title": "Map Name"
           },
-          "name": {
+          "creator_username": {
             "anyOf": [
               {
                 "type": "string"
@@ -451,23 +467,7 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
-          },
-          "scoped_dataset_ids": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Scoped Dataset Ids",
-            "type": "array"
-          },
-          "token_hint": {
-            "title": "Token Hint",
-            "type": "string"
-          },
-          "use_count": {
-            "default": 0,
-            "title": "Use Count",
-            "type": "integer"
+            "title": "Creator Username"
           }
         },
         "required": [
@@ -507,42 +507,36 @@
       },
       "AdminJobResponse": {
         "properties": {
-          "can_retry": {
-            "description": "Whether the failed job can be retried with its retained source.",
-            "title": "Can Retry",
-            "type": "boolean"
-          },
-          "completed_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Timestamp when the job finished (success or failure).",
-            "title": "Completed At"
-          },
-          "created_at": {
-            "description": "Timestamp when the job was queued.",
-            "format": "date-time",
-            "title": "Created At",
+          "id": {
+            "description": "Unique ingestion job identifier.",
+            "format": "uuid",
+            "title": "Id",
             "type": "string"
           },
-          "created_by": {
+          "status": {
+            "description": "Current job status: 'pending', 'running', 'complete', 'failed', or 'cancelled'.",
+            "enum": [
+              "pending",
+              "running",
+              "complete",
+              "failed",
+              "cancelled",
+              "fanned_out"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "source_filename": {
             "anyOf": [
               {
-                "format": "uuid",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "ID of the user who initiated the job.",
-            "title": "Created By"
+            "description": "Original filename of the uploaded file, if applicable.",
+            "title": "Source Filename"
           },
           "dataset_id": {
             "anyOf": [
@@ -569,11 +563,10 @@
             "description": "Error details if the job failed.",
             "title": "Error Message"
           },
-          "id": {
-            "description": "Unique ingestion job identifier.",
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
+          "can_retry": {
+            "description": "Whether the failed job can be retried with its retained source.",
+            "title": "Can Retry",
+            "type": "boolean"
           },
           "retry_reason": {
             "anyOf": [
@@ -586,44 +579,6 @@
             ],
             "description": "Why the job cannot be retried, when retry is unavailable.",
             "title": "Retry Reason"
-          },
-          "source_filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Original filename of the uploaded file, if applicable.",
-            "title": "Source Filename"
-          },
-          "started_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Timestamp when the worker began processing the job.",
-            "title": "Started At"
-          },
-          "status": {
-            "description": "Current job status: 'pending', 'running', 'complete', 'failed', or 'cancelled'.",
-            "enum": [
-              "pending",
-              "running",
-              "complete",
-              "failed",
-              "cancelled",
-              "fanned_out"
-            ],
-            "title": "Status",
-            "type": "string"
           },
           "user_metadata": {
             "anyOf": [
@@ -638,6 +593,19 @@
             "description": "User-supplied metadata captured at upload time (title, summary, tags, vrt_type, file_type, warnings, etc.). Heterogeneous shape across ingest paths -- canonical keys: title, summary, visibility, file_type, vrt_type, warnings.",
             "title": "User Metadata"
           },
+          "created_by": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the user who initiated the job.",
+            "title": "Created By"
+          },
           "username": {
             "anyOf": [
               {
@@ -649,6 +617,38 @@
             ],
             "description": "Username of the user who initiated the job.",
             "title": "Username"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Timestamp when the worker began processing the job.",
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Timestamp when the job finished (success or failure).",
+            "title": "Completed At"
+          },
+          "created_at": {
+            "description": "Timestamp when the job was queued.",
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           }
         },
         "required": [
@@ -692,39 +692,6 @@
       },
       "AdminShareTokenResponse": {
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "created_by": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created By"
-          },
-          "embed_token_count": {
-            "default": 0,
-            "title": "Embed Token Count",
-            "type": "integer"
-          },
-          "expires_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expires At"
-          },
           "id": {
             "anyOf": [
               {
@@ -736,17 +703,6 @@
               }
             ],
             "title": "Id"
-          },
-          "is_active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Active"
           },
           "map_id": {
             "format": "uuid",
@@ -767,6 +723,50 @@
               }
             ],
             "title": "Token"
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "embed_token_count": {
+            "default": 0,
+            "title": "Embed Token Count",
+            "type": "integer"
           }
         },
         "required": [
@@ -780,6 +780,20 @@
       },
       "AdminUserCreate": {
         "properties": {
+          "username": {
+            "description": "Login username (3-150 chars). Must be unique across the system.",
+            "maxLength": 150,
+            "minLength": 3,
+            "title": "Username",
+            "type": "string"
+          },
+          "password": {
+            "description": "Initial password (policy: min 12 chars, 3+ character classes). The user can change this after first login.",
+            "maxLength": 256,
+            "minLength": 8,
+            "title": "Password",
+            "type": "string"
+          },
           "email": {
             "anyOf": [
               {
@@ -794,24 +808,10 @@
             "description": "Optional email address. Used for OAuth account linking and notifications.",
             "title": "Email"
           },
-          "password": {
-            "description": "Initial password (policy: min 12 chars, 3+ character classes). The user can change this after first login.",
-            "maxLength": 256,
-            "minLength": 8,
-            "title": "Password",
-            "type": "string"
-          },
           "role": {
             "default": "viewer",
             "description": "User role: 'admin', 'editor', or 'viewer'. Defaults to 'viewer'.",
             "title": "Role",
-            "type": "string"
-          },
-          "username": {
-            "description": "Login username (3-150 chars). Must be unique across the system.",
-            "maxLength": 150,
-            "minLength": 3,
-            "title": "Username",
             "type": "string"
           }
         },
@@ -839,18 +839,25 @@
       "AnalysisMaterializeRequest": {
         "description": "Parameters for materializing an analysis result as a new dataset.",
         "properties": {
-          "by_field": {
-            "anyOf": [
-              {
-                "maxLength": 63,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
+          "operation": {
+            "enum": [
+              "buffer",
+              "centroid",
+              "clip",
+              "dissolve",
+              "spatial_join",
+              "measure",
+              "select_by_location",
+              "intersect"
             ],
-            "description": "Optional group-by column for dissolve",
-            "title": "By Field"
+            "title": "Operation",
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
           },
           "distance_meters": {
             "anyOf": [
@@ -865,6 +872,45 @@
             ],
             "description": "Buffer distance in meters (buffer only)",
             "title": "Distance Meters"
+          },
+          "mask": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)",
+            "title": "Mask"
+          },
+          "mask_dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Polygon dataset supplying the second layer: the area clipped to, selected against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a drawn polygon has none.",
+            "title": "Mask Dataset Id"
+          },
+          "by_field": {
+            "anyOf": [
+              {
+                "maxLength": 63,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional group-by column for dissolve",
+            "title": "By Field"
           },
           "join_dataset_id": {
             "anyOf": [
@@ -894,52 +940,6 @@
             ],
             "description": "Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)",
             "title": "Join Fields"
-          },
-          "mask": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)",
-            "title": "Mask"
-          },
-          "mask_dataset_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Polygon dataset supplying the second layer: the area clipped to, selected against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a drawn polygon has none.",
-            "title": "Mask Dataset Id"
-          },
-          "operation": {
-            "enum": [
-              "buffer",
-              "centroid",
-              "clip",
-              "dissolve",
-              "spatial_join",
-              "measure",
-              "select_by_location",
-              "intersect"
-            ],
-            "title": "Operation",
-            "type": "string"
-          },
-          "title": {
-            "maxLength": 500,
-            "minLength": 1,
-            "title": "Title",
-            "type": "string"
           }
         },
         "required": [
@@ -972,20 +972,18 @@
       "AnalysisPreviewRequest": {
         "description": "Parameters for a synchronous analysis preview.\n\nDeliberately flat (no discriminated union) so SDK generators keep the\nendpoint; per-operation requiredness is enforced by the validator.",
         "properties": {
-          "bbox": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "number"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
+          "operation": {
+            "enum": [
+              "buffer",
+              "centroid",
+              "clip",
+              "spatial_join",
+              "measure",
+              "select_by_location",
+              "intersect"
             ],
-            "description": "[minx, miny, maxx, maxy] in EPSG:4326, typically the map's current viewport. When present, only source features intersecting the envelope are considered before the preview's row cap applies, so a capped result reflects what is on screen rather than an arbitrary sample in ingest order (fix(#727)). Applies to every operation, not just one, so it is deliberately absent from _ANALYSIS_PARAM_OWNERS \u2014 omit it to preview the whole dataset, unchanged from before this field existed.",
-            "title": "Bbox"
+            "title": "Operation",
+            "type": "string"
           },
           "distance_meters": {
             "anyOf": [
@@ -1000,6 +998,32 @@
             ],
             "description": "Buffer distance in meters (buffer only)",
             "title": "Distance Meters"
+          },
+          "mask": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)",
+            "title": "Mask"
+          },
+          "mask_dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Polygon dataset supplying the second layer: the area clipped to, selected against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a drawn polygon has none.",
+            "title": "Mask Dataset Id"
           },
           "join_dataset_id": {
             "anyOf": [
@@ -1030,44 +1054,20 @@
             "description": "Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)",
             "title": "Join Fields"
           },
-          "mask": {
+          "bbox": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)",
-            "title": "Mask"
-          },
-          "mask_dataset_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Polygon dataset supplying the second layer: the area clipped to, selected against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a drawn polygon has none.",
-            "title": "Mask Dataset Id"
-          },
-          "operation": {
-            "enum": [
-              "buffer",
-              "centroid",
-              "clip",
-              "spatial_join",
-              "measure",
-              "select_by_location",
-              "intersect"
-            ],
-            "title": "Operation",
-            "type": "string"
+            "description": "[minx, miny, maxx, maxy] in EPSG:4326, typically the map's current viewport. When present, only source features intersecting the envelope are considered before the preview's row cap applies, so a capped result reflects what is on screen rather than an arbitrary sample in ingest order (fix(#727)). Applies to every operation, not just one, so it is deliberately absent from _ANALYSIS_PARAM_OWNERS \u2014 omit it to preview the whole dataset, unchanged from before this field existed.",
+            "title": "Bbox"
           }
         },
         "required": [
@@ -1079,6 +1079,19 @@
       "AnalysisPreviewResponse": {
         "description": "GeoJSON FeatureCollection preview of an analysis operation.",
         "properties": {
+          "geojson": {
+            "additionalProperties": true,
+            "title": "Geojson",
+            "type": "object"
+          },
+          "feature_count": {
+            "title": "Feature Count",
+            "type": "integer"
+          },
+          "truncated": {
+            "title": "Truncated",
+            "type": "boolean"
+          },
           "bbox": {
             "anyOf": [
               {
@@ -1093,27 +1106,6 @@
             ],
             "title": "Bbox"
           },
-          "feature_count": {
-            "title": "Feature Count",
-            "type": "integer"
-          },
-          "geojson": {
-            "additionalProperties": true,
-            "title": "Geojson",
-            "type": "object"
-          },
-          "match_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Exact total across the WHOLE source, not just the previewed features \u2014 WHOLE meaning the request's bbox when one was sent, the same sense source_feature_count uses that word. What it counts is per-operation, so read it against the operation you sent rather than as one number: select_by_location gives the selected source features and intersect gives the output pieces, and for both of those it IS the output total; spatial_join gives intersecting source/join PAIRS, which is NOT the output total, because the join keeps every source row (use source_feature_count for that operation). intersect and spatial_join both scope this total to a bbox on the request; select_by_location's count is a separate uncapped query the request's bbox does not reach, so it stays unscoped even though its preview rows are viewport-limited too. Null for operations that report no such total, and when the count could not be computed within the query budget",
-            "title": "Match Count"
-          },
           "source_feature_count": {
             "anyOf": [
               {
@@ -1126,9 +1118,17 @@
             "description": "Total feature count of the source dataset (1:1 operations only; null when the operation filters rows, e.g. clip). When the request carried a bbox this is a LIVE count of rows intersecting it rather than the dataset's cached whole-table total (fix(#727)) \u2014 also null, same as match_count, when that live count could not be computed within the query budget",
             "title": "Source Feature Count"
           },
-          "truncated": {
-            "title": "Truncated",
-            "type": "boolean"
+          "match_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Exact total across the WHOLE source, not just the previewed features \u2014 WHOLE meaning the request's bbox when one was sent, the same sense source_feature_count uses that word. What it counts is per-operation, so read it against the operation you sent rather than as one number: select_by_location gives the selected source features and intersect gives the output pieces, and for both of those it IS the output total; spatial_join gives intersecting source/join PAIRS, which is NOT the output total, because the join keeps every source row (use source_feature_count for that operation). intersect and spatial_join both scope this total to a bbox on the request; select_by_location's count is a separate uncapped query the request's bbox does not reach, so it stays unscoped even though its preview rows are viewport-limited too. Null for operations that report no such total, and when the count could not be computed within the query budget",
+            "title": "Match Count"
           }
         },
         "required": [
@@ -1141,6 +1141,13 @@
       },
       "ApiKeyCreateRequest": {
         "properties": {
+          "name": {
+            "description": "Human-readable label for the API key",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
           "expires_at": {
             "anyOf": [
               {
@@ -1153,13 +1160,6 @@
             ],
             "description": "Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.",
             "title": "Expires At"
-          },
-          "name": {
-            "description": "Human-readable label for the API key",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
           },
           "scope": {
             "default": "full",
@@ -1180,9 +1180,23 @@
       },
       "ApiKeyCreateResponse": {
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "key": {
+            "description": "The API key secret (shown only once)",
+            "title": "Key",
+            "type": "string"
+          },
+          "fingerprint": {
+            "description": "Non-secret key identifier (prefix and last four characters)",
+            "title": "Fingerprint",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
             "type": "string"
           },
           "expires_at": {
@@ -1198,28 +1212,14 @@
             "description": "Expiry timestamp; null means the key does not expire",
             "title": "Expires At"
           },
-          "fingerprint": {
-            "description": "Non-secret key identifier (prefix and last four characters)",
-            "title": "Fingerprint",
-            "type": "string"
-          },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
-          "key": {
-            "description": "The API key secret (shown only once)",
-            "title": "Key",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
           "scope": {
             "description": "Privilege scope: 'full' or 'read_only' (#875)",
             "title": "Scope",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
             "type": "string"
           }
         },
@@ -1236,10 +1236,30 @@
       },
       "ApiKeyListItem": {
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
+          "id": {
+            "format": "uuid",
+            "title": "Id",
             "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "fingerprint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Non-secret key identifier; null for keys created before fingerprint support",
+            "title": "Fingerprint"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
           },
           "expires_at": {
             "anyOf": [
@@ -1254,26 +1274,15 @@
             "description": "Expiry timestamp; null means the key does not expire",
             "title": "Expires At"
           },
-          "fingerprint": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Non-secret key identifier; null for keys created before fingerprint support",
-            "title": "Fingerprint"
-          },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
+          "scope": {
+            "description": "Privilege scope: 'full' or 'read_only' (#875)",
+            "title": "Scope",
             "type": "string"
           },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           },
           "last_used_at": {
             "anyOf": [
@@ -1286,15 +1295,6 @@
               }
             ],
             "title": "Last Used At"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "scope": {
-            "description": "Privilege scope: 'full' or 'read_only' (#875)",
-            "title": "Scope",
-            "type": "string"
           }
         },
         "required": [
@@ -1389,7 +1389,21 @@
       },
       "AttributeMetadataResponse": {
         "properties": {
-          "data_type": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "dataset_id": {
+            "format": "uuid",
+            "title": "Dataset Id",
+            "type": "string"
+          },
+          "field_name": {
+            "title": "Field Name",
+            "type": "string"
+          },
+          "title": {
             "anyOf": [
               {
                 "type": "string"
@@ -1398,12 +1412,7 @@
                 "type": "null"
               }
             ],
-            "title": "Data Type"
-          },
-          "dataset_id": {
-            "format": "uuid",
-            "title": "Dataset Id",
-            "type": "string"
+            "title": "Title"
           },
           "description": {
             "anyOf": [
@@ -1416,6 +1425,28 @@
             ],
             "title": "Description"
           },
+          "data_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Type"
+          },
+          "units": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Units"
+          },
           "domain_type": {
             "anyOf": [
               {
@@ -1426,6 +1457,18 @@
               }
             ],
             "title": "Domain Type"
+          },
+          "semantic_role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Inferred role: geometry, identifier, measure, etc.",
+            "title": "Semantic Role"
           },
           "example_values": {
             "anyOf": [
@@ -1440,31 +1483,6 @@
             "description": "Sample values from the column",
             "title": "Example Values"
           },
-          "field_name": {
-            "title": "Field Name",
-            "type": "string"
-          },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
-          "is_current": {
-            "description": "False if column was removed in a later version",
-            "title": "Is Current",
-            "type": "boolean"
-          },
-          "is_nullable": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Nullable"
-          },
           "ordinal_position": {
             "anyOf": [
               {
@@ -1477,39 +1495,21 @@
             "description": "Column position in the table (1-based)",
             "title": "Ordinal Position"
           },
-          "semantic_role": {
+          "is_nullable": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Inferred role: geometry, identifier, measure, etc.",
-            "title": "Semantic Role"
+            "title": "Is Nullable"
           },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "units": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Units"
+          "is_current": {
+            "description": "False if column was removed in a later version",
+            "title": "Is Current",
+            "type": "boolean"
           },
           "user_modified_fields": {
             "description": "Field names manually edited by a user",
@@ -1537,6 +1537,19 @@
       },
       "AttributeMetadataUpdate": {
         "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Human-friendly column display name",
+            "title": "Title"
+          },
           "description": {
             "anyOf": [
               {
@@ -1548,6 +1561,42 @@
               }
             ],
             "title": "Description"
+          },
+          "units": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Measurement units, e.g. meters, kg",
+            "title": "Units"
+          },
+          "semantic_role": {
+            "anyOf": [
+              {
+                "enum": [
+                  "geometry",
+                  "identifier",
+                  "measure",
+                  "temporal",
+                  "categorical",
+                  "category",
+                  "label",
+                  "foreign_key",
+                  "other"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Column role: geometry, identifier, measure, etc.",
+            "title": "Semantic Role"
           },
           "domain_type": {
             "anyOf": [
@@ -1573,55 +1622,6 @@
             ],
             "description": "Value domain: continuous, categorical, coded, etc.",
             "title": "Domain Type"
-          },
-          "semantic_role": {
-            "anyOf": [
-              {
-                "enum": [
-                  "geometry",
-                  "identifier",
-                  "measure",
-                  "temporal",
-                  "categorical",
-                  "category",
-                  "label",
-                  "foreign_key",
-                  "other"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Column role: geometry, identifier, measure, etc.",
-            "title": "Semantic Role"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "maxLength": 500,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Human-friendly column display name",
-            "title": "Title"
-          },
-          "units": {
-            "anyOf": [
-              {
-                "maxLength": 50,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Measurement units, e.g. meters, kg",
-            "title": "Units"
           }
         },
         "title": "AttributeMetadataUpdate",
@@ -1650,68 +1650,9 @@
       },
       "AuditLogResponse": {
         "properties": {
-          "action": {
-            "title": "Action",
-            "type": "string"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "details": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Details"
-          },
           "id": {
             "format": "uuid",
             "title": "Id",
-            "type": "string"
-          },
-          "ip_address": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ip Address"
-          },
-          "resource_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Resource Id"
-          },
-          "resource_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Resource Name"
-          },
-          "resource_type": {
-            "title": "Resource Type",
             "type": "string"
           },
           "user_id": {
@@ -1736,6 +1677,65 @@
               }
             ],
             "title": "Username"
+          },
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "resource_type": {
+            "title": "Resource Type",
+            "type": "string"
+          },
+          "resource_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource Id"
+          },
+          "resource_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource Name"
+          },
+          "details": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Details"
+          },
+          "ip_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip Address"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           }
         },
         "required": [
@@ -1753,24 +1753,24 @@
       },
       "BackfillResponse": {
         "properties": {
-          "created": {
-            "description": "Number of new embeddings created.",
-            "title": "Created",
-            "type": "integer"
-          },
-          "errors": {
-            "description": "Number of records that failed during embedding generation.",
-            "title": "Errors",
-            "type": "integer"
-          },
           "processed": {
             "description": "Number of records processed in this backfill batch.",
             "title": "Processed",
             "type": "integer"
           },
+          "created": {
+            "description": "Number of new embeddings created.",
+            "title": "Created",
+            "type": "integer"
+          },
           "skipped": {
             "description": "Number of records skipped because an embedding already existed.",
             "title": "Skipped",
+            "type": "integer"
+          },
+          "errors": {
+            "description": "Number of records that failed during embedding generation.",
+            "title": "Errors",
             "type": "integer"
           }
         },
@@ -1786,28 +1786,15 @@
       "BasemapConfig": {
         "additionalProperties": false,
         "properties": {
-          "background_color": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Map canvas background color in #RRGGBB hex format, or null to use the basemap default.",
-            "title": "Background Color"
+          "label_mode": {
+            "$ref": "#/components/schemas/BasemapLabelMode",
+            "default": "full",
+            "description": "Basemap label prominence."
           },
-          "basemap_position": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/BasemapPosition"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no migration)."
+          "road_visibility": {
+            "$ref": "#/components/schemas/BasemapSublayerVisibility",
+            "default": "full",
+            "description": "Road and transit sublayer visibility where supported."
           },
           "boundary_visibility": {
             "$ref": "#/components/schemas/BasemapSublayerVisibility",
@@ -1820,34 +1807,10 @@
             "title": "Building Visibility",
             "type": "boolean"
           },
-          "label_mode": {
-            "$ref": "#/components/schemas/BasemapLabelMode",
-            "default": "full",
-            "description": "Basemap label prominence."
-          },
           "land_water_tone": {
             "$ref": "#/components/schemas/BasemapLandWaterTone",
             "default": "default",
             "description": "Land and water color treatment where supported."
-          },
-          "opacity": {
-            "default": 1.0,
-            "description": "Master basemap opacity 0.0-1.0",
-            "maximum": 1.0,
-            "minimum": 0.0,
-            "title": "Opacity",
-            "type": "number"
-          },
-          "projection": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/BasemapProjection"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Map projection: 'mercator' (default) or experimental 'globe'. null/undefined loads as 'mercator' on the client."
           },
           "relief_contrast": {
             "anyOf": [
@@ -1860,10 +1823,25 @@
             ],
             "description": "Optional contrast hint for relief-oriented basemap styling."
           },
-          "road_visibility": {
-            "$ref": "#/components/schemas/BasemapSublayerVisibility",
-            "default": "full",
-            "description": "Road and transit sublayer visibility where supported."
+          "opacity": {
+            "default": 1.0,
+            "description": "Master basemap opacity 0.0-1.0",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Opacity",
+            "type": "number"
+          },
+          "background_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Map canvas background color in #RRGGBB hex format, or null to use the basemap default.",
+            "title": "Background Color"
           },
           "sublayer_overrides": {
             "anyOf": [
@@ -1879,6 +1857,28 @@
             ],
             "description": "Per-sublayer style overrides keyed by semantic sublayer ID (e.g. 'road', 'boundary', 'building'). Key set is opaque \u2014 unknown future sublayer IDs are accepted without rejection. See CONTEXT.md D-01.",
             "title": "Sublayer Overrides"
+          },
+          "basemap_position": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BasemapPosition"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no migration)."
+          },
+          "projection": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BasemapProjection"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Map projection: 'mercator' (default) or experimental 'globe'. null/undefined loads as 'mercator' on the client."
           }
         },
         "title": "BasemapConfig",
@@ -1924,6 +1924,31 @@
       "BasemapPublicResponse": {
         "description": "Public basemap response \u2014 excludes api_key.",
         "properties": {
+          "id": {
+            "description": "Unique basemap identifier.",
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "description": "Display label.",
+            "title": "Label",
+            "type": "string"
+          },
+          "url": {
+            "description": "Tile URL or style JSON URL with API key already substituted (or omitted) for client use.",
+            "title": "Url",
+            "type": "string"
+          },
+          "enabled": {
+            "description": "Whether the basemap is currently selectable.",
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "is_preset": {
+            "description": "Whether this is a built-in preset.",
+            "title": "Is Preset",
+            "type": "boolean"
+          },
           "attribution": {
             "anyOf": [
               {
@@ -1935,31 +1960,6 @@
             ],
             "description": "Attribution string for the basemap source.",
             "title": "Attribution"
-          },
-          "enabled": {
-            "description": "Whether the basemap is currently selectable.",
-            "title": "Enabled",
-            "type": "boolean"
-          },
-          "id": {
-            "description": "Unique basemap identifier.",
-            "title": "Id",
-            "type": "string"
-          },
-          "is_preset": {
-            "description": "Whether this is a built-in preset.",
-            "title": "Is Preset",
-            "type": "boolean"
-          },
-          "label": {
-            "description": "Display label.",
-            "title": "Label",
-            "type": "string"
-          },
-          "url": {
-            "description": "Tile URL or style JSON URL with API key already substituted (or omitted) for client use.",
-            "title": "Url",
-            "type": "string"
           }
         },
         "required": [
@@ -1992,6 +1992,32 @@
       },
       "Body_login_auth_login_post": {
         "properties": {
+          "grant_type": {
+            "anyOf": [
+              {
+                "pattern": "^password$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          },
+          "password": {
+            "format": "password",
+            "title": "Password",
+            "type": "string"
+          },
+          "scope": {
+            "default": "",
+            "title": "Scope",
+            "type": "string"
+          },
           "client_id": {
             "anyOf": [
               {
@@ -2014,32 +2040,6 @@
             ],
             "format": "password",
             "title": "Client Secret"
-          },
-          "grant_type": {
-            "anyOf": [
-              {
-                "pattern": "^password$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grant Type"
-          },
-          "password": {
-            "format": "password",
-            "title": "Password",
-            "type": "string"
-          },
-          "scope": {
-            "default": "",
-            "title": "Scope",
-            "type": "string"
-          },
-          "username": {
-            "title": "Username",
-            "type": "string"
           }
         },
         "required": [
@@ -2108,14 +2108,14 @@
       },
       "BulkDeleteItem": {
         "properties": {
-          "confirm_title": {
-            "maxLength": 500,
-            "title": "Confirm Title",
-            "type": "string"
-          },
           "dataset_id": {
             "format": "uuid",
             "title": "Dataset Id",
+            "type": "string"
+          },
+          "confirm_title": {
+            "maxLength": 500,
+            "title": "Confirm Title",
             "type": "string"
           }
         },
@@ -2243,6 +2243,10 @@
             "title": "Dataset Id",
             "type": "string"
           },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
           "detail": {
             "anyOf": [
               {
@@ -2253,10 +2257,6 @@
               }
             ],
             "title": "Detail"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string"
           }
         },
         "required": [
@@ -2268,6 +2268,18 @@
       },
       "BulkRegisterItem": {
         "properties": {
+          "table_name": {
+            "description": "PostgreSQL table name to register.",
+            "maxLength": 63,
+            "title": "Table Name",
+            "type": "string"
+          },
+          "title": {
+            "description": "Human-readable dataset title.",
+            "maxLength": 500,
+            "title": "Title",
+            "type": "string"
+          },
           "summary": {
             "anyOf": [
               {
@@ -2280,18 +2292,6 @@
             ],
             "description": "Optional dataset description.",
             "title": "Summary"
-          },
-          "table_name": {
-            "description": "PostgreSQL table name to register.",
-            "maxLength": 63,
-            "title": "Table Name",
-            "type": "string"
-          },
-          "title": {
-            "description": "Human-readable dataset title.",
-            "maxLength": 500,
-            "title": "Title",
-            "type": "string"
           },
           "visibility": {
             "default": "private",
@@ -2349,6 +2349,16 @@
       },
       "BulkRegisterResult": {
         "properties": {
+          "table_name": {
+            "description": "Source table that was processed.",
+            "title": "Table Name",
+            "type": "string"
+          },
+          "status": {
+            "description": "Per-row outcome: 'success', 'skipped', or 'error'.",
+            "title": "Status",
+            "type": "string"
+          },
           "dataset_id": {
             "anyOf": [
               {
@@ -2362,28 +2372,6 @@
             "description": "ID of the created dataset on success.",
             "title": "Dataset Id"
           },
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Error message on failure.",
-            "title": "Error"
-          },
-          "status": {
-            "description": "Per-row outcome: 'success', 'skipped', or 'error'.",
-            "title": "Status",
-            "type": "string"
-          },
-          "table_name": {
-            "description": "Source table that was processed.",
-            "title": "Table Name",
-            "type": "string"
-          },
           "title": {
             "anyOf": [
               {
@@ -2395,6 +2383,18 @@
             ],
             "description": "Title of the created dataset on success.",
             "title": "Title"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error message on failure.",
+            "title": "Error"
           }
         },
         "required": [
@@ -2438,6 +2438,28 @@
       },
       "CatalogStatsResponse": {
         "properties": {
+          "total_datasets": {
+            "description": "Total number of datasets in the catalog.",
+            "title": "Total Datasets",
+            "type": "integer"
+          },
+          "recent_additions": {
+            "description": "Number of datasets added in the last 30 days.",
+            "title": "Recent Additions",
+            "type": "integer"
+          },
+          "total_storage_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Total storage used by all dataset tables, in bytes. Null if calculation is unavailable.",
+            "title": "Total Storage Bytes"
+          },
           "datasets_by_geometry_type": {
             "additionalProperties": {
               "type": "integer"
@@ -2454,34 +2476,6 @@
             "title": "Datasets By Visibility",
             "type": "object"
           },
-          "recent_additions": {
-            "description": "Number of datasets added in the last 30 days.",
-            "title": "Recent Additions",
-            "type": "integer"
-          },
-          "total_datasets": {
-            "description": "Total number of datasets in the catalog.",
-            "title": "Total Datasets",
-            "type": "integer"
-          },
-          "total_storage_bytes": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Total storage used by all dataset tables, in bytes. Null if calculation is unavailable.",
-            "title": "Total Storage Bytes"
-          },
-          "total_users": {
-            "default": 0,
-            "description": "Total number of users in the system.",
-            "title": "Total Users",
-            "type": "integer"
-          },
           "users_by_status": {
             "additionalProperties": {
               "type": "integer"
@@ -2490,6 +2484,12 @@
             "description": "Histogram of users keyed by status (active, deactivated, pending).",
             "title": "Users By Status",
             "type": "object"
+          },
+          "total_users": {
+            "default": 0,
+            "description": "Total number of users in the system.",
+            "title": "Total Users",
+            "type": "integer"
           }
         },
         "required": [
@@ -2527,19 +2527,55 @@
       },
       "ChatAction": {
         "properties": {
-          "bbox": {
+          "type": {
+            "enum": [
+              "set_filter",
+              "set_style",
+              "set_data_driven_style",
+              "set_label",
+              "toggle_visibility",
+              "add_layer",
+              "remove_layer",
+              "show_query_result",
+              "set_opacity"
+            ],
+            "title": "Type",
+            "type": "string"
+          },
+          "layer_id": {
             "anyOf": [
               {
-                "items": {
-                  "type": "number"
-                },
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Layer Id"
+          },
+          "expression": {
+            "anyOf": [
+              {
+                "items": {},
                 "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Bbox"
+            "title": "Expression"
+          },
+          "paint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paint"
           },
           "clear_paint": {
             "anyOf": [
@@ -2555,19 +2591,40 @@
             ],
             "title": "Clear Paint"
           },
-          "columns": {
+          "replace_paint": {
             "anyOf": [
               {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Columns"
+            "title": "Replace Paint"
+          },
+          "style_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Style Config"
+          },
+          "label_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label Config"
           },
           "dataset_id": {
             "anyOf": [
@@ -2591,61 +2648,16 @@
             ],
             "title": "Dataset Name"
           },
-          "distance_meters": {
+          "visible": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Distance Meters"
-          },
-          "expression": {
-            "anyOf": [
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expression"
-          },
-          "geojson": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GeoJSONFeatureCollection"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "label_config": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Label Config"
-          },
-          "layer_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Layer Id"
+            "title": "Visible"
           },
           "opacity": {
             "anyOf": [
@@ -2660,50 +2672,29 @@
             ],
             "title": "Opacity"
           },
-          "operation": {
+          "geojson": {
             "anyOf": [
               {
-                "type": "string"
+                "$ref": "#/components/schemas/GeoJSONFeatureCollection"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Operation"
+            ]
           },
-          "paint": {
+          "bbox": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Paint"
-          },
-          "replace_paint": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Replace Paint"
-          },
-          "row_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Row Count"
+            "title": "Bbox"
           },
           "rows": {
             "anyOf": [
@@ -2720,17 +2711,30 @@
             ],
             "title": "Rows"
           },
-          "style_config": {
+          "columns": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Style Config"
+            "title": "Columns"
+          },
+          "row_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Row Count"
           },
           "truncated": {
             "anyOf": [
@@ -2743,31 +2747,27 @@
             ],
             "title": "Truncated"
           },
-          "type": {
-            "enum": [
-              "set_filter",
-              "set_style",
-              "set_data_driven_style",
-              "set_label",
-              "toggle_visibility",
-              "add_layer",
-              "remove_layer",
-              "show_query_result",
-              "set_opacity"
-            ],
-            "title": "Type",
-            "type": "string"
-          },
-          "visible": {
+          "operation": {
             "anyOf": [
               {
-                "type": "boolean"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Visible"
+            "title": "Operation"
+          },
+          "distance_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance Meters"
           }
         },
         "required": [
@@ -2779,16 +2779,16 @@
       "ChatHistoryMessage": {
         "description": "A single message in the conversation history.",
         "properties": {
-          "content": {
-            "title": "Content",
-            "type": "string"
-          },
           "role": {
             "enum": [
               "user",
               "assistant"
             ],
             "title": "Role",
+            "type": "string"
+          },
+          "content": {
+            "title": "Content",
             "type": "string"
           }
         },
@@ -2802,6 +2802,44 @@
       "ChatMapLayer": {
         "description": "Layer state sent from frontend for chat context.",
         "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "dataset_id": {
+            "title": "Dataset Id",
+            "type": "string"
+          },
+          "dataset_table_name": {
+            "title": "Dataset Table Name",
+            "type": "string"
+          },
+          "geometry_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Geometry Type"
+          },
+          "layer_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Layer Type"
+          },
           "column_info": {
             "anyOf": [
               {
@@ -2816,14 +2854,6 @@
               }
             ],
             "title": "Column Info"
-          },
-          "dataset_id": {
-            "title": "Dataset Id",
-            "type": "string"
-          },
-          "dataset_table_name": {
-            "title": "Dataset Table Name",
-            "type": "string"
           },
           "dataset_title": {
             "anyOf": [
@@ -2847,6 +2877,23 @@
             ],
             "title": "Feature Count"
           },
+          "sample_values": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sample Values"
+          },
+          "visible": {
+            "default": true,
+            "title": "Visible",
+            "type": "boolean"
+          },
           "filter": {
             "anyOf": [
               {
@@ -2863,21 +2910,6 @@
             ],
             "title": "Filter"
           },
-          "geometry_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Geometry Type"
-          },
-          "id": {
-            "title": "Id",
-            "type": "string"
-          },
           "label_config": {
             "anyOf": [
               {
@@ -2889,45 +2921,6 @@
               }
             ],
             "title": "Label Config"
-          },
-          "layer_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Layer Type"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "paint": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Paint"
-          },
-          "sample_values": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sample Values"
           },
           "style_config": {
             "anyOf": [
@@ -2941,10 +2934,17 @@
             ],
             "title": "Style Config"
           },
-          "visible": {
-            "default": true,
-            "title": "Visible",
-            "type": "boolean"
+          "paint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paint"
           }
         },
         "required": [
@@ -2958,12 +2958,21 @@
       },
       "ChatRequest": {
         "properties": {
-          "history": {
+          "message": {
+            "maxLength": 2000,
+            "minLength": 1,
+            "title": "Message",
+            "type": "string"
+          },
+          "map_id": {
+            "title": "Map Id",
+            "type": "string"
+          },
+          "layers": {
             "items": {
-              "$ref": "#/components/schemas/ChatHistoryMessage"
+              "$ref": "#/components/schemas/ChatMapLayer"
             },
-            "maxItems": 20,
-            "title": "History",
+            "title": "Layers",
             "type": "array"
           },
           "language": {
@@ -2977,22 +2986,13 @@
             ],
             "title": "Language"
           },
-          "layers": {
+          "history": {
             "items": {
-              "$ref": "#/components/schemas/ChatMapLayer"
+              "$ref": "#/components/schemas/ChatHistoryMessage"
             },
-            "title": "Layers",
+            "maxItems": 20,
+            "title": "History",
             "type": "array"
-          },
-          "map_id": {
-            "title": "Map Id",
-            "type": "string"
-          },
-          "message": {
-            "maxLength": 2000,
-            "minLength": 1,
-            "title": "Message",
-            "type": "string"
           }
         },
         "required": [
@@ -3005,16 +3005,16 @@
       },
       "ChatResponse": {
         "properties": {
+          "explanation": {
+            "title": "Explanation",
+            "type": "string"
+          },
           "actions": {
             "items": {
               "$ref": "#/components/schemas/ChatAction"
             },
             "title": "Actions",
             "type": "array"
-          },
-          "explanation": {
-            "title": "Explanation",
-            "type": "string"
           }
         },
         "required": [
@@ -3046,6 +3046,14 @@
       },
       "CollectionCreate": {
         "properties": {
+          "name": {
+            "description": "Display name for the collection",
+            "example": "NYC Open Data",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
           "description": {
             "anyOf": [
               {
@@ -3059,14 +3067,6 @@
             "description": "Optional text description",
             "example": "Datasets from the NYC Open Data portal",
             "title": "Description"
-          },
-          "name": {
-            "description": "Display name for the collection",
-            "example": "NYC Open Data",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
           }
         },
         "required": [
@@ -3078,10 +3078,6 @@
       "CollectionFacetItem": {
         "description": "A collection facet entry.",
         "properties": {
-          "dataset_count": {
-            "title": "Dataset Count",
-            "type": "integer"
-          },
           "id": {
             "title": "Id",
             "type": "string"
@@ -3089,6 +3085,10 @@
           "name": {
             "title": "Name",
             "type": "string"
+          },
+          "dataset_count": {
+            "title": "Dataset Count",
+            "type": "integer"
           }
         },
         "required": [
@@ -3142,10 +3142,25 @@
       },
       "CollectionResponse": {
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
+          "id": {
+            "format": "uuid",
+            "title": "Id",
             "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
           },
           "created_by": {
             "anyOf": [
@@ -3159,20 +3174,19 @@
             ],
             "title": "Created By"
           },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
           "dataset_count": {
             "title": "Dataset Count",
             "type": "integer"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
           },
           "extent_bbox": {
             "anyOf": [
@@ -3188,27 +3202,6 @@
             ],
             "title": "Extent Bbox"
           },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "temporal_end": {
-            "anyOf": [
-              {
-                "format": "date",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Temporal End"
-          },
           "temporal_start": {
             "anyOf": [
               {
@@ -3221,10 +3214,17 @@
             ],
             "title": "Temporal Start"
           },
-          "updated_at": {
-            "format": "date-time",
-            "title": "Updated At",
-            "type": "string"
+          "temporal_end": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Temporal End"
           }
         },
         "required": [
@@ -3241,19 +3241,6 @@
       },
       "CollectionUpdate": {
         "properties": {
-          "description": {
-            "anyOf": [
-              {
-                "maxLength": 2000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Updated description",
-            "title": "Description"
-          },
           "name": {
             "anyOf": [
               {
@@ -3267,6 +3254,19 @@
             ],
             "description": "Updated display name",
             "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Updated description",
+            "title": "Description"
           }
         },
         "title": "CollectionUpdate",
@@ -3357,16 +3357,16 @@
             "title": "Items",
             "type": "array"
           },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          },
           "limit": {
             "title": "Limit",
             "type": "integer"
           },
           "offset": {
             "title": "Offset",
-            "type": "integer"
-          },
-          "total": {
-            "title": "Total",
             "type": "integer"
           }
         },
@@ -3425,6 +3425,25 @@
       "ColumnInfo": {
         "description": "Describes a single column in a dataset's attribute table.",
         "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          },
+          "semantic_role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Semantic Role"
+          },
           "domain_type": {
             "anyOf": [
               {
@@ -3435,10 +3454,6 @@
               }
             ],
             "title": "Domain Type"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
           },
           "sample_values": {
             "anyOf": [
@@ -3452,17 +3467,6 @@
             ],
             "title": "Sample Values"
           },
-          "semantic_role": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Semantic Role"
-          },
           "stats": {
             "anyOf": [
               {
@@ -3474,10 +3478,6 @@
               }
             ],
             "title": "Stats"
-          },
-          "type": {
-            "title": "Type",
-            "type": "string"
           }
         },
         "required": [
@@ -3539,10 +3539,62 @@
       },
       "ColumnStatsResponse": {
         "properties": {
+          "min": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min"
+          },
+          "max": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max"
+          },
           "count": {
             "default": 0,
             "title": "Count",
             "type": "integer"
+          },
+          "mean": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean"
+          },
+          "quantiles": {
+            "default": [],
+            "items": {
+              "type": "number"
+            },
+            "title": "Quantiles",
+            "type": "array"
+          },
+          "stddev": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stddev"
           },
           "data_type": {
             "anyOf": [
@@ -3567,58 +3619,6 @@
             ],
             "description": "Distinct non-null value count (categorical columns only).",
             "title": "Distinct Count"
-          },
-          "max": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max"
-          },
-          "mean": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mean"
-          },
-          "min": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Min"
-          },
-          "quantiles": {
-            "default": [],
-            "items": {
-              "type": "number"
-            },
-            "title": "Quantiles",
-            "type": "array"
-          },
-          "stddev": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Stddev"
           }
         },
         "title": "ColumnStatsResponse",
@@ -3626,10 +3626,6 @@
       },
       "ColumnValuesResponse": {
         "properties": {
-          "count": {
-            "title": "Count",
-            "type": "integer"
-          },
           "values": {
             "items": {
               "anyOf": [
@@ -3649,6 +3645,10 @@
             },
             "title": "Values",
             "type": "array"
+          },
+          "count": {
+            "title": "Count",
+            "type": "integer"
           }
         },
         "required": [
@@ -3661,6 +3661,90 @@
       "CommitRequest": {
         "description": "Wire-level schema for ``POST /ingest/commit/{job_id}``.\n\nPreserved as a flat union of all possible commit fields so that the\nFastAPI route signature renders correctly in OpenAPI and so that the\nfrontend's ``CommitImportRequest`` TypeScript type stays unchanged.\n\nThe route handler re-validates the body against a subclass chosen by\n``_pick_commit_subclass(job)`` (see ``app.ingest.router``):\n\n  - ``VectorCommitRequest`` \u2014 default for file uploads\n  - ``RasterCommitRequest`` \u2014 when ``job.user_metadata['file_type'] == 'raster'``\n  - ``ServiceCommitRequest`` \u2014 when ``job.source_url`` is set and ``job.file_path`` is None\n\nFor new internal code that constructs a commit view, prefer importing\nthe appropriate subclass directly. This flat class is the wire contract,\nnot an implementation detail.",
         "properties": {
+          "title": {
+            "description": "Human-readable dataset title.",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "maxLength": 5000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional dataset description shown in the catalog.",
+            "title": "Summary"
+          },
+          "visibility": {
+            "default": "private",
+            "description": "Dataset visibility level: 'private' (owner-only), 'restricted' (RBAC-controlled), 'internal' (all users), 'public' (anonymous access).",
+            "enum": [
+              "private",
+              "restricted",
+              "internal",
+              "public"
+            ],
+            "title": "Visibility",
+            "type": "string"
+          },
+          "srid_override": {
+            "anyOf": [
+              {
+                "maximum": 998999.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.",
+            "title": "Srid Override"
+          },
+          "token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional confirmation token returned by the preview step. Required for some workflows.",
+            "title": "Token"
+          },
+          "temporal_start": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO 8601 start of the dataset's temporal extent.",
+            "title": "Temporal Start"
+          },
+          "temporal_end": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO 8601 end of the dataset's temporal extent.",
+            "title": "Temporal End"
+          },
           "compression": {
             "anyOf": [
               {
@@ -3673,7 +3757,7 @@
             "description": "Raster only: target compression for COG output (e.g. 'LZW', 'DEFLATE').",
             "title": "Compression"
           },
-          "geom_column": {
+          "resampling": {
             "anyOf": [
               {
                 "type": "string"
@@ -3682,20 +3766,8 @@
                 "type": "null"
               }
             ],
-            "description": "CSV/Excel only: name of the WKT geometry column (alternative to x_column/y_column).",
-            "title": "Geom Column"
-          },
-          "layer_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Multi-layer source only: name of the specific layer to ingest.",
-            "title": "Layer Name"
+            "description": "Raster only: resampling method for COG conversion (e.g. 'nearest', 'bilinear', 'cubic').",
+            "title": "Resampling"
           },
           "nodata_override": {
             "anyOf": [
@@ -3712,7 +3784,7 @@
             "description": "Raster only: nodata value to use when source has none defined.",
             "title": "Nodata Override"
           },
-          "resampling": {
+          "layer_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -3721,92 +3793,8 @@
                 "type": "null"
               }
             ],
-            "description": "Raster only: resampling method for COG conversion (e.g. 'nearest', 'bilinear', 'cubic').",
-            "title": "Resampling"
-          },
-          "srid_override": {
-            "anyOf": [
-              {
-                "maximum": 998999.0,
-                "minimum": 1.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.",
-            "title": "Srid Override"
-          },
-          "summary": {
-            "anyOf": [
-              {
-                "maxLength": 5000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Optional dataset description shown in the catalog.",
-            "title": "Summary"
-          },
-          "temporal_end": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ISO 8601 end of the dataset's temporal extent.",
-            "title": "Temporal End"
-          },
-          "temporal_start": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ISO 8601 start of the dataset's temporal extent.",
-            "title": "Temporal Start"
-          },
-          "title": {
-            "description": "Human-readable dataset title.",
-            "maxLength": 500,
-            "minLength": 1,
-            "title": "Title",
-            "type": "string"
-          },
-          "token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Optional confirmation token returned by the preview step. Required for some workflows.",
-            "title": "Token"
-          },
-          "visibility": {
-            "default": "private",
-            "description": "Dataset visibility level: 'private' (owner-only), 'restricted' (RBAC-controlled), 'internal' (all users), 'public' (anonymous access).",
-            "enum": [
-              "private",
-              "restricted",
-              "internal",
-              "public"
-            ],
-            "title": "Visibility",
-            "type": "string"
+            "description": "Multi-layer source only: name of the specific layer to ingest.",
+            "title": "Layer Name"
           },
           "x_column": {
             "anyOf": [
@@ -3831,6 +3819,18 @@
             ],
             "description": "CSV/Excel only: name of the latitude/Y coordinate column.",
             "title": "Y Column"
+          },
+          "geom_column": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "CSV/Excel only: name of the WKT geometry column (alternative to x_column/y_column).",
+            "title": "Geom Column"
           }
         },
         "required": [
@@ -3847,14 +3847,14 @@
             "title": "Job Id",
             "type": "string"
           },
-          "message": {
-            "description": "Human-readable commit result.",
-            "title": "Message",
-            "type": "string"
-          },
           "status": {
             "description": "Updated job status after commit.",
             "title": "Status",
+            "type": "string"
+          },
+          "message": {
+            "description": "Human-readable commit result.",
+            "title": "Message",
             "type": "string"
           }
         },
@@ -3869,6 +3869,19 @@
       "ConfigImportRequest": {
         "description": "Payload for importing configuration.",
         "properties": {
+          "settings": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional settings to import. Omit to import only OAuth providers.",
+            "title": "Settings"
+          },
           "oauth_providers": {
             "anyOf": [
               {
@@ -3884,19 +3897,6 @@
             ],
             "description": "Optional OAuth providers to import. Client secrets must be re-supplied via the admin UI after import.",
             "title": "Oauth Providers"
-          },
-          "settings": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Optional settings to import. Omit to import only OAuth providers.",
-            "title": "Settings"
           }
         },
         "title": "ConfigImportRequest",
@@ -3919,10 +3919,21 @@
       },
       "ConfigResponse": {
         "properties": {
+          "registration_enabled": {
+            "description": "Whether self-service registration is open",
+            "title": "Registration Enabled",
+            "type": "boolean"
+          },
           "allow_signup": {
             "default": false,
             "description": "Whether self-serve registration is open. Alias for registration_enabled; login UI uses this to show/hide the signup link.",
             "title": "Allow Signup",
+            "type": "boolean"
+          },
+          "email_verification_required": {
+            "default": false,
+            "description": "When true, new self-registered users must verify their email before logging in. Default false for back-compat-safe parsing by older clients.",
+            "title": "Email Verification Required",
             "type": "boolean"
           },
           "auth_methods": {
@@ -3933,11 +3944,11 @@
             "title": "Auth Methods",
             "type": "array"
           },
-          "banner_color": {
-            "default": "warning",
-            "description": "Theme token for the site banner color: warning | info | success | destructive.",
-            "title": "Banner Color",
-            "type": "string"
+          "landing_first": {
+            "default": false,
+            "description": "When true, unauthenticated visits to '/' are redirected to '/login' as the product landing page. Default false (search catalog is the root).",
+            "title": "Landing First",
+            "type": "boolean"
           },
           "banner_enabled": {
             "default": false,
@@ -3951,27 +3962,16 @@
             "title": "Banner Text",
             "type": "string"
           },
-          "email_verification_required": {
-            "default": false,
-            "description": "When true, new self-registered users must verify their email before logging in. Default false for back-compat-safe parsing by older clients.",
-            "title": "Email Verification Required",
-            "type": "boolean"
-          },
-          "landing_first": {
-            "default": false,
-            "description": "When true, unauthenticated visits to '/' are redirected to '/login' as the product landing page. Default false (search catalog is the root).",
-            "title": "Landing First",
-            "type": "boolean"
+          "banner_color": {
+            "default": "warning",
+            "description": "Theme token for the site banner color: warning | info | success | destructive.",
+            "title": "Banner Color",
+            "type": "string"
           },
           "password_login_enabled": {
             "default": true,
             "description": "When false, password login is disabled for users without manage_settings. Default true for back-compat-safe parsing by older clients.",
             "title": "Password Login Enabled",
-            "type": "boolean"
-          },
-          "registration_enabled": {
-            "description": "Whether self-service registration is open",
-            "title": "Registration Enabled",
             "type": "boolean"
           }
         },
@@ -4001,6 +4001,10 @@
       "ConnectivityResult": {
         "description": "Aggregate connectivity validation result.",
         "properties": {
+          "storage": {
+            "$ref": "#/components/schemas/ServiceProbeResult",
+            "description": "Object storage probe result."
+          },
           "cache": {
             "$ref": "#/components/schemas/ServiceProbeResult",
             "description": "Cache backend probe result."
@@ -4012,10 +4016,6 @@
             "description": "Per-provider OIDC discovery probe results, keyed by provider slug.",
             "title": "Oidc Providers",
             "type": "object"
-          },
-          "storage": {
-            "$ref": "#/components/schemas/ServiceProbeResult",
-            "description": "Object storage probe result."
           }
         },
         "required": [
@@ -4029,18 +4029,18 @@
       "ConnectorDefinitionResponse": {
         "description": "Public, non-secret connector capabilities advertised by an overlay.",
         "properties": {
-          "config_schema": {
-            "additionalProperties": true,
-            "title": "Config Schema",
-            "type": "object"
+          "name": {
+            "title": "Name",
+            "type": "string"
           },
           "display_name": {
             "title": "Display Name",
             "type": "string"
           },
-          "name": {
-            "title": "Name",
-            "type": "string"
+          "config_schema": {
+            "additionalProperties": true,
+            "title": "Config Schema",
+            "type": "object"
           },
           "supports_credentials": {
             "default": false,
@@ -4063,11 +4063,6 @@
       },
       "ConnectorDiscoverRequest": {
         "properties": {
-          "config": {
-            "additionalProperties": true,
-            "title": "Config",
-            "type": "object"
-          },
           "credential_id": {
             "anyOf": [
               {
@@ -4080,6 +4075,11 @@
               }
             ],
             "title": "Credential Id"
+          },
+          "config": {
+            "additionalProperties": true,
+            "title": "Config",
+            "type": "object"
           }
         },
         "title": "ConnectorDiscoverRequest",
@@ -4103,11 +4103,6 @@
       },
       "ConnectorIngestRequest": {
         "properties": {
-          "config": {
-            "additionalProperties": true,
-            "title": "Config",
-            "type": "object"
-          },
           "credential_id": {
             "anyOf": [
               {
@@ -4120,6 +4115,11 @@
               }
             ],
             "title": "Credential Id"
+          },
+          "config": {
+            "additionalProperties": true,
+            "title": "Config",
+            "type": "object"
           },
           "resource_id": {
             "description": "API-safe opaque handle returned by connector discovery.",
@@ -4185,6 +4185,12 @@
             "title": "Id",
             "type": "string"
           },
+          "name": {
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
           "kind": {
             "maxLength": 64,
             "minLength": 1,
@@ -4196,12 +4202,6 @@
             "additionalProperties": true,
             "title": "Metadata",
             "type": "object"
-          },
-          "name": {
-            "maxLength": 500,
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
           }
         },
         "required": [
@@ -4214,30 +4214,11 @@
       },
       "ContactCreate": {
         "properties": {
-          "email": {
-            "anyOf": [
-              {
-                "format": "email",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "extra_json": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Arbitrary extra fields stored as JSON",
-            "title": "Extra Json"
+          "role": {
+            "description": "ISO CI_RoleCode, e.g. pointOfContact, author",
+            "maxLength": 30,
+            "title": "Role",
+            "type": "string"
           },
           "name": {
             "anyOf": [
@@ -4250,6 +4231,18 @@
               }
             ],
             "title": "Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "format": "email",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
           },
           "organization": {
             "anyOf": [
@@ -4275,11 +4268,18 @@
             ],
             "title": "Phone"
           },
-          "role": {
-            "description": "ISO CI_RoleCode, e.g. pointOfContact, author",
-            "maxLength": 30,
-            "title": "Role",
-            "type": "string"
+          "extra_json": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Arbitrary extra fields stored as JSON",
+            "title": "Extra Json"
           },
           "sort_order": {
             "default": 0,
@@ -4319,32 +4319,18 @@
       },
       "ContactResponse": {
         "properties": {
-          "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "extra_json": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Extra Json"
-          },
           "id": {
             "format": "uuid",
             "title": "Id",
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "title": "Record Id",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
             "type": "string"
           },
           "name": {
@@ -4357,6 +4343,17 @@
               }
             ],
             "title": "Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
           },
           "organization": {
             "anyOf": [
@@ -4380,14 +4377,17 @@
             ],
             "title": "Phone"
           },
-          "record_id": {
-            "format": "uuid",
-            "title": "Record Id",
-            "type": "string"
-          },
-          "role": {
-            "title": "Role",
-            "type": "string"
+          "extra_json": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extra Json"
           },
           "sort_order": {
             "title": "Sort Order",
@@ -4410,29 +4410,17 @@
       },
       "ContactUpdate": {
         "properties": {
-          "email": {
+          "role": {
             "anyOf": [
               {
-                "format": "email",
+                "maxLength": 30,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Email"
-          },
-          "extra_json": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Extra Json"
+            "title": "Role"
           },
           "name": {
             "anyOf": [
@@ -4445,6 +4433,18 @@
               }
             ],
             "title": "Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "format": "email",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
           },
           "organization": {
             "anyOf": [
@@ -4470,17 +4470,17 @@
             ],
             "title": "Phone"
           },
-          "role": {
+          "extra_json": {
             "anyOf": [
               {
-                "maxLength": 30,
-                "type": "string"
+                "additionalProperties": true,
+                "type": "object"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Role"
+            "title": "Extra Json"
           },
           "sort_order": {
             "anyOf": [
@@ -4501,17 +4501,17 @@
       },
       "CreateEmptyDatasetRequest": {
         "properties": {
+          "title": {
+            "maxLength": 500,
+            "title": "Title",
+            "type": "string"
+          },
           "columns": {
             "items": {
               "$ref": "#/components/schemas/ColumnDefinition"
             },
             "title": "Columns",
             "type": "array"
-          },
-          "title": {
-            "maxLength": 500,
-            "title": "Title",
-            "type": "string"
           }
         },
         "required": [
@@ -4523,20 +4523,13 @@
       },
       "CreateLayerRequest": {
         "properties": {
-          "columns": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/ColumnDef"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Optional initial column definitions",
-            "title": "Columns"
+          "title": {
+            "description": "Display name for the new layer",
+            "example": "Survey Points",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
           },
           "geometry_type": {
             "description": "OGC geometry type: Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon",
@@ -4557,13 +4550,20 @@
             "description": "Optional text description of the layer",
             "title": "Summary"
           },
-          "title": {
-            "description": "Display name for the new layer",
-            "example": "Survey Points",
-            "maxLength": 500,
-            "minLength": 1,
-            "title": "Title",
-            "type": "string"
+          "columns": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ColumnDef"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional initial column definitions",
+            "title": "Columns"
           }
         },
         "required": [
@@ -4575,31 +4575,10 @@
       },
       "CreateLayerResponse": {
         "properties": {
-          "created_at": {
-            "description": "Creation timestamp",
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "feature_count": {
-            "description": "Number of features (0 for new layers)",
-            "title": "Feature Count",
-            "type": "integer"
-          },
-          "geometry_type": {
-            "description": "OGC geometry type",
-            "title": "Geometry Type",
-            "type": "string"
-          },
           "id": {
             "description": "Dataset ID of the created layer",
             "format": "uuid",
             "title": "Id",
-            "type": "string"
-          },
-          "table_name": {
-            "description": "PostGIS table name in the data schema",
-            "title": "Table Name",
             "type": "string"
           },
           "title": {
@@ -4607,9 +4586,30 @@
             "title": "Title",
             "type": "string"
           },
+          "table_name": {
+            "description": "PostGIS table name in the data schema",
+            "title": "Table Name",
+            "type": "string"
+          },
+          "geometry_type": {
+            "description": "OGC geometry type",
+            "title": "Geometry Type",
+            "type": "string"
+          },
+          "feature_count": {
+            "description": "Number of features (0 for new layers)",
+            "title": "Feature Count",
+            "type": "integer"
+          },
           "visibility": {
             "description": "Visibility level: private, internal, or public",
             "title": "Visibility",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "Creation timestamp",
+            "format": "date-time",
+            "title": "Created At",
             "type": "string"
           }
         },
@@ -4628,17 +4628,15 @@
       "DatasetChatRequest": {
         "description": "Dataset-scoped chat: no map, no client-supplied layer state.\n\nThe server resolves ALL dataset context (table name, columns, samples)\nauthoritatively from the DB \u2014 the client only names the dataset.",
         "properties": {
+          "message": {
+            "maxLength": 2000,
+            "minLength": 1,
+            "title": "Message",
+            "type": "string"
+          },
           "dataset_id": {
             "title": "Dataset Id",
             "type": "string"
-          },
-          "history": {
-            "items": {
-              "$ref": "#/components/schemas/ChatHistoryMessage"
-            },
-            "maxItems": 20,
-            "title": "History",
-            "type": "array"
           },
           "language": {
             "anyOf": [
@@ -4651,11 +4649,13 @@
             ],
             "title": "Language"
           },
-          "message": {
-            "maxLength": 2000,
-            "minLength": 1,
-            "title": "Message",
-            "type": "string"
+          "history": {
+            "items": {
+              "$ref": "#/components/schemas/ChatHistoryMessage"
+            },
+            "maxItems": 20,
+            "title": "History",
+            "type": "array"
           }
         },
         "required": [
@@ -4711,7 +4711,49 @@
           }
         ],
         "properties": {
-          "access_constraints": {
+          "title": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "maxLength": 5000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "enum": [
+                  "private",
+                  "restricted",
+                  "internal",
+                  "public"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Access level: private, restricted, internal, or public",
+            "title": "Visibility"
+          },
+          "license": {
             "anyOf": [
               {
                 "maxLength": 1000,
@@ -4721,20 +4763,19 @@
                 "type": "null"
               }
             ],
-            "title": "Access Constraints"
+            "title": "License"
           },
-          "data_vintage_end": {
+          "source_organization": {
             "anyOf": [
               {
-                "format": "date",
+                "maxLength": 1000,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "End of temporal coverage",
-            "title": "Data Vintage End"
+            "title": "Source Organization"
           },
           "data_vintage_start": {
             "anyOf": [
@@ -4749,42 +4790,18 @@
             "description": "Start of temporal coverage",
             "title": "Data Vintage Start"
           },
-          "is_dem": {
+          "data_vintage_end": {
             "anyOf": [
               {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Flag raster as a Digital Elevation Model for terrain rendering",
-            "title": "Is Dem"
-          },
-          "language": {
-            "anyOf": [
-              {
-                "maxLength": 35,
+                "format": "date",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "BCP 47 primary language tag, e.g. en, fr, or pt-BR",
-            "title": "Language"
-          },
-          "license": {
-            "anyOf": [
-              {
-                "maxLength": 1000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "License"
+            "description": "End of temporal coverage",
+            "title": "Data Vintage End"
           },
           "lineage_summary": {
             "anyOf": [
@@ -4798,137 +4815,6 @@
             ],
             "description": "Free-text provenance / lineage statement",
             "title": "Lineage Summary"
-          },
-          "owner_org": {
-            "anyOf": [
-              {
-                "maxLength": 1000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Owning organization name",
-            "title": "Owner Org"
-          },
-          "quality_statement": {
-            "anyOf": [
-              {
-                "maxLength": 5000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Quality Statement"
-          },
-          "record_status": {
-            "anyOf": [
-              {
-                "maxLength": 20,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.",
-            "title": "Record Status"
-          },
-          "sensitivity_classification": {
-            "anyOf": [
-              {
-                "maxLength": 20,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "e.g. public, confidential, restricted",
-            "title": "Sensitivity Classification"
-          },
-          "source_organization": {
-            "anyOf": [
-              {
-                "maxLength": 1000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Organization"
-          },
-          "source_url": {
-            "anyOf": [
-              {
-                "maxLength": 2000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "URL the data was originally fetched from",
-            "title": "Source Url"
-          },
-          "summary": {
-            "anyOf": [
-              {
-                "maxLength": 5000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Summary"
-          },
-          "theme_category": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ISO topic category codes",
-            "title": "Theme Category"
-          },
-          "tile_columns": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "maxItems": 100,
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Ordered vector-tile property allowlist; null restores zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.",
-            "title": "Tile Columns"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "maxLength": 500,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
           },
           "update_frequency": {
             "anyOf": [
@@ -4955,23 +4841,137 @@
             ],
             "title": "Usage Constraints"
           },
-          "visibility": {
+          "access_constraints": {
             "anyOf": [
               {
-                "enum": [
-                  "private",
-                  "restricted",
-                  "internal",
-                  "public"
-                ],
+                "maxLength": 1000,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Access level: private, restricted, internal, or public",
-            "title": "Visibility"
+            "title": "Access Constraints"
+          },
+          "sensitivity_classification": {
+            "anyOf": [
+              {
+                "maxLength": 20,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "e.g. public, confidential, restricted",
+            "title": "Sensitivity Classification"
+          },
+          "theme_category": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO topic category codes",
+            "title": "Theme Category"
+          },
+          "record_status": {
+            "anyOf": [
+              {
+                "maxLength": 20,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.",
+            "title": "Record Status"
+          },
+          "owner_org": {
+            "anyOf": [
+              {
+                "maxLength": 1000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Owning organization name",
+            "title": "Owner Org"
+          },
+          "quality_statement": {
+            "anyOf": [
+              {
+                "maxLength": 5000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Statement"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "URL the data was originally fetched from",
+            "title": "Source Url"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "maxLength": 35,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "BCP 47 primary language tag, e.g. en, fr, or pt-BR",
+            "title": "Language"
+          },
+          "is_dem": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Flag raster as a Digital Elevation Model for terrain rendering",
+            "title": "Is Dem"
+          },
+          "tile_columns": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 100,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Ordered vector-tile property allowlist; null restores zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.",
+            "title": "Tile Columns"
           }
         },
         "title": "DatasetMeta",
@@ -4979,18 +4979,11 @@
       },
       "DatasetRelationshipCreate": {
         "properties": {
-          "label": {
-            "anyOf": [
-              {
-                "maxLength": 500,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Optional display label for this relationship",
-            "title": "Label"
+          "target_dataset_id": {
+            "description": "UUID of the dataset to link to",
+            "format": "uuid",
+            "title": "Target Dataset Id",
+            "type": "string"
           },
           "source_column": {
             "description": "Join column in the source dataset",
@@ -5005,11 +4998,18 @@
             "title": "Target Column",
             "type": "string"
           },
-          "target_dataset_id": {
-            "description": "UUID of the dataset to link to",
-            "format": "uuid",
-            "title": "Target Dataset Id",
-            "type": "string"
+          "label": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional display label for this relationship",
+            "title": "Label"
           }
         },
         "required": [
@@ -5048,6 +5048,28 @@
             "title": "Id",
             "type": "string"
           },
+          "source_dataset_id": {
+            "format": "uuid",
+            "title": "Source Dataset Id",
+            "type": "string"
+          },
+          "target_dataset_id": {
+            "format": "uuid",
+            "title": "Target Dataset Id",
+            "type": "string"
+          },
+          "source_column": {
+            "title": "Source Column",
+            "type": "string"
+          },
+          "target_column": {
+            "title": "Target Column",
+            "type": "string"
+          },
+          "relationship_type": {
+            "title": "Relationship Type",
+            "type": "string"
+          },
           "label": {
             "anyOf": [
               {
@@ -5058,28 +5080,6 @@
               }
             ],
             "title": "Label"
-          },
-          "relationship_type": {
-            "title": "Relationship Type",
-            "type": "string"
-          },
-          "source_column": {
-            "title": "Source Column",
-            "type": "string"
-          },
-          "source_dataset_id": {
-            "format": "uuid",
-            "title": "Source Dataset Id",
-            "type": "string"
-          },
-          "target_column": {
-            "title": "Target Column",
-            "type": "string"
-          },
-          "target_dataset_id": {
-            "format": "uuid",
-            "title": "Target Dataset Id",
-            "type": "string"
           },
           "target_dataset_title": {
             "anyOf": [
@@ -5107,126 +5107,38 @@
       },
       "DatasetResponse": {
         "properties": {
-          "access_constraints": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Access Constraints"
-          },
-          "collections": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/CollectionRef"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Collections"
-          },
-          "column_info": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/ColumnInfo"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Column names, types, and stats",
-            "title": "Column Info"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
+          "id": {
+            "format": "uuid",
+            "title": "Id",
             "type": "string"
           },
-          "created_by": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created By"
-          },
-          "created_by_display": {
-            "title": "Created By Display",
+          "record_id": {
+            "description": "Parent catalog record UUID",
+            "format": "uuid",
+            "title": "Record Id",
             "type": "string"
           },
-          "current_version": {
-            "default": 1,
-            "description": "Monotonic version counter",
-            "title": "Current Version",
-            "type": "integer"
+          "table_name": {
+            "description": "Internal PostGIS table name",
+            "title": "Table Name",
+            "type": "string"
           },
-          "data_vintage_end": {
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "summary": {
             "anyOf": [
               {
-                "format": "date",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "End of temporal coverage",
-            "title": "Data Vintage End"
+            "title": "Summary"
           },
-          "data_vintage_start": {
-            "anyOf": [
-              {
-                "format": "date",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Start of temporal coverage",
-            "title": "Data Vintage Start"
-          },
-          "derived_from": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/DerivedFromResponse"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Provenance for an analysis output. Null for a dataset that was not derived, and also for a requester who cannot access the source dataset \u2014 the two are deliberately indistinguishable."
-          },
-          "extent_bbox": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "number"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Bounding box [west, south, east, north] per RFC 7946 \u00a75.2. west > east on an antimeridian-crossing extent.",
-            "title": "Extent Bbox"
-          },
-          "feature_count": {
+          "srid": {
             "anyOf": [
               {
                 "type": "integer"
@@ -5235,7 +5147,8 @@
                 "type": "null"
               }
             ],
-            "title": "Feature Count"
+            "description": "Current EPSG SRID of stored geometry",
+            "title": "Srid"
           },
           "geometry_type": {
             "anyOf": [
@@ -5255,11 +5168,6 @@
             "title": "Has Generic Geometry",
             "type": "boolean"
           },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
           "is_3d": {
             "anyOf": [
               {
@@ -5271,105 +5179,6 @@
             ],
             "description": "True if geometry has Z dimension",
             "title": "Is 3D"
-          },
-          "language": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ISO 639-1 language code, e.g. en, fr",
-            "title": "Language"
-          },
-          "last_checked_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Last time GeoLens contacted the origin at all, whether the attempt succeeded or failed",
-            "title": "Last Checked At"
-          },
-          "last_edited_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Edited At"
-          },
-          "last_edited_by_display": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Edited By Display"
-          },
-          "last_refreshed_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Last committed successful refresh \u2014 not the last attempt",
-            "title": "Last Refreshed At"
-          },
-          "license": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "License"
-          },
-          "lineage_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Free-text provenance / lineage statement",
-            "title": "Lineage Summary"
-          },
-          "metadata_warnings": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Advisory warnings produced by a metadata update \u2014 e.g. a visibility or status change exposing keywords inherited from an analysis source the new audience cannot open (feat #1070). Only ever set on the PATCH response; the change has already applied.",
-            "title": "Metadata Warnings"
           },
           "n_dims": {
             "anyOf": [
@@ -5383,6 +5192,199 @@
             "description": "Number of coordinate dimensions (2, 3, or 4)",
             "title": "N Dims"
           },
+          "z_min": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Minimum Z value across all features",
+            "title": "Z Min"
+          },
+          "z_max": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum Z value across all features",
+            "title": "Z Max"
+          },
+          "feature_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Count"
+          },
+          "extent_bbox": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Bounding box [west, south, east, north] per RFC 7946 \u00a75.2. west > east on an antimeridian-crossing extent.",
+            "title": "Extent Bbox"
+          },
+          "column_info": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ColumnInfo"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Column names, types, and stats",
+            "title": "Column Info"
+          },
+          "license": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "License"
+          },
+          "source_organization": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Organization"
+          },
+          "data_vintage_start": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Start of temporal coverage",
+            "title": "Data Vintage Start"
+          },
+          "data_vintage_end": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "End of temporal coverage",
+            "title": "Data Vintage End"
+          },
+          "quality_detail": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/QualityDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Automated quality assessment results"
+          },
+          "source_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Original file format, e.g. GPKG, SHP",
+            "title": "Source Format"
+          },
+          "source_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Filename"
+          },
+          "tile_columns": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Ordered vector-tile property allowlist; null uses zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.",
+            "title": "Tile Columns"
+          },
+          "original_srid": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "EPSG SRID of the uploaded source file",
+            "title": "Original Srid"
+          },
+          "current_version": {
+            "default": 1,
+            "description": "Monotonic version counter",
+            "title": "Current Version",
+            "type": "integer"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "URL the data was originally fetched from",
+            "title": "Source Url"
+          },
           "origin": {
             "anyOf": [
               {
@@ -5394,19 +5396,6 @@
             ],
             "description": "How the data entered the catalog: upload, postgis, service, stac, or created. Computed from source_format and record_type, not stored; null for collections and VRTs, which have no origin of their own.",
             "title": "Origin"
-          },
-          "origin_ref": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Typed per-origin payload with a `kind` discriminator, e.g. {\"kind\": \"service\", \"service_type\": \"wfs\", \"url\": \"...\", \"layer_id\": \"0\"}. Never contains credentials.",
-            "title": "Origin Ref"
           },
           "origin_uri": {
             "anyOf": [
@@ -5421,17 +5410,237 @@
             "description": "Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.",
             "title": "Origin Uri"
           },
-          "original_srid": {
+          "origin_ref": {
             "anyOf": [
               {
-                "type": "integer"
+                "additionalProperties": true,
+                "type": "object"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "EPSG SRID of the uploaded source file",
-            "title": "Original Srid"
+            "description": "Typed per-origin payload with a `kind` discriminator, e.g. {\"kind\": \"service\", \"service_type\": \"wfs\", \"url\": \"...\", \"layer_id\": \"0\"}. Never contains credentials.",
+            "title": "Origin Ref"
+          },
+          "last_refreshed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last committed successful refresh \u2014 not the last attempt",
+            "title": "Last Refreshed At"
+          },
+          "last_checked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last time GeoLens contacted the origin at all, whether the attempt succeeded or failed",
+            "title": "Last Checked At"
+          },
+          "source_health": {
+            "default": "unknown",
+            "description": "healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an origin kind with nothing to probe.",
+            "title": "Source Health",
+            "type": "string"
+          },
+          "source_health_detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Short redacted reason for a non-healthy state",
+            "title": "Source Health Detail"
+          },
+          "schema_drift_status": {
+            "default": "unknown",
+            "description": "none, drifted, or unknown. Set at refresh commit from the schema diff; 'unknown' until a refresh has run.",
+            "title": "Schema Drift Status",
+            "type": "string"
+          },
+          "quality_statement": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Statement"
+          },
+          "visibility": {
+            "description": "Access level: private, restricted, internal, public",
+            "title": "Visibility",
+            "type": "string"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "created_by_display": {
+            "title": "Created By Display",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "last_edited_by_display": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Edited By Display"
+          },
+          "last_edited_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Edited At"
+          },
+          "collections": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CollectionRef"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collections"
+          },
+          "record_status": {
+            "default": "draft",
+            "description": "Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.",
+            "title": "Record Status",
+            "type": "string"
+          },
+          "lineage_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Free-text provenance / lineage statement",
+            "title": "Lineage Summary"
+          },
+          "derived_from": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DerivedFromResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Provenance for an analysis output. Null for a dataset that was not derived, and also for a requester who cannot access the source dataset \u2014 the two are deliberately indistinguishable."
+          },
+          "update_frequency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO maintenance frequency code",
+            "title": "Update Frequency"
+          },
+          "usage_constraints": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Usage Constraints"
+          },
+          "access_constraints": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Access Constraints"
+          },
+          "sensitivity_classification": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "e.g. public, confidential, restricted",
+            "title": "Sensitivity Classification"
+          },
+          "theme_category": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO topic category codes",
+            "title": "Theme Category"
           },
           "owner_org": {
             "anyOf": [
@@ -5457,27 +5666,23 @@
             ],
             "title": "Published At"
           },
-          "quality_detail": {
+          "updated_by": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/QualityDetail"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Automated quality assessment results"
-          },
-          "quality_statement": {
-            "anyOf": [
-              {
+                "format": "uuid",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Quality Statement"
+            "title": "Updated By"
+          },
+          "record_type": {
+            "default": "vector_dataset",
+            "description": "Record type: 'vector_dataset' (spatial features), 'raster_dataset' (single COG), 'vrt_dataset' (VRT mosaic), 'table' (non-spatial tabular), 'map' (saved map), 'service' (catalogued remote service), 'collection' (flat dataset group).",
+            "title": "Record Type",
+            "type": "string"
           },
           "raster": {
             "anyOf": [
@@ -5489,119 +5694,6 @@
               }
             ],
             "description": "Raster-specific metadata (null for vectors)"
-          },
-          "record_id": {
-            "description": "Parent catalog record UUID",
-            "format": "uuid",
-            "title": "Record Id",
-            "type": "string"
-          },
-          "record_status": {
-            "default": "draft",
-            "description": "Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.",
-            "title": "Record Status",
-            "type": "string"
-          },
-          "record_type": {
-            "default": "vector_dataset",
-            "description": "Record type: 'vector_dataset' (spatial features), 'raster_dataset' (single COG), 'vrt_dataset' (VRT mosaic), 'table' (non-spatial tabular), 'map' (saved map), 'service' (catalogued remote service), 'collection' (flat dataset group).",
-            "title": "Record Type",
-            "type": "string"
-          },
-          "schema_drift_status": {
-            "default": "unknown",
-            "description": "none, drifted, or unknown. Set at refresh commit from the schema diff; 'unknown' until a refresh has run.",
-            "title": "Schema Drift Status",
-            "type": "string"
-          },
-          "sensitivity_classification": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "e.g. public, confidential, restricted",
-            "title": "Sensitivity Classification"
-          },
-          "source_filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Filename"
-          },
-          "source_format": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Original file format, e.g. GPKG, SHP",
-            "title": "Source Format"
-          },
-          "source_health": {
-            "default": "unknown",
-            "description": "healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an origin kind with nothing to probe.",
-            "title": "Source Health",
-            "type": "string"
-          },
-          "source_health_detail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Short redacted reason for a non-healthy state",
-            "title": "Source Health Detail"
-          },
-          "source_organization": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Organization"
-          },
-          "source_url": {
-            "anyOf": [
-              {
-                "maxLength": 2000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "URL the data was originally fetched from",
-            "title": "Source Url"
-          },
-          "srid": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Current EPSG SRID of stored geometry",
-            "title": "Srid"
           },
           "stac_assets": {
             "anyOf": [
@@ -5632,7 +5724,7 @@
             ],
             "title": "Stac Extensions"
           },
-          "summary": {
+          "language": {
             "anyOf": [
               {
                 "type": "string"
@@ -5641,14 +5733,10 @@
                 "type": "null"
               }
             ],
-            "title": "Summary"
+            "description": "ISO 639-1 language code, e.g. en, fr",
+            "title": "Language"
           },
-          "table_name": {
-            "description": "Internal PostGIS table name",
-            "title": "Table Name",
-            "type": "string"
-          },
-          "theme_category": {
+          "metadata_warnings": {
             "anyOf": [
               {
                 "items": {
@@ -5660,96 +5748,8 @@
                 "type": "null"
               }
             ],
-            "description": "ISO topic category codes",
-            "title": "Theme Category"
-          },
-          "tile_columns": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Ordered vector-tile property allowlist; null uses zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.",
-            "title": "Tile Columns"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "update_frequency": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ISO maintenance frequency code",
-            "title": "Update Frequency"
-          },
-          "updated_at": {
-            "format": "date-time",
-            "title": "Updated At",
-            "type": "string"
-          },
-          "updated_by": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated By"
-          },
-          "usage_constraints": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Usage Constraints"
-          },
-          "visibility": {
-            "description": "Access level: private, restricted, internal, public",
-            "title": "Visibility",
-            "type": "string"
-          },
-          "z_max": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Maximum Z value across all features",
-            "title": "Z Max"
-          },
-          "z_min": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Minimum Z value across all features",
-            "title": "Z Min"
+            "description": "Advisory warnings produced by a metadata update \u2014 e.g. a visibility or status change exposing keywords inherited from an analysis source the new audience cannot open (feat #1070). Only ever set on the PATCH response; the change has already applied.",
+            "title": "Metadata Warnings"
           }
         },
         "required": [
@@ -5771,17 +5771,25 @@
       },
       "DatasetRowsResponse": {
         "properties": {
-          "approximate_total": {
-            "description": "Estimated total row count (may use pg stats)",
-            "title": "Approximate Total",
-            "type": "integer"
-          },
           "columns": {
             "items": {
               "$ref": "#/components/schemas/ColumnChange"
             },
             "title": "Columns",
             "type": "array"
+          },
+          "rows": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Rows",
+            "type": "array"
+          },
+          "approximate_total": {
+            "description": "Estimated total row count (may use pg stats)",
+            "title": "Approximate Total",
+            "type": "integer"
           },
           "next_cursor": {
             "anyOf": [
@@ -5794,14 +5802,6 @@
             ],
             "description": "Cursor value for the next page, null if last",
             "title": "Next Cursor"
-          },
-          "rows": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Rows",
-            "type": "array"
           }
         },
         "required": [
@@ -5814,16 +5814,16 @@
       },
       "DatasetVersionListResponse": {
         "properties": {
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          },
           "versions": {
             "items": {
               "$ref": "#/components/schemas/DatasetVersionResponse"
             },
             "title": "Versions",
             "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
           }
         },
         "required": [
@@ -5835,48 +5835,19 @@
       },
       "DatasetVersionResponse": {
         "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
           "dataset_id": {
             "format": "uuid",
             "title": "Dataset Id",
             "type": "string"
           },
-          "feature_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Feature Count"
-          },
-          "file_hash": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "File Hash"
-          },
-          "geometry_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Geometry Type"
-          },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
+          "version_number": {
+            "title": "Version Number",
+            "type": "integer"
           },
           "source_filename": {
             "anyOf": [
@@ -5900,6 +5871,17 @@
             ],
             "title": "Source Format"
           },
+          "feature_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Count"
+          },
           "srid": {
             "anyOf": [
               {
@@ -5911,10 +5893,27 @@
             ],
             "title": "Srid"
           },
-          "uploaded_at": {
-            "format": "date-time",
-            "title": "Uploaded At",
-            "type": "string"
+          "geometry_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Geometry Type"
+          },
+          "file_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Hash"
           },
           "uploaded_by": {
             "anyOf": [
@@ -5928,9 +5927,10 @@
             ],
             "title": "Uploaded By"
           },
-          "version_number": {
-            "title": "Version Number",
-            "type": "integer"
+          "uploaded_at": {
+            "format": "date-time",
+            "title": "Uploaded At",
+            "type": "string"
           }
         },
         "required": [
@@ -5952,17 +5952,17 @@
       "DbfTruncationCollisionWarning": {
         "additionalProperties": false,
         "properties": {
+          "kind": {
+            "const": "dbf_truncation_collision",
+            "title": "Kind",
+            "type": "string"
+          },
           "details": {
             "items": {
               "$ref": "#/components/schemas/DbfTruncationDetail"
             },
             "title": "Details",
             "type": "array"
-          },
-          "kind": {
-            "const": "dbf_truncation_collision",
-            "title": "Kind",
-            "type": "string"
           }
         },
         "required": [
@@ -5975,16 +5975,16 @@
       "DbfTruncationDetail": {
         "additionalProperties": false,
         "properties": {
+          "truncated": {
+            "title": "Truncated",
+            "type": "string"
+          },
           "originals": {
             "items": {
               "type": "string"
             },
             "title": "Originals",
             "type": "array"
-          },
-          "truncated": {
-            "title": "Truncated",
-            "type": "string"
           }
         },
         "required": [
@@ -5997,11 +5997,6 @@
       "DerivedFromResponse": {
         "description": "Provenance for an analysis output: what it came from, and how.\n\nfix(#765 review): declared as a model rather than ``dict[str, Any]``. The\ndict spelled itself into the checked-in OpenAPI as bare\n``additionalProperties: true``, so both generated SDKs lost the shape \u2014 the\nTypeScript one degraded to an index signature and the Python one to an\nempty additional-properties container. The stable shape was documented in\nprose and mirrored by hand in the frontend types while the SDKs, which is\nwhere most consumers actually meet it, could not use it type-safely.\n\n``params`` stays untyped on purpose: it is the operation's own parameter\ndict, so its keys differ per operation (``distance_meters`` for a buffer,\n``mask_source``/``mask_dataset_id`` for a clip), and it is additionally\nREDACTED per requester \u2014 ``visible_derived_from`` drops any embedded\ndataset id the caller cannot see. A union of per-operation models would\ndescribe a shape the redaction is free to punch holes in.",
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
           "dataset_id": {
             "description": "The dataset this one was derived from",
             "format": "uuid",
@@ -6018,6 +6013,11 @@
             "description": "Operation parameters, minus any dataset reference the requester cannot access",
             "title": "Params",
             "type": "object"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           }
         },
         "required": [
@@ -6063,17 +6063,10 @@
       },
       "DiscoveredTable": {
         "properties": {
-          "estimated_rows": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "PostgreSQL row count estimate from `pg_class.reltuples`.",
-            "title": "Estimated Rows"
+          "table_name": {
+            "description": "PostgreSQL table name in the `data` schema.",
+            "title": "Table Name",
+            "type": "string"
           },
           "geometry_type": {
             "anyOf": [
@@ -6099,10 +6092,17 @@
             "description": "Coordinate reference system EPSG code, if defined.",
             "title": "Srid"
           },
-          "table_name": {
-            "description": "PostgreSQL table name in the `data` schema.",
-            "title": "Table Name",
-            "type": "string"
+          "estimated_rows": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "PostgreSQL row count estimate from `pg_class.reltuples`.",
+            "title": "Estimated Rows"
           }
         },
         "required": [
@@ -6116,18 +6116,6 @@
       },
       "DistributionCreate": {
         "properties": {
-          "description": {
-            "anyOf": [
-              {
-                "maxLength": 2000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
           "distribution_type": {
             "description": "e.g. download, api, ogc_wms, ogc_wfs",
             "maxLength": 30,
@@ -6140,24 +6128,35 @@
             "title": "Format",
             "type": "string"
           },
-          "is_primary": {
-            "default": false,
-            "description": "Mark as the preferred distribution",
-            "title": "Is Primary",
-            "type": "boolean"
+          "url": {
+            "description": "Access URL for this distribution",
+            "maxLength": 2048,
+            "title": "Url",
+            "type": "string"
           },
-          "media_type": {
+          "title": {
             "anyOf": [
               {
-                "maxLength": 100,
+                "maxLength": 500,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "IANA media type, e.g. application/geo+json",
-            "title": "Media Type"
+            "title": "Title"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
           },
           "protocol": {
             "anyOf": [
@@ -6172,23 +6171,24 @@
             "description": "Transfer protocol, e.g. HTTPS, OGC:WFS",
             "title": "Protocol"
           },
-          "title": {
+          "media_type": {
             "anyOf": [
               {
-                "maxLength": 500,
+                "maxLength": 100,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Title"
+            "description": "IANA media type, e.g. application/geo+json",
+            "title": "Media Type"
           },
-          "url": {
-            "description": "Access URL for this distribution",
-            "maxLength": 2048,
-            "title": "Url",
-            "type": "string"
+          "is_primary": {
+            "default": false,
+            "description": "Mark as the preferred distribution",
+            "title": "Is Primary",
+            "type": "boolean"
           }
         },
         "required": [
@@ -6222,21 +6222,15 @@
       },
       "DistributionResponse": {
         "properties": {
-          "auto_generated": {
-            "description": "True if created automatically by the system",
-            "title": "Auto Generated",
-            "type": "boolean"
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
           },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
+          "record_id": {
+            "format": "uuid",
+            "title": "Record Id",
+            "type": "string"
           },
           "distribution_type": {
             "title": "Distribution Type",
@@ -6253,40 +6247,8 @@
             ],
             "title": "Format"
           },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
-          "is_primary": {
-            "title": "Is Primary",
-            "type": "boolean"
-          },
-          "media_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Media Type"
-          },
-          "protocol": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Protocol"
-          },
-          "record_id": {
-            "format": "uuid",
-            "title": "Record Id",
+          "url": {
+            "title": "Url",
             "type": "string"
           },
           "title": {
@@ -6300,9 +6262,47 @@
             ],
             "title": "Title"
           },
-          "url": {
-            "title": "Url",
-            "type": "string"
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "protocol": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protocol"
+          },
+          "media_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Media Type"
+          },
+          "is_primary": {
+            "title": "Is Primary",
+            "type": "boolean"
+          },
+          "auto_generated": {
+            "description": "True if created automatically by the system",
+            "title": "Auto Generated",
+            "type": "boolean"
           }
         },
         "required": [
@@ -6323,18 +6323,6 @@
       },
       "DistributionUpdate": {
         "properties": {
-          "description": {
-            "anyOf": [
-              {
-                "maxLength": 2000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
           "distribution_type": {
             "anyOf": [
               {
@@ -6359,40 +6347,17 @@
             ],
             "title": "Format"
           },
-          "is_primary": {
+          "url": {
             "anyOf": [
               {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Primary"
-          },
-          "media_type": {
-            "anyOf": [
-              {
-                "maxLength": 100,
+                "maxLength": 2048,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Media Type"
-          },
-          "protocol": {
-            "anyOf": [
-              {
-                "maxLength": 100,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Protocol"
+            "title": "Url"
           },
           "title": {
             "anyOf": [
@@ -6406,17 +6371,52 @@
             ],
             "title": "Title"
           },
-          "url": {
+          "description": {
             "anyOf": [
               {
-                "maxLength": 2048,
+                "maxLength": 2000,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Url"
+            "title": "Description"
+          },
+          "protocol": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protocol"
+          },
+          "media_type": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Media Type"
+          },
+          "is_primary": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Primary"
           }
         },
         "title": "DistributionUpdate",
@@ -6424,16 +6424,16 @@
       },
       "DownloadTokenResponse": {
         "properties": {
+          "token": {
+            "description": "Short-lived download-scoped JWT (typ='download', TTL \u2264 120s)",
+            "title": "Token",
+            "type": "string"
+          },
           "expires_in": {
             "default": 120,
             "description": "Seconds until the download token expires",
             "title": "Expires In",
             "type": "integer"
-          },
-          "token": {
-            "description": "Short-lived download-scoped JWT (typ='download', TTL \u2264 120s)",
-            "title": "Token",
-            "type": "string"
           }
         },
         "required": [
@@ -6445,6 +6445,12 @@
       "DryRunResponse": {
         "description": "Result of a dry-run import showing what would change.",
         "properties": {
+          "settings": {
+            "additionalProperties": true,
+            "description": "Per-setting diff result keyed by setting name.",
+            "title": "Settings",
+            "type": "object"
+          },
           "oauth_providers": {
             "additionalProperties": true,
             "description": "Per-provider diff result keyed by slug.",
@@ -6462,12 +6468,6 @@
             ],
             "description": "Short-lived signed confirmation token required to apply an overwrite. Bound to the normalized payload, overwrite mode, and current configuration state.",
             "title": "Preview Token"
-          },
-          "settings": {
-            "additionalProperties": true,
-            "description": "Per-setting diff result keyed by setting name.",
-            "title": "Settings",
-            "type": "object"
           }
         },
         "required": [
@@ -6479,73 +6479,14 @@
       },
       "DuplicateMapResponse": {
         "properties": {
-          "basemap_config": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/BasemapConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "basemap_style": {
-            "title": "Basemap Style",
+          "id": {
+            "format": "uuid",
+            "title": "Id",
             "type": "string"
           },
-          "bearing": {
-            "title": "Bearing",
-            "type": "number"
-          },
-          "center_lat": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center Lat"
-          },
-          "center_lng": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center Lng"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
+          "name": {
+            "title": "Name",
             "type": "string"
-          },
-          "created_by": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created By"
-          },
-          "created_by_username": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created By Username"
           },
           "description": {
             "anyOf": [
@@ -6558,11 +6499,110 @@
             ],
             "title": "Description"
           },
-          "excluded_layer_count": {
-            "default": 0,
-            "description": "Layers skipped due to access restrictions",
-            "title": "Excluded Layer Count",
-            "type": "integer"
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "center_lng": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Lng"
+          },
+          "center_lat": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Lat"
+          },
+          "zoom": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Zoom"
+          },
+          "bearing": {
+            "title": "Bearing",
+            "type": "number"
+          },
+          "pitch": {
+            "title": "Pitch",
+            "type": "number"
+          },
+          "basemap_style": {
+            "title": "Basemap Style",
+            "type": "string"
+          },
+          "show_basemap_labels": {
+            "title": "Show Basemap Labels",
+            "type": "boolean"
+          },
+          "basemap_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BasemapConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "terrain_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TerrainConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/MapVisibility"
+          },
+          "thumbnail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thumbnail Url"
+          },
+          "og_image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Og Image Url"
           },
           "forked_from_id": {
             "anyOf": [
@@ -6588,14 +6628,38 @@
             ],
             "title": "Forked From Name"
           },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
+          "created_by": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "created_by_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By Username"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
             "type": "string"
           },
-          "layer_count": {
-            "title": "Layer Count",
-            "type": "integer"
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
           },
           "layers": {
             "items": {
@@ -6604,46 +6668,9 @@
             "title": "Layers",
             "type": "array"
           },
-          "legend_title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Legend Title"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "notes": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Notes"
-          },
-          "og_image_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Og Image Url"
-          },
-          "pitch": {
-            "title": "Pitch",
-            "type": "number"
+          "layer_count": {
+            "title": "Layer Count",
+            "type": "integer"
           },
           "plugins": {
             "anyOf": [
@@ -6659,21 +6686,7 @@
             ],
             "title": "Plugins"
           },
-          "show_basemap_labels": {
-            "title": "Show Basemap Labels",
-            "type": "boolean"
-          },
-          "terrain_config": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TerrainConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "thumbnail_url": {
+          "legend_title": {
             "anyOf": [
               {
                 "type": "string"
@@ -6682,26 +6695,13 @@
                 "type": "null"
               }
             ],
-            "title": "Thumbnail Url"
+            "title": "Legend Title"
           },
-          "updated_at": {
-            "format": "date-time",
-            "title": "Updated At",
-            "type": "string"
-          },
-          "visibility": {
-            "$ref": "#/components/schemas/MapVisibility"
-          },
-          "zoom": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Zoom"
+          "excluded_layer_count": {
+            "default": 0,
+            "description": "Layers skipped due to access restrictions",
+            "title": "Excluded Layer Count",
+            "type": "integer"
           }
         },
         "required": [
@@ -6757,25 +6757,6 @@
       },
       "EmbedTokenCreate": {
         "properties": {
-          "allowed_origins": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "maxItems": 50,
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Restrict embedding to these origins. Omit or null allows any origin; non-empty origin restrictions require advanced sharing controls.",
-            "example": [
-              "https://dashboard.example.com"
-            ],
-            "title": "Allowed Origins"
-          },
           "expires_in_days": {
             "default": 30,
             "description": "Token lifetime in days (1-365). The default 30-day lifetime is always available; custom lifetimes require advanced sharing controls.",
@@ -6799,6 +6780,25 @@
             "description": "Human-readable label for the token",
             "example": "Public dashboard embed",
             "title": "Name"
+          },
+          "allowed_origins": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 50,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Restrict embedding to these origins. Omit or null allows any origin; non-empty origin restrictions require advanced sharing controls.",
+            "example": [
+              "https://dashboard.example.com"
+            ],
+            "title": "Allowed Origins"
           }
         },
         "title": "EmbedTokenCreate",
@@ -6806,50 +6806,10 @@
       },
       "EmbedTokenCreatedResponse": {
         "properties": {
-          "allowed_origins": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Allowed Origins"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "expires_at": {
-            "format": "date-time",
-            "title": "Expires At",
-            "type": "string"
-          },
           "id": {
             "format": "uuid",
             "title": "Id",
             "type": "string"
-          },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
-          },
-          "last_used_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Used At"
           },
           "map_id": {
             "format": "uuid",
@@ -6867,8 +6827,8 @@
             ],
             "title": "Name"
           },
-          "raw_token": {
-            "title": "Raw Token",
+          "token_hint": {
+            "title": "Token Hint",
             "type": "string"
           },
           "scoped_dataset_ids": {
@@ -6878,14 +6838,54 @@
             "title": "Scoped Dataset Ids",
             "type": "array"
           },
-          "token_hint": {
-            "title": "Token Hint",
+          "allowed_origins": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Origins"
+          },
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
             "type": "string"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
           },
           "use_count": {
             "default": 0,
             "title": "Use Count",
             "type": "integer"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "raw_token": {
+            "title": "Raw Token",
+            "type": "string"
           }
         },
         "required": [
@@ -6924,50 +6924,10 @@
       },
       "EmbedTokenResponse": {
         "properties": {
-          "allowed_origins": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Allowed Origins"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "expires_at": {
-            "format": "date-time",
-            "title": "Expires At",
-            "type": "string"
-          },
           "id": {
             "format": "uuid",
             "title": "Id",
             "type": "string"
-          },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
-          },
-          "last_used_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Used At"
           },
           "map_id": {
             "format": "uuid",
@@ -6985,6 +6945,10 @@
             ],
             "title": "Name"
           },
+          "token_hint": {
+            "title": "Token Hint",
+            "type": "string"
+          },
           "scoped_dataset_ids": {
             "items": {
               "type": "string"
@@ -6992,14 +6956,50 @@
             "title": "Scoped Dataset Ids",
             "type": "array"
           },
-          "token_hint": {
-            "title": "Token Hint",
+          "allowed_origins": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Origins"
+          },
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
             "type": "string"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
           },
           "use_count": {
             "default": 0,
             "title": "Use Count",
             "type": "integer"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           }
         },
         "required": [
@@ -7038,10 +7038,10 @@
       },
       "EmbeddingStatsResponse": {
         "properties": {
-          "coverage_percent": {
-            "description": "Embedding coverage as a percentage (0-100).",
-            "title": "Coverage Percent",
-            "type": "number"
+          "total_records": {
+            "description": "Total number of records in the catalog.",
+            "title": "Total Records",
+            "type": "integer"
           },
           "embedded_records": {
             "description": "Number of records that have an embedding stored.",
@@ -7053,10 +7053,10 @@
             "title": "Missing Records",
             "type": "integer"
           },
-          "total_records": {
-            "description": "Total number of records in the catalog.",
-            "title": "Total Records",
-            "type": "integer"
+          "coverage_percent": {
+            "description": "Embedding coverage as a percentage (0-100).",
+            "title": "Coverage Percent",
+            "type": "number"
           }
         },
         "required": [
@@ -7100,14 +7100,13 @@
       "FacetCountResponse": {
         "description": "Multi-group facet counts for the search sidebar.",
         "properties": {
-          "collections": {
-            "default": [],
-            "description": "Collections containing matched records",
-            "items": {
-              "$ref": "#/components/schemas/CollectionFacetItem"
+          "record_type": {
+            "additionalProperties": {
+              "type": "integer"
             },
-            "title": "Collections",
-            "type": "array"
+            "description": "Hit counts keyed by record type",
+            "title": "Record Type",
+            "type": "object"
           },
           "keywords": {
             "default": [],
@@ -7117,14 +7116,6 @@
             },
             "title": "Keywords",
             "type": "array"
-          },
-          "record_type": {
-            "additionalProperties": {
-              "type": "integer"
-            },
-            "description": "Hit counts keyed by record type",
-            "title": "Record Type",
-            "type": "object"
           },
           "source_organization": {
             "default": [],
@@ -7143,6 +7134,15 @@
             },
             "title": "Srid",
             "type": "array"
+          },
+          "collections": {
+            "default": [],
+            "description": "Collections containing matched records",
+            "items": {
+              "$ref": "#/components/schemas/CollectionFacetItem"
+            },
+            "title": "Collections",
+            "type": "array"
           }
         },
         "required": [
@@ -7154,13 +7154,13 @@
       "FacetValueCount": {
         "description": "A single facet value with count.",
         "properties": {
-          "count": {
-            "title": "Count",
-            "type": "integer"
-          },
           "value": {
             "title": "Value",
             "type": "string"
+          },
+          "count": {
+            "title": "Count",
+            "type": "integer"
           }
         },
         "required": [
@@ -7248,31 +7248,6 @@
       "FanOutLayerResult": {
         "description": "Per-layer outcome from the fan-out commit operation.",
         "properties": {
-          "dataset_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ID of the new Dataset record created for this layer. Null on failure.",
-            "title": "Dataset Id"
-          },
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "User-safe error description when status='failed'. Never contains internal file paths.",
-            "title": "Error"
-          },
           "layer_name": {
             "description": "Layer name from the request.",
             "title": "Layer Name",
@@ -7291,6 +7266,19 @@
             "description": "ID of the cloned IngestJob queued for this layer. Null on failure.",
             "title": "New Job Id"
           },
+          "dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the new Dataset record created for this layer. Null on failure.",
+            "title": "Dataset Id"
+          },
           "status": {
             "description": "'queued' if the task was dispatched; 'failed' if an error occurred.",
             "enum": [
@@ -7299,6 +7287,18 @@
             ],
             "title": "Status",
             "type": "string"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "User-safe error description when status='failed'. Never contains internal file paths.",
+            "title": "Error"
           }
         },
         "required": [
@@ -7374,8 +7374,8 @@
           },
           "properties": {
             "additionalProperties": true,
-            "title": "Properties",
-            "type": "object"
+            "type": "object",
+            "title": "Properties"
           }
         },
         "required": [
@@ -7422,6 +7422,11 @@
         "additionalProperties": true,
         "description": "A GeoJSON Feature.",
         "properties": {
+          "type": {
+            "default": "Feature",
+            "title": "Type",
+            "type": "string"
+          },
           "geometry": {
             "anyOf": [
               {
@@ -7445,11 +7450,6 @@
               }
             ],
             "title": "Properties"
-          },
-          "type": {
-            "default": "Feature",
-            "title": "Type",
-            "type": "string"
           }
         },
         "title": "GeoJSONFeature",
@@ -7459,6 +7459,11 @@
         "additionalProperties": true,
         "description": "A GeoJSON FeatureCollection.",
         "properties": {
+          "type": {
+            "default": "FeatureCollection",
+            "title": "Type",
+            "type": "string"
+          },
           "features": {
             "default": [],
             "items": {
@@ -7466,11 +7471,6 @@
             },
             "title": "Features",
             "type": "array"
-          },
-          "type": {
-            "default": "FeatureCollection",
-            "title": "Type",
-            "type": "string"
           }
         },
         "title": "GeoJSONFeatureCollection",
@@ -7479,11 +7479,6 @@
       "GeoJSONGeometry": {
         "description": "A GeoJSON geometry object (RFC 7946).",
         "properties": {
-          "coordinates": {
-            "items": {},
-            "title": "Coordinates",
-            "type": "array"
-          },
           "type": {
             "enum": [
               "Point",
@@ -7495,6 +7490,11 @@
             ],
             "title": "Type",
             "type": "string"
+          },
+          "coordinates": {
+            "items": {},
+            "title": "Coordinates",
+            "type": "array"
           }
         },
         "required": [
@@ -7507,17 +7507,17 @@
       "GeoJSONGeometryCollection": {
         "description": "A GeoJSON GeometryCollection (RFC 7946 \u00a73.1.8).\n\nfix(#430 codex r9): carries ``geometries`` instead of ``coordinates``, so\nit needs its own model \u2014 only generic-GEOMETRY datasets accept it on write\n(enforced in the service), and any stored collection must serialize back\nout on read.\n\nDeliberately NON-recursive (codex r13, refuted): PostGIS cannot round-trip\nnested collections through the GeoJSON boundary in either direction \u2014\nST_GeomFromGeoJSON rejects them on write and ST_AsGeoJSON raises\n'GeoJson: geometry not supported' on read \u2014 so a recursive model could\nnever receive one and would only convert the write-side 422 into a raw\ndatabase 500. The write schemas add a raw-payload guard for a clear 422.",
         "properties": {
+          "type": {
+            "const": "GeometryCollection",
+            "title": "Type",
+            "type": "string"
+          },
           "geometries": {
             "items": {
               "$ref": "#/components/schemas/GeoJSONGeometry"
             },
             "title": "Geometries",
             "type": "array"
-          },
-          "type": {
-            "const": "GeometryCollection",
-            "title": "Type",
-            "type": "string"
           }
         },
         "required": [
@@ -7542,6 +7542,14 @@
       },
       "HealthResponse": {
         "properties": {
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
+          },
           "build": {
             "anyOf": [
               {
@@ -7559,14 +7567,6 @@
             },
             "title": "Providers",
             "type": "object"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string"
-          },
-          "version": {
-            "title": "Version",
-            "type": "string"
           }
         },
         "required": [
@@ -7580,28 +7580,6 @@
       "ImportResult": {
         "description": "Summary of what was applied during an import.",
         "properties": {
-          "oauth_accounts_deleted": {
-            "default": 0,
-            "description": "Number of dependent OAuth account links cascade-deleted in overwrite mode.",
-            "minimum": 0.0,
-            "title": "Oauth Accounts Deleted",
-            "type": "integer"
-          },
-          "oauth_created": {
-            "description": "Number of new OAuth providers created.",
-            "title": "Oauth Created",
-            "type": "integer"
-          },
-          "oauth_deleted": {
-            "description": "Number of OAuth providers deleted (overwrite mode only).",
-            "title": "Oauth Deleted",
-            "type": "integer"
-          },
-          "oauth_updated": {
-            "description": "Number of existing OAuth providers updated.",
-            "title": "Oauth Updated",
-            "type": "integer"
-          },
           "settings_applied": {
             "description": "Number of settings successfully updated.",
             "title": "Settings Applied",
@@ -7619,6 +7597,28 @@
             },
             "title": "Settings Skipped Restricted",
             "type": "array"
+          },
+          "oauth_created": {
+            "description": "Number of new OAuth providers created.",
+            "title": "Oauth Created",
+            "type": "integer"
+          },
+          "oauth_updated": {
+            "description": "Number of existing OAuth providers updated.",
+            "title": "Oauth Updated",
+            "type": "integer"
+          },
+          "oauth_deleted": {
+            "description": "Number of OAuth providers deleted (overwrite mode only).",
+            "title": "Oauth Deleted",
+            "type": "integer"
+          },
+          "oauth_accounts_deleted": {
+            "default": 0,
+            "description": "Number of dependent OAuth account links cascade-deleted in overwrite mode.",
+            "minimum": 0.0,
+            "title": "Oauth Accounts Deleted",
+            "type": "integer"
           }
         },
         "required": [
@@ -7633,19 +7633,14 @@
       },
       "InfrastructureConfig": {
         "properties": {
+          "storage_provider": {
+            "description": "Active storage backend ('local' or 's3').",
+            "title": "Storage Provider",
+            "type": "string"
+          },
           "cache_provider": {
             "description": "Active cache backend ('memory' or 'redis').",
             "title": "Cache Provider",
-            "type": "string"
-          },
-          "cdn_configured": {
-            "description": "Whether a CDN base URL is configured for tile delivery.",
-            "title": "Cdn Configured",
-            "type": "boolean"
-          },
-          "database_pooler": {
-            "description": "Active connection pooler mode ('sqlalchemy' or 'external').",
-            "title": "Database Pooler",
             "type": "string"
           },
           "database_type": {
@@ -7653,9 +7648,9 @@
             "title": "Database Type",
             "type": "string"
           },
-          "storage_provider": {
-            "description": "Active storage backend ('local' or 's3').",
-            "title": "Storage Provider",
+          "database_pooler": {
+            "description": "Active connection pooler mode ('sqlalchemy' or 'external').",
+            "title": "Database Pooler",
             "type": "string"
           },
           "tile_cache": {
@@ -7667,6 +7662,11 @@
             "description": "Tile cache TTL in seconds.",
             "title": "Tile Cache Ttl",
             "type": "integer"
+          },
+          "cdn_configured": {
+            "description": "Whether a CDN base URL is configured for tile delivery.",
+            "title": "Cdn Configured",
+            "type": "boolean"
           }
         },
         "required": [
@@ -7714,140 +7714,10 @@
       },
       "JobStatusResponse": {
         "properties": {
-          "archive_failed": {
-            "default": false,
-            "title": "Archive Failed",
-            "type": "boolean"
-          },
-          "can_retry": {
-            "title": "Can Retry",
-            "type": "boolean"
-          },
-          "completed_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Completed At"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "current_step": {
-            "anyOf": [
-              {
-                "enum": [
-                  "queued",
-                  "validating",
-                  "ogr2ogr",
-                  "finalize",
-                  "complete",
-                  "cog_convert",
-                  "quicklook",
-                  "analyzing",
-                  "registering"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Current Step"
-          },
-          "dataset_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Id"
-          },
-          "error_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error Message"
-          },
           "id": {
             "format": "uuid",
             "title": "Id",
             "type": "string"
-          },
-          "progress": {
-            "anyOf": [
-              {
-                "maximum": 1.0,
-                "minimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Progress"
-          },
-          "retry_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Retry Reason"
-          },
-          "rows_processed": {
-            "anyOf": [
-              {
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rows Processed"
-          },
-          "source_filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Filename"
-          },
-          "started_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Started At"
           },
           "status": {
             "enum": [
@@ -7861,18 +7731,54 @@
             "title": "Status",
             "type": "string"
           },
-          "temporal_parse_errors": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "propertyNames": {
-              "enum": [
-                "temporal_start",
-                "temporal_end"
-              ]
-            },
-            "title": "Temporal Parse Errors",
-            "type": "object"
+          "dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Id"
+          },
+          "source_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Filename"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "can_retry": {
+            "title": "Can Retry",
+            "type": "boolean"
+          },
+          "retry_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retry Reason"
           },
           "warning_message": {
             "anyOf": [
@@ -7909,6 +7815,100 @@
             },
             "title": "Warnings",
             "type": "array"
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Progress"
+          },
+          "current_step": {
+            "anyOf": [
+              {
+                "enum": [
+                  "queued",
+                  "validating",
+                  "ogr2ogr",
+                  "finalize",
+                  "complete",
+                  "cog_convert",
+                  "quicklook",
+                  "analyzing",
+                  "registering"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Step"
+          },
+          "rows_processed": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rows Processed"
+          },
+          "archive_failed": {
+            "default": false,
+            "title": "Archive Failed",
+            "type": "boolean"
+          },
+          "temporal_parse_errors": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "enum": [
+                "temporal_start",
+                "temporal_end"
+              ]
+            },
+            "title": "Temporal Parse Errors",
+            "type": "object"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           }
         },
         "required": [
@@ -7933,13 +7933,6 @@
             "title": "Keyword",
             "type": "string"
           },
-          "keyword_type": {
-            "default": "theme",
-            "description": "ISO MD_KeywordTypeCode, e.g. theme, place, discipline",
-            "maxLength": 20,
-            "title": "Keyword Type",
-            "type": "string"
-          },
           "vocabulary_uri": {
             "anyOf": [
               {
@@ -7952,6 +7945,13 @@
             ],
             "description": "URI of the controlled vocabulary",
             "title": "Vocabulary Uri"
+          },
+          "keyword_type": {
+            "default": "theme",
+            "description": "ISO MD_KeywordTypeCode, e.g. theme, place, discipline",
+            "maxLength": 20,
+            "title": "Keyword Type",
+            "type": "string"
           }
         },
         "required": [
@@ -7962,12 +7962,6 @@
       },
       "KeywordListResponse": {
         "properties": {
-          "inherited_audience_gap": {
-            "default": false,
-            "description": "True when at least one keyword is inherited AND this record's audience \u2014 at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters, which are honored only for the record's owner and admins \u2014 includes someone who cannot open the source dataset (feat #1070).",
-            "title": "Inherited Audience Gap",
-            "type": "boolean"
-          },
           "keywords": {
             "items": {
               "$ref": "#/components/schemas/KeywordResponse"
@@ -7978,6 +7972,12 @@
           "total": {
             "title": "Total",
             "type": "integer"
+          },
+          "inherited_audience_gap": {
+            "default": false,
+            "description": "True when at least one keyword is inherited AND this record's audience \u2014 at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters, which are honored only for the record's owner and admins \u2014 includes someone who cannot open the source dataset (feat #1070).",
+            "title": "Inherited Audience Gap",
+            "type": "boolean"
           }
         },
         "required": [
@@ -7994,23 +7994,13 @@
             "title": "Id",
             "type": "string"
           },
-          "inherited": {
-            "default": false,
-            "description": "True when this keyword also exists on the dataset this record was derived from (feat #1070). Derived at read time from derived_from; only ever true for a requester who can access that source dataset, so everyone else sees false \u2014 matching the derived_from redaction.",
-            "title": "Inherited",
-            "type": "boolean"
-          },
-          "keyword": {
-            "title": "Keyword",
-            "type": "string"
-          },
-          "keyword_type": {
-            "title": "Keyword Type",
-            "type": "string"
-          },
           "record_id": {
             "format": "uuid",
             "title": "Record Id",
+            "type": "string"
+          },
+          "keyword": {
+            "title": "Keyword",
             "type": "string"
           },
           "vocabulary_uri": {
@@ -8023,6 +8013,16 @@
               }
             ],
             "title": "Vocabulary Uri"
+          },
+          "keyword_type": {
+            "title": "Keyword Type",
+            "type": "string"
+          },
+          "inherited": {
+            "default": false,
+            "description": "True when this keyword also exists on the dataset this record was derived from (feat #1070). Derived at read time from derived_from; only ever true for a requester who can access that source dataset, so everyone else sees false \u2014 matching the derived_from redaction.",
+            "title": "Inherited",
+            "type": "boolean"
           }
         },
         "required": [
@@ -8076,6 +8076,11 @@
       },
       "LandingPage": {
         "properties": {
+          "title": {
+            "description": "OGC API landing page title.",
+            "title": "Title",
+            "type": "string"
+          },
           "description": {
             "description": "Human-readable API description.",
             "title": "Description",
@@ -8088,11 +8093,6 @@
             },
             "title": "Links",
             "type": "array"
-          },
-          "title": {
-            "description": "OGC API landing page title.",
-            "title": "Title",
-            "type": "string"
           }
         },
         "required": [
@@ -8105,17 +8105,22 @@
       },
       "LayerInfo": {
         "properties": {
-          "feature_count": {
+          "name": {
+            "description": "Internal layer identifier used by the source service.",
+            "title": "Name",
+            "type": "string"
+          },
+          "title": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Total feature count if reported by the service.",
-            "title": "Feature Count"
+            "description": "Human-readable layer title from the service capabilities.",
+            "title": "Title"
           },
           "geometry_type": {
             "anyOf": [
@@ -8129,14 +8134,22 @@
             "description": "Detected geometry type for the layer.",
             "title": "Geometry Type"
           },
-          "kind": {
-            "default": "vector",
-            "description": "Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image/*. Everything else (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'.",
-            "enum": [
-              "vector",
-              "raster"
+          "feature_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "title": "Kind",
+            "description": "Total feature count if reported by the service.",
+            "title": "Feature Count"
+          },
+          "layer_type": {
+            "default": "layer",
+            "description": "Layer kind: 'layer' (spatial) or 'table' (non-spatial attribute table).",
+            "title": "Layer Type",
             "type": "string"
           },
           "layer_id": {
@@ -8154,17 +8167,6 @@
             "description": "Numeric or string layer ID used by ArcGIS services.",
             "title": "Layer Id"
           },
-          "layer_type": {
-            "default": "layer",
-            "description": "Layer kind: 'layer' (spatial) or 'table' (non-spatial attribute table).",
-            "title": "Layer Type",
-            "type": "string"
-          },
-          "name": {
-            "description": "Internal layer identifier used by the source service.",
-            "title": "Name",
-            "type": "string"
-          },
           "object_id_field": {
             "anyOf": [
               {
@@ -8177,17 +8179,15 @@
             "description": "ArcGIS object ID field name, used for stable pagination.",
             "title": "Object Id Field"
           },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
+          "kind": {
+            "default": "vector",
+            "description": "Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image/*. Everything else (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'.",
+            "enum": [
+              "vector",
+              "raster"
             ],
-            "description": "Human-readable layer title from the service capabilities.",
-            "title": "Title"
+            "title": "Kind",
+            "type": "string"
           }
         },
         "required": [
@@ -8198,6 +8198,10 @@
       },
       "LayerPreview": {
         "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
           "feature_count": {
             "anyOf": [
               {
@@ -8219,10 +8223,6 @@
               }
             ],
             "title": "Field Count"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
           }
         },
         "required": [
@@ -8248,6 +8248,10 @@
       },
       "ManifestApplyEntryResult": {
         "properties": {
+          "dataset_key": {
+            "title": "Dataset Key",
+            "type": "string"
+          },
           "action": {
             "enum": [
               "create",
@@ -8257,29 +8261,6 @@
             ],
             "title": "Action",
             "type": "string"
-          },
-          "dataset_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Id"
-          },
-          "dataset_key": {
-            "title": "Dataset Key",
-            "type": "string"
-          },
-          "errors": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Errors",
-            "type": "array"
           },
           "job_id": {
             "anyOf": [
@@ -8293,9 +8274,28 @@
             ],
             "title": "Job Id"
           },
+          "dataset_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Id"
+          },
           "message": {
             "title": "Message",
             "type": "string"
+          },
+          "errors": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Errors",
+            "type": "array"
           }
         },
         "required": [
@@ -8309,6 +8309,11 @@
       "ManifestApplyRequest": {
         "additionalProperties": false,
         "properties": {
+          "manifest_version": {
+            "const": "1",
+            "title": "Manifest Version",
+            "type": "string"
+          },
           "catalog": {
             "$ref": "#/components/schemas/ManifestCatalog"
           },
@@ -8325,11 +8330,6 @@
             "default": false,
             "title": "Dry Run",
             "type": "boolean"
-          },
-          "manifest_version": {
-            "const": "1",
-            "title": "Manifest Version",
-            "type": "string"
           }
         },
         "required": [
@@ -8369,15 +8369,11 @@
       "ManifestCatalog": {
         "additionalProperties": false,
         "properties": {
-          "contact": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ManifestContact"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          "title": {
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
           },
           "description": {
             "anyOf": [
@@ -8405,11 +8401,15 @@
             ],
             "title": "Organization"
           },
-          "title": {
-            "maxLength": 500,
-            "minLength": 1,
-            "title": "Title",
-            "type": "string"
+          "contact": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ManifestContact"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -8421,19 +8421,6 @@
       "ManifestContact": {
         "additionalProperties": false,
         "properties": {
-          "email": {
-            "anyOf": [
-              {
-                "format": "email",
-                "maxLength": 320,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
           "name": {
             "anyOf": [
               {
@@ -8446,6 +8433,19 @@
               }
             ],
             "title": "Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "format": "email",
+                "maxLength": 320,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
           },
           "url": {
             "anyOf": [
@@ -8467,6 +8467,20 @@
       "ManifestDataset": {
         "additionalProperties": false,
         "properties": {
+          "key": {
+            "description": "Stable dataset identity key used for idempotent apply operations.",
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$",
+            "title": "Key",
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          },
           "description": {
             "anyOf": [
               {
@@ -8480,13 +8494,14 @@
             ],
             "title": "Description"
           },
-          "key": {
-            "description": "Stable dataset identity key used for idempotent apply operations.",
-            "maxLength": 128,
-            "minLength": 1,
-            "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$",
-            "title": "Key",
-            "type": "string"
+          "sources": {
+            "items": {
+              "$ref": "#/components/schemas/ManifestSource"
+            },
+            "maxItems": 1,
+            "minItems": 1,
+            "title": "Sources",
+            "type": "array"
           },
           "metadata": {
             "anyOf": [
@@ -8500,21 +8515,6 @@
           },
           "publication": {
             "$ref": "#/components/schemas/ManifestPublication"
-          },
-          "sources": {
-            "items": {
-              "$ref": "#/components/schemas/ManifestSource"
-            },
-            "maxItems": 1,
-            "minItems": 1,
-            "title": "Sources",
-            "type": "array"
-          },
-          "title": {
-            "maxLength": 500,
-            "minLength": 1,
-            "title": "Title",
-            "type": "string"
           }
         },
         "required": [
@@ -8529,6 +8529,60 @@
       "ManifestMetadata": {
         "additionalProperties": false,
         "properties": {
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "organization": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization"
+          },
+          "crs": {
+            "anyOf": [
+              {
+                "pattern": "^EPSG:[0-9]{1,6}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crs"
+          },
+          "license": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "License"
+          },
           "attribution": {
             "anyOf": [
               {
@@ -8560,60 +8614,6 @@
               }
             ],
             "title": "Bbox"
-          },
-          "crs": {
-            "anyOf": [
-              {
-                "pattern": "^EPSG:[0-9]{1,6}$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Crs"
-          },
-          "license": {
-            "anyOf": [
-              {
-                "maxLength": 500,
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "License"
-          },
-          "organization": {
-            "anyOf": [
-              {
-                "maxLength": 500,
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Organization"
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "items": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tags"
           }
         },
         "title": "ManifestMetadata",
@@ -8639,6 +8639,36 @@
       "ManifestSource": {
         "additionalProperties": false,
         "properties": {
+          "type": {
+            "description": "Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, or xls; raster_cog sources require tif or tiff.",
+            "enum": [
+              "vector",
+              "raster_cog"
+            ],
+            "title": "Type",
+            "type": "string"
+          },
+          "uri": {
+            "description": "Relative path (no `..` traversal), HTTP(S) URL, or storage URI.",
+            "maxLength": 2000,
+            "minLength": 1,
+            "pattern": "^(?:(?:\\./)?[^\\s:/][^\\s:]*|https?://[^\\s]+|s3://[^\\s]+|gs://[^\\s]+|az://[^\\s]+|abfs://[^\\s]+)$",
+            "title": "Uri",
+            "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
           "description": {
             "anyOf": [
               {
@@ -8677,36 +8707,6 @@
               }
             ],
             "title": "Layer"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "maxLength": 500,
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "type": {
-            "description": "Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, or xls; raster_cog sources require tif or tiff.",
-            "enum": [
-              "vector",
-              "raster_cog"
-            ],
-            "title": "Type",
-            "type": "string"
-          },
-          "uri": {
-            "description": "Relative path (no `..` traversal), HTTP(S) URL, or storage URI.",
-            "maxLength": 2000,
-            "minLength": 1,
-            "pattern": "^(?:(?:\\./)?[^\\s:/][^\\s:]*|https?://[^\\s]+|s3://[^\\s]+|gs://[^\\s]+|az://[^\\s]+|abfs://[^\\s]+)$",
-            "title": "Uri",
-            "type": "string"
           }
         },
         "required": [
@@ -8718,14 +8718,14 @@
       },
       "MapAccessResponse": {
         "properties": {
-          "can_edit": {
-            "description": "True when the current request may open the map builder",
-            "title": "Can Edit",
-            "type": "boolean"
-          },
           "can_view": {
             "description": "True when the current request may read the map",
             "title": "Can View",
+            "type": "boolean"
+          },
+          "can_edit": {
+            "description": "True when the current request may open the map builder",
+            "title": "Can Edit",
             "type": "boolean"
           }
         },
@@ -8738,16 +8738,13 @@
       },
       "MapCreate": {
         "properties": {
-          "basemap_config": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/BasemapConfig"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Curated map-level basemap appearance preferences"
+          "name": {
+            "description": "Map display name",
+            "example": "NYC Infrastructure",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
           },
           "description": {
             "anyOf": [
@@ -8762,14 +8759,6 @@
             "description": "Short description for sharing",
             "example": "Buildings, parks, and transit routes in Manhattan",
             "title": "Description"
-          },
-          "name": {
-            "description": "Map display name",
-            "example": "NYC Infrastructure",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
           },
           "notes": {
             "anyOf": [
@@ -8794,6 +8783,17 @@
               }
             ],
             "description": "Map-level terrain source and exaggeration preferences"
+          },
+          "basemap_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BasemapConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Curated map-level basemap appearance preferences"
           }
         },
         "required": [
@@ -8836,6 +8836,12 @@
       },
       "MapGenerateRequest": {
         "properties": {
+          "prompt": {
+            "maxLength": 1000,
+            "minLength": 3,
+            "title": "Prompt",
+            "type": "string"
+          },
           "language": {
             "anyOf": [
               {
@@ -8846,12 +8852,6 @@
               }
             ],
             "title": "Language"
-          },
-          "prompt": {
-            "maxLength": 1000,
-            "minLength": 3,
-            "title": "Prompt",
-            "type": "string"
           }
         },
         "required": [
@@ -8862,17 +8862,6 @@
       },
       "MapGenerateResponse": {
         "properties": {
-          "datasets_used": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Datasets Used",
-            "type": "array"
-          },
-          "explanation": {
-            "title": "Explanation",
-            "type": "string"
-          },
           "map_id": {
             "title": "Map Id",
             "type": "string"
@@ -8880,6 +8869,17 @@
           "map_name": {
             "title": "Map Name",
             "type": "string"
+          },
+          "explanation": {
+            "title": "Explanation",
+            "type": "string"
+          },
+          "datasets_used": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Datasets Used",
+            "type": "array"
           }
         },
         "required": [
@@ -8893,8 +8893,14 @@
       },
       "MapHistoryEventResponse": {
         "properties": {
-          "action": {
-            "title": "Action",
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "map_id": {
+            "format": "uuid",
+            "title": "Map Id",
             "type": "string"
           },
           "actor_id": {
@@ -8920,28 +8926,8 @@
             ],
             "title": "Actor Username"
           },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "details": {
-            "additionalProperties": true,
-            "title": "Details",
-            "type": "object"
-          },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
-          "map_id": {
-            "format": "uuid",
-            "title": "Map Id",
-            "type": "string"
-          },
-          "summary": {
-            "title": "Summary",
+          "target_type": {
+            "title": "Target Type",
             "type": "string"
           },
           "target_id": {
@@ -8967,8 +8953,22 @@
             ],
             "title": "Target Name"
           },
-          "target_type": {
-            "title": "Target Type",
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "details": {
+            "additionalProperties": true,
+            "title": "Details",
+            "type": "object"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
             "type": "string"
           }
         },
@@ -8992,16 +8992,16 @@
             "title": "Events",
             "type": "array"
           },
-          "limit": {
-            "title": "Limit",
+          "total": {
+            "title": "Total",
             "type": "integer"
           },
           "skip": {
             "title": "Skip",
             "type": "integer"
           },
-          "total": {
-            "title": "Total",
+          "limit": {
+            "title": "Limit",
             "type": "integer"
           }
         },
@@ -9032,21 +9032,28 @@
       },
       "MapIconResponse": {
         "properties": {
-          "builtin": {
-            "default": false,
-            "title": "Builtin",
-            "type": "boolean"
-          },
           "id": {
             "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "slug": {
+            "title": "Slug",
             "type": "string"
           },
           "media_type": {
             "title": "Media Type",
             "type": "string"
           },
-          "name": {
-            "title": "Name",
+          "url": {
+            "title": "Url",
+            "type": "string"
+          },
+          "sprite_id": {
+            "title": "Sprite Id",
             "type": "string"
           },
           "size_bytes": {
@@ -9060,17 +9067,10 @@
             ],
             "title": "Size Bytes"
           },
-          "slug": {
-            "title": "Slug",
-            "type": "string"
-          },
-          "sprite_id": {
-            "title": "Sprite Id",
-            "type": "string"
-          },
-          "url": {
-            "title": "Url",
-            "type": "string"
+          "builtin": {
+            "default": false,
+            "title": "Builtin",
+            "type": "boolean"
           }
         },
         "required": [
@@ -9095,11 +9095,20 @@
             "title": "Added",
             "type": "array"
           },
-          "fallback_full_replace": {
-            "default": false,
-            "description": "Client hint only; PATCH never performs full replacement",
-            "title": "Fallback Full Replace",
-            "type": "boolean"
+          "updated": {
+            "items": {
+              "$ref": "#/components/schemas/MapLayerPatch"
+            },
+            "title": "Updated",
+            "type": "array"
+          },
+          "removed": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "title": "Removed",
+            "type": "array"
           },
           "order": {
             "anyOf": [
@@ -9117,20 +9126,11 @@
             "description": "Optional stable layer ID order for existing layers",
             "title": "Order"
           },
-          "removed": {
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "title": "Removed",
-            "type": "array"
-          },
-          "updated": {
-            "items": {
-              "$ref": "#/components/schemas/MapLayerPatch"
-            },
-            "title": "Updated",
-            "type": "array"
+          "fallback_full_replace": {
+            "default": false,
+            "description": "Client hint only; PATCH never performs full replacement",
+            "title": "Fallback Full Replace",
+            "type": "boolean"
           }
         },
         "title": "MapLayerDiffRequest",
@@ -9138,10 +9138,70 @@
       },
       "MapLayerInput": {
         "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Existing layer id to update in place (full-save reconcile)",
+            "title": "Id"
+          },
           "dataset_id": {
             "format": "uuid",
             "title": "Dataset Id",
             "type": "string"
+          },
+          "sort_order": {
+            "default": 0,
+            "description": "Draw order (lower draws first)",
+            "maximum": 32767.0,
+            "minimum": 0.0,
+            "title": "Sort Order",
+            "type": "integer"
+          },
+          "visible": {
+            "default": true,
+            "title": "Visible",
+            "type": "boolean"
+          },
+          "opacity": {
+            "default": 1.0,
+            "description": "Layer opacity 0.0-1.0",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Opacity",
+            "type": "number"
+          },
+          "paint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "MapLibre paint properties override",
+            "title": "Paint"
+          },
+          "layout": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "MapLibre layout properties override",
+            "title": "Layout"
           },
           "display_name": {
             "anyOf": [
@@ -9169,19 +9229,6 @@
             "description": "MapLibre filter expression",
             "title": "Filter"
           },
-          "id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Existing layer id to update in place (full-save reconcile)",
-            "title": "Id"
-          },
           "label_config": {
             "anyOf": [
               {
@@ -9195,53 +9242,6 @@
             "description": "Text label configuration",
             "title": "Label Config"
           },
-          "layer_type": {
-            "anyOf": [
-              {
-                "pattern": "^(vector_geolens|raster_geolens|geojson)$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Auto-detected from record_type if omitted",
-            "title": "Layer Type"
-          },
-          "layout": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "MapLibre layout properties override",
-            "title": "Layout"
-          },
-          "opacity": {
-            "default": 1.0,
-            "description": "Layer opacity 0.0-1.0",
-            "maximum": 1.0,
-            "minimum": 0.0,
-            "title": "Opacity",
-            "type": "number"
-          },
-          "paint": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "MapLibre paint properties override",
-            "title": "Paint"
-          },
           "popup_config": {
             "anyOf": [
               {
@@ -9252,20 +9252,6 @@
               }
             ],
             "description": "Popup configuration: {enabled, expression, visible_fields}"
-          },
-          "show_in_legend": {
-            "default": true,
-            "description": "Whether to include in the map legend",
-            "title": "Show In Legend",
-            "type": "boolean"
-          },
-          "sort_order": {
-            "default": 0,
-            "description": "Draw order (lower draws first)",
-            "maximum": 32767.0,
-            "minimum": 0.0,
-            "title": "Sort Order",
-            "type": "integer"
           },
           "style_config": {
             "anyOf": [
@@ -9280,9 +9266,23 @@
             "description": "Data-driven and builder UI style configuration. Builder-only state lives under builder, e.g. fill_disabled, stroke_disabled, outline settings, heatmap metadata, and height_column.",
             "title": "Style Config"
           },
-          "visible": {
+          "layer_type": {
+            "anyOf": [
+              {
+                "pattern": "^(vector_geolens|raster_geolens|geojson)$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Auto-detected from record_type if omitted",
+            "title": "Layer Type"
+          },
+          "show_in_legend": {
             "default": true,
-            "title": "Visible",
+            "description": "Whether to include in the map legend",
+            "title": "Show In Legend",
             "type": "boolean"
           }
         },
@@ -9294,73 +9294,34 @@
       },
       "MapLayerPatch": {
         "properties": {
-          "display_name": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "filter": {
-            "anyOf": [
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "MapLibre filter expression",
-            "title": "Filter"
-          },
           "id": {
             "format": "uuid",
             "title": "Id",
             "type": "string"
           },
-          "label_config": {
+          "sort_order": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
+                "maximum": 32767.0,
+                "minimum": 0.0,
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Text label configuration",
-            "title": "Label Config"
+            "title": "Sort Order"
           },
-          "layer_type": {
+          "visible": {
             "anyOf": [
               {
-                "pattern": "^(vector_geolens|raster_geolens|geojson)$",
-                "type": "string"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Layer Type"
-          },
-          "layout": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "MapLibre layout properties override",
-            "title": "Layout"
+            "title": "Visible"
           },
           "opacity": {
             "anyOf": [
@@ -9388,41 +9349,7 @@
             "description": "MapLibre paint properties override",
             "title": "Paint"
           },
-          "popup_config": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PopupConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "show_in_legend": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Show In Legend"
-          },
-          "sort_order": {
-            "anyOf": [
-              {
-                "maximum": 32767.0,
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sort Order"
-          },
-          "style_config": {
+          "layout": {
             "anyOf": [
               {
                 "additionalProperties": true,
@@ -9432,162 +9359,13 @@
                 "type": "null"
               }
             ],
-            "title": "Style Config"
-          },
-          "visible": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Visible"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "MapLayerPatch",
-        "type": "object"
-      },
-      "MapLayerResponse": {
-        "properties": {
-          "band_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Band Count"
-          },
-          "dataset_column_info": {
-            "anyOf": [
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Column Info"
-          },
-          "dataset_extent_bbox": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "number"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Extent Bbox"
-          },
-          "dataset_feature_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Feature Count"
-          },
-          "dataset_geometry_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Geometry Type"
-          },
-          "dataset_id": {
-            "format": "uuid",
-            "title": "Dataset Id",
-            "type": "string"
-          },
-          "dataset_name": {
-            "title": "Dataset Name",
-            "type": "string"
-          },
-          "dataset_record_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Record Type"
-          },
-          "dataset_sample_values": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Sample Values"
-          },
-          "dataset_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Status"
-          },
-          "dataset_table_name": {
-            "title": "Dataset Table Name",
-            "type": "string"
-          },
-          "dataset_visibility": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Visibility"
-          },
-          "dem_vertical_units": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dem Vertical Units"
+            "description": "MapLibre layout properties override",
+            "title": "Layout"
           },
           "display_name": {
             "anyOf": [
               {
+                "maxLength": 255,
                 "type": "string"
               },
               {
@@ -9606,12 +9384,256 @@
                 "type": "null"
               }
             ],
+            "description": "MapLibre filter expression",
             "title": "Filter"
           },
+          "label_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Text label configuration",
+            "title": "Label Config"
+          },
+          "popup_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PopupConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "style_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Style Config"
+          },
+          "layer_type": {
+            "anyOf": [
+              {
+                "pattern": "^(vector_geolens|raster_geolens|geojson)$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Layer Type"
+          },
+          "show_in_legend": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Legend"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "MapLayerPatch",
+        "type": "object"
+      },
+      "MapLayerResponse": {
+        "properties": {
           "id": {
             "format": "uuid",
             "title": "Id",
             "type": "string"
+          },
+          "dataset_id": {
+            "format": "uuid",
+            "title": "Dataset Id",
+            "type": "string"
+          },
+          "dataset_name": {
+            "title": "Dataset Name",
+            "type": "string"
+          },
+          "dataset_geometry_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Geometry Type"
+          },
+          "dataset_table_name": {
+            "title": "Dataset Table Name",
+            "type": "string"
+          },
+          "dataset_extent_bbox": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Extent Bbox"
+          },
+          "dataset_column_info": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Column Info"
+          },
+          "dataset_feature_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Feature Count"
+          },
+          "dataset_sample_values": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Sample Values"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "sort_order": {
+            "title": "Sort Order",
+            "type": "integer"
+          },
+          "visible": {
+            "title": "Visible",
+            "type": "boolean"
+          },
+          "opacity": {
+            "title": "Opacity",
+            "type": "number"
+          },
+          "paint": {
+            "additionalProperties": true,
+            "title": "Paint",
+            "type": "object"
+          },
+          "layout": {
+            "additionalProperties": true,
+            "title": "Layout",
+            "type": "object"
+          },
+          "layer_type": {
+            "default": "vector_geolens",
+            "title": "Layer Type",
+            "type": "string"
+          },
+          "dataset_record_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Record Type"
+          },
+          "filter": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filter"
+          },
+          "label_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label Config"
+          },
+          "popup_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PopupConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "style_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Style Config"
+          },
+          "show_in_legend": {
+            "default": true,
+            "title": "Show In Legend",
+            "type": "boolean"
           },
           "is_3d": {
             "anyOf": [
@@ -9635,67 +9657,27 @@
             ],
             "title": "Is Dem"
           },
-          "label_config": {
+          "dem_vertical_units": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Label Config"
+            "title": "Dem Vertical Units"
           },
-          "layer_type": {
-            "default": "vector_geolens",
-            "title": "Layer Type",
-            "type": "string"
-          },
-          "layout": {
-            "additionalProperties": true,
-            "title": "Layout",
-            "type": "object"
-          },
-          "opacity": {
-            "title": "Opacity",
-            "type": "number"
-          },
-          "paint": {
-            "additionalProperties": true,
-            "title": "Paint",
-            "type": "object"
-          },
-          "popup_config": {
+          "band_count": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PopupConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "show_in_legend": {
-            "default": true,
-            "title": "Show In Legend",
-            "type": "boolean"
-          },
-          "sort_order": {
-            "title": "Sort Order",
-            "type": "integer"
-          },
-          "style_config": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Style Config"
+            "title": "Band Count"
           },
           "tile_version": {
             "anyOf": [
@@ -9708,9 +9690,27 @@
             ],
             "title": "Tile Version"
           },
-          "visible": {
-            "title": "Visible",
-            "type": "boolean"
+          "dataset_visibility": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Visibility"
+          },
+          "dataset_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Status"
           }
         },
         "required": [
@@ -9752,34 +9752,36 @@
       },
       "MapResponse": {
         "properties": {
-          "basemap_config": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/BasemapConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "basemap_style": {
-            "title": "Basemap Style",
+          "id": {
+            "format": "uuid",
+            "title": "Id",
             "type": "string"
           },
-          "bearing": {
-            "title": "Bearing",
-            "type": "number"
+          "name": {
+            "title": "Name",
+            "type": "string"
           },
-          "center_lat": {
+          "description": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Center Lat"
+            "title": "Description"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
           },
           "center_lng": {
             "anyOf": [
@@ -9792,35 +9794,68 @@
             ],
             "title": "Center Lng"
           },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
+          "center_lat": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Lat"
+          },
+          "zoom": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Zoom"
+          },
+          "bearing": {
+            "title": "Bearing",
+            "type": "number"
+          },
+          "pitch": {
+            "title": "Pitch",
+            "type": "number"
+          },
+          "basemap_style": {
+            "title": "Basemap Style",
             "type": "string"
           },
-          "created_by": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created By"
+          "show_basemap_labels": {
+            "title": "Show Basemap Labels",
+            "type": "boolean"
           },
-          "created_by_username": {
+          "basemap_config": {
             "anyOf": [
               {
-                "type": "string"
+                "$ref": "#/components/schemas/BasemapConfig"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Created By Username"
+            ]
           },
-          "description": {
+          "terrain_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TerrainConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/MapVisibility"
+          },
+          "thumbnail_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -9829,7 +9864,18 @@
                 "type": "null"
               }
             ],
-            "title": "Description"
+            "title": "Thumbnail Url"
+          },
+          "og_image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Og Image Url"
           },
           "forked_from_id": {
             "anyOf": [
@@ -9855,14 +9901,38 @@
             ],
             "title": "Forked From Name"
           },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
+          "created_by": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "created_by_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By Username"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
             "type": "string"
           },
-          "layer_count": {
-            "title": "Layer Count",
-            "type": "integer"
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
           },
           "layers": {
             "items": {
@@ -9871,46 +9941,9 @@
             "title": "Layers",
             "type": "array"
           },
-          "legend_title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Legend Title"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "notes": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Notes"
-          },
-          "og_image_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Og Image Url"
-          },
-          "pitch": {
-            "title": "Pitch",
-            "type": "number"
+          "layer_count": {
+            "title": "Layer Count",
+            "type": "integer"
           },
           "plugins": {
             "anyOf": [
@@ -9926,21 +9959,7 @@
             ],
             "title": "Plugins"
           },
-          "show_basemap_labels": {
-            "title": "Show Basemap Labels",
-            "type": "boolean"
-          },
-          "terrain_config": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TerrainConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "thumbnail_url": {
+          "legend_title": {
             "anyOf": [
               {
                 "type": "string"
@@ -9949,26 +9968,7 @@
                 "type": "null"
               }
             ],
-            "title": "Thumbnail Url"
-          },
-          "updated_at": {
-            "format": "date-time",
-            "title": "Updated At",
-            "type": "string"
-          },
-          "visibility": {
-            "$ref": "#/components/schemas/MapVisibility"
-          },
-          "zoom": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Zoom"
+            "title": "Legend Title"
           }
         },
         "required": [
@@ -9996,18 +9996,43 @@
         "additionalProperties": true,
         "description": "Typed request body for POST /maps/import \u2014 API-01 / M-05.\n\nMirrors the top-level keys of the MapLibre Style Specification that\n``parse_maplibre_style_import`` actually reads. ``extra=\"allow\"`` keeps\nforward-compatibility with future MapLibre fields (e.g. ``projection``,\n``light``, ``transition``) so adding a new key on the client side\ndoesn't require a server release.\n\nReplacing the previous bare-``dict`` body parameter removes\n``additionalProperties: true`` from the OpenAPI schema and lets\nopenapi-python-client generate a navigable named model class.",
         "properties": {
-          "bearing": {
+          "version": {
             "anyOf": [
               {
-                "maximum": 180.0,
-                "minimum": -180.0,
-                "type": "number"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Bearing"
+            "description": "MapLibre style version (always 8 in current spec)",
+            "title": "Version"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name for the imported map",
+            "title": "Name"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Free-form metadata bag (used by GeoLens for center/zoom/basemap hints)",
+            "title": "Metadata"
           },
           "center": {
             "anyOf": [
@@ -10024,59 +10049,31 @@
             "description": "[longitude, latitude] map center",
             "title": "Center"
           },
-          "glyphs": {
+          "zoom": {
             "anyOf": [
               {
-                "maxLength": 2000,
-                "type": "string"
+                "maximum": 24.0,
+                "minimum": 0.0,
+                "type": "number"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Glyphs"
+            "title": "Zoom"
           },
-          "layers": {
+          "bearing": {
             "anyOf": [
               {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
+                "maximum": 180.0,
+                "minimum": -180.0,
+                "type": "number"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "MapLibre layer specifications",
-            "title": "Layers"
-          },
-          "metadata": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Free-form metadata bag (used by GeoLens for center/zoom/basemap hints)",
-            "title": "Metadata"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Display name for the imported map",
-            "title": "Name"
+            "title": "Bearing"
           },
           "pitch": {
             "anyOf": [
@@ -10116,6 +10113,18 @@
             ],
             "title": "Sprite"
           },
+          "glyphs": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Glyphs"
+          },
           "terrain": {
             "anyOf": [
               {
@@ -10129,30 +10138,21 @@
             "description": "MapLibre terrain config (source + exaggeration)",
             "title": "Terrain"
           },
-          "version": {
+          "layers": {
             "anyOf": [
               {
-                "type": "integer"
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "MapLibre style version (always 8 in current spec)",
-            "title": "Version"
-          },
-          "zoom": {
-            "anyOf": [
-              {
-                "maximum": 24.0,
-                "minimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Zoom"
+            "description": "MapLibre layer specifications",
+            "title": "Layers"
           }
         },
         "title": "MapStyleImportRequest",
@@ -10176,16 +10176,6 @@
       },
       "MapStyleImportSummary": {
         "properties": {
-          "layers_imported": {
-            "default": 0,
-            "title": "Layers Imported",
-            "type": "integer"
-          },
-          "layers_skipped": {
-            "default": 0,
-            "title": "Layers Skipped",
-            "type": "integer"
-          },
           "sources_matched": {
             "default": 0,
             "title": "Sources Matched",
@@ -10194,6 +10184,16 @@
           "sources_unsupported": {
             "default": 0,
             "title": "Sources Unsupported",
+            "type": "integer"
+          },
+          "layers_imported": {
+            "default": 0,
+            "title": "Layers Imported",
+            "type": "integer"
+          },
+          "layers_skipped": {
+            "default": 0,
+            "title": "Layers Skipped",
             "type": "integer"
           },
           "warnings": {
@@ -10213,17 +10213,6 @@
             "title": "Code",
             "type": "string"
           },
-          "layer_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Layer Id"
-          },
           "message": {
             "title": "Message",
             "type": "string"
@@ -10238,6 +10227,17 @@
               }
             ],
             "title": "Source Id"
+          },
+          "layer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Layer Id"
           }
         },
         "required": [
@@ -10249,21 +10249,14 @@
       },
       "MapSummaryResponse": {
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
+          "id": {
+            "format": "uuid",
+            "title": "Id",
             "type": "string"
           },
-          "created_by_username": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created By Username"
+          "name": {
+            "title": "Name",
+            "type": "string"
           },
           "description": {
             "anyOf": [
@@ -10276,18 +10269,19 @@
             ],
             "title": "Description"
           },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
+          "visibility": {
+            "$ref": "#/components/schemas/MapVisibility"
           },
-          "layer_count": {
-            "title": "Layer Count",
-            "type": "integer"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
+          "thumbnail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thumbnail Url"
           },
           "thumbnail_updated_at": {
             "anyOf": [
@@ -10301,7 +10295,11 @@
             ],
             "title": "Thumbnail Updated At"
           },
-          "thumbnail_url": {
+          "layer_count": {
+            "title": "Layer Count",
+            "type": "integer"
+          },
+          "created_by_username": {
             "anyOf": [
               {
                 "type": "string"
@@ -10310,15 +10308,17 @@
                 "type": "null"
               }
             ],
-            "title": "Thumbnail Url"
+            "title": "Created By Username"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           },
           "updated_at": {
             "format": "date-time",
             "title": "Updated At",
             "type": "string"
-          },
-          "visibility": {
-            "$ref": "#/components/schemas/MapVisibility"
           }
         },
         "required": [
@@ -10335,18 +10335,19 @@
       },
       "MapUpdate": {
         "properties": {
-          "basemap_config": {
+          "name": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/BasemapConfig"
+                "maxLength": 255,
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Curated map-level basemap appearance preferences"
+            "title": "Name"
           },
-          "basemap_style": {
+          "description": {
             "anyOf": [
               {
                 "maxLength": 2000,
@@ -10356,8 +10357,57 @@
                 "type": "null"
               }
             ],
-            "description": "Basemap style ID or URL",
-            "title": "Basemap Style"
+            "title": "Description"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "maxLength": 50000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "center_lng": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Map center longitude",
+            "title": "Center Lng"
+          },
+          "center_lat": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Map center latitude",
+            "title": "Center Lat"
+          },
+          "zoom": {
+            "anyOf": [
+              {
+                "maximum": 24.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Map zoom level",
+            "title": "Zoom"
           },
           "bearing": {
             "anyOf": [
@@ -10373,95 +10423,6 @@
             "description": "Map rotation in degrees",
             "title": "Bearing"
           },
-          "center_lat": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Map center latitude",
-            "title": "Center Lat"
-          },
-          "center_lng": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Map center longitude",
-            "title": "Center Lng"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "maxLength": 2000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "layers": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/MapLayerInput"
-                },
-                "maxItems": 200,
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Full replacement layer list (max 200 layers)",
-            "title": "Layers"
-          },
-          "legend_title": {
-            "anyOf": [
-              {
-                "maxLength": 120,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Custom map-level legend title. Null/empty leaves the legend without a heading override (ENH-06).",
-            "title": "Legend Title"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "notes": {
-            "anyOf": [
-              {
-                "maxLength": 50000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Notes"
-          },
           "pitch": {
             "anyOf": [
               {
@@ -10476,21 +10437,18 @@
             "description": "Map tilt in degrees (0-85)",
             "title": "Pitch"
           },
-          "plugins": {
+          "basemap_style": {
             "anyOf": [
               {
-                "items": {
-                  "type": "string"
-                },
-                "maxItems": 50,
-                "type": "array"
+                "maxLength": 2000,
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Enabled plugin IDs, e.g. ['measurement']",
-            "title": "Plugins"
+            "description": "Basemap style ID or URL",
+            "title": "Basemap Style"
           },
           "show_basemap_labels": {
             "anyOf": [
@@ -10502,6 +10460,17 @@
               }
             ],
             "title": "Show Basemap Labels"
+          },
+          "basemap_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BasemapConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Curated map-level basemap appearance preferences"
           },
           "terrain_config": {
             "anyOf": [
@@ -10525,19 +10494,50 @@
             ],
             "description": "private, internal, or public"
           },
-          "zoom": {
+          "layers": {
             "anyOf": [
               {
-                "maximum": 24.0,
-                "minimum": 0.0,
-                "type": "number"
+                "items": {
+                  "$ref": "#/components/schemas/MapLayerInput"
+                },
+                "maxItems": 200,
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Map zoom level",
-            "title": "Zoom"
+            "description": "Full replacement layer list (max 200 layers)",
+            "title": "Layers"
+          },
+          "plugins": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 50,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Enabled plugin IDs, e.g. ['measurement']",
+            "title": "Plugins"
+          },
+          "legend_title": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Custom map-level legend title. Null/empty leaves the legend without a heading override (ENH-06).",
+            "title": "Legend Title"
           }
         },
         "title": "MapUpdate",
@@ -10556,20 +10556,20 @@
         "additionalProperties": false,
         "description": "fix(#888): how much geometry the Web Mercator clamp destroyed.\n\nThe clamp is a box, not a latitude cutoff: longitude -180 to 180 and\nlatitude -85.06 to 85.06. Either bound can be the one that cost the user\ngeometry, so clients must not present this as a latitude-only problem\n(fix(#899 codex r1)).\n\n``dropped_features`` lost their geometry entirely (a valid point at lat\n-89.95 becomes ``MULTIPOINT EMPTY``); ``clipped_features`` survived in\nreduced form.",
         "properties": {
-          "clip_skipped": {
-            "default": false,
-            "title": "Clip Skipped",
-            "type": "boolean"
+          "dropped_features": {
+            "minimum": 0.0,
+            "title": "Dropped Features",
+            "type": "integer"
           },
           "clipped_features": {
             "minimum": 0.0,
             "title": "Clipped Features",
             "type": "integer"
           },
-          "dropped_features": {
-            "minimum": 0.0,
-            "title": "Dropped Features",
-            "type": "integer"
+          "clip_skipped": {
+            "default": false,
+            "title": "Clip Skipped",
+            "type": "boolean"
           }
         },
         "required": [
@@ -10582,13 +10582,13 @@
       "MercatorClipWarning": {
         "additionalProperties": false,
         "properties": {
-          "details": {
-            "$ref": "#/components/schemas/MercatorClipDetail"
-          },
           "kind": {
             "const": "mercator_clip",
             "title": "Kind",
             "type": "string"
+          },
+          "details": {
+            "$ref": "#/components/schemas/MercatorClipDetail"
           }
         },
         "required": [
@@ -10648,6 +10648,11 @@
             "title": "Channel",
             "type": "string"
           },
+          "ok": {
+            "description": "True if the channel delivered the test notification without error.",
+            "title": "Ok",
+            "type": "boolean"
+          },
           "error": {
             "anyOf": [
               {
@@ -10659,11 +10664,6 @@
             ],
             "description": "Safe error string (exception type name + short message) if ok=False, else null. Never contains secrets.",
             "title": "Error"
-          },
-          "ok": {
-            "description": "True if the channel delivered the test notification without error.",
-            "title": "Ok",
-            "type": "boolean"
           }
         },
         "required": [
@@ -10676,6 +10676,11 @@
       "NotificationTestResponse": {
         "description": "Response for POST /settings/notifications/test/ (NOTIF-06).\n\nAlways returns HTTP 200 \u2014 a channel delivery failure is captured in the\nper-channel ``channels`` list rather than as a 5xx. Never contains secret\nvalues (T-1229-09 / NOTIF-05).",
         "properties": {
+          "sent": {
+            "description": "True if at least one channel successfully delivered the test notification.",
+            "title": "Sent",
+            "type": "boolean"
+          },
           "channels": {
             "description": "Per-channel delivery results. Empty when no channel is configured.",
             "items": {
@@ -10688,11 +10693,6 @@
             "description": "Human-readable summary of the test result.",
             "title": "Message",
             "type": "string"
-          },
-          "sent": {
-            "description": "True if at least one channel successfully delivered the test notification.",
-            "title": "Sent",
-            "type": "boolean"
           }
         },
         "required": [
@@ -10706,18 +10706,32 @@
       "OAuthProviderCreate": {
         "description": "Schema for creating a new OAuth provider.",
         "properties": {
-          "authorize_url": {
-            "anyOf": [
-              {
-                "maxLength": 512,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
+          "slug": {
+            "description": "URL-safe identifier used in callback URLs (e.g. 'google', 'azure-ad'). Lowercase, digits, and hyphens only.",
+            "maxLength": 50,
+            "minLength": 1,
+            "pattern": "^[a-z0-9-]+$",
+            "title": "Slug",
+            "type": "string"
+          },
+          "display_name": {
+            "description": "Human-readable label shown on the login page button.",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Display Name",
+            "type": "string"
+          },
+          "provider_type": {
+            "description": "OAuth or SAML provider type. 'google' and 'microsoft' auto-populate the discovery URL; 'oidc' is generic OAuth/OIDC; 'github' uses GitHub's fixed OAuth2 endpoints (no discovery URL); 'saml' is available only on SAML-enabled deployments.",
+            "enum": [
+              "google",
+              "microsoft",
+              "oidc",
+              "saml",
+              "github"
             ],
-            "description": "Authorization endpoint. Only needed when discovery_url is not set.",
-            "title": "Authorize Url"
+            "title": "Provider Type",
+            "type": "string"
           },
           "client_id": {
             "anyOf": [
@@ -10745,13 +10759,6 @@
             "description": "OAuth client secret issued by the IdP. Stored encrypted; never returned in responses. Required for OAuth/OIDC providers; omit for SAML.",
             "title": "Client Secret"
           },
-          "default_role": {
-            "default": "viewer",
-            "description": "Role assigned to new users created via this provider: 'viewer', 'editor', or 'admin'.",
-            "maxLength": 50,
-            "title": "Default Role",
-            "type": "string"
-          },
           "discovery_url": {
             "anyOf": [
               {
@@ -10765,56 +10772,44 @@
             "description": "OIDC discovery URL ending in `.well-known/openid-configuration`. Auto-populated for Google and Microsoft.",
             "title": "Discovery Url"
           },
-          "display_name": {
-            "description": "Human-readable label shown on the login page button.",
-            "maxLength": 100,
-            "minLength": 1,
-            "title": "Display Name",
-            "type": "string"
-          },
-          "enabled": {
-            "default": true,
-            "description": "Whether the provider button appears on the login page.",
-            "title": "Enabled",
-            "type": "boolean"
-          },
-          "group_claim": {
+          "authorize_url": {
             "anyOf": [
               {
-                "maxLength": 100,
+                "maxLength": 512,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Name of the JWT/userinfo claim (or SAML attribute) that contains group memberships. Set to enable group-based role mapping.",
-            "title": "Group Claim"
+            "description": "Authorization endpoint. Only needed when discovery_url is not set.",
+            "title": "Authorize Url"
           },
-          "group_role_mapping": {
+          "token_url": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "JSON object mapping IdP group names to GeoLens roles. First match wins. Falls back to default_role if no group matches.",
-            "title": "Group Role Mapping"
-          },
-          "idp_certificate": {
-            "anyOf": [
-              {
+                "maxLength": 512,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "SAML IdP signing certificate (PEM). Required for SAML providers. Stored Fernet-encrypted at rest; never returned in responses.",
-            "title": "Idp Certificate"
+            "description": "Token endpoint. Only needed when discovery_url is not set.",
+            "title": "Token Url"
+          },
+          "userinfo_url": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Userinfo endpoint. Only needed when discovery_url is not set.",
+            "title": "Userinfo Url"
           },
           "idp_entity_id": {
             "anyOf": [
@@ -10842,32 +10837,17 @@
             "description": "SAML IdP SSO URL (HTTP-Redirect or HTTP-POST binding). Required for SAML providers.",
             "title": "Idp Sso Url"
           },
-          "provider_type": {
-            "description": "OAuth or SAML provider type. 'google' and 'microsoft' auto-populate the discovery URL; 'oidc' is generic OAuth/OIDC; 'github' uses GitHub's fixed OAuth2 endpoints (no discovery URL); 'saml' is available only on SAML-enabled deployments.",
-            "enum": [
-              "google",
-              "microsoft",
-              "oidc",
-              "saml",
-              "github"
+          "idp_certificate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "title": "Provider Type",
-            "type": "string"
-          },
-          "scopes": {
-            "default": "openid profile email",
-            "description": "Space-separated OAuth scopes.",
-            "maxLength": 500,
-            "title": "Scopes",
-            "type": "string"
-          },
-          "slug": {
-            "description": "URL-safe identifier used in callback URLs (e.g. 'google', 'azure-ad'). Lowercase, digits, and hyphens only.",
-            "maxLength": 50,
-            "minLength": 1,
-            "pattern": "^[a-z0-9-]+$",
-            "title": "Slug",
-            "type": "string"
+            "description": "SAML IdP signing certificate (PEM). Required for SAML providers. Stored Fernet-encrypted at rest; never returned in responses.",
+            "title": "Idp Certificate"
           },
           "sp_entity_id": {
             "anyOf": [
@@ -10882,31 +10862,51 @@
             "description": "SP entityID for this provider. Required for SAML providers. Default suggestion: {public_api_url}/auth/saml/{slug}.",
             "title": "Sp Entity Id"
           },
-          "token_url": {
-            "anyOf": [
-              {
-                "maxLength": 512,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Token endpoint. Only needed when discovery_url is not set.",
-            "title": "Token Url"
+          "scopes": {
+            "default": "openid profile email",
+            "description": "Space-separated OAuth scopes.",
+            "maxLength": 500,
+            "title": "Scopes",
+            "type": "string"
           },
-          "userinfo_url": {
+          "default_role": {
+            "default": "viewer",
+            "description": "Role assigned to new users created via this provider: 'viewer', 'editor', or 'admin'.",
+            "maxLength": 50,
+            "title": "Default Role",
+            "type": "string"
+          },
+          "group_claim": {
             "anyOf": [
               {
-                "maxLength": 512,
+                "maxLength": 100,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Userinfo endpoint. Only needed when discovery_url is not set.",
-            "title": "Userinfo Url"
+            "description": "Name of the JWT/userinfo claim (or SAML attribute) that contains group memberships. Set to enable group-based role mapping.",
+            "title": "Group Claim"
+          },
+          "group_role_mapping": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "JSON object mapping IdP group names to GeoLens roles. First match wins. Falls back to default_role if no group matches.",
+            "title": "Group Role Mapping"
+          },
+          "enabled": {
+            "default": true,
+            "description": "Whether the provider button appears on the login page.",
+            "title": "Enabled",
+            "type": "boolean"
           }
         },
         "required": [
@@ -10920,6 +10920,11 @@
       "OAuthProviderPublic": {
         "description": "Minimal provider info for the login page (no secrets, no config).",
         "properties": {
+          "slug": {
+            "description": "URL-safe identifier used in the callback URL.",
+            "title": "Slug",
+            "type": "string"
+          },
           "display_name": {
             "description": "Label shown on the login page button.",
             "title": "Display Name",
@@ -10928,11 +10933,6 @@
           "provider_type": {
             "description": "Provider type, used by the frontend to pick the right icon.",
             "title": "Provider Type",
-            "type": "string"
-          },
-          "slug": {
-            "description": "URL-safe identifier used in the callback URL.",
-            "title": "Slug",
             "type": "string"
           }
         },
@@ -10947,17 +10947,26 @@
       "OAuthProviderResponse": {
         "description": "Response schema for OAuth/SAML provider.\n\nWrite-only credentials are never exposed:\n  - ``client_secret_encrypted`` (OAuth client secret) \u2014 excluded.\n  - ``idp_certificate`` (SAML IdP signing cert, Fernet-encrypted at rest) \u2014 excluded.\n\nThe 3 non-secret SAML fields (``idp_entity_id``, ``idp_sso_url``,\n``sp_entity_id``) ARE exposed so the admin UI can display them.\n\nPitfall 11 interaction: those 3 fields are declared with ``deferred=True``\non the OAuth ORM model so community DBs (which lack the columns) do not\ncrash on SELECT. Pydantic's ``from_attributes=True`` would normally trigger\nan implicit deferred load on attribute access, which fails under FastAPI's\nasync context with ``MissingGreenlet``. The ``model_validator(mode=\"before\")``\nbelow reads the SAML fields directly from ``obj.__dict__`` so unloaded\nattributes default to None instead of triggering IO. SAML admin endpoints\nthat need the values must use ``undefer_group(\"saml\")`` at query time.",
         "properties": {
-          "authorize_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Authorization endpoint.",
-            "title": "Authorize Url"
+          "id": {
+            "description": "Unique provider identifier.",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "slug": {
+            "description": "URL-safe identifier used in the callback URL.",
+            "title": "Slug",
+            "type": "string"
+          },
+          "display_name": {
+            "description": "Label shown on the login page button.",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "provider_type": {
+            "description": "Provider type: 'google', 'microsoft', 'oidc', or 'saml'.",
+            "title": "Provider Type",
+            "type": "string"
           },
           "client_id": {
             "anyOf": [
@@ -10971,17 +10980,6 @@
             "description": "OAuth client ID. Visible to admins; never exposes client_secret. Null for SAML providers.",
             "title": "Client Id"
           },
-          "created_at": {
-            "description": "Timestamp the provider was created.",
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "default_role": {
-            "description": "Default role assigned to new users.",
-            "title": "Default Role",
-            "type": "string"
-          },
           "discovery_url": {
             "anyOf": [
               {
@@ -10994,15 +10992,87 @@
             "description": "OIDC discovery URL.",
             "title": "Discovery Url"
           },
-          "display_name": {
-            "description": "Label shown on the login page button.",
-            "title": "Display Name",
+          "authorize_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Authorization endpoint.",
+            "title": "Authorize Url"
+          },
+          "token_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Token endpoint.",
+            "title": "Token Url"
+          },
+          "userinfo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Userinfo endpoint.",
+            "title": "Userinfo Url"
+          },
+          "idp_entity_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "SAML IdP entityID (SAML providers only).",
+            "title": "Idp Entity Id"
+          },
+          "idp_sso_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "SAML IdP SSO URL (SAML providers only).",
+            "title": "Idp Sso Url"
+          },
+          "sp_entity_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "SP entityID for this SAML provider (SAML providers only).",
+            "title": "Sp Entity Id"
+          },
+          "scopes": {
+            "description": "Space-separated OAuth scopes.",
+            "title": "Scopes",
             "type": "string"
           },
-          "enabled": {
-            "description": "Whether the provider button appears on the login page.",
-            "title": "Enabled",
-            "type": "boolean"
+          "default_role": {
+            "description": "Default role assigned to new users.",
+            "title": "Default Role",
+            "type": "string"
           },
           "group_claim": {
             "anyOf": [
@@ -11029,92 +11099,22 @@
             "description": "Group-to-role mapping rules.",
             "title": "Group Role Mapping"
           },
-          "id": {
-            "description": "Unique provider identifier.",
-            "format": "uuid",
-            "title": "Id",
+          "enabled": {
+            "description": "Whether the provider button appears on the login page.",
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "created_at": {
+            "description": "Timestamp the provider was created.",
+            "format": "date-time",
+            "title": "Created At",
             "type": "string"
-          },
-          "idp_entity_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "SAML IdP entityID (SAML providers only).",
-            "title": "Idp Entity Id"
-          },
-          "idp_sso_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "SAML IdP SSO URL (SAML providers only).",
-            "title": "Idp Sso Url"
-          },
-          "provider_type": {
-            "description": "Provider type: 'google', 'microsoft', 'oidc', or 'saml'.",
-            "title": "Provider Type",
-            "type": "string"
-          },
-          "scopes": {
-            "description": "Space-separated OAuth scopes.",
-            "title": "Scopes",
-            "type": "string"
-          },
-          "slug": {
-            "description": "URL-safe identifier used in the callback URL.",
-            "title": "Slug",
-            "type": "string"
-          },
-          "sp_entity_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "SP entityID for this SAML provider (SAML providers only).",
-            "title": "Sp Entity Id"
-          },
-          "token_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Token endpoint.",
-            "title": "Token Url"
           },
           "updated_at": {
             "description": "Timestamp the provider was last updated.",
             "format": "date-time",
             "title": "Updated At",
             "type": "string"
-          },
-          "userinfo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Userinfo endpoint.",
-            "title": "Userinfo Url"
           }
         },
         "required": [
@@ -11134,18 +11134,53 @@
       "OAuthProviderUpdate": {
         "description": "Schema for updating an existing OAuth provider. All fields optional.",
         "properties": {
-          "authorize_url": {
+          "slug": {
             "anyOf": [
               {
-                "maxLength": 512,
+                "maxLength": 50,
+                "minLength": 1,
+                "pattern": "^[a-z0-9-]+$",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Updated authorization endpoint.",
-            "title": "Authorize Url"
+            "description": "New slug. Changes the callback URL \u2014 coordinate with the IdP before updating.",
+            "title": "Slug"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New display label.",
+            "title": "Display Name"
+          },
+          "provider_type": {
+            "anyOf": [
+              {
+                "enum": [
+                  "google",
+                  "microsoft",
+                  "oidc",
+                  "saml",
+                  "github"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New provider type. Rarely changed after creation.",
+            "title": "Provider Type"
           },
           "client_id": {
             "anyOf": [
@@ -11175,19 +11210,6 @@
             "description": "New client secret. Omit to leave unchanged; setting this rotates the stored secret.",
             "title": "Client Secret"
           },
-          "default_role": {
-            "anyOf": [
-              {
-                "maxLength": 50,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Updated default role for new users.",
-            "title": "Default Role"
-          },
           "discovery_url": {
             "anyOf": [
               {
@@ -11201,69 +11223,44 @@
             "description": "Updated OIDC discovery URL.",
             "title": "Discovery Url"
           },
-          "display_name": {
+          "authorize_url": {
             "anyOf": [
               {
-                "maxLength": 100,
-                "minLength": 1,
+                "maxLength": 512,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "New display label.",
-            "title": "Display Name"
+            "description": "Updated authorization endpoint.",
+            "title": "Authorize Url"
           },
-          "enabled": {
+          "token_url": {
             "anyOf": [
               {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Set to false to hide the provider button without deleting the configuration.",
-            "title": "Enabled"
-          },
-          "group_claim": {
-            "anyOf": [
-              {
-                "maxLength": 100,
+                "maxLength": 512,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Updated group claim name.",
-            "title": "Group Claim"
+            "description": "Updated token endpoint.",
+            "title": "Token Url"
           },
-          "group_role_mapping": {
+          "userinfo_url": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Updated group-to-role mapping. Pass an empty object to clear.",
-            "title": "Group Role Mapping"
-          },
-          "idp_certificate": {
-            "anyOf": [
-              {
+                "maxLength": 512,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Updated SAML IdP signing certificate (PEM). Setting this rotates the stored cert; omit to leave unchanged.",
-            "title": "Idp Certificate"
+            "description": "Updated userinfo endpoint.",
+            "title": "Userinfo Url"
           },
           "idp_entity_id": {
             "anyOf": [
@@ -11291,52 +11288,17 @@
             "description": "Updated SAML IdP SSO URL.",
             "title": "Idp Sso Url"
           },
-          "provider_type": {
+          "idp_certificate": {
             "anyOf": [
               {
-                "enum": [
-                  "google",
-                  "microsoft",
-                  "oidc",
-                  "saml",
-                  "github"
-                ],
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "New provider type. Rarely changed after creation.",
-            "title": "Provider Type"
-          },
-          "scopes": {
-            "anyOf": [
-              {
-                "maxLength": 500,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Updated space-separated scopes.",
-            "title": "Scopes"
-          },
-          "slug": {
-            "anyOf": [
-              {
-                "maxLength": 50,
-                "minLength": 1,
-                "pattern": "^[a-z0-9-]+$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "New slug. Changes the callback URL \u2014 coordinate with the IdP before updating.",
-            "title": "Slug"
+            "description": "Updated SAML IdP signing certificate (PEM). Setting this rotates the stored cert; omit to leave unchanged.",
+            "title": "Idp Certificate"
           },
           "sp_entity_id": {
             "anyOf": [
@@ -11351,31 +11313,69 @@
             "description": "Updated SP entityID.",
             "title": "Sp Entity Id"
           },
-          "token_url": {
+          "scopes": {
             "anyOf": [
               {
-                "maxLength": 512,
+                "maxLength": 500,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Updated token endpoint.",
-            "title": "Token Url"
+            "description": "Updated space-separated scopes.",
+            "title": "Scopes"
           },
-          "userinfo_url": {
+          "default_role": {
             "anyOf": [
               {
-                "maxLength": 512,
+                "maxLength": 50,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Updated userinfo endpoint.",
-            "title": "Userinfo Url"
+            "description": "Updated default role for new users.",
+            "title": "Default Role"
+          },
+          "group_claim": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Updated group claim name.",
+            "title": "Group Claim"
+          },
+          "group_role_mapping": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Updated group-to-role mapping. Pass an empty object to clear.",
+            "title": "Group Role Mapping"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set to false to hide the provider button without deleting the configuration.",
+            "title": "Enabled"
           }
         },
         "title": "OAuthProviderUpdate",
@@ -11387,6 +11387,21 @@
           "href": {
             "title": "Href",
             "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
           },
           "roles": {
             "anyOf": [
@@ -11401,21 +11416,6 @@
               }
             ],
             "title": "Roles"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "type": {
-            "title": "Type",
-            "type": "string"
           }
         },
         "required": [
@@ -11428,16 +11428,15 @@
       "OGCCollectionMetadata": {
         "description": "Per-dataset collection metadata per OGC API Features.",
         "properties": {
-          "crs": {
-            "default": [
-              "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-            ],
-            "description": "Coordinate reference systems supported for items in this collection.",
-            "items": {
-              "type": "string"
-            },
-            "title": "Crs",
-            "type": "array"
+          "id": {
+            "description": "Stable collection identifier (typically the dataset ID).",
+            "title": "Id",
+            "type": "string"
+          },
+          "title": {
+            "description": "Human-readable collection title.",
+            "title": "Title",
+            "type": "string"
           },
           "description": {
             "anyOf": [
@@ -11464,16 +11463,22 @@
             "description": "Spatial and temporal extent (OGC API Features extent object).",
             "title": "Extent"
           },
-          "id": {
-            "description": "Stable collection identifier (typically the dataset ID).",
-            "title": "Id",
-            "type": "string"
-          },
           "itemType": {
             "default": "feature",
             "description": "Type of items in the collection: 'feature' for vector feature collections, 'coverage' for raster/VRT collections (which expose tiles instead of feature items).",
             "title": "Itemtype",
             "type": "string"
+          },
+          "crs": {
+            "default": [
+              "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "description": "Coordinate reference systems supported for items in this collection.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Crs",
+            "type": "array"
           },
           "links": {
             "description": "Collection navigation links (self, items, queryables, etc.).",
@@ -11482,11 +11487,6 @@
             },
             "title": "Links",
             "type": "array"
-          },
-          "title": {
-            "description": "Human-readable collection title.",
-            "title": "Title",
-            "type": "string"
           }
         },
         "required": [
@@ -11500,24 +11500,16 @@
       "OGCCollectionMetadataResponse": {
         "description": "Response for /collections/datasets single collection metadata.",
         "properties": {
-          "description": {
-            "title": "Description",
-            "type": "string"
-          },
-          "extent": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Extent"
-          },
           "id": {
             "title": "Id",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "description": {
+            "title": "Description",
             "type": "string"
           },
           "itemType": {
@@ -11533,6 +11525,18 @@
             "title": "Links",
             "type": "array"
           },
+          "extent": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extent"
+          },
           "summaries": {
             "anyOf": [
               {
@@ -11544,10 +11548,6 @@
               }
             ],
             "title": "Summaries"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
           }
         },
         "required": [
@@ -11588,6 +11588,32 @@
       "OGCFeatureCollectionResponse": {
         "description": "OGC API Records FeatureCollection with match counts.",
         "properties": {
+          "type": {
+            "default": "FeatureCollection",
+            "title": "Type",
+            "type": "string"
+          },
+          "timeStamp": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timestamp"
+          },
+          "numberMatched": {
+            "description": "Total records matching the query",
+            "title": "Numbermatched",
+            "type": "integer"
+          },
+          "numberReturned": {
+            "description": "Number of records in this response page",
+            "title": "Numberreturned",
+            "type": "integer"
+          },
           "features": {
             "items": {
               "$ref": "#/components/schemas/OGCRecordResponse"
@@ -11609,32 +11635,6 @@
             ],
             "description": "Pagination and self links",
             "title": "Links"
-          },
-          "numberMatched": {
-            "description": "Total records matching the query",
-            "title": "Numbermatched",
-            "type": "integer"
-          },
-          "numberReturned": {
-            "description": "Number of records in this response page",
-            "title": "Numberreturned",
-            "type": "integer"
-          },
-          "timeStamp": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Timestamp"
-          },
-          "type": {
-            "default": "FeatureCollection",
-            "title": "Type",
-            "type": "string"
           }
         },
         "required": [
@@ -11657,6 +11657,11 @@
             "title": "Rel",
             "type": "string"
           },
+          "type": {
+            "description": "Media type of the linked resource (e.g. 'application/json', 'application/geo+json').",
+            "title": "Type",
+            "type": "string"
+          },
           "title": {
             "anyOf": [
               {
@@ -11668,11 +11673,6 @@
             ],
             "description": "Optional human-readable label for the link.",
             "title": "Title"
-          },
-          "type": {
-            "description": "Media type of the linked resource (e.g. 'application/json', 'application/geo+json').",
-            "title": "Type",
-            "type": "string"
           }
         },
         "required": [
@@ -11686,12 +11686,12 @@
       "OGCRecordLink": {
         "description": "Link object in OGC API Records.",
         "properties": {
-          "href": {
-            "title": "Href",
-            "type": "string"
-          },
           "rel": {
             "title": "Rel",
+            "type": "string"
+          },
+          "href": {
+            "title": "Href",
             "type": "string"
           },
           "type": {
@@ -11710,47 +11710,24 @@
       "OGCRecordProperties": {
         "description": "Properties block of an OGC API Records Feature.",
         "properties": {
-          "band_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Band Count"
+          "type": {
+            "default": "dataset",
+            "title": "Type",
+            "type": "string"
           },
-          "column_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Number of columns in the dataset (populated from column_info length).",
-            "title": "Column Count"
+          "title": {
+            "title": "Title",
+            "type": "string"
           },
-          "constraints": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Constraints"
+          "description": {
+            "title": "Description",
+            "type": "string"
           },
-          "contacts": {
+          "keywords": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "type": "string"
             },
-            "title": "Contacts",
+            "title": "Keywords",
             "type": "array"
           },
           "created": {
@@ -11764,286 +11741,6 @@
               }
             ],
             "title": "Created"
-          },
-          "crs": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Crs"
-          },
-          "crs_is_geographic": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "True when the raster CRS is geographic (gsd/res are degrees, not meters); None when the CRS class is unknown.",
-            "title": "Crs Is Geographic"
-          },
-          "dataset_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dataset Count"
-          },
-          "description": {
-            "title": "Description",
-            "type": "string"
-          },
-          "distributions": {
-            "anyOf": [
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Distributions"
-          },
-          "externalIds": {
-            "description": "Identifiers assigned by the described resource's source system.",
-            "items": {
-              "type": "string"
-            },
-            "title": "Externalids",
-            "type": "array"
-          },
-          "feature_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Feature Count"
-          },
-          "formats": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Formats"
-          },
-          "geometry_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Geometry Type"
-          },
-          "gsd": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gsd"
-          },
-          "has_quicklook": {
-            "default": false,
-            "title": "Has Quicklook",
-            "type": "boolean"
-          },
-          "keywords": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Keywords",
-            "type": "array"
-          },
-          "language": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Language"
-          },
-          "license": {
-            "title": "License",
-            "type": "string"
-          },
-          "lineage": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lineage"
-          },
-          "never_edited": {
-            "default": false,
-            "title": "Never Edited",
-            "type": "boolean"
-          },
-          "quality_detail": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Quality Detail"
-          },
-          "quality_statement": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Quality Statement"
-          },
-          "record_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Record Status"
-          },
-          "record_type": {
-            "default": "vector_dataset",
-            "title": "Record Type",
-            "type": "string"
-          },
-          "rights": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rights"
-          },
-          "row_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Row count for tabular records (alias for feature_count when record_type='table').",
-            "title": "Row Count"
-          },
-          "source_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Count"
-          },
-          "source_format": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac', 'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.",
-            "title": "Source Format"
-          },
-          "source_organization": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Organization"
-          },
-          "themes": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Themes",
-            "type": "array"
-          },
-          "time": {
-            "additionalProperties": true,
-            "title": "Time",
-            "type": "object"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "type": {
-            "default": "dataset",
-            "title": "Type",
-            "type": "string"
-          },
-          "update_frequency": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Update Frequency"
           },
           "updated": {
             "anyOf": [
@@ -12068,6 +11765,287 @@
             ],
             "title": "Updated By Display"
           },
+          "never_edited": {
+            "default": false,
+            "title": "Never Edited",
+            "type": "boolean"
+          },
+          "crs": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crs"
+          },
+          "record_type": {
+            "default": "vector_dataset",
+            "title": "Record Type",
+            "type": "string"
+          },
+          "band_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Band Count"
+          },
+          "geometry_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Geometry Type"
+          },
+          "feature_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Count"
+          },
+          "row_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Row count for tabular records (alias for feature_count when record_type='table').",
+            "title": "Row Count"
+          },
+          "column_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Number of columns in the dataset (populated from column_info length).",
+            "title": "Column Count"
+          },
+          "license": {
+            "title": "License",
+            "type": "string"
+          },
+          "source_organization": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Organization"
+          },
+          "source_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac', 'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.",
+            "title": "Source Format"
+          },
+          "quality_detail": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Detail"
+          },
+          "quality_statement": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Statement"
+          },
+          "formats": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Formats"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "externalIds": {
+            "description": "Identifiers assigned by the described resource's source system.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Externalids",
+            "type": "array"
+          },
+          "themes": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Themes",
+            "type": "array"
+          },
+          "rights": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rights"
+          },
+          "contacts": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Contacts",
+            "type": "array"
+          },
+          "time": {
+            "additionalProperties": true,
+            "title": "Time",
+            "type": "object"
+          },
+          "lineage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lineage"
+          },
+          "update_frequency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Update Frequency"
+          },
+          "constraints": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Constraints"
+          },
+          "distributions": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distributions"
+          },
+          "record_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Record Status"
+          },
+          "has_quicklook": {
+            "default": false,
+            "title": "Has Quicklook",
+            "type": "boolean"
+          },
+          "gsd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gsd"
+          },
+          "crs_is_geographic": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "True when the raster CRS is geographic (gsd/res are degrees, not meters); None when the CRS class is unknown.",
+            "title": "Crs Is Geographic"
+          },
           "vrt_type": {
             "anyOf": [
               {
@@ -12078,6 +12056,28 @@
               }
             ],
             "title": "Vrt Type"
+          },
+          "source_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Count"
+          },
+          "dataset_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Count"
           }
         },
         "required": [
@@ -12095,6 +12095,56 @@
       "OGCRecordResponse": {
         "description": "Single OGC API Records Feature.",
         "properties": {
+          "type": {
+            "default": "Feature",
+            "title": "Type",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "conformsTo": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conformsto"
+          },
+          "time": {
+            "additionalProperties": true,
+            "title": "Time",
+            "type": "object"
+          },
+          "geometry": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Geometry"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/OGCRecordProperties"
+          },
+          "links": {
+            "items": {
+              "$ref": "#/components/schemas/OGCRecordLink"
+            },
+            "title": "Links",
+            "type": "array"
+          },
           "assets": {
             "anyOf": [
               {
@@ -12122,56 +12172,6 @@
               }
             ],
             "title": "Bbox"
-          },
-          "conformsTo": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Conformsto"
-          },
-          "geometry": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Geometry"
-          },
-          "id": {
-            "title": "Id",
-            "type": "string"
-          },
-          "links": {
-            "items": {
-              "$ref": "#/components/schemas/OGCRecordLink"
-            },
-            "title": "Links",
-            "type": "array"
-          },
-          "properties": {
-            "$ref": "#/components/schemas/OGCRecordProperties"
-          },
-          "time": {
-            "additionalProperties": true,
-            "title": "Time",
-            "type": "object"
-          },
-          "type": {
-            "default": "Feature",
-            "title": "Type",
-            "type": "string"
           }
         },
         "required": [
@@ -12299,11 +12299,11 @@
       },
       "PresignedUploadRequest": {
         "properties": {
-          "content_type": {
-            "default": "application/octet-stream",
-            "description": "MIME type to associate with the uploaded object.",
+          "filename": {
+            "description": "Original filename being uploaded. Used to determine the file extension and content disposition.",
             "maxLength": 255,
-            "title": "Content Type",
+            "minLength": 1,
+            "title": "Filename",
             "type": "string"
           },
           "file_size": {
@@ -12312,11 +12312,11 @@
             "title": "File Size",
             "type": "integer"
           },
-          "filename": {
-            "description": "Original filename being uploaded. Used to determine the file extension and content disposition.",
+          "content_type": {
+            "default": "application/octet-stream",
+            "description": "MIME type to associate with the uploaded object.",
             "maxLength": 255,
-            "minLength": 1,
-            "title": "Filename",
+            "title": "Content Type",
             "type": "string"
           }
         },
@@ -12335,17 +12335,13 @@
             "title": "Job Id",
             "type": "string"
           },
-          "part_size": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Byte size of each part in a multipart upload.",
-            "title": "Part Size"
+          "urls": {
+            "description": "One presigned PUT URL per part. Single-element list for single-part uploads.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Urls",
+            "type": "array"
           },
           "s3_key": {
             "description": "Object key in the S3 bucket where the file will be stored.",
@@ -12364,13 +12360,17 @@
             "description": "S3 multipart upload ID, set only for multipart uploads.",
             "title": "Upload Id"
           },
-          "urls": {
-            "description": "One presigned PUT URL per part. Single-element list for single-part uploads.",
-            "items": {
-              "type": "string"
-            },
-            "title": "Urls",
-            "type": "array"
+          "part_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Byte size of each part in a multipart upload.",
+            "title": "Part Size"
           }
         },
         "required": [
@@ -12383,6 +12383,24 @@
       },
       "PreviewResponse": {
         "properties": {
+          "job_id": {
+            "description": "Identifier of the ingestion job being previewed.",
+            "format": "uuid",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "source_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Original filename of the uploaded file, if known.",
+            "title": "Source Filename"
+          },
           "columns": {
             "description": "Detected attribute columns. Each entry includes name, type, and nullability.",
             "items": {
@@ -12403,18 +12421,17 @@
             "description": "Detected coordinate reference system EPSG code, or null if undetermined.",
             "title": "Crs"
           },
-          "detected_geometry_columns": {
+          "geometry_type": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Auto-detected lat/lon or geometry columns for CSV/Excel sources. Null for native geospatial formats.",
-            "title": "Detected Geometry Columns"
+            "description": "Detected geometry type (Point, LineString, Polygon, MultiPolygon, etc.), or null for non-spatial data.",
+            "title": "Geometry Type"
           },
           "feature_count": {
             "anyOf": [
@@ -12428,23 +12445,14 @@
             "description": "Total number of features in the source file, if known.",
             "title": "Feature Count"
           },
-          "geometry_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Detected geometry type (Point, LineString, Polygon, MultiPolygon, etc.), or null for non-spatial data.",
-            "title": "Geometry Type"
-          },
-          "job_id": {
-            "description": "Identifier of the ingestion job being previewed.",
-            "format": "uuid",
-            "title": "Job Id",
-            "type": "string"
+          "sample_rows": {
+            "description": "Up to 5 sample rows from the source file for preview purposes.",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Sample Rows",
+            "type": "array"
           },
           "layer_name": {
             "description": "Name of the layer being previewed. Defaults to the source filename for single-layer files.",
@@ -12466,26 +12474,18 @@
             "description": "List of all layers in multi-layer sources (e.g. GeoPackage). Null for single-layer files.",
             "title": "Layers"
           },
-          "sample_rows": {
-            "description": "Up to 5 sample rows from the source file for preview purposes.",
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Sample Rows",
-            "type": "array"
-          },
-          "source_filename": {
+          "detected_geometry_columns": {
             "anyOf": [
               {
-                "type": "string"
+                "additionalProperties": true,
+                "type": "object"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Original filename of the uploaded file, if known.",
-            "title": "Source Filename"
+            "description": "Auto-detected lat/lon or geometry columns for CSV/Excel sources. Null for native geospatial formats.",
+            "title": "Detected Geometry Columns"
           }
         },
         "required": [
@@ -12503,6 +12503,13 @@
       },
       "ProbeRequest": {
         "properties": {
+          "url": {
+            "description": "Service URL to probe. May be a WFS GetCapabilities URL or an ArcGIS service endpoint.",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Url",
+            "type": "string"
+          },
           "token": {
             "anyOf": [
               {
@@ -12515,13 +12522,6 @@
             ],
             "description": "Optional auth token for protected services (passed as query parameter or bearer token depending on service type).",
             "title": "Token"
-          },
-          "url": {
-            "description": "Service URL to probe. May be a WFS GetCapabilities URL or an ArcGIS service endpoint.",
-            "maxLength": 2048,
-            "minLength": 1,
-            "title": "Url",
-            "type": "string"
           }
         },
         "required": [
@@ -12532,6 +12532,16 @@
       },
       "ProbeResponse": {
         "properties": {
+          "service_type": {
+            "description": "Detected service type, e.g. 'WFS 2.0' or 'ArcGIS FeatureServer'.",
+            "title": "Service Type",
+            "type": "string"
+          },
+          "url": {
+            "description": "Normalized service URL after probing.",
+            "title": "Url",
+            "type": "string"
+          },
           "layers": {
             "description": "Layers exposed by the probed service.",
             "items": {
@@ -12554,16 +12564,6 @@
             ],
             "description": "Auto-selected layer ID when the input URL contained a specific layer number.",
             "title": "Selected Layer Id"
-          },
-          "service_type": {
-            "description": "Detected service type, e.g. 'WFS 2.0' or 'ArcGIS FeatureServer'.",
-            "title": "Service Type",
-            "type": "string"
-          },
-          "url": {
-            "description": "Normalized service URL after probing.",
-            "title": "Url",
-            "type": "string"
           }
         },
         "required": [
@@ -12584,6 +12584,19 @@
           }
         ],
         "properties": {
+          "type": {
+            "default": "about:blank",
+            "title": "Type",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "integer"
+          },
           "detail": {
             "anyOf": [
               {
@@ -12599,19 +12612,6 @@
               }
             ],
             "title": "Detail"
-          },
-          "status": {
-            "title": "Status",
-            "type": "integer"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "type": {
-            "default": "about:blank",
-            "title": "Type",
-            "type": "string"
           }
         },
         "required": [
@@ -12624,6 +12624,16 @@
       },
       "ProviderHealth": {
         "properties": {
+          "status": {
+            "description": "Provider health status: 'ok' or 'error'.",
+            "title": "Status",
+            "type": "string"
+          },
+          "latency_ms": {
+            "description": "Latency of the most recent health probe in milliseconds.",
+            "title": "Latency Ms",
+            "type": "number"
+          },
           "error": {
             "anyOf": [
               {
@@ -12635,16 +12645,6 @@
             ],
             "description": "Error message when status is 'error'.",
             "title": "Error"
-          },
-          "latency_ms": {
-            "description": "Latency of the most recent health probe in milliseconds.",
-            "title": "Latency Ms",
-            "type": "number"
-          },
-          "status": {
-            "description": "Provider health status: 'ok' or 'error'.",
-            "title": "Status",
-            "type": "string"
           }
         },
         "required": [
@@ -12657,36 +12657,17 @@
       "QualityDetail": {
         "description": "Automated quality assessment results.",
         "properties": {
-          "attribute_completeness": {
+          "overall": {
             "maximum": 100.0,
             "minimum": 0.0,
-            "title": "Attribute Completeness",
+            "title": "Overall",
             "type": "number"
           },
-          "computed_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Computed At"
-          },
-          "crs_defined": {
-            "anyOf": [
-              {
-                "maximum": 100.0,
-                "minimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Crs Defined"
+          "metadata_completeness": {
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "Metadata Completeness",
+            "type": "number"
           },
           "geometry_validity": {
             "anyOf": [
@@ -12701,17 +12682,36 @@
             ],
             "title": "Geometry Validity"
           },
-          "metadata_completeness": {
+          "attribute_completeness": {
             "maximum": 100.0,
             "minimum": 0.0,
-            "title": "Metadata Completeness",
+            "title": "Attribute Completeness",
             "type": "number"
           },
-          "overall": {
-            "maximum": 100.0,
-            "minimum": 0.0,
-            "title": "Overall",
-            "type": "number"
+          "crs_defined": {
+            "anyOf": [
+              {
+                "maximum": 100.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crs Defined"
+          },
+          "computed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Computed At"
           }
         },
         "required": [
@@ -12739,27 +12739,15 @@
       },
       "RasterBandInfo": {
         "properties": {
-          "color_interp": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Color interpretation, e.g. Red, Green, Gray",
-            "title": "Color Interp"
+          "index": {
+            "description": "1-based band index",
+            "title": "Index",
+            "type": "integer"
           },
           "dtype": {
             "description": "Pixel data type, e.g. uint8, float32",
             "title": "Dtype",
             "type": "string"
-          },
-          "index": {
-            "description": "1-based band index",
-            "title": "Index",
-            "type": "integer"
           },
           "nodata": {
             "anyOf": [
@@ -12772,6 +12760,18 @@
             ],
             "description": "Nodata sentinel value for this band",
             "title": "Nodata"
+          },
+          "color_interp": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Color interpretation, e.g. Red, Green, Gray",
+            "title": "Color Interp"
           }
         },
         "required": [
@@ -12795,6 +12795,11 @@
             "description": "Direct file download URL",
             "title": "Download Url"
           },
+          "tile_url": {
+            "description": "Titiler tile endpoint for this raster",
+            "title": "Tile Url",
+            "type": "string"
+          },
           "s3_uri": {
             "anyOf": [
               {
@@ -12806,11 +12811,6 @@
             ],
             "description": "S3 object URI, e.g. s3://bucket/key.tif",
             "title": "S3 Uri"
-          },
-          "tile_url": {
-            "description": "Titiler tile endpoint for this raster",
-            "title": "Tile Url",
-            "type": "string"
           }
         },
         "required": [
@@ -12821,59 +12821,6 @@
       },
       "RasterMetadata": {
         "properties": {
-          "band_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Band Count"
-          },
-          "bands": {
-            "default": [],
-            "items": {
-              "$ref": "#/components/schemas/RasterBandInfo"
-            },
-            "title": "Bands",
-            "type": "array"
-          },
-          "compression": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Internal compression, e.g. DEFLATE, LZW",
-            "title": "Compression"
-          },
-          "connect": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RasterConnect"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "crs_is_geographic": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "True when the raster CRS is geographic (res_x/res_y are degrees, not meters); None when the CRS class is unknown.",
-            "title": "Crs Is Geographic"
-          },
           "epsg": {
             "anyOf": [
               {
@@ -12886,19 +12833,7 @@
             "description": "EPSG code of the raster CRS",
             "title": "Epsg"
           },
-          "height": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Raster height in pixels",
-            "title": "Height"
-          },
-          "is_dem": {
+          "crs_is_geographic": {
             "anyOf": [
               {
                 "type": "boolean"
@@ -12907,20 +12842,8 @@
                 "type": "null"
               }
             ],
-            "description": "True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade",
-            "title": "Is Dem"
-          },
-          "nodata": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Global nodata sentinel value",
-            "title": "Nodata"
+            "description": "True when the raster CRS is geographic (res_x/res_y are degrees, not meters); None when the CRS class is unknown.",
+            "title": "Crs Is Geographic"
           },
           "res_x": {
             "anyOf": [
@@ -12946,7 +12869,30 @@
             "description": "Pixel resolution in Y (CRS units)",
             "title": "Res Y"
           },
-          "resolution_strategy": {
+          "band_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Band Count"
+          },
+          "is_dem": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade",
+            "title": "Is Dem"
+          },
+          "nodata": {
             "anyOf": [
               {
                 "type": "string"
@@ -12955,8 +12901,44 @@
                 "type": "null"
               }
             ],
-            "description": "VRT resolution strategy, e.g. highest, average",
-            "title": "Resolution Strategy"
+            "description": "Global nodata sentinel value",
+            "title": "Nodata"
+          },
+          "compression": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Internal compression, e.g. DEFLATE, LZW",
+            "title": "Compression"
+          },
+          "width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Raster width in pixels",
+            "title": "Width"
+          },
+          "height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Raster height in pixels",
+            "title": "Height"
           },
           "size_bytes": {
             "anyOf": [
@@ -12970,17 +12952,35 @@
             "description": "File size on disk in bytes",
             "title": "Size Bytes"
           },
-          "source_count": {
+          "tile_url": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Number of source rasters in a VRT mosaic",
-            "title": "Source Count"
+            "description": "Titiler XYZ tile endpoint",
+            "title": "Tile Url"
+          },
+          "bands": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RasterBandInfo"
+            },
+            "title": "Bands",
+            "type": "array"
+          },
+          "connect": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RasterConnect"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "status": {
             "anyOf": [
@@ -12994,18 +12994,6 @@
             "description": "Processing status, e.g. ready, failed",
             "title": "Status"
           },
-          "tile_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Titiler XYZ tile endpoint",
-            "title": "Tile Url"
-          },
           "vrt_type": {
             "anyOf": [
               {
@@ -13018,7 +13006,7 @@
             "description": "VRT variant: mosaic or timeseries",
             "title": "Vrt Type"
           },
-          "width": {
+          "source_count": {
             "anyOf": [
               {
                 "type": "integer"
@@ -13027,26 +13015,10 @@
                 "type": "null"
               }
             ],
-            "description": "Raster width in pixels",
-            "title": "Width"
-          }
-        },
-        "title": "RasterMetadata",
-        "type": "object"
-      },
-      "RasterPreviewResponse": {
-        "properties": {
-          "band_count": {
-            "description": "Number of raster bands.",
-            "title": "Band Count",
-            "type": "integer"
+            "description": "Number of source rasters in a VRT mosaic",
+            "title": "Source Count"
           },
-          "compliance_reason": {
-            "description": "Explanation of COG compliance status. Lists missing requirements when not compliant.",
-            "title": "Compliance Reason",
-            "type": "string"
-          },
-          "compression": {
+          "resolution_strategy": {
             "anyOf": [
               {
                 "type": "string"
@@ -13055,8 +13027,32 @@
                 "type": "null"
               }
             ],
-            "description": "Existing compression method (e.g. 'LZW', 'DEFLATE'), or null for uncompressed.",
-            "title": "Compression"
+            "description": "VRT resolution strategy, e.g. highest, average",
+            "title": "Resolution Strategy"
+          }
+        },
+        "title": "RasterMetadata",
+        "type": "object"
+      },
+      "RasterPreviewResponse": {
+        "properties": {
+          "job_id": {
+            "description": "Identifier of the raster ingestion job being previewed.",
+            "format": "uuid",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "source_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Original filename of the uploaded raster file.",
+            "title": "Source Filename"
           },
           "crs_epsg": {
             "anyOf": [
@@ -13082,37 +13078,24 @@
             "description": "Full WKT representation of the raster's CRS.",
             "title": "Crs Wkt"
           },
-          "dtype": {
-            "description": "Pixel data type (e.g. 'uint8', 'float32').",
-            "title": "Dtype",
-            "type": "string"
+          "band_count": {
+            "description": "Number of raster bands.",
+            "title": "Band Count",
+            "type": "integer"
           },
-          "file_size_bytes": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Source file size in bytes.",
-            "title": "File Size Bytes"
+          "width": {
+            "description": "Raster width in pixels.",
+            "title": "Width",
+            "type": "integer"
           },
           "height": {
             "description": "Raster height in pixels.",
             "title": "Height",
             "type": "integer"
           },
-          "is_cog_compliant": {
-            "description": "Whether the source file is already a Cloud-Optimized GeoTIFF.",
-            "title": "Is Cog Compliant",
-            "type": "boolean"
-          },
-          "job_id": {
-            "description": "Identifier of the raster ingestion job being previewed.",
-            "format": "uuid",
-            "title": "Job Id",
+          "dtype": {
+            "description": "Pixel data type (e.g. 'uint8', 'float32').",
+            "title": "Dtype",
             "type": "string"
           },
           "nodata": {
@@ -13140,7 +13123,7 @@
             "title": "Res Y",
             "type": "number"
           },
-          "source_filename": {
+          "compression": {
             "anyOf": [
               {
                 "type": "string"
@@ -13149,8 +13132,30 @@
                 "type": "null"
               }
             ],
-            "description": "Original filename of the uploaded raster file.",
-            "title": "Source Filename"
+            "description": "Existing compression method (e.g. 'LZW', 'DEFLATE'), or null for uncompressed.",
+            "title": "Compression"
+          },
+          "file_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Source file size in bytes.",
+            "title": "File Size Bytes"
+          },
+          "is_cog_compliant": {
+            "description": "Whether the source file is already a Cloud-Optimized GeoTIFF.",
+            "title": "Is Cog Compliant",
+            "type": "boolean"
+          },
+          "compliance_reason": {
+            "description": "Explanation of COG compliance status. Lists missing requirements when not compliant.",
+            "title": "Compliance Reason",
+            "type": "string"
           },
           "temporal_start": {
             "anyOf": [
@@ -13164,11 +13169,6 @@
             ],
             "description": "ISO 8601 acquisition timestamp parsed from raster metadata, if present.",
             "title": "Temporal Start"
-          },
-          "width": {
-            "description": "Raster width in pixels.",
-            "title": "Width",
-            "type": "integer"
           }
         },
         "required": [
@@ -13194,6 +13194,31 @@
       "RasterTileToken": {
         "description": "A raster tile template, signed like its vector sibling.\n\nfix(#688): the raster shape used to carry no signature at all, so a client\nfollowing the API contract literally received an *unauthenticated* template\nfor a private raster. MapLibre issues the tile image requests itself and\nattaches no `X-Api-Key`, so an API-key-only client could not render one \u2014\nthe workarounds were `setTransformRequest` (not available to every consumer)\nor `?api_key=` in the tile URL, which puts a non-expiring unscoped\ncredential into tile URLs, server logs, and saved client project files.\n\n`tile_url` now arrives with `sig`/`exp`/`scope` already in its query string,\nso the template is self-sufficient and expires. The three are also returned\nas fields, mirroring `VectorTileToken`, for clients that rebuild the URL.",
         "properties": {
+          "kind": {
+            "const": "raster",
+            "title": "Kind",
+            "type": "string"
+          },
+          "tile_url": {
+            "title": "Tile Url",
+            "type": "string"
+          },
+          "sig": {
+            "title": "Sig",
+            "type": "string"
+          },
+          "exp": {
+            "title": "Exp",
+            "type": "integer"
+          },
+          "scope": {
+            "title": "Scope",
+            "type": "string"
+          },
+          "expires_in": {
+            "title": "Expires In",
+            "type": "integer"
+          },
           "bounds": {
             "anyOf": [
               {
@@ -13208,45 +13233,20 @@
             ],
             "title": "Bounds"
           },
-          "exp": {
-            "title": "Exp",
+          "minzoom": {
+            "title": "Minzoom",
             "type": "integer"
-          },
-          "expires_in": {
-            "title": "Expires In",
-            "type": "integer"
-          },
-          "format": {
-            "title": "Format",
-            "type": "string"
-          },
-          "kind": {
-            "const": "raster",
-            "title": "Kind",
-            "type": "string"
           },
           "maxzoom": {
             "title": "Maxzoom",
             "type": "integer"
           },
-          "minzoom": {
-            "title": "Minzoom",
-            "type": "integer"
-          },
-          "scope": {
-            "title": "Scope",
-            "type": "string"
-          },
-          "sig": {
-            "title": "Sig",
-            "type": "string"
-          },
           "tile_size": {
             "title": "Tile Size",
             "type": "integer"
           },
-          "tile_url": {
-            "title": "Tile Url",
+          "format": {
+            "title": "Format",
             "type": "string"
           }
         },
@@ -13282,19 +13282,6 @@
       },
       "RegisterRequest": {
         "properties": {
-          "summary": {
-            "anyOf": [
-              {
-                "maxLength": 5000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Optional dataset description.",
-            "title": "Summary"
-          },
           "table_name": {
             "description": "PostgreSQL table name in the `data` schema (max 63 chars per PostgreSQL identifier limit).",
             "maxLength": 63,
@@ -13307,6 +13294,19 @@
             "maxLength": 500,
             "title": "Title",
             "type": "string"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "maxLength": 5000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional dataset description.",
+            "title": "Summary"
           },
           "visibility": {
             "default": "private",
@@ -13359,27 +13359,13 @@
       },
       "RelatedDatasetItem": {
         "properties": {
-          "band_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Band Count"
+          "id": {
+            "title": "Id",
+            "type": "string"
           },
-          "feature_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Feature Count"
+          "name": {
+            "title": "Name",
+            "type": "string"
           },
           "geometry_type": {
             "anyOf": [
@@ -13392,13 +13378,10 @@
             ],
             "title": "Geometry Type"
           },
-          "id": {
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
+          "similarity": {
+            "description": "Cosine similarity score (0-1)",
+            "title": "Similarity",
+            "type": "number"
           },
           "record_type": {
             "anyOf": [
@@ -13411,10 +13394,27 @@
             ],
             "title": "Record Type"
           },
-          "similarity": {
-            "description": "Cosine similarity score (0-1)",
-            "title": "Similarity",
-            "type": "number"
+          "feature_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Count"
+          },
+          "band_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Band Count"
           }
         },
         "required": [
@@ -13498,17 +13498,17 @@
       "ReservedRenameWarning": {
         "additionalProperties": false,
         "properties": {
+          "kind": {
+            "const": "reserved_rename",
+            "title": "Kind",
+            "type": "string"
+          },
           "details": {
             "items": {
               "$ref": "#/components/schemas/ReservedRenameDetail"
             },
             "title": "Details",
             "type": "array"
-          },
-          "kind": {
-            "const": "reserved_rename",
-            "title": "Kind",
-            "type": "string"
           }
         },
         "required": [
@@ -13520,18 +13520,6 @@
       },
       "ReuploadCommitRequest": {
         "properties": {
-          "layer_name": {
-            "anyOf": [
-              {
-                "maxLength": 500,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Layer Name"
-          },
           "srid_override": {
             "anyOf": [
               {
@@ -13556,6 +13544,18 @@
               }
             ],
             "title": "Token"
+          },
+          "layer_name": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Layer Name"
           }
         },
         "title": "ReuploadCommitRequest",
@@ -13568,12 +13568,12 @@
             "title": "Job Id",
             "type": "string"
           },
-          "message": {
-            "title": "Message",
-            "type": "string"
-          },
           "status": {
             "title": "Status",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
             "type": "string"
           }
         },
@@ -13605,20 +13605,21 @@
       },
       "ReuploadPreviewResponse": {
         "properties": {
-          "all_layers": {
+          "job_id": {
+            "format": "uuid",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "source_filename": {
             "anyOf": [
               {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "All Layers"
+            "title": "Source Filename"
           },
           "columns": {
             "items": {
@@ -13638,17 +13639,6 @@
             ],
             "title": "Crs"
           },
-          "feature_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Feature Count"
-          },
           "geometry_type": {
             "anyOf": [
               {
@@ -13660,14 +13650,46 @@
             ],
             "title": "Geometry Type"
           },
-          "job_id": {
-            "format": "uuid",
-            "title": "Job Id",
-            "type": "string"
+          "feature_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Count"
+          },
+          "sample_rows": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Sample Rows",
+            "type": "array"
           },
           "layer_name": {
             "title": "Layer Name",
             "type": "string"
+          },
+          "schema_diff": {
+            "$ref": "#/components/schemas/SchemaDiff"
+          },
+          "all_layers": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "All Layers"
           },
           "previous_source_layer": {
             "anyOf": [
@@ -13679,28 +13701,6 @@
               }
             ],
             "title": "Previous Source Layer"
-          },
-          "sample_rows": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Sample Rows",
-            "type": "array"
-          },
-          "schema_diff": {
-            "$ref": "#/components/schemas/SchemaDiff"
-          },
-          "source_filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Filename"
           }
         },
         "required": [
@@ -13724,13 +13724,13 @@
             "title": "Job Id",
             "type": "string"
           },
-          "message": {
-            "title": "Message",
-            "type": "string"
-          },
           "status": {
             "default": "pending",
             "title": "Status",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
             "type": "string"
           }
         },
@@ -13743,19 +13743,15 @@
       },
       "ReuploadServicePreviewRequest": {
         "properties": {
-          "layer_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Layer Id"
+          "url": {
+            "maxLength": 2048,
+            "title": "Url",
+            "type": "string"
+          },
+          "service_type": {
+            "maxLength": 50,
+            "title": "Service Type",
+            "type": "string"
           },
           "layer_name": {
             "maxLength": 500,
@@ -13774,22 +13770,19 @@
             ],
             "title": "Layer Title"
           },
-          "object_id_field": {
+          "layer_id": {
             "anyOf": [
               {
-                "maxLength": 200,
+                "type": "integer"
+              },
+              {
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Object Id Field"
-          },
-          "service_type": {
-            "maxLength": 50,
-            "title": "Service Type",
-            "type": "string"
+            "title": "Layer Id"
           },
           "token": {
             "anyOf": [
@@ -13803,10 +13796,17 @@
             ],
             "title": "Token"
           },
-          "url": {
-            "maxLength": 2048,
-            "title": "Url",
-            "type": "string"
+          "object_id_field": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Id Field"
           }
         },
         "required": [
@@ -13820,17 +13820,17 @@
       "SSEActionsEvent": {
         "description": "Validated map-edit actions produced by streaming chat.",
         "properties": {
+          "type": {
+            "const": "actions",
+            "title": "Type",
+            "type": "string"
+          },
           "actions": {
             "items": {
               "$ref": "#/components/schemas/ChatAction"
             },
             "title": "Actions",
             "type": "array"
-          },
-          "type": {
-            "const": "actions",
-            "title": "Type",
-            "type": "string"
           }
         },
         "required": [
@@ -13843,13 +13843,13 @@
       "SSEChatDoneEvent": {
         "description": "Terminal payload for a successful streaming chat request.",
         "properties": {
-          "explanation": {
-            "title": "Explanation",
-            "type": "string"
-          },
           "type": {
             "const": "done",
             "title": "Type",
+            "type": "string"
+          },
+          "explanation": {
+            "title": "Explanation",
             "type": "string"
           }
         },
@@ -13863,6 +13863,11 @@
       "SSEErrorEvent": {
         "description": "Error payload carried inside an already-open SSE response.",
         "properties": {
+          "type": {
+            "const": "error",
+            "title": "Type",
+            "type": "string"
+          },
           "message": {
             "anyOf": [
               {
@@ -13891,11 +13896,6 @@
             "default": null,
             "description": "HTTP-equivalent status for router-level failures; provider and model errors raised inside the stream may omit it.",
             "title": "Status"
-          },
-          "type": {
-            "const": "error",
-            "title": "Type",
-            "type": "string"
           }
         },
         "required": [
@@ -13908,15 +13908,9 @@
       "SSEMapDoneEvent": {
         "description": "Terminal payload for a successful streaming map-generation request.",
         "properties": {
-          "datasets_used": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Datasets Used",
-            "type": "array"
-          },
-          "explanation": {
-            "title": "Explanation",
+          "type": {
+            "const": "done",
+            "title": "Type",
             "type": "string"
           },
           "map_id": {
@@ -13927,10 +13921,16 @@
             "title": "Map Name",
             "type": "string"
           },
-          "type": {
-            "const": "done",
-            "title": "Type",
+          "explanation": {
+            "title": "Explanation",
             "type": "string"
+          },
+          "datasets_used": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Datasets Used",
+            "type": "array"
           }
         },
         "required": [
@@ -13946,13 +13946,13 @@
       "SSETokenEvent": {
         "description": "Token payload carried by a ``token`` server-sent event.",
         "properties": {
-          "text": {
-            "title": "Text",
-            "type": "string"
-          },
           "type": {
             "const": "token",
             "title": "Type",
+            "type": "string"
+          },
+          "text": {
+            "title": "Text",
             "type": "string"
           }
         },
@@ -13966,18 +13966,18 @@
       "SSEToolResultEvent": {
         "description": "Progress payload emitted when an AI tool finishes.",
         "properties": {
-          "success": {
-            "title": "Success",
-            "type": "boolean"
+          "type": {
+            "const": "tool_result",
+            "title": "Type",
+            "type": "string"
           },
           "tool": {
             "title": "Tool",
             "type": "string"
           },
-          "type": {
-            "const": "tool_result",
-            "title": "Type",
-            "type": "string"
+          "success": {
+            "title": "Success",
+            "type": "boolean"
           }
         },
         "required": [
@@ -13991,17 +13991,17 @@
       "SSEToolStartEvent": {
         "description": "Progress payload emitted when an AI tool starts.",
         "properties": {
-          "label": {
-            "title": "Label",
+          "type": {
+            "const": "tool_start",
+            "title": "Type",
             "type": "string"
           },
           "tool": {
             "title": "Tool",
             "type": "string"
           },
-          "type": {
-            "const": "tool_start",
-            "title": "Type",
+          "label": {
+            "title": "Label",
             "type": "string"
           }
         },
@@ -14061,11 +14061,6 @@
       "SavedSearchResponse": {
         "description": "Response for a single saved search.",
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
           "id": {
             "format": "uuid",
             "title": "Id",
@@ -14079,6 +14074,11 @@
             "additionalProperties": true,
             "title": "Params",
             "type": "object"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           },
           "updated_at": {
             "format": "date-time",
@@ -14114,21 +14114,13 @@
             "title": "Columns Removed",
             "type": "array"
           },
-          "row_count_delta": {
-            "description": "row_count_new minus row_count_old",
-            "title": "Row Count Delta",
-            "type": "integer"
-          },
-          "row_count_new": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Row Count New"
+          "type_changes": {
+            "description": "Columns whose data type changed",
+            "items": {
+              "$ref": "#/components/schemas/TypeChange"
+            },
+            "title": "Type Changes",
+            "type": "array"
           },
           "row_count_old": {
             "anyOf": [
@@ -14141,13 +14133,21 @@
             ],
             "title": "Row Count Old"
           },
-          "type_changes": {
-            "description": "Columns whose data type changed",
-            "items": {
-              "$ref": "#/components/schemas/TypeChange"
-            },
-            "title": "Type Changes",
-            "type": "array"
+          "row_count_new": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Row Count New"
+          },
+          "row_count_delta": {
+            "description": "row_count_new minus row_count_old",
+            "title": "Row Count Delta",
+            "type": "integer"
           }
         },
         "required": [
@@ -14163,16 +14163,9 @@
       },
       "ServiceHealth": {
         "properties": {
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error"
+          "status": {
+            "title": "Status",
+            "type": "string"
           },
           "latency_ms": {
             "anyOf": [
@@ -14185,9 +14178,16 @@
             ],
             "title": "Latency Ms"
           },
-          "status": {
-            "title": "Status",
-            "type": "string"
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
           }
         },
         "required": [
@@ -14198,20 +14198,19 @@
       },
       "ServicePreviewRequest": {
         "properties": {
-          "layer_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ArcGIS layer ID, when applicable.",
-            "title": "Layer Id"
+          "url": {
+            "description": "Normalized service URL from a previous probe response.",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Url",
+            "type": "string"
+          },
+          "service_type": {
+            "description": "Service type from the probe response, e.g. 'WFS 2.0.0' or 'ArcGIS FeatureServer'.",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Service Type",
+            "type": "string"
           },
           "layer_name": {
             "description": "Name of the specific layer to preview, from the probe layers list.",
@@ -14233,25 +14232,20 @@
             "description": "Human-readable layer title from the probe LayerInfo.",
             "title": "Layer Title"
           },
-          "object_id_field": {
+          "layer_id": {
             "anyOf": [
               {
-                "maxLength": 200,
+                "type": "integer"
+              },
+              {
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "ArcGIS OID field name used for orderByFields during preview pagination.",
-            "title": "Object Id Field"
-          },
-          "service_type": {
-            "description": "Service type from the probe response, e.g. 'WFS 2.0.0' or 'ArcGIS FeatureServer'.",
-            "maxLength": 100,
-            "minLength": 1,
-            "title": "Service Type",
-            "type": "string"
+            "description": "ArcGIS layer ID, when applicable.",
+            "title": "Layer Id"
           },
           "token": {
             "anyOf": [
@@ -14266,12 +14260,18 @@
             "description": "Optional auth token for protected services.",
             "title": "Token"
           },
-          "url": {
-            "description": "Normalized service URL from a previous probe response.",
-            "maxLength": 2048,
-            "minLength": 1,
-            "title": "Url",
-            "type": "string"
+          "object_id_field": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ArcGIS OID field name used for orderByFields during preview pagination.",
+            "title": "Object Id Field"
           }
         },
         "required": [
@@ -14284,6 +14284,24 @@
       },
       "ServicePreviewResponse": {
         "properties": {
+          "job_id": {
+            "description": "IngestJob ID for the preview. Use this to commit the import.",
+            "format": "uuid",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "source_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Layer name acting as a source filename for downstream ingestion logic.",
+            "title": "Source Filename"
+          },
           "columns": {
             "description": "Detected attribute columns: [{'name': str, 'type': str}, ...].",
             "items": {
@@ -14307,18 +14325,6 @@
             "description": "Detected EPSG code for the layer's CRS.",
             "title": "Crs"
           },
-          "feature_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Total feature count if reported by the source service.",
-            "title": "Feature Count"
-          },
           "geometry_type": {
             "anyOf": [
               {
@@ -14331,16 +14337,17 @@
             "description": "Detected geometry type.",
             "title": "Geometry Type"
           },
-          "job_id": {
-            "description": "IngestJob ID for the preview. Use this to commit the import.",
-            "format": "uuid",
-            "title": "Job Id",
-            "type": "string"
-          },
-          "layer_name": {
-            "description": "Layer name as it appears in the remote service.",
-            "title": "Layer Name",
-            "type": "string"
+          "feature_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Total feature count if reported by the source service.",
+            "title": "Feature Count"
           },
           "sample_rows": {
             "description": "Up to 5 sample rows for preview display.",
@@ -14351,17 +14358,10 @@
             "title": "Sample Rows",
             "type": "array"
           },
-          "source_filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Layer name acting as a source filename for downstream ingestion logic.",
-            "title": "Source Filename"
+          "layer_name": {
+            "description": "Layer name as it appears in the remote service.",
+            "title": "Layer Name",
+            "type": "string"
           }
         },
         "required": [
@@ -14380,23 +14380,6 @@
       "ServiceProbeResult": {
         "description": "Result of a single service connectivity probe.",
         "properties": {
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Error message when status is 'error'.",
-            "title": "Error"
-          },
-          "latency_ms": {
-            "description": "Round-trip latency in milliseconds.",
-            "title": "Latency Ms",
-            "type": "number"
-          },
           "name": {
             "description": "Service name (e.g. 'storage', 'cache', 'oidc:google').",
             "title": "Name",
@@ -14410,6 +14393,23 @@
             ],
             "title": "Status",
             "type": "string"
+          },
+          "latency_ms": {
+            "description": "Round-trip latency in milliseconds.",
+            "title": "Latency Ms",
+            "type": "number"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error message when status is 'error'.",
+            "title": "Error"
           }
         },
         "required": [
@@ -14428,19 +14428,19 @@
             "title": "Key",
             "type": "string"
           },
-          "label": {
-            "description": "Human-readable label for display in the admin UI.",
-            "title": "Label",
-            "type": "string"
+          "value": {
+            "description": "Current value. Type depends on the setting.",
+            "title": "Value"
           },
           "source": {
             "description": "Where the value came from: 'default' (built-in default), 'overridden' (admin set via UI), or 'env_only' (configured via environment variable, read-only).",
             "title": "Source",
             "type": "string"
           },
-          "value": {
-            "description": "Current value. Type depends on the setting.",
-            "title": "Value"
+          "label": {
+            "description": "Human-readable label for display in the admin UI.",
+            "title": "Label",
+            "type": "string"
           }
         },
         "required": [
@@ -14553,6 +14553,23 @@
       },
       "ShareTokenResponse": {
         "properties": {
+          "token": {
+            "description": "Raw token on create, hint on retrieve",
+            "title": "Token",
+            "type": "string"
+          },
+          "share_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Full shareable URL \u2014 only returned on create",
+            "title": "Share Url"
+          },
           "expires_at": {
             "anyOf": [
               {
@@ -14569,23 +14586,6 @@
             "default": true,
             "title": "Is Active",
             "type": "boolean"
-          },
-          "share_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Full shareable URL \u2014 only returned on create",
-            "title": "Share Url"
-          },
-          "token": {
-            "description": "Raw token on create, hint on retrieve",
-            "title": "Token",
-            "type": "string"
           }
         },
         "required": [
@@ -14596,6 +14596,44 @@
       },
       "SharedLayerResponse": {
         "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "dataset_id": {
+            "title": "Dataset Id",
+            "type": "string"
+          },
+          "dataset_name": {
+            "title": "Dataset Name",
+            "type": "string"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "table_name": {
+            "title": "Table Name",
+            "type": "string"
+          },
+          "geometry_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Geometry Type"
+          },
           "column_info": {
             "anyOf": [
               {
@@ -14611,12 +14649,31 @@
             ],
             "title": "Column Info"
           },
-          "dataset_id": {
-            "title": "Dataset Id",
-            "type": "string"
+          "sort_order": {
+            "title": "Sort Order",
+            "type": "integer"
           },
-          "dataset_name": {
-            "title": "Dataset Name",
+          "visible": {
+            "title": "Visible",
+            "type": "boolean"
+          },
+          "opacity": {
+            "title": "Opacity",
+            "type": "number"
+          },
+          "paint": {
+            "additionalProperties": true,
+            "title": "Paint",
+            "type": "object"
+          },
+          "layout": {
+            "additionalProperties": true,
+            "title": "Layout",
+            "type": "object"
+          },
+          "layer_type": {
+            "default": "vector_geolens",
+            "title": "Layer Type",
             "type": "string"
           },
           "dataset_record_type": {
@@ -14630,39 +14687,6 @@
             ],
             "title": "Dataset Record Type"
           },
-          "dem_vertical_units": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dem Vertical Units"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "feature_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Feature Count"
-          },
           "filter": {
             "anyOf": [
               {
@@ -14674,43 +14698,6 @@
               }
             ],
             "title": "Filter"
-          },
-          "geometry_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Geometry Type"
-          },
-          "id": {
-            "title": "Id",
-            "type": "string"
-          },
-          "is_3d": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is 3D"
-          },
-          "is_dem": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Dem"
           },
           "label_config": {
             "anyOf": [
@@ -14724,25 +14711,6 @@
             ],
             "title": "Label Config"
           },
-          "layer_type": {
-            "default": "vector_geolens",
-            "title": "Layer Type",
-            "type": "string"
-          },
-          "layout": {
-            "additionalProperties": true,
-            "title": "Layout",
-            "type": "object"
-          },
-          "opacity": {
-            "title": "Opacity",
-            "type": "number"
-          },
-          "paint": {
-            "additionalProperties": true,
-            "title": "Paint",
-            "type": "object"
-          },
           "popup_config": {
             "anyOf": [
               {
@@ -14752,15 +14720,6 @@
                 "type": "null"
               }
             ]
-          },
-          "show_in_legend": {
-            "default": true,
-            "title": "Show In Legend",
-            "type": "boolean"
-          },
-          "sort_order": {
-            "title": "Sort Order",
-            "type": "integer"
           },
           "style_config": {
             "anyOf": [
@@ -14774,13 +14733,58 @@
             ],
             "title": "Style Config"
           },
-          "table_name": {
-            "title": "Table Name",
-            "type": "string"
+          "show_in_legend": {
+            "default": true,
+            "title": "Show In Legend",
+            "type": "boolean"
           },
           "tile_url": {
             "title": "Tile Url",
             "type": "string"
+          },
+          "is_dem": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Dem"
+          },
+          "dem_vertical_units": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dem Vertical Units"
+          },
+          "is_3d": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is 3D"
+          },
+          "feature_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Count"
           },
           "tile_version": {
             "anyOf": [
@@ -14792,10 +14796,6 @@
               }
             ],
             "title": "Tile Version"
-          },
-          "visible": {
-            "title": "Visible",
-            "type": "boolean"
           }
         },
         "required": [
@@ -14816,31 +14816,9 @@
       },
       "SharedMapResponse": {
         "properties": {
-          "basemap_config": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/BasemapConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "basemap_style": {
-            "title": "Basemap Style",
+          "name": {
+            "title": "Name",
             "type": "string"
-          },
-          "bearing": {
-            "title": "Bearing",
-            "type": "number"
-          },
-          "center_lat": {
-            "title": "Center Lat",
-            "type": "number"
-          },
-          "center_lng": {
-            "title": "Center Lng",
-            "type": "number"
           },
           "description": {
             "anyOf": [
@@ -14853,17 +14831,59 @@
             ],
             "title": "Description"
           },
+          "center_lng": {
+            "title": "Center Lng",
+            "type": "number"
+          },
+          "center_lat": {
+            "title": "Center Lat",
+            "type": "number"
+          },
+          "zoom": {
+            "title": "Zoom",
+            "type": "number"
+          },
+          "bearing": {
+            "title": "Bearing",
+            "type": "number"
+          },
+          "pitch": {
+            "title": "Pitch",
+            "type": "number"
+          },
+          "basemap_style": {
+            "title": "Basemap Style",
+            "type": "string"
+          },
+          "show_basemap_labels": {
+            "default": true,
+            "title": "Show Basemap Labels",
+            "type": "boolean"
+          },
+          "basemap_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BasemapConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "terrain_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TerrainConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "has_non_public_layers": {
             "default": false,
             "title": "Has Non Public Layers",
             "type": "boolean"
-          },
-          "layers": {
-            "items": {
-              "$ref": "#/components/schemas/SharedLayerResponse"
-            },
-            "title": "Layers",
-            "type": "array"
           },
           "legend_title": {
             "anyOf": [
@@ -14876,32 +14896,12 @@
             ],
             "title": "Legend Title"
           },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "pitch": {
-            "title": "Pitch",
-            "type": "number"
-          },
-          "show_basemap_labels": {
-            "default": true,
-            "title": "Show Basemap Labels",
-            "type": "boolean"
-          },
-          "terrain_config": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TerrainConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "zoom": {
-            "title": "Zoom",
-            "type": "number"
+          "layers": {
+            "items": {
+              "$ref": "#/components/schemas/SharedLayerResponse"
+            },
+            "title": "Layers",
+            "type": "array"
           }
         },
         "required": [
@@ -14920,6 +14920,32 @@
       },
       "StacAsset": {
         "properties": {
+          "href": {
+            "title": "Href",
+            "type": "string"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
           "description": {
             "anyOf": [
               {
@@ -14930,10 +14956,6 @@
               }
             ],
             "title": "Description"
-          },
-          "href": {
-            "title": "Href",
-            "type": "string"
           },
           "roles": {
             "anyOf": [
@@ -14959,28 +14981,6 @@
               }
             ],
             "title": "Size Bytes"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
           }
         },
         "required": [
@@ -14992,31 +14992,16 @@
       "StacCatalog": {
         "description": "STAC Catalog / landing page response.",
         "properties": {
-          "conformsTo": {
-            "description": "List of conformance URIs declaring which STAC and OGC API standards the catalog implements.",
-            "items": {
-              "type": "string"
-            },
-            "title": "Conformsto",
-            "type": "array"
-          },
-          "description": {
-            "description": "Human-readable catalog description.",
-            "title": "Description",
+          "type": {
+            "default": "Catalog",
+            "description": "STAC object type. Always 'Catalog' for the landing page.",
+            "title": "Type",
             "type": "string"
           },
           "id": {
             "description": "Stable identifier for the catalog.",
             "title": "Id",
             "type": "string"
-          },
-          "links": {
-            "description": "Catalog navigation links (self, root, search, collections, etc.).",
-            "items": {
-              "$ref": "#/components/schemas/StacLink"
-            },
-            "title": "Links",
-            "type": "array"
           },
           "stac_version": {
             "default": "1.0.0",
@@ -15029,11 +15014,26 @@
             "title": "Title",
             "type": "string"
           },
-          "type": {
-            "default": "Catalog",
-            "description": "STAC object type. Always 'Catalog' for the landing page.",
-            "title": "Type",
+          "description": {
+            "description": "Human-readable catalog description.",
+            "title": "Description",
             "type": "string"
+          },
+          "conformsTo": {
+            "description": "List of conformance URIs declaring which STAC and OGC API standards the catalog implements.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Conformsto",
+            "type": "array"
+          },
+          "links": {
+            "description": "Catalog navigation links (self, root, search, collections, etc.).",
+            "items": {
+              "$ref": "#/components/schemas/StacLink"
+            },
+            "title": "Links",
+            "type": "array"
           }
         },
         "required": [
@@ -15050,41 +15050,21 @@
         "additionalProperties": true,
         "description": "A single STAC Collection response (permissive \u2014 allows extra STAC fields).",
         "properties": {
-          "description": {
-            "default": "",
-            "description": "Collection description.",
-            "title": "Description",
+          "type": {
+            "default": "Collection",
+            "description": "STAC object type.",
+            "title": "Type",
             "type": "string"
-          },
-          "extent": {
-            "additionalProperties": true,
-            "description": "Spatial and temporal extent of items in the collection.",
-            "title": "Extent",
-            "type": "object"
-          },
-          "id": {
-            "description": "Stable collection identifier.",
-            "title": "Id",
-            "type": "string"
-          },
-          "license": {
-            "default": "proprietary",
-            "description": "SPDX license identifier or 'proprietary'.",
-            "title": "License",
-            "type": "string"
-          },
-          "links": {
-            "description": "Collection navigation links.",
-            "items": {
-              "$ref": "#/components/schemas/StacLink"
-            },
-            "title": "Links",
-            "type": "array"
           },
           "stac_version": {
             "default": "1.0.0",
             "description": "STAC specification version.",
             "title": "Stac Version",
+            "type": "string"
+          },
+          "id": {
+            "description": "Stable collection identifier.",
+            "title": "Id",
             "type": "string"
           },
           "title": {
@@ -15099,11 +15079,31 @@
             "description": "Human-readable collection title.",
             "title": "Title"
           },
-          "type": {
-            "default": "Collection",
-            "description": "STAC object type.",
-            "title": "Type",
+          "description": {
+            "default": "",
+            "description": "Collection description.",
+            "title": "Description",
             "type": "string"
+          },
+          "license": {
+            "default": "proprietary",
+            "description": "SPDX license identifier or 'proprietary'.",
+            "title": "License",
+            "type": "string"
+          },
+          "extent": {
+            "additionalProperties": true,
+            "description": "Spatial and temporal extent of items in the collection.",
+            "title": "Extent",
+            "type": "object"
+          },
+          "links": {
+            "description": "Collection navigation links.",
+            "items": {
+              "$ref": "#/components/schemas/StacLink"
+            },
+            "title": "Links",
+            "type": "array"
           }
         },
         "required": [
@@ -15143,6 +15143,42 @@
       },
       "StacCollectionSummary": {
         "properties": {
+          "id": {
+            "description": "Collection identifier.",
+            "title": "Id",
+            "type": "string"
+          },
+          "title": {
+            "description": "Collection title.",
+            "title": "Title",
+            "type": "string"
+          },
+          "description": {
+            "description": "Collection description.",
+            "title": "Description",
+            "type": "string"
+          },
+          "license": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "SPDX license identifier.",
+            "title": "License"
+          },
+          "keywords": {
+            "default": [],
+            "description": "Collection keywords.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Keywords",
+            "type": "array"
+          },
           "bbox": {
             "anyOf": [
               {
@@ -15158,38 +15194,7 @@
             "description": "Spatial extent as [west, south, east, north].",
             "title": "Bbox"
           },
-          "description": {
-            "description": "Collection description.",
-            "title": "Description",
-            "type": "string"
-          },
-          "id": {
-            "description": "Collection identifier.",
-            "title": "Id",
-            "type": "string"
-          },
-          "item_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Number of items if reported by the API.",
-            "title": "Item Count"
-          },
-          "keywords": {
-            "default": [],
-            "description": "Collection keywords.",
-            "items": {
-              "type": "string"
-            },
-            "title": "Keywords",
-            "type": "array"
-          },
-          "license": {
+          "temporal_start": {
             "anyOf": [
               {
                 "type": "string"
@@ -15198,8 +15203,8 @@
                 "type": "null"
               }
             ],
-            "description": "SPDX license identifier.",
-            "title": "License"
+            "description": "Start of temporal extent (ISO 8601).",
+            "title": "Temporal Start"
           },
           "temporal_end": {
             "anyOf": [
@@ -15213,22 +15218,17 @@
             "description": "End of temporal extent (ISO 8601).",
             "title": "Temporal End"
           },
-          "temporal_start": {
+          "item_count": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Start of temporal extent (ISO 8601).",
-            "title": "Temporal Start"
-          },
-          "title": {
-            "description": "Collection title.",
-            "title": "Title",
-            "type": "string"
+            "description": "Number of items if reported by the API.",
+            "title": "Item Count"
           }
         },
         "required": [
@@ -15241,6 +15241,11 @@
       },
       "StacCollectionsResponse": {
         "properties": {
+          "url": {
+            "description": "STAC API URL that was queried.",
+            "title": "Url",
+            "type": "string"
+          },
           "collections": {
             "description": "Available collections.",
             "items": {
@@ -15248,11 +15253,6 @@
             },
             "title": "Collections",
             "type": "array"
-          },
-          "url": {
-            "description": "STAC API URL that was queried.",
-            "title": "Url",
-            "type": "string"
           }
         },
         "required": [
@@ -15298,9 +15298,19 @@
       },
       "StacConnectResponse": {
         "properties": {
+          "url": {
+            "description": "Normalized STAC API URL.",
+            "title": "Url",
+            "type": "string"
+          },
           "catalog_id": {
             "description": "Catalog identifier from the landing page.",
             "title": "Catalog Id",
+            "type": "string"
+          },
+          "title": {
+            "description": "Catalog title.",
+            "title": "Title",
             "type": "string"
           },
           "description": {
@@ -15311,16 +15321,6 @@
           "stac_version": {
             "description": "STAC specification version.",
             "title": "Stac Version",
-            "type": "string"
-          },
-          "title": {
-            "description": "Catalog title.",
-            "title": "Title",
-            "type": "string"
-          },
-          "url": {
-            "description": "Normalized STAC API URL.",
-            "title": "Url",
             "type": "string"
           }
         },
@@ -15342,12 +15342,12 @@
             "title": "Limit",
             "type": "integer"
           },
-          "matched": {
-            "title": "Matched",
-            "type": "integer"
-          },
           "returned": {
             "title": "Returned",
+            "type": "integer"
+          },
+          "matched": {
+            "title": "Matched",
             "type": "integer"
           }
         },
@@ -15361,6 +15361,37 @@
       },
       "StacImportItem": {
         "properties": {
+          "id": {
+            "description": "STAC item ID.",
+            "maxLength": 2048,
+            "title": "Id",
+            "type": "string"
+          },
+          "collection": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Parent collection ID.",
+            "title": "Collection"
+          },
+          "title": {
+            "description": "Title to use for the GeoLens dataset.",
+            "maxLength": 500,
+            "title": "Title",
+            "type": "string"
+          },
+          "data_asset_href": {
+            "description": "URL of the COG asset to reference.",
+            "maxLength": 4096,
+            "title": "Data Asset Href",
+            "type": "string"
+          },
           "bbox": {
             "anyOf": [
               {
@@ -15376,37 +15407,17 @@
             "description": "Item bounding box.",
             "title": "Bbox"
           },
-          "collection": {
+          "epsg": {
             "anyOf": [
               {
-                "maxLength": 255,
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Parent collection ID.",
-            "title": "Collection"
-          },
-          "data_asset_href": {
-            "description": "URL of the COG asset to reference.",
-            "maxLength": 4096,
-            "title": "Data Asset Href",
-            "type": "string"
-          },
-          "datetime_end": {
-            "anyOf": [
-              {
-                "maxLength": 50,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Temporal end.",
-            "title": "Datetime End"
+            "description": "EPSG code.",
+            "title": "Epsg"
           },
           "datetime_start": {
             "anyOf": [
@@ -15421,23 +15432,18 @@
             "description": "Temporal start.",
             "title": "Datetime Start"
           },
-          "epsg": {
+          "datetime_end": {
             "anyOf": [
               {
-                "type": "integer"
+                "maxLength": 50,
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "EPSG code.",
-            "title": "Epsg"
-          },
-          "id": {
-            "description": "STAC item ID.",
-            "maxLength": 2048,
-            "title": "Id",
-            "type": "string"
+            "description": "Temporal end.",
+            "title": "Datetime End"
           },
           "keywords": {
             "default": [],
@@ -15448,12 +15454,6 @@
             "maxItems": 100,
             "title": "Keywords",
             "type": "array"
-          },
-          "title": {
-            "description": "Title to use for the GeoLens dataset.",
-            "maxLength": 500,
-            "title": "Title",
-            "type": "string"
           }
         },
         "required": [
@@ -15466,6 +15466,13 @@
       },
       "StacImportRequest": {
         "properties": {
+          "url": {
+            "description": "STAC API URL for provenance.",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Url",
+            "type": "string"
+          },
           "items": {
             "description": "Items to import (max 50 per request).",
             "items": {
@@ -15475,13 +15482,6 @@
             "minItems": 1,
             "title": "Items",
             "type": "array"
-          },
-          "url": {
-            "description": "STAC API URL for provenance.",
-            "maxLength": 2048,
-            "minLength": 1,
-            "title": "Url",
-            "type": "string"
           },
           "visibility": {
             "default": "private",
@@ -15505,16 +15505,6 @@
       },
       "StacImportResponse": {
         "properties": {
-          "created": {
-            "description": "Number of datasets created.",
-            "title": "Created",
-            "type": "integer"
-          },
-          "errors": {
-            "description": "Number of items that failed.",
-            "title": "Errors",
-            "type": "integer"
-          },
           "results": {
             "description": "Per-item import results.",
             "items": {
@@ -15523,9 +15513,19 @@
             "title": "Results",
             "type": "array"
           },
+          "created": {
+            "description": "Number of datasets created.",
+            "title": "Created",
+            "type": "integer"
+          },
           "skipped": {
             "description": "Number of items skipped (duplicates).",
             "title": "Skipped",
+            "type": "integer"
+          },
+          "errors": {
+            "description": "Number of items that failed.",
+            "title": "Errors",
             "type": "integer"
           }
         },
@@ -15540,6 +15540,11 @@
       },
       "StacImportResult": {
         "properties": {
+          "item_id": {
+            "description": "STAC item ID that was processed.",
+            "title": "Item Id",
+            "type": "string"
+          },
           "dataset_id": {
             "anyOf": [
               {
@@ -15553,6 +15558,16 @@
             "description": "Created GeoLens dataset ID.",
             "title": "Dataset Id"
           },
+          "status": {
+            "description": "Import result status.",
+            "enum": [
+              "created",
+              "skipped",
+              "error"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
           "error": {
             "anyOf": [
               {
@@ -15564,21 +15579,6 @@
             ],
             "description": "Error message if failed.",
             "title": "Error"
-          },
-          "item_id": {
-            "description": "STAC item ID that was processed.",
-            "title": "Item Id",
-            "type": "string"
-          },
-          "status": {
-            "description": "Import result status.",
-            "enum": [
-              "created",
-              "skipped",
-              "error"
-            ],
-            "title": "Status",
-            "type": "string"
           }
         },
         "required": [
@@ -15592,6 +15592,35 @@
         "additionalProperties": true,
         "description": "A STAC asset attached to an Item.",
         "properties": {
+          "href": {
+            "description": "URL of the asset resource.",
+            "title": "Href",
+            "type": "string"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Asset media type.",
+            "title": "Type"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Human-readable asset title.",
+            "title": "Title"
+          },
           "description": {
             "anyOf": [
               {
@@ -15603,11 +15632,6 @@
             ],
             "description": "Human-readable asset description.",
             "title": "Description"
-          },
-          "href": {
-            "description": "URL of the asset resource.",
-            "title": "Href",
-            "type": "string"
           },
           "roles": {
             "anyOf": [
@@ -15623,30 +15647,6 @@
             ],
             "description": "Semantic roles such as data or visual.",
             "title": "Roles"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Human-readable asset title.",
-            "title": "Title"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Asset media type.",
-            "title": "Type"
           }
         },
         "required": [
@@ -15673,8 +15673,11 @@
           }
         ],
         "properties": {
-          "context": {
-            "$ref": "#/components/schemas/StacContext"
+          "type": {
+            "const": "FeatureCollection",
+            "default": "FeatureCollection",
+            "title": "Type",
+            "type": "string"
           },
           "features": {
             "items": {
@@ -15698,11 +15701,8 @@
             "title": "Numberreturned",
             "type": "integer"
           },
-          "type": {
-            "const": "FeatureCollection",
-            "default": "FeatureCollection",
-            "title": "Type",
-            "type": "string"
+          "context": {
+            "$ref": "#/components/schemas/StacContext"
           }
         },
         "required": [
@@ -15731,7 +15731,7 @@
             "description": "Item timestamp, or null when a temporal interval is supplied.",
             "title": "Datetime"
           },
-          "description": {
+          "start_datetime": {
             "anyOf": [
               {
                 "type": "string"
@@ -15740,8 +15740,8 @@
                 "type": "null"
               }
             ],
-            "description": "Human-readable item description.",
-            "title": "Description"
+            "description": "Start of the item's temporal interval.",
+            "title": "Start Datetime"
           },
           "end_datetime": {
             "anyOf": [
@@ -15755,18 +15755,6 @@
             "description": "End of the item's temporal interval.",
             "title": "End Datetime"
           },
-          "start_datetime": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Start of the item's temporal interval.",
-            "title": "Start Datetime"
-          },
           "title": {
             "anyOf": [
               {
@@ -15778,6 +15766,18 @@
             ],
             "description": "Human-readable item title.",
             "title": "Title"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Human-readable item description.",
+            "title": "Description"
           }
         },
         "required": [
@@ -15803,12 +15803,44 @@
           }
         ],
         "properties": {
-          "assets": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/StacItemAsset"
+          "type": {
+            "const": "Feature",
+            "default": "Feature",
+            "title": "Type",
+            "type": "string"
+          },
+          "stac_version": {
+            "description": "STAC specification version.",
+            "title": "Stac Version",
+            "type": "string"
+          },
+          "stac_extensions": {
+            "description": "STAC extension schema URIs in use.",
+            "items": {
+              "type": "string"
             },
-            "title": "Assets",
-            "type": "object"
+            "title": "Stac Extensions",
+            "type": "array"
+          },
+          "id": {
+            "description": "Stable item identifier.",
+            "title": "Id",
+            "type": "string"
+          },
+          "geometry": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GeoJSONGeometryCollection"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJSONGeometry"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Item footprint as GeoJSON, or null when unavailable.",
+            "title": "Geometry"
           },
           "bbox": {
             "anyOf": [
@@ -15863,6 +15895,23 @@
             "description": "Item bounding box with exactly four 2D or six 3D coordinates.",
             "title": "Bbox"
           },
+          "properties": {
+            "$ref": "#/components/schemas/StacItemProperties"
+          },
+          "links": {
+            "items": {
+              "$ref": "#/components/schemas/StacLink"
+            },
+            "title": "Links",
+            "type": "array"
+          },
+          "assets": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/StacItemAsset"
+            },
+            "title": "Assets",
+            "type": "object"
+          },
           "collection": {
             "anyOf": [
               {
@@ -15874,55 +15923,6 @@
             ],
             "description": "Identifier of the containing STAC Collection.",
             "title": "Collection"
-          },
-          "geometry": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GeoJSONGeometryCollection"
-              },
-              {
-                "$ref": "#/components/schemas/GeoJSONGeometry"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Item footprint as GeoJSON, or null when unavailable.",
-            "title": "Geometry"
-          },
-          "id": {
-            "description": "Stable item identifier.",
-            "title": "Id",
-            "type": "string"
-          },
-          "links": {
-            "items": {
-              "$ref": "#/components/schemas/StacLink"
-            },
-            "title": "Links",
-            "type": "array"
-          },
-          "properties": {
-            "$ref": "#/components/schemas/StacItemProperties"
-          },
-          "stac_extensions": {
-            "description": "STAC extension schema URIs in use.",
-            "items": {
-              "type": "string"
-            },
-            "title": "Stac Extensions",
-            "type": "array"
-          },
-          "stac_version": {
-            "description": "STAC specification version.",
-            "title": "Stac Version",
-            "type": "string"
-          },
-          "type": {
-            "const": "Feature",
-            "default": "Feature",
-            "title": "Type",
-            "type": "string"
           }
         },
         "required": [
@@ -15938,10 +15938,27 @@
       },
       "StacItemSummary": {
         "properties": {
-          "asset_count": {
-            "description": "Number of assets on this item.",
-            "title": "Asset Count",
-            "type": "integer"
+          "id": {
+            "description": "Item identifier.",
+            "title": "Id",
+            "type": "string"
+          },
+          "collection": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Parent collection ID.",
+            "title": "Collection"
+          },
+          "title": {
+            "description": "Item title (falls back to ID).",
+            "title": "Title",
+            "type": "string"
           },
           "bbox": {
             "anyOf": [
@@ -15958,66 +15975,6 @@
             "description": "Item bounding box.",
             "title": "Bbox"
           },
-          "cloud_cover": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Cloud cover percentage (eo extension).",
-            "title": "Cloud Cover"
-          },
-          "collection": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Parent collection ID.",
-            "title": "Collection"
-          },
-          "data_asset_href": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "URL of the primary data asset (COG).",
-            "title": "Data Asset Href"
-          },
-          "data_asset_size_bytes": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Size of the primary data asset in bytes (from STAC file:size). None when not in manifest.",
-            "title": "Data Asset Size Bytes"
-          },
-          "data_asset_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Media type of the data asset.",
-            "title": "Data Asset Type"
-          },
           "datetime": {
             "anyOf": [
               {
@@ -16030,18 +15987,6 @@
             "description": "Primary datetime (ISO 8601).",
             "title": "Datetime"
           },
-          "datetime_end": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "End datetime for ranges.",
-            "title": "Datetime End"
-          },
           "datetime_start": {
             "anyOf": [
               {
@@ -16053,6 +15998,18 @@
             ],
             "description": "Start datetime for ranges.",
             "title": "Datetime Start"
+          },
+          "datetime_end": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "End datetime for ranges.",
+            "title": "Datetime End"
           },
           "epsg": {
             "anyOf": [
@@ -16078,10 +16035,53 @@
             "description": "Ground sample distance in meters.",
             "title": "Gsd"
           },
-          "id": {
-            "description": "Item identifier.",
-            "title": "Id",
-            "type": "string"
+          "cloud_cover": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Cloud cover percentage (eo extension).",
+            "title": "Cloud Cover"
+          },
+          "data_asset_href": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "URL of the primary data asset (COG).",
+            "title": "Data Asset Href"
+          },
+          "data_asset_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Media type of the data asset.",
+            "title": "Data Asset Type"
+          },
+          "data_asset_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Size of the primary data asset in bytes (from STAC file:size). None when not in manifest.",
+            "title": "Data Asset Size Bytes"
           },
           "thumbnail_href": {
             "anyOf": [
@@ -16095,10 +16095,10 @@
             "description": "Thumbnail URL if available.",
             "title": "Thumbnail Href"
           },
-          "title": {
-            "description": "Item title (falls back to ID).",
-            "title": "Title",
-            "type": "string"
+          "asset_count": {
+            "description": "Number of assets on this item.",
+            "title": "Asset Count",
+            "type": "integer"
           }
         },
         "required": [
@@ -16117,18 +16117,6 @@
             "title": "Href",
             "type": "string"
           },
-          "method": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "HTTP method to use (defaults to GET).",
-            "title": "Method"
-          },
           "rel": {
             "description": "Link relation type (e.g. 'self', 'root', 'parent', 'item', 'data').",
             "title": "Rel",
@@ -16145,6 +16133,18 @@
             ],
             "description": "Media type of the linked resource (e.g. 'application/json').",
             "title": "Type"
+          },
+          "method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "HTTP method to use (defaults to GET).",
+            "title": "Method"
           }
         },
         "required": [
@@ -16185,6 +16185,17 @@
             ],
             "title": "Bbox"
           },
+          "datetime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Datetime"
+          },
           "collections": {
             "anyOf": [
               {
@@ -16198,17 +16209,6 @@
               }
             ],
             "title": "Collections"
-          },
-          "datetime": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Datetime"
           },
           "ids": {
             "anyOf": [
@@ -16256,6 +16256,28 @@
       },
       "StacSearchRequest": {
         "properties": {
+          "url": {
+            "description": "STAC API root URL.",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Url",
+            "type": "string"
+          },
+          "collections": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Filter by collection IDs.",
+            "title": "Collections"
+          },
           "bbox": {
             "anyOf": [
               {
@@ -16272,21 +16294,6 @@
             ],
             "description": "Bounding box filter as [west, south, east, north].",
             "title": "Bbox"
-          },
-          "collections": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Filter by collection IDs.",
-            "title": "Collections"
           },
           "datetime_range": {
             "anyOf": [
@@ -16307,13 +16314,6 @@
             "minimum": 1.0,
             "title": "Limit",
             "type": "integer"
-          },
-          "url": {
-            "description": "STAC API root URL.",
-            "maxLength": 2048,
-            "minLength": 1,
-            "title": "Url",
-            "type": "string"
           }
         },
         "required": [
@@ -16359,40 +16359,12 @@
       },
       "StaleCleanupResponse": {
         "properties": {
-          "local_files_reaped": {
-            "title": "Local Files Reaped",
-            "type": "integer"
-          },
           "pending_failed": {
             "title": "Pending Failed",
             "type": "integer"
           },
           "running_failed": {
             "title": "Running Failed",
-            "type": "integer"
-          },
-          "staged_cleanup_failures": {
-            "title": "Staged Cleanup Failures",
-            "type": "integer"
-          },
-          "staged_paths_considered": {
-            "title": "Staged Paths Considered",
-            "type": "integer"
-          },
-          "staged_paths_skipped": {
-            "title": "Staged Paths Skipped",
-            "type": "integer"
-          },
-          "storage_objects_reaped": {
-            "title": "Storage Objects Reaped",
-            "type": "integer"
-          },
-          "terminal_jobs_purged": {
-            "title": "Terminal Jobs Purged",
-            "type": "integer"
-          },
-          "total_affected": {
-            "title": "Total Affected",
             "type": "integer"
           },
           "total_cleaned": {
@@ -16405,6 +16377,34 @@
           },
           "vrt_generations_failed": {
             "title": "Vrt Generations Failed",
+            "type": "integer"
+          },
+          "terminal_jobs_purged": {
+            "title": "Terminal Jobs Purged",
+            "type": "integer"
+          },
+          "staged_paths_considered": {
+            "title": "Staged Paths Considered",
+            "type": "integer"
+          },
+          "local_files_reaped": {
+            "title": "Local Files Reaped",
+            "type": "integer"
+          },
+          "storage_objects_reaped": {
+            "title": "Storage Objects Reaped",
+            "type": "integer"
+          },
+          "staged_paths_skipped": {
+            "title": "Staged Paths Skipped",
+            "type": "integer"
+          },
+          "staged_cleanup_failures": {
+            "title": "Staged Cleanup Failures",
+            "type": "integer"
+          },
+          "total_affected": {
+            "title": "Total Affected",
             "type": "integer"
           }
         },
@@ -16456,6 +16456,10 @@
             "title": "Id",
             "type": "string"
           },
+          "record_status": {
+            "title": "Record Status",
+            "type": "string"
+          },
           "metadata_warnings": {
             "anyOf": [
               {
@@ -16470,10 +16474,6 @@
             ],
             "description": "Advisory warnings from the status change \u2014 the same inherited-keyword disclosure check the metadata PATCH runs (feat #1070, fix #1178 review). The transition has already applied.",
             "title": "Metadata Warnings"
-          },
-          "record_status": {
-            "title": "Record Status",
-            "type": "string"
           }
         },
         "required": [
@@ -16487,6 +16487,32 @@
         "additionalProperties": false,
         "description": "Per-sublayer style override for a single basemap sublayer.\n\nAll fields are nullable \u2014 a ``None`` value means \"use the basemap default\".\nOnly ``#RRGGBB`` hex strings are accepted for color fields; ``None`` means\nthe basemap default color is preserved.  Numeric ranges are clamped at\nvalidation time (Pydantic ``ge``/``le`` constraints).\n\nThe key set of ``BasemapConfig.sublayer_overrides`` is treated as opaque\n(forward-compatible with future sublayer IDs) \u2014 see CONTEXT.md D-01.\n\nSecurity:\n    extra=\"forbid\" locks the D-14 scope guardrail: unknown style axes such\n    as dash patterns, line caps, halo blur, and text-font are rejected at\n    validation time (T-1059A-03).",
         "properties": {
+          "stroke_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Stroke color in #RRGGBB hex format, or null to use the basemap default.",
+            "title": "Stroke Color"
+          },
+          "stroke_width": {
+            "anyOf": [
+              {
+                "maximum": 20.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Stroke width in pixels (0-20), or null to use the basemap default.",
+            "title": "Stroke Width"
+          },
           "casing_color": {
             "anyOf": [
               {
@@ -16513,20 +16539,6 @@
             "description": "Casing width in pixels (0-20), or null to use the basemap default.",
             "title": "Casing Width"
           },
-          "max_zoom": {
-            "anyOf": [
-              {
-                "maximum": 24.0,
-                "minimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Maximum zoom level at which the sublayer is visible (0-24), or null for default.",
-            "title": "Max Zoom"
-          },
           "min_zoom": {
             "anyOf": [
               {
@@ -16541,6 +16553,20 @@
             "description": "Minimum zoom level at which the sublayer is visible (0-24), or null for default.",
             "title": "Min Zoom"
           },
+          "max_zoom": {
+            "anyOf": [
+              {
+                "maximum": 24.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum zoom level at which the sublayer is visible (0-24), or null for default.",
+            "title": "Max Zoom"
+          },
           "opacity": {
             "anyOf": [
               {
@@ -16554,32 +16580,6 @@
             ],
             "description": "Per-sublayer opacity (0-1), or null to use the basemap default. Composes on top of BasemapConfig.opacity (the whole-basemap master opacity): the rendered opacity is override.opacity * master_opacity (builder-audit #338 CORR-01). The UI opacity slider in BasemapSublayerEditorScene persists through this field: MapBuilderPage.handleSublayerOpacityChange -> setBasemapSublayerOpacity -> updateBasemapSublayerOverride writes config.sublayer_overrides[key].opacity.",
             "title": "Opacity"
-          },
-          "stroke_color": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Stroke color in #RRGGBB hex format, or null to use the basemap default.",
-            "title": "Stroke Color"
-          },
-          "stroke_width": {
-            "anyOf": [
-              {
-                "maximum": 20.0,
-                "minimum": 0.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Stroke width in pixels (0-20), or null to use the basemap default.",
-            "title": "Stroke Width"
           }
         },
         "title": "SublayerOverride",
@@ -16608,14 +16608,14 @@
             "title": "Dataset Id",
             "type": "string"
           },
-          "table_name": {
-            "description": "Source PostgreSQL table that was registered.",
-            "title": "Table Name",
-            "type": "string"
-          },
           "title": {
             "description": "Title of the registered dataset.",
             "title": "Title",
+            "type": "string"
+          },
+          "table_name": {
+            "description": "Source PostgreSQL table that was registered.",
+            "title": "Table Name",
             "type": "string"
           }
         },
@@ -16635,13 +16635,6 @@
             "title": "Enabled",
             "type": "boolean"
           },
-          "exaggeration": {
-            "default": 1.0,
-            "maximum": 3.0,
-            "minimum": 0.0,
-            "title": "Exaggeration",
-            "type": "number"
-          },
           "source_dataset_id": {
             "anyOf": [
               {
@@ -16653,6 +16646,13 @@
               }
             ],
             "title": "Source Dataset Id"
+          },
+          "exaggeration": {
+            "default": 1.0,
+            "maximum": 3.0,
+            "minimum": 0.0,
+            "title": "Exaggeration",
+            "type": "number"
           }
         },
         "title": "TerrainConfig",
@@ -16688,7 +16688,7 @@
             "description": "CDN origin URL for tile delivery, if configured.",
             "title": "Cdn Base Url"
           },
-          "mvt_source_layer_prefix": {
+          "public_app_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -16697,9 +16697,8 @@
                 "type": "null"
               }
             ],
-            "default": "data",
-            "description": "Schema prefix emitted inside vector-tile source-layer names. Null when a multi-tenant request has no resolved tenant context.",
-            "title": "Mvt Source Layer Prefix"
+            "description": "Browser-facing app URL used for share links and OAuth redirects.",
+            "title": "Public App Url"
           },
           "public_api_url": {
             "anyOf": [
@@ -16713,18 +16712,6 @@
             "description": "Externally-reachable API base URL used in OGC self-links.",
             "title": "Public Api Url"
           },
-          "public_app_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Browser-facing app URL used for share links and OAuth redirects.",
-            "title": "Public App Url"
-          },
           "public_base_url": {
             "anyOf": [
               {
@@ -16736,6 +16723,19 @@
             ],
             "description": "Deprecated alias for public_api_url. Will be removed in a future release.",
             "title": "Public Base Url"
+          },
+          "mvt_source_layer_prefix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "data",
+            "description": "Schema prefix emitted inside vector-tile source-layer names. Null when a multi-tenant request has no resolved tenant context.",
+            "title": "Mvt Source Layer Prefix"
           }
         },
         "title": "TileConfigResponse",
@@ -16797,11 +16797,6 @@
             "title": "Access Token",
             "type": "string"
           },
-          "expires_in": {
-            "description": "Seconds until the access token expires",
-            "title": "Expires In",
-            "type": "integer"
-          },
           "refresh_token": {
             "description": "Opaque token used to obtain a new access token",
             "title": "Refresh Token",
@@ -16811,6 +16806,11 @@
             "default": "bearer",
             "title": "Token Type",
             "type": "string"
+          },
+          "expires_in": {
+            "description": "Seconds until the access token expires",
+            "title": "Expires In",
+            "type": "integer"
           }
         },
         "required": [
@@ -16823,16 +16823,16 @@
       },
       "TranslationListResponse": {
         "properties": {
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          },
           "translations": {
             "items": {
               "$ref": "#/components/schemas/TranslationResponse"
             },
             "title": "Translations",
             "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
           }
         },
         "required": [
@@ -16844,13 +16844,17 @@
       },
       "TranslationResponse": {
         "properties": {
+          "record_id": {
+            "format": "uuid",
+            "title": "Record Id",
+            "type": "string"
+          },
           "language": {
             "title": "Language",
             "type": "string"
           },
-          "record_id": {
-            "format": "uuid",
-            "title": "Record Id",
+          "title": {
+            "title": "Title",
             "type": "string"
           },
           "summary": {
@@ -16863,10 +16867,6 @@
               }
             ],
             "title": "Summary"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
           }
         },
         "required": [
@@ -16880,6 +16880,12 @@
       },
       "TranslationUpsert": {
         "properties": {
+          "title": {
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          },
           "summary": {
             "anyOf": [
               {
@@ -16891,12 +16897,6 @@
               }
             ],
             "title": "Summary"
-          },
-          "title": {
-            "maxLength": 500,
-            "minLength": 1,
-            "title": "Title",
-            "type": "string"
           }
         },
         "required": [
@@ -16911,12 +16911,12 @@
             "title": "Name",
             "type": "string"
           },
-          "new_type": {
-            "title": "New Type",
-            "type": "string"
-          },
           "old_type": {
             "title": "Old Type",
+            "type": "string"
+          },
+          "new_type": {
+            "title": "New Type",
             "type": "string"
           }
         },
@@ -16930,25 +16930,25 @@
       },
       "UploadConfigResponse": {
         "properties": {
-          "allowed_extensions": {
-            "description": "Comma-separated list of allowed file extensions.",
-            "title": "Allowed Extensions",
-            "type": "string"
-          },
-          "max_file_size_bytes": {
-            "description": "Maximum allowed upload size in bytes.",
-            "title": "Max File Size Bytes",
-            "type": "integer"
+          "presigned_uploads": {
+            "description": "Whether presigned S3 uploads are enabled (requires `STORAGE_PROVIDER=s3`).",
+            "title": "Presigned Uploads",
+            "type": "boolean"
           },
           "presigned_threshold_bytes": {
             "description": "File size threshold (bytes) above which multipart presigned URLs are used.",
             "title": "Presigned Threshold Bytes",
             "type": "integer"
           },
-          "presigned_uploads": {
-            "description": "Whether presigned S3 uploads are enabled (requires `STORAGE_PROVIDER=s3`).",
-            "title": "Presigned Uploads",
-            "type": "boolean"
+          "max_file_size_bytes": {
+            "description": "Maximum allowed upload size in bytes.",
+            "title": "Max File Size Bytes",
+            "type": "integer"
+          },
+          "allowed_extensions": {
+            "description": "Comma-separated list of allowed file extensions.",
+            "title": "Allowed Extensions",
+            "type": "string"
           },
           "remaining_dataset_quota": {
             "anyOf": [
@@ -16980,15 +16980,15 @@
             "title": "Job Id",
             "type": "string"
           },
-          "message": {
-            "description": "Human-readable message describing the upload result.",
-            "title": "Message",
-            "type": "string"
-          },
           "status": {
             "default": "pending",
             "description": "Initial job status. Always 'pending' on creation.",
             "title": "Status",
+            "type": "string"
+          },
+          "message": {
+            "description": "Human-readable message describing the upload result.",
+            "title": "Message",
             "type": "string"
           }
         },
@@ -17001,6 +17001,22 @@
       },
       "UserCreate": {
         "properties": {
+          "username": {
+            "description": "Unique login name",
+            "example": "jdoe",
+            "maxLength": 150,
+            "minLength": 3,
+            "title": "Username",
+            "type": "string"
+          },
+          "password": {
+            "description": "Plaintext password (policy: min 12 chars, 3+ character classes)",
+            "example": "securePass123!",
+            "maxLength": 256,
+            "minLength": 8,
+            "title": "Password",
+            "type": "string"
+          },
           "email": {
             "anyOf": [
               {
@@ -17015,22 +17031,6 @@
             "description": "Optional email address",
             "example": "jdoe@example.com",
             "title": "Email"
-          },
-          "password": {
-            "description": "Plaintext password (policy: min 12 chars, 3+ character classes)",
-            "example": "securePass123!",
-            "maxLength": 256,
-            "minLength": 8,
-            "title": "Password",
-            "type": "string"
-          },
-          "username": {
-            "description": "Unique login name",
-            "example": "jdoe",
-            "maxLength": 150,
-            "minLength": 3,
-            "title": "Username",
-            "type": "string"
           }
         },
         "required": [
@@ -17042,11 +17042,6 @@
       },
       "UserListResponse": {
         "properties": {
-          "total": {
-            "description": "Total number of users matching the query (across all pages).",
-            "title": "Total",
-            "type": "integer"
-          },
           "users": {
             "description": "Page of users matching the query.",
             "items": {
@@ -17054,6 +17049,11 @@
             },
             "title": "Users",
             "type": "array"
+          },
+          "total": {
+            "description": "Total number of users matching the query (across all pages).",
+            "title": "Total",
+            "type": "integer"
           }
         },
         "required": [
@@ -17091,16 +17091,16 @@
             "title": "Bytes Used",
             "type": "integer"
           },
-          "count_cap": {
-            "title": "Count Cap",
-            "type": "integer"
-          },
           "dataset_count": {
             "title": "Dataset Count",
             "type": "integer"
           },
           "storage_cap": {
             "title": "Storage Cap",
+            "type": "integer"
+          },
+          "count_cap": {
+            "title": "Count Cap",
             "type": "integer"
           }
         },
@@ -17115,9 +17115,13 @@
       },
       "UserResponse": {
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
             "type": "string"
           },
           "email": {
@@ -17131,14 +17135,20 @@
             ],
             "title": "Email"
           },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
           "is_active": {
             "title": "Is Active",
             "type": "boolean"
+          },
+          "status": {
+            "description": "Account status: active, pending, suspended, or deactivated.",
+            "enum": [
+              "active",
+              "pending",
+              "suspended",
+              "deactivated"
+            ],
+            "title": "Status",
+            "type": "string"
           },
           "last_login_at": {
             "anyOf": [
@@ -17152,6 +17162,19 @@
             ],
             "title": "Last Login At"
           },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "roles": {
+            "description": "Assigned role names, e.g. ['admin', 'editor']",
+            "items": {
+              "type": "string"
+            },
+            "title": "Roles",
+            "type": "array"
+          },
           "quota_usage": {
             "anyOf": [
               {
@@ -17162,29 +17185,6 @@
               }
             ],
             "description": "Per-user storage quota usage. Populated only on admin list responses; None when the caller did not load usage (e.g. /auth/me, single-user GET)."
-          },
-          "roles": {
-            "description": "Assigned role names, e.g. ['admin', 'editor']",
-            "items": {
-              "type": "string"
-            },
-            "title": "Roles",
-            "type": "array"
-          },
-          "status": {
-            "description": "Account status: active, pending, suspended, or deactivated.",
-            "enum": [
-              "active",
-              "pending",
-              "suspended",
-              "deactivated"
-            ],
-            "title": "Status",
-            "type": "string"
-          },
-          "username": {
-            "title": "Username",
-            "type": "string"
           }
         },
         "required": [
@@ -17227,19 +17227,6 @@
             "description": "Legacy account-state toggle. False maps to 'deactivated' and true maps to 'active'. Prefer the explicit status field.",
             "title": "Is Active"
           },
-          "role": {
-            "anyOf": [
-              {
-                "maxLength": 50,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "New role: 'admin', 'editor', or 'viewer'. Omit to leave unchanged.",
-            "title": "Role"
-          },
           "status": {
             "anyOf": [
               {
@@ -17256,6 +17243,19 @@
             ],
             "description": "Explicit account lifecycle state. Pending registrations must use the approve/reject endpoints.",
             "title": "Status"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New role: 'admin', 'editor', or 'viewer'. Omit to leave unchanged.",
+            "title": "Role"
           }
         },
         "title": "UserUpdate",
@@ -17263,13 +17263,6 @@
       },
       "ValidationError": {
         "properties": {
-          "ctx": {
-            "title": "Context",
-            "type": "object"
-          },
-          "input": {
-            "title": "Input"
-          },
           "loc": {
             "items": {
               "anyOf": [
@@ -17291,6 +17284,13 @@
           "type": {
             "title": "Error Type",
             "type": "string"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "title": "Context",
+            "type": "object"
           }
         },
         "required": [
@@ -17330,6 +17330,10 @@
       },
       "ValidationResultResponse": {
         "properties": {
+          "is_valid": {
+            "title": "Is Valid",
+            "type": "boolean"
+          },
           "errors": {
             "items": {
               "$ref": "#/components/schemas/ValidationIssue"
@@ -17337,9 +17341,12 @@
             "title": "Errors",
             "type": "array"
           },
-          "is_valid": {
-            "title": "Is Valid",
-            "type": "boolean"
+          "warnings": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationIssue"
+            },
+            "title": "Warnings",
+            "type": "array"
           },
           "quality_score": {
             "anyOf": [
@@ -17352,13 +17359,6 @@
               }
             ],
             "title": "Quality Score"
-          },
-          "warnings": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationIssue"
-            },
-            "title": "Warnings",
-            "type": "array"
           }
         },
         "required": [
@@ -17371,26 +17371,26 @@
       },
       "VectorTileToken": {
         "properties": {
-          "exp": {
-            "title": "Exp",
-            "type": "integer"
-          },
-          "expires_in": {
-            "title": "Expires In",
-            "type": "integer"
-          },
           "kind": {
             "const": "vector",
             "title": "Kind",
             "type": "string"
           },
+          "sig": {
+            "title": "Sig",
+            "type": "string"
+          },
+          "exp": {
+            "title": "Exp",
+            "type": "integer"
+          },
           "scope": {
             "title": "Scope",
             "type": "string"
           },
-          "sig": {
-            "title": "Sig",
-            "type": "string"
+          "expires_in": {
+            "title": "Expires In",
+            "type": "integer"
           }
         },
         "required": [
@@ -17420,11 +17420,6 @@
       },
       "VisibilityCheckResponse": {
         "properties": {
-          "has_non_public": {
-            "description": "True if any layer references a non-public dataset",
-            "title": "Has Non Public",
-            "type": "boolean"
-          },
           "non_public_datasets": {
             "description": "Titles of datasets not publicly visible",
             "items": {
@@ -17432,6 +17427,11 @@
             },
             "title": "Non Public Datasets",
             "type": "array"
+          },
+          "has_non_public": {
+            "description": "True if any layer references a non-public dataset",
+            "title": "Has Non Public",
+            "type": "boolean"
           }
         },
         "required": [
@@ -17443,10 +17443,6 @@
       },
       "VrtActiveGeneration": {
         "properties": {
-          "elapsed_seconds": {
-            "title": "Elapsed Seconds",
-            "type": "number"
-          },
           "generation_id": {
             "format": "uuid",
             "title": "Generation Id",
@@ -17456,6 +17452,10 @@
             "format": "date-time",
             "title": "Started At",
             "type": "string"
+          },
+          "elapsed_seconds": {
+            "title": "Elapsed Seconds",
+            "type": "number"
           }
         },
         "required": [
@@ -17483,16 +17483,6 @@
       },
       "VrtCreateRequest": {
         "properties": {
-          "resolution_strategy": {
-            "description": "How to resolve mismatched source resolutions: 'finest' uses the highest, 'coarsest' uses the lowest, 'average' computes the mean.",
-            "enum": [
-              "finest",
-              "coarsest",
-              "average"
-            ],
-            "title": "Resolution Strategy",
-            "type": "string"
-          },
           "source_dataset_ids": {
             "description": "Source raster dataset IDs to include in the VRT mosaic or band stack (1-500).",
             "items": {
@@ -17503,6 +17493,31 @@
             "minItems": 1,
             "title": "Source Dataset Ids",
             "type": "array"
+          },
+          "vrt_type": {
+            "description": "Type of VRT to create. 'mosaic' tiles sources spatially; 'band_stack' aligns same-extent sources as multi-band output.",
+            "enum": [
+              "mosaic",
+              "band_stack"
+            ],
+            "title": "Vrt Type",
+            "type": "string"
+          },
+          "resolution_strategy": {
+            "description": "How to resolve mismatched source resolutions: 'finest' uses the highest, 'coarsest' uses the lowest, 'average' computes the mean.",
+            "enum": [
+              "finest",
+              "coarsest",
+              "average"
+            ],
+            "title": "Resolution Strategy",
+            "type": "string"
+          },
+          "title": {
+            "description": "Human-readable title for the resulting VRT dataset.",
+            "maxLength": 500,
+            "title": "Title",
+            "type": "string"
           },
           "summary": {
             "anyOf": [
@@ -17517,12 +17532,6 @@
             "description": "Optional description for the VRT dataset.",
             "title": "Summary"
           },
-          "title": {
-            "description": "Human-readable title for the resulting VRT dataset.",
-            "maxLength": 500,
-            "title": "Title",
-            "type": "string"
-          },
           "visibility": {
             "default": "private",
             "description": "Visibility level for the resulting VRT dataset.",
@@ -17533,15 +17542,6 @@
               "public"
             ],
             "title": "Visibility",
-            "type": "string"
-          },
-          "vrt_type": {
-            "description": "Type of VRT to create. 'mosaic' tiles sources spatially; 'band_stack' aligns same-extent sources as multi-band output.",
-            "enum": [
-              "mosaic",
-              "band_stack"
-            ],
-            "title": "Vrt Type",
             "type": "string"
           }
         },
@@ -17562,15 +17562,15 @@
             "title": "Job Id",
             "type": "string"
           },
-          "message": {
-            "description": "Human-readable acceptance message.",
-            "title": "Message",
-            "type": "string"
-          },
           "status": {
             "default": "accepted",
             "description": "Initial job status. Always 'accepted' on creation.",
             "title": "Status",
+            "type": "string"
+          },
+          "message": {
+            "description": "Human-readable acceptance message.",
+            "title": "Message",
             "type": "string"
           }
         },
@@ -17583,6 +17583,27 @@
       },
       "VrtGenerationItem": {
         "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
           "completed_at": {
             "anyOf": [
               {
@@ -17617,11 +17638,6 @@
             ],
             "title": "Error Message"
           },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
           "source_count": {
             "anyOf": [
               {
@@ -17632,22 +17648,6 @@
               }
             ],
             "title": "Source Count"
-          },
-          "started_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Started At"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string"
           },
           "triggered_by": {
             "anyOf": [
@@ -17697,15 +17697,15 @@
             "title": "Job Id",
             "type": "string"
           },
-          "message": {
-            "description": "Human-readable acceptance message.",
-            "title": "Message",
-            "type": "string"
-          },
           "status": {
             "default": "accepted",
             "description": "Initial job status.",
             "title": "Status",
+            "type": "string"
+          },
+          "message": {
+            "description": "Human-readable acceptance message.",
+            "title": "Message",
             "type": "string"
           }
         },
@@ -17723,6 +17723,10 @@
             "title": "Dataset Id",
             "type": "string"
           },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
           "status": {
             "enum": [
               "healthy",
@@ -17730,10 +17734,6 @@
               "inaccessible"
             ],
             "title": "Status",
-            "type": "string"
-          },
-          "title": {
-            "title": "Title",
             "type": "string"
           }
         },
@@ -17747,6 +17747,19 @@
       },
       "VrtSourceItem": {
         "properties": {
+          "dataset_id": {
+            "format": "uuid",
+            "title": "Dataset Id",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "position": {
+            "title": "Position",
+            "type": "integer"
+          },
           "band_count": {
             "anyOf": [
               {
@@ -17757,40 +17770,6 @@
               }
             ],
             "title": "Band Count"
-          },
-          "crs_epsg": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Crs Epsg"
-          },
-          "dataset_id": {
-            "format": "uuid",
-            "title": "Dataset Id",
-            "type": "string"
-          },
-          "extent_bbox": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "number"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Extent Bbox"
-          },
-          "position": {
-            "title": "Position",
-            "type": "integer"
           },
           "resolution_x": {
             "anyOf": [
@@ -17814,9 +17793,30 @@
             ],
             "title": "Resolution Y"
           },
-          "title": {
-            "title": "Title",
-            "type": "string"
+          "crs_epsg": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crs Epsg"
+          },
+          "extent_bbox": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extent Bbox"
           }
         },
         "required": [
@@ -17845,15 +17845,14 @@
       },
       "VrtStatusResponse": {
         "properties": {
-          "active_generation": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/VrtActiveGeneration"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          "status": {
+            "enum": [
+              "ready",
+              "regenerating",
+              "failed"
+            ],
+            "title": "Status",
+            "type": "string"
           },
           "last_generation_at": {
             "anyOf": [
@@ -17871,21 +17870,22 @@
             "title": "Source Count",
             "type": "integer"
           },
+          "active_generation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VrtActiveGeneration"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "source_health": {
             "items": {
               "$ref": "#/components/schemas/VrtSourceHealth"
             },
             "title": "Source Health",
             "type": "array"
-          },
-          "status": {
-            "enum": [
-              "ready",
-              "regenerating",
-              "failed"
-            ],
-            "title": "Status",
-            "type": "string"
           }
         },
         "required": [
@@ -28501,6 +28501,28 @@
                 "schema": {
                   "description": "FeatureCollection response as defined by OGC API - Features.",
                   "properties": {
+                    "type": {
+                      "const": "FeatureCollection",
+                      "default": "FeatureCollection",
+                      "description": "GeoJSON object type.",
+                      "title": "Type",
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "description": "ISO 8601 timestamp the response was generated.",
+                      "title": "Timestamp",
+                      "type": "string"
+                    },
+                    "numberMatched": {
+                      "description": "Total number of features matching the query (across all pages).",
+                      "title": "Numbermatched",
+                      "type": "integer"
+                    },
+                    "numberReturned": {
+                      "description": "Number of features in this response page.",
+                      "title": "Numberreturned",
+                      "type": "integer"
+                    },
                     "features": {
                       "description": "GeoJSON features returned by the query.",
                       "items": {
@@ -28524,6 +28546,11 @@
                             "title": "Rel",
                             "type": "string"
                           },
+                          "type": {
+                            "description": "Media type of the linked resource (e.g. 'application/json', 'application/geo+json').",
+                            "title": "Type",
+                            "type": "string"
+                          },
                           "title": {
                             "anyOf": [
                               {
@@ -28535,11 +28562,6 @@
                             ],
                             "description": "Optional human-readable label for the link.",
                             "title": "Title"
-                          },
-                          "type": {
-                            "description": "Media type of the linked resource (e.g. 'application/json', 'application/geo+json').",
-                            "title": "Type",
-                            "type": "string"
                           }
                         },
                         "required": [
@@ -28552,28 +28574,6 @@
                       },
                       "title": "Links",
                       "type": "array"
-                    },
-                    "numberMatched": {
-                      "description": "Total number of features matching the query (across all pages).",
-                      "title": "Numbermatched",
-                      "type": "integer"
-                    },
-                    "numberReturned": {
-                      "description": "Number of features in this response page.",
-                      "title": "Numberreturned",
-                      "type": "integer"
-                    },
-                    "timeStamp": {
-                      "description": "ISO 8601 timestamp the response was generated.",
-                      "title": "Timestamp",
-                      "type": "string"
-                    },
-                    "type": {
-                      "const": "FeatureCollection",
-                      "default": "FeatureCollection",
-                      "description": "GeoJSON object type.",
-                      "title": "Type",
-                      "type": "string"
                     }
                   },
                   "required": [
@@ -28718,16 +28718,23 @@
                 "schema": {
                   "description": "Single GeoJSON Feature response.",
                   "properties": {
+                    "type": {
+                      "const": "Feature",
+                      "default": "Feature",
+                      "description": "GeoJSON object type.",
+                      "title": "Type",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "Feature identifier within the collection.",
+                      "title": "Id",
+                      "type": "integer"
+                    },
                     "geometry": {
                       "anyOf": [
                         {
                           "description": "A GeoJSON geometry object (RFC 7946).",
                           "properties": {
-                            "coordinates": {
-                              "items": {},
-                              "title": "Coordinates",
-                              "type": "array"
-                            },
                             "type": {
                               "enum": [
                                 "Point",
@@ -28739,6 +28746,11 @@
                               ],
                               "title": "Type",
                               "type": "string"
+                            },
+                            "coordinates": {
+                              "items": {},
+                              "title": "Coordinates",
+                              "type": "array"
                             }
                           },
                           "required": [
@@ -28754,10 +28766,18 @@
                       ],
                       "description": "GeoJSON geometry of the feature, or null for geometry-less features."
                     },
-                    "id": {
-                      "description": "Feature identifier within the collection.",
-                      "title": "Id",
-                      "type": "integer"
+                    "properties": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": true,
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Feature attributes as a JSON object.",
+                      "title": "Properties"
                     },
                     "links": {
                       "default": [],
@@ -28774,6 +28794,11 @@
                             "title": "Rel",
                             "type": "string"
                           },
+                          "type": {
+                            "description": "Media type of the linked resource (e.g. 'application/json', 'application/geo+json').",
+                            "title": "Type",
+                            "type": "string"
+                          },
                           "title": {
                             "anyOf": [
                               {
@@ -28785,11 +28810,6 @@
                             ],
                             "description": "Optional human-readable label for the link.",
                             "title": "Title"
-                          },
-                          "type": {
-                            "description": "Media type of the linked resource (e.g. 'application/json', 'application/geo+json').",
-                            "title": "Type",
-                            "type": "string"
                           }
                         },
                         "required": [
@@ -28802,26 +28822,6 @@
                       },
                       "title": "Links",
                       "type": "array"
-                    },
-                    "properties": {
-                      "anyOf": [
-                        {
-                          "additionalProperties": true,
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "description": "Feature attributes as a JSON object.",
-                      "title": "Properties"
-                    },
-                    "type": {
-                      "const": "Feature",
-                      "default": "Feature",
-                      "description": "GeoJSON object type.",
-                      "title": "Type",
-                      "type": "string"
                     }
                   },
                   "required": [
@@ -33429,24 +33429,48 @@
                 "schema": {
                   "description": "A GeoJSON FeatureCollection with OGC API Features pagination fields.",
                   "properties": {
+                    "type": {
+                      "const": "FeatureCollection",
+                      "default": "FeatureCollection",
+                      "title": "Type",
+                      "type": "string"
+                    },
+                    "numberMatched": {
+                      "title": "Numbermatched",
+                      "type": "integer"
+                    },
+                    "numberReturned": {
+                      "title": "Numberreturned",
+                      "type": "integer"
+                    },
                     "features": {
                       "items": {
                         "description": "A single GeoJSON Feature.",
                         "properties": {
+                          "type": {
+                            "const": "Feature",
+                            "default": "Feature",
+                            "title": "Type",
+                            "type": "string"
+                          },
+                          "id": {
+                            "title": "Id",
+                            "type": "integer"
+                          },
                           "geometry": {
                             "anyOf": [
                               {
                                 "description": "A GeoJSON GeometryCollection (RFC 7946 \u00a73.1.8).\n\nfix(#430 codex r9): carries ``geometries`` instead of ``coordinates``, so\nit needs its own model \u2014 only generic-GEOMETRY datasets accept it on write\n(enforced in the service), and any stored collection must serialize back\nout on read.\n\nDeliberately NON-recursive (codex r13, refuted): PostGIS cannot round-trip\nnested collections through the GeoJSON boundary in either direction \u2014\nST_GeomFromGeoJSON rejects them on write and ST_AsGeoJSON raises\n'GeoJson: geometry not supported' on read \u2014 so a recursive model could\nnever receive one and would only convert the write-side 422 into a raw\ndatabase 500. The write schemas add a raw-payload guard for a clear 422.",
                                 "properties": {
+                                  "type": {
+                                    "const": "GeometryCollection",
+                                    "title": "Type",
+                                    "type": "string"
+                                  },
                                   "geometries": {
                                     "items": {
                                       "description": "A GeoJSON geometry object (RFC 7946).",
                                       "properties": {
-                                        "coordinates": {
-                                          "items": {},
-                                          "title": "Coordinates",
-                                          "type": "array"
-                                        },
                                         "type": {
                                           "enum": [
                                             "Point",
@@ -33458,6 +33482,11 @@
                                           ],
                                           "title": "Type",
                                           "type": "string"
+                                        },
+                                        "coordinates": {
+                                          "items": {},
+                                          "title": "Coordinates",
+                                          "type": "array"
                                         }
                                       },
                                       "required": [
@@ -33469,11 +33498,6 @@
                                     },
                                     "title": "Geometries",
                                     "type": "array"
-                                  },
-                                  "type": {
-                                    "const": "GeometryCollection",
-                                    "title": "Type",
-                                    "type": "string"
                                   }
                                 },
                                 "required": [
@@ -33486,11 +33510,6 @@
                               {
                                 "description": "A GeoJSON geometry object (RFC 7946).",
                                 "properties": {
-                                  "coordinates": {
-                                    "items": {},
-                                    "title": "Coordinates",
-                                    "type": "array"
-                                  },
                                   "type": {
                                     "enum": [
                                       "Point",
@@ -33502,6 +33521,11 @@
                                     ],
                                     "title": "Type",
                                     "type": "string"
+                                  },
+                                  "coordinates": {
+                                    "items": {},
+                                    "title": "Coordinates",
+                                    "type": "array"
                                   }
                                 },
                                 "required": [
@@ -33517,20 +33541,10 @@
                             ],
                             "title": "Geometry"
                           },
-                          "id": {
-                            "title": "Id",
-                            "type": "integer"
-                          },
                           "properties": {
+                            "type": "object",
                             "additionalProperties": true,
-                            "title": "Properties",
-                            "type": "object"
-                          },
-                          "type": {
-                            "const": "Feature",
-                            "default": "Feature",
-                            "title": "Type",
-                            "type": "string"
+                            "title": "Properties"
                           }
                         },
                         "required": [
@@ -33546,12 +33560,12 @@
                     "links": {
                       "items": {
                         "properties": {
-                          "href": {
-                            "title": "Href",
-                            "type": "string"
-                          },
                           "rel": {
                             "title": "Rel",
+                            "type": "string"
+                          },
+                          "href": {
+                            "title": "Href",
                             "type": "string"
                           },
                           "type": {
@@ -33569,20 +33583,6 @@
                       },
                       "title": "Links",
                       "type": "array"
-                    },
-                    "numberMatched": {
-                      "title": "Numbermatched",
-                      "type": "integer"
-                    },
-                    "numberReturned": {
-                      "title": "Numberreturned",
-                      "type": "integer"
-                    },
-                    "type": {
-                      "const": "FeatureCollection",
-                      "default": "FeatureCollection",
-                      "title": "Type",
-                      "type": "string"
                     }
                   },
                   "required": [
@@ -33739,20 +33739,30 @@
                 "schema": {
                   "description": "A single GeoJSON Feature.",
                   "properties": {
+                    "type": {
+                      "const": "Feature",
+                      "default": "Feature",
+                      "title": "Type",
+                      "type": "string"
+                    },
+                    "id": {
+                      "title": "Id",
+                      "type": "integer"
+                    },
                     "geometry": {
                       "anyOf": [
                         {
                           "description": "A GeoJSON GeometryCollection (RFC 7946 \u00a73.1.8).\n\nfix(#430 codex r9): carries ``geometries`` instead of ``coordinates``, so\nit needs its own model \u2014 only generic-GEOMETRY datasets accept it on write\n(enforced in the service), and any stored collection must serialize back\nout on read.\n\nDeliberately NON-recursive (codex r13, refuted): PostGIS cannot round-trip\nnested collections through the GeoJSON boundary in either direction \u2014\nST_GeomFromGeoJSON rejects them on write and ST_AsGeoJSON raises\n'GeoJson: geometry not supported' on read \u2014 so a recursive model could\nnever receive one and would only convert the write-side 422 into a raw\ndatabase 500. The write schemas add a raw-payload guard for a clear 422.",
                           "properties": {
+                            "type": {
+                              "const": "GeometryCollection",
+                              "title": "Type",
+                              "type": "string"
+                            },
                             "geometries": {
                               "items": {
                                 "description": "A GeoJSON geometry object (RFC 7946).",
                                 "properties": {
-                                  "coordinates": {
-                                    "items": {},
-                                    "title": "Coordinates",
-                                    "type": "array"
-                                  },
                                   "type": {
                                     "enum": [
                                       "Point",
@@ -33764,6 +33774,11 @@
                                     ],
                                     "title": "Type",
                                     "type": "string"
+                                  },
+                                  "coordinates": {
+                                    "items": {},
+                                    "title": "Coordinates",
+                                    "type": "array"
                                   }
                                 },
                                 "required": [
@@ -33775,11 +33790,6 @@
                               },
                               "title": "Geometries",
                               "type": "array"
-                            },
-                            "type": {
-                              "const": "GeometryCollection",
-                              "title": "Type",
-                              "type": "string"
                             }
                           },
                           "required": [
@@ -33792,11 +33802,6 @@
                         {
                           "description": "A GeoJSON geometry object (RFC 7946).",
                           "properties": {
-                            "coordinates": {
-                              "items": {},
-                              "title": "Coordinates",
-                              "type": "array"
-                            },
                             "type": {
                               "enum": [
                                 "Point",
@@ -33808,6 +33813,11 @@
                               ],
                               "title": "Type",
                               "type": "string"
+                            },
+                            "coordinates": {
+                              "items": {},
+                              "title": "Coordinates",
+                              "type": "array"
                             }
                           },
                           "required": [
@@ -33823,20 +33833,10 @@
                       ],
                       "title": "Geometry"
                     },
-                    "id": {
-                      "title": "Id",
-                      "type": "integer"
-                    },
                     "properties": {
+                      "type": "object",
                       "additionalProperties": true,
-                      "title": "Properties",
-                      "type": "object"
-                    },
-                    "type": {
-                      "const": "Feature",
-                      "default": "Feature",
-                      "title": "Type",
-                      "type": "string"
+                      "title": "Properties"
                     }
                   },
                   "required": [
@@ -34146,20 +34146,30 @@
                 "schema": {
                   "description": "A single GeoJSON Feature.",
                   "properties": {
+                    "type": {
+                      "const": "Feature",
+                      "default": "Feature",
+                      "title": "Type",
+                      "type": "string"
+                    },
+                    "id": {
+                      "title": "Id",
+                      "type": "integer"
+                    },
                     "geometry": {
                       "anyOf": [
                         {
                           "description": "A GeoJSON GeometryCollection (RFC 7946 \u00a73.1.8).\n\nfix(#430 codex r9): carries ``geometries`` instead of ``coordinates``, so\nit needs its own model \u2014 only generic-GEOMETRY datasets accept it on write\n(enforced in the service), and any stored collection must serialize back\nout on read.\n\nDeliberately NON-recursive (codex r13, refuted): PostGIS cannot round-trip\nnested collections through the GeoJSON boundary in either direction \u2014\nST_GeomFromGeoJSON rejects them on write and ST_AsGeoJSON raises\n'GeoJson: geometry not supported' on read \u2014 so a recursive model could\nnever receive one and would only convert the write-side 422 into a raw\ndatabase 500. The write schemas add a raw-payload guard for a clear 422.",
                           "properties": {
+                            "type": {
+                              "const": "GeometryCollection",
+                              "title": "Type",
+                              "type": "string"
+                            },
                             "geometries": {
                               "items": {
                                 "description": "A GeoJSON geometry object (RFC 7946).",
                                 "properties": {
-                                  "coordinates": {
-                                    "items": {},
-                                    "title": "Coordinates",
-                                    "type": "array"
-                                  },
                                   "type": {
                                     "enum": [
                                       "Point",
@@ -34171,6 +34181,11 @@
                                     ],
                                     "title": "Type",
                                     "type": "string"
+                                  },
+                                  "coordinates": {
+                                    "items": {},
+                                    "title": "Coordinates",
+                                    "type": "array"
                                   }
                                 },
                                 "required": [
@@ -34182,11 +34197,6 @@
                               },
                               "title": "Geometries",
                               "type": "array"
-                            },
-                            "type": {
-                              "const": "GeometryCollection",
-                              "title": "Type",
-                              "type": "string"
                             }
                           },
                           "required": [
@@ -34199,11 +34209,6 @@
                         {
                           "description": "A GeoJSON geometry object (RFC 7946).",
                           "properties": {
-                            "coordinates": {
-                              "items": {},
-                              "title": "Coordinates",
-                              "type": "array"
-                            },
                             "type": {
                               "enum": [
                                 "Point",
@@ -34215,6 +34220,11 @@
                               ],
                               "title": "Type",
                               "type": "string"
+                            },
+                            "coordinates": {
+                              "items": {},
+                              "title": "Coordinates",
+                              "type": "array"
                             }
                           },
                           "required": [
@@ -34230,20 +34240,10 @@
                       ],
                       "title": "Geometry"
                     },
-                    "id": {
-                      "title": "Id",
-                      "type": "integer"
-                    },
                     "properties": {
+                      "type": "object",
                       "additionalProperties": true,
-                      "title": "Properties",
-                      "type": "object"
-                    },
-                    "type": {
-                      "const": "Feature",
-                      "default": "Feature",
-                      "title": "Type",
-                      "type": "string"
+                      "title": "Properties"
                     }
                   },
                   "required": [
@@ -34407,20 +34407,30 @@
                 "schema": {
                   "description": "A single GeoJSON Feature.",
                   "properties": {
+                    "type": {
+                      "const": "Feature",
+                      "default": "Feature",
+                      "title": "Type",
+                      "type": "string"
+                    },
+                    "id": {
+                      "title": "Id",
+                      "type": "integer"
+                    },
                     "geometry": {
                       "anyOf": [
                         {
                           "description": "A GeoJSON GeometryCollection (RFC 7946 \u00a73.1.8).\n\nfix(#430 codex r9): carries ``geometries`` instead of ``coordinates``, so\nit needs its own model \u2014 only generic-GEOMETRY datasets accept it on write\n(enforced in the service), and any stored collection must serialize back\nout on read.\n\nDeliberately NON-recursive (codex r13, refuted): PostGIS cannot round-trip\nnested collections through the GeoJSON boundary in either direction \u2014\nST_GeomFromGeoJSON rejects them on write and ST_AsGeoJSON raises\n'GeoJson: geometry not supported' on read \u2014 so a recursive model could\nnever receive one and would only convert the write-side 422 into a raw\ndatabase 500. The write schemas add a raw-payload guard for a clear 422.",
                           "properties": {
+                            "type": {
+                              "const": "GeometryCollection",
+                              "title": "Type",
+                              "type": "string"
+                            },
                             "geometries": {
                               "items": {
                                 "description": "A GeoJSON geometry object (RFC 7946).",
                                 "properties": {
-                                  "coordinates": {
-                                    "items": {},
-                                    "title": "Coordinates",
-                                    "type": "array"
-                                  },
                                   "type": {
                                     "enum": [
                                       "Point",
@@ -34432,6 +34442,11 @@
                                     ],
                                     "title": "Type",
                                     "type": "string"
+                                  },
+                                  "coordinates": {
+                                    "items": {},
+                                    "title": "Coordinates",
+                                    "type": "array"
                                   }
                                 },
                                 "required": [
@@ -34443,11 +34458,6 @@
                               },
                               "title": "Geometries",
                               "type": "array"
-                            },
-                            "type": {
-                              "const": "GeometryCollection",
-                              "title": "Type",
-                              "type": "string"
                             }
                           },
                           "required": [
@@ -34460,11 +34470,6 @@
                         {
                           "description": "A GeoJSON geometry object (RFC 7946).",
                           "properties": {
-                            "coordinates": {
-                              "items": {},
-                              "title": "Coordinates",
-                              "type": "array"
-                            },
                             "type": {
                               "enum": [
                                 "Point",
@@ -34476,6 +34481,11 @@
                               ],
                               "title": "Type",
                               "type": "string"
+                            },
+                            "coordinates": {
+                              "items": {},
+                              "title": "Coordinates",
+                              "type": "array"
                             }
                           },
                           "required": [
@@ -34491,20 +34501,10 @@
                       ],
                       "title": "Geometry"
                     },
-                    "id": {
-                      "title": "Id",
-                      "type": "integer"
-                    },
                     "properties": {
+                      "type": "object",
                       "additionalProperties": true,
-                      "title": "Properties",
-                      "type": "object"
-                    },
-                    "type": {
-                      "const": "Feature",
-                      "default": "Feature",
-                      "title": "Type",
-                      "type": "string"
+                      "title": "Properties"
                     }
                   },
                   "required": [
@@ -34678,20 +34678,30 @@
                 "schema": {
                   "description": "A single GeoJSON Feature.",
                   "properties": {
+                    "type": {
+                      "const": "Feature",
+                      "default": "Feature",
+                      "title": "Type",
+                      "type": "string"
+                    },
+                    "id": {
+                      "title": "Id",
+                      "type": "integer"
+                    },
                     "geometry": {
                       "anyOf": [
                         {
                           "description": "A GeoJSON GeometryCollection (RFC 7946 \u00a73.1.8).\n\nfix(#430 codex r9): carries ``geometries`` instead of ``coordinates``, so\nit needs its own model \u2014 only generic-GEOMETRY datasets accept it on write\n(enforced in the service), and any stored collection must serialize back\nout on read.\n\nDeliberately NON-recursive (codex r13, refuted): PostGIS cannot round-trip\nnested collections through the GeoJSON boundary in either direction \u2014\nST_GeomFromGeoJSON rejects them on write and ST_AsGeoJSON raises\n'GeoJson: geometry not supported' on read \u2014 so a recursive model could\nnever receive one and would only convert the write-side 422 into a raw\ndatabase 500. The write schemas add a raw-payload guard for a clear 422.",
                           "properties": {
+                            "type": {
+                              "const": "GeometryCollection",
+                              "title": "Type",
+                              "type": "string"
+                            },
                             "geometries": {
                               "items": {
                                 "description": "A GeoJSON geometry object (RFC 7946).",
                                 "properties": {
-                                  "coordinates": {
-                                    "items": {},
-                                    "title": "Coordinates",
-                                    "type": "array"
-                                  },
                                   "type": {
                                     "enum": [
                                       "Point",
@@ -34703,6 +34713,11 @@
                                     ],
                                     "title": "Type",
                                     "type": "string"
+                                  },
+                                  "coordinates": {
+                                    "items": {},
+                                    "title": "Coordinates",
+                                    "type": "array"
                                   }
                                 },
                                 "required": [
@@ -34714,11 +34729,6 @@
                               },
                               "title": "Geometries",
                               "type": "array"
-                            },
-                            "type": {
-                              "const": "GeometryCollection",
-                              "title": "Type",
-                              "type": "string"
                             }
                           },
                           "required": [
@@ -34731,11 +34741,6 @@
                         {
                           "description": "A GeoJSON geometry object (RFC 7946).",
                           "properties": {
-                            "coordinates": {
-                              "items": {},
-                              "title": "Coordinates",
-                              "type": "array"
-                            },
                             "type": {
                               "enum": [
                                 "Point",
@@ -34747,6 +34752,11 @@
                               ],
                               "title": "Type",
                               "type": "string"
+                            },
+                            "coordinates": {
+                              "items": {},
+                              "title": "Coordinates",
+                              "type": "array"
                             }
                           },
                           "required": [
@@ -34762,20 +34772,10 @@
                       ],
                       "title": "Geometry"
                     },
-                    "id": {
-                      "title": "Id",
-                      "type": "integer"
-                    },
                     "properties": {
+                      "type": "object",
                       "additionalProperties": true,
-                      "title": "Properties",
-                      "type": "object"
-                    },
-                    "type": {
-                      "const": "Feature",
-                      "default": "Feature",
-                      "title": "Type",
-                      "type": "string"
+                      "title": "Properties"
                     }
                   },
                   "required": [

--- a/backend/scripts/dump_openapi.py
+++ b/backend/scripts/dump_openapi.py
@@ -26,9 +26,30 @@ def _load_spec() -> dict:
     return app.openapi()
 
 
+def ordered_for_snapshot(node, *, preserve_keys: bool = False):
+    """Recursively sort dict keys, except each schema's ``properties`` map.
+
+    fix(#1257): property insertion order is Pydantic field declaration order,
+    and openapi-python-client derives generated constructor argument order
+    from it — alphabetizing it silently reorders positional arguments for SDK
+    consumers whenever an optional field is added. Everything else stays
+    sorted for deterministic, diff-friendly snapshots.
+    """
+    if isinstance(node, dict):
+        keys = node if preserve_keys else sorted(node)
+        return {
+            k: ordered_for_snapshot(node[k], preserve_keys=(k == "properties"))
+            for k in keys
+        }
+    if isinstance(node, list):
+        return [ordered_for_snapshot(v) for v in node]
+    return node
+
+
 def _dump(spec: dict) -> str:
-    # Sorted keys + trailing newline → deterministic diff-friendly output.
-    return json.dumps(spec, indent=2, sort_keys=True) + "\n"
+    # Sorted keys + trailing newline → deterministic diff-friendly output,
+    # with schema property order preserved (see ordered_for_snapshot).
+    return json.dumps(ordered_for_snapshot(spec), indent=2) + "\n"
 
 
 def main() -> int:

--- a/backend/tests/test_openapi_property_order.py
+++ b/backend/tests/test_openapi_property_order.py
@@ -1,0 +1,94 @@
+"""fix(#1257): schema property order must follow Pydantic declaration order.
+
+openapi-python-client derives generated constructor argument order from each
+schema's ``properties`` insertion order. ``sort_keys=True`` alphabetized it,
+so adding an optional field silently reordered positional arguments for SDK
+consumers (v1.10.0: ``bbox`` displaced ``distance_meters`` in
+``AnalysisPreviewRequest``). These tests pin the serializer contract for both
+snapshot writers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from app.api.main import app
+from app.modules.catalog.datasets.domain.schemas import AnalysisPreviewRequest
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+REPO_ROOT = BACKEND_ROOT.parent
+
+
+def _load_by_path(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+dump_openapi = _load_by_path(
+    "dump_openapi_under_test", BACKEND_ROOT / "scripts" / "dump_openapi.py"
+)
+flatten_defs = _load_by_path(
+    "flatten_defs_under_test", REPO_ROOT / "scripts" / "flatten_openapi_defs.py"
+)
+
+SAMPLE = {
+    "zeta": 1,
+    "components": {
+        "schemas": {
+            "Thing": {
+                "type": "object",
+                "title": "Thing",
+                "properties": {
+                    "operation": {"type": "string"},
+                    "distance_meters": {"type": "number", "title": "Zz"},
+                    "bbox": {
+                        "type": "object",
+                        # a property's own schema is still sorted...
+                        "title": "BBox",
+                        "properties": {
+                            # ...but nested properties maps are preserved too
+                            "xmax": {"type": "number"},
+                            "xmin": {"type": "number"},
+                        },
+                    },
+                },
+            }
+        }
+    },
+    "alpha": [{"b": 1, "a": 2}],
+}
+
+
+def test_ordered_for_snapshot_preserves_properties_and_sorts_the_rest():
+    ordered = dump_openapi.ordered_for_snapshot(SAMPLE)
+
+    assert list(ordered) == ["alpha", "components", "zeta"]
+    thing = ordered["components"]["schemas"]["Thing"]
+    assert list(thing) == ["properties", "title", "type"]
+    assert list(thing["properties"]) == ["operation", "distance_meters", "bbox"]
+    bbox = thing["properties"]["bbox"]
+    assert list(bbox) == ["properties", "title", "type"]
+    assert list(bbox["properties"]) == ["xmax", "xmin"]
+    assert list(ordered["alpha"][0]) == ["a", "b"]
+
+
+def test_flatten_serializer_mirrors_dump_openapi():
+    assert flatten_defs._ordered_for_snapshot(
+        SAMPLE
+    ) == dump_openapi.ordered_for_snapshot(SAMPLE)
+
+
+def test_dumped_spec_property_order_matches_pydantic_declaration():
+    app.openapi_schema = None
+    spec = json.loads(dump_openapi._dump(app.openapi()))
+
+    schema = spec["components"]["schemas"]["AnalysisPreviewRequest"]
+    declared = list(AnalysisPreviewRequest.model_fields)
+    assert list(schema["properties"]) == declared
+    # The v1.10.0 regression shape: alphabetization pulled `bbox` ahead of
+    # `distance_meters`; declaration order keeps it where the model says.
+    assert declared.index("bbox") > declared.index("distance_meters")

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -5033,11 +5033,6 @@ export interface components {
              */
             configured: boolean;
             /**
-             * Error
-             * @description Short sanitized failure reason. Never contains the key or raw provider error bodies.
-             */
-            error?: string | null;
-            /**
              * Ok
              * @description Whether the live provider call succeeded. None when not configured (no call was made).
              */
@@ -5047,6 +5042,11 @@ export interface components {
              * @description HTTP status returned by the provider on failure, when available.
              */
             status?: number | null;
+            /**
+             * Error
+             * @description Short sanitized failure reason. Never contains the key or raw provider error bodies.
+             */
+            error?: string | null;
         };
         /**
          * AIProbeReport
@@ -5059,39 +5059,39 @@ export interface components {
         /** AIStatusResponse */
         AIStatusResponse: {
             /**
-             * Configured
-             * @description Whether an API key is configured. AI features require both 'enabled' and 'configured'.
+             * Provider
+             * @description Active AI provider name (e.g. 'anthropic', 'openai').
              */
-            configured: boolean;
+            provider: string | null;
+            /**
+             * Model
+             * @description Active model name (e.g. 'claude-sonnet-4-20250514').
+             */
+            model: string | null;
             /**
              * Enabled
              * @description Whether AI features are enabled for this instance.
              */
             enabled: boolean;
             /**
-             * Has Embeddings
-             * @description Whether at least one record has embeddings stored.
-             * @default false
+             * Configured
+             * @description Whether an API key is configured. AI features require both 'enabled' and 'configured'.
              */
-            has_embeddings: boolean;
-            /**
-             * Model
-             * @description Active model name (e.g. 'claude-sonnet-4-20250514').
-             */
-            model: string | null;
-            /** @description Live provider probe results. Only present when the request opted in via ?probe=true. */
-            probe?: components["schemas"]["AIProbeReport"] | null;
-            /**
-             * Provider
-             * @description Active AI provider name (e.g. 'anthropic', 'openai').
-             */
-            provider: string | null;
+            configured: boolean;
             /**
              * Semantic Search Enabled
              * @description Whether pgvector-backed semantic search is enabled.
              * @default false
              */
             semantic_search_enabled: boolean;
+            /**
+             * Has Embeddings
+             * @description Whether at least one record has embeddings stored.
+             * @default false
+             */
+            has_embeddings: boolean;
+            /** @description Live provider probe results. Only present when the request opted in via ?probe=true. */
+            probe?: components["schemas"]["AIProbeReport"] | null;
         };
         /** AIStatusUpdate */
         AIStatusUpdate: {
@@ -5113,15 +5113,21 @@ export interface components {
         /** AdminApiKeyCreateRequest */
         AdminApiKeyCreateRequest: {
             /**
-             * Expires At
-             * @description Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
+             * User Id
+             * Format: uuid
+             * @description ID of the user the new API key will belong to.
              */
-            expires_at?: string | null;
+            user_id: string;
             /**
              * Name
              * @description Human-readable label for the API key (e.g. 'CI pipeline', 'QGIS desktop').
              */
             name: string;
+            /**
+             * Expires At
+             * @description Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
+             */
+            expires_at?: string | null;
             /**
              * Scope
              * @description Privilege scope (#875). 'full' impersonates the owner completely, the pre-existing behavior. 'read_only' authenticates GET, HEAD and OPTIONS requests only; any other method is refused with 403. A service-account key minted for an application is the usual case for 'read_only'.
@@ -5129,31 +5135,9 @@ export interface components {
              * @enum {string}
              */
             scope: "full" | "read_only";
-            /**
-             * User Id
-             * Format: uuid
-             * @description ID of the user the new API key will belong to.
-             */
-            user_id: string;
         };
         /** AdminApiKeyListItem */
         AdminApiKeyListItem: {
-            /**
-             * Created At
-             * Format: date-time
-             * @description Timestamp when the key was created.
-             */
-            created_at: string;
-            /**
-             * Expires At
-             * @description Expiry timestamp; null means the key does not expire.
-             */
-            expires_at?: string | null;
-            /**
-             * Fingerprint
-             * @description Non-secret key identifier; null for legacy keys.
-             */
-            fingerprint: string | null;
             /**
              * Id
              * Format: uuid
@@ -5161,31 +5145,47 @@ export interface components {
              */
             id: string;
             /**
-             * Is Active
-             * @description Whether the key is active. Inactive keys cannot authenticate.
+             * User Id
+             * Format: uuid
+             * @description Owning user's ID.
              */
-            is_active: boolean;
-            /**
-             * Last Used At
-             * @description Timestamp of the most recent successful authentication using this key.
-             */
-            last_used_at: string | null;
+            user_id: string;
             /**
              * Name
              * @description Human-readable label.
              */
             name: string;
             /**
+             * Fingerprint
+             * @description Non-secret key identifier; null for legacy keys.
+             */
+            fingerprint: string | null;
+            /**
+             * Is Active
+             * @description Whether the key is active. Inactive keys cannot authenticate.
+             */
+            is_active: boolean;
+            /**
+             * Expires At
+             * @description Expiry timestamp; null means the key does not expire.
+             */
+            expires_at?: string | null;
+            /**
              * Scope
              * @description Privilege scope: 'full' or 'read_only' (#875).
              */
             scope: string;
             /**
-             * User Id
-             * Format: uuid
-             * @description Owning user's ID.
+             * Created At
+             * Format: date-time
+             * @description Timestamp when the key was created.
              */
-            user_id: string;
+            created_at: string;
+            /**
+             * Last Used At
+             * @description Timestamp of the most recent successful authentication using this key.
+             */
+            last_used_at: string | null;
         };
         /** AdminApiKeyListResponse */
         AdminApiKeyListResponse: {
@@ -5209,47 +5209,47 @@ export interface components {
         };
         /** AdminEmbedTokenResponse */
         AdminEmbedTokenResponse: {
-            /** Allowed Origins */
-            allowed_origins?: string[] | null;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Creator Username */
-            creator_username?: string | null;
-            /**
-             * Expires At
-             * Format: date-time
-             */
-            expires_at: string;
             /**
              * Id
              * Format: uuid
              */
             id: string;
-            /** Is Active */
-            is_active: boolean;
-            /** Last Used At */
-            last_used_at?: string | null;
             /**
              * Map Id
              * Format: uuid
              */
             map_id: string;
-            /** Map Name */
-            map_name?: string | null;
             /** Name */
             name?: string | null;
-            /** Scoped Dataset Ids */
-            scoped_dataset_ids: string[];
             /** Token Hint */
             token_hint: string;
+            /** Scoped Dataset Ids */
+            scoped_dataset_ids: string[];
+            /** Allowed Origins */
+            allowed_origins?: string[] | null;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+            /** Is Active */
+            is_active: boolean;
             /**
              * Use Count
              * @default 0
              */
             use_count: number;
+            /** Last Used At */
+            last_used_at?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Map Name */
+            map_name?: string | null;
+            /** Creator Username */
+            creator_username?: string | null;
         };
         /** AdminJobListResponse */
         AdminJobListResponse: {
@@ -5267,26 +5267,22 @@ export interface components {
         /** AdminJobResponse */
         AdminJobResponse: {
             /**
-             * Can Retry
-             * @description Whether the failed job can be retried with its retained source.
+             * Id
+             * Format: uuid
+             * @description Unique ingestion job identifier.
              */
-            can_retry: boolean;
+            id: string;
             /**
-             * Completed At
-             * @description Timestamp when the job finished (success or failure).
+             * Status
+             * @description Current job status: 'pending', 'running', 'complete', 'failed', or 'cancelled'.
+             * @enum {string}
              */
-            completed_at: string | null;
+            status: "pending" | "running" | "complete" | "failed" | "cancelled" | "fanned_out";
             /**
-             * Created At
-             * Format: date-time
-             * @description Timestamp when the job was queued.
+             * Source Filename
+             * @description Original filename of the uploaded file, if applicable.
              */
-            created_at: string;
-            /**
-             * Created By
-             * @description ID of the user who initiated the job.
-             */
-            created_by: string | null;
+            source_filename: string | null;
             /**
              * Dataset Id
              * @description ID of the dataset created by this job, if completed successfully.
@@ -5298,32 +5294,15 @@ export interface components {
              */
             error_message: string | null;
             /**
-             * Id
-             * Format: uuid
-             * @description Unique ingestion job identifier.
+             * Can Retry
+             * @description Whether the failed job can be retried with its retained source.
              */
-            id: string;
+            can_retry: boolean;
             /**
              * Retry Reason
              * @description Why the job cannot be retried, when retry is unavailable.
              */
             retry_reason: string | null;
-            /**
-             * Source Filename
-             * @description Original filename of the uploaded file, if applicable.
-             */
-            source_filename: string | null;
-            /**
-             * Started At
-             * @description Timestamp when the worker began processing the job.
-             */
-            started_at: string | null;
-            /**
-             * Status
-             * @description Current job status: 'pending', 'running', 'complete', 'failed', or 'cancelled'.
-             * @enum {string}
-             */
-            status: "pending" | "running" | "complete" | "failed" | "cancelled" | "fanned_out";
             /**
              * User Metadata
              * @description User-supplied metadata captured at upload time (title, summary, tags, vrt_type, file_type, warnings, etc.). Heterogeneous shape across ingest paths -- canonical keys: title, summary, visibility, file_type, vrt_type, warnings.
@@ -5332,10 +5311,31 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
+             * Created By
+             * @description ID of the user who initiated the job.
+             */
+            created_by: string | null;
+            /**
              * Username
              * @description Username of the user who initiated the job.
              */
             username: string | null;
+            /**
+             * Started At
+             * @description Timestamp when the worker began processing the job.
+             */
+            started_at: string | null;
+            /**
+             * Completed At
+             * @description Timestamp when the job finished (success or failure).
+             */
+            completed_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             * @description Timestamp when the job was queued.
+             */
+            created_at: string;
         };
         /** AdminShareTokenListResponse */
         AdminShareTokenListResponse: {
@@ -5346,6 +5346,21 @@ export interface components {
         };
         /** AdminShareTokenResponse */
         AdminShareTokenResponse: {
+            /** Id */
+            id?: string | null;
+            /**
+             * Map Id
+             * Format: uuid
+             */
+            map_id: string;
+            /** Map Name */
+            map_name: string;
+            /** Token */
+            token?: string | null;
+            /** Is Active */
+            is_active?: boolean | null;
+            /** Expires At */
+            expires_at?: string | null;
             /**
              * Created At
              * Format: date-time
@@ -5358,45 +5373,30 @@ export interface components {
              * @default 0
              */
             embed_token_count: number;
-            /** Expires At */
-            expires_at?: string | null;
-            /** Id */
-            id?: string | null;
-            /** Is Active */
-            is_active?: boolean | null;
-            /**
-             * Map Id
-             * Format: uuid
-             */
-            map_id: string;
-            /** Map Name */
-            map_name: string;
-            /** Token */
-            token?: string | null;
         };
         /** AdminUserCreate */
         AdminUserCreate: {
             /**
-             * Email
-             * @description Optional email address. Used for OAuth account linking and notifications.
+             * Username
+             * @description Login username (3-150 chars). Must be unique across the system.
              */
-            email?: string | null;
+            username: string;
             /**
              * Password
              * @description Initial password (policy: min 12 chars, 3+ character classes). The user can change this after first login.
              */
             password: string;
             /**
+             * Email
+             * @description Optional email address. Used for OAuth account linking and notifications.
+             */
+            email?: string | null;
+            /**
              * Role
              * @description User role: 'admin', 'editor', or 'viewer'. Defaults to 'viewer'.
              * @default viewer
              */
             role: string;
-            /**
-             * Username
-             * @description Login username (3-150 chars). Must be unique across the system.
-             */
-            username: string;
         };
         /** AlterColumnTypeRequest */
         AlterColumnTypeRequest: {
@@ -5412,25 +5412,17 @@ export interface components {
          */
         AnalysisMaterializeRequest: {
             /**
-             * By Field
-             * @description Optional group-by column for dissolve
+             * Operation
+             * @enum {string}
              */
-            by_field?: string | null;
+            operation: "buffer" | "centroid" | "clip" | "dissolve" | "spatial_join" | "measure" | "select_by_location" | "intersect";
+            /** Title */
+            title: string;
             /**
              * Distance Meters
              * @description Buffer distance in meters (buffer only)
              */
             distance_meters?: number | null;
-            /**
-             * Join Dataset Id
-             * @description Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
-             */
-            join_dataset_id?: string | null;
-            /**
-             * Join Fields
-             * @description Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
-             */
-            join_fields?: string[] | null;
             /**
              * Mask
              * @description GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)
@@ -5444,12 +5436,20 @@ export interface components {
              */
             mask_dataset_id?: string | null;
             /**
-             * Operation
-             * @enum {string}
+             * By Field
+             * @description Optional group-by column for dissolve
              */
-            operation: "buffer" | "centroid" | "clip" | "dissolve" | "spatial_join" | "measure" | "select_by_location" | "intersect";
-            /** Title */
-            title: string;
+            by_field?: string | null;
+            /**
+             * Join Dataset Id
+             * @description Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
+             */
+            join_dataset_id?: string | null;
+            /**
+             * Join Fields
+             * @description Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
+             */
+            join_fields?: string[] | null;
         };
         /**
          * AnalysisMaterializeResponse
@@ -5473,25 +5473,15 @@ export interface components {
          */
         AnalysisPreviewRequest: {
             /**
-             * Bbox
-             * @description [minx, miny, maxx, maxy] in EPSG:4326, typically the map's current viewport. When present, only source features intersecting the envelope are considered before the preview's row cap applies, so a capped result reflects what is on screen rather than an arbitrary sample in ingest order (fix(#727)). Applies to every operation, not just one, so it is deliberately absent from _ANALYSIS_PARAM_OWNERS — omit it to preview the whole dataset, unchanged from before this field existed.
+             * Operation
+             * @enum {string}
              */
-            bbox?: number[] | null;
+            operation: "buffer" | "centroid" | "clip" | "spatial_join" | "measure" | "select_by_location" | "intersect";
             /**
              * Distance Meters
              * @description Buffer distance in meters (buffer only)
              */
             distance_meters?: number | null;
-            /**
-             * Join Dataset Id
-             * @description Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
-             */
-            join_dataset_id?: string | null;
-            /**
-             * Join Fields
-             * @description Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
-             */
-            join_fields?: string[] | null;
             /**
              * Mask
              * @description GeoJSON Polygon or MultiPolygon geometry in EPSG:4326 (clip and select_by_location)
@@ -5505,49 +5495,59 @@ export interface components {
              */
             mask_dataset_id?: string | null;
             /**
-             * Operation
-             * @enum {string}
+             * Join Dataset Id
+             * @description Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
              */
-            operation: "buffer" | "centroid" | "clip" | "spatial_join" | "measure" | "select_by_location" | "intersect";
+            join_dataset_id?: string | null;
+            /**
+             * Join Fields
+             * @description Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
+             */
+            join_fields?: string[] | null;
+            /**
+             * Bbox
+             * @description [minx, miny, maxx, maxy] in EPSG:4326, typically the map's current viewport. When present, only source features intersecting the envelope are considered before the preview's row cap applies, so a capped result reflects what is on screen rather than an arbitrary sample in ingest order (fix(#727)). Applies to every operation, not just one, so it is deliberately absent from _ANALYSIS_PARAM_OWNERS — omit it to preview the whole dataset, unchanged from before this field existed.
+             */
+            bbox?: number[] | null;
         };
         /**
          * AnalysisPreviewResponse
          * @description GeoJSON FeatureCollection preview of an analysis operation.
          */
         AnalysisPreviewResponse: {
-            /** Bbox */
-            bbox?: number[] | null;
-            /** Feature Count */
-            feature_count: number;
             /** Geojson */
             geojson: {
                 [key: string]: unknown;
             };
-            /**
-             * Match Count
-             * @description Exact total across the WHOLE source, not just the previewed features — WHOLE meaning the request's bbox when one was sent, the same sense source_feature_count uses that word. What it counts is per-operation, so read it against the operation you sent rather than as one number: select_by_location gives the selected source features and intersect gives the output pieces, and for both of those it IS the output total; spatial_join gives intersecting source/join PAIRS, which is NOT the output total, because the join keeps every source row (use source_feature_count for that operation). intersect and spatial_join both scope this total to a bbox on the request; select_by_location's count is a separate uncapped query the request's bbox does not reach, so it stays unscoped even though its preview rows are viewport-limited too. Null for operations that report no such total, and when the count could not be computed within the query budget
-             */
-            match_count?: number | null;
+            /** Feature Count */
+            feature_count: number;
+            /** Truncated */
+            truncated: boolean;
+            /** Bbox */
+            bbox?: number[] | null;
             /**
              * Source Feature Count
              * @description Total feature count of the source dataset (1:1 operations only; null when the operation filters rows, e.g. clip). When the request carried a bbox this is a LIVE count of rows intersecting it rather than the dataset's cached whole-table total (fix(#727)) — also null, same as match_count, when that live count could not be computed within the query budget
              */
             source_feature_count?: number | null;
-            /** Truncated */
-            truncated: boolean;
+            /**
+             * Match Count
+             * @description Exact total across the WHOLE source, not just the previewed features — WHOLE meaning the request's bbox when one was sent, the same sense source_feature_count uses that word. What it counts is per-operation, so read it against the operation you sent rather than as one number: select_by_location gives the selected source features and intersect gives the output pieces, and for both of those it IS the output total; spatial_join gives intersecting source/join PAIRS, which is NOT the output total, because the join keeps every source row (use source_feature_count for that operation). intersect and spatial_join both scope this total to a bbox on the request; select_by_location's count is a separate uncapped query the request's bbox does not reach, so it stays unscoped even though its preview rows are viewport-limited too. Null for operations that report no such total, and when the count could not be computed within the query budget
+             */
+            match_count?: number | null;
         };
         /** ApiKeyCreateRequest */
         ApiKeyCreateRequest: {
-            /**
-             * Expires At
-             * @description Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
-             */
-            expires_at?: string | null;
             /**
              * Name
              * @description Human-readable label for the API key
              */
             name: string;
+            /**
+             * Expires At
+             * @description Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
+             */
+            expires_at?: string | null;
             /**
              * Scope
              * @description Privilege scope (#875). 'full' impersonates the owner completely, the pre-existing behavior. 'read_only' authenticates GET, HEAD and OPTIONS requests only; any other method is refused with 403.
@@ -5559,21 +5559,6 @@ export interface components {
         /** ApiKeyCreateResponse */
         ApiKeyCreateResponse: {
             /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /**
-             * Expires At
-             * @description Expiry timestamp; null means the key does not expire
-             */
-            expires_at?: string | null;
-            /**
-             * Fingerprint
-             * @description Non-secret key identifier (prefix and last four characters)
-             */
-            fingerprint: string;
-            /**
              * Id
              * Format: uuid
              */
@@ -5583,47 +5568,62 @@ export interface components {
              * @description The API key secret (shown only once)
              */
             key: string;
+            /**
+             * Fingerprint
+             * @description Non-secret key identifier (prefix and last four characters)
+             */
+            fingerprint: string;
             /** Name */
             name: string;
-            /**
-             * Scope
-             * @description Privilege scope: 'full' or 'read_only' (#875)
-             */
-            scope: string;
-        };
-        /** ApiKeyListItem */
-        ApiKeyListItem: {
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
             /**
              * Expires At
              * @description Expiry timestamp; null means the key does not expire
              */
             expires_at?: string | null;
             /**
-             * Fingerprint
-             * @description Non-secret key identifier; null for keys created before fingerprint support
+             * Scope
+             * @description Privilege scope: 'full' or 'read_only' (#875)
              */
-            fingerprint: string | null;
+            scope: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
+        /** ApiKeyListItem */
+        ApiKeyListItem: {
             /**
              * Id
              * Format: uuid
              */
             id: string;
-            /** Is Active */
-            is_active: boolean;
-            /** Last Used At */
-            last_used_at: string | null;
             /** Name */
             name: string;
+            /**
+             * Fingerprint
+             * @description Non-secret key identifier; null for keys created before fingerprint support
+             */
+            fingerprint: string | null;
+            /** Is Active */
+            is_active: boolean;
+            /**
+             * Expires At
+             * @description Expiry timestamp; null means the key does not expire
+             */
+            expires_at?: string | null;
             /**
              * Scope
              * @description Privilege scope: 'full' or 'read_only' (#875)
              */
             scope: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Last Used At */
+            last_used_at: string | null;
         };
         /** ApiKeyListResponse */
         ApiKeyListResponse: {
@@ -5665,50 +5665,50 @@ export interface components {
         };
         /** AttributeMetadataResponse */
         AttributeMetadataResponse: {
-            /** Data Type */
-            data_type: string | null;
-            /**
-             * Dataset Id
-             * Format: uuid
-             */
-            dataset_id: string;
-            /** Description */
-            description: string | null;
-            /** Domain Type */
-            domain_type: string | null;
-            /**
-             * Example Values
-             * @description Sample values from the column
-             */
-            example_values?: unknown[] | null;
-            /** Field Name */
-            field_name: string;
             /**
              * Id
              * Format: uuid
              */
             id: string;
             /**
-             * Is Current
-             * @description False if column was removed in a later version
+             * Dataset Id
+             * Format: uuid
              */
-            is_current: boolean;
-            /** Is Nullable */
-            is_nullable?: boolean | null;
-            /**
-             * Ordinal Position
-             * @description Column position in the table (1-based)
-             */
-            ordinal_position?: number | null;
+            dataset_id: string;
+            /** Field Name */
+            field_name: string;
+            /** Title */
+            title: string | null;
+            /** Description */
+            description: string | null;
+            /** Data Type */
+            data_type: string | null;
+            /** Units */
+            units: string | null;
+            /** Domain Type */
+            domain_type: string | null;
             /**
              * Semantic Role
              * @description Inferred role: geometry, identifier, measure, etc.
              */
             semantic_role?: string | null;
-            /** Title */
-            title: string | null;
-            /** Units */
-            units: string | null;
+            /**
+             * Example Values
+             * @description Sample values from the column
+             */
+            example_values?: unknown[] | null;
+            /**
+             * Ordinal Position
+             * @description Column position in the table (1-based)
+             */
+            ordinal_position?: number | null;
+            /** Is Nullable */
+            is_nullable?: boolean | null;
+            /**
+             * Is Current
+             * @description False if column was removed in a later version
+             */
+            is_current: boolean;
             /**
              * User Modified Fields
              * @description Field names manually edited by a user
@@ -5717,28 +5717,28 @@ export interface components {
         };
         /** AttributeMetadataUpdate */
         AttributeMetadataUpdate: {
+            /**
+             * Title
+             * @description Human-friendly column display name
+             */
+            title?: string | null;
             /** Description */
             description?: string | null;
             /**
-             * Domain Type
-             * @description Value domain: continuous, categorical, coded, etc.
+             * Units
+             * @description Measurement units, e.g. meters, kg
              */
-            domain_type?: ("continuous" | "discrete" | "categorical" | "coded" | "codedValue" | "boolean" | "text" | "date" | "temporal" | "geometry" | "range") | null;
+            units?: string | null;
             /**
              * Semantic Role
              * @description Column role: geometry, identifier, measure, etc.
              */
             semantic_role?: ("geometry" | "identifier" | "measure" | "temporal" | "categorical" | "category" | "label" | "foreign_key" | "other") | null;
             /**
-             * Title
-             * @description Human-friendly column display name
+             * Domain Type
+             * @description Value domain: continuous, categorical, coded, etc.
              */
-            title?: string | null;
-            /**
-             * Units
-             * @description Measurement units, e.g. meters, kg
-             */
-            units?: string | null;
+            domain_type?: ("continuous" | "discrete" | "categorical" | "coded" | "codedValue" | "boolean" | "text" | "date" | "temporal" | "geometry" | "range") | null;
         };
         /** AuditLogListResponse */
         AuditLogListResponse: {
@@ -5749,67 +5749,70 @@ export interface components {
         };
         /** AuditLogResponse */
         AuditLogResponse: {
-            /** Action */
-            action: string;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Details */
-            details: {
-                [key: string]: unknown;
-            } | null;
             /**
              * Id
              * Format: uuid
              */
             id: string;
-            /** Ip Address */
-            ip_address: string | null;
-            /** Resource Id */
-            resource_id: string | null;
-            /** Resource Name */
-            resource_name?: string | null;
-            /** Resource Type */
-            resource_type: string;
             /** User Id */
             user_id: string | null;
             /** Username */
             username?: string | null;
+            /** Action */
+            action: string;
+            /** Resource Type */
+            resource_type: string;
+            /** Resource Id */
+            resource_id: string | null;
+            /** Resource Name */
+            resource_name?: string | null;
+            /** Details */
+            details: {
+                [key: string]: unknown;
+            } | null;
+            /** Ip Address */
+            ip_address: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
         };
         /** BackfillResponse */
         BackfillResponse: {
-            /**
-             * Created
-             * @description Number of new embeddings created.
-             */
-            created: number;
-            /**
-             * Errors
-             * @description Number of records that failed during embedding generation.
-             */
-            errors: number;
             /**
              * Processed
              * @description Number of records processed in this backfill batch.
              */
             processed: number;
             /**
+             * Created
+             * @description Number of new embeddings created.
+             */
+            created: number;
+            /**
              * Skipped
              * @description Number of records skipped because an embedding already existed.
              */
             skipped: number;
+            /**
+             * Errors
+             * @description Number of records that failed during embedding generation.
+             */
+            errors: number;
         };
         /** BasemapConfig */
         BasemapConfig: {
             /**
-             * Background Color
-             * @description Map canvas background color in #RRGGBB hex format, or null to use the basemap default.
+             * @description Basemap label prominence.
+             * @default full
              */
-            background_color?: string | null;
-            /** @description Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no migration). */
-            basemap_position?: components["schemas"]["BasemapPosition"] | null;
+            label_mode: components["schemas"]["BasemapLabelMode"];
+            /**
+             * @description Road and transit sublayer visibility where supported.
+             * @default full
+             */
+            road_visibility: components["schemas"]["BasemapSublayerVisibility"];
             /**
              * @description Administrative boundary sublayer visibility where supported.
              * @default full
@@ -5822,30 +5825,23 @@ export interface components {
              */
             building_visibility: boolean;
             /**
-             * @description Basemap label prominence.
-             * @default full
-             */
-            label_mode: components["schemas"]["BasemapLabelMode"];
-            /**
              * @description Land and water color treatment where supported.
              * @default default
              */
             land_water_tone: components["schemas"]["BasemapLandWaterTone"];
+            /** @description Optional contrast hint for relief-oriented basemap styling. */
+            relief_contrast?: components["schemas"]["BasemapReliefContrast"] | null;
             /**
              * Opacity
              * @description Master basemap opacity 0.0-1.0
              * @default 1
              */
             opacity: number;
-            /** @description Map projection: 'mercator' (default) or experimental 'globe'. null/undefined loads as 'mercator' on the client. */
-            projection?: components["schemas"]["BasemapProjection"] | null;
-            /** @description Optional contrast hint for relief-oriented basemap styling. */
-            relief_contrast?: components["schemas"]["BasemapReliefContrast"] | null;
             /**
-             * @description Road and transit sublayer visibility where supported.
-             * @default full
+             * Background Color
+             * @description Map canvas background color in #RRGGBB hex format, or null to use the basemap default.
              */
-            road_visibility: components["schemas"]["BasemapSublayerVisibility"];
+            background_color?: string | null;
             /**
              * Sublayer Overrides
              * @description Per-sublayer style overrides keyed by semantic sublayer ID (e.g. 'road', 'boundary', 'building'). Key set is opaque — unknown future sublayer IDs are accepted without rejection. See CONTEXT.md D-01.
@@ -5853,6 +5849,10 @@ export interface components {
             sublayer_overrides?: {
                 [key: string]: components["schemas"]["SublayerOverride"];
             } | null;
+            /** @description Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no migration). */
+            basemap_position?: components["schemas"]["BasemapPosition"] | null;
+            /** @description Map projection: 'mercator' (default) or experimental 'globe'. null/undefined loads as 'mercator' on the client. */
+            projection?: components["schemas"]["BasemapProjection"] | null;
         };
         /**
          * BasemapLabelMode
@@ -5882,25 +5882,10 @@ export interface components {
          */
         BasemapPublicResponse: {
             /**
-             * Attribution
-             * @description Attribution string for the basemap source.
-             */
-            attribution?: string | null;
-            /**
-             * Enabled
-             * @description Whether the basemap is currently selectable.
-             */
-            enabled: boolean;
-            /**
              * Id
              * @description Unique basemap identifier.
              */
             id: string;
-            /**
-             * Is Preset
-             * @description Whether this is a built-in preset.
-             */
-            is_preset: boolean;
             /**
              * Label
              * @description Display label.
@@ -5911,6 +5896,21 @@ export interface components {
              * @description Tile URL or style JSON URL with API key already substituted (or omitted) for client use.
              */
             url: string;
+            /**
+             * Enabled
+             * @description Whether the basemap is currently selectable.
+             */
+            enabled: boolean;
+            /**
+             * Is Preset
+             * @description Whether this is a built-in preset.
+             */
+            is_preset: boolean;
+            /**
+             * Attribution
+             * @description Attribution string for the basemap source.
+             */
+            attribution?: string | null;
         };
         /**
          * BasemapReliefContrast
@@ -5924,15 +5924,10 @@ export interface components {
         BasemapSublayerVisibility: "full" | "subtle" | "hidden";
         /** Body_login_auth_login_post */
         Body_login_auth_login_post: {
-            /** Client Id */
-            client_id?: string | null;
-            /**
-             * Client Secret
-             * Format: password
-             */
-            client_secret?: string | null;
             /** Grant Type */
             grant_type?: string | null;
+            /** Username */
+            username: string;
             /**
              * Password
              * Format: password
@@ -5943,8 +5938,13 @@ export interface components {
              * @default
              */
             scope: string;
-            /** Username */
-            username: string;
+            /** Client Id */
+            client_id?: string | null;
+            /**
+             * Client Secret
+             * Format: password
+             */
+            client_secret?: string | null;
         };
         /** Body_reupload_dataset_datasets__dataset_id__reupload_post */
         Body_reupload_dataset_datasets__dataset_id__reupload_post: {
@@ -5974,13 +5974,13 @@ export interface components {
         };
         /** BulkDeleteItem */
         BulkDeleteItem: {
-            /** Confirm Title */
-            confirm_title: string;
             /**
              * Dataset Id
              * Format: uuid
              */
             dataset_id: string;
+            /** Confirm Title */
+            confirm_title: string;
         };
         /**
          * BulkDeleteLayersFailure
@@ -6037,18 +6037,13 @@ export interface components {
              * Format: uuid
              */
             dataset_id: string;
-            /** Detail */
-            detail?: string | null;
             /** Status */
             status: string;
+            /** Detail */
+            detail?: string | null;
         };
         /** BulkRegisterItem */
         BulkRegisterItem: {
-            /**
-             * Summary
-             * @description Optional dataset description.
-             */
-            summary?: string | null;
             /**
              * Table Name
              * @description PostgreSQL table name to register.
@@ -6059,6 +6054,11 @@ export interface components {
              * @description Human-readable dataset title.
              */
             title: string;
+            /**
+             * Summary
+             * @description Optional dataset description.
+             */
+            summary?: string | null;
             /**
              * Visibility
              * @description Dataset visibility level.
@@ -6086,30 +6086,30 @@ export interface components {
         /** BulkRegisterResult */
         BulkRegisterResult: {
             /**
-             * Dataset Id
-             * @description ID of the created dataset on success.
+             * Table Name
+             * @description Source table that was processed.
              */
-            dataset_id?: string | null;
-            /**
-             * Error
-             * @description Error message on failure.
-             */
-            error?: string | null;
+            table_name: string;
             /**
              * Status
              * @description Per-row outcome: 'success', 'skipped', or 'error'.
              */
             status: string;
             /**
-             * Table Name
-             * @description Source table that was processed.
+             * Dataset Id
+             * @description ID of the created dataset on success.
              */
-            table_name: string;
+            dataset_id?: string | null;
             /**
              * Title
              * @description Title of the created dataset on success.
              */
             title?: string | null;
+            /**
+             * Error
+             * @description Error message on failure.
+             */
+            error?: string | null;
         };
         /** BulkRevokeRequest */
         BulkRevokeRequest: {
@@ -6123,6 +6123,21 @@ export interface components {
         };
         /** CatalogStatsResponse */
         CatalogStatsResponse: {
+            /**
+             * Total Datasets
+             * @description Total number of datasets in the catalog.
+             */
+            total_datasets: number;
+            /**
+             * Recent Additions
+             * @description Number of datasets added in the last 30 days.
+             */
+            recent_additions: number;
+            /**
+             * Total Storage Bytes
+             * @description Total storage used by all dataset tables, in bytes. Null if calculation is unavailable.
+             */
+            total_storage_bytes: number | null;
             /**
              * Datasets By Geometry Type
              * @description Histogram of datasets keyed by geometry type (Point, MultiPolygon, etc.).
@@ -6138,27 +6153,6 @@ export interface components {
                 [key: string]: number;
             };
             /**
-             * Recent Additions
-             * @description Number of datasets added in the last 30 days.
-             */
-            recent_additions: number;
-            /**
-             * Total Datasets
-             * @description Total number of datasets in the catalog.
-             */
-            total_datasets: number;
-            /**
-             * Total Storage Bytes
-             * @description Total storage used by all dataset tables, in bytes. Null if calculation is unavailable.
-             */
-            total_storage_bytes: number | null;
-            /**
-             * Total Users
-             * @description Total number of users in the system.
-             * @default 0
-             */
-            total_users: number;
-            /**
              * Users By Status
              * @description Histogram of users keyed by status (active, deactivated, pending).
              * @default {}
@@ -6166,6 +6160,12 @@ export interface components {
             users_by_status: {
                 [key: string]: number;
             };
+            /**
+             * Total Users
+             * @description Total number of users in the system.
+             * @default 0
+             */
+            total_users: number;
         };
         /** ChangePasswordRequest */
         ChangePasswordRequest: {
@@ -6179,111 +6179,95 @@ export interface components {
         };
         /** ChatAction */
         ChatAction: {
-            /** Bbox */
-            bbox?: number[] | null;
-            /** Clear Paint */
-            clear_paint?: string[] | null;
-            /** Columns */
-            columns?: string[] | null;
-            /** Dataset Id */
-            dataset_id?: string | null;
-            /** Dataset Name */
-            dataset_name?: string | null;
-            /** Distance Meters */
-            distance_meters?: number | null;
-            /** Expression */
-            expression?: unknown[] | null;
-            geojson?: components["schemas"]["GeoJSONFeatureCollection"] | null;
-            /** Label Config */
-            label_config?: {
-                [key: string]: unknown;
-            } | null;
-            /** Layer Id */
-            layer_id?: string | null;
-            /** Opacity */
-            opacity?: number | null;
-            /** Operation */
-            operation?: string | null;
-            /** Paint */
-            paint?: {
-                [key: string]: unknown;
-            } | null;
-            /** Replace Paint */
-            replace_paint?: boolean | null;
-            /** Row Count */
-            row_count?: number | null;
-            /** Rows */
-            rows?: unknown[][] | null;
-            /** Style Config */
-            style_config?: {
-                [key: string]: unknown;
-            } | null;
-            /** Truncated */
-            truncated?: boolean | null;
             /**
              * Type
              * @enum {string}
              */
             type: "set_filter" | "set_style" | "set_data_driven_style" | "set_label" | "toggle_visibility" | "add_layer" | "remove_layer" | "show_query_result" | "set_opacity";
+            /** Layer Id */
+            layer_id?: string | null;
+            /** Expression */
+            expression?: unknown[] | null;
+            /** Paint */
+            paint?: {
+                [key: string]: unknown;
+            } | null;
+            /** Clear Paint */
+            clear_paint?: string[] | null;
+            /** Replace Paint */
+            replace_paint?: boolean | null;
+            /** Style Config */
+            style_config?: {
+                [key: string]: unknown;
+            } | null;
+            /** Label Config */
+            label_config?: {
+                [key: string]: unknown;
+            } | null;
+            /** Dataset Id */
+            dataset_id?: string | null;
+            /** Dataset Name */
+            dataset_name?: string | null;
             /** Visible */
             visible?: boolean | null;
+            /** Opacity */
+            opacity?: number | null;
+            geojson?: components["schemas"]["GeoJSONFeatureCollection"] | null;
+            /** Bbox */
+            bbox?: number[] | null;
+            /** Rows */
+            rows?: unknown[][] | null;
+            /** Columns */
+            columns?: string[] | null;
+            /** Row Count */
+            row_count?: number | null;
+            /** Truncated */
+            truncated?: boolean | null;
+            /** Operation */
+            operation?: string | null;
+            /** Distance Meters */
+            distance_meters?: number | null;
         };
         /**
          * ChatHistoryMessage
          * @description A single message in the conversation history.
          */
         ChatHistoryMessage: {
-            /** Content */
-            content: string;
             /**
              * Role
              * @enum {string}
              */
             role: "user" | "assistant";
+            /** Content */
+            content: string;
         };
         /**
          * ChatMapLayer
          * @description Layer state sent from frontend for chat context.
          */
         ChatMapLayer: {
-            /** Column Info */
-            column_info?: {
-                [key: string]: unknown;
-            }[] | null;
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
             /** Dataset Id */
             dataset_id: string;
             /** Dataset Table Name */
             dataset_table_name: string;
+            /** Geometry Type */
+            geometry_type?: string | null;
+            /** Layer Type */
+            layer_type?: string | null;
+            /** Column Info */
+            column_info?: {
+                [key: string]: unknown;
+            }[] | null;
             /** Dataset Title */
             dataset_title?: string | null;
             /** Feature Count */
             feature_count?: number | null;
-            /** Filter */
-            filter?: unknown[] | {
-                [key: string]: unknown;
-            } | null;
-            /** Geometry Type */
-            geometry_type?: string | null;
-            /** Id */
-            id: string;
-            /** Label Config */
-            label_config?: {
-                [key: string]: unknown;
-            } | null;
-            /** Layer Type */
-            layer_type?: string | null;
-            /** Name */
-            name: string;
-            /** Paint */
-            paint?: {
-                [key: string]: unknown;
-            } | null;
             /** Sample Values */
             sample_values?: {
-                [key: string]: unknown;
-            } | null;
-            /** Style Config */
-            style_config?: {
                 [key: string]: unknown;
             } | null;
             /**
@@ -6291,26 +6275,42 @@ export interface components {
              * @default true
              */
             visible: boolean;
+            /** Filter */
+            filter?: unknown[] | {
+                [key: string]: unknown;
+            } | null;
+            /** Label Config */
+            label_config?: {
+                [key: string]: unknown;
+            } | null;
+            /** Style Config */
+            style_config?: {
+                [key: string]: unknown;
+            } | null;
+            /** Paint */
+            paint?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** ChatRequest */
         ChatRequest: {
-            /** History */
-            history?: components["schemas"]["ChatHistoryMessage"][];
-            /** Language */
-            language?: string | null;
-            /** Layers */
-            layers: components["schemas"]["ChatMapLayer"][];
-            /** Map Id */
-            map_id: string;
             /** Message */
             message: string;
+            /** Map Id */
+            map_id: string;
+            /** Layers */
+            layers: components["schemas"]["ChatMapLayer"][];
+            /** Language */
+            language?: string | null;
+            /** History */
+            history?: components["schemas"]["ChatHistoryMessage"][];
         };
         /** ChatResponse */
         ChatResponse: {
-            /** Actions */
-            actions: components["schemas"]["ChatAction"][];
             /** Explanation */
             explanation: string;
+            /** Actions */
+            actions: components["schemas"]["ChatAction"][];
         };
         /** CollectionAddDatasetsRequest */
         CollectionAddDatasetsRequest: {
@@ -6323,29 +6323,29 @@ export interface components {
         /** CollectionCreate */
         CollectionCreate: {
             /**
-             * Description
-             * @description Optional text description
-             * @example Datasets from the NYC Open Data portal
-             */
-            description?: string | null;
-            /**
              * Name
              * @description Display name for the collection
              * @example NYC Open Data
              */
             name: string;
+            /**
+             * Description
+             * @description Optional text description
+             * @example Datasets from the NYC Open Data portal
+             */
+            description?: string | null;
         };
         /**
          * CollectionFacetItem
          * @description A collection facet entry.
          */
         CollectionFacetItem: {
-            /** Dataset Count */
-            dataset_count: number;
             /** Id */
             id: string;
             /** Name */
             name: string;
+            /** Dataset Count */
+            dataset_count: number;
         };
         /** CollectionListResponse */
         CollectionListResponse: {
@@ -6370,47 +6370,47 @@ export interface components {
         /** CollectionResponse */
         CollectionResponse: {
             /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Created By */
-            created_by: string | null;
-            /** Dataset Count */
-            dataset_count: number;
-            /** Description */
-            description: string | null;
-            /** Extent Bbox */
-            extent_bbox?: number[] | null;
-            /**
              * Id
              * Format: uuid
              */
             id: string;
             /** Name */
             name: string;
-            /** Temporal End */
-            temporal_end?: string | null;
-            /** Temporal Start */
-            temporal_start?: string | null;
+            /** Description */
+            description: string | null;
+            /** Created By */
+            created_by: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
             /**
              * Updated At
              * Format: date-time
              */
             updated_at: string;
+            /** Dataset Count */
+            dataset_count: number;
+            /** Extent Bbox */
+            extent_bbox?: number[] | null;
+            /** Temporal Start */
+            temporal_start?: string | null;
+            /** Temporal End */
+            temporal_end?: string | null;
         };
         /** CollectionUpdate */
         CollectionUpdate: {
-            /**
-             * Description
-             * @description Updated description
-             */
-            description?: string | null;
             /**
              * Name
              * @description Updated display name
              */
             name?: string | null;
+            /**
+             * Description
+             * @description Updated description
+             */
+            description?: string | null;
         };
         /** ColumnChange */
         ColumnChange: {
@@ -6450,12 +6450,12 @@ export interface components {
         ColumnDdlFeedResponse: {
             /** Items */
             items: components["schemas"]["ColumnDdlEntry"][];
+            /** Total */
+            total: number;
             /** Limit */
             limit: number;
             /** Offset */
             offset: number;
-            /** Total */
-            total: number;
         };
         /** ColumnDef */
         ColumnDef: {
@@ -6479,20 +6479,20 @@ export interface components {
          * @description Describes a single column in a dataset's attribute table.
          */
         ColumnInfo: {
-            /** Domain Type */
-            domain_type?: string | null;
             /** Name */
             name: string;
-            /** Sample Values */
-            sample_values?: unknown[] | null;
+            /** Type */
+            type: string;
             /** Semantic Role */
             semantic_role?: string | null;
+            /** Domain Type */
+            domain_type?: string | null;
+            /** Sample Values */
+            sample_values?: unknown[] | null;
             /** Stats */
             stats?: {
                 [key: string]: unknown;
             } | null;
-            /** Type */
-            type: string;
         };
         /** ColumnListResponse */
         ColumnListResponse: {
@@ -6521,11 +6521,24 @@ export interface components {
         };
         /** ColumnStatsResponse */
         ColumnStatsResponse: {
+            /** Min */
+            min?: number | null;
+            /** Max */
+            max?: number | null;
             /**
              * Count
              * @default 0
              */
             count: number;
+            /** Mean */
+            mean?: number | null;
+            /**
+             * Quantiles
+             * @default []
+             */
+            quantiles: number[];
+            /** Stddev */
+            stddev?: number | null;
             /**
              * Data Type
              * @description 'categorical' for non-numeric columns; null for numeric.
@@ -6536,26 +6549,13 @@ export interface components {
              * @description Distinct non-null value count (categorical columns only).
              */
             distinct_count?: number | null;
-            /** Max */
-            max?: number | null;
-            /** Mean */
-            mean?: number | null;
-            /** Min */
-            min?: number | null;
-            /**
-             * Quantiles
-             * @default []
-             */
-            quantiles: number[];
-            /** Stddev */
-            stddev?: number | null;
         };
         /** ColumnValuesResponse */
         ColumnValuesResponse: {
-            /** Count */
-            count: number;
             /** Values */
             values: (string | number | null)[];
+            /** Count */
+            count: number;
         };
         /**
          * CommitRequest
@@ -6578,60 +6578,15 @@ export interface components {
          */
         CommitRequest: {
             /**
-             * Compression
-             * @description Raster only: target compression for COG output (e.g. 'LZW', 'DEFLATE').
-             */
-            compression?: string | null;
-            /**
-             * Geom Column
-             * @description CSV/Excel only: name of the WKT geometry column (alternative to x_column/y_column).
-             */
-            geom_column?: string | null;
-            /**
-             * Layer Name
-             * @description Multi-layer source only: name of the specific layer to ingest.
-             */
-            layer_name?: string | null;
-            /**
-             * Nodata Override
-             * @description Raster only: nodata value to use when source has none defined.
-             */
-            nodata_override?: number | string | null;
-            /**
-             * Resampling
-             * @description Raster only: resampling method for COG conversion (e.g. 'nearest', 'bilinear', 'cubic').
-             */
-            resampling?: string | null;
-            /**
-             * Srid Override
-             * @description EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.
-             */
-            srid_override?: number | null;
-            /**
-             * Summary
-             * @description Optional dataset description shown in the catalog.
-             */
-            summary?: string | null;
-            /**
-             * Temporal End
-             * @description ISO 8601 end of the dataset's temporal extent.
-             */
-            temporal_end?: string | null;
-            /**
-             * Temporal Start
-             * @description ISO 8601 start of the dataset's temporal extent.
-             */
-            temporal_start?: string | null;
-            /**
              * Title
              * @description Human-readable dataset title.
              */
             title: string;
             /**
-             * Token
-             * @description Optional confirmation token returned by the preview step. Required for some workflows.
+             * Summary
+             * @description Optional dataset description shown in the catalog.
              */
-            token?: string | null;
+            summary?: string | null;
             /**
              * Visibility
              * @description Dataset visibility level: 'private' (owner-only), 'restricted' (RBAC-controlled), 'internal' (all users), 'public' (anonymous access).
@@ -6639,6 +6594,46 @@ export interface components {
              * @enum {string}
              */
             visibility: "private" | "restricted" | "internal" | "public";
+            /**
+             * Srid Override
+             * @description EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.
+             */
+            srid_override?: number | null;
+            /**
+             * Token
+             * @description Optional confirmation token returned by the preview step. Required for some workflows.
+             */
+            token?: string | null;
+            /**
+             * Temporal Start
+             * @description ISO 8601 start of the dataset's temporal extent.
+             */
+            temporal_start?: string | null;
+            /**
+             * Temporal End
+             * @description ISO 8601 end of the dataset's temporal extent.
+             */
+            temporal_end?: string | null;
+            /**
+             * Compression
+             * @description Raster only: target compression for COG output (e.g. 'LZW', 'DEFLATE').
+             */
+            compression?: string | null;
+            /**
+             * Resampling
+             * @description Raster only: resampling method for COG conversion (e.g. 'nearest', 'bilinear', 'cubic').
+             */
+            resampling?: string | null;
+            /**
+             * Nodata Override
+             * @description Raster only: nodata value to use when source has none defined.
+             */
+            nodata_override?: number | string | null;
+            /**
+             * Layer Name
+             * @description Multi-layer source only: name of the specific layer to ingest.
+             */
+            layer_name?: string | null;
             /**
              * X Column
              * @description CSV/Excel only: name of the longitude/X coordinate column.
@@ -6649,6 +6644,11 @@ export interface components {
              * @description CSV/Excel only: name of the latitude/Y coordinate column.
              */
             y_column?: string | null;
+            /**
+             * Geom Column
+             * @description CSV/Excel only: name of the WKT geometry column (alternative to x_column/y_column).
+             */
+            geom_column?: string | null;
         };
         /** CommitResponse */
         CommitResponse: {
@@ -6659,15 +6659,15 @@ export interface components {
              */
             job_id: string;
             /**
-             * Message
-             * @description Human-readable commit result.
-             */
-            message: string;
-            /**
              * Status
              * @description Updated job status after commit.
              */
             status: string;
+            /**
+             * Message
+             * @description Human-readable commit result.
+             */
+            message: string;
         };
         /**
          * ConfigImportRequest
@@ -6675,19 +6675,19 @@ export interface components {
          */
         ConfigImportRequest: {
             /**
-             * Oauth Providers
-             * @description Optional OAuth providers to import. Client secrets must be re-supplied via the admin UI after import.
-             */
-            oauth_providers?: {
-                [key: string]: unknown;
-            }[] | null;
-            /**
              * Settings
              * @description Optional settings to import. Omit to import only OAuth providers.
              */
             settings?: {
                 [key: string]: unknown;
             } | null;
+            /**
+             * Oauth Providers
+             * @description Optional OAuth providers to import. Client secrets must be re-supplied via the admin UI after import.
+             */
+            oauth_providers?: {
+                [key: string]: unknown;
+            }[] | null;
         };
         /**
          * ConfigModeResponse
@@ -6703,22 +6703,33 @@ export interface components {
         /** ConfigResponse */
         ConfigResponse: {
             /**
+             * Registration Enabled
+             * @description Whether self-service registration is open
+             */
+            registration_enabled: boolean;
+            /**
              * Allow Signup
              * @description Whether self-serve registration is open. Alias for registration_enabled; login UI uses this to show/hide the signup link.
              * @default false
              */
             allow_signup: boolean;
             /**
+             * Email Verification Required
+             * @description When true, new self-registered users must verify their email before logging in. Default false for back-compat-safe parsing by older clients.
+             * @default false
+             */
+            email_verification_required: boolean;
+            /**
              * Auth Methods
              * @description Auth methods contributed by the active AuthExtension. Empty by default; compatible deployments may add methods such as ['saml']. Login UI can render conditional sign-in options without needing admin OAuthProvider access.
              */
             auth_methods?: string[];
             /**
-             * Banner Color
-             * @description Theme token for the site banner color: warning | info | success | destructive.
-             * @default warning
+             * Landing First
+             * @description When true, unauthenticated visits to '/' are redirected to '/login' as the product landing page. Default false (search catalog is the root).
+             * @default false
              */
-            banner_color: string;
+            landing_first: boolean;
             /**
              * Banner Enabled
              * @description When true and banner_text is non-empty, the site-wide announcement banner is shown. Default false.
@@ -6732,28 +6743,17 @@ export interface components {
              */
             banner_text: string;
             /**
-             * Email Verification Required
-             * @description When true, new self-registered users must verify their email before logging in. Default false for back-compat-safe parsing by older clients.
-             * @default false
+             * Banner Color
+             * @description Theme token for the site banner color: warning | info | success | destructive.
+             * @default warning
              */
-            email_verification_required: boolean;
-            /**
-             * Landing First
-             * @description When true, unauthenticated visits to '/' are redirected to '/login' as the product landing page. Default false (search catalog is the root).
-             * @default false
-             */
-            landing_first: boolean;
+            banner_color: string;
             /**
              * Password Login Enabled
              * @description When false, password login is disabled for users without manage_settings. Default true for back-compat-safe parsing by older clients.
              * @default true
              */
             password_login_enabled: boolean;
-            /**
-             * Registration Enabled
-             * @description Whether self-service registration is open
-             */
-            registration_enabled: boolean;
         };
         /** ConformanceResponse */
         ConformanceResponse: {
@@ -6768,6 +6768,8 @@ export interface components {
          * @description Aggregate connectivity validation result.
          */
         ConnectivityResult: {
+            /** @description Object storage probe result. */
+            storage: components["schemas"]["ServiceProbeResult"];
             /** @description Cache backend probe result. */
             cache: components["schemas"]["ServiceProbeResult"];
             /**
@@ -6777,22 +6779,20 @@ export interface components {
             oidc_providers: {
                 [key: string]: components["schemas"]["ServiceProbeResult"];
             };
-            /** @description Object storage probe result. */
-            storage: components["schemas"]["ServiceProbeResult"];
         };
         /**
          * ConnectorDefinitionResponse
          * @description Public, non-secret connector capabilities advertised by an overlay.
          */
         ConnectorDefinitionResponse: {
+            /** Name */
+            name: string;
+            /** Display Name */
+            display_name: string;
             /** Config Schema */
             config_schema: {
                 [key: string]: unknown;
             };
-            /** Display Name */
-            display_name: string;
-            /** Name */
-            name: string;
             /**
              * Supports Credentials
              * @default false
@@ -6806,12 +6806,12 @@ export interface components {
         };
         /** ConnectorDiscoverRequest */
         ConnectorDiscoverRequest: {
+            /** Credential Id */
+            credential_id?: string | null;
             /** Config */
             config?: {
                 [key: string]: unknown;
             };
-            /** Credential Id */
-            credential_id?: string | null;
         };
         /** ConnectorDiscoverResponse */
         ConnectorDiscoverResponse: {
@@ -6820,12 +6820,12 @@ export interface components {
         };
         /** ConnectorIngestRequest */
         ConnectorIngestRequest: {
+            /** Credential Id */
+            credential_id?: string | null;
             /** Config */
             config?: {
                 [key: string]: unknown;
             };
-            /** Credential Id */
-            credential_id?: string | null;
             /**
              * Resource Id
              * @description API-safe opaque handle returned by connector discovery.
@@ -6858,19 +6858,30 @@ export interface components {
              * @description API-safe opaque resource handle. This is never a provider URL, signed locator, or credential.
              */
             id: string;
+            /** Name */
+            name: string;
             /** Kind */
             kind: string;
             /** Metadata */
             metadata?: {
                 [key: string]: unknown;
             };
-            /** Name */
-            name: string;
         };
         /** ContactCreate */
         ContactCreate: {
+            /**
+             * Role
+             * @description ISO CI_RoleCode, e.g. pointOfContact, author
+             */
+            role: string;
+            /** Name */
+            name?: string | null;
             /** Email */
             email?: string | null;
+            /** Organization */
+            organization?: string | null;
+            /** Phone */
+            phone?: string | null;
             /**
              * Extra Json
              * @description Arbitrary extra fields stored as JSON
@@ -6878,17 +6889,6 @@ export interface components {
             extra_json?: {
                 [key: string]: unknown;
             } | null;
-            /** Name */
-            name?: string | null;
-            /** Organization */
-            organization?: string | null;
-            /** Phone */
-            phone?: string | null;
-            /**
-             * Role
-             * @description ISO CI_RoleCode, e.g. pointOfContact, author
-             */
-            role: string;
             /**
              * Sort Order
              * @description Display ordering (lower first)
@@ -6905,23 +6905,11 @@ export interface components {
         };
         /** ContactResponse */
         ContactResponse: {
-            /** Email */
-            email: string | null;
-            /** Extra Json */
-            extra_json: {
-                [key: string]: unknown;
-            } | null;
             /**
              * Id
              * Format: uuid
              */
             id: string;
-            /** Name */
-            name: string | null;
-            /** Organization */
-            organization: string | null;
-            /** Phone */
-            phone: string | null;
             /**
              * Record Id
              * Format: uuid
@@ -6929,42 +6917,55 @@ export interface components {
             record_id: string;
             /** Role */
             role: string;
+            /** Name */
+            name: string | null;
+            /** Email */
+            email: string | null;
+            /** Organization */
+            organization: string | null;
+            /** Phone */
+            phone: string | null;
+            /** Extra Json */
+            extra_json: {
+                [key: string]: unknown;
+            } | null;
             /** Sort Order */
             sort_order: number;
         };
         /** ContactUpdate */
         ContactUpdate: {
-            /** Email */
-            email?: string | null;
-            /** Extra Json */
-            extra_json?: {
-                [key: string]: unknown;
-            } | null;
+            /** Role */
+            role?: string | null;
             /** Name */
             name?: string | null;
+            /** Email */
+            email?: string | null;
             /** Organization */
             organization?: string | null;
             /** Phone */
             phone?: string | null;
-            /** Role */
-            role?: string | null;
+            /** Extra Json */
+            extra_json?: {
+                [key: string]: unknown;
+            } | null;
             /** Sort Order */
             sort_order?: number | null;
         };
         /** CreateEmptyDatasetRequest */
         CreateEmptyDatasetRequest: {
-            /** Columns */
-            columns: components["schemas"]["ColumnDefinition"][];
             /** Title */
             title: string;
+            /** Columns */
+            columns: components["schemas"]["ColumnDefinition"][];
         };
         /** CreateLayerRequest */
         CreateLayerRequest: {
             /**
-             * Columns
-             * @description Optional initial column definitions
+             * Title
+             * @description Display name for the new layer
+             * @example Survey Points
              */
-            columns?: components["schemas"]["ColumnDef"][] | null;
+            title: string;
             /**
              * Geometry Type
              * @description OGC geometry type: Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon
@@ -6977,30 +6978,13 @@ export interface components {
              */
             summary?: string | null;
             /**
-             * Title
-             * @description Display name for the new layer
-             * @example Survey Points
+             * Columns
+             * @description Optional initial column definitions
              */
-            title: string;
+            columns?: components["schemas"]["ColumnDef"][] | null;
         };
         /** CreateLayerResponse */
         CreateLayerResponse: {
-            /**
-             * Created At
-             * Format: date-time
-             * @description Creation timestamp
-             */
-            created_at: string;
-            /**
-             * Feature Count
-             * @description Number of features (0 for new layers)
-             */
-            feature_count: number;
-            /**
-             * Geometry Type
-             * @description OGC geometry type
-             */
-            geometry_type: string;
             /**
              * Id
              * Format: uuid
@@ -7008,20 +6992,36 @@ export interface components {
              */
             id: string;
             /**
-             * Table Name
-             * @description PostGIS table name in the data schema
-             */
-            table_name: string;
-            /**
              * Title
              * @description Display name
              */
             title: string;
             /**
+             * Table Name
+             * @description PostGIS table name in the data schema
+             */
+            table_name: string;
+            /**
+             * Geometry Type
+             * @description OGC geometry type
+             */
+            geometry_type: string;
+            /**
+             * Feature Count
+             * @description Number of features (0 for new layers)
+             */
+            feature_count: number;
+            /**
              * Visibility
              * @description Visibility level: private, internal, or public
              */
             visibility: string;
+            /**
+             * Created At
+             * Format: date-time
+             * @description Creation timestamp
+             */
+            created_at: string;
         };
         /**
          * DatasetChatRequest
@@ -7031,14 +7031,14 @@ export interface components {
          *     authoritatively from the DB — the client only names the dataset.
          */
         DatasetChatRequest: {
-            /** Dataset Id */
-            dataset_id: string;
-            /** History */
-            history?: components["schemas"]["ChatHistoryMessage"][];
-            /** Language */
-            language?: string | null;
             /** Message */
             message: string;
+            /** Dataset Id */
+            dataset_id: string;
+            /** Language */
+            language?: string | null;
+            /** History */
+            history?: components["schemas"]["ChatHistoryMessage"][];
         };
         /** DatasetDeleteRequest */
         DatasetDeleteRequest: {
@@ -7068,35 +7068,58 @@ export interface components {
          *     }
          */
         DatasetMeta: {
-            /** Access Constraints */
-            access_constraints?: string | null;
+            /** Title */
+            title?: string | null;
+            /** Summary */
+            summary?: string | null;
             /**
-             * Data Vintage End
-             * @description End of temporal coverage
+             * Visibility
+             * @description Access level: private, restricted, internal, or public
              */
-            data_vintage_end?: string | null;
+            visibility?: ("private" | "restricted" | "internal" | "public") | null;
+            /** License */
+            license?: string | null;
+            /** Source Organization */
+            source_organization?: string | null;
             /**
              * Data Vintage Start
              * @description Start of temporal coverage
              */
             data_vintage_start?: string | null;
             /**
-             * Is Dem
-             * @description Flag raster as a Digital Elevation Model for terrain rendering
+             * Data Vintage End
+             * @description End of temporal coverage
              */
-            is_dem?: boolean | null;
-            /**
-             * Language
-             * @description BCP 47 primary language tag, e.g. en, fr, or pt-BR
-             */
-            language?: string | null;
-            /** License */
-            license?: string | null;
+            data_vintage_end?: string | null;
             /**
              * Lineage Summary
              * @description Free-text provenance / lineage statement
              */
             lineage_summary?: string | null;
+            /**
+             * Update Frequency
+             * @description ISO maintenance frequency code
+             */
+            update_frequency?: string | null;
+            /** Usage Constraints */
+            usage_constraints?: string | null;
+            /** Access Constraints */
+            access_constraints?: string | null;
+            /**
+             * Sensitivity Classification
+             * @description e.g. public, confidential, restricted
+             */
+            sensitivity_classification?: string | null;
+            /**
+             * Theme Category
+             * @description ISO topic category codes
+             */
+            theme_category?: string[] | null;
+            /**
+             * Record Status
+             * @description Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
+             */
+            record_status?: string | null;
             /**
              * Owner Org
              * @description Owning organization name
@@ -7105,56 +7128,34 @@ export interface components {
             /** Quality Statement */
             quality_statement?: string | null;
             /**
-             * Record Status
-             * @description Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
-             */
-            record_status?: string | null;
-            /**
-             * Sensitivity Classification
-             * @description e.g. public, confidential, restricted
-             */
-            sensitivity_classification?: string | null;
-            /** Source Organization */
-            source_organization?: string | null;
-            /**
              * Source Url
              * @description URL the data was originally fetched from
              */
             source_url?: string | null;
-            /** Summary */
-            summary?: string | null;
             /**
-             * Theme Category
-             * @description ISO topic category codes
+             * Language
+             * @description BCP 47 primary language tag, e.g. en, fr, or pt-BR
              */
-            theme_category?: string[] | null;
+            language?: string | null;
+            /**
+             * Is Dem
+             * @description Flag raster as a Digital Elevation Model for terrain rendering
+             */
+            is_dem?: boolean | null;
             /**
              * Tile Columns
              * @description Ordered vector-tile property allowlist; null restores zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.
              */
             tile_columns?: string[] | null;
-            /** Title */
-            title?: string | null;
-            /**
-             * Update Frequency
-             * @description ISO maintenance frequency code
-             */
-            update_frequency?: string | null;
-            /** Usage Constraints */
-            usage_constraints?: string | null;
-            /**
-             * Visibility
-             * @description Access level: private, restricted, internal, or public
-             */
-            visibility?: ("private" | "restricted" | "internal" | "public") | null;
         };
         /** DatasetRelationshipCreate */
         DatasetRelationshipCreate: {
             /**
-             * Label
-             * @description Optional display label for this relationship
+             * Target Dataset Id
+             * Format: uuid
+             * @description UUID of the dataset to link to
              */
-            label?: string | null;
+            target_dataset_id: string;
             /**
              * Source Column
              * @description Join column in the source dataset
@@ -7167,11 +7168,10 @@ export interface components {
              */
             target_column: string;
             /**
-             * Target Dataset Id
-             * Format: uuid
-             * @description UUID of the dataset to link to
+             * Label
+             * @description Optional display label for this relationship
              */
-            target_dataset_id: string;
+            label?: string | null;
         };
         /**
          * DatasetRelationshipListResponse
@@ -7195,72 +7195,54 @@ export interface components {
              * Format: uuid
              */
             id: string;
-            /** Label */
-            label: string | null;
-            /** Relationship Type */
-            relationship_type: string;
-            /** Source Column */
-            source_column: string;
             /**
              * Source Dataset Id
              * Format: uuid
              */
             source_dataset_id: string;
-            /** Target Column */
-            target_column: string;
             /**
              * Target Dataset Id
              * Format: uuid
              */
             target_dataset_id: string;
+            /** Source Column */
+            source_column: string;
+            /** Target Column */
+            target_column: string;
+            /** Relationship Type */
+            relationship_type: string;
+            /** Label */
+            label: string | null;
             /** Target Dataset Title */
             target_dataset_title?: string | null;
         };
         /** DatasetResponse */
         DatasetResponse: {
-            /** Access Constraints */
-            access_constraints?: string | null;
-            /** Collections */
-            collections?: components["schemas"]["CollectionRef"][] | null;
             /**
-             * Column Info
-             * @description Column names, types, and stats
+             * Id
+             * Format: uuid
              */
-            column_info?: components["schemas"]["ColumnInfo"][] | null;
+            id: string;
             /**
-             * Created At
-             * Format: date-time
+             * Record Id
+             * Format: uuid
+             * @description Parent catalog record UUID
              */
-            created_at: string;
-            /** Created By */
-            created_by: string | null;
-            /** Created By Display */
-            created_by_display: string;
+            record_id: string;
             /**
-             * Current Version
-             * @description Monotonic version counter
-             * @default 1
+             * Table Name
+             * @description Internal PostGIS table name
              */
-            current_version: number;
+            table_name: string;
+            /** Title */
+            title: string;
+            /** Summary */
+            summary: string | null;
             /**
-             * Data Vintage End
-             * @description End of temporal coverage
+             * Srid
+             * @description Current EPSG SRID of stored geometry
              */
-            data_vintage_end?: string | null;
-            /**
-             * Data Vintage Start
-             * @description Start of temporal coverage
-             */
-            data_vintage_start?: string | null;
-            /** @description Provenance for an analysis output. Null for a dataset that was not derived, and also for a requester who cannot access the source dataset — the two are deliberately indistinguishable. */
-            derived_from?: components["schemas"]["DerivedFromResponse"] | null;
-            /**
-             * Extent Bbox
-             * @description Bounding box [west, south, east, north] per RFC 7946 §5.2. west > east on an antimeridian-crossing extent.
-             */
-            extent_bbox?: number[] | null;
-            /** Feature Count */
-            feature_count: number | null;
+            srid?: number | null;
             /**
              * Geometry Type
              * @description OGC geometry type, e.g. MultiPolygon
@@ -7273,56 +7255,91 @@ export interface components {
              */
             has_generic_geometry: boolean;
             /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /**
              * Is 3D
              * @description True if geometry has Z dimension
              */
             is_3d?: boolean | null;
-            /**
-             * Language
-             * @description ISO 639-1 language code, e.g. en, fr
-             */
-            language?: string | null;
-            /**
-             * Last Checked At
-             * @description Last time GeoLens contacted the origin at all, whether the attempt succeeded or failed
-             */
-            last_checked_at?: string | null;
-            /** Last Edited At */
-            last_edited_at?: string | null;
-            /** Last Edited By Display */
-            last_edited_by_display?: string | null;
-            /**
-             * Last Refreshed At
-             * @description Last committed successful refresh — not the last attempt
-             */
-            last_refreshed_at?: string | null;
-            /** License */
-            license?: string | null;
-            /**
-             * Lineage Summary
-             * @description Free-text provenance / lineage statement
-             */
-            lineage_summary?: string | null;
-            /**
-             * Metadata Warnings
-             * @description Advisory warnings produced by a metadata update — e.g. a visibility or status change exposing keywords inherited from an analysis source the new audience cannot open (feat #1070). Only ever set on the PATCH response; the change has already applied.
-             */
-            metadata_warnings?: string[] | null;
             /**
              * N Dims
              * @description Number of coordinate dimensions (2, 3, or 4)
              */
             n_dims?: number | null;
             /**
+             * Z Min
+             * @description Minimum Z value across all features
+             */
+            z_min?: number | null;
+            /**
+             * Z Max
+             * @description Maximum Z value across all features
+             */
+            z_max?: number | null;
+            /** Feature Count */
+            feature_count: number | null;
+            /**
+             * Extent Bbox
+             * @description Bounding box [west, south, east, north] per RFC 7946 §5.2. west > east on an antimeridian-crossing extent.
+             */
+            extent_bbox?: number[] | null;
+            /**
+             * Column Info
+             * @description Column names, types, and stats
+             */
+            column_info?: components["schemas"]["ColumnInfo"][] | null;
+            /** License */
+            license?: string | null;
+            /** Source Organization */
+            source_organization?: string | null;
+            /**
+             * Data Vintage Start
+             * @description Start of temporal coverage
+             */
+            data_vintage_start?: string | null;
+            /**
+             * Data Vintage End
+             * @description End of temporal coverage
+             */
+            data_vintage_end?: string | null;
+            /** @description Automated quality assessment results */
+            quality_detail?: components["schemas"]["QualityDetail"] | null;
+            /**
+             * Source Format
+             * @description Original file format, e.g. GPKG, SHP
+             */
+            source_format?: string | null;
+            /** Source Filename */
+            source_filename: string | null;
+            /**
+             * Tile Columns
+             * @description Ordered vector-tile property allowlist; null uses zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.
+             */
+            tile_columns?: string[] | null;
+            /**
+             * Original Srid
+             * @description EPSG SRID of the uploaded source file
+             */
+            original_srid?: number | null;
+            /**
+             * Current Version
+             * @description Monotonic version counter
+             * @default 1
+             */
+            current_version: number;
+            /**
+             * Source Url
+             * @description URL the data was originally fetched from
+             */
+            source_url?: string | null;
+            /**
              * Origin
              * @description How the data entered the catalog: upload, postgis, service, stac, or created. Computed from source_format and record_type, not stored; null for collections and VRTs, which have no origin of their own.
              */
             origin?: string | null;
+            /**
+             * Origin Uri
+             * @description Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.
+             */
+            origin_uri?: string | null;
             /**
              * Origin Ref
              * @description Typed per-origin payload with a `kind` discriminator, e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials.
@@ -7331,64 +7348,15 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * Origin Uri
-             * @description Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.
+             * Last Refreshed At
+             * @description Last committed successful refresh — not the last attempt
              */
-            origin_uri?: string | null;
+            last_refreshed_at?: string | null;
             /**
-             * Original Srid
-             * @description EPSG SRID of the uploaded source file
+             * Last Checked At
+             * @description Last time GeoLens contacted the origin at all, whether the attempt succeeded or failed
              */
-            original_srid?: number | null;
-            /**
-             * Owner Org
-             * @description Owning organization name
-             */
-            owner_org?: string | null;
-            /** Published At */
-            published_at?: string | null;
-            /** @description Automated quality assessment results */
-            quality_detail?: components["schemas"]["QualityDetail"] | null;
-            /** Quality Statement */
-            quality_statement?: string | null;
-            /** @description Raster-specific metadata (null for vectors) */
-            raster?: components["schemas"]["RasterMetadata"] | null;
-            /**
-             * Record Id
-             * Format: uuid
-             * @description Parent catalog record UUID
-             */
-            record_id: string;
-            /**
-             * Record Status
-             * @description Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
-             * @default draft
-             */
-            record_status: string;
-            /**
-             * Record Type
-             * @description Record type: 'vector_dataset' (spatial features), 'raster_dataset' (single COG), 'vrt_dataset' (VRT mosaic), 'table' (non-spatial tabular), 'map' (saved map), 'service' (catalogued remote service), 'collection' (flat dataset group).
-             * @default vector_dataset
-             */
-            record_type: string;
-            /**
-             * Schema Drift Status
-             * @description none, drifted, or unknown. Set at refresh commit from the schema diff; 'unknown' until a refresh has run.
-             * @default unknown
-             */
-            schema_drift_status: string;
-            /**
-             * Sensitivity Classification
-             * @description e.g. public, confidential, restricted
-             */
-            sensitivity_classification?: string | null;
-            /** Source Filename */
-            source_filename: string | null;
-            /**
-             * Source Format
-             * @description Original file format, e.g. GPKG, SHP
-             */
-            source_format?: string | null;
+            last_checked_at?: string | null;
             /**
              * Source Health
              * @description healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an origin kind with nothing to probe.
@@ -7400,18 +7368,88 @@ export interface components {
              * @description Short redacted reason for a non-healthy state
              */
             source_health_detail?: string | null;
-            /** Source Organization */
-            source_organization?: string | null;
             /**
-             * Source Url
-             * @description URL the data was originally fetched from
+             * Schema Drift Status
+             * @description none, drifted, or unknown. Set at refresh commit from the schema diff; 'unknown' until a refresh has run.
+             * @default unknown
              */
-            source_url?: string | null;
+            schema_drift_status: string;
+            /** Quality Statement */
+            quality_statement?: string | null;
             /**
-             * Srid
-             * @description Current EPSG SRID of stored geometry
+             * Visibility
+             * @description Access level: private, restricted, internal, public
              */
-            srid?: number | null;
+            visibility: string;
+            /** Created By */
+            created_by: string | null;
+            /** Created By Display */
+            created_by_display: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Last Edited By Display */
+            last_edited_by_display?: string | null;
+            /** Last Edited At */
+            last_edited_at?: string | null;
+            /** Collections */
+            collections?: components["schemas"]["CollectionRef"][] | null;
+            /**
+             * Record Status
+             * @description Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
+             * @default draft
+             */
+            record_status: string;
+            /**
+             * Lineage Summary
+             * @description Free-text provenance / lineage statement
+             */
+            lineage_summary?: string | null;
+            /** @description Provenance for an analysis output. Null for a dataset that was not derived, and also for a requester who cannot access the source dataset — the two are deliberately indistinguishable. */
+            derived_from?: components["schemas"]["DerivedFromResponse"] | null;
+            /**
+             * Update Frequency
+             * @description ISO maintenance frequency code
+             */
+            update_frequency?: string | null;
+            /** Usage Constraints */
+            usage_constraints?: string | null;
+            /** Access Constraints */
+            access_constraints?: string | null;
+            /**
+             * Sensitivity Classification
+             * @description e.g. public, confidential, restricted
+             */
+            sensitivity_classification?: string | null;
+            /**
+             * Theme Category
+             * @description ISO topic category codes
+             */
+            theme_category?: string[] | null;
+            /**
+             * Owner Org
+             * @description Owning organization name
+             */
+            owner_org?: string | null;
+            /** Published At */
+            published_at?: string | null;
+            /** Updated By */
+            updated_by?: string | null;
+            /**
+             * Record Type
+             * @description Record type: 'vector_dataset' (spatial features), 'raster_dataset' (single COG), 'vrt_dataset' (VRT mosaic), 'table' (non-spatial tabular), 'map' (saved map), 'service' (catalogued remote service), 'collection' (flat dataset group).
+             * @default vector_dataset
+             */
+            record_type: string;
+            /** @description Raster-specific metadata (null for vectors) */
+            raster?: components["schemas"]["RasterMetadata"] | null;
             /**
              * Stac Assets
              * @description STAC-style asset dictionary
@@ -7421,131 +7459,93 @@ export interface components {
             } | null;
             /** Stac Extensions */
             stac_extensions?: string[] | null;
-            /** Summary */
-            summary: string | null;
             /**
-             * Table Name
-             * @description Internal PostGIS table name
+             * Language
+             * @description ISO 639-1 language code, e.g. en, fr
              */
-            table_name: string;
+            language?: string | null;
             /**
-             * Theme Category
-             * @description ISO topic category codes
+             * Metadata Warnings
+             * @description Advisory warnings produced by a metadata update — e.g. a visibility or status change exposing keywords inherited from an analysis source the new audience cannot open (feat #1070). Only ever set on the PATCH response; the change has already applied.
              */
-            theme_category?: string[] | null;
-            /**
-             * Tile Columns
-             * @description Ordered vector-tile property allowlist; null uses zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.
-             */
-            tile_columns?: string[] | null;
-            /** Title */
-            title: string;
-            /**
-             * Update Frequency
-             * @description ISO maintenance frequency code
-             */
-            update_frequency?: string | null;
-            /**
-             * Updated At
-             * Format: date-time
-             */
-            updated_at: string;
-            /** Updated By */
-            updated_by?: string | null;
-            /** Usage Constraints */
-            usage_constraints?: string | null;
-            /**
-             * Visibility
-             * @description Access level: private, restricted, internal, public
-             */
-            visibility: string;
-            /**
-             * Z Max
-             * @description Maximum Z value across all features
-             */
-            z_max?: number | null;
-            /**
-             * Z Min
-             * @description Minimum Z value across all features
-             */
-            z_min?: number | null;
+            metadata_warnings?: string[] | null;
         };
         /** DatasetRowsResponse */
         DatasetRowsResponse: {
+            /** Columns */
+            columns: components["schemas"]["ColumnChange"][];
+            /** Rows */
+            rows: {
+                [key: string]: unknown;
+            }[];
             /**
              * Approximate Total
              * @description Estimated total row count (may use pg stats)
              */
             approximate_total: number;
-            /** Columns */
-            columns: components["schemas"]["ColumnChange"][];
             /**
              * Next Cursor
              * @description Cursor value for the next page, null if last
              */
             next_cursor?: number | null;
-            /** Rows */
-            rows: {
-                [key: string]: unknown;
-            }[];
         };
         /** DatasetVersionListResponse */
         DatasetVersionListResponse: {
-            /** Total */
-            total: number;
             /** Versions */
             versions: components["schemas"]["DatasetVersionResponse"][];
+            /** Total */
+            total: number;
         };
         /** DatasetVersionResponse */
         DatasetVersionResponse: {
-            /**
-             * Dataset Id
-             * Format: uuid
-             */
-            dataset_id: string;
-            /** Feature Count */
-            feature_count: number | null;
-            /** File Hash */
-            file_hash: string | null;
-            /** Geometry Type */
-            geometry_type: string | null;
             /**
              * Id
              * Format: uuid
              */
             id: string;
+            /**
+             * Dataset Id
+             * Format: uuid
+             */
+            dataset_id: string;
+            /** Version Number */
+            version_number: number;
             /** Source Filename */
             source_filename: string | null;
             /** Source Format */
             source_format: string | null;
+            /** Feature Count */
+            feature_count: number | null;
             /** Srid */
             srid: number | null;
+            /** Geometry Type */
+            geometry_type: string | null;
+            /** File Hash */
+            file_hash: string | null;
+            /** Uploaded By */
+            uploaded_by: string | null;
             /**
              * Uploaded At
              * Format: date-time
              */
             uploaded_at: string;
-            /** Uploaded By */
-            uploaded_by: string | null;
-            /** Version Number */
-            version_number: number;
         };
         /** DbfTruncationCollisionWarning */
         DbfTruncationCollisionWarning: {
-            /** Details */
-            details: components["schemas"]["DbfTruncationDetail"][];
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             kind: "dbf_truncation_collision";
+            /** Details */
+            details: components["schemas"]["DbfTruncationDetail"][];
         };
         /** DbfTruncationDetail */
         DbfTruncationDetail: {
-            /** Originals */
-            originals: string[];
             /** Truncated */
             truncated: string;
+            /** Originals */
+            originals: string[];
         };
         /**
          * DerivedFromResponse
@@ -7568,11 +7568,6 @@ export interface components {
          */
         DerivedFromResponse: {
             /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /**
              * Dataset Id
              * Format: uuid
              * @description The dataset this one was derived from
@@ -7590,6 +7585,11 @@ export interface components {
             params: {
                 [key: string]: unknown;
             };
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
         };
         /**
          * DetectEmbeddingDimsResponse
@@ -7613,10 +7613,10 @@ export interface components {
         /** DiscoveredTable */
         DiscoveredTable: {
             /**
-             * Estimated Rows
-             * @description PostgreSQL row count estimate from `pg_class.reltuples`.
+             * Table Name
+             * @description PostgreSQL table name in the `data` schema.
              */
-            estimated_rows: number | null;
+            table_name: string;
             /**
              * Geometry Type
              * @description Detected geometry type, or null for non-spatial tables.
@@ -7628,15 +7628,13 @@ export interface components {
              */
             srid: number | null;
             /**
-             * Table Name
-             * @description PostgreSQL table name in the `data` schema.
+             * Estimated Rows
+             * @description PostgreSQL row count estimate from `pg_class.reltuples`.
              */
-            table_name: string;
+            estimated_rows: number | null;
         };
         /** DistributionCreate */
         DistributionCreate: {
-            /** Description */
-            description?: string | null;
             /**
              * Distribution Type
              * @description e.g. download, api, ogc_wms, ogc_wfs
@@ -7648,28 +7646,30 @@ export interface components {
              */
             format: string;
             /**
-             * Is Primary
-             * @description Mark as the preferred distribution
-             * @default false
+             * Url
+             * @description Access URL for this distribution
              */
-            is_primary: boolean;
+            url: string;
+            /** Title */
+            title?: string | null;
+            /** Description */
+            description?: string | null;
+            /**
+             * Protocol
+             * @description Transfer protocol, e.g. HTTPS, OGC:WFS
+             */
+            protocol?: string | null;
             /**
              * Media Type
              * @description IANA media type, e.g. application/geo+json
              */
             media_type?: string | null;
             /**
-             * Protocol
-             * @description Transfer protocol, e.g. HTTPS, OGC:WFS
+             * Is Primary
+             * @description Mark as the preferred distribution
+             * @default false
              */
-            protocol?: string | null;
-            /** Title */
-            title?: string | null;
-            /**
-             * Url
-             * @description Access URL for this distribution
-             */
-            url: string;
+            is_primary: boolean;
         };
         /** DistributionListResponse */
         DistributionListResponse: {
@@ -7681,75 +7681,82 @@ export interface components {
         /** DistributionResponse */
         DistributionResponse: {
             /**
-             * Auto Generated
-             * @description True if created automatically by the system
-             */
-            auto_generated: boolean;
-            /** Description */
-            description: string | null;
-            /** Distribution Type */
-            distribution_type: string;
-            /** Format */
-            format: string | null;
-            /**
              * Id
              * Format: uuid
              */
             id: string;
-            /** Is Primary */
-            is_primary: boolean;
-            /** Media Type */
-            media_type: string | null;
-            /** Protocol */
-            protocol: string | null;
             /**
              * Record Id
              * Format: uuid
              */
             record_id: string;
-            /** Title */
-            title: string | null;
+            /** Distribution Type */
+            distribution_type: string;
+            /** Format */
+            format: string | null;
             /** Url */
             url: string;
+            /** Title */
+            title: string | null;
+            /** Description */
+            description: string | null;
+            /** Protocol */
+            protocol: string | null;
+            /** Media Type */
+            media_type: string | null;
+            /** Is Primary */
+            is_primary: boolean;
+            /**
+             * Auto Generated
+             * @description True if created automatically by the system
+             */
+            auto_generated: boolean;
         };
         /** DistributionUpdate */
         DistributionUpdate: {
-            /** Description */
-            description?: string | null;
             /** Distribution Type */
             distribution_type?: string | null;
             /** Format */
             format?: string | null;
-            /** Is Primary */
-            is_primary?: boolean | null;
-            /** Media Type */
-            media_type?: string | null;
-            /** Protocol */
-            protocol?: string | null;
-            /** Title */
-            title?: string | null;
             /** Url */
             url?: string | null;
+            /** Title */
+            title?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Protocol */
+            protocol?: string | null;
+            /** Media Type */
+            media_type?: string | null;
+            /** Is Primary */
+            is_primary?: boolean | null;
         };
         /** DownloadTokenResponse */
         DownloadTokenResponse: {
+            /**
+             * Token
+             * @description Short-lived download-scoped JWT (typ='download', TTL ≤ 120s)
+             */
+            token: string;
             /**
              * Expires In
              * @description Seconds until the download token expires
              * @default 120
              */
             expires_in: number;
-            /**
-             * Token
-             * @description Short-lived download-scoped JWT (typ='download', TTL ≤ 120s)
-             */
-            token: string;
         };
         /**
          * DryRunResponse
          * @description Result of a dry-run import showing what would change.
          */
         DryRunResponse: {
+            /**
+             * Settings
+             * @description Per-setting diff result keyed by setting name.
+             */
+            settings: {
+                [key: string]: unknown;
+            };
             /**
              * Oauth Providers
              * @description Per-provider diff result keyed by slug.
@@ -7762,42 +7769,41 @@ export interface components {
              * @description Short-lived signed confirmation token required to apply an overwrite. Bound to the normalized payload, overwrite mode, and current configuration state.
              */
             preview_token?: string | null;
-            /**
-             * Settings
-             * @description Per-setting diff result keyed by setting name.
-             */
-            settings: {
-                [key: string]: unknown;
-            };
         };
         /** DuplicateMapResponse */
         DuplicateMapResponse: {
-            basemap_config?: components["schemas"]["BasemapConfig"] | null;
-            /** Basemap Style */
-            basemap_style: string;
-            /** Bearing */
-            bearing: number;
-            /** Center Lat */
-            center_lat: number | null;
-            /** Center Lng */
-            center_lng: number | null;
             /**
-             * Created At
-             * Format: date-time
+             * Id
+             * Format: uuid
              */
-            created_at: string;
-            /** Created By */
-            created_by: string | null;
-            /** Created By Username */
-            created_by_username?: string | null;
+            id: string;
+            /** Name */
+            name: string;
             /** Description */
             description: string | null;
-            /**
-             * Excluded Layer Count
-             * @description Layers skipped due to access restrictions
-             * @default 0
-             */
-            excluded_layer_count: number;
+            /** Notes */
+            notes?: string | null;
+            /** Center Lng */
+            center_lng: number | null;
+            /** Center Lat */
+            center_lat: number | null;
+            /** Zoom */
+            zoom: number | null;
+            /** Bearing */
+            bearing: number;
+            /** Pitch */
+            pitch: number;
+            /** Basemap Style */
+            basemap_style: string;
+            /** Show Basemap Labels */
+            show_basemap_labels: boolean;
+            basemap_config?: components["schemas"]["BasemapConfig"] | null;
+            terrain_config?: components["schemas"]["TerrainConfig"] | null;
+            visibility: components["schemas"]["MapVisibility"];
+            /** Thumbnail Url */
+            thumbnail_url?: string | null;
+            /** Og Image Url */
+            og_image_url?: string | null;
             /**
              * Forked From Id
              * @description Source map UUID if this is a fork
@@ -7805,40 +7811,34 @@ export interface components {
             forked_from_id?: string | null;
             /** Forked From Name */
             forked_from_name?: string | null;
+            /** Created By */
+            created_by: string | null;
+            /** Created By Username */
+            created_by_username?: string | null;
             /**
-             * Id
-             * Format: uuid
+             * Created At
+             * Format: date-time
              */
-            id: string;
-            /** Layer Count */
-            layer_count: number;
-            /** Layers */
-            layers: components["schemas"]["MapLayerResponse"][];
-            /** Legend Title */
-            legend_title?: string | null;
-            /** Name */
-            name: string;
-            /** Notes */
-            notes?: string | null;
-            /** Og Image Url */
-            og_image_url?: string | null;
-            /** Pitch */
-            pitch: number;
-            /** Plugins */
-            plugins?: string[] | null;
-            /** Show Basemap Labels */
-            show_basemap_labels: boolean;
-            terrain_config?: components["schemas"]["TerrainConfig"] | null;
-            /** Thumbnail Url */
-            thumbnail_url?: string | null;
+            created_at: string;
             /**
              * Updated At
              * Format: date-time
              */
             updated_at: string;
-            visibility: components["schemas"]["MapVisibility"];
-            /** Zoom */
-            zoom: number | null;
+            /** Layers */
+            layers: components["schemas"]["MapLayerResponse"][];
+            /** Layer Count */
+            layer_count: number;
+            /** Plugins */
+            plugins?: string[] | null;
+            /** Legend Title */
+            legend_title?: string | null;
+            /**
+             * Excluded Layer Count
+             * @description Layers skipped due to access restrictions
+             * @default 0
+             */
+            excluded_layer_count: number;
         };
         /**
          * EditionInfoResponse
@@ -7865,14 +7865,6 @@ export interface components {
         /** EmbedTokenCreate */
         EmbedTokenCreate: {
             /**
-             * Allowed Origins
-             * @description Restrict embedding to these origins. Omit or null allows any origin; non-empty origin restrictions require advanced sharing controls.
-             * @example [
-             *       "https://dashboard.example.com"
-             *     ]
-             */
-            allowed_origins?: string[] | null;
-            /**
              * Expires In Days
              * @description Token lifetime in days (1-365). The default 30-day lifetime is always available; custom lifetimes require advanced sharing controls.
              * @default 30
@@ -7885,30 +7877,22 @@ export interface components {
              * @example Public dashboard embed
              */
             name?: string | null;
+            /**
+             * Allowed Origins
+             * @description Restrict embedding to these origins. Omit or null allows any origin; non-empty origin restrictions require advanced sharing controls.
+             * @example [
+             *       "https://dashboard.example.com"
+             *     ]
+             */
+            allowed_origins?: string[] | null;
         };
         /** EmbedTokenCreatedResponse */
         EmbedTokenCreatedResponse: {
-            /** Allowed Origins */
-            allowed_origins?: string[] | null;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /**
-             * Expires At
-             * Format: date-time
-             */
-            expires_at: string;
             /**
              * Id
              * Format: uuid
              */
             id: string;
-            /** Is Active */
-            is_active: boolean;
-            /** Last Used At */
-            last_used_at?: string | null;
             /**
              * Map Id
              * Format: uuid
@@ -7916,17 +7900,33 @@ export interface components {
             map_id: string;
             /** Name */
             name?: string | null;
-            /** Raw Token */
-            raw_token: string;
-            /** Scoped Dataset Ids */
-            scoped_dataset_ids: string[];
             /** Token Hint */
             token_hint: string;
+            /** Scoped Dataset Ids */
+            scoped_dataset_ids: string[];
+            /** Allowed Origins */
+            allowed_origins?: string[] | null;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+            /** Is Active */
+            is_active: boolean;
             /**
              * Use Count
              * @default 0
              */
             use_count: number;
+            /** Last Used At */
+            last_used_at?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Raw Token */
+            raw_token: string;
         };
         /** EmbedTokenListResponse */
         EmbedTokenListResponse: {
@@ -7937,27 +7937,11 @@ export interface components {
         };
         /** EmbedTokenResponse */
         EmbedTokenResponse: {
-            /** Allowed Origins */
-            allowed_origins?: string[] | null;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /**
-             * Expires At
-             * Format: date-time
-             */
-            expires_at: string;
             /**
              * Id
              * Format: uuid
              */
             id: string;
-            /** Is Active */
-            is_active: boolean;
-            /** Last Used At */
-            last_used_at?: string | null;
             /**
              * Map Id
              * Format: uuid
@@ -7965,15 +7949,31 @@ export interface components {
             map_id: string;
             /** Name */
             name?: string | null;
-            /** Scoped Dataset Ids */
-            scoped_dataset_ids: string[];
             /** Token Hint */
             token_hint: string;
+            /** Scoped Dataset Ids */
+            scoped_dataset_ids: string[];
+            /** Allowed Origins */
+            allowed_origins?: string[] | null;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+            /** Is Active */
+            is_active: boolean;
             /**
              * Use Count
              * @default 0
              */
             use_count: number;
+            /** Last Used At */
+            last_used_at?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
         };
         /** EmbedTokenUpdate */
         EmbedTokenUpdate: {
@@ -7986,10 +7986,10 @@ export interface components {
         /** EmbeddingStatsResponse */
         EmbeddingStatsResponse: {
             /**
-             * Coverage Percent
-             * @description Embedding coverage as a percentage (0-100).
+             * Total Records
+             * @description Total number of records in the catalog.
              */
-            coverage_percent: number;
+            total_records: number;
             /**
              * Embedded Records
              * @description Number of records that have an embedding stored.
@@ -8001,10 +8001,10 @@ export interface components {
              */
             missing_records: number;
             /**
-             * Total Records
-             * @description Total number of records in the catalog.
+             * Coverage Percent
+             * @description Embedding coverage as a percentage (0-100).
              */
-            total_records: number;
+            coverage_percent: number;
         };
         /**
          * EnterpriseTabsResponse
@@ -8028,24 +8028,18 @@ export interface components {
          */
         FacetCountResponse: {
             /**
-             * Collections
-             * @description Collections containing matched records
-             * @default []
-             */
-            collections: components["schemas"]["CollectionFacetItem"][];
-            /**
-             * Keywords
-             * @description Top keyword tags with counts
-             * @default []
-             */
-            keywords: components["schemas"]["FacetValueCount"][];
-            /**
              * Record Type
              * @description Hit counts keyed by record type
              */
             record_type: {
                 [key: string]: number;
             };
+            /**
+             * Keywords
+             * @description Top keyword tags with counts
+             * @default []
+             */
+            keywords: components["schemas"]["FacetValueCount"][];
             /**
              * Source Organization
              * @description Top organizations with counts
@@ -8058,16 +8052,22 @@ export interface components {
              * @default []
              */
             srid: components["schemas"]["FacetValueCount"][];
+            /**
+             * Collections
+             * @description Collections containing matched records
+             * @default []
+             */
+            collections: components["schemas"]["CollectionFacetItem"][];
         };
         /**
          * FacetValueCount
          * @description A single facet value with count.
          */
         FacetValueCount: {
-            /** Count */
-            count: number;
             /** Value */
             value: string;
+            /** Count */
+            count: number;
         };
         /**
          * FanOutCommitRequest
@@ -8122,16 +8122,6 @@ export interface components {
          */
         FanOutLayerResult: {
             /**
-             * Dataset Id
-             * @description ID of the new Dataset record created for this layer. Null on failure.
-             */
-            dataset_id?: string | null;
-            /**
-             * Error
-             * @description User-safe error description when status='failed'. Never contains internal file paths.
-             */
-            error?: string | null;
-            /**
              * Layer Name
              * @description Layer name from the request.
              */
@@ -8142,11 +8132,21 @@ export interface components {
              */
             new_job_id?: string | null;
             /**
+             * Dataset Id
+             * @description ID of the new Dataset record created for this layer. Null on failure.
+             */
+            dataset_id?: string | null;
+            /**
              * Status
              * @description 'queued' if the task was dispatched; 'failed' if an error occurred.
              * @enum {string}
              */
             status: "queued" | "failed";
+            /**
+             * Error
+             * @description User-safe error description when status='failed'. Never contains internal file paths.
+             */
+            error?: string | null;
         };
         /**
          * FeatureCreate
@@ -8205,6 +8205,11 @@ export interface components {
          * @description A GeoJSON Feature.
          */
         GeoJSONFeature: {
+            /**
+             * Type
+             * @default Feature
+             */
+            type: string;
             /** Geometry */
             geometry?: {
                 [key: string]: unknown;
@@ -8213,11 +8218,6 @@ export interface components {
             properties?: {
                 [key: string]: unknown;
             } | null;
-            /**
-             * Type
-             * @default Feature
-             */
-            type: string;
         } & {
             [key: string]: unknown;
         };
@@ -8227,15 +8227,15 @@ export interface components {
          */
         GeoJSONFeatureCollection: {
             /**
-             * Features
-             * @default []
-             */
-            features: components["schemas"]["GeoJSONFeature"][];
-            /**
              * Type
              * @default FeatureCollection
              */
             type: string;
+            /**
+             * Features
+             * @default []
+             */
+            features: components["schemas"]["GeoJSONFeature"][];
         } & {
             [key: string]: unknown;
         };
@@ -8244,13 +8244,13 @@ export interface components {
          * @description A GeoJSON geometry object (RFC 7946).
          */
         GeoJSONGeometry: {
-            /** Coordinates */
-            coordinates: unknown[];
             /**
              * Type
              * @enum {string}
              */
             type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+            /** Coordinates */
+            coordinates: unknown[];
         };
         /**
          * GeoJSONGeometryCollection
@@ -8269,13 +8269,13 @@ export interface components {
          *     database 500. The write schemas add a raw-payload guard for a clear 422.
          */
         GeoJSONGeometryCollection: {
-            /** Geometries */
-            geometries: components["schemas"]["GeoJSONGeometry"][];
             /**
              * Type
              * @constant
              */
             type: "GeometryCollection";
+            /** Geometries */
+            geometries: components["schemas"]["GeoJSONGeometry"][];
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -8284,43 +8284,22 @@ export interface components {
         };
         /** HealthResponse */
         HealthResponse: {
+            /** Status */
+            status: string;
+            /** Version */
+            version: string;
             /** Build */
             build?: string | null;
             /** Providers */
             providers: {
                 [key: string]: components["schemas"]["ServiceHealth"];
             };
-            /** Status */
-            status: string;
-            /** Version */
-            version: string;
         };
         /**
          * ImportResult
          * @description Summary of what was applied during an import.
          */
         ImportResult: {
-            /**
-             * Oauth Accounts Deleted
-             * @description Number of dependent OAuth account links cascade-deleted in overwrite mode.
-             * @default 0
-             */
-            oauth_accounts_deleted: number;
-            /**
-             * Oauth Created
-             * @description Number of new OAuth providers created.
-             */
-            oauth_created: number;
-            /**
-             * Oauth Deleted
-             * @description Number of OAuth providers deleted (overwrite mode only).
-             */
-            oauth_deleted: number;
-            /**
-             * Oauth Updated
-             * @description Number of existing OAuth providers updated.
-             */
-            oauth_updated: number;
             /**
              * Settings Applied
              * @description Number of settings successfully updated.
@@ -8336,34 +8315,50 @@ export interface components {
              * @description Names of restricted setting keys that were skipped by the current runtime.
              */
             settings_skipped_restricted?: string[];
+            /**
+             * Oauth Created
+             * @description Number of new OAuth providers created.
+             */
+            oauth_created: number;
+            /**
+             * Oauth Updated
+             * @description Number of existing OAuth providers updated.
+             */
+            oauth_updated: number;
+            /**
+             * Oauth Deleted
+             * @description Number of OAuth providers deleted (overwrite mode only).
+             */
+            oauth_deleted: number;
+            /**
+             * Oauth Accounts Deleted
+             * @description Number of dependent OAuth account links cascade-deleted in overwrite mode.
+             * @default 0
+             */
+            oauth_accounts_deleted: number;
         };
         /** InfrastructureConfig */
         InfrastructureConfig: {
+            /**
+             * Storage Provider
+             * @description Active storage backend ('local' or 's3').
+             */
+            storage_provider: string;
             /**
              * Cache Provider
              * @description Active cache backend ('memory' or 'redis').
              */
             cache_provider: string;
             /**
-             * Cdn Configured
-             * @description Whether a CDN base URL is configured for tile delivery.
-             */
-            cdn_configured: boolean;
-            /**
-             * Database Pooler
-             * @description Active connection pooler mode ('sqlalchemy' or 'external').
-             */
-            database_pooler: string;
-            /**
              * Database Type
              * @description Database flavor (e.g. 'postgres', 'managed-postgres').
              */
             database_type: string;
             /**
-             * Storage Provider
-             * @description Active storage backend ('local' or 's3').
+             * Database Pooler
+             * @description Active connection pooler mode ('sqlalchemy' or 'external').
              */
-            storage_provider: string;
+            database_pooler: string;
             /**
              * Tile Cache
              * @description Tile caching backend in use.
@@ -8374,6 +8369,11 @@ export interface components {
              * @description Tile cache TTL in seconds.
              */
             tile_cache_ttl: number;
+            /**
+             * Cdn Configured
+             * @description Whether a CDN base URL is configured for tile delivery.
+             */
+            cdn_configured: boolean;
         };
         /** InfrastructureResponse */
         InfrastructureResponse: {
@@ -8398,12 +8398,46 @@ export interface components {
         /** JobStatusResponse */
         JobStatusResponse: {
             /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "pending" | "running" | "complete" | "failed" | "cancelled" | "fanned_out";
+            /** Dataset Id */
+            dataset_id: string | null;
+            /** Source Filename */
+            source_filename: string | null;
+            /** Error Message */
+            error_message: string | null;
+            /** Can Retry */
+            can_retry: boolean;
+            /** Retry Reason */
+            retry_reason: string | null;
+            /** Warning Message */
+            warning_message?: string | null;
+            /** Warnings */
+            warnings?: (components["schemas"]["ReservedRenameWarning"] | components["schemas"]["DbfTruncationCollisionWarning"] | components["schemas"]["MercatorClipWarning"])[];
+            /** Progress */
+            progress?: number | null;
+            /** Current Step */
+            current_step?: ("queued" | "validating" | "ogr2ogr" | "finalize" | "complete" | "cog_convert" | "quicklook" | "analyzing" | "registering") | null;
+            /** Rows Processed */
+            rows_processed?: number | null;
+            /**
              * Archive Failed
              * @default false
              */
             archive_failed: boolean;
-            /** Can Retry */
-            can_retry: boolean;
+            /** Temporal Parse Errors */
+            temporal_parse_errors?: {
+                [key: string]: string;
+            };
+            /** Started At */
+            started_at: string | null;
             /** Completed At */
             completed_at: string | null;
             /**
@@ -8411,69 +8445,35 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
-            /** Current Step */
-            current_step?: ("queued" | "validating" | "ogr2ogr" | "finalize" | "complete" | "cog_convert" | "quicklook" | "analyzing" | "registering") | null;
-            /** Dataset Id */
-            dataset_id: string | null;
-            /** Error Message */
-            error_message: string | null;
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /** Progress */
-            progress?: number | null;
-            /** Retry Reason */
-            retry_reason: string | null;
-            /** Rows Processed */
-            rows_processed?: number | null;
-            /** Source Filename */
-            source_filename: string | null;
-            /** Started At */
-            started_at: string | null;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "pending" | "running" | "complete" | "failed" | "cancelled" | "fanned_out";
-            /** Temporal Parse Errors */
-            temporal_parse_errors?: {
-                [key: string]: string;
-            };
-            /** Warning Message */
-            warning_message?: string | null;
-            /** Warnings */
-            warnings?: (components["schemas"]["ReservedRenameWarning"] | components["schemas"]["DbfTruncationCollisionWarning"] | components["schemas"]["MercatorClipWarning"])[];
         };
         /** KeywordCreate */
         KeywordCreate: {
             /** Keyword */
             keyword: string;
             /**
+             * Vocabulary Uri
+             * @description URI of the controlled vocabulary
+             */
+            vocabulary_uri?: string | null;
+            /**
              * Keyword Type
              * @description ISO MD_KeywordTypeCode, e.g. theme, place, discipline
              * @default theme
              */
             keyword_type: string;
-            /**
-             * Vocabulary Uri
-             * @description URI of the controlled vocabulary
-             */
-            vocabulary_uri?: string | null;
         };
         /** KeywordListResponse */
         KeywordListResponse: {
+            /** Keywords */
+            keywords: components["schemas"]["KeywordResponse"][];
+            /** Total */
+            total: number;
             /**
              * Inherited Audience Gap
              * @description True when at least one keyword is inherited AND this record's audience — at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters, which are honored only for the record's owner and admins — includes someone who cannot open the source dataset (feat #1070).
              * @default false
              */
             inherited_audience_gap: boolean;
-            /** Keywords */
-            keywords: components["schemas"]["KeywordResponse"][];
-            /** Total */
-            total: number;
         };
         /** KeywordResponse */
         KeywordResponse: {
@@ -8483,22 +8483,22 @@ export interface components {
              */
             id: string;
             /**
+             * Record Id
+             * Format: uuid
+             */
+            record_id: string;
+            /** Keyword */
+            keyword: string;
+            /** Vocabulary Uri */
+            vocabulary_uri: string | null;
+            /** Keyword Type */
+            keyword_type: string;
+            /**
              * Inherited
              * @description True when this keyword also exists on the dataset this record was derived from (feat #1070). Derived at read time from derived_from; only ever true for a requester who can access that source dataset, so everyone else sees false — matching the derived_from redaction.
              * @default false
              */
             inherited: boolean;
-            /** Keyword */
-            keyword: string;
-            /** Keyword Type */
-            keyword_type: string;
-            /**
-             * Record Id
-             * Format: uuid
-             */
-            record_id: string;
-            /** Vocabulary Uri */
-            vocabulary_uri: string | null;
         };
         /**
          * KeywordSuggestion
@@ -8530,6 +8530,11 @@ export interface components {
         /** LandingPage */
         LandingPage: {
             /**
+             * Title
+             * @description OGC API landing page title.
+             */
+            title: string;
+            /**
              * Description
              * @description Human-readable API description.
              */
@@ -8539,36 +8544,29 @@ export interface components {
              * @description Top-level navigation links to conformance, collections, and API document.
              */
             links: components["schemas"]["OGCLink"][];
-            /**
-             * Title
-             * @description OGC API landing page title.
-             */
-            title: string;
         };
         /** LayerInfo */
         LayerInfo: {
             /**
-             * Feature Count
-             * @description Total feature count if reported by the service.
+             * Name
+             * @description Internal layer identifier used by the source service.
              */
-            feature_count?: number | null;
+            name: string;
+            /**
+             * Title
+             * @description Human-readable layer title from the service capabilities.
+             */
+            title?: string | null;
             /**
              * Geometry Type
              * @description Detected geometry type for the layer.
              */
             geometry_type?: string | null;
             /**
-             * Kind
-             * @description Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image/*. Everything else (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'.
-             * @default vector
-             * @enum {string}
+             * Feature Count
+             * @description Total feature count if reported by the service.
              */
-            kind: "vector" | "raster";
-            /**
-             * Layer Id
-             * @description Numeric or string layer ID used by ArcGIS services.
-             */
-            layer_id?: number | string | null;
+            feature_count?: number | null;
             /**
              * Layer Type
              * @description Layer kind: 'layer' (spatial) or 'table' (non-spatial attribute table).
@@ -8576,29 +8574,31 @@ export interface components {
              */
             layer_type: string;
             /**
-             * Name
-             * @description Internal layer identifier used by the source service.
+             * Layer Id
+             * @description Numeric or string layer ID used by ArcGIS services.
              */
-            name: string;
+            layer_id?: number | string | null;
             /**
              * Object Id Field
              * @description ArcGIS object ID field name, used for stable pagination.
              */
             object_id_field?: string | null;
             /**
-             * Title
-             * @description Human-readable layer title from the service capabilities.
+             * Kind
+             * @description Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image/*. Everything else (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'.
+             * @default vector
+             * @enum {string}
              */
-            title?: string | null;
+            kind: "vector" | "raster";
         };
         /** LayerPreview */
         LayerPreview: {
+            /** Name */
+            name: string;
             /** Feature Count */
             feature_count?: number | null;
             /** Field Count */
             field_count?: number | null;
-            /** Name */
-            name: string;
         };
         /**
          * LineageDraftResponse
@@ -8613,24 +8613,29 @@ export interface components {
         };
         /** ManifestApplyEntryResult */
         ManifestApplyEntryResult: {
+            /** Dataset Key */
+            dataset_key: string;
             /**
              * Action
              * @enum {string}
              */
             action: "create" | "update" | "skip" | "error";
-            /** Dataset Id */
-            dataset_id?: string | null;
-            /** Dataset Key */
-            dataset_key: string;
-            /** Errors */
-            errors?: string[];
             /** Job Id */
             job_id?: string | null;
+            /** Dataset Id */
+            dataset_id?: string | null;
             /** Message */
             message: string;
+            /** Errors */
+            errors?: string[];
         };
         /** ManifestApplyRequest */
         ManifestApplyRequest: {
+            /**
+             * Manifest Version
+             * @constant
+             */
+            manifest_version: "1";
             catalog: components["schemas"]["ManifestCatalog"];
             /** Datasets */
             datasets: components["schemas"]["ManifestDataset"][];
@@ -8639,11 +8644,6 @@ export interface components {
              * @default false
              */
             dry_run: boolean;
-            /**
-             * Manifest Version
-             * @constant
-             */
-            manifest_version: "1";
         };
         /** ManifestApplyResponse */
         ManifestApplyResponse: {
@@ -8656,53 +8656,53 @@ export interface components {
         };
         /** ManifestCatalog */
         ManifestCatalog: {
-            contact?: components["schemas"]["ManifestContact"] | null;
+            /** Title */
+            title: string;
             /** Description */
             description?: string | null;
             /** Organization */
             organization?: string | null;
-            /** Title */
-            title: string;
+            contact?: components["schemas"]["ManifestContact"] | null;
         };
         /** ManifestContact */
         ManifestContact: {
-            /** Email */
-            email?: string | null;
             /** Name */
             name?: string | null;
+            /** Email */
+            email?: string | null;
             /** Url */
             url?: string | null;
         };
         /** ManifestDataset */
         ManifestDataset: {
-            /** Description */
-            description?: string | null;
             /**
              * Key
              * @description Stable dataset identity key used for idempotent apply operations.
              */
             key: string;
-            metadata?: components["schemas"]["ManifestMetadata"] | null;
-            publication: components["schemas"]["ManifestPublication"];
-            /** Sources */
-            sources: components["schemas"]["ManifestSource"][];
             /** Title */
             title: string;
+            /** Description */
+            description?: string | null;
+            /** Sources */
+            sources: components["schemas"]["ManifestSource"][];
+            metadata?: components["schemas"]["ManifestMetadata"] | null;
+            publication: components["schemas"]["ManifestPublication"];
         };
         /** ManifestMetadata */
         ManifestMetadata: {
-            /** Attribution */
-            attribution?: string | null;
-            /** Bbox */
-            bbox?: number[] | null;
+            /** Tags */
+            tags?: string[] | null;
+            /** Organization */
+            organization?: string | null;
             /** Crs */
             crs?: string | null;
             /** License */
             license?: string | null;
-            /** Organization */
-            organization?: string | null;
-            /** Tags */
-            tags?: string[] | null;
+            /** Attribution */
+            attribution?: string | null;
+            /** Bbox */
+            bbox?: number[] | null;
         };
         /** ManifestPublication */
         ManifestPublication: {
@@ -8714,14 +8714,6 @@ export interface components {
         };
         /** ManifestSource */
         ManifestSource: {
-            /** Description */
-            description?: string | null;
-            /** Format */
-            format?: string | null;
-            /** Layer */
-            layer?: string | null;
-            /** Title */
-            title?: string | null;
             /**
              * Type
              * @description Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, or xls; raster_cog sources require tif or tiff.
@@ -8733,30 +8725,30 @@ export interface components {
              * @description Relative path (no `..` traversal), HTTP(S) URL, or storage URI.
              */
             uri: string;
+            /** Title */
+            title?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Format */
+            format?: string | null;
+            /** Layer */
+            layer?: string | null;
         };
         /** MapAccessResponse */
         MapAccessResponse: {
-            /**
-             * Can Edit
-             * @description True when the current request may open the map builder
-             */
-            can_edit: boolean;
             /**
              * Can View
              * @description True when the current request may read the map
              */
             can_view: boolean;
+            /**
+             * Can Edit
+             * @description True when the current request may open the map builder
+             */
+            can_edit: boolean;
         };
         /** MapCreate */
         MapCreate: {
-            /** @description Curated map-level basemap appearance preferences */
-            basemap_config?: components["schemas"]["BasemapConfig"] | null;
-            /**
-             * Description
-             * @description Short description for sharing
-             * @example Buildings, parks, and transit routes in Manhattan
-             */
-            description?: string | null;
             /**
              * Name
              * @description Map display name
@@ -8764,12 +8756,20 @@ export interface components {
              */
             name: string;
             /**
+             * Description
+             * @description Short description for sharing
+             * @example Buildings, parks, and transit routes in Manhattan
+             */
+            description?: string | null;
+            /**
              * Notes
              * @description Private notes (not shown publicly)
              */
             notes?: string | null;
             /** @description Map-level terrain source and exaggeration preferences */
             terrain_config?: components["schemas"]["TerrainConfig"] | null;
+            /** @description Curated map-level basemap appearance preferences */
+            basemap_config?: components["schemas"]["BasemapConfig"] | null;
         };
         /** MapDefaultsResponse */
         MapDefaultsResponse: {
@@ -8791,39 +8791,24 @@ export interface components {
         };
         /** MapGenerateRequest */
         MapGenerateRequest: {
-            /** Language */
-            language?: string | null;
             /** Prompt */
             prompt: string;
+            /** Language */
+            language?: string | null;
         };
         /** MapGenerateResponse */
         MapGenerateResponse: {
-            /** Datasets Used */
-            datasets_used: string[];
-            /** Explanation */
-            explanation: string;
             /** Map Id */
             map_id: string;
             /** Map Name */
             map_name: string;
+            /** Explanation */
+            explanation: string;
+            /** Datasets Used */
+            datasets_used: string[];
         };
         /** MapHistoryEventResponse */
         MapHistoryEventResponse: {
-            /** Action */
-            action: string;
-            /** Actor Id */
-            actor_id?: string | null;
-            /** Actor Username */
-            actor_username?: string | null;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Details */
-            details?: {
-                [key: string]: unknown;
-            };
             /**
              * Id
              * Format: uuid
@@ -8834,25 +8819,40 @@ export interface components {
              * Format: uuid
              */
             map_id: string;
-            /** Summary */
-            summary: string;
+            /** Actor Id */
+            actor_id?: string | null;
+            /** Actor Username */
+            actor_username?: string | null;
+            /** Target Type */
+            target_type: string;
             /** Target Id */
             target_id?: string | null;
             /** Target Name */
             target_name?: string | null;
-            /** Target Type */
-            target_type: string;
+            /** Action */
+            action: string;
+            /** Summary */
+            summary: string;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
         };
         /** MapHistoryListResponse */
         MapHistoryListResponse: {
             /** Events */
             events: components["schemas"]["MapHistoryEventResponse"][];
-            /** Limit */
-            limit: number;
-            /** Skip */
-            skip: number;
             /** Total */
             total: number;
+            /** Skip */
+            skip: number;
+            /** Limit */
+            limit: number;
         };
         /** MapIconListResponse */
         MapIconListResponse: {
@@ -8861,25 +8861,25 @@ export interface components {
         };
         /** MapIconResponse */
         MapIconResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Slug */
+            slug: string;
+            /** Media Type */
+            media_type: string;
+            /** Url */
+            url: string;
+            /** Sprite Id */
+            sprite_id: string;
+            /** Size Bytes */
+            size_bytes?: number | null;
             /**
              * Builtin
              * @default false
              */
             builtin: boolean;
-            /** Id */
-            id: string;
-            /** Media Type */
-            media_type: string;
-            /** Name */
-            name: string;
-            /** Size Bytes */
-            size_bytes?: number | null;
-            /** Slug */
-            slug: string;
-            /** Sprite Id */
-            sprite_id: string;
-            /** Url */
-            url: string;
         };
         /** MapLayerDiffRequest */
         MapLayerDiffRequest: {
@@ -8888,63 +8888,45 @@ export interface components {
              * @description Layers to append (max 200)
              */
             added?: components["schemas"]["MapLayerInput"][];
+            /** Updated */
+            updated?: components["schemas"]["MapLayerPatch"][];
+            /** Removed */
+            removed?: string[];
+            /**
+             * Order
+             * @description Optional stable layer ID order for existing layers
+             */
+            order?: string[] | null;
             /**
              * Fallback Full Replace
              * @description Client hint only; PATCH never performs full replacement
              * @default false
              */
             fallback_full_replace: boolean;
-            /**
-             * Order
-             * @description Optional stable layer ID order for existing layers
-             */
-            order?: string[] | null;
-            /** Removed */
-            removed?: string[];
-            /** Updated */
-            updated?: components["schemas"]["MapLayerPatch"][];
         };
         /** MapLayerInput */
         MapLayerInput: {
-            /**
-             * Dataset Id
-             * Format: uuid
-             */
-            dataset_id: string;
-            /**
-             * Display Name
-             * @description Label shown in the layer list
-             */
-            display_name?: string | null;
-            /**
-             * Filter
-             * @description MapLibre filter expression
-             */
-            filter?: unknown[] | null;
             /**
              * Id
              * @description Existing layer id to update in place (full-save reconcile)
              */
             id?: string | null;
             /**
-             * Label Config
-             * @description Text label configuration
+             * Dataset Id
+             * Format: uuid
              */
-            label_config?: {
-                [key: string]: unknown;
-            } | null;
+            dataset_id: string;
             /**
-             * Layer Type
-             * @description Auto-detected from record_type if omitted
+             * Sort Order
+             * @description Draw order (lower draws first)
+             * @default 0
              */
-            layer_type?: string | null;
+            sort_order: number;
             /**
-             * Layout
-             * @description MapLibre layout properties override
+             * Visible
+             * @default true
              */
-            layout?: {
-                [key: string]: unknown;
-            } | null;
+            visible: boolean;
             /**
              * Opacity
              * @description Layer opacity 0.0-1.0
@@ -8958,20 +8940,32 @@ export interface components {
             paint?: {
                 [key: string]: unknown;
             } | null;
+            /**
+             * Layout
+             * @description MapLibre layout properties override
+             */
+            layout?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Display Name
+             * @description Label shown in the layer list
+             */
+            display_name?: string | null;
+            /**
+             * Filter
+             * @description MapLibre filter expression
+             */
+            filter?: unknown[] | null;
+            /**
+             * Label Config
+             * @description Text label configuration
+             */
+            label_config?: {
+                [key: string]: unknown;
+            } | null;
             /** @description Popup configuration: {enabled, expression, visible_fields} */
             popup_config?: components["schemas"]["PopupConfig"] | null;
-            /**
-             * Show In Legend
-             * @description Whether to include in the map legend
-             * @default true
-             */
-            show_in_legend: boolean;
-            /**
-             * Sort Order
-             * @description Draw order (lower draws first)
-             * @default 0
-             */
-            sort_order: number;
             /**
              * Style Config
              * @description Data-driven and builder UI style configuration. Builder-only state lives under builder, e.g. fill_disabled, stroke_disabled, outline settings, heatmap metadata, and height_column.
@@ -8980,41 +8974,28 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * Visible
+             * Layer Type
+             * @description Auto-detected from record_type if omitted
+             */
+            layer_type?: string | null;
+            /**
+             * Show In Legend
+             * @description Whether to include in the map legend
              * @default true
              */
-            visible: boolean;
+            show_in_legend: boolean;
         };
         /** MapLayerPatch */
         MapLayerPatch: {
-            /** Display Name */
-            display_name?: string | null;
-            /**
-             * Filter
-             * @description MapLibre filter expression
-             */
-            filter?: unknown[] | null;
             /**
              * Id
              * Format: uuid
              */
             id: string;
-            /**
-             * Label Config
-             * @description Text label configuration
-             */
-            label_config?: {
-                [key: string]: unknown;
-            } | null;
-            /** Layer Type */
-            layer_type?: string | null;
-            /**
-             * Layout
-             * @description MapLibre layout properties override
-             */
-            layout?: {
-                [key: string]: unknown;
-            } | null;
+            /** Sort Order */
+            sort_order?: number | null;
+            /** Visible */
+            visible?: boolean | null;
             /** Opacity */
             opacity?: number | null;
             /**
@@ -9024,32 +9005,44 @@ export interface components {
             paint?: {
                 [key: string]: unknown;
             } | null;
+            /**
+             * Layout
+             * @description MapLibre layout properties override
+             */
+            layout?: {
+                [key: string]: unknown;
+            } | null;
+            /** Display Name */
+            display_name?: string | null;
+            /**
+             * Filter
+             * @description MapLibre filter expression
+             */
+            filter?: unknown[] | null;
+            /**
+             * Label Config
+             * @description Text label configuration
+             */
+            label_config?: {
+                [key: string]: unknown;
+            } | null;
             popup_config?: components["schemas"]["PopupConfig"] | null;
-            /** Show In Legend */
-            show_in_legend?: boolean | null;
-            /** Sort Order */
-            sort_order?: number | null;
             /** Style Config */
             style_config?: {
                 [key: string]: unknown;
             } | null;
-            /** Visible */
-            visible?: boolean | null;
+            /** Layer Type */
+            layer_type?: string | null;
+            /** Show In Legend */
+            show_in_legend?: boolean | null;
         };
         /** MapLayerResponse */
         MapLayerResponse: {
-            /** Band Count */
-            band_count?: number | null;
-            /** Dataset Column Info */
-            dataset_column_info?: {
-                [key: string]: unknown;
-            }[] | null;
-            /** Dataset Extent Bbox */
-            dataset_extent_bbox: number[] | null;
-            /** Dataset Feature Count */
-            dataset_feature_count?: number | null;
-            /** Dataset Geometry Type */
-            dataset_geometry_type: string | null;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
             /**
              * Dataset Id
              * Format: uuid
@@ -9057,68 +9050,75 @@ export interface components {
             dataset_id: string;
             /** Dataset Name */
             dataset_name: string;
-            /** Dataset Record Type */
-            dataset_record_type?: string | null;
+            /** Dataset Geometry Type */
+            dataset_geometry_type: string | null;
+            /** Dataset Table Name */
+            dataset_table_name: string;
+            /** Dataset Extent Bbox */
+            dataset_extent_bbox: number[] | null;
+            /** Dataset Column Info */
+            dataset_column_info?: {
+                [key: string]: unknown;
+            }[] | null;
+            /** Dataset Feature Count */
+            dataset_feature_count?: number | null;
             /** Dataset Sample Values */
             dataset_sample_values?: {
                 [key: string]: unknown;
             } | null;
-            /** Dataset Status */
-            dataset_status?: string | null;
-            /** Dataset Table Name */
-            dataset_table_name: string;
-            /** Dataset Visibility */
-            dataset_visibility?: string | null;
-            /** Dem Vertical Units */
-            dem_vertical_units?: string | null;
             /** Display Name */
             display_name?: string | null;
-            /** Filter */
-            filter?: unknown[] | null;
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /** Is 3D */
-            is_3d?: boolean | null;
-            /** Is Dem */
-            is_dem?: boolean | null;
-            /** Label Config */
-            label_config?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Layer Type
-             * @default vector_geolens
-             */
-            layer_type: string;
-            /** Layout */
-            layout: {
-                [key: string]: unknown;
-            };
+            /** Sort Order */
+            sort_order: number;
+            /** Visible */
+            visible: boolean;
             /** Opacity */
             opacity: number;
             /** Paint */
             paint: {
                 [key: string]: unknown;
             };
+            /** Layout */
+            layout: {
+                [key: string]: unknown;
+            };
+            /**
+             * Layer Type
+             * @default vector_geolens
+             */
+            layer_type: string;
+            /** Dataset Record Type */
+            dataset_record_type?: string | null;
+            /** Filter */
+            filter?: unknown[] | null;
+            /** Label Config */
+            label_config?: {
+                [key: string]: unknown;
+            } | null;
             popup_config?: components["schemas"]["PopupConfig"] | null;
+            /** Style Config */
+            style_config?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Show In Legend
              * @default true
              */
             show_in_legend: boolean;
-            /** Sort Order */
-            sort_order: number;
-            /** Style Config */
-            style_config?: {
-                [key: string]: unknown;
-            } | null;
+            /** Is 3D */
+            is_3d?: boolean | null;
+            /** Is Dem */
+            is_dem?: boolean | null;
+            /** Dem Vertical Units */
+            dem_vertical_units?: string | null;
+            /** Band Count */
+            band_count?: number | null;
             /** Tile Version */
             tile_version?: number | null;
-            /** Visible */
-            visible: boolean;
+            /** Dataset Visibility */
+            dataset_visibility?: string | null;
+            /** Dataset Status */
+            dataset_status?: string | null;
         };
         /** MapListResponse */
         MapListResponse: {
@@ -9129,26 +9129,38 @@ export interface components {
         };
         /** MapResponse */
         MapResponse: {
-            basemap_config?: components["schemas"]["BasemapConfig"] | null;
-            /** Basemap Style */
-            basemap_style: string;
-            /** Bearing */
-            bearing: number;
-            /** Center Lat */
-            center_lat: number | null;
-            /** Center Lng */
-            center_lng: number | null;
             /**
-             * Created At
-             * Format: date-time
+             * Id
+             * Format: uuid
              */
-            created_at: string;
-            /** Created By */
-            created_by: string | null;
-            /** Created By Username */
-            created_by_username?: string | null;
+            id: string;
+            /** Name */
+            name: string;
             /** Description */
             description: string | null;
+            /** Notes */
+            notes?: string | null;
+            /** Center Lng */
+            center_lng: number | null;
+            /** Center Lat */
+            center_lat: number | null;
+            /** Zoom */
+            zoom: number | null;
+            /** Bearing */
+            bearing: number;
+            /** Pitch */
+            pitch: number;
+            /** Basemap Style */
+            basemap_style: string;
+            /** Show Basemap Labels */
+            show_basemap_labels: boolean;
+            basemap_config?: components["schemas"]["BasemapConfig"] | null;
+            terrain_config?: components["schemas"]["TerrainConfig"] | null;
+            visibility: components["schemas"]["MapVisibility"];
+            /** Thumbnail Url */
+            thumbnail_url?: string | null;
+            /** Og Image Url */
+            og_image_url?: string | null;
             /**
              * Forked From Id
              * @description Source map UUID if this is a fork
@@ -9156,40 +9168,28 @@ export interface components {
             forked_from_id?: string | null;
             /** Forked From Name */
             forked_from_name?: string | null;
+            /** Created By */
+            created_by: string | null;
+            /** Created By Username */
+            created_by_username?: string | null;
             /**
-             * Id
-             * Format: uuid
+             * Created At
+             * Format: date-time
              */
-            id: string;
-            /** Layer Count */
-            layer_count: number;
-            /** Layers */
-            layers: components["schemas"]["MapLayerResponse"][];
-            /** Legend Title */
-            legend_title?: string | null;
-            /** Name */
-            name: string;
-            /** Notes */
-            notes?: string | null;
-            /** Og Image Url */
-            og_image_url?: string | null;
-            /** Pitch */
-            pitch: number;
-            /** Plugins */
-            plugins?: string[] | null;
-            /** Show Basemap Labels */
-            show_basemap_labels: boolean;
-            terrain_config?: components["schemas"]["TerrainConfig"] | null;
-            /** Thumbnail Url */
-            thumbnail_url?: string | null;
+            created_at: string;
             /**
              * Updated At
              * Format: date-time
              */
             updated_at: string;
-            visibility: components["schemas"]["MapVisibility"];
-            /** Zoom */
-            zoom: number | null;
+            /** Layers */
+            layers: components["schemas"]["MapLayerResponse"][];
+            /** Layer Count */
+            layer_count: number;
+            /** Plugins */
+            plugins?: string[] | null;
+            /** Legend Title */
+            legend_title?: string | null;
         };
         /**
          * MapStyleImportRequest
@@ -9206,22 +9206,16 @@ export interface components {
          *     openapi-python-client generate a navigable named model class.
          */
         MapStyleImportRequest: {
-            /** Bearing */
-            bearing?: number | null;
             /**
-             * Center
-             * @description [longitude, latitude] map center
+             * Version
+             * @description MapLibre style version (always 8 in current spec)
              */
-            center?: number[] | null;
-            /** Glyphs */
-            glyphs?: string | null;
+            version?: number | null;
             /**
-             * Layers
-             * @description MapLibre layer specifications
+             * Name
+             * @description Display name for the imported map
              */
-            layers?: {
-                [key: string]: unknown;
-            }[] | null;
+            name?: string | null;
             /**
              * Metadata
              * @description Free-form metadata bag (used by GeoLens for center/zoom/basemap hints)
@@ -9230,10 +9224,14 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * Name
-             * @description Display name for the imported map
+             * Center
+             * @description [longitude, latitude] map center
              */
-            name?: string | null;
+            center?: number[] | null;
+            /** Zoom */
+            zoom?: number | null;
+            /** Bearing */
+            bearing?: number | null;
             /** Pitch */
             pitch?: number | null;
             /**
@@ -9245,6 +9243,8 @@ export interface components {
             } | null;
             /** Sprite */
             sprite?: string | null;
+            /** Glyphs */
+            glyphs?: string | null;
             /**
              * Terrain
              * @description MapLibre terrain config (source + exaggeration)
@@ -9253,12 +9253,12 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * Version
-             * @description MapLibre style version (always 8 in current spec)
+             * Layers
+             * @description MapLibre layer specifications
              */
-            version?: number | null;
-            /** Zoom */
-            zoom?: number | null;
+            layers?: {
+                [key: string]: unknown;
+            }[] | null;
         } & {
             [key: string]: unknown;
         };
@@ -9270,16 +9270,6 @@ export interface components {
         /** MapStyleImportSummary */
         MapStyleImportSummary: {
             /**
-             * Layers Imported
-             * @default 0
-             */
-            layers_imported: number;
-            /**
-             * Layers Skipped
-             * @default 0
-             */
-            layers_skipped: number;
-            /**
              * Sources Matched
              * @default 0
              */
@@ -9289,6 +9279,16 @@ export interface components {
              * @default 0
              */
             sources_unsupported: number;
+            /**
+             * Layers Imported
+             * @default 0
+             */
+            layers_imported: number;
+            /**
+             * Layers Skipped
+             * @default 0
+             */
+            layers_skipped: number;
             /** Warnings */
             warnings?: components["schemas"]["MapStyleImportWarning"][];
         };
@@ -9296,105 +9296,105 @@ export interface components {
         MapStyleImportWarning: {
             /** Code */
             code: string;
-            /** Layer Id */
-            layer_id?: string | null;
             /** Message */
             message: string;
             /** Source Id */
             source_id?: string | null;
+            /** Layer Id */
+            layer_id?: string | null;
         };
         /** MapSummaryResponse */
         MapSummaryResponse: {
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Created By Username */
-            created_by_username?: string | null;
-            /** Description */
-            description: string | null;
             /**
              * Id
              * Format: uuid
              */
             id: string;
-            /** Layer Count */
-            layer_count: number;
             /** Name */
             name: string;
-            /** Thumbnail Updated At */
-            thumbnail_updated_at?: string | null;
+            /** Description */
+            description: string | null;
+            visibility: components["schemas"]["MapVisibility"];
             /** Thumbnail Url */
             thumbnail_url?: string | null;
+            /** Thumbnail Updated At */
+            thumbnail_updated_at?: string | null;
+            /** Layer Count */
+            layer_count: number;
+            /** Created By Username */
+            created_by_username?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
             /**
              * Updated At
              * Format: date-time
              */
             updated_at: string;
-            visibility: components["schemas"]["MapVisibility"];
         };
         /** MapUpdate */
         MapUpdate: {
-            /** @description Curated map-level basemap appearance preferences */
-            basemap_config?: components["schemas"]["BasemapConfig"] | null;
+            /** Name */
+            name?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Notes */
+            notes?: string | null;
             /**
-             * Basemap Style
-             * @description Basemap style ID or URL
+             * Center Lng
+             * @description Map center longitude
              */
-            basemap_style?: string | null;
-            /**
-             * Bearing
-             * @description Map rotation in degrees
-             */
-            bearing?: number | null;
+            center_lng?: number | null;
             /**
              * Center Lat
              * @description Map center latitude
              */
             center_lat?: number | null;
             /**
-             * Center Lng
-             * @description Map center longitude
+             * Zoom
+             * @description Map zoom level
              */
-            center_lng?: number | null;
-            /** Description */
-            description?: string | null;
+            zoom?: number | null;
             /**
-             * Layers
-             * @description Full replacement layer list (max 200 layers)
+             * Bearing
+             * @description Map rotation in degrees
              */
-            layers?: components["schemas"]["MapLayerInput"][] | null;
-            /**
-             * Legend Title
-             * @description Custom map-level legend title. Null/empty leaves the legend without a heading override (ENH-06).
-             */
-            legend_title?: string | null;
-            /** Name */
-            name?: string | null;
-            /** Notes */
-            notes?: string | null;
+            bearing?: number | null;
             /**
              * Pitch
              * @description Map tilt in degrees (0-85)
              */
             pitch?: number | null;
             /**
-             * Plugins
-             * @description Enabled plugin IDs, e.g. ['measurement']
+             * Basemap Style
+             * @description Basemap style ID or URL
              */
-            plugins?: string[] | null;
+            basemap_style?: string | null;
             /** Show Basemap Labels */
             show_basemap_labels?: boolean | null;
+            /** @description Curated map-level basemap appearance preferences */
+            basemap_config?: components["schemas"]["BasemapConfig"] | null;
             /** @description Map-level terrain source and exaggeration preferences */
             terrain_config?: components["schemas"]["TerrainConfig"] | null;
             /** @description private, internal, or public */
             visibility?: components["schemas"]["MapVisibility"] | null;
             /**
-             * Zoom
-             * @description Map zoom level
+             * Layers
+             * @description Full replacement layer list (max 200 layers)
              */
-            zoom?: number | null;
+            layers?: components["schemas"]["MapLayerInput"][] | null;
+            /**
+             * Plugins
+             * @description Enabled plugin IDs, e.g. ['measurement']
+             */
+            plugins?: string[] | null;
+            /**
+             * Legend Title
+             * @description Custom map-level legend title. Null/empty leaves the legend without a heading override (ENH-06).
+             */
+            legend_title?: string | null;
         };
         /**
          * MapVisibility
@@ -9415,24 +9415,24 @@ export interface components {
          *     reduced form.
          */
         MercatorClipDetail: {
+            /** Dropped Features */
+            dropped_features: number;
+            /** Clipped Features */
+            clipped_features: number;
             /**
              * Clip Skipped
              * @default false
              */
             clip_skipped: boolean;
-            /** Clipped Features */
-            clipped_features: number;
-            /** Dropped Features */
-            dropped_features: number;
         };
         /** MercatorClipWarning */
         MercatorClipWarning: {
-            details: components["schemas"]["MercatorClipDetail"];
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             kind: "mercator_clip";
+            details: components["schemas"]["MercatorClipDetail"];
         };
         /**
          * MetadataAssistRequest
@@ -9484,15 +9484,15 @@ export interface components {
              */
             channel: string;
             /**
-             * Error
-             * @description Safe error string (exception type name + short message) if ok=False, else null. Never contains secrets.
-             */
-            error?: string | null;
-            /**
              * Ok
              * @description True if the channel delivered the test notification without error.
              */
             ok: boolean;
+            /**
+             * Error
+             * @description Safe error string (exception type name + short message) if ok=False, else null. Never contains secrets.
+             */
+            error?: string | null;
         };
         /**
          * NotificationTestResponse
@@ -9504,6 +9504,11 @@ export interface components {
          */
         NotificationTestResponse: {
             /**
+             * Sent
+             * @description True if at least one channel successfully delivered the test notification.
+             */
+            sent: boolean;
+            /**
              * Channels
              * @description Per-channel delivery results. Empty when no channel is configured.
              */
@@ -9513,11 +9518,6 @@ export interface components {
              * @description Human-readable summary of the test result.
              */
             message: string;
-            /**
-             * Sent
-             * @description True if at least one channel successfully delivered the test notification.
-             */
-            sent: boolean;
         };
         /**
          * OAuthProviderCreate
@@ -9525,10 +9525,21 @@ export interface components {
          */
         OAuthProviderCreate: {
             /**
-             * Authorize Url
-             * @description Authorization endpoint. Only needed when discovery_url is not set.
+             * Slug
+             * @description URL-safe identifier used in callback URLs (e.g. 'google', 'azure-ad'). Lowercase, digits, and hyphens only.
              */
-            authorize_url?: string | null;
+            slug: string;
+            /**
+             * Display Name
+             * @description Human-readable label shown on the login page button.
+             */
+            display_name: string;
+            /**
+             * Provider Type
+             * @description OAuth or SAML provider type. 'google' and 'microsoft' auto-populate the discovery URL; 'oidc' is generic OAuth/OIDC; 'github' uses GitHub's fixed OAuth2 endpoints (no discovery URL); 'saml' is available only on SAML-enabled deployments.
+             * @enum {string}
+             */
+            provider_type: "google" | "microsoft" | "oidc" | "saml" | "github";
             /**
              * Client Id
              * @description OAuth client ID issued by the IdP. Required for OAuth/OIDC providers; omit for SAML.
@@ -9540,27 +9551,57 @@ export interface components {
              */
             client_secret?: string | null;
             /**
-             * Default Role
-             * @description Role assigned to new users created via this provider: 'viewer', 'editor', or 'admin'.
-             * @default viewer
-             */
-            default_role: string;
-            /**
              * Discovery Url
              * @description OIDC discovery URL ending in `.well-known/openid-configuration`. Auto-populated for Google and Microsoft.
              */
             discovery_url?: string | null;
             /**
-             * Display Name
-             * @description Human-readable label shown on the login page button.
+             * Authorize Url
+             * @description Authorization endpoint. Only needed when discovery_url is not set.
              */
-            display_name: string;
+            authorize_url?: string | null;
             /**
-             * Enabled
-             * @description Whether the provider button appears on the login page.
-             * @default true
+             * Token Url
+             * @description Token endpoint. Only needed when discovery_url is not set.
              */
-            enabled: boolean;
+            token_url?: string | null;
+            /**
+             * Userinfo Url
+             * @description Userinfo endpoint. Only needed when discovery_url is not set.
+             */
+            userinfo_url?: string | null;
+            /**
+             * Idp Entity Id
+             * @description SAML IdP entityID. Required for SAML providers.
+             */
+            idp_entity_id?: string | null;
+            /**
+             * Idp Sso Url
+             * @description SAML IdP SSO URL (HTTP-Redirect or HTTP-POST binding). Required for SAML providers.
+             */
+            idp_sso_url?: string | null;
+            /**
+             * Idp Certificate
+             * @description SAML IdP signing certificate (PEM). Required for SAML providers. Stored Fernet-encrypted at rest; never returned in responses.
+             */
+            idp_certificate?: string | null;
+            /**
+             * Sp Entity Id
+             * @description SP entityID for this provider. Required for SAML providers. Default suggestion: {public_api_url}/auth/saml/{slug}.
+             */
+            sp_entity_id?: string | null;
+            /**
+             * Scopes
+             * @description Space-separated OAuth scopes.
+             * @default openid profile email
+             */
+            scopes: string;
+            /**
+             * Default Role
+             * @description Role assigned to new users created via this provider: 'viewer', 'editor', or 'admin'.
+             * @default viewer
+             */
+            default_role: string;
             /**
              * Group Claim
              * @description Name of the JWT/userinfo claim (or SAML attribute) that contains group memberships. Set to enable group-based role mapping.
@@ -9574,58 +9615,22 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * Idp Certificate
-             * @description SAML IdP signing certificate (PEM). Required for SAML providers. Stored Fernet-encrypted at rest; never returned in responses.
+             * Enabled
+             * @description Whether the provider button appears on the login page.
+             * @default true
              */
-            idp_certificate?: string | null;
-            /**
-             * Idp Entity Id
-             * @description SAML IdP entityID. Required for SAML providers.
-             */
-            idp_entity_id?: string | null;
-            /**
-             * Idp Sso Url
-             * @description SAML IdP SSO URL (HTTP-Redirect or HTTP-POST binding). Required for SAML providers.
-             */
-            idp_sso_url?: string | null;
-            /**
-             * Provider Type
-             * @description OAuth or SAML provider type. 'google' and 'microsoft' auto-populate the discovery URL; 'oidc' is generic OAuth/OIDC; 'github' uses GitHub's fixed OAuth2 endpoints (no discovery URL); 'saml' is available only on SAML-enabled deployments.
-             * @enum {string}
-             */
-            provider_type: "google" | "microsoft" | "oidc" | "saml" | "github";
-            /**
-             * Scopes
-             * @description Space-separated OAuth scopes.
-             * @default openid profile email
-             */
-            scopes: string;
-            /**
-             * Slug
-             * @description URL-safe identifier used in callback URLs (e.g. 'google', 'azure-ad'). Lowercase, digits, and hyphens only.
-             */
-            slug: string;
-            /**
-             * Sp Entity Id
-             * @description SP entityID for this provider. Required for SAML providers. Default suggestion: {public_api_url}/auth/saml/{slug}.
-             */
-            sp_entity_id?: string | null;
-            /**
-             * Token Url
-             * @description Token endpoint. Only needed when discovery_url is not set.
-             */
-            token_url?: string | null;
-            /**
-             * Userinfo Url
-             * @description Userinfo endpoint. Only needed when discovery_url is not set.
-             */
-            userinfo_url?: string | null;
+            enabled: boolean;
         };
         /**
          * OAuthProviderPublic
          * @description Minimal provider info for the login page (no secrets, no config).
          */
         OAuthProviderPublic: {
+            /**
+             * Slug
+             * @description URL-safe identifier used in the callback URL.
+             */
+            slug: string;
             /**
              * Display Name
              * @description Label shown on the login page button.
@@ -9636,11 +9641,6 @@ export interface components {
              * @description Provider type, used by the frontend to pick the right icon.
              */
             provider_type: string;
-            /**
-             * Slug
-             * @description URL-safe identifier used in the callback URL.
-             */
-            slug: string;
         };
         /**
          * OAuthProviderResponse
@@ -9664,41 +9664,76 @@ export interface components {
          */
         OAuthProviderResponse: {
             /**
-             * Authorize Url
-             * @description Authorization endpoint.
+             * Id
+             * Format: uuid
+             * @description Unique provider identifier.
              */
-            authorize_url?: string | null;
+            id: string;
             /**
-             * Client Id
-             * @description OAuth client ID. Visible to admins; never exposes client_secret. Null for SAML providers.
+             * Slug
+             * @description URL-safe identifier used in the callback URL.
              */
-            client_id?: string | null;
-            /**
-             * Created At
-             * Format: date-time
-             * @description Timestamp the provider was created.
-             */
-            created_at: string;
-            /**
-             * Default Role
-             * @description Default role assigned to new users.
-             */
-            default_role: string;
-            /**
-             * Discovery Url
-             * @description OIDC discovery URL.
-             */
-            discovery_url?: string | null;
+            slug: string;
             /**
              * Display Name
              * @description Label shown on the login page button.
              */
             display_name: string;
             /**
-             * Enabled
-             * @description Whether the provider button appears on the login page.
+             * Provider Type
+             * @description Provider type: 'google', 'microsoft', 'oidc', or 'saml'.
              */
-            enabled: boolean;
+            provider_type: string;
+            /**
+             * Client Id
+             * @description OAuth client ID. Visible to admins; never exposes client_secret. Null for SAML providers.
+             */
+            client_id?: string | null;
+            /**
+             * Discovery Url
+             * @description OIDC discovery URL.
+             */
+            discovery_url?: string | null;
+            /**
+             * Authorize Url
+             * @description Authorization endpoint.
+             */
+            authorize_url?: string | null;
+            /**
+             * Token Url
+             * @description Token endpoint.
+             */
+            token_url?: string | null;
+            /**
+             * Userinfo Url
+             * @description Userinfo endpoint.
+             */
+            userinfo_url?: string | null;
+            /**
+             * Idp Entity Id
+             * @description SAML IdP entityID (SAML providers only).
+             */
+            idp_entity_id?: string | null;
+            /**
+             * Idp Sso Url
+             * @description SAML IdP SSO URL (SAML providers only).
+             */
+            idp_sso_url?: string | null;
+            /**
+             * Sp Entity Id
+             * @description SP entityID for this SAML provider (SAML providers only).
+             */
+            sp_entity_id?: string | null;
+            /**
+             * Scopes
+             * @description Space-separated OAuth scopes.
+             */
+            scopes: string;
+            /**
+             * Default Role
+             * @description Default role assigned to new users.
+             */
+            default_role: string;
             /**
              * Group Claim
              * @description Claim name used for group-based role mapping.
@@ -9712,57 +9747,22 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * Id
-             * Format: uuid
-             * @description Unique provider identifier.
+             * Enabled
+             * @description Whether the provider button appears on the login page.
              */
-            id: string;
+            enabled: boolean;
             /**
-             * Idp Entity Id
-             * @description SAML IdP entityID (SAML providers only).
+             * Created At
+             * Format: date-time
+             * @description Timestamp the provider was created.
              */
-            idp_entity_id?: string | null;
-            /**
-             * Idp Sso Url
-             * @description SAML IdP SSO URL (SAML providers only).
-             */
-            idp_sso_url?: string | null;
-            /**
-             * Provider Type
-             * @description Provider type: 'google', 'microsoft', 'oidc', or 'saml'.
-             */
-            provider_type: string;
-            /**
-             * Scopes
-             * @description Space-separated OAuth scopes.
-             */
-            scopes: string;
-            /**
-             * Slug
-             * @description URL-safe identifier used in the callback URL.
-             */
-            slug: string;
-            /**
-             * Sp Entity Id
-             * @description SP entityID for this SAML provider (SAML providers only).
-             */
-            sp_entity_id?: string | null;
-            /**
-             * Token Url
-             * @description Token endpoint.
-             */
-            token_url?: string | null;
+            created_at: string;
             /**
              * Updated At
              * Format: date-time
              * @description Timestamp the provider was last updated.
              */
             updated_at: string;
-            /**
-             * Userinfo Url
-             * @description Userinfo endpoint.
-             */
-            userinfo_url?: string | null;
         };
         /**
          * OAuthProviderUpdate
@@ -9770,10 +9770,20 @@ export interface components {
          */
         OAuthProviderUpdate: {
             /**
-             * Authorize Url
-             * @description Updated authorization endpoint.
+             * Slug
+             * @description New slug. Changes the callback URL — coordinate with the IdP before updating.
              */
-            authorize_url?: string | null;
+            slug?: string | null;
+            /**
+             * Display Name
+             * @description New display label.
+             */
+            display_name?: string | null;
+            /**
+             * Provider Type
+             * @description New provider type. Rarely changed after creation.
+             */
+            provider_type?: ("google" | "microsoft" | "oidc" | "saml" | "github") | null;
             /**
              * Client Id
              * @description New client ID. Set when rotating credentials.
@@ -9785,25 +9795,55 @@ export interface components {
              */
             client_secret?: string | null;
             /**
-             * Default Role
-             * @description Updated default role for new users.
-             */
-            default_role?: string | null;
-            /**
              * Discovery Url
              * @description Updated OIDC discovery URL.
              */
             discovery_url?: string | null;
             /**
-             * Display Name
-             * @description New display label.
+             * Authorize Url
+             * @description Updated authorization endpoint.
              */
-            display_name?: string | null;
+            authorize_url?: string | null;
             /**
-             * Enabled
-             * @description Set to false to hide the provider button without deleting the configuration.
+             * Token Url
+             * @description Updated token endpoint.
              */
-            enabled?: boolean | null;
+            token_url?: string | null;
+            /**
+             * Userinfo Url
+             * @description Updated userinfo endpoint.
+             */
+            userinfo_url?: string | null;
+            /**
+             * Idp Entity Id
+             * @description Updated SAML IdP entityID.
+             */
+            idp_entity_id?: string | null;
+            /**
+             * Idp Sso Url
+             * @description Updated SAML IdP SSO URL.
+             */
+            idp_sso_url?: string | null;
+            /**
+             * Idp Certificate
+             * @description Updated SAML IdP signing certificate (PEM). Setting this rotates the stored cert; omit to leave unchanged.
+             */
+            idp_certificate?: string | null;
+            /**
+             * Sp Entity Id
+             * @description Updated SP entityID.
+             */
+            sp_entity_id?: string | null;
+            /**
+             * Scopes
+             * @description Updated space-separated scopes.
+             */
+            scopes?: string | null;
+            /**
+             * Default Role
+             * @description Updated default role for new users.
+             */
+            default_role?: string | null;
             /**
              * Group Claim
              * @description Updated group claim name.
@@ -9817,50 +9857,10 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * Idp Certificate
-             * @description Updated SAML IdP signing certificate (PEM). Setting this rotates the stored cert; omit to leave unchanged.
+             * Enabled
+             * @description Set to false to hide the provider button without deleting the configuration.
              */
-            idp_certificate?: string | null;
-            /**
-             * Idp Entity Id
-             * @description Updated SAML IdP entityID.
-             */
-            idp_entity_id?: string | null;
-            /**
-             * Idp Sso Url
-             * @description Updated SAML IdP SSO URL.
-             */
-            idp_sso_url?: string | null;
-            /**
-             * Provider Type
-             * @description New provider type. Rarely changed after creation.
-             */
-            provider_type?: ("google" | "microsoft" | "oidc" | "saml" | "github") | null;
-            /**
-             * Scopes
-             * @description Updated space-separated scopes.
-             */
-            scopes?: string | null;
-            /**
-             * Slug
-             * @description New slug. Changes the callback URL — coordinate with the IdP before updating.
-             */
-            slug?: string | null;
-            /**
-             * Sp Entity Id
-             * @description Updated SP entityID.
-             */
-            sp_entity_id?: string | null;
-            /**
-             * Token Url
-             * @description Updated token endpoint.
-             */
-            token_url?: string | null;
-            /**
-             * Userinfo Url
-             * @description Updated userinfo endpoint.
-             */
-            userinfo_url?: string | null;
+            enabled?: boolean | null;
         };
         /**
          * OGCAsset
@@ -9869,12 +9869,12 @@ export interface components {
         OGCAsset: {
             /** Href */
             href: string;
-            /** Roles */
-            roles?: string[] | null;
-            /** Title */
-            title?: string | null;
             /** Type */
             type: string;
+            /** Title */
+            title?: string | null;
+            /** Roles */
+            roles?: string[] | null;
         };
         /**
          * OGCCollectionMetadata
@@ -9882,13 +9882,15 @@ export interface components {
          */
         OGCCollectionMetadata: {
             /**
-             * Crs
-             * @description Coordinate reference systems supported for items in this collection.
-             * @default [
-             *       "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-             *     ]
+             * Id
+             * @description Stable collection identifier (typically the dataset ID).
              */
-            crs: string[];
+            id: string;
+            /**
+             * Title
+             * @description Human-readable collection title.
+             */
+            title: string;
             /**
              * Description
              * @description Collection description.
@@ -9902,40 +9904,36 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * Id
-             * @description Stable collection identifier (typically the dataset ID).
-             */
-            id: string;
-            /**
              * Itemtype
              * @description Type of items in the collection: 'feature' for vector feature collections, 'coverage' for raster/VRT collections (which expose tiles instead of feature items).
              * @default feature
              */
             itemType: string;
             /**
+             * Crs
+             * @description Coordinate reference systems supported for items in this collection.
+             * @default [
+             *       "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+             *     ]
+             */
+            crs: string[];
+            /**
              * Links
              * @description Collection navigation links (self, items, queryables, etc.).
              */
             links: components["schemas"]["OGCLink"][];
-            /**
-             * Title
-             * @description Human-readable collection title.
-             */
-            title: string;
         };
         /**
          * OGCCollectionMetadataResponse
          * @description Response for /collections/datasets single collection metadata.
          */
         OGCCollectionMetadataResponse: {
-            /** Description */
-            description: string;
-            /** Extent */
-            extent?: {
-                [key: string]: unknown;
-            } | null;
             /** Id */
             id: string;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string;
             /**
              * Itemtype
              * @default record
@@ -9945,12 +9943,14 @@ export interface components {
             links: {
                 [key: string]: unknown;
             }[];
+            /** Extent */
+            extent?: {
+                [key: string]: unknown;
+            } | null;
             /** Summaries */
             summaries?: {
                 [key: string]: unknown;
             } | null;
-            /** Title */
-            title: string;
         };
         /**
          * OGCCollectionsResponse
@@ -9972,13 +9972,13 @@ export interface components {
          * @description OGC API Records FeatureCollection with match counts.
          */
         OGCFeatureCollectionResponse: {
-            /** Features */
-            features: components["schemas"]["OGCRecordResponse"][];
             /**
-             * Links
-             * @description Pagination and self links
+             * Type
+             * @default FeatureCollection
              */
-            links?: components["schemas"]["OGCRecordLink"][] | null;
+            type: string;
+            /** Timestamp */
+            timeStamp?: string | null;
             /**
              * Numbermatched
              * @description Total records matching the query
@@ -9989,13 +9989,13 @@ export interface components {
              * @description Number of records in this response page
              */
             numberReturned: number;
-            /** Timestamp */
-            timeStamp?: string | null;
+            /** Features */
+            features: components["schemas"]["OGCRecordResponse"][];
             /**
-             * Type
-             * @default FeatureCollection
+             * Links
+             * @description Pagination and self links
              */
-            type: string;
+            links?: components["schemas"]["OGCRecordLink"][] | null;
         };
         /** OGCLink */
         OGCLink: {
@@ -10010,25 +10010,25 @@ export interface components {
              */
             rel: string;
             /**
-             * Title
-             * @description Optional human-readable label for the link.
-             */
-            title?: string | null;
-            /**
              * Type
              * @description Media type of the linked resource (e.g. 'application/json', 'application/geo+json').
              */
             type: string;
+            /**
+             * Title
+             * @description Optional human-readable label for the link.
+             */
+            title?: string | null;
         };
         /**
          * OGCRecordLink
          * @description Link object in OGC API Records.
          */
         OGCRecordLink: {
-            /** Href */
-            href: string;
             /** Rel */
             rel: string;
+            /** Href */
+            href: string;
             /** Type */
             type: string;
         };
@@ -10037,153 +10037,153 @@ export interface components {
          * @description Properties block of an OGC API Records Feature.
          */
         OGCRecordProperties: {
-            /** Band Count */
-            band_count?: number | null;
             /**
-             * Column Count
-             * @description Number of columns in the dataset (populated from column_info length).
+             * Type
+             * @default dataset
              */
-            column_count?: number | null;
-            /** Constraints */
-            constraints?: {
-                [key: string]: unknown;
-            } | null;
-            /** Contacts */
-            contacts: {
-                [key: string]: unknown;
-            }[];
-            /** Created */
-            created?: string | null;
-            /** Crs */
-            crs?: string | null;
-            /**
-             * Crs Is Geographic
-             * @description True when the raster CRS is geographic (gsd/res are degrees, not meters); None when the CRS class is unknown.
-             */
-            crs_is_geographic?: boolean | null;
-            /** Dataset Count */
-            dataset_count?: number | null;
+            type: string;
+            /** Title */
+            title: string;
             /** Description */
             description: string;
-            /** Distributions */
-            distributions?: {
-                [key: string]: unknown;
-            }[] | null;
-            /**
-             * Externalids
-             * @description Identifiers assigned by the described resource's source system.
-             */
-            externalIds?: string[];
-            /** Feature Count */
-            feature_count?: number | null;
-            /** Formats */
-            formats?: string[] | null;
-            /** Geometry Type */
-            geometry_type?: string | null;
-            /** Gsd */
-            gsd?: number | null;
-            /**
-             * Has Quicklook
-             * @default false
-             */
-            has_quicklook: boolean;
             /** Keywords */
             keywords: string[];
-            /** Language */
-            language?: string | null;
-            /** License */
-            license: string;
-            /** Lineage */
-            lineage?: string | null;
+            /** Created */
+            created?: string | null;
+            /** Updated */
+            updated?: string | null;
+            /** Updated By Display */
+            updated_by_display?: string | null;
             /**
              * Never Edited
              * @default false
              */
             never_edited: boolean;
+            /** Crs */
+            crs?: string | null;
+            /**
+             * Record Type
+             * @default vector_dataset
+             */
+            record_type: string;
+            /** Band Count */
+            band_count?: number | null;
+            /** Geometry Type */
+            geometry_type?: string | null;
+            /** Feature Count */
+            feature_count?: number | null;
+            /**
+             * Row Count
+             * @description Row count for tabular records (alias for feature_count when record_type='table').
+             */
+            row_count?: number | null;
+            /**
+             * Column Count
+             * @description Number of columns in the dataset (populated from column_info length).
+             */
+            column_count?: number | null;
+            /** License */
+            license: string;
+            /** Source Organization */
+            source_organization?: string | null;
+            /**
+             * Source Format
+             * @description Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac', 'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.
+             */
+            source_format?: string | null;
             /** Quality Detail */
             quality_detail?: {
                 [key: string]: unknown;
             } | null;
             /** Quality Statement */
             quality_statement?: string | null;
-            /** Record Status */
-            record_status?: string | null;
+            /** Formats */
+            formats?: string[] | null;
+            /** Language */
+            language?: string | null;
             /**
-             * Record Type
-             * @default vector_dataset
+             * Externalids
+             * @description Identifiers assigned by the described resource's source system.
              */
-            record_type: string;
-            /** Rights */
-            rights?: string | null;
-            /**
-             * Row Count
-             * @description Row count for tabular records (alias for feature_count when record_type='table').
-             */
-            row_count?: number | null;
-            /** Source Count */
-            source_count?: number | null;
-            /**
-             * Source Format
-             * @description Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac', 'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.
-             */
-            source_format?: string | null;
-            /** Source Organization */
-            source_organization?: string | null;
+            externalIds?: string[];
             /** Themes */
             themes: {
+                [key: string]: unknown;
+            }[];
+            /** Rights */
+            rights?: string | null;
+            /** Contacts */
+            contacts: {
                 [key: string]: unknown;
             }[];
             /** Time */
             time: {
                 [key: string]: unknown;
             };
-            /** Title */
-            title: string;
-            /**
-             * Type
-             * @default dataset
-             */
-            type: string;
+            /** Lineage */
+            lineage?: string | null;
             /** Update Frequency */
             update_frequency?: string | null;
-            /** Updated */
-            updated?: string | null;
-            /** Updated By Display */
-            updated_by_display?: string | null;
+            /** Constraints */
+            constraints?: {
+                [key: string]: unknown;
+            } | null;
+            /** Distributions */
+            distributions?: {
+                [key: string]: unknown;
+            }[] | null;
+            /** Record Status */
+            record_status?: string | null;
+            /**
+             * Has Quicklook
+             * @default false
+             */
+            has_quicklook: boolean;
+            /** Gsd */
+            gsd?: number | null;
+            /**
+             * Crs Is Geographic
+             * @description True when the raster CRS is geographic (gsd/res are degrees, not meters); None when the CRS class is unknown.
+             */
+            crs_is_geographic?: boolean | null;
             /** Vrt Type */
             vrt_type?: string | null;
+            /** Source Count */
+            source_count?: number | null;
+            /** Dataset Count */
+            dataset_count?: number | null;
         };
         /**
          * OGCRecordResponse
          * @description Single OGC API Records Feature.
          */
         OGCRecordResponse: {
+            /**
+             * Type
+             * @default Feature
+             */
+            type: string;
+            /** Id */
+            id: string;
+            /** Conformsto */
+            conformsTo?: string[] | null;
+            /** Time */
+            time: {
+                [key: string]: unknown;
+            };
+            /** Geometry */
+            geometry?: {
+                [key: string]: unknown;
+            } | null;
+            properties: components["schemas"]["OGCRecordProperties"];
+            /** Links */
+            links: components["schemas"]["OGCRecordLink"][];
             /** Assets */
             assets?: {
                 [key: string]: components["schemas"]["OGCAsset"];
             } | null;
             /** Bbox */
             bbox?: number[] | null;
-            /** Conformsto */
-            conformsTo?: string[] | null;
-            /** Geometry */
-            geometry?: {
-                [key: string]: unknown;
-            } | null;
-            /** Id */
-            id: string;
-            /** Links */
-            links: components["schemas"]["OGCRecordLink"][];
-            properties: components["schemas"]["OGCRecordProperties"];
-            /** Time */
-            time: {
-                [key: string]: unknown;
-            };
-            /**
-             * Type
-             * @default Feature
-             */
-            type: string;
         };
         /**
          * OgImageUploadRequest
@@ -10257,21 +10257,21 @@ export interface components {
         /** PresignedUploadRequest */
         PresignedUploadRequest: {
             /**
-             * Content Type
-             * @description MIME type to associate with the uploaded object.
-             * @default application/octet-stream
+             * Filename
+             * @description Original filename being uploaded. Used to determine the file extension and content disposition.
              */
-            content_type: string;
+            filename: string;
             /**
              * File Size
              * @description Total file size in bytes. Used to decide between single-part and multipart upload.
              */
             file_size: number;
             /**
-             * Filename
-             * @description Original filename being uploaded. Used to determine the file extension and content disposition.
+             * Content Type
+             * @description MIME type to associate with the uploaded object.
+             * @default application/octet-stream
              */
-            filename: string;
+            content_type: string;
         };
         /** PresignedUploadResponse */
         PresignedUploadResponse: {
@@ -10282,10 +10282,10 @@ export interface components {
              */
             job_id: string;
             /**
-             * Part Size
-             * @description Byte size of each part in a multipart upload.
+             * Urls
+             * @description One presigned PUT URL per part. Single-element list for single-part uploads.
              */
-            part_size?: number | null;
+            urls: string[];
             /**
              * S3 Key
              * @description Object key in the S3 bucket where the file will be stored.
@@ -10297,13 +10297,24 @@ export interface components {
              */
             upload_id?: string | null;
             /**
-             * Urls
-             * @description One presigned PUT URL per part. Single-element list for single-part uploads.
+             * Part Size
+             * @description Byte size of each part in a multipart upload.
              */
-            urls: string[];
+            part_size?: number | null;
         };
         /** PreviewResponse */
         PreviewResponse: {
+            /**
+             * Job Id
+             * Format: uuid
+             * @description Identifier of the ingestion job being previewed.
+             */
+            job_id: string;
+            /**
+             * Source Filename
+             * @description Original filename of the uploaded file, if known.
+             */
+            source_filename: string | null;
             /**
              * Columns
              * @description Detected attribute columns. Each entry includes name, type, and nullability.
@@ -10315,28 +10326,22 @@ export interface components {
              */
             crs: number | null;
             /**
-             * Detected Geometry Columns
-             * @description Auto-detected lat/lon or geometry columns for CSV/Excel sources. Null for native geospatial formats.
+             * Geometry Type
+             * @description Detected geometry type (Point, LineString, Polygon, MultiPolygon, etc.), or null for non-spatial data.
              */
-            detected_geometry_columns?: {
-                [key: string]: unknown;
-            } | null;
+            geometry_type: string | null;
             /**
              * Feature Count
              * @description Total number of features in the source file, if known.
              */
             feature_count: number | null;
             /**
-             * Geometry Type
-             * @description Detected geometry type (Point, LineString, Polygon, MultiPolygon, etc.), or null for non-spatial data.
+             * Sample Rows
+             * @description Up to 5 sample rows from the source file for preview purposes.
              */
-            geometry_type: string | null;
-            /**
-             * Job Id
-             * Format: uuid
-             * @description Identifier of the ingestion job being previewed.
-             */
-            job_id: string;
+            sample_rows: {
+                [key: string]: unknown;
+            }[];
             /**
              * Layer Name
              * @description Name of the layer being previewed. Defaults to the source filename for single-layer files.
@@ -10348,43 +10353,28 @@ export interface components {
              */
             layers?: components["schemas"]["LayerPreview"][] | null;
             /**
-             * Sample Rows
-             * @description Up to 5 sample rows from the source file for preview purposes.
+             * Detected Geometry Columns
+             * @description Auto-detected lat/lon or geometry columns for CSV/Excel sources. Null for native geospatial formats.
              */
-            sample_rows: {
+            detected_geometry_columns?: {
                 [key: string]: unknown;
-            }[];
-            /**
-             * Source Filename
-             * @description Original filename of the uploaded file, if known.
-             */
-            source_filename: string | null;
+            } | null;
         };
         /** ProbeRequest */
         ProbeRequest: {
-            /**
-             * Token
-             * @description Optional auth token for protected services (passed as query parameter or bearer token depending on service type).
-             */
-            token?: string | null;
             /**
              * Url
              * @description Service URL to probe. May be a WFS GetCapabilities URL or an ArcGIS service endpoint.
              */
             url: string;
+            /**
+             * Token
+             * @description Optional auth token for protected services (passed as query parameter or bearer token depending on service type).
+             */
+            token?: string | null;
         };
         /** ProbeResponse */
         ProbeResponse: {
-            /**
-             * Layers
-             * @description Layers exposed by the probed service.
-             */
-            layers: components["schemas"]["LayerInfo"][];
-            /**
-             * Selected Layer Id
-             * @description Auto-selected layer ID when the input URL contained a specific layer number.
-             */
-            selected_layer_id?: number | string | null;
             /**
              * Service Type
              * @description Detected service type, e.g. 'WFS 2.0' or 'ArcGIS FeatureServer'.
@@ -10395,6 +10385,16 @@ export interface components {
              * @description Normalized service URL after probing.
              */
             url: string;
+            /**
+             * Layers
+             * @description Layers exposed by the probed service.
+             */
+            layers: components["schemas"]["LayerInfo"][];
+            /**
+             * Selected Layer Id
+             * @description Auto-selected layer ID when the input URL contained a specific layer number.
+             */
+            selected_layer_id?: number | string | null;
         };
         /**
          * ProblemDetail
@@ -10406,55 +10406,55 @@ export interface components {
          *     }
          */
         ProblemDetail: {
-            /** Detail */
-            detail: string | {
-                [key: string]: unknown;
-            } | unknown[];
-            /** Status */
-            status: number;
-            /** Title */
-            title: string;
             /**
              * Type
              * @default about:blank
              */
             type: string;
+            /** Title */
+            title: string;
+            /** Status */
+            status: number;
+            /** Detail */
+            detail: string | {
+                [key: string]: unknown;
+            } | unknown[];
         };
         /** ProviderHealth */
         ProviderHealth: {
             /**
-             * Error
-             * @description Error message when status is 'error'.
+             * Status
+             * @description Provider health status: 'ok' or 'error'.
              */
-            error?: string | null;
+            status: string;
             /**
              * Latency Ms
              * @description Latency of the most recent health probe in milliseconds.
              */
             latency_ms: number;
             /**
-             * Status
-             * @description Provider health status: 'ok' or 'error'.
+             * Error
+             * @description Error message when status is 'error'.
              */
-            status: string;
+            error?: string | null;
         };
         /**
          * QualityDetail
          * @description Automated quality assessment results.
          */
         QualityDetail: {
-            /** Attribute Completeness */
-            attribute_completeness: number;
-            /** Computed At */
-            computed_at?: string | null;
-            /** Crs Defined */
-            crs_defined?: number | null;
-            /** Geometry Validity */
-            geometry_validity?: number | null;
-            /** Metadata Completeness */
-            metadata_completeness: number;
             /** Overall */
             overall: number;
+            /** Metadata Completeness */
+            metadata_completeness: number;
+            /** Geometry Validity */
+            geometry_validity?: number | null;
+            /** Attribute Completeness */
+            attribute_completeness: number;
+            /** Crs Defined */
+            crs_defined?: number | null;
+            /** Computed At */
+            computed_at?: string | null;
         };
         /**
          * QualityStatementDraftResponse
@@ -10470,25 +10470,25 @@ export interface components {
         /** RasterBandInfo */
         RasterBandInfo: {
             /**
-             * Color Interp
-             * @description Color interpretation, e.g. Red, Green, Gray
+             * Index
+             * @description 1-based band index
              */
-            color_interp?: string | null;
+            index: number;
             /**
              * Dtype
              * @description Pixel data type, e.g. uint8, float32
              */
             dtype: string;
             /**
-             * Index
-             * @description 1-based band index
-             */
-            index: number;
-            /**
              * Nodata
              * @description Nodata sentinel value for this band
              */
             nodata?: string | null;
+            /**
+             * Color Interp
+             * @description Color interpretation, e.g. Red, Green, Gray
+             */
+            color_interp?: string | null;
         };
         /** RasterConnect */
         RasterConnect: {
@@ -10498,46 +10498,40 @@ export interface components {
              */
             download_url?: string | null;
             /**
-             * S3 Uri
-             * @description S3 object URI, e.g. s3://bucket/key.tif
-             */
-            s3_uri?: string | null;
-            /**
              * Tile Url
              * @description Titiler tile endpoint for this raster
              */
             tile_url: string;
+            /**
+             * S3 Uri
+             * @description S3 object URI, e.g. s3://bucket/key.tif
+             */
+            s3_uri?: string | null;
         };
         /** RasterMetadata */
         RasterMetadata: {
-            /** Band Count */
-            band_count?: number | null;
-            /**
-             * Bands
-             * @default []
-             */
-            bands: components["schemas"]["RasterBandInfo"][];
-            /**
-             * Compression
-             * @description Internal compression, e.g. DEFLATE, LZW
-             */
-            compression?: string | null;
-            connect?: components["schemas"]["RasterConnect"] | null;
-            /**
-             * Crs Is Geographic
-             * @description True when the raster CRS is geographic (res_x/res_y are degrees, not meters); None when the CRS class is unknown.
-             */
-            crs_is_geographic?: boolean | null;
             /**
              * Epsg
              * @description EPSG code of the raster CRS
              */
             epsg?: number | null;
             /**
-             * Height
-             * @description Raster height in pixels
+             * Crs Is Geographic
+             * @description True when the raster CRS is geographic (res_x/res_y are degrees, not meters); None when the CRS class is unknown.
              */
-            height?: number | null;
+            crs_is_geographic?: boolean | null;
+            /**
+             * Res X
+             * @description Pixel resolution in X (CRS units)
+             */
+            res_x?: number | null;
+            /**
+             * Res Y
+             * @description Pixel resolution in Y (CRS units)
+             */
+            res_y?: number | null;
+            /** Band Count */
+            band_count?: number | null;
             /**
              * Is Dem
              * @description True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade
@@ -10549,68 +10543,70 @@ export interface components {
              */
             nodata?: string | null;
             /**
-             * Res X
-             * @description Pixel resolution in X (CRS units)
+             * Compression
+             * @description Internal compression, e.g. DEFLATE, LZW
              */
-            res_x?: number | null;
+            compression?: string | null;
             /**
-             * Res Y
-             * @description Pixel resolution in Y (CRS units)
+             * Width
+             * @description Raster width in pixels
              */
-            res_y?: number | null;
+            width?: number | null;
             /**
-             * Resolution Strategy
-             * @description VRT resolution strategy, e.g. highest, average
+             * Height
+             * @description Raster height in pixels
              */
-            resolution_strategy?: string | null;
+            height?: number | null;
             /**
              * Size Bytes
              * @description File size on disk in bytes
              */
             size_bytes?: number | null;
             /**
-             * Source Count
-             * @description Number of source rasters in a VRT mosaic
+             * Tile Url
+             * @description Titiler XYZ tile endpoint
              */
-            source_count?: number | null;
+            tile_url?: string | null;
+            /**
+             * Bands
+             * @default []
+             */
+            bands: components["schemas"]["RasterBandInfo"][];
+            connect?: components["schemas"]["RasterConnect"] | null;
             /**
              * Status
              * @description Processing status, e.g. ready, failed
              */
             status?: string | null;
             /**
-             * Tile Url
-             * @description Titiler XYZ tile endpoint
-             */
-            tile_url?: string | null;
-            /**
              * Vrt Type
              * @description VRT variant: mosaic or timeseries
              */
             vrt_type?: string | null;
             /**
-             * Width
-             * @description Raster width in pixels
+             * Source Count
+             * @description Number of source rasters in a VRT mosaic
              */
-            width?: number | null;
+            source_count?: number | null;
+            /**
+             * Resolution Strategy
+             * @description VRT resolution strategy, e.g. highest, average
+             */
+            resolution_strategy?: string | null;
         };
         /** RasterPreviewResponse */
         RasterPreviewResponse: {
             /**
-             * Band Count
-             * @description Number of raster bands.
+             * Job Id
+             * Format: uuid
+             * @description Identifier of the raster ingestion job being previewed.
              */
-            band_count: number;
+            job_id: string;
             /**
-             * Compliance Reason
-             * @description Explanation of COG compliance status. Lists missing requirements when not compliant.
+             * Source Filename
+             * @description Original filename of the uploaded raster file.
              */
-            compliance_reason: string;
-            /**
-             * Compression
-             * @description Existing compression method (e.g. 'LZW', 'DEFLATE'), or null for uncompressed.
-             */
-            compression: string | null;
+            source_filename: string | null;
             /**
              * Crs Epsg
              * @description Detected EPSG code for the raster's CRS, if available.
@@ -10622,31 +10618,25 @@ export interface components {
              */
             crs_wkt: string | null;
             /**
-             * Dtype
-             * @description Pixel data type (e.g. 'uint8', 'float32').
+             * Band Count
+             * @description Number of raster bands.
              */
-            dtype: string;
+            band_count: number;
             /**
-             * File Size Bytes
-             * @description Source file size in bytes.
+             * Width
+             * @description Raster width in pixels.
              */
-            file_size_bytes: number | null;
+            width: number;
             /**
              * Height
              * @description Raster height in pixels.
              */
             height: number;
             /**
-             * Is Cog Compliant
-             * @description Whether the source file is already a Cloud-Optimized GeoTIFF.
+             * Dtype
+             * @description Pixel data type (e.g. 'uint8', 'float32').
              */
-            is_cog_compliant: boolean;
-            /**
-             * Job Id
-             * Format: uuid
-             * @description Identifier of the raster ingestion job being previewed.
-             */
-            job_id: string;
+            dtype: string;
             /**
              * Nodata
              * @description Nodata value for the raster, if defined.
@@ -10663,20 +10653,30 @@ export interface components {
              */
             res_y: number;
             /**
-             * Source Filename
-             * @description Original filename of the uploaded raster file.
+             * Compression
+             * @description Existing compression method (e.g. 'LZW', 'DEFLATE'), or null for uncompressed.
              */
-            source_filename: string | null;
+            compression: string | null;
+            /**
+             * File Size Bytes
+             * @description Source file size in bytes.
+             */
+            file_size_bytes: number | null;
+            /**
+             * Is Cog Compliant
+             * @description Whether the source file is already a Cloud-Optimized GeoTIFF.
+             */
+            is_cog_compliant: boolean;
+            /**
+             * Compliance Reason
+             * @description Explanation of COG compliance status. Lists missing requirements when not compliant.
+             */
+            compliance_reason: string;
             /**
              * Temporal Start
              * @description ISO 8601 acquisition timestamp parsed from raster metadata, if present.
              */
             temporal_start?: string | null;
-            /**
-             * Width
-             * @description Raster width in pixels.
-             */
-            width: number;
         };
         /**
          * RasterTileToken
@@ -10695,31 +10695,31 @@ export interface components {
          *     as fields, mirroring `VectorTileToken`, for clients that rebuild the URL.
          */
         RasterTileToken: {
-            /** Bounds */
-            bounds: number[] | null;
-            /** Exp */
-            exp: number;
-            /** Expires In */
-            expires_in: number;
-            /** Format */
-            format: string;
             /**
              * Kind
              * @constant
              */
             kind: "raster";
-            /** Maxzoom */
-            maxzoom: number;
-            /** Minzoom */
-            minzoom: number;
-            /** Scope */
-            scope: string;
-            /** Sig */
-            sig: string;
-            /** Tile Size */
-            tile_size: number;
             /** Tile Url */
             tile_url: string;
+            /** Sig */
+            sig: string;
+            /** Exp */
+            exp: number;
+            /** Scope */
+            scope: string;
+            /** Expires In */
+            expires_in: number;
+            /** Bounds */
+            bounds: number[] | null;
+            /** Minzoom */
+            minzoom: number;
+            /** Maxzoom */
+            maxzoom: number;
+            /** Tile Size */
+            tile_size: number;
+            /** Format */
+            format: string;
         };
         /** RefreshRequest */
         RefreshRequest: {
@@ -10728,11 +10728,6 @@ export interface components {
         };
         /** RegisterRequest */
         RegisterRequest: {
-            /**
-             * Summary
-             * @description Optional dataset description.
-             */
-            summary?: string | null;
             /**
              * Table Name
              * @description PostgreSQL table name in the `data` schema (max 63 chars per PostgreSQL identifier limit).
@@ -10743,6 +10738,11 @@ export interface components {
              * @description Human-readable dataset title shown in the catalog.
              */
             title: string;
+            /**
+             * Summary
+             * @description Optional dataset description.
+             */
+            summary?: string | null;
             /**
              * Visibility
              * @description Dataset visibility level.
@@ -10763,23 +10763,23 @@ export interface components {
         };
         /** RelatedDatasetItem */
         RelatedDatasetItem: {
-            /** Band Count */
-            band_count?: number | null;
-            /** Feature Count */
-            feature_count?: number | null;
-            /** Geometry Type */
-            geometry_type: string | null;
             /** Id */
             id: string;
             /** Name */
             name: string;
-            /** Record Type */
-            record_type?: string | null;
+            /** Geometry Type */
+            geometry_type: string | null;
             /**
              * Similarity
              * @description Cosine similarity score (0-1)
              */
             similarity: number;
+            /** Record Type */
+            record_type?: string | null;
+            /** Feature Count */
+            feature_count?: number | null;
+            /** Band Count */
+            band_count?: number | null;
         };
         /** RelatedDatasetsResponse */
         RelatedDatasetsResponse: {
@@ -10814,22 +10814,22 @@ export interface components {
         };
         /** ReservedRenameWarning */
         ReservedRenameWarning: {
-            /** Details */
-            details: components["schemas"]["ReservedRenameDetail"][];
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             kind: "reserved_rename";
+            /** Details */
+            details: components["schemas"]["ReservedRenameDetail"][];
         };
         /** ReuploadCommitRequest */
         ReuploadCommitRequest: {
-            /** Layer Name */
-            layer_name?: string | null;
             /** Srid Override */
             srid_override?: number | null;
             /** Token */
             token?: string | null;
+            /** Layer Name */
+            layer_name?: string | null;
         };
         /** ReuploadCommitResponse */
         ReuploadCommitResponse: {
@@ -10838,10 +10838,10 @@ export interface components {
              * Format: uuid
              */
             job_id: string;
-            /** Message */
-            message: string;
             /** Status */
             status: string;
+            /** Message */
+            message: string;
         };
         /** ReuploadPreviewRequest */
         ReuploadPreviewRequest: {
@@ -10850,34 +10850,34 @@ export interface components {
         };
         /** ReuploadPreviewResponse */
         ReuploadPreviewResponse: {
-            /** All Layers */
-            all_layers?: {
-                [key: string]: unknown;
-            }[] | null;
-            /** Columns */
-            columns: components["schemas"]["ColumnChange"][];
-            /** Crs */
-            crs: number | null;
-            /** Feature Count */
-            feature_count: number | null;
-            /** Geometry Type */
-            geometry_type: string | null;
             /**
              * Job Id
              * Format: uuid
              */
             job_id: string;
-            /** Layer Name */
-            layer_name: string;
-            /** Previous Source Layer */
-            previous_source_layer?: string | null;
+            /** Source Filename */
+            source_filename: string | null;
+            /** Columns */
+            columns: components["schemas"]["ColumnChange"][];
+            /** Crs */
+            crs: number | null;
+            /** Geometry Type */
+            geometry_type: string | null;
+            /** Feature Count */
+            feature_count: number | null;
             /** Sample Rows */
             sample_rows: {
                 [key: string]: unknown;
             }[];
+            /** Layer Name */
+            layer_name: string;
             schema_diff: components["schemas"]["SchemaDiff"];
-            /** Source Filename */
-            source_filename: string | null;
+            /** All Layers */
+            all_layers?: {
+                [key: string]: unknown;
+            }[] | null;
+            /** Previous Source Layer */
+            previous_source_layer?: string | null;
         };
         /** ReuploadResponse */
         ReuploadResponse: {
@@ -10886,62 +10886,67 @@ export interface components {
              * Format: uuid
              */
             job_id: string;
-            /** Message */
-            message: string;
             /**
              * Status
              * @default pending
              */
             status: string;
+            /** Message */
+            message: string;
         };
         /** ReuploadServicePreviewRequest */
         ReuploadServicePreviewRequest: {
-            /** Layer Id */
-            layer_id?: number | string | null;
+            /** Url */
+            url: string;
+            /** Service Type */
+            service_type: string;
             /** Layer Name */
             layer_name: string;
             /** Layer Title */
             layer_title?: string | null;
-            /** Object Id Field */
-            object_id_field?: string | null;
-            /** Service Type */
-            service_type: string;
+            /** Layer Id */
+            layer_id?: number | string | null;
             /** Token */
             token?: string | null;
-            /** Url */
-            url: string;
+            /** Object Id Field */
+            object_id_field?: string | null;
         };
         /**
          * SSEActionsEvent
          * @description Validated map-edit actions produced by streaming chat.
          */
         SSEActionsEvent: {
-            /** Actions */
-            actions: components["schemas"]["ChatAction"][];
             /**
              * Type
              * @constant
              */
             type: "actions";
+            /** Actions */
+            actions: components["schemas"]["ChatAction"][];
         };
         /**
          * SSEChatDoneEvent
          * @description Terminal payload for a successful streaming chat request.
          */
         SSEChatDoneEvent: {
-            /** Explanation */
-            explanation: string;
             /**
              * Type
              * @constant
              */
             type: "done";
+            /** Explanation */
+            explanation: string;
         };
         /**
          * SSEErrorEvent
          * @description Error payload carried inside an already-open SSE response.
          */
         SSEErrorEvent: {
+            /**
+             * Type
+             * @constant
+             */
+            type: "error";
             /** Message */
             message: string | {
                 [key: string]: unknown;
@@ -10952,73 +10957,68 @@ export interface components {
              * @default null
              */
             status: number | null;
-            /**
-             * Type
-             * @constant
-             */
-            type: "error";
         };
         /**
          * SSEMapDoneEvent
          * @description Terminal payload for a successful streaming map-generation request.
          */
         SSEMapDoneEvent: {
-            /** Datasets Used */
-            datasets_used: string[];
-            /** Explanation */
-            explanation: string;
-            /** Map Id */
-            map_id: string;
-            /** Map Name */
-            map_name: string;
             /**
              * Type
              * @constant
              */
             type: "done";
+            /** Map Id */
+            map_id: string;
+            /** Map Name */
+            map_name: string;
+            /** Explanation */
+            explanation: string;
+            /** Datasets Used */
+            datasets_used: string[];
         };
         /**
          * SSETokenEvent
          * @description Token payload carried by a ``token`` server-sent event.
          */
         SSETokenEvent: {
-            /** Text */
-            text: string;
             /**
              * Type
              * @constant
              */
             type: "token";
+            /** Text */
+            text: string;
         };
         /**
          * SSEToolResultEvent
          * @description Progress payload emitted when an AI tool finishes.
          */
         SSEToolResultEvent: {
-            /** Success */
-            success: boolean;
-            /** Tool */
-            tool: string;
             /**
              * Type
              * @constant
              */
             type: "tool_result";
+            /** Tool */
+            tool: string;
+            /** Success */
+            success: boolean;
         };
         /**
          * SSEToolStartEvent
          * @description Progress payload emitted when an AI tool starts.
          */
         SSEToolStartEvent: {
-            /** Label */
-            label: string;
-            /** Tool */
-            tool: string;
             /**
              * Type
              * @constant
              */
             type: "tool_start";
+            /** Tool */
+            tool: string;
+            /** Label */
+            label: string;
         };
         /**
          * SavedSearchCreate
@@ -11051,11 +11051,6 @@ export interface components {
          */
         SavedSearchResponse: {
             /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /**
              * Id
              * Format: uuid
              */
@@ -11066,6 +11061,11 @@ export interface components {
             params: {
                 [key: string]: unknown;
             };
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
             /**
              * Updated At
              * Format: date-time
@@ -11085,36 +11085,41 @@ export interface components {
              */
             columns_removed: components["schemas"]["ColumnChange"][];
             /**
-             * Row Count Delta
-             * @description row_count_new minus row_count_old
-             */
-            row_count_delta: number;
-            /** Row Count New */
-            row_count_new: number | null;
-            /** Row Count Old */
-            row_count_old: number | null;
-            /**
              * Type Changes
              * @description Columns whose data type changed
              */
             type_changes: components["schemas"]["TypeChange"][];
+            /** Row Count Old */
+            row_count_old: number | null;
+            /** Row Count New */
+            row_count_new: number | null;
+            /**
+             * Row Count Delta
+             * @description row_count_new minus row_count_old
+             */
+            row_count_delta: number;
         };
         /** ServiceHealth */
         ServiceHealth: {
-            /** Error */
-            error?: string | null;
-            /** Latency Ms */
-            latency_ms?: number | null;
             /** Status */
             status: string;
+            /** Latency Ms */
+            latency_ms?: number | null;
+            /** Error */
+            error?: string | null;
         };
         /** ServicePreviewRequest */
         ServicePreviewRequest: {
             /**
-             * Layer Id
-             * @description ArcGIS layer ID, when applicable.
+             * Url
+             * @description Normalized service URL from a previous probe response.
              */
-            layer_id?: number | string | null;
+            url: string;
+            /**
+             * Service Type
+             * @description Service type from the probe response, e.g. 'WFS 2.0.0' or 'ArcGIS FeatureServer'.
+             */
+            service_type: string;
             /**
              * Layer Name
              * @description Name of the specific layer to preview, from the probe layers list.
@@ -11126,28 +11131,34 @@ export interface components {
              */
             layer_title?: string | null;
             /**
-             * Object Id Field
-             * @description ArcGIS OID field name used for orderByFields during preview pagination.
+             * Layer Id
+             * @description ArcGIS layer ID, when applicable.
              */
-            object_id_field?: string | null;
-            /**
-             * Service Type
-             * @description Service type from the probe response, e.g. 'WFS 2.0.0' or 'ArcGIS FeatureServer'.
-             */
-            service_type: string;
+            layer_id?: number | string | null;
             /**
              * Token
              * @description Optional auth token for protected services.
              */
             token?: string | null;
             /**
-             * Url
-             * @description Normalized service URL from a previous probe response.
+             * Object Id Field
+             * @description ArcGIS OID field name used for orderByFields during preview pagination.
              */
-            url: string;
+            object_id_field?: string | null;
         };
         /** ServicePreviewResponse */
         ServicePreviewResponse: {
+            /**
+             * Job Id
+             * Format: uuid
+             * @description IngestJob ID for the preview. Use this to commit the import.
+             */
+            job_id: string;
+            /**
+             * Source Filename
+             * @description Layer name acting as a source filename for downstream ingestion logic.
+             */
+            source_filename: string | null;
             /**
              * Columns
              * @description Detected attribute columns: [{'name': str, 'type': str}, ...].
@@ -11161,26 +11172,15 @@ export interface components {
              */
             crs: number | null;
             /**
-             * Feature Count
-             * @description Total feature count if reported by the source service.
-             */
-            feature_count: number | null;
-            /**
              * Geometry Type
              * @description Detected geometry type.
              */
             geometry_type: string | null;
             /**
-             * Job Id
-             * Format: uuid
-             * @description IngestJob ID for the preview. Use this to commit the import.
+             * Feature Count
+             * @description Total feature count if reported by the source service.
              */
-            job_id: string;
-            /**
-             * Layer Name
-             * @description Layer name as it appears in the remote service.
-             */
-            layer_name: string;
+            feature_count: number | null;
             /**
              * Sample Rows
              * @description Up to 5 sample rows for preview display.
@@ -11189,26 +11189,16 @@ export interface components {
                 [key: string]: unknown;
             }[];
             /**
-             * Source Filename
-             * @description Layer name acting as a source filename for downstream ingestion logic.
+             * Layer Name
+             * @description Layer name as it appears in the remote service.
              */
-            source_filename: string | null;
+            layer_name: string;
         };
         /**
          * ServiceProbeResult
          * @description Result of a single service connectivity probe.
          */
         ServiceProbeResult: {
-            /**
-             * Error
-             * @description Error message when status is 'error'.
-             */
-            error?: string | null;
-            /**
-             * Latency Ms
-             * @description Round-trip latency in milliseconds.
-             */
-            latency_ms: number;
             /**
              * Name
              * @description Service name (e.g. 'storage', 'cache', 'oidc:google').
@@ -11220,6 +11210,16 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "error";
+            /**
+             * Latency Ms
+             * @description Round-trip latency in milliseconds.
+             */
+            latency_ms: number;
+            /**
+             * Error
+             * @description Error message when status is 'error'.
+             */
+            error?: string | null;
         };
         /**
          * SettingItem
@@ -11232,20 +11232,20 @@ export interface components {
              */
             key: string;
             /**
-             * Label
-             * @description Human-readable label for display in the admin UI.
+             * Value
+             * @description Current value. Type depends on the setting.
              */
-            label: string;
+            value: unknown;
             /**
              * Source
              * @description Where the value came from: 'default' (built-in default), 'overridden' (admin set via UI), or 'env_only' (configured via environment variable, read-only).
              */
             source: string;
             /**
-             * Value
-             * @description Current value. Type depends on the setting.
+             * Label
+             * @description Human-readable label for display in the admin UI.
              */
-            value: unknown;
+            label: string;
         };
         /**
          * SettingsAllResponse
@@ -11304,6 +11304,16 @@ export interface components {
         };
         /** ShareTokenResponse */
         ShareTokenResponse: {
+            /**
+             * Token
+             * @description Raw token on create, hint on retrieve
+             */
+            token: string;
+            /**
+             * Share Url
+             * @description Full shareable URL — only returned on create
+             */
+            share_url?: string | null;
             /** Expires At */
             expires_at?: string | null;
             /**
@@ -11311,134 +11321,124 @@ export interface components {
              * @default true
              */
             is_active: boolean;
-            /**
-             * Share Url
-             * @description Full shareable URL — only returned on create
-             */
-            share_url?: string | null;
-            /**
-             * Token
-             * @description Raw token on create, hint on retrieve
-             */
-            token: string;
         };
         /** SharedLayerResponse */
         SharedLayerResponse: {
-            /** Column Info */
-            column_info?: {
-                [key: string]: unknown;
-            }[] | null;
+            /** Id */
+            id: string;
             /** Dataset Id */
             dataset_id: string;
             /** Dataset Name */
             dataset_name: string;
-            /** Dataset Record Type */
-            dataset_record_type?: string | null;
-            /** Dem Vertical Units */
-            dem_vertical_units?: string | null;
             /** Display Name */
             display_name?: string | null;
-            /** Feature Count */
-            feature_count?: number | null;
-            /** Filter */
-            filter?: unknown[] | null;
+            /** Table Name */
+            table_name: string;
             /** Geometry Type */
             geometry_type: string | null;
-            /** Id */
-            id: string;
-            /** Is 3D */
-            is_3d?: boolean | null;
-            /** Is Dem */
-            is_dem?: boolean | null;
-            /** Label Config */
-            label_config?: {
+            /** Column Info */
+            column_info?: {
                 [key: string]: unknown;
-            } | null;
-            /**
-             * Layer Type
-             * @default vector_geolens
-             */
-            layer_type: string;
-            /** Layout */
-            layout: {
-                [key: string]: unknown;
-            };
+            }[] | null;
+            /** Sort Order */
+            sort_order: number;
+            /** Visible */
+            visible: boolean;
             /** Opacity */
             opacity: number;
             /** Paint */
             paint: {
                 [key: string]: unknown;
             };
+            /** Layout */
+            layout: {
+                [key: string]: unknown;
+            };
+            /**
+             * Layer Type
+             * @default vector_geolens
+             */
+            layer_type: string;
+            /** Dataset Record Type */
+            dataset_record_type?: string | null;
+            /** Filter */
+            filter?: unknown[] | null;
+            /** Label Config */
+            label_config?: {
+                [key: string]: unknown;
+            } | null;
             popup_config?: components["schemas"]["PopupConfig"] | null;
+            /** Style Config */
+            style_config?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Show In Legend
              * @default true
              */
             show_in_legend: boolean;
-            /** Sort Order */
-            sort_order: number;
-            /** Style Config */
-            style_config?: {
-                [key: string]: unknown;
-            } | null;
-            /** Table Name */
-            table_name: string;
             /** Tile Url */
             tile_url: string;
+            /** Is Dem */
+            is_dem?: boolean | null;
+            /** Dem Vertical Units */
+            dem_vertical_units?: string | null;
+            /** Is 3D */
+            is_3d?: boolean | null;
+            /** Feature Count */
+            feature_count?: number | null;
             /** Tile Version */
             tile_version?: number | null;
-            /** Visible */
-            visible: boolean;
         };
         /** SharedMapResponse */
         SharedMapResponse: {
-            basemap_config?: components["schemas"]["BasemapConfig"] | null;
-            /** Basemap Style */
-            basemap_style: string;
-            /** Bearing */
-            bearing: number;
-            /** Center Lat */
-            center_lat: number;
-            /** Center Lng */
-            center_lng: number;
-            /** Description */
-            description: string | null;
-            /**
-             * Has Non Public Layers
-             * @default false
-             */
-            has_non_public_layers: boolean;
-            /** Layers */
-            layers: components["schemas"]["SharedLayerResponse"][];
-            /** Legend Title */
-            legend_title?: string | null;
             /** Name */
             name: string;
+            /** Description */
+            description: string | null;
+            /** Center Lng */
+            center_lng: number;
+            /** Center Lat */
+            center_lat: number;
+            /** Zoom */
+            zoom: number;
+            /** Bearing */
+            bearing: number;
             /** Pitch */
             pitch: number;
+            /** Basemap Style */
+            basemap_style: string;
             /**
              * Show Basemap Labels
              * @default true
              */
             show_basemap_labels: boolean;
+            basemap_config?: components["schemas"]["BasemapConfig"] | null;
             terrain_config?: components["schemas"]["TerrainConfig"] | null;
-            /** Zoom */
-            zoom: number;
+            /**
+             * Has Non Public Layers
+             * @default false
+             */
+            has_non_public_layers: boolean;
+            /** Legend Title */
+            legend_title?: string | null;
+            /** Layers */
+            layers: components["schemas"]["SharedLayerResponse"][];
         };
         /** StacAsset */
         StacAsset: {
-            /** Description */
-            description?: string | null;
             /** Href */
             href: string;
+            /** Type */
+            type?: string | null;
+            /** Title */
+            title?: string | null;
+            /** Description */
+            description?: string | null;
             /** Roles */
             roles?: string[] | null;
             /** Size Bytes */
             size_bytes?: number | null;
-            /** Title */
-            title?: string | null;
-            /** Type */
-            type?: string | null;
         };
         /**
          * StacCatalog
@@ -11446,25 +11446,16 @@ export interface components {
          */
         StacCatalog: {
             /**
-             * Conformsto
-             * @description List of conformance URIs declaring which STAC and OGC API standards the catalog implements.
+             * Type
+             * @description STAC object type. Always 'Catalog' for the landing page.
+             * @default Catalog
              */
-            conformsTo: string[];
-            /**
-             * Description
-             * @description Human-readable catalog description.
-             */
-            description: string;
+            type: string;
             /**
              * Id
              * @description Stable identifier for the catalog.
              */
             id: string;
-            /**
-             * Links
-             * @description Catalog navigation links (self, root, search, collections, etc.).
-             */
-            links: components["schemas"]["StacLink"][];
             /**
              * Stac Version
              * @description STAC specification version implemented.
@@ -11477,11 +11468,20 @@ export interface components {
              */
             title: string;
             /**
-             * Type
-             * @description STAC object type. Always 'Catalog' for the landing page.
-             * @default Catalog
+             * Description
+             * @description Human-readable catalog description.
              */
-            type: string;
+            description: string;
+            /**
+             * Conformsto
+             * @description List of conformance URIs declaring which STAC and OGC API standards the catalog implements.
+             */
+            conformsTo: string[];
+            /**
+             * Links
+             * @description Catalog navigation links (self, root, search, collections, etc.).
+             */
+            links: components["schemas"]["StacLink"][];
         };
         /**
          * StacCollection
@@ -11489,11 +11489,39 @@ export interface components {
          */
         StacCollection: {
             /**
+             * Type
+             * @description STAC object type.
+             * @default Collection
+             */
+            type: string;
+            /**
+             * Stac Version
+             * @description STAC specification version.
+             * @default 1.0.0
+             */
+            stac_version: string;
+            /**
+             * Id
+             * @description Stable collection identifier.
+             */
+            id: string;
+            /**
+             * Title
+             * @description Human-readable collection title.
+             */
+            title?: string | null;
+            /**
              * Description
              * @description Collection description.
              * @default
              */
             description: string;
+            /**
+             * License
+             * @description SPDX license identifier or 'proprietary'.
+             * @default proprietary
+             */
+            license: string;
             /**
              * Extent
              * @description Spatial and temporal extent of items in the collection.
@@ -11502,38 +11530,10 @@ export interface components {
                 [key: string]: unknown;
             };
             /**
-             * Id
-             * @description Stable collection identifier.
-             */
-            id: string;
-            /**
-             * License
-             * @description SPDX license identifier or 'proprietary'.
-             * @default proprietary
-             */
-            license: string;
-            /**
              * Links
              * @description Collection navigation links.
              */
             links: components["schemas"]["StacLink"][];
-            /**
-             * Stac Version
-             * @description STAC specification version.
-             * @default 1.0.0
-             */
-            stac_version: string;
-            /**
-             * Title
-             * @description Human-readable collection title.
-             */
-            title?: string | null;
-            /**
-             * Type
-             * @description STAC object type.
-             * @default Collection
-             */
-            type: string;
         } & {
             [key: string]: unknown;
         };
@@ -11556,25 +11556,25 @@ export interface components {
         /** StacCollectionSummary */
         StacCollectionSummary: {
             /**
-             * Bbox
-             * @description Spatial extent as [west, south, east, north].
+             * Id
+             * @description Collection identifier.
              */
-            bbox?: number[] | null;
+            id: string;
+            /**
+             * Title
+             * @description Collection title.
+             */
+            title: string;
             /**
              * Description
              * @description Collection description.
              */
             description: string;
             /**
-             * Id
-             * @description Collection identifier.
+             * License
+             * @description SPDX license identifier.
              */
-            id: string;
-            /**
-             * Item Count
-             * @description Number of items if reported by the API.
-             */
-            item_count?: number | null;
+            license?: string | null;
             /**
              * Keywords
              * @description Collection keywords.
@@ -11582,38 +11582,38 @@ export interface components {
              */
             keywords: string[];
             /**
-             * License
-             * @description SPDX license identifier.
+             * Bbox
+             * @description Spatial extent as [west, south, east, north].
              */
-            license?: string | null;
-            /**
-             * Temporal End
-             * @description End of temporal extent (ISO 8601).
-             */
-            temporal_end?: string | null;
+            bbox?: number[] | null;
             /**
              * Temporal Start
              * @description Start of temporal extent (ISO 8601).
              */
             temporal_start?: string | null;
             /**
-             * Title
-             * @description Collection title.
+             * Temporal End
+             * @description End of temporal extent (ISO 8601).
              */
-            title: string;
+            temporal_end?: string | null;
+            /**
+             * Item Count
+             * @description Number of items if reported by the API.
+             */
+            item_count?: number | null;
         };
         /** StacCollectionsResponse */
         StacCollectionsResponse: {
-            /**
-             * Collections
-             * @description Available collections.
-             */
-            collections: components["schemas"]["StacCollectionSummary"][];
             /**
              * Url
              * @description STAC API URL that was queried.
              */
             url: string;
+            /**
+             * Collections
+             * @description Available collections.
+             */
+            collections: components["schemas"]["StacCollectionSummary"][];
         };
         /**
          * StacConformance
@@ -11637,10 +11637,20 @@ export interface components {
         /** StacConnectResponse */
         StacConnectResponse: {
             /**
+             * Url
+             * @description Normalized STAC API URL.
+             */
+            url: string;
+            /**
              * Catalog Id
              * @description Catalog identifier from the landing page.
              */
             catalog_id: string;
+            /**
+             * Title
+             * @description Catalog title.
+             */
+            title: string;
             /**
              * Description
              * @description Catalog description.
@@ -11651,16 +11661,6 @@ export interface components {
              * @description STAC specification version.
              */
             stac_version: string;
-            /**
-             * Title
-             * @description Catalog title.
-             */
-            title: string;
-            /**
-             * Url
-             * @description Normalized STAC API URL.
-             */
-            url: string;
         };
         /**
          * StacContext
@@ -11669,74 +11669,74 @@ export interface components {
         StacContext: {
             /** Limit */
             limit: number;
-            /** Matched */
-            matched: number;
             /** Returned */
             returned: number;
+            /** Matched */
+            matched: number;
         } & {
             [key: string]: unknown;
         };
         /** StacImportItem */
         StacImportItem: {
             /**
-             * Bbox
-             * @description Item bounding box.
+             * Id
+             * @description STAC item ID.
              */
-            bbox?: number[] | null;
+            id: string;
             /**
              * Collection
              * @description Parent collection ID.
              */
             collection?: string | null;
             /**
+             * Title
+             * @description Title to use for the GeoLens dataset.
+             */
+            title: string;
+            /**
              * Data Asset Href
              * @description URL of the COG asset to reference.
              */
             data_asset_href: string;
             /**
-             * Datetime End
-             * @description Temporal end.
+             * Bbox
+             * @description Item bounding box.
              */
-            datetime_end?: string | null;
-            /**
-             * Datetime Start
-             * @description Temporal start.
-             */
-            datetime_start?: string | null;
+            bbox?: number[] | null;
             /**
              * Epsg
              * @description EPSG code.
              */
             epsg?: number | null;
             /**
-             * Id
-             * @description STAC item ID.
+             * Datetime Start
+             * @description Temporal start.
              */
-            id: string;
+            datetime_start?: string | null;
+            /**
+             * Datetime End
+             * @description Temporal end.
+             */
+            datetime_end?: string | null;
             /**
              * Keywords
              * @description Keywords from STAC collection.
              * @default []
              */
             keywords: string[];
-            /**
-             * Title
-             * @description Title to use for the GeoLens dataset.
-             */
-            title: string;
         };
         /** StacImportRequest */
         StacImportRequest: {
-            /**
-             * Items
-             * @description Items to import (max 50 per request).
-             */
-            items: components["schemas"]["StacImportItem"][];
             /**
              * Url
              * @description STAC API URL for provenance.
              */
             url: string;
+            /**
+             * Items
+             * @description Items to import (max 50 per request).
+             */
+            items: components["schemas"]["StacImportItem"][];
             /**
              * Visibility
              * @description Visibility for imported datasets.
@@ -11748,49 +11748,49 @@ export interface components {
         /** StacImportResponse */
         StacImportResponse: {
             /**
-             * Created
-             * @description Number of datasets created.
-             */
-            created: number;
-            /**
-             * Errors
-             * @description Number of items that failed.
-             */
-            errors: number;
-            /**
              * Results
              * @description Per-item import results.
              */
             results: components["schemas"]["StacImportResult"][];
             /**
+             * Created
+             * @description Number of datasets created.
+             */
+            created: number;
+            /**
              * Skipped
              * @description Number of items skipped (duplicates).
              */
             skipped: number;
+            /**
+             * Errors
+             * @description Number of items that failed.
+             */
+            errors: number;
         };
         /** StacImportResult */
         StacImportResult: {
-            /**
-             * Dataset Id
-             * @description Created GeoLens dataset ID.
-             */
-            dataset_id?: string | null;
-            /**
-             * Error
-             * @description Error message if failed.
-             */
-            error?: string | null;
             /**
              * Item Id
              * @description STAC item ID that was processed.
              */
             item_id: string;
             /**
+             * Dataset Id
+             * @description Created GeoLens dataset ID.
+             */
+            dataset_id?: string | null;
+            /**
              * Status
              * @description Import result status.
              * @enum {string}
              */
             status: "created" | "skipped" | "error";
+            /**
+             * Error
+             * @description Error message if failed.
+             */
+            error?: string | null;
         };
         /**
          * StacItemAsset
@@ -11798,30 +11798,30 @@ export interface components {
          */
         StacItemAsset: {
             /**
-             * Description
-             * @description Human-readable asset description.
-             */
-            description?: string | null;
-            /**
              * Href
              * @description URL of the asset resource.
              */
             href: string;
             /**
-             * Roles
-             * @description Semantic roles such as data or visual.
+             * Type
+             * @description Asset media type.
              */
-            roles?: string[] | null;
+            type?: string | null;
             /**
              * Title
              * @description Human-readable asset title.
              */
             title?: string | null;
             /**
-             * Type
-             * @description Asset media type.
+             * Description
+             * @description Human-readable asset description.
              */
-            type?: string | null;
+            description?: string | null;
+            /**
+             * Roles
+             * @description Semantic roles such as data or visual.
+             */
+            roles?: string[] | null;
         } & {
             [key: string]: unknown;
         };
@@ -11842,7 +11842,12 @@ export interface components {
          *     }
          */
         StacItemCollectionResponse: {
-            context: components["schemas"]["StacContext"];
+            /**
+             * Type
+             * @default FeatureCollection
+             * @constant
+             */
+            type: "FeatureCollection";
             /** Features */
             features: components["schemas"]["StacItemResponse"][];
             /** Links */
@@ -11851,12 +11856,7 @@ export interface components {
             numberMatched: number;
             /** Numberreturned */
             numberReturned: number;
-            /**
-             * Type
-             * @default FeatureCollection
-             * @constant
-             */
-            type: "FeatureCollection";
+            context: components["schemas"]["StacContext"];
         } & {
             [key: string]: unknown;
         };
@@ -11871,25 +11871,25 @@ export interface components {
              */
             datetime: string | null;
             /**
-             * Description
-             * @description Human-readable item description.
+             * Start Datetime
+             * @description Start of the item's temporal interval.
              */
-            description?: string | null;
+            start_datetime?: string | null;
             /**
              * End Datetime
              * @description End of the item's temporal interval.
              */
             end_datetime?: string | null;
             /**
-             * Start Datetime
-             * @description Start of the item's temporal interval.
-             */
-            start_datetime?: string | null;
-            /**
              * Title
              * @description Human-readable item title.
              */
             title?: string | null;
+            /**
+             * Description
+             * @description Human-readable item description.
+             */
+            description?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -11909,10 +11909,32 @@ export interface components {
          *     }
          */
         StacItemResponse: {
-            /** Assets */
-            assets: {
-                [key: string]: components["schemas"]["StacItemAsset"];
-            };
+            /**
+             * Type
+             * @default Feature
+             * @constant
+             */
+            type: "Feature";
+            /**
+             * Stac Version
+             * @description STAC specification version.
+             */
+            stac_version: string;
+            /**
+             * Stac Extensions
+             * @description STAC extension schema URIs in use.
+             */
+            stac_extensions?: string[];
+            /**
+             * Id
+             * @description Stable item identifier.
+             */
+            id: string;
+            /**
+             * Geometry
+             * @description Item footprint as GeoJSON, or null when unavailable.
+             */
+            geometry: components["schemas"]["GeoJSONGeometryCollection"] | components["schemas"]["GeoJSONGeometry"] | null;
             /**
              * Bbox
              * @description Item bounding box with exactly four 2D or six 3D coordinates.
@@ -11930,95 +11952,58 @@ export interface components {
                 number,
                 number
             ] | null;
+            properties: components["schemas"]["StacItemProperties"];
+            /** Links */
+            links: components["schemas"]["StacLink"][];
+            /** Assets */
+            assets: {
+                [key: string]: components["schemas"]["StacItemAsset"];
+            };
             /**
              * Collection
              * @description Identifier of the containing STAC Collection.
              */
             collection?: string | null;
-            /**
-             * Geometry
-             * @description Item footprint as GeoJSON, or null when unavailable.
-             */
-            geometry: components["schemas"]["GeoJSONGeometryCollection"] | components["schemas"]["GeoJSONGeometry"] | null;
-            /**
-             * Id
-             * @description Stable item identifier.
-             */
-            id: string;
-            /** Links */
-            links: components["schemas"]["StacLink"][];
-            properties: components["schemas"]["StacItemProperties"];
-            /**
-             * Stac Extensions
-             * @description STAC extension schema URIs in use.
-             */
-            stac_extensions?: string[];
-            /**
-             * Stac Version
-             * @description STAC specification version.
-             */
-            stac_version: string;
-            /**
-             * Type
-             * @default Feature
-             * @constant
-             */
-            type: "Feature";
         } & {
             [key: string]: unknown;
         };
         /** StacItemSummary */
         StacItemSummary: {
             /**
-             * Asset Count
-             * @description Number of assets on this item.
+             * Id
+             * @description Item identifier.
              */
-            asset_count: number;
-            /**
-             * Bbox
-             * @description Item bounding box.
-             */
-            bbox?: number[] | null;
-            /**
-             * Cloud Cover
-             * @description Cloud cover percentage (eo extension).
-             */
-            cloud_cover?: number | null;
+            id: string;
             /**
              * Collection
              * @description Parent collection ID.
              */
             collection?: string | null;
             /**
-             * Data Asset Href
-             * @description URL of the primary data asset (COG).
+             * Title
+             * @description Item title (falls back to ID).
              */
-            data_asset_href?: string | null;
+            title: string;
             /**
-             * Data Asset Size Bytes
-             * @description Size of the primary data asset in bytes (from STAC file:size). None when not in manifest.
+             * Bbox
+             * @description Item bounding box.
              */
-            data_asset_size_bytes?: number | null;
-            /**
-             * Data Asset Type
-             * @description Media type of the data asset.
-             */
-            data_asset_type?: string | null;
+            bbox?: number[] | null;
             /**
              * Datetime
              * @description Primary datetime (ISO 8601).
              */
             datetime?: string | null;
             /**
-             * Datetime End
-             * @description End datetime for ranges.
-             */
-            datetime_end?: string | null;
-            /**
              * Datetime Start
              * @description Start datetime for ranges.
              */
             datetime_start?: string | null;
+            /**
+             * Datetime End
+             * @description End datetime for ranges.
+             */
+            datetime_end?: string | null;
             /**
              * Epsg
              * @description EPSG code from proj extension.
@@ -12030,20 +12015,35 @@ export interface components {
              */
             gsd?: number | null;
             /**
-             * Id
-             * @description Item identifier.
+             * Cloud Cover
+             * @description Cloud cover percentage (eo extension).
              */
-            id: string;
+            cloud_cover?: number | null;
+            /**
+             * Data Asset Href
+             * @description URL of the primary data asset (COG).
+             */
+            data_asset_href?: string | null;
+            /**
+             * Data Asset Type
+             * @description Media type of the data asset.
+             */
+            data_asset_type?: string | null;
+            /**
+             * Data Asset Size Bytes
+             * @description Size of the primary data asset in bytes (from STAC file:size). None when not in manifest.
+             */
+            data_asset_size_bytes?: number | null;
             /**
              * Thumbnail Href
              * @description Thumbnail URL if available.
              */
             thumbnail_href?: string | null;
             /**
-             * Title
-             * @description Item title (falls back to ID).
+             * Asset Count
+             * @description Number of assets on this item.
              */
-            title: string;
+            asset_count: number;
         };
         /**
          * StacLink
@@ -12056,11 +12056,6 @@ export interface components {
              */
             href: string;
             /**
-             * Method
-             * @description HTTP method to use (defaults to GET).
-             */
-            method?: string | null;
-            /**
              * Rel
              * @description Link relation type (e.g. 'self', 'root', 'parent', 'item', 'data').
              */
@@ -12070,6 +12065,11 @@ export interface components {
              * @description Media type of the linked resource (e.g. 'application/json').
              */
             type?: string | null;
+            /**
+             * Method
+             * @description HTTP method to use (defaults to GET).
+             */
+            method?: string | null;
         };
         /**
          * StacSearchBody
@@ -12090,10 +12090,10 @@ export interface components {
         StacSearchBody: {
             /** Bbox */
             bbox?: number[] | null;
-            /** Collections */
-            collections?: string[] | null;
             /** Datetime */
             datetime?: string | null;
+            /** Collections */
+            collections?: string[] | null;
             /** Ids */
             ids?: string[] | null;
             /** Intersects */
@@ -12116,15 +12116,20 @@ export interface components {
         /** StacSearchRequest */
         StacSearchRequest: {
             /**
-             * Bbox
-             * @description Bounding box filter as [west, south, east, north].
+             * Url
+             * @description STAC API root URL.
              */
-            bbox?: number[] | null;
+            url: string;
             /**
              * Collections
              * @description Filter by collection IDs.
              */
             collections?: string[] | null;
+            /**
+             * Bbox
+             * @description Bounding box filter as [west, south, east, north].
+             */
+            bbox?: number[] | null;
             /**
              * Datetime Range
              * @description Temporal filter in STAC datetime format (e.g. '2023-01-01/2023-12-31').
@@ -12136,11 +12141,6 @@ export interface components {
              * @default 20
              */
             limit: number;
-            /**
-             * Url
-             * @description STAC API root URL.
-             */
-            url: string;
         };
         /** StacSearchResponse */
         StacSearchResponse: {
@@ -12162,30 +12162,30 @@ export interface components {
         };
         /** StaleCleanupResponse */
         StaleCleanupResponse: {
-            /** Local Files Reaped */
-            local_files_reaped: number;
             /** Pending Failed */
             pending_failed: number;
             /** Running Failed */
             running_failed: number;
-            /** Staged Cleanup Failures */
-            staged_cleanup_failures: number;
-            /** Staged Paths Considered */
-            staged_paths_considered: number;
-            /** Staged Paths Skipped */
-            staged_paths_skipped: number;
-            /** Storage Objects Reaped */
-            storage_objects_reaped: number;
-            /** Terminal Jobs Purged */
-            terminal_jobs_purged: number;
-            /** Total Affected */
-            total_affected: number;
             /** Total Cleaned */
             total_cleaned: number;
             /** Vrt Assets Recovered */
             vrt_assets_recovered: number;
             /** Vrt Generations Failed */
             vrt_generations_failed: number;
+            /** Terminal Jobs Purged */
+            terminal_jobs_purged: number;
+            /** Staged Paths Considered */
+            staged_paths_considered: number;
+            /** Local Files Reaped */
+            local_files_reaped: number;
+            /** Storage Objects Reaped */
+            storage_objects_reaped: number;
+            /** Staged Paths Skipped */
+            staged_paths_skipped: number;
+            /** Staged Cleanup Failures */
+            staged_cleanup_failures: number;
+            /** Total Affected */
+            total_affected: number;
         };
         /**
          * StatusUpdate
@@ -12207,13 +12207,13 @@ export interface components {
         StatusUpdateResponse: {
             /** Id */
             id: string;
+            /** Record Status */
+            record_status: string;
             /**
              * Metadata Warnings
              * @description Advisory warnings from the status change — the same inherited-keyword disclosure check the metadata PATCH runs (feat #1070, fix #1178 review). The transition has already applied.
              */
             metadata_warnings?: string[] | null;
-            /** Record Status */
-            record_status: string;
         };
         /**
          * SublayerOverride
@@ -12234,6 +12234,16 @@ export interface components {
          */
         SublayerOverride: {
             /**
+             * Stroke Color
+             * @description Stroke color in #RRGGBB hex format, or null to use the basemap default.
+             */
+            stroke_color?: string | null;
+            /**
+             * Stroke Width
+             * @description Stroke width in pixels (0-20), or null to use the basemap default.
+             */
+            stroke_width?: number | null;
+            /**
              * Casing Color
              * @description Casing color in #RRGGBB hex format, or null to use the basemap default.
              */
@@ -12244,30 +12254,20 @@ export interface components {
              */
             casing_width?: number | null;
             /**
-             * Max Zoom
-             * @description Maximum zoom level at which the sublayer is visible (0-24), or null for default.
-             */
-            max_zoom?: number | null;
-            /**
              * Min Zoom
              * @description Minimum zoom level at which the sublayer is visible (0-24), or null for default.
              */
             min_zoom?: number | null;
             /**
+             * Max Zoom
+             * @description Maximum zoom level at which the sublayer is visible (0-24), or null for default.
+             */
+            max_zoom?: number | null;
+            /**
              * Opacity
              * @description Per-sublayer opacity (0-1), or null to use the basemap default. Composes on top of BasemapConfig.opacity (the whole-basemap master opacity): the rendered opacity is override.opacity * master_opacity (builder-audit #338 CORR-01). The UI opacity slider in BasemapSublayerEditorScene persists through this field: MapBuilderPage.handleSublayerOpacityChange -> setBasemapSublayerOpacity -> updateBasemapSublayerOverride writes config.sublayer_overrides[key].opacity.
              */
             opacity?: number | null;
-            /**
-             * Stroke Color
-             * @description Stroke color in #RRGGBB hex format, or null to use the basemap default.
-             */
-            stroke_color?: string | null;
-            /**
-             * Stroke Width
-             * @description Stroke width in pixels (0-20), or null to use the basemap default.
-             */
-            stroke_width?: number | null;
         };
         /**
          * SummaryDraftResponse
@@ -12289,15 +12289,15 @@ export interface components {
              */
             dataset_id: string;
             /**
-             * Table Name
-             * @description Source PostgreSQL table that was registered.
-             */
-            table_name: string;
-            /**
              * Title
              * @description Title of the registered dataset.
              */
             title: string;
+            /**
+             * Table Name
+             * @description Source PostgreSQL table that was registered.
+             */
+            table_name: string;
         };
         /** TerrainConfig */
         TerrainConfig: {
@@ -12306,13 +12306,13 @@ export interface components {
              * @default false
              */
             enabled: boolean;
+            /** Source Dataset Id */
+            source_dataset_id?: string | null;
             /**
              * Exaggeration
              * @default 1
              */
             exaggeration: number;
-            /** Source Dataset Id */
-            source_dataset_id?: string | null;
         };
         /**
          * ThumbnailUploadRequest
@@ -12347,26 +12347,26 @@ export interface components {
              */
             cdn_base_url?: string | null;
             /**
-             * Mvt Source Layer Prefix
-             * @description Schema prefix emitted inside vector-tile source-layer names. Null when a multi-tenant request has no resolved tenant context.
-             * @default data
+             * Public App Url
+             * @description Browser-facing app URL used for share links and OAuth redirects.
              */
-            mvt_source_layer_prefix: string | null;
+            public_app_url?: string | null;
             /**
              * Public Api Url
              * @description Externally-reachable API base URL used in OGC self-links.
              */
             public_api_url?: string | null;
             /**
-             * Public App Url
-             * @description Browser-facing app URL used for share links and OAuth redirects.
-             */
-            public_app_url?: string | null;
-            /**
              * Public Base Url
              * @description Deprecated alias for public_api_url. Will be removed in a future release.
              */
             public_base_url?: string | null;
+            /**
+             * Mvt Source Layer Prefix
+             * @description Schema prefix emitted inside vector-tile source-layer names. Null when a multi-tenant request has no resolved tenant context.
+             * @default data
+             */
+            mvt_source_layer_prefix: string | null;
         };
         /**
          * TileTokenBatchRequest
@@ -12405,11 +12405,6 @@ export interface components {
              */
             access_token: string;
             /**
-             * Expires In
-             * @description Seconds until the access token expires
-             */
-            expires_in: number;
-            /**
              * Refresh Token
              * @description Opaque token used to obtain a new access token
              */
@@ -12419,66 +12414,71 @@ export interface components {
              * @default bearer
              */
             token_type: string;
+            /**
+             * Expires In
+             * @description Seconds until the access token expires
+             */
+            expires_in: number;
         };
         /** TranslationListResponse */
         TranslationListResponse: {
-            /** Total */
-            total: number;
             /** Translations */
             translations: components["schemas"]["TranslationResponse"][];
+            /** Total */
+            total: number;
         };
         /** TranslationResponse */
         TranslationResponse: {
-            /** Language */
-            language: string;
             /**
              * Record Id
              * Format: uuid
              */
             record_id: string;
-            /** Summary */
-            summary: string | null;
+            /** Language */
+            language: string;
             /** Title */
             title: string;
+            /** Summary */
+            summary: string | null;
         };
         /** TranslationUpsert */
         TranslationUpsert: {
-            /** Summary */
-            summary?: string | null;
             /** Title */
             title: string;
+            /** Summary */
+            summary?: string | null;
         };
         /** TypeChange */
         TypeChange: {
             /** Name */
             name: string;
-            /** New Type */
-            new_type: string;
             /** Old Type */
             old_type: string;
+            /** New Type */
+            new_type: string;
         };
         /** UploadConfigResponse */
         UploadConfigResponse: {
             /**
-             * Allowed Extensions
-             * @description Comma-separated list of allowed file extensions.
+             * Presigned Uploads
+             * @description Whether presigned S3 uploads are enabled (requires `STORAGE_PROVIDER=s3`).
              */
-            allowed_extensions: string;
-            /**
-             * Max File Size Bytes
-             * @description Maximum allowed upload size in bytes.
-             */
-            max_file_size_bytes: number;
+            presigned_uploads: boolean;
             /**
              * Presigned Threshold Bytes
              * @description File size threshold (bytes) above which multipart presigned URLs are used.
              */
             presigned_threshold_bytes: number;
             /**
-             * Presigned Uploads
-             * @description Whether presigned S3 uploads are enabled (requires `STORAGE_PROVIDER=s3`).
+             * Max File Size Bytes
+             * @description Maximum allowed upload size in bytes.
              */
-            presigned_uploads: boolean;
+            max_file_size_bytes: number;
+            /**
+             * Allowed Extensions
+             * @description Comma-separated list of allowed file extensions.
+             */
+            allowed_extensions: string;
             /**
              * Remaining Dataset Quota
              * @description Datasets the caller may still create before hitting the per-user count cap, or null when no count cap is configured (unlimited). Advisory UX hint only — the cap is enforced server-side at upload.
@@ -12494,25 +12494,25 @@ export interface components {
              */
             job_id: string;
             /**
-             * Message
-             * @description Human-readable message describing the upload result.
-             */
-            message: string;
-            /**
              * Status
              * @description Initial job status. Always 'pending' on creation.
              * @default pending
              */
             status: string;
+            /**
+             * Message
+             * @description Human-readable message describing the upload result.
+             */
+            message: string;
         };
         /** UserCreate */
         UserCreate: {
             /**
-             * Email
-             * @description Optional email address
-             * @example jdoe@example.com
+             * Username
+             * @description Unique login name
+             * @example jdoe
              */
-            email?: string | null;
+            username: string;
             /**
              * Password
              * @description Plaintext password (policy: min 12 chars, 3+ character classes)
@@ -12520,24 +12520,24 @@ export interface components {
              */
             password: string;
             /**
-             * Username
-             * @description Unique login name
-             * @example jdoe
+             * Email
+             * @description Optional email address
+             * @example jdoe@example.com
              */
-            username: string;
+            email?: string | null;
         };
         /** UserListResponse */
         UserListResponse: {
-            /**
-             * Total
-             * @description Total number of users matching the query (across all pages).
-             */
-            total: number;
             /**
              * Users
              * @description Page of users matching the query.
              */
             users: components["schemas"]["UserResponse"][];
+            /**
+             * Total
+             * @description Total number of users matching the query (across all pages).
+             */
+            total: number;
         };
         /** UserNameItem */
         UserNameItem: {
@@ -12560,46 +12560,46 @@ export interface components {
         UserQuotaUsage: {
             /** Bytes Used */
             bytes_used: number;
-            /** Count Cap */
-            count_cap: number;
             /** Dataset Count */
             dataset_count: number;
             /** Storage Cap */
             storage_cap: number;
+            /** Count Cap */
+            count_cap: number;
         };
         /** UserResponse */
         UserResponse: {
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Email */
-            email: string | null;
             /**
              * Id
              * Format: uuid
              */
             id: string;
+            /** Username */
+            username: string;
+            /** Email */
+            email: string | null;
             /** Is Active */
             is_active: boolean;
-            /** Last Login At */
-            last_login_at: string | null;
-            /** @description Per-user storage quota usage. Populated only on admin list responses; None when the caller did not load usage (e.g. /auth/me, single-user GET). */
-            quota_usage?: components["schemas"]["UserQuotaUsage"] | null;
-            /**
-             * Roles
-             * @description Assigned role names, e.g. ['admin', 'editor']
-             */
-            roles: string[];
             /**
              * Status
              * @description Account status: active, pending, suspended, or deactivated.
              * @enum {string}
              */
             status: "active" | "pending" | "suspended" | "deactivated";
-            /** Username */
-            username: string;
+            /** Last Login At */
+            last_login_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Roles
+             * @description Assigned role names, e.g. ['admin', 'editor']
+             */
+            roles: string[];
+            /** @description Per-user storage quota usage. Populated only on admin list responses; None when the caller did not load usage (e.g. /auth/me, single-user GET). */
+            quota_usage?: components["schemas"]["UserQuotaUsage"] | null;
         };
         /** UserUpdate */
         UserUpdate: {
@@ -12614,28 +12614,28 @@ export interface components {
              */
             is_active?: boolean | null;
             /**
-             * Role
-             * @description New role: 'admin', 'editor', or 'viewer'. Omit to leave unchanged.
-             */
-            role?: string | null;
-            /**
              * Status
              * @description Explicit account lifecycle state. Pending registrations must use the approve/reject endpoints.
              */
             status?: ("active" | "suspended" | "deactivated") | null;
+            /**
+             * Role
+             * @description New role: 'admin', 'editor', or 'viewer'. Omit to leave unchanged.
+             */
+            role?: string | null;
         };
         /** ValidationError */
         ValidationError: {
-            /** Context */
-            ctx?: Record<string, never>;
-            /** Input */
-            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */
             msg: string;
             /** Error Type */
             type: string;
+            /** Input */
+            input?: unknown;
+            /** Context */
+            ctx?: Record<string, never>;
         };
         /** ValidationIssue */
         ValidationIssue: {
@@ -12651,32 +12651,32 @@ export interface components {
         };
         /** ValidationResultResponse */
         ValidationResultResponse: {
-            /** Errors */
-            errors: components["schemas"]["ValidationIssue"][];
             /** Is Valid */
             is_valid: boolean;
+            /** Errors */
+            errors: components["schemas"]["ValidationIssue"][];
+            /** Warnings */
+            warnings: components["schemas"]["ValidationIssue"][];
             /** Quality Score */
             quality_score?: {
                 [key: string]: unknown;
             } | null;
-            /** Warnings */
-            warnings: components["schemas"]["ValidationIssue"][];
         };
         /** VectorTileToken */
         VectorTileToken: {
-            /** Exp */
-            exp: number;
-            /** Expires In */
-            expires_in: number;
             /**
              * Kind
              * @constant
              */
             kind: "vector";
-            /** Scope */
-            scope: string;
             /** Sig */
             sig: string;
+            /** Exp */
+            exp: number;
+            /** Scope */
+            scope: string;
+            /** Expires In */
+            expires_in: number;
         };
         /** VerifyEmailRequest */
         VerifyEmailRequest: {
@@ -12689,20 +12689,18 @@ export interface components {
         /** VisibilityCheckResponse */
         VisibilityCheckResponse: {
             /**
-             * Has Non Public
-             * @description True if any layer references a non-public dataset
-             */
-            has_non_public: boolean;
-            /**
              * Non Public Datasets
              * @description Titles of datasets not publicly visible
              */
             non_public_datasets: string[];
+            /**
+             * Has Non Public
+             * @description True if any layer references a non-public dataset
+             */
+            has_non_public: boolean;
         };
         /** VrtActiveGeneration */
         VrtActiveGeneration: {
-            /** Elapsed Seconds */
-            elapsed_seconds: number;
             /**
              * Generation Id
              * Format: uuid
@@ -12713,6 +12711,8 @@ export interface components {
              * Format: date-time
              */
             started_at: string;
+            /** Elapsed Seconds */
+            elapsed_seconds: number;
         };
         /** VrtAddSourceRequest */
         VrtAddSourceRequest: {
@@ -12726,26 +12726,32 @@ export interface components {
         /** VrtCreateRequest */
         VrtCreateRequest: {
             /**
+             * Source Dataset Ids
+             * @description Source raster dataset IDs to include in the VRT mosaic or band stack (1-500).
+             */
+            source_dataset_ids: string[];
+            /**
+             * Vrt Type
+             * @description Type of VRT to create. 'mosaic' tiles sources spatially; 'band_stack' aligns same-extent sources as multi-band output.
+             * @enum {string}
+             */
+            vrt_type: "mosaic" | "band_stack";
+            /**
              * Resolution Strategy
              * @description How to resolve mismatched source resolutions: 'finest' uses the highest, 'coarsest' uses the lowest, 'average' computes the mean.
              * @enum {string}
              */
             resolution_strategy: "finest" | "coarsest" | "average";
             /**
-             * Source Dataset Ids
-             * @description Source raster dataset IDs to include in the VRT mosaic or band stack (1-500).
+             * Title
+             * @description Human-readable title for the resulting VRT dataset.
              */
-            source_dataset_ids: string[];
+            title: string;
             /**
              * Summary
              * @description Optional description for the VRT dataset.
              */
             summary?: string | null;
-            /**
-             * Title
-             * @description Human-readable title for the resulting VRT dataset.
-             */
-            title: string;
             /**
              * Visibility
              * @description Visibility level for the resulting VRT dataset.
@@ -12753,12 +12759,6 @@ export interface components {
              * @enum {string}
              */
             visibility: "private" | "restricted" | "internal" | "public";
-            /**
-             * Vrt Type
-             * @description Type of VRT to create. 'mosaic' tiles sources spatially; 'band_stack' aligns same-extent sources as multi-band output.
-             * @enum {string}
-             */
-            vrt_type: "mosaic" | "band_stack";
         };
         /** VrtCreateResponse */
         VrtCreateResponse: {
@@ -12769,36 +12769,36 @@ export interface components {
              */
             job_id: string;
             /**
-             * Message
-             * @description Human-readable acceptance message.
-             */
-            message: string;
-            /**
              * Status
              * @description Initial job status. Always 'accepted' on creation.
              * @default accepted
              */
             status: string;
+            /**
+             * Message
+             * @description Human-readable acceptance message.
+             */
+            message: string;
         };
         /** VrtGenerationItem */
         VrtGenerationItem: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Status */
+            status: string;
+            /** Started At */
+            started_at?: string | null;
             /** Completed At */
             completed_at?: string | null;
             /** Duration Seconds */
             duration_seconds?: number | null;
             /** Error Message */
             error_message?: string | null;
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
             /** Source Count */
             source_count?: number | null;
-            /** Started At */
-            started_at?: string | null;
-            /** Status */
-            status: string;
             /** Triggered By */
             triggered_by?: string | null;
         };
@@ -12818,16 +12818,16 @@ export interface components {
              */
             job_id: string;
             /**
-             * Message
-             * @description Human-readable acceptance message.
-             */
-            message: string;
-            /**
              * Status
              * @description Initial job status.
              * @default accepted
              */
             status: string;
+            /**
+             * Message
+             * @description Human-readable acceptance message.
+             */
+            message: string;
         };
         /** VrtSourceHealth */
         VrtSourceHealth: {
@@ -12836,35 +12836,35 @@ export interface components {
              * Format: uuid
              */
             dataset_id: string;
+            /** Title */
+            title: string;
             /**
              * Status
              * @enum {string}
              */
             status: "healthy" | "missing" | "inaccessible";
-            /** Title */
-            title: string;
         };
         /** VrtSourceItem */
         VrtSourceItem: {
-            /** Band Count */
-            band_count?: number | null;
-            /** Crs Epsg */
-            crs_epsg?: number | null;
             /**
              * Dataset Id
              * Format: uuid
              */
             dataset_id: string;
-            /** Extent Bbox */
-            extent_bbox?: number[] | null;
+            /** Title */
+            title: string;
             /** Position */
             position: number;
+            /** Band Count */
+            band_count?: number | null;
             /** Resolution X */
             resolution_x?: number | null;
             /** Resolution Y */
             resolution_y?: number | null;
-            /** Title */
-            title: string;
+            /** Crs Epsg */
+            crs_epsg?: number | null;
+            /** Extent Bbox */
+            extent_bbox?: number[] | null;
         };
         /** VrtSourceListResponse */
         VrtSourceListResponse: {
@@ -12873,18 +12873,18 @@ export interface components {
         };
         /** VrtStatusResponse */
         VrtStatusResponse: {
-            active_generation?: components["schemas"]["VrtActiveGeneration"] | null;
-            /** Last Generation At */
-            last_generation_at?: string | null;
-            /** Source Count */
-            source_count: number;
-            /** Source Health */
-            source_health: components["schemas"]["VrtSourceHealth"][];
             /**
              * Status
              * @enum {string}
              */
             status: "ready" | "regenerating" | "failed";
+            /** Last Generation At */
+            last_generation_at?: string | null;
+            /** Source Count */
+            source_count: number;
+            active_generation?: components["schemas"]["VrtActiveGeneration"] | null;
+            /** Source Health */
+            source_health: components["schemas"]["VrtSourceHealth"][];
         };
     };
     responses: never;
@@ -19891,6 +19891,28 @@ export interface operations {
                 content: {
                     "application/geo+json": {
                         /**
+                         * Type
+                         * @description GeoJSON object type.
+                         * @default FeatureCollection
+                         * @constant
+                         */
+                        type: "FeatureCollection";
+                        /**
+                         * Timestamp
+                         * @description ISO 8601 timestamp the response was generated.
+                         */
+                        timeStamp?: string;
+                        /**
+                         * Numbermatched
+                         * @description Total number of features matching the query (across all pages).
+                         */
+                        numberMatched: number;
+                        /**
+                         * Numberreturned
+                         * @description Number of features in this response page.
+                         */
+                        numberReturned: number;
+                        /**
                          * Features
                          * @description GeoJSON features returned by the query.
                          */
@@ -19913,38 +19935,16 @@ export interface operations {
                              */
                             rel: string;
                             /**
-                             * Title
-                             * @description Optional human-readable label for the link.
-                             */
-                            title?: string | null;
-                            /**
                              * Type
                              * @description Media type of the linked resource (e.g. 'application/json', 'application/geo+json').
                              */
                             type: string;
+                            /**
+                             * Title
+                             * @description Optional human-readable label for the link.
+                             */
+                            title?: string | null;
                         }[];
-                        /**
-                         * Numbermatched
-                         * @description Total number of features matching the query (across all pages).
-                         */
-                        numberMatched: number;
-                        /**
-                         * Numberreturned
-                         * @description Number of features in this response page.
-                         */
-                        numberReturned: number;
-                        /**
-                         * Timestamp
-                         * @description ISO 8601 timestamp the response was generated.
-                         */
-                        timeStamp?: string;
-                        /**
-                         * Type
-                         * @description GeoJSON object type.
-                         * @default FeatureCollection
-                         * @constant
-                         */
-                        type: "FeatureCollection";
                     };
                     "application/json": unknown;
                 };
@@ -20019,21 +20019,35 @@ export interface operations {
                 };
                 content: {
                     "application/geo+json": {
-                        /** @description GeoJSON geometry of the feature, or null for geometry-less features. */
-                        geometry: {
-                            /** Coordinates */
-                            coordinates: unknown[];
-                            /**
-                             * Type
-                             * @enum {string}
-                             */
-                            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                        } | null;
+                        /**
+                         * Type
+                         * @description GeoJSON object type.
+                         * @default Feature
+                         * @constant
+                         */
+                        type: "Feature";
                         /**
                          * Id
                          * @description Feature identifier within the collection.
                          */
                         id: number;
+                        /** @description GeoJSON geometry of the feature, or null for geometry-less features. */
+                        geometry: {
+                            /**
+                             * Type
+                             * @enum {string}
+                             */
+                            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                            /** Coordinates */
+                            coordinates: unknown[];
+                        } | null;
+                        /**
+                         * Properties
+                         * @description Feature attributes as a JSON object.
+                         */
+                        properties: {
+                            [key: string]: unknown;
+                        } | null;
                         /**
                          * Links
                          * @description Self-reference and related-resource links.
@@ -20051,30 +20065,16 @@ export interface operations {
                              */
                             rel: string;
                             /**
-                             * Title
-                             * @description Optional human-readable label for the link.
-                             */
-                            title?: string | null;
-                            /**
                              * Type
                              * @description Media type of the linked resource (e.g. 'application/json', 'application/geo+json').
                              */
                             type: string;
+                            /**
+                             * Title
+                             * @description Optional human-readable label for the link.
+                             */
+                            title?: string | null;
                         }[];
-                        /**
-                         * Properties
-                         * @description Feature attributes as a JSON object.
-                         */
-                        properties: {
-                            [key: string]: unknown;
-                        } | null;
-                        /**
-                         * Type
-                         * @description GeoJSON object type.
-                         * @default Feature
-                         * @constant
-                         */
-                        type: "Feature";
                     };
                     "application/json": unknown;
                 };
@@ -23200,66 +23200,66 @@ export interface operations {
                 };
                 content: {
                     "application/geo+json": {
-                        /** Features */
-                        features: {
-                            /** Geometry */
-                            geometry?: {
-                                /** Geometries */
-                                geometries: {
-                                    /** Coordinates */
-                                    coordinates: unknown[];
-                                    /**
-                                     * Type
-                                     * @enum {string}
-                                     */
-                                    type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                                }[];
-                                /**
-                                 * Type
-                                 * @constant
-                                 */
-                                type: "GeometryCollection";
-                            } | {
-                                /** Coordinates */
-                                coordinates: unknown[];
-                                /**
-                                 * Type
-                                 * @enum {string}
-                                 */
-                                type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                            } | null;
-                            /** Id */
-                            id: number;
-                            /** Properties */
-                            properties: {
-                                [key: string]: unknown;
-                            };
-                            /**
-                             * Type
-                             * @default Feature
-                             * @constant
-                             */
-                            type: "Feature";
-                        }[];
-                        /** Links */
-                        links: {
-                            /** Href */
-                            href: string;
-                            /** Rel */
-                            rel: string;
-                            /** Type */
-                            type: string;
-                        }[];
-                        /** Numbermatched */
-                        numberMatched: number;
-                        /** Numberreturned */
-                        numberReturned: number;
                         /**
                          * Type
                          * @default FeatureCollection
                          * @constant
                          */
                         type: "FeatureCollection";
+                        /** Numbermatched */
+                        numberMatched: number;
+                        /** Numberreturned */
+                        numberReturned: number;
+                        /** Features */
+                        features: {
+                            /**
+                             * Type
+                             * @default Feature
+                             * @constant
+                             */
+                            type: "Feature";
+                            /** Id */
+                            id: number;
+                            /** Geometry */
+                            geometry?: {
+                                /**
+                                 * Type
+                                 * @constant
+                                 */
+                                type: "GeometryCollection";
+                                /** Geometries */
+                                geometries: {
+                                    /**
+                                     * Type
+                                     * @enum {string}
+                                     */
+                                    type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                                    /** Coordinates */
+                                    coordinates: unknown[];
+                                }[];
+                            } | {
+                                /**
+                                 * Type
+                                 * @enum {string}
+                                 */
+                                type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                                /** Coordinates */
+                                coordinates: unknown[];
+                            } | null;
+                            /** Properties */
+                            properties: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                        /** Links */
+                        links: {
+                            /** Rel */
+                            rel: string;
+                            /** Href */
+                            href: string;
+                            /** Type */
+                            type: string;
+                        }[];
                     };
                     "application/json": unknown;
                 };
@@ -23362,44 +23362,44 @@ export interface operations {
                 };
                 content: {
                     "application/geo+json": {
-                        /** Geometry */
-                        geometry?: {
-                            /** Geometries */
-                            geometries: {
-                                /** Coordinates */
-                                coordinates: unknown[];
-                                /**
-                                 * Type
-                                 * @enum {string}
-                                 */
-                                type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                            }[];
-                            /**
-                             * Type
-                             * @constant
-                             */
-                            type: "GeometryCollection";
-                        } | {
-                            /** Coordinates */
-                            coordinates: unknown[];
-                            /**
-                             * Type
-                             * @enum {string}
-                             */
-                            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                        } | null;
-                        /** Id */
-                        id: number;
-                        /** Properties */
-                        properties: {
-                            [key: string]: unknown;
-                        };
                         /**
                          * Type
                          * @default Feature
                          * @constant
                          */
                         type: "Feature";
+                        /** Id */
+                        id: number;
+                        /** Geometry */
+                        geometry?: {
+                            /**
+                             * Type
+                             * @constant
+                             */
+                            type: "GeometryCollection";
+                            /** Geometries */
+                            geometries: {
+                                /**
+                                 * Type
+                                 * @enum {string}
+                                 */
+                                type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                                /** Coordinates */
+                                coordinates: unknown[];
+                            }[];
+                        } | {
+                            /**
+                             * Type
+                             * @enum {string}
+                             */
+                            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                            /** Coordinates */
+                            coordinates: unknown[];
+                        } | null;
+                        /** Properties */
+                        properties: {
+                            [key: string]: unknown;
+                        };
                     };
                     "application/json": unknown;
                 };
@@ -23508,44 +23508,44 @@ export interface operations {
                 };
                 content: {
                     "application/geo+json": {
-                        /** Geometry */
-                        geometry?: {
-                            /** Geometries */
-                            geometries: {
-                                /** Coordinates */
-                                coordinates: unknown[];
-                                /**
-                                 * Type
-                                 * @enum {string}
-                                 */
-                                type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                            }[];
-                            /**
-                             * Type
-                             * @constant
-                             */
-                            type: "GeometryCollection";
-                        } | {
-                            /** Coordinates */
-                            coordinates: unknown[];
-                            /**
-                             * Type
-                             * @enum {string}
-                             */
-                            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                        } | null;
-                        /** Id */
-                        id: number;
-                        /** Properties */
-                        properties: {
-                            [key: string]: unknown;
-                        };
                         /**
                          * Type
                          * @default Feature
                          * @constant
                          */
                         type: "Feature";
+                        /** Id */
+                        id: number;
+                        /** Geometry */
+                        geometry?: {
+                            /**
+                             * Type
+                             * @constant
+                             */
+                            type: "GeometryCollection";
+                            /** Geometries */
+                            geometries: {
+                                /**
+                                 * Type
+                                 * @enum {string}
+                                 */
+                                type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                                /** Coordinates */
+                                coordinates: unknown[];
+                            }[];
+                        } | {
+                            /**
+                             * Type
+                             * @enum {string}
+                             */
+                            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                            /** Coordinates */
+                            coordinates: unknown[];
+                        } | null;
+                        /** Properties */
+                        properties: {
+                            [key: string]: unknown;
+                        };
                     };
                     "application/json": unknown;
                 };
@@ -23649,44 +23649,44 @@ export interface operations {
                 };
                 content: {
                     "application/geo+json": {
-                        /** Geometry */
-                        geometry?: {
-                            /** Geometries */
-                            geometries: {
-                                /** Coordinates */
-                                coordinates: unknown[];
-                                /**
-                                 * Type
-                                 * @enum {string}
-                                 */
-                                type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                            }[];
-                            /**
-                             * Type
-                             * @constant
-                             */
-                            type: "GeometryCollection";
-                        } | {
-                            /** Coordinates */
-                            coordinates: unknown[];
-                            /**
-                             * Type
-                             * @enum {string}
-                             */
-                            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                        } | null;
-                        /** Id */
-                        id: number;
-                        /** Properties */
-                        properties: {
-                            [key: string]: unknown;
-                        };
                         /**
                          * Type
                          * @default Feature
                          * @constant
                          */
                         type: "Feature";
+                        /** Id */
+                        id: number;
+                        /** Geometry */
+                        geometry?: {
+                            /**
+                             * Type
+                             * @constant
+                             */
+                            type: "GeometryCollection";
+                            /** Geometries */
+                            geometries: {
+                                /**
+                                 * Type
+                                 * @enum {string}
+                                 */
+                                type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                                /** Coordinates */
+                                coordinates: unknown[];
+                            }[];
+                        } | {
+                            /**
+                             * Type
+                             * @enum {string}
+                             */
+                            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                            /** Coordinates */
+                            coordinates: unknown[];
+                        } | null;
+                        /** Properties */
+                        properties: {
+                            [key: string]: unknown;
+                        };
                     };
                     "application/json": unknown;
                 };
@@ -23903,44 +23903,44 @@ export interface operations {
                 };
                 content: {
                     "application/geo+json": {
-                        /** Geometry */
-                        geometry?: {
-                            /** Geometries */
-                            geometries: {
-                                /** Coordinates */
-                                coordinates: unknown[];
-                                /**
-                                 * Type
-                                 * @enum {string}
-                                 */
-                                type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                            }[];
-                            /**
-                             * Type
-                             * @constant
-                             */
-                            type: "GeometryCollection";
-                        } | {
-                            /** Coordinates */
-                            coordinates: unknown[];
-                            /**
-                             * Type
-                             * @enum {string}
-                             */
-                            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
-                        } | null;
-                        /** Id */
-                        id: number;
-                        /** Properties */
-                        properties: {
-                            [key: string]: unknown;
-                        };
                         /**
                          * Type
                          * @default Feature
                          * @constant
                          */
                         type: "Feature";
+                        /** Id */
+                        id: number;
+                        /** Geometry */
+                        geometry?: {
+                            /**
+                             * Type
+                             * @constant
+                             */
+                            type: "GeometryCollection";
+                            /** Geometries */
+                            geometries: {
+                                /**
+                                 * Type
+                                 * @enum {string}
+                                 */
+                                type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                                /** Coordinates */
+                                coordinates: unknown[];
+                            }[];
+                        } | {
+                            /**
+                             * Type
+                             * @enum {string}
+                             */
+                            type: "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+                            /** Coordinates */
+                            coordinates: unknown[];
+                        } | null;
+                        /** Properties */
+                        properties: {
+                            [key: string]: unknown;
+                        };
                     };
                     "application/json": unknown;
                 };

--- a/scripts/flatten_openapi_defs.py
+++ b/scripts/flatten_openapi_defs.py
@@ -51,9 +51,11 @@ script ``sys.exit(1)`` with a clear error message.
 
 Determinism
 -----------
-``json.dumps(spec, sort_keys=True, indent=2) + "\n"`` matches the format
-used by ``backend/scripts/dump_openapi.py`` so the flattened intermediate
-is also reproducible across machines.
+Output serialization matches ``backend/scripts/dump_openapi.py``: every
+dict key sorted EXCEPT each schema's ``properties`` map, whose insertion
+order is Pydantic field declaration order and drives generated SDK
+constructor argument order (fix #1257). The flattened intermediate stays
+reproducible across machines.
 
 Usage
 -----
@@ -75,8 +77,31 @@ from typing import Any
 
 
 def _serialize(node: Any) -> str:
-    """Sorted-keys JSON for byte-identical equality checks."""
+    """Sorted-keys JSON for byte-identical equality checks.
+
+    Deliberately still fully sorted (unlike the output serializer): this
+    feeds content-identity comparison and the sha1 synthetic names, which
+    must not churn when only property order changes.
+    """
     return json.dumps(node, sort_keys=True)
+
+
+def _ordered_for_snapshot(node: Any, *, preserve_keys: bool = False) -> Any:
+    """Recursively sort dict keys, except each schema's ``properties`` map.
+
+    Mirror of ``ordered_for_snapshot`` in backend/scripts/dump_openapi.py
+    (duplicated because this script runs standalone via --no-project);
+    fix(#1257) — property order drives SDK constructor argument order.
+    """
+    if isinstance(node, dict):
+        keys = node if preserve_keys else sorted(node)
+        return {
+            k: _ordered_for_snapshot(node[k], preserve_keys=(k == "properties"))
+            for k in keys
+        }
+    if isinstance(node, list):
+        return [_ordered_for_snapshot(v) for v in node]
+    return node
 
 
 def _synthetic_name(base: str, schema: Any) -> str:
@@ -323,8 +348,10 @@ def main() -> int:
                 continue
             flat_components[name] = schema
 
-    # Same serialization style as dump_openapi.py.
-    output_text = json.dumps(flattened, indent=2, sort_keys=True) + "\n"
+    # Same serialization style as dump_openapi.py: sorted keys except each
+    # schema's `properties` map, whose order drives generated SDK
+    # constructor argument order (fix #1257).
+    output_text = json.dumps(_ordered_for_snapshot(flattened), indent=2) + "\n"
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(output_text)
 

--- a/sdks/python/geolens/models/admin_api_key_create_request.py
+++ b/sdks/python/geolens/models/admin_api_key_create_request.py
@@ -25,8 +25,8 @@ T = TypeVar("T", bound="AdminApiKeyCreateRequest")
 class AdminApiKeyCreateRequest:
     """
     Attributes:
-        name (str): Human-readable label for the API key (e.g. 'CI pipeline', 'QGIS desktop').
         user_id (UUID): ID of the user the new API key will belong to.
+        name (str): Human-readable label for the API key (e.g. 'CI pipeline', 'QGIS desktop').
         expires_at (datetime.datetime | None | Unset): Optional expiry timestamp (RFC 3339, timezone-aware). Omit or
             null for a non-expiring key; expired keys stop authenticating.
         scope (AdminApiKeyCreateRequestScope | Unset): Privilege scope (#875). 'full' impersonates the owner completely,
@@ -35,16 +35,16 @@ class AdminApiKeyCreateRequest:
             'full'.
     """
 
-    name: str
     user_id: UUID
+    name: str
     expires_at: datetime.datetime | None | Unset = UNSET
     scope: AdminApiKeyCreateRequestScope | Unset = "full"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        name = self.name
-
         user_id = str(self.user_id)
+
+        name = self.name
 
         expires_at: None | str | Unset
         if isinstance(self.expires_at, Unset):
@@ -62,8 +62,8 @@ class AdminApiKeyCreateRequest:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "name": name,
                 "user_id": user_id,
+                "name": name,
             }
         )
         if expires_at is not UNSET:
@@ -76,9 +76,9 @@ class AdminApiKeyCreateRequest:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        name = d.pop("name")
-
         user_id = UUID(d.pop("user_id"))
+
+        name = d.pop("name")
 
         def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -105,8 +105,8 @@ class AdminApiKeyCreateRequest:
             scope = check_admin_api_key_create_request_scope(_scope)
 
         admin_api_key_create_request = cls(
-            name=name,
             user_id=user_id,
+            name=name,
             expires_at=expires_at,
             scope=scope,
         )

--- a/sdks/python/geolens/models/admin_api_key_list_item.py
+++ b/sdks/python/geolens/models/admin_api_key_list_item.py
@@ -21,49 +21,49 @@ T = TypeVar("T", bound="AdminApiKeyListItem")
 class AdminApiKeyListItem:
     """
     Attributes:
-        created_at (datetime.datetime): Timestamp when the key was created.
-        fingerprint (None | str): Non-secret key identifier; null for legacy keys.
         id (UUID): Unique API key identifier.
-        is_active (bool): Whether the key is active. Inactive keys cannot authenticate.
-        last_used_at (datetime.datetime | None): Timestamp of the most recent successful authentication using this key.
-        name (str): Human-readable label.
-        scope (str): Privilege scope: 'full' or 'read_only' (#875).
         user_id (UUID): Owning user's ID.
+        name (str): Human-readable label.
+        fingerprint (None | str): Non-secret key identifier; null for legacy keys.
+        is_active (bool): Whether the key is active. Inactive keys cannot authenticate.
+        scope (str): Privilege scope: 'full' or 'read_only' (#875).
+        created_at (datetime.datetime): Timestamp when the key was created.
+        last_used_at (datetime.datetime | None): Timestamp of the most recent successful authentication using this key.
         expires_at (datetime.datetime | None | Unset): Expiry timestamp; null means the key does not expire.
     """
 
-    created_at: datetime.datetime
-    fingerprint: None | str
     id: UUID
-    is_active: bool
-    last_used_at: datetime.datetime | None
-    name: str
-    scope: str
     user_id: UUID
+    name: str
+    fingerprint: None | str
+    is_active: bool
+    scope: str
+    created_at: datetime.datetime
+    last_used_at: datetime.datetime | None
     expires_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
+        id = str(self.id)
+
+        user_id = str(self.user_id)
+
+        name = self.name
 
         fingerprint: None | str
         fingerprint = self.fingerprint
 
-        id = str(self.id)
-
         is_active = self.is_active
+
+        scope = self.scope
+
+        created_at = self.created_at.isoformat()
 
         last_used_at: None | str
         if isinstance(self.last_used_at, datetime.datetime):
             last_used_at = self.last_used_at.isoformat()
         else:
             last_used_at = self.last_used_at
-
-        name = self.name
-
-        scope = self.scope
-
-        user_id = str(self.user_id)
 
         expires_at: None | str | Unset
         if isinstance(self.expires_at, Unset):
@@ -77,14 +77,14 @@ class AdminApiKeyListItem:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "fingerprint": fingerprint,
                 "id": id,
-                "is_active": is_active,
-                "last_used_at": last_used_at,
-                "name": name,
-                "scope": scope,
                 "user_id": user_id,
+                "name": name,
+                "fingerprint": fingerprint,
+                "is_active": is_active,
+                "scope": scope,
+                "created_at": created_at,
+                "last_used_at": last_used_at,
             }
         )
         if expires_at is not UNSET:
@@ -95,7 +95,11 @@ class AdminApiKeyListItem:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
+        id = UUID(d.pop("id"))
+
+        user_id = UUID(d.pop("user_id"))
+
+        name = d.pop("name")
 
         def _parse_fingerprint(data: object) -> None | str:
             if data is None:
@@ -104,9 +108,11 @@ class AdminApiKeyListItem:
 
         fingerprint = _parse_fingerprint(d.pop("fingerprint"))
 
-        id = UUID(d.pop("id"))
-
         is_active = d.pop("is_active")
+
+        scope = d.pop("scope")
+
+        created_at = isoparse(d.pop("created_at"))
 
         def _parse_last_used_at(data: object) -> datetime.datetime | None:
             if data is None:
@@ -122,12 +128,6 @@ class AdminApiKeyListItem:
             return cast(datetime.datetime | None, data)
 
         last_used_at = _parse_last_used_at(d.pop("last_used_at"))
-
-        name = d.pop("name")
-
-        scope = d.pop("scope")
-
-        user_id = UUID(d.pop("user_id"))
 
         def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -147,14 +147,14 @@ class AdminApiKeyListItem:
         expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
 
         admin_api_key_list_item = cls(
-            created_at=created_at,
-            fingerprint=fingerprint,
             id=id,
-            is_active=is_active,
-            last_used_at=last_used_at,
-            name=name,
-            scope=scope,
             user_id=user_id,
+            name=name,
+            fingerprint=fingerprint,
+            is_active=is_active,
+            scope=scope,
+            created_at=created_at,
+            last_used_at=last_used_at,
             expires_at=expires_at,
         )
 

--- a/sdks/python/geolens/models/admin_embed_token_response.py
+++ b/sdks/python/geolens/models/admin_embed_token_response.py
@@ -21,50 +21,56 @@ T = TypeVar("T", bound="AdminEmbedTokenResponse")
 class AdminEmbedTokenResponse:
     """
     Attributes:
-        created_at (datetime.datetime):
-        expires_at (datetime.datetime):
         id (UUID):
-        is_active (bool):
         map_id (UUID):
-        scoped_dataset_ids (list[str]):
         token_hint (str):
+        scoped_dataset_ids (list[str]):
+        expires_at (datetime.datetime):
+        is_active (bool):
+        created_at (datetime.datetime):
+        name (None | str | Unset):
         allowed_origins (list[str] | None | Unset):
-        creator_username (None | str | Unset):
+        use_count (int | Unset):  Default: 0.
         last_used_at (datetime.datetime | None | Unset):
         map_name (None | str | Unset):
-        name (None | str | Unset):
-        use_count (int | Unset):  Default: 0.
+        creator_username (None | str | Unset):
     """
 
-    created_at: datetime.datetime
-    expires_at: datetime.datetime
     id: UUID
-    is_active: bool
     map_id: UUID
-    scoped_dataset_ids: list[str]
     token_hint: str
+    scoped_dataset_ids: list[str]
+    expires_at: datetime.datetime
+    is_active: bool
+    created_at: datetime.datetime
+    name: None | str | Unset = UNSET
     allowed_origins: list[str] | None | Unset = UNSET
-    creator_username: None | str | Unset = UNSET
+    use_count: int | Unset = 0
     last_used_at: datetime.datetime | None | Unset = UNSET
     map_name: None | str | Unset = UNSET
-    name: None | str | Unset = UNSET
-    use_count: int | Unset = 0
+    creator_username: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
-
-        expires_at = self.expires_at.isoformat()
-
         id = str(self.id)
-
-        is_active = self.is_active
 
         map_id = str(self.map_id)
 
+        token_hint = self.token_hint
+
         scoped_dataset_ids = self.scoped_dataset_ids
 
-        token_hint = self.token_hint
+        expires_at = self.expires_at.isoformat()
+
+        is_active = self.is_active
+
+        created_at = self.created_at.isoformat()
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
 
         allowed_origins: list[str] | None | Unset
         if isinstance(self.allowed_origins, Unset):
@@ -75,11 +81,7 @@ class AdminEmbedTokenResponse:
         else:
             allowed_origins = self.allowed_origins
 
-        creator_username: None | str | Unset
-        if isinstance(self.creator_username, Unset):
-            creator_username = UNSET
-        else:
-            creator_username = self.creator_username
+        use_count = self.use_count
 
         last_used_at: None | str | Unset
         if isinstance(self.last_used_at, Unset):
@@ -95,58 +97,65 @@ class AdminEmbedTokenResponse:
         else:
             map_name = self.map_name
 
-        name: None | str | Unset
-        if isinstance(self.name, Unset):
-            name = UNSET
+        creator_username: None | str | Unset
+        if isinstance(self.creator_username, Unset):
+            creator_username = UNSET
         else:
-            name = self.name
-
-        use_count = self.use_count
+            creator_username = self.creator_username
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "expires_at": expires_at,
                 "id": id,
-                "is_active": is_active,
                 "map_id": map_id,
-                "scoped_dataset_ids": scoped_dataset_ids,
                 "token_hint": token_hint,
+                "scoped_dataset_ids": scoped_dataset_ids,
+                "expires_at": expires_at,
+                "is_active": is_active,
+                "created_at": created_at,
             }
         )
+        if name is not UNSET:
+            field_dict["name"] = name
         if allowed_origins is not UNSET:
             field_dict["allowed_origins"] = allowed_origins
-        if creator_username is not UNSET:
-            field_dict["creator_username"] = creator_username
+        if use_count is not UNSET:
+            field_dict["use_count"] = use_count
         if last_used_at is not UNSET:
             field_dict["last_used_at"] = last_used_at
         if map_name is not UNSET:
             field_dict["map_name"] = map_name
-        if name is not UNSET:
-            field_dict["name"] = name
-        if use_count is not UNSET:
-            field_dict["use_count"] = use_count
+        if creator_username is not UNSET:
+            field_dict["creator_username"] = creator_username
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
-
-        expires_at = isoparse(d.pop("expires_at"))
-
         id = UUID(d.pop("id"))
-
-        is_active = d.pop("is_active")
 
         map_id = UUID(d.pop("map_id"))
 
+        token_hint = d.pop("token_hint")
+
         scoped_dataset_ids = cast(list[str], d.pop("scoped_dataset_ids"))
 
-        token_hint = d.pop("token_hint")
+        expires_at = isoparse(d.pop("expires_at"))
+
+        is_active = d.pop("is_active")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
 
         def _parse_allowed_origins(data: object) -> list[str] | None | Unset:
             if data is None:
@@ -165,14 +174,7 @@ class AdminEmbedTokenResponse:
 
         allowed_origins = _parse_allowed_origins(d.pop("allowed_origins", UNSET))
 
-        def _parse_creator_username(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        creator_username = _parse_creator_username(d.pop("creator_username", UNSET))
+        use_count = d.pop("use_count", UNSET)
 
         def _parse_last_used_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -200,31 +202,29 @@ class AdminEmbedTokenResponse:
 
         map_name = _parse_map_name(d.pop("map_name", UNSET))
 
-        def _parse_name(data: object) -> None | str | Unset:
+        def _parse_creator_username(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        name = _parse_name(d.pop("name", UNSET))
-
-        use_count = d.pop("use_count", UNSET)
+        creator_username = _parse_creator_username(d.pop("creator_username", UNSET))
 
         admin_embed_token_response = cls(
-            created_at=created_at,
-            expires_at=expires_at,
             id=id,
-            is_active=is_active,
             map_id=map_id,
-            scoped_dataset_ids=scoped_dataset_ids,
             token_hint=token_hint,
+            scoped_dataset_ids=scoped_dataset_ids,
+            expires_at=expires_at,
+            is_active=is_active,
+            created_at=created_at,
+            name=name,
             allowed_origins=allowed_origins,
-            creator_username=creator_username,
+            use_count=use_count,
             last_used_at=last_used_at,
             map_name=map_name,
-            name=name,
-            use_count=use_count,
+            creator_username=creator_username,
         )
 
         admin_embed_token_response.additional_properties = d

--- a/sdks/python/geolens/models/admin_job_response.py
+++ b/sdks/python/geolens/models/admin_job_response.py
@@ -27,36 +27,36 @@ T = TypeVar("T", bound="AdminJobResponse")
 class AdminJobResponse:
     """
     Attributes:
-        can_retry (bool): Whether the failed job can be retried with its retained source.
-        completed_at (datetime.datetime | None): Timestamp when the job finished (success or failure).
-        created_at (datetime.datetime): Timestamp when the job was queued.
-        created_by (None | UUID): ID of the user who initiated the job.
+        id (UUID): Unique ingestion job identifier.
+        status (AdminJobResponseStatus): Current job status: 'pending', 'running', 'complete', 'failed', or 'cancelled'.
+        source_filename (None | str): Original filename of the uploaded file, if applicable.
         dataset_id (None | UUID): ID of the dataset created by this job, if completed successfully.
         error_message (None | str): Error details if the job failed.
-        id (UUID): Unique ingestion job identifier.
+        can_retry (bool): Whether the failed job can be retried with its retained source.
         retry_reason (None | str): Why the job cannot be retried, when retry is unavailable.
-        source_filename (None | str): Original filename of the uploaded file, if applicable.
-        started_at (datetime.datetime | None): Timestamp when the worker began processing the job.
-        status (AdminJobResponseStatus): Current job status: 'pending', 'running', 'complete', 'failed', or 'cancelled'.
         user_metadata (AdminJobResponseUserMetadataType0 | None): User-supplied metadata captured at upload time (title,
             summary, tags, vrt_type, file_type, warnings, etc.). Heterogeneous shape across ingest paths -- canonical keys:
             title, summary, visibility, file_type, vrt_type, warnings.
+        created_by (None | UUID): ID of the user who initiated the job.
         username (None | str): Username of the user who initiated the job.
+        started_at (datetime.datetime | None): Timestamp when the worker began processing the job.
+        completed_at (datetime.datetime | None): Timestamp when the job finished (success or failure).
+        created_at (datetime.datetime): Timestamp when the job was queued.
     """
 
-    can_retry: bool
-    completed_at: datetime.datetime | None
-    created_at: datetime.datetime
-    created_by: None | UUID
+    id: UUID
+    status: AdminJobResponseStatus
+    source_filename: None | str
     dataset_id: None | UUID
     error_message: None | str
-    id: UUID
+    can_retry: bool
     retry_reason: None | str
-    source_filename: None | str
-    started_at: datetime.datetime | None
-    status: AdminJobResponseStatus
     user_metadata: AdminJobResponseUserMetadataType0 | None
+    created_by: None | UUID
     username: None | str
+    started_at: datetime.datetime | None
+    completed_at: datetime.datetime | None
+    created_at: datetime.datetime
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -64,21 +64,12 @@ class AdminJobResponse:
             AdminJobResponseUserMetadataType0,
         )
 
-        can_retry = self.can_retry
+        id = str(self.id)
 
-        completed_at: None | str
-        if isinstance(self.completed_at, datetime.datetime):
-            completed_at = self.completed_at.isoformat()
-        else:
-            completed_at = self.completed_at
+        status: str = self.status
 
-        created_at = self.created_at.isoformat()
-
-        created_by: None | str
-        if isinstance(self.created_by, UUID):
-            created_by = str(self.created_by)
-        else:
-            created_by = self.created_by
+        source_filename: None | str
+        source_filename = self.source_filename
 
         dataset_id: None | str
         if isinstance(self.dataset_id, UUID):
@@ -89,21 +80,10 @@ class AdminJobResponse:
         error_message: None | str
         error_message = self.error_message
 
-        id = str(self.id)
+        can_retry = self.can_retry
 
         retry_reason: None | str
         retry_reason = self.retry_reason
-
-        source_filename: None | str
-        source_filename = self.source_filename
-
-        started_at: None | str
-        if isinstance(self.started_at, datetime.datetime):
-            started_at = self.started_at.isoformat()
-        else:
-            started_at = self.started_at
-
-        status: str = self.status
 
         user_metadata: dict[str, Any] | None
         if isinstance(self.user_metadata, AdminJobResponseUserMetadataType0):
@@ -111,26 +91,46 @@ class AdminJobResponse:
         else:
             user_metadata = self.user_metadata
 
+        created_by: None | str
+        if isinstance(self.created_by, UUID):
+            created_by = str(self.created_by)
+        else:
+            created_by = self.created_by
+
         username: None | str
         username = self.username
+
+        started_at: None | str
+        if isinstance(self.started_at, datetime.datetime):
+            started_at = self.started_at.isoformat()
+        else:
+            started_at = self.started_at
+
+        completed_at: None | str
+        if isinstance(self.completed_at, datetime.datetime):
+            completed_at = self.completed_at.isoformat()
+        else:
+            completed_at = self.completed_at
+
+        created_at = self.created_at.isoformat()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "can_retry": can_retry,
-                "completed_at": completed_at,
-                "created_at": created_at,
-                "created_by": created_by,
+                "id": id,
+                "status": status,
+                "source_filename": source_filename,
                 "dataset_id": dataset_id,
                 "error_message": error_message,
-                "id": id,
+                "can_retry": can_retry,
                 "retry_reason": retry_reason,
-                "source_filename": source_filename,
-                "started_at": started_at,
-                "status": status,
                 "user_metadata": user_metadata,
+                "created_by": created_by,
                 "username": username,
+                "started_at": started_at,
+                "completed_at": completed_at,
+                "created_at": created_at,
             }
         )
 
@@ -143,39 +143,16 @@ class AdminJobResponse:
         )
 
         d = dict(src_dict)
-        can_retry = d.pop("can_retry")
+        id = UUID(d.pop("id"))
 
-        def _parse_completed_at(data: object) -> datetime.datetime | None:
+        status = check_admin_job_response_status(d.pop("status"))
+
+        def _parse_source_filename(data: object) -> None | str:
             if data is None:
                 return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                completed_at_type_0 = isoparse(data)
+            return cast(None | str, data)
 
-                return completed_at_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None, data)
-
-        completed_at = _parse_completed_at(d.pop("completed_at"))
-
-        created_at = isoparse(d.pop("created_at"))
-
-        def _parse_created_by(data: object) -> None | UUID:
-            if data is None:
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                created_by_type_0 = UUID(data)
-
-                return created_by_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | UUID, data)
-
-        created_by = _parse_created_by(d.pop("created_by"))
+        source_filename = _parse_source_filename(d.pop("source_filename"))
 
         def _parse_dataset_id(data: object) -> None | UUID:
             if data is None:
@@ -199,7 +176,7 @@ class AdminJobResponse:
 
         error_message = _parse_error_message(d.pop("error_message"))
 
-        id = UUID(d.pop("id"))
+        can_retry = d.pop("can_retry")
 
         def _parse_retry_reason(data: object) -> None | str:
             if data is None:
@@ -207,30 +184,6 @@ class AdminJobResponse:
             return cast(None | str, data)
 
         retry_reason = _parse_retry_reason(d.pop("retry_reason"))
-
-        def _parse_source_filename(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        source_filename = _parse_source_filename(d.pop("source_filename"))
-
-        def _parse_started_at(data: object) -> datetime.datetime | None:
-            if data is None:
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                started_at_type_0 = isoparse(data)
-
-                return started_at_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None, data)
-
-        started_at = _parse_started_at(d.pop("started_at"))
-
-        status = check_admin_job_response_status(d.pop("status"))
 
         def _parse_user_metadata(
             data: object,
@@ -249,6 +202,21 @@ class AdminJobResponse:
 
         user_metadata = _parse_user_metadata(d.pop("user_metadata"))
 
+        def _parse_created_by(data: object) -> None | UUID:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                created_by_type_0 = UUID(data)
+
+                return created_by_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | UUID, data)
+
+        created_by = _parse_created_by(d.pop("created_by"))
+
         def _parse_username(data: object) -> None | str:
             if data is None:
                 return data
@@ -256,20 +224,52 @@ class AdminJobResponse:
 
         username = _parse_username(d.pop("username"))
 
+        def _parse_started_at(data: object) -> datetime.datetime | None:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                started_at_type_0 = isoparse(data)
+
+                return started_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None, data)
+
+        started_at = _parse_started_at(d.pop("started_at"))
+
+        def _parse_completed_at(data: object) -> datetime.datetime | None:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                completed_at_type_0 = isoparse(data)
+
+                return completed_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None, data)
+
+        completed_at = _parse_completed_at(d.pop("completed_at"))
+
+        created_at = isoparse(d.pop("created_at"))
+
         admin_job_response = cls(
-            can_retry=can_retry,
-            completed_at=completed_at,
-            created_at=created_at,
-            created_by=created_by,
+            id=id,
+            status=status,
+            source_filename=source_filename,
             dataset_id=dataset_id,
             error_message=error_message,
-            id=id,
+            can_retry=can_retry,
             retry_reason=retry_reason,
-            source_filename=source_filename,
-            started_at=started_at,
-            status=status,
             user_metadata=user_metadata,
+            created_by=created_by,
             username=username,
+            started_at=started_at,
+            completed_at=completed_at,
+            created_at=created_at,
         )
 
         admin_job_response.additional_properties = d

--- a/sdks/python/geolens/models/admin_share_token_response.py
+++ b/sdks/python/geolens/models/admin_share_token_response.py
@@ -21,47 +21,37 @@ T = TypeVar("T", bound="AdminShareTokenResponse")
 class AdminShareTokenResponse:
     """
     Attributes:
-        created_at (datetime.datetime):
-        created_by (None | str):
         map_id (UUID):
         map_name (str):
-        embed_token_count (int | Unset):  Default: 0.
-        expires_at (datetime.datetime | None | Unset):
+        created_at (datetime.datetime):
+        created_by (None | str):
         id (None | Unset | UUID):
-        is_active (bool | None | Unset):
         token (None | str | Unset):
+        is_active (bool | None | Unset):
+        expires_at (datetime.datetime | None | Unset):
+        embed_token_count (int | Unset):  Default: 0.
     """
 
-    created_at: datetime.datetime
-    created_by: None | str
     map_id: UUID
     map_name: str
-    embed_token_count: int | Unset = 0
-    expires_at: datetime.datetime | None | Unset = UNSET
+    created_at: datetime.datetime
+    created_by: None | str
     id: None | Unset | UUID = UNSET
-    is_active: bool | None | Unset = UNSET
     token: None | str | Unset = UNSET
+    is_active: bool | None | Unset = UNSET
+    expires_at: datetime.datetime | None | Unset = UNSET
+    embed_token_count: int | Unset = 0
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
-
-        created_by: None | str
-        created_by = self.created_by
-
         map_id = str(self.map_id)
 
         map_name = self.map_name
 
-        embed_token_count = self.embed_token_count
+        created_at = self.created_at.isoformat()
 
-        expires_at: None | str | Unset
-        if isinstance(self.expires_at, Unset):
-            expires_at = UNSET
-        elif isinstance(self.expires_at, datetime.datetime):
-            expires_at = self.expires_at.isoformat()
-        else:
-            expires_at = self.expires_at
+        created_by: None | str
+        created_by = self.created_by
 
         id: None | str | Unset
         if isinstance(self.id, Unset):
@@ -71,44 +61,58 @@ class AdminShareTokenResponse:
         else:
             id = self.id
 
-        is_active: bool | None | Unset
-        if isinstance(self.is_active, Unset):
-            is_active = UNSET
-        else:
-            is_active = self.is_active
-
         token: None | str | Unset
         if isinstance(self.token, Unset):
             token = UNSET
         else:
             token = self.token
 
+        is_active: bool | None | Unset
+        if isinstance(self.is_active, Unset):
+            is_active = UNSET
+        else:
+            is_active = self.is_active
+
+        expires_at: None | str | Unset
+        if isinstance(self.expires_at, Unset):
+            expires_at = UNSET
+        elif isinstance(self.expires_at, datetime.datetime):
+            expires_at = self.expires_at.isoformat()
+        else:
+            expires_at = self.expires_at
+
+        embed_token_count = self.embed_token_count
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "created_by": created_by,
                 "map_id": map_id,
                 "map_name": map_name,
+                "created_at": created_at,
+                "created_by": created_by,
             }
         )
-        if embed_token_count is not UNSET:
-            field_dict["embed_token_count"] = embed_token_count
-        if expires_at is not UNSET:
-            field_dict["expires_at"] = expires_at
         if id is not UNSET:
             field_dict["id"] = id
-        if is_active is not UNSET:
-            field_dict["is_active"] = is_active
         if token is not UNSET:
             field_dict["token"] = token
+        if is_active is not UNSET:
+            field_dict["is_active"] = is_active
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
+        if embed_token_count is not UNSET:
+            field_dict["embed_token_count"] = embed_token_count
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        map_id = UUID(d.pop("map_id"))
+
+        map_name = d.pop("map_name")
+
         created_at = isoparse(d.pop("created_at"))
 
         def _parse_created_by(data: object) -> None | str:
@@ -117,29 +121,6 @@ class AdminShareTokenResponse:
             return cast(None | str, data)
 
         created_by = _parse_created_by(d.pop("created_by"))
-
-        map_id = UUID(d.pop("map_id"))
-
-        map_name = d.pop("map_name")
-
-        embed_token_count = d.pop("embed_token_count", UNSET)
-
-        def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                expires_at_type_0 = isoparse(data)
-
-                return expires_at_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None | Unset, data)
-
-        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
 
         def _parse_id(data: object) -> None | Unset | UUID:
             if data is None:
@@ -158,15 +139,6 @@ class AdminShareTokenResponse:
 
         id = _parse_id(d.pop("id", UNSET))
 
-        def _parse_is_active(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        is_active = _parse_is_active(d.pop("is_active", UNSET))
-
         def _parse_token(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -176,16 +148,44 @@ class AdminShareTokenResponse:
 
         token = _parse_token(d.pop("token", UNSET))
 
+        def _parse_is_active(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_active = _parse_is_active(d.pop("is_active", UNSET))
+
+        def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                expires_at_type_0 = isoparse(data)
+
+                return expires_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
+
+        embed_token_count = d.pop("embed_token_count", UNSET)
+
         admin_share_token_response = cls(
-            created_at=created_at,
-            created_by=created_by,
             map_id=map_id,
             map_name=map_name,
-            embed_token_count=embed_token_count,
-            expires_at=expires_at,
+            created_at=created_at,
+            created_by=created_by,
             id=id,
-            is_active=is_active,
             token=token,
+            is_active=is_active,
+            expires_at=expires_at,
+            embed_token_count=embed_token_count,
         )
 
         admin_share_token_response.additional_properties = d

--- a/sdks/python/geolens/models/admin_user_create.py
+++ b/sdks/python/geolens/models/admin_user_create.py
@@ -18,23 +18,23 @@ T = TypeVar("T", bound="AdminUserCreate")
 class AdminUserCreate:
     """
     Attributes:
+        username (str): Login username (3-150 chars). Must be unique across the system.
         password (str): Initial password (policy: min 12 chars, 3+ character classes). The user can change this after
             first login.
-        username (str): Login username (3-150 chars). Must be unique across the system.
         email (None | str | Unset): Optional email address. Used for OAuth account linking and notifications.
         role (str | Unset): User role: 'admin', 'editor', or 'viewer'. Defaults to 'viewer'. Default: 'viewer'.
     """
 
-    password: str
     username: str
+    password: str
     email: None | str | Unset = UNSET
     role: str | Unset = "viewer"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        password = self.password
-
         username = self.username
+
+        password = self.password
 
         email: None | str | Unset
         if isinstance(self.email, Unset):
@@ -48,8 +48,8 @@ class AdminUserCreate:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "password": password,
                 "username": username,
+                "password": password,
             }
         )
         if email is not UNSET:
@@ -62,9 +62,9 @@ class AdminUserCreate:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        password = d.pop("password")
-
         username = d.pop("username")
+
+        password = d.pop("password")
 
         def _parse_email(data: object) -> None | str | Unset:
             if data is None:
@@ -78,8 +78,8 @@ class AdminUserCreate:
         role = d.pop("role", UNSET)
 
         admin_user_create = cls(
-            password=password,
             username=username,
+            password=password,
             email=email,
             role=role,
         )

--- a/sdks/python/geolens/models/ai_probe_check.py
+++ b/sdks/python/geolens/models/ai_probe_check.py
@@ -20,25 +20,19 @@ class AIProbeCheck:
 
     Attributes:
         configured (bool): Whether this purpose has a provider key configured. False means no probe call was made.
-        error (None | str | Unset): Short sanitized failure reason. Never contains the key or raw provider error bodies.
         ok (bool | None | Unset): Whether the live provider call succeeded. None when not configured (no call was made).
         status (int | None | Unset): HTTP status returned by the provider on failure, when available.
+        error (None | str | Unset): Short sanitized failure reason. Never contains the key or raw provider error bodies.
     """
 
     configured: bool
-    error: None | str | Unset = UNSET
     ok: bool | None | Unset = UNSET
     status: int | None | Unset = UNSET
+    error: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         configured = self.configured
-
-        error: None | str | Unset
-        if isinstance(self.error, Unset):
-            error = UNSET
-        else:
-            error = self.error
 
         ok: bool | None | Unset
         if isinstance(self.ok, Unset):
@@ -52,6 +46,12 @@ class AIProbeCheck:
         else:
             status = self.status
 
+        error: None | str | Unset
+        if isinstance(self.error, Unset):
+            error = UNSET
+        else:
+            error = self.error
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -59,12 +59,12 @@ class AIProbeCheck:
                 "configured": configured,
             }
         )
-        if error is not UNSET:
-            field_dict["error"] = error
         if ok is not UNSET:
             field_dict["ok"] = ok
         if status is not UNSET:
             field_dict["status"] = status
+        if error is not UNSET:
+            field_dict["error"] = error
 
         return field_dict
 
@@ -72,15 +72,6 @@ class AIProbeCheck:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         configured = d.pop("configured")
-
-        def _parse_error(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        error = _parse_error(d.pop("error", UNSET))
 
         def _parse_ok(data: object) -> bool | None | Unset:
             if data is None:
@@ -100,11 +91,20 @@ class AIProbeCheck:
 
         status = _parse_status(d.pop("status", UNSET))
 
+        def _parse_error(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        error = _parse_error(d.pop("error", UNSET))
+
         ai_probe_check = cls(
             configured=configured,
-            error=error,
             ok=ok,
             status=status,
+            error=error,
         )
 
         ai_probe_check.additional_properties = d

--- a/sdks/python/geolens/models/ai_status_response.py
+++ b/sdks/python/geolens/models/ai_status_response.py
@@ -21,37 +21,39 @@ T = TypeVar("T", bound="AIStatusResponse")
 class AIStatusResponse:
     """
     Attributes:
-        configured (bool): Whether an API key is configured. AI features require both 'enabled' and 'configured'.
-        enabled (bool): Whether AI features are enabled for this instance.
-        model (None | str): Active model name (e.g. 'claude-sonnet-4-20250514').
         provider (None | str): Active AI provider name (e.g. 'anthropic', 'openai').
+        model (None | str): Active model name (e.g. 'claude-sonnet-4-20250514').
+        enabled (bool): Whether AI features are enabled for this instance.
+        configured (bool): Whether an API key is configured. AI features require both 'enabled' and 'configured'.
+        semantic_search_enabled (bool | Unset): Whether pgvector-backed semantic search is enabled. Default: False.
         has_embeddings (bool | Unset): Whether at least one record has embeddings stored. Default: False.
         probe (AIProbeReport | None | Unset): Live provider probe results. Only present when the request opted in via
             ?probe=true.
-        semantic_search_enabled (bool | Unset): Whether pgvector-backed semantic search is enabled. Default: False.
     """
 
-    configured: bool
-    enabled: bool
-    model: None | str
     provider: None | str
+    model: None | str
+    enabled: bool
+    configured: bool
+    semantic_search_enabled: bool | Unset = False
     has_embeddings: bool | Unset = False
     probe: AIProbeReport | None | Unset = UNSET
-    semantic_search_enabled: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.ai_probe_report import AIProbeReport
 
-        configured = self.configured
-
-        enabled = self.enabled
+        provider: None | str
+        provider = self.provider
 
         model: None | str
         model = self.model
 
-        provider: None | str
-        provider = self.provider
+        enabled = self.enabled
+
+        configured = self.configured
+
+        semantic_search_enabled = self.semantic_search_enabled
 
         has_embeddings = self.has_embeddings
 
@@ -63,24 +65,22 @@ class AIStatusResponse:
         else:
             probe = self.probe
 
-        semantic_search_enabled = self.semantic_search_enabled
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "configured": configured,
-                "enabled": enabled,
-                "model": model,
                 "provider": provider,
+                "model": model,
+                "enabled": enabled,
+                "configured": configured,
             }
         )
+        if semantic_search_enabled is not UNSET:
+            field_dict["semantic_search_enabled"] = semantic_search_enabled
         if has_embeddings is not UNSET:
             field_dict["has_embeddings"] = has_embeddings
         if probe is not UNSET:
             field_dict["probe"] = probe
-        if semantic_search_enabled is not UNSET:
-            field_dict["semantic_search_enabled"] = semantic_search_enabled
 
         return field_dict
 
@@ -89,9 +89,13 @@ class AIStatusResponse:
         from ..models.ai_probe_report import AIProbeReport
 
         d = dict(src_dict)
-        configured = d.pop("configured")
 
-        enabled = d.pop("enabled")
+        def _parse_provider(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        provider = _parse_provider(d.pop("provider"))
 
         def _parse_model(data: object) -> None | str:
             if data is None:
@@ -100,12 +104,11 @@ class AIStatusResponse:
 
         model = _parse_model(d.pop("model"))
 
-        def _parse_provider(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
+        enabled = d.pop("enabled")
 
-        provider = _parse_provider(d.pop("provider"))
+        configured = d.pop("configured")
+
+        semantic_search_enabled = d.pop("semantic_search_enabled", UNSET)
 
         has_embeddings = d.pop("has_embeddings", UNSET)
 
@@ -126,16 +129,14 @@ class AIStatusResponse:
 
         probe = _parse_probe(d.pop("probe", UNSET))
 
-        semantic_search_enabled = d.pop("semantic_search_enabled", UNSET)
-
         ai_status_response = cls(
-            configured=configured,
-            enabled=enabled,
-            model=model,
             provider=provider,
+            model=model,
+            enabled=enabled,
+            configured=configured,
+            semantic_search_enabled=semantic_search_enabled,
             has_embeddings=has_embeddings,
             probe=probe,
-            semantic_search_enabled=semantic_search_enabled,
         )
 
         ai_status_response.additional_properties = d

--- a/sdks/python/geolens/models/analysis_materialize_request.py
+++ b/sdks/python/geolens/models/analysis_materialize_request.py
@@ -33,28 +33,28 @@ class AnalysisMaterializeRequest:
     Attributes:
         operation (AnalysisMaterializeRequestOperation):
         title (str):
-        by_field (None | str | Unset): Optional group-by column for dissolve
         distance_meters (float | None | Unset): Buffer distance in meters (buffer only)
-        join_dataset_id (None | Unset | UUID): Dataset to join against; each source feature gains a count of the
-            features from it that intersect (spatial_join only)
-        join_fields (list[str] | None | Unset): Columns to copy from the intersecting join feature, prefixed 'join_' in
-            the output. Ties break on the lowest join-layer gid (spatial_join only)
         mask (AnalysisMaterializeRequestMaskType0 | None | Unset): GeoJSON Polygon or MultiPolygon geometry in EPSG:4326
             (clip and select_by_location)
         mask_dataset_id (None | Unset | UUID): Polygon dataset supplying the second layer: the area clipped to, selected
             against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is
             REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a
             drawn polygon has none.
+        by_field (None | str | Unset): Optional group-by column for dissolve
+        join_dataset_id (None | Unset | UUID): Dataset to join against; each source feature gains a count of the
+            features from it that intersect (spatial_join only)
+        join_fields (list[str] | None | Unset): Columns to copy from the intersecting join feature, prefixed 'join_' in
+            the output. Ties break on the lowest join-layer gid (spatial_join only)
     """
 
     operation: AnalysisMaterializeRequestOperation
     title: str
-    by_field: None | str | Unset = UNSET
     distance_meters: float | None | Unset = UNSET
-    join_dataset_id: None | Unset | UUID = UNSET
-    join_fields: list[str] | None | Unset = UNSET
     mask: AnalysisMaterializeRequestMaskType0 | None | Unset = UNSET
     mask_dataset_id: None | Unset | UUID = UNSET
+    by_field: None | str | Unset = UNSET
+    join_dataset_id: None | Unset | UUID = UNSET
+    join_fields: list[str] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -66,17 +66,33 @@ class AnalysisMaterializeRequest:
 
         title = self.title
 
-        by_field: None | str | Unset
-        if isinstance(self.by_field, Unset):
-            by_field = UNSET
-        else:
-            by_field = self.by_field
-
         distance_meters: float | None | Unset
         if isinstance(self.distance_meters, Unset):
             distance_meters = UNSET
         else:
             distance_meters = self.distance_meters
+
+        mask: dict[str, Any] | None | Unset
+        if isinstance(self.mask, Unset):
+            mask = UNSET
+        elif isinstance(self.mask, AnalysisMaterializeRequestMaskType0):
+            mask = self.mask.to_dict()
+        else:
+            mask = self.mask
+
+        mask_dataset_id: None | str | Unset
+        if isinstance(self.mask_dataset_id, Unset):
+            mask_dataset_id = UNSET
+        elif isinstance(self.mask_dataset_id, UUID):
+            mask_dataset_id = str(self.mask_dataset_id)
+        else:
+            mask_dataset_id = self.mask_dataset_id
+
+        by_field: None | str | Unset
+        if isinstance(self.by_field, Unset):
+            by_field = UNSET
+        else:
+            by_field = self.by_field
 
         join_dataset_id: None | str | Unset
         if isinstance(self.join_dataset_id, Unset):
@@ -95,22 +111,6 @@ class AnalysisMaterializeRequest:
         else:
             join_fields = self.join_fields
 
-        mask: dict[str, Any] | None | Unset
-        if isinstance(self.mask, Unset):
-            mask = UNSET
-        elif isinstance(self.mask, AnalysisMaterializeRequestMaskType0):
-            mask = self.mask.to_dict()
-        else:
-            mask = self.mask
-
-        mask_dataset_id: None | str | Unset
-        if isinstance(self.mask_dataset_id, Unset):
-            mask_dataset_id = UNSET
-        elif isinstance(self.mask_dataset_id, UUID):
-            mask_dataset_id = str(self.mask_dataset_id)
-        else:
-            mask_dataset_id = self.mask_dataset_id
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -119,18 +119,18 @@ class AnalysisMaterializeRequest:
                 "title": title,
             }
         )
-        if by_field is not UNSET:
-            field_dict["by_field"] = by_field
         if distance_meters is not UNSET:
             field_dict["distance_meters"] = distance_meters
-        if join_dataset_id is not UNSET:
-            field_dict["join_dataset_id"] = join_dataset_id
-        if join_fields is not UNSET:
-            field_dict["join_fields"] = join_fields
         if mask is not UNSET:
             field_dict["mask"] = mask
         if mask_dataset_id is not UNSET:
             field_dict["mask_dataset_id"] = mask_dataset_id
+        if by_field is not UNSET:
+            field_dict["by_field"] = by_field
+        if join_dataset_id is not UNSET:
+            field_dict["join_dataset_id"] = join_dataset_id
+        if join_fields is not UNSET:
+            field_dict["join_fields"] = join_fields
 
         return field_dict
 
@@ -145,15 +145,6 @@ class AnalysisMaterializeRequest:
 
         title = d.pop("title")
 
-        def _parse_by_field(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        by_field = _parse_by_field(d.pop("by_field", UNSET))
-
         def _parse_distance_meters(data: object) -> float | None | Unset:
             if data is None:
                 return data
@@ -162,40 +153,6 @@ class AnalysisMaterializeRequest:
             return cast(float | None | Unset, data)
 
         distance_meters = _parse_distance_meters(d.pop("distance_meters", UNSET))
-
-        def _parse_join_dataset_id(data: object) -> None | Unset | UUID:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                join_dataset_id_type_0 = UUID(data)
-
-                return join_dataset_id_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | Unset | UUID, data)
-
-        join_dataset_id = _parse_join_dataset_id(d.pop("join_dataset_id", UNSET))
-
-        def _parse_join_fields(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                join_fields_type_0 = cast(list[str], data)
-
-                return join_fields_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        join_fields = _parse_join_fields(d.pop("join_fields", UNSET))
 
         def _parse_mask(
             data: object,
@@ -233,15 +190,58 @@ class AnalysisMaterializeRequest:
 
         mask_dataset_id = _parse_mask_dataset_id(d.pop("mask_dataset_id", UNSET))
 
+        def _parse_by_field(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        by_field = _parse_by_field(d.pop("by_field", UNSET))
+
+        def _parse_join_dataset_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                join_dataset_id_type_0 = UUID(data)
+
+                return join_dataset_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        join_dataset_id = _parse_join_dataset_id(d.pop("join_dataset_id", UNSET))
+
+        def _parse_join_fields(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                join_fields_type_0 = cast(list[str], data)
+
+                return join_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        join_fields = _parse_join_fields(d.pop("join_fields", UNSET))
+
         analysis_materialize_request = cls(
             operation=operation,
             title=title,
-            by_field=by_field,
             distance_meters=distance_meters,
-            join_dataset_id=join_dataset_id,
-            join_fields=join_fields,
             mask=mask,
             mask_dataset_id=mask_dataset_id,
+            by_field=by_field,
+            join_dataset_id=join_dataset_id,
+            join_fields=join_fields,
         )
 
         analysis_materialize_request.additional_properties = d

--- a/sdks/python/geolens/models/analysis_preview_request.py
+++ b/sdks/python/geolens/models/analysis_preview_request.py
@@ -33,31 +33,31 @@ class AnalysisPreviewRequest:
 
         Attributes:
             operation (AnalysisPreviewRequestOperation):
-            bbox (list[float] | None | Unset): [minx, miny, maxx, maxy] in EPSG:4326, typically the map's current viewport.
-                When present, only source features intersecting the envelope are considered before the preview's row cap
-                applies, so a capped result reflects what is on screen rather than an arbitrary sample in ingest order
-                (fix(#727)). Applies to every operation, not just one, so it is deliberately absent from _ANALYSIS_PARAM_OWNERS
-                — omit it to preview the whole dataset, unchanged from before this field existed.
             distance_meters (float | None | Unset): Buffer distance in meters (buffer only)
-            join_dataset_id (None | Unset | UUID): Dataset to join against; each source feature gains a count of the
-                features from it that intersect (spatial_join only)
-            join_fields (list[str] | None | Unset): Columns to copy from the intersecting join feature, prefixed 'join_' in
-                the output. Ties break on the lowest join-layer gid (spatial_join only)
             mask (AnalysisPreviewRequestMaskType0 | None | Unset): GeoJSON Polygon or MultiPolygon geometry in EPSG:4326
                 (clip and select_by_location)
             mask_dataset_id (None | Unset | UUID): Polygon dataset supplying the second layer: the area clipped to, selected
                 against, or overlaid with. For clip and select_by_location it is the alternative to `mask`; for intersect it is
                 REQUIRED and `mask` is rejected, because an overlay carries the second layer's attributes onto its output and a
                 drawn polygon has none.
+            join_dataset_id (None | Unset | UUID): Dataset to join against; each source feature gains a count of the
+                features from it that intersect (spatial_join only)
+            join_fields (list[str] | None | Unset): Columns to copy from the intersecting join feature, prefixed 'join_' in
+                the output. Ties break on the lowest join-layer gid (spatial_join only)
+            bbox (list[float] | None | Unset): [minx, miny, maxx, maxy] in EPSG:4326, typically the map's current viewport.
+                When present, only source features intersecting the envelope are considered before the preview's row cap
+                applies, so a capped result reflects what is on screen rather than an arbitrary sample in ingest order
+                (fix(#727)). Applies to every operation, not just one, so it is deliberately absent from _ANALYSIS_PARAM_OWNERS
+                — omit it to preview the whole dataset, unchanged from before this field existed.
     """
 
     operation: AnalysisPreviewRequestOperation
-    bbox: list[float] | None | Unset = UNSET
     distance_meters: float | None | Unset = UNSET
-    join_dataset_id: None | Unset | UUID = UNSET
-    join_fields: list[str] | None | Unset = UNSET
     mask: AnalysisPreviewRequestMaskType0 | None | Unset = UNSET
     mask_dataset_id: None | Unset | UUID = UNSET
+    join_dataset_id: None | Unset | UUID = UNSET
+    join_fields: list[str] | None | Unset = UNSET
+    bbox: list[float] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -67,20 +67,27 @@ class AnalysisPreviewRequest:
 
         operation: str = self.operation
 
-        bbox: list[float] | None | Unset
-        if isinstance(self.bbox, Unset):
-            bbox = UNSET
-        elif isinstance(self.bbox, list):
-            bbox = self.bbox
-
-        else:
-            bbox = self.bbox
-
         distance_meters: float | None | Unset
         if isinstance(self.distance_meters, Unset):
             distance_meters = UNSET
         else:
             distance_meters = self.distance_meters
+
+        mask: dict[str, Any] | None | Unset
+        if isinstance(self.mask, Unset):
+            mask = UNSET
+        elif isinstance(self.mask, AnalysisPreviewRequestMaskType0):
+            mask = self.mask.to_dict()
+        else:
+            mask = self.mask
+
+        mask_dataset_id: None | str | Unset
+        if isinstance(self.mask_dataset_id, Unset):
+            mask_dataset_id = UNSET
+        elif isinstance(self.mask_dataset_id, UUID):
+            mask_dataset_id = str(self.mask_dataset_id)
+        else:
+            mask_dataset_id = self.mask_dataset_id
 
         join_dataset_id: None | str | Unset
         if isinstance(self.join_dataset_id, Unset):
@@ -99,21 +106,14 @@ class AnalysisPreviewRequest:
         else:
             join_fields = self.join_fields
 
-        mask: dict[str, Any] | None | Unset
-        if isinstance(self.mask, Unset):
-            mask = UNSET
-        elif isinstance(self.mask, AnalysisPreviewRequestMaskType0):
-            mask = self.mask.to_dict()
-        else:
-            mask = self.mask
+        bbox: list[float] | None | Unset
+        if isinstance(self.bbox, Unset):
+            bbox = UNSET
+        elif isinstance(self.bbox, list):
+            bbox = self.bbox
 
-        mask_dataset_id: None | str | Unset
-        if isinstance(self.mask_dataset_id, Unset):
-            mask_dataset_id = UNSET
-        elif isinstance(self.mask_dataset_id, UUID):
-            mask_dataset_id = str(self.mask_dataset_id)
         else:
-            mask_dataset_id = self.mask_dataset_id
+            bbox = self.bbox
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -122,18 +122,18 @@ class AnalysisPreviewRequest:
                 "operation": operation,
             }
         )
-        if bbox is not UNSET:
-            field_dict["bbox"] = bbox
         if distance_meters is not UNSET:
             field_dict["distance_meters"] = distance_meters
-        if join_dataset_id is not UNSET:
-            field_dict["join_dataset_id"] = join_dataset_id
-        if join_fields is not UNSET:
-            field_dict["join_fields"] = join_fields
         if mask is not UNSET:
             field_dict["mask"] = mask
         if mask_dataset_id is not UNSET:
             field_dict["mask_dataset_id"] = mask_dataset_id
+        if join_dataset_id is not UNSET:
+            field_dict["join_dataset_id"] = join_dataset_id
+        if join_fields is not UNSET:
+            field_dict["join_fields"] = join_fields
+        if bbox is not UNSET:
+            field_dict["bbox"] = bbox
 
         return field_dict
 
@@ -146,23 +146,6 @@ class AnalysisPreviewRequest:
         d = dict(src_dict)
         operation = check_analysis_preview_request_operation(d.pop("operation"))
 
-        def _parse_bbox(data: object) -> list[float] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                bbox_type_0 = cast(list[float], data)
-
-                return bbox_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[float] | None | Unset, data)
-
-        bbox = _parse_bbox(d.pop("bbox", UNSET))
-
         def _parse_distance_meters(data: object) -> float | None | Unset:
             if data is None:
                 return data
@@ -171,40 +154,6 @@ class AnalysisPreviewRequest:
             return cast(float | None | Unset, data)
 
         distance_meters = _parse_distance_meters(d.pop("distance_meters", UNSET))
-
-        def _parse_join_dataset_id(data: object) -> None | Unset | UUID:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                join_dataset_id_type_0 = UUID(data)
-
-                return join_dataset_id_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | Unset | UUID, data)
-
-        join_dataset_id = _parse_join_dataset_id(d.pop("join_dataset_id", UNSET))
-
-        def _parse_join_fields(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                join_fields_type_0 = cast(list[str], data)
-
-                return join_fields_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        join_fields = _parse_join_fields(d.pop("join_fields", UNSET))
 
         def _parse_mask(data: object) -> AnalysisPreviewRequestMaskType0 | None | Unset:
             if data is None:
@@ -240,14 +189,65 @@ class AnalysisPreviewRequest:
 
         mask_dataset_id = _parse_mask_dataset_id(d.pop("mask_dataset_id", UNSET))
 
+        def _parse_join_dataset_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                join_dataset_id_type_0 = UUID(data)
+
+                return join_dataset_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        join_dataset_id = _parse_join_dataset_id(d.pop("join_dataset_id", UNSET))
+
+        def _parse_join_fields(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                join_fields_type_0 = cast(list[str], data)
+
+                return join_fields_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        join_fields = _parse_join_fields(d.pop("join_fields", UNSET))
+
+        def _parse_bbox(data: object) -> list[float] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                bbox_type_0 = cast(list[float], data)
+
+                return bbox_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[float] | None | Unset, data)
+
+        bbox = _parse_bbox(d.pop("bbox", UNSET))
+
         analysis_preview_request = cls(
             operation=operation,
-            bbox=bbox,
             distance_meters=distance_meters,
-            join_dataset_id=join_dataset_id,
-            join_fields=join_fields,
             mask=mask,
             mask_dataset_id=mask_dataset_id,
+            join_dataset_id=join_dataset_id,
+            join_fields=join_fields,
+            bbox=bbox,
         )
 
         analysis_preview_request.additional_properties = d

--- a/sdks/python/geolens/models/analysis_preview_response.py
+++ b/sdks/python/geolens/models/analysis_preview_response.py
@@ -24,10 +24,14 @@ class AnalysisPreviewResponse:
     """GeoJSON FeatureCollection preview of an analysis operation.
 
     Attributes:
-        feature_count (int):
         geojson (AnalysisPreviewResponseGeojson):
+        feature_count (int):
         truncated (bool):
         bbox (list[float] | None | Unset):
+        source_feature_count (int | None | Unset): Total feature count of the source dataset (1:1 operations only; null
+            when the operation filters rows, e.g. clip). When the request carried a bbox this is a LIVE count of rows
+            intersecting it rather than the dataset's cached whole-table total (fix(#727)) — also null, same as match_count,
+            when that live count could not be computed within the query budget
         match_count (int | None | Unset): Exact total across the WHOLE source, not just the previewed features — WHOLE
             meaning the request's bbox when one was sent, the same sense source_feature_count uses that word. What it counts
             is per-operation, so read it against the operation you sent rather than as one number: select_by_location gives
@@ -37,24 +41,20 @@ class AnalysisPreviewResponse:
             to a bbox on the request; select_by_location's count is a separate uncapped query the request's bbox does not
             reach, so it stays unscoped even though its preview rows are viewport-limited too. Null for operations that
             report no such total, and when the count could not be computed within the query budget
-        source_feature_count (int | None | Unset): Total feature count of the source dataset (1:1 operations only; null
-            when the operation filters rows, e.g. clip). When the request carried a bbox this is a LIVE count of rows
-            intersecting it rather than the dataset's cached whole-table total (fix(#727)) — also null, same as match_count,
-            when that live count could not be computed within the query budget
     """
 
-    feature_count: int
     geojson: AnalysisPreviewResponseGeojson
+    feature_count: int
     truncated: bool
     bbox: list[float] | None | Unset = UNSET
-    match_count: int | None | Unset = UNSET
     source_feature_count: int | None | Unset = UNSET
+    match_count: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        feature_count = self.feature_count
-
         geojson = self.geojson.to_dict()
+
+        feature_count = self.feature_count
 
         truncated = self.truncated
 
@@ -67,33 +67,33 @@ class AnalysisPreviewResponse:
         else:
             bbox = self.bbox
 
-        match_count: int | None | Unset
-        if isinstance(self.match_count, Unset):
-            match_count = UNSET
-        else:
-            match_count = self.match_count
-
         source_feature_count: int | None | Unset
         if isinstance(self.source_feature_count, Unset):
             source_feature_count = UNSET
         else:
             source_feature_count = self.source_feature_count
 
+        match_count: int | None | Unset
+        if isinstance(self.match_count, Unset):
+            match_count = UNSET
+        else:
+            match_count = self.match_count
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "feature_count": feature_count,
                 "geojson": geojson,
+                "feature_count": feature_count,
                 "truncated": truncated,
             }
         )
         if bbox is not UNSET:
             field_dict["bbox"] = bbox
-        if match_count is not UNSET:
-            field_dict["match_count"] = match_count
         if source_feature_count is not UNSET:
             field_dict["source_feature_count"] = source_feature_count
+        if match_count is not UNSET:
+            field_dict["match_count"] = match_count
 
         return field_dict
 
@@ -104,9 +104,9 @@ class AnalysisPreviewResponse:
         )
 
         d = dict(src_dict)
-        feature_count = d.pop("feature_count")
-
         geojson = AnalysisPreviewResponseGeojson.from_dict(d.pop("geojson"))
+
+        feature_count = d.pop("feature_count")
 
         truncated = d.pop("truncated")
 
@@ -127,15 +127,6 @@ class AnalysisPreviewResponse:
 
         bbox = _parse_bbox(d.pop("bbox", UNSET))
 
-        def _parse_match_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        match_count = _parse_match_count(d.pop("match_count", UNSET))
-
         def _parse_source_feature_count(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -147,13 +138,22 @@ class AnalysisPreviewResponse:
             d.pop("source_feature_count", UNSET)
         )
 
+        def _parse_match_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        match_count = _parse_match_count(d.pop("match_count", UNSET))
+
         analysis_preview_response = cls(
-            feature_count=feature_count,
             geojson=geojson,
+            feature_count=feature_count,
             truncated=truncated,
             bbox=bbox,
-            match_count=match_count,
             source_feature_count=source_feature_count,
+            match_count=match_count,
         )
 
         analysis_preview_response.additional_properties = d

--- a/sdks/python/geolens/models/api_key_create_response.py
+++ b/sdks/python/geolens/models/api_key_create_response.py
@@ -21,36 +21,36 @@ T = TypeVar("T", bound="ApiKeyCreateResponse")
 class ApiKeyCreateResponse:
     """
     Attributes:
-        created_at (datetime.datetime):
-        fingerprint (str): Non-secret key identifier (prefix and last four characters)
         id (UUID):
         key (str): The API key secret (shown only once)
+        fingerprint (str): Non-secret key identifier (prefix and last four characters)
         name (str):
         scope (str): Privilege scope: 'full' or 'read_only' (#875)
+        created_at (datetime.datetime):
         expires_at (datetime.datetime | None | Unset): Expiry timestamp; null means the key does not expire
     """
 
-    created_at: datetime.datetime
-    fingerprint: str
     id: UUID
     key: str
+    fingerprint: str
     name: str
     scope: str
+    created_at: datetime.datetime
     expires_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
-
-        fingerprint = self.fingerprint
-
         id = str(self.id)
 
         key = self.key
 
+        fingerprint = self.fingerprint
+
         name = self.name
 
         scope = self.scope
+
+        created_at = self.created_at.isoformat()
 
         expires_at: None | str | Unset
         if isinstance(self.expires_at, Unset):
@@ -64,12 +64,12 @@ class ApiKeyCreateResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "fingerprint": fingerprint,
                 "id": id,
                 "key": key,
+                "fingerprint": fingerprint,
                 "name": name,
                 "scope": scope,
+                "created_at": created_at,
             }
         )
         if expires_at is not UNSET:
@@ -80,17 +80,17 @@ class ApiKeyCreateResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
-
-        fingerprint = d.pop("fingerprint")
-
         id = UUID(d.pop("id"))
 
         key = d.pop("key")
 
+        fingerprint = d.pop("fingerprint")
+
         name = d.pop("name")
 
         scope = d.pop("scope")
+
+        created_at = isoparse(d.pop("created_at"))
 
         def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -110,12 +110,12 @@ class ApiKeyCreateResponse:
         expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
 
         api_key_create_response = cls(
-            created_at=created_at,
-            fingerprint=fingerprint,
             id=id,
             key=key,
+            fingerprint=fingerprint,
             name=name,
             scope=scope,
+            created_at=created_at,
             expires_at=expires_at,
         )
 

--- a/sdks/python/geolens/models/api_key_list_item.py
+++ b/sdks/python/geolens/models/api_key_list_item.py
@@ -21,45 +21,45 @@ T = TypeVar("T", bound="ApiKeyListItem")
 class ApiKeyListItem:
     """
     Attributes:
-        created_at (datetime.datetime):
-        fingerprint (None | str): Non-secret key identifier; null for keys created before fingerprint support
         id (UUID):
-        is_active (bool):
-        last_used_at (datetime.datetime | None):
         name (str):
+        fingerprint (None | str): Non-secret key identifier; null for keys created before fingerprint support
+        is_active (bool):
         scope (str): Privilege scope: 'full' or 'read_only' (#875)
+        created_at (datetime.datetime):
+        last_used_at (datetime.datetime | None):
         expires_at (datetime.datetime | None | Unset): Expiry timestamp; null means the key does not expire
     """
 
-    created_at: datetime.datetime
-    fingerprint: None | str
     id: UUID
-    is_active: bool
-    last_used_at: datetime.datetime | None
     name: str
+    fingerprint: None | str
+    is_active: bool
     scope: str
+    created_at: datetime.datetime
+    last_used_at: datetime.datetime | None
     expires_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
+        id = str(self.id)
+
+        name = self.name
 
         fingerprint: None | str
         fingerprint = self.fingerprint
 
-        id = str(self.id)
-
         is_active = self.is_active
+
+        scope = self.scope
+
+        created_at = self.created_at.isoformat()
 
         last_used_at: None | str
         if isinstance(self.last_used_at, datetime.datetime):
             last_used_at = self.last_used_at.isoformat()
         else:
             last_used_at = self.last_used_at
-
-        name = self.name
-
-        scope = self.scope
 
         expires_at: None | str | Unset
         if isinstance(self.expires_at, Unset):
@@ -73,13 +73,13 @@ class ApiKeyListItem:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "fingerprint": fingerprint,
                 "id": id,
-                "is_active": is_active,
-                "last_used_at": last_used_at,
                 "name": name,
+                "fingerprint": fingerprint,
+                "is_active": is_active,
                 "scope": scope,
+                "created_at": created_at,
+                "last_used_at": last_used_at,
             }
         )
         if expires_at is not UNSET:
@@ -90,7 +90,9 @@ class ApiKeyListItem:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
+        id = UUID(d.pop("id"))
+
+        name = d.pop("name")
 
         def _parse_fingerprint(data: object) -> None | str:
             if data is None:
@@ -99,9 +101,11 @@ class ApiKeyListItem:
 
         fingerprint = _parse_fingerprint(d.pop("fingerprint"))
 
-        id = UUID(d.pop("id"))
-
         is_active = d.pop("is_active")
+
+        scope = d.pop("scope")
+
+        created_at = isoparse(d.pop("created_at"))
 
         def _parse_last_used_at(data: object) -> datetime.datetime | None:
             if data is None:
@@ -117,10 +121,6 @@ class ApiKeyListItem:
             return cast(datetime.datetime | None, data)
 
         last_used_at = _parse_last_used_at(d.pop("last_used_at"))
-
-        name = d.pop("name")
-
-        scope = d.pop("scope")
 
         def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -140,13 +140,13 @@ class ApiKeyListItem:
         expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
 
         api_key_list_item = cls(
-            created_at=created_at,
-            fingerprint=fingerprint,
             id=id,
-            is_active=is_active,
-            last_used_at=last_used_at,
             name=name,
+            fingerprint=fingerprint,
+            is_active=is_active,
             scope=scope,
+            created_at=created_at,
+            last_used_at=last_used_at,
             expires_at=expires_at,
         )
 

--- a/sdks/python/geolens/models/attribute_metadata_response.py
+++ b/sdks/python/geolens/models/attribute_metadata_response.py
@@ -19,63 +19,69 @@ T = TypeVar("T", bound="AttributeMetadataResponse")
 class AttributeMetadataResponse:
     """
     Attributes:
-        data_type (None | str):
-        dataset_id (UUID):
-        description (None | str):
-        domain_type (None | str):
-        field_name (str):
         id (UUID):
-        is_current (bool): False if column was removed in a later version
+        dataset_id (UUID):
+        field_name (str):
         title (None | str):
+        description (None | str):
+        data_type (None | str):
         units (None | str):
+        domain_type (None | str):
+        is_current (bool): False if column was removed in a later version
         user_modified_fields (list[str]): Field names manually edited by a user
-        example_values (list[Any] | None | Unset): Sample values from the column
-        is_nullable (bool | None | Unset):
-        ordinal_position (int | None | Unset): Column position in the table (1-based)
         semantic_role (None | str | Unset): Inferred role: geometry, identifier, measure, etc.
+        example_values (list[Any] | None | Unset): Sample values from the column
+        ordinal_position (int | None | Unset): Column position in the table (1-based)
+        is_nullable (bool | None | Unset):
     """
 
-    data_type: None | str
-    dataset_id: UUID
-    description: None | str
-    domain_type: None | str
-    field_name: str
     id: UUID
-    is_current: bool
+    dataset_id: UUID
+    field_name: str
     title: None | str
+    description: None | str
+    data_type: None | str
     units: None | str
+    domain_type: None | str
+    is_current: bool
     user_modified_fields: list[str]
-    example_values: list[Any] | None | Unset = UNSET
-    is_nullable: bool | None | Unset = UNSET
-    ordinal_position: int | None | Unset = UNSET
     semantic_role: None | str | Unset = UNSET
+    example_values: list[Any] | None | Unset = UNSET
+    ordinal_position: int | None | Unset = UNSET
+    is_nullable: bool | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        data_type: None | str
-        data_type = self.data_type
+        id = str(self.id)
 
         dataset_id = str(self.dataset_id)
 
-        description: None | str
-        description = self.description
-
-        domain_type: None | str
-        domain_type = self.domain_type
-
         field_name = self.field_name
-
-        id = str(self.id)
-
-        is_current = self.is_current
 
         title: None | str
         title = self.title
 
+        description: None | str
+        description = self.description
+
+        data_type: None | str
+        data_type = self.data_type
+
         units: None | str
         units = self.units
 
+        domain_type: None | str
+        domain_type = self.domain_type
+
+        is_current = self.is_current
+
         user_modified_fields = self.user_modified_fields
+
+        semantic_role: None | str | Unset
+        if isinstance(self.semantic_role, Unset):
+            semantic_role = UNSET
+        else:
+            semantic_role = self.semantic_role
 
         example_values: list[Any] | None | Unset
         if isinstance(self.example_values, Unset):
@@ -86,83 +92,53 @@ class AttributeMetadataResponse:
         else:
             example_values = self.example_values
 
-        is_nullable: bool | None | Unset
-        if isinstance(self.is_nullable, Unset):
-            is_nullable = UNSET
-        else:
-            is_nullable = self.is_nullable
-
         ordinal_position: int | None | Unset
         if isinstance(self.ordinal_position, Unset):
             ordinal_position = UNSET
         else:
             ordinal_position = self.ordinal_position
 
-        semantic_role: None | str | Unset
-        if isinstance(self.semantic_role, Unset):
-            semantic_role = UNSET
+        is_nullable: bool | None | Unset
+        if isinstance(self.is_nullable, Unset):
+            is_nullable = UNSET
         else:
-            semantic_role = self.semantic_role
+            is_nullable = self.is_nullable
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "data_type": data_type,
-                "dataset_id": dataset_id,
-                "description": description,
-                "domain_type": domain_type,
-                "field_name": field_name,
                 "id": id,
-                "is_current": is_current,
+                "dataset_id": dataset_id,
+                "field_name": field_name,
                 "title": title,
+                "description": description,
+                "data_type": data_type,
                 "units": units,
+                "domain_type": domain_type,
+                "is_current": is_current,
                 "user_modified_fields": user_modified_fields,
             }
         )
-        if example_values is not UNSET:
-            field_dict["example_values"] = example_values
-        if is_nullable is not UNSET:
-            field_dict["is_nullable"] = is_nullable
-        if ordinal_position is not UNSET:
-            field_dict["ordinal_position"] = ordinal_position
         if semantic_role is not UNSET:
             field_dict["semantic_role"] = semantic_role
+        if example_values is not UNSET:
+            field_dict["example_values"] = example_values
+        if ordinal_position is not UNSET:
+            field_dict["ordinal_position"] = ordinal_position
+        if is_nullable is not UNSET:
+            field_dict["is_nullable"] = is_nullable
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
-        def _parse_data_type(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        data_type = _parse_data_type(d.pop("data_type"))
+        id = UUID(d.pop("id"))
 
         dataset_id = UUID(d.pop("dataset_id"))
 
-        def _parse_description(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        description = _parse_description(d.pop("description"))
-
-        def _parse_domain_type(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        domain_type = _parse_domain_type(d.pop("domain_type"))
-
         field_name = d.pop("field_name")
-
-        id = UUID(d.pop("id"))
-
-        is_current = d.pop("is_current")
 
         def _parse_title(data: object) -> None | str:
             if data is None:
@@ -171,6 +147,20 @@ class AttributeMetadataResponse:
 
         title = _parse_title(d.pop("title"))
 
+        def _parse_description(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        description = _parse_description(d.pop("description"))
+
+        def _parse_data_type(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        data_type = _parse_data_type(d.pop("data_type"))
+
         def _parse_units(data: object) -> None | str:
             if data is None:
                 return data
@@ -178,7 +168,25 @@ class AttributeMetadataResponse:
 
         units = _parse_units(d.pop("units"))
 
+        def _parse_domain_type(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        domain_type = _parse_domain_type(d.pop("domain_type"))
+
+        is_current = d.pop("is_current")
+
         user_modified_fields = cast(list[str], d.pop("user_modified_fields"))
+
+        def _parse_semantic_role(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        semantic_role = _parse_semantic_role(d.pop("semantic_role", UNSET))
 
         def _parse_example_values(data: object) -> list[Any] | None | Unset:
             if data is None:
@@ -197,15 +205,6 @@ class AttributeMetadataResponse:
 
         example_values = _parse_example_values(d.pop("example_values", UNSET))
 
-        def _parse_is_nullable(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        is_nullable = _parse_is_nullable(d.pop("is_nullable", UNSET))
-
         def _parse_ordinal_position(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -215,30 +214,30 @@ class AttributeMetadataResponse:
 
         ordinal_position = _parse_ordinal_position(d.pop("ordinal_position", UNSET))
 
-        def _parse_semantic_role(data: object) -> None | str | Unset:
+        def _parse_is_nullable(data: object) -> bool | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(None | str | Unset, data)
+            return cast(bool | None | Unset, data)
 
-        semantic_role = _parse_semantic_role(d.pop("semantic_role", UNSET))
+        is_nullable = _parse_is_nullable(d.pop("is_nullable", UNSET))
 
         attribute_metadata_response = cls(
-            data_type=data_type,
-            dataset_id=dataset_id,
-            description=description,
-            domain_type=domain_type,
-            field_name=field_name,
             id=id,
-            is_current=is_current,
+            dataset_id=dataset_id,
+            field_name=field_name,
             title=title,
+            description=description,
+            data_type=data_type,
             units=units,
+            domain_type=domain_type,
+            is_current=is_current,
             user_modified_fields=user_modified_fields,
-            example_values=example_values,
-            is_nullable=is_nullable,
-            ordinal_position=ordinal_position,
             semantic_role=semantic_role,
+            example_values=example_values,
+            ordinal_position=ordinal_position,
+            is_nullable=is_nullable,
         )
 
         attribute_metadata_response.additional_properties = d

--- a/sdks/python/geolens/models/attribute_metadata_update.py
+++ b/sdks/python/geolens/models/attribute_metadata_update.py
@@ -30,36 +30,40 @@ T = TypeVar("T", bound="AttributeMetadataUpdate")
 class AttributeMetadataUpdate:
     """
     Attributes:
+        title (None | str | Unset): Human-friendly column display name
         description (None | str | Unset):
-        domain_type (AttributeMetadataUpdateDomainTypeType0 | None | Unset): Value domain: continuous, categorical,
-            coded, etc.
+        units (None | str | Unset): Measurement units, e.g. meters, kg
         semantic_role (AttributeMetadataUpdateSemanticRoleType0 | None | Unset): Column role: geometry, identifier,
             measure, etc.
-        title (None | str | Unset): Human-friendly column display name
-        units (None | str | Unset): Measurement units, e.g. meters, kg
+        domain_type (AttributeMetadataUpdateDomainTypeType0 | None | Unset): Value domain: continuous, categorical,
+            coded, etc.
     """
 
-    description: None | str | Unset = UNSET
-    domain_type: AttributeMetadataUpdateDomainTypeType0 | None | Unset = UNSET
-    semantic_role: AttributeMetadataUpdateSemanticRoleType0 | None | Unset = UNSET
     title: None | str | Unset = UNSET
+    description: None | str | Unset = UNSET
     units: None | str | Unset = UNSET
+    semantic_role: AttributeMetadataUpdateSemanticRoleType0 | None | Unset = UNSET
+    domain_type: AttributeMetadataUpdateDomainTypeType0 | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
+        else:
+            title = self.title
+
         description: None | str | Unset
         if isinstance(self.description, Unset):
             description = UNSET
         else:
             description = self.description
 
-        domain_type: None | str | Unset
-        if isinstance(self.domain_type, Unset):
-            domain_type = UNSET
-        elif isinstance(self.domain_type, str):
-            domain_type = self.domain_type
+        units: None | str | Unset
+        if isinstance(self.units, Unset):
+            units = UNSET
         else:
-            domain_type = self.domain_type
+            units = self.units
 
         semantic_role: None | str | Unset
         if isinstance(self.semantic_role, Unset):
@@ -69,37 +73,42 @@ class AttributeMetadataUpdate:
         else:
             semantic_role = self.semantic_role
 
-        title: None | str | Unset
-        if isinstance(self.title, Unset):
-            title = UNSET
+        domain_type: None | str | Unset
+        if isinstance(self.domain_type, Unset):
+            domain_type = UNSET
+        elif isinstance(self.domain_type, str):
+            domain_type = self.domain_type
         else:
-            title = self.title
-
-        units: None | str | Unset
-        if isinstance(self.units, Unset):
-            units = UNSET
-        else:
-            units = self.units
+            domain_type = self.domain_type
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if description is not UNSET:
-            field_dict["description"] = description
-        if domain_type is not UNSET:
-            field_dict["domain_type"] = domain_type
-        if semantic_role is not UNSET:
-            field_dict["semantic_role"] = semantic_role
         if title is not UNSET:
             field_dict["title"] = title
+        if description is not UNSET:
+            field_dict["description"] = description
         if units is not UNSET:
             field_dict["units"] = units
+        if semantic_role is not UNSET:
+            field_dict["semantic_role"] = semantic_role
+        if domain_type is not UNSET:
+            field_dict["domain_type"] = domain_type
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+
+        def _parse_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        title = _parse_title(d.pop("title", UNSET))
 
         def _parse_description(data: object) -> None | str | Unset:
             if data is None:
@@ -110,26 +119,14 @@ class AttributeMetadataUpdate:
 
         description = _parse_description(d.pop("description", UNSET))
 
-        def _parse_domain_type(
-            data: object,
-        ) -> AttributeMetadataUpdateDomainTypeType0 | None | Unset:
+        def _parse_units(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                domain_type_type_0 = check_attribute_metadata_update_domain_type_type_0(
-                    data
-                )
+            return cast(None | str | Unset, data)
 
-                return domain_type_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(AttributeMetadataUpdateDomainTypeType0 | None | Unset, data)
-
-        domain_type = _parse_domain_type(d.pop("domain_type", UNSET))
+        units = _parse_units(d.pop("units", UNSET))
 
         def _parse_semantic_role(
             data: object,
@@ -152,30 +149,33 @@ class AttributeMetadataUpdate:
 
         semantic_role = _parse_semantic_role(d.pop("semantic_role", UNSET))
 
-        def _parse_title(data: object) -> None | str | Unset:
+        def _parse_domain_type(
+            data: object,
+        ) -> AttributeMetadataUpdateDomainTypeType0 | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(None | str | Unset, data)
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                domain_type_type_0 = check_attribute_metadata_update_domain_type_type_0(
+                    data
+                )
 
-        title = _parse_title(d.pop("title", UNSET))
+                return domain_type_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(AttributeMetadataUpdateDomainTypeType0 | None | Unset, data)
 
-        def _parse_units(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        units = _parse_units(d.pop("units", UNSET))
+        domain_type = _parse_domain_type(d.pop("domain_type", UNSET))
 
         attribute_metadata_update = cls(
-            description=description,
-            domain_type=domain_type,
-            semantic_role=semantic_role,
             title=title,
+            description=description,
             units=units,
+            semantic_role=semantic_role,
+            domain_type=domain_type,
         )
 
         attribute_metadata_update.additional_properties = d

--- a/sdks/python/geolens/models/audit_log_response.py
+++ b/sdks/python/geolens/models/audit_log_response.py
@@ -24,28 +24,28 @@ T = TypeVar("T", bound="AuditLogResponse")
 class AuditLogResponse:
     """
     Attributes:
-        action (str):
-        created_at (datetime.datetime):
-        details (AuditLogResponseDetailsType0 | None):
         id (UUID):
-        ip_address (None | str):
-        resource_id (None | UUID):
-        resource_type (str):
         user_id (None | UUID):
-        resource_name (None | str | Unset):
+        action (str):
+        resource_type (str):
+        resource_id (None | UUID):
+        details (AuditLogResponseDetailsType0 | None):
+        ip_address (None | str):
+        created_at (datetime.datetime):
         username (None | str | Unset):
+        resource_name (None | str | Unset):
     """
 
-    action: str
-    created_at: datetime.datetime
-    details: AuditLogResponseDetailsType0 | None
     id: UUID
-    ip_address: None | str
-    resource_id: None | UUID
-    resource_type: str
     user_id: None | UUID
-    resource_name: None | str | Unset = UNSET
+    action: str
+    resource_type: str
+    resource_id: None | UUID
+    details: AuditLogResponseDetailsType0 | None
+    ip_address: None | str
+    created_at: datetime.datetime
     username: None | str | Unset = UNSET
+    resource_name: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -53,28 +53,7 @@ class AuditLogResponse:
             AuditLogResponseDetailsType0,
         )
 
-        action = self.action
-
-        created_at = self.created_at.isoformat()
-
-        details: dict[str, Any] | None
-        if isinstance(self.details, AuditLogResponseDetailsType0):
-            details = self.details.to_dict()
-        else:
-            details = self.details
-
         id = str(self.id)
-
-        ip_address: None | str
-        ip_address = self.ip_address
-
-        resource_id: None | str
-        if isinstance(self.resource_id, UUID):
-            resource_id = str(self.resource_id)
-        else:
-            resource_id = self.resource_id
-
-        resource_type = self.resource_type
 
         user_id: None | str
         if isinstance(self.user_id, UUID):
@@ -82,11 +61,26 @@ class AuditLogResponse:
         else:
             user_id = self.user_id
 
-        resource_name: None | str | Unset
-        if isinstance(self.resource_name, Unset):
-            resource_name = UNSET
+        action = self.action
+
+        resource_type = self.resource_type
+
+        resource_id: None | str
+        if isinstance(self.resource_id, UUID):
+            resource_id = str(self.resource_id)
         else:
-            resource_name = self.resource_name
+            resource_id = self.resource_id
+
+        details: dict[str, Any] | None
+        if isinstance(self.details, AuditLogResponseDetailsType0):
+            details = self.details.to_dict()
+        else:
+            details = self.details
+
+        ip_address: None | str
+        ip_address = self.ip_address
+
+        created_at = self.created_at.isoformat()
 
         username: None | str | Unset
         if isinstance(self.username, Unset):
@@ -94,24 +88,30 @@ class AuditLogResponse:
         else:
             username = self.username
 
+        resource_name: None | str | Unset
+        if isinstance(self.resource_name, Unset):
+            resource_name = UNSET
+        else:
+            resource_name = self.resource_name
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "action": action,
-                "created_at": created_at,
-                "details": details,
                 "id": id,
-                "ip_address": ip_address,
-                "resource_id": resource_id,
-                "resource_type": resource_type,
                 "user_id": user_id,
+                "action": action,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "details": details,
+                "ip_address": ip_address,
+                "created_at": created_at,
             }
         )
-        if resource_name is not UNSET:
-            field_dict["resource_name"] = resource_name
         if username is not UNSET:
             field_dict["username"] = username
+        if resource_name is not UNSET:
+            field_dict["resource_name"] = resource_name
 
         return field_dict
 
@@ -122,50 +122,7 @@ class AuditLogResponse:
         )
 
         d = dict(src_dict)
-        action = d.pop("action")
-
-        created_at = isoparse(d.pop("created_at"))
-
-        def _parse_details(data: object) -> AuditLogResponseDetailsType0 | None:
-            if data is None:
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                details_type_0 = AuditLogResponseDetailsType0.from_dict(data)
-
-                return details_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(AuditLogResponseDetailsType0 | None, data)
-
-        details = _parse_details(d.pop("details"))
-
         id = UUID(d.pop("id"))
-
-        def _parse_ip_address(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        ip_address = _parse_ip_address(d.pop("ip_address"))
-
-        def _parse_resource_id(data: object) -> None | UUID:
-            if data is None:
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                resource_id_type_0 = UUID(data)
-
-                return resource_id_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | UUID, data)
-
-        resource_id = _parse_resource_id(d.pop("resource_id"))
-
-        resource_type = d.pop("resource_type")
 
         def _parse_user_id(data: object) -> None | UUID:
             if data is None:
@@ -182,14 +139,48 @@ class AuditLogResponse:
 
         user_id = _parse_user_id(d.pop("user_id"))
 
-        def _parse_resource_name(data: object) -> None | str | Unset:
+        action = d.pop("action")
+
+        resource_type = d.pop("resource_type")
+
+        def _parse_resource_id(data: object) -> None | UUID:
             if data is None:
                 return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                resource_id_type_0 = UUID(data)
 
-        resource_name = _parse_resource_name(d.pop("resource_name", UNSET))
+                return resource_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | UUID, data)
+
+        resource_id = _parse_resource_id(d.pop("resource_id"))
+
+        def _parse_details(data: object) -> AuditLogResponseDetailsType0 | None:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                details_type_0 = AuditLogResponseDetailsType0.from_dict(data)
+
+                return details_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(AuditLogResponseDetailsType0 | None, data)
+
+        details = _parse_details(d.pop("details"))
+
+        def _parse_ip_address(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        ip_address = _parse_ip_address(d.pop("ip_address"))
+
+        created_at = isoparse(d.pop("created_at"))
 
         def _parse_username(data: object) -> None | str | Unset:
             if data is None:
@@ -200,17 +191,26 @@ class AuditLogResponse:
 
         username = _parse_username(d.pop("username", UNSET))
 
+        def _parse_resource_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        resource_name = _parse_resource_name(d.pop("resource_name", UNSET))
+
         audit_log_response = cls(
-            action=action,
-            created_at=created_at,
-            details=details,
             id=id,
-            ip_address=ip_address,
-            resource_id=resource_id,
-            resource_type=resource_type,
             user_id=user_id,
-            resource_name=resource_name,
+            action=action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            details=details,
+            ip_address=ip_address,
+            created_at=created_at,
             username=username,
+            resource_name=resource_name,
         )
 
         audit_log_response.additional_properties = d

--- a/sdks/python/geolens/models/backfill_response.py
+++ b/sdks/python/geolens/models/backfill_response.py
@@ -14,35 +14,35 @@ T = TypeVar("T", bound="BackfillResponse")
 class BackfillResponse:
     """
     Attributes:
-        created (int): Number of new embeddings created.
-        errors (int): Number of records that failed during embedding generation.
         processed (int): Number of records processed in this backfill batch.
+        created (int): Number of new embeddings created.
         skipped (int): Number of records skipped because an embedding already existed.
+        errors (int): Number of records that failed during embedding generation.
     """
 
-    created: int
-    errors: int
     processed: int
+    created: int
     skipped: int
+    errors: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created = self.created
-
-        errors = self.errors
-
         processed = self.processed
 
+        created = self.created
+
         skipped = self.skipped
+
+        errors = self.errors
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created": created,
-                "errors": errors,
                 "processed": processed,
+                "created": created,
                 "skipped": skipped,
+                "errors": errors,
             }
         )
 
@@ -51,19 +51,19 @@ class BackfillResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        created = d.pop("created")
-
-        errors = d.pop("errors")
-
         processed = d.pop("processed")
+
+        created = d.pop("created")
 
         skipped = d.pop("skipped")
 
+        errors = d.pop("errors")
+
         backfill_response = cls(
-            created=created,
-            errors=errors,
             processed=processed,
+            created=created,
             skipped=skipped,
+            errors=errors,
         )
 
         backfill_response.additional_properties = d

--- a/sdks/python/geolens/models/basemap_config.py
+++ b/sdks/python/geolens/models/basemap_config.py
@@ -34,57 +34,51 @@ T = TypeVar("T", bound="BasemapConfig")
 class BasemapConfig:
     """
     Attributes:
-        background_color (None | str | Unset): Map canvas background color in #RRGGBB hex format, or null to use the
-            basemap default.
-        basemap_position (BasemapPosition | None | Unset): Whether the basemap renders above ('top') or below ('bottom',
-            default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no
-            migration).
+        label_mode (BasemapLabelMode | Unset):
+        road_visibility (BasemapSublayerVisibility | Unset):
         boundary_visibility (BasemapSublayerVisibility | Unset):
         building_visibility (bool | Unset): Whether supported building/3D building basemap layers are shown. Default:
             True.
-        label_mode (BasemapLabelMode | Unset):
         land_water_tone (BasemapLandWaterTone | Unset):
-        opacity (float | Unset): Master basemap opacity 0.0-1.0 Default: 1.0.
-        projection (BasemapProjection | None | Unset): Map projection: 'mercator' (default) or experimental 'globe'.
-            null/undefined loads as 'mercator' on the client.
         relief_contrast (BasemapReliefContrast | None | Unset): Optional contrast hint for relief-oriented basemap
             styling.
-        road_visibility (BasemapSublayerVisibility | Unset):
+        opacity (float | Unset): Master basemap opacity 0.0-1.0 Default: 1.0.
+        background_color (None | str | Unset): Map canvas background color in #RRGGBB hex format, or null to use the
+            basemap default.
         sublayer_overrides (BasemapConfigSublayerOverridesType0 | None | Unset): Per-sublayer style overrides keyed by
             semantic sublayer ID (e.g. 'road', 'boundary', 'building'). Key set is opaque — unknown future sublayer IDs are
             accepted without rejection. See CONTEXT.md D-01.
+        basemap_position (BasemapPosition | None | Unset): Whether the basemap renders above ('top') or below ('bottom',
+            default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no
+            migration).
+        projection (BasemapProjection | None | Unset): Map projection: 'mercator' (default) or experimental 'globe'.
+            null/undefined loads as 'mercator' on the client.
     """
 
-    background_color: None | str | Unset = UNSET
-    basemap_position: BasemapPosition | None | Unset = UNSET
+    label_mode: BasemapLabelMode | Unset = UNSET
+    road_visibility: BasemapSublayerVisibility | Unset = UNSET
     boundary_visibility: BasemapSublayerVisibility | Unset = UNSET
     building_visibility: bool | Unset = True
-    label_mode: BasemapLabelMode | Unset = UNSET
     land_water_tone: BasemapLandWaterTone | Unset = UNSET
-    opacity: float | Unset = 1.0
-    projection: BasemapProjection | None | Unset = UNSET
     relief_contrast: BasemapReliefContrast | None | Unset = UNSET
-    road_visibility: BasemapSublayerVisibility | Unset = UNSET
+    opacity: float | Unset = 1.0
+    background_color: None | str | Unset = UNSET
     sublayer_overrides: BasemapConfigSublayerOverridesType0 | None | Unset = UNSET
+    basemap_position: BasemapPosition | None | Unset = UNSET
+    projection: BasemapProjection | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.basemap_config_sublayer_overrides_type_0 import (
             BasemapConfigSublayerOverridesType0,
         )
 
-        background_color: None | str | Unset
-        if isinstance(self.background_color, Unset):
-            background_color = UNSET
-        else:
-            background_color = self.background_color
+        label_mode: str | Unset = UNSET
+        if not isinstance(self.label_mode, Unset):
+            label_mode = self.label_mode
 
-        basemap_position: None | str | Unset
-        if isinstance(self.basemap_position, Unset):
-            basemap_position = UNSET
-        elif isinstance(self.basemap_position, str):
-            basemap_position = self.basemap_position
-        else:
-            basemap_position = self.basemap_position
+        road_visibility: str | Unset = UNSET
+        if not isinstance(self.road_visibility, Unset):
+            road_visibility = self.road_visibility
 
         boundary_visibility: str | Unset = UNSET
         if not isinstance(self.boundary_visibility, Unset):
@@ -92,23 +86,9 @@ class BasemapConfig:
 
         building_visibility = self.building_visibility
 
-        label_mode: str | Unset = UNSET
-        if not isinstance(self.label_mode, Unset):
-            label_mode = self.label_mode
-
         land_water_tone: str | Unset = UNSET
         if not isinstance(self.land_water_tone, Unset):
             land_water_tone = self.land_water_tone
-
-        opacity = self.opacity
-
-        projection: None | str | Unset
-        if isinstance(self.projection, Unset):
-            projection = UNSET
-        elif isinstance(self.projection, str):
-            projection = self.projection
-        else:
-            projection = self.projection
 
         relief_contrast: None | str | Unset
         if isinstance(self.relief_contrast, Unset):
@@ -118,9 +98,13 @@ class BasemapConfig:
         else:
             relief_contrast = self.relief_contrast
 
-        road_visibility: str | Unset = UNSET
-        if not isinstance(self.road_visibility, Unset):
-            road_visibility = self.road_visibility
+        opacity = self.opacity
+
+        background_color: None | str | Unset
+        if isinstance(self.background_color, Unset):
+            background_color = UNSET
+        else:
+            background_color = self.background_color
 
         sublayer_overrides: dict[str, Any] | None | Unset
         if isinstance(self.sublayer_overrides, Unset):
@@ -130,31 +114,47 @@ class BasemapConfig:
         else:
             sublayer_overrides = self.sublayer_overrides
 
+        basemap_position: None | str | Unset
+        if isinstance(self.basemap_position, Unset):
+            basemap_position = UNSET
+        elif isinstance(self.basemap_position, str):
+            basemap_position = self.basemap_position
+        else:
+            basemap_position = self.basemap_position
+
+        projection: None | str | Unset
+        if isinstance(self.projection, Unset):
+            projection = UNSET
+        elif isinstance(self.projection, str):
+            projection = self.projection
+        else:
+            projection = self.projection
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
-        if background_color is not UNSET:
-            field_dict["background_color"] = background_color
-        if basemap_position is not UNSET:
-            field_dict["basemap_position"] = basemap_position
+        if label_mode is not UNSET:
+            field_dict["label_mode"] = label_mode
+        if road_visibility is not UNSET:
+            field_dict["road_visibility"] = road_visibility
         if boundary_visibility is not UNSET:
             field_dict["boundary_visibility"] = boundary_visibility
         if building_visibility is not UNSET:
             field_dict["building_visibility"] = building_visibility
-        if label_mode is not UNSET:
-            field_dict["label_mode"] = label_mode
         if land_water_tone is not UNSET:
             field_dict["land_water_tone"] = land_water_tone
-        if opacity is not UNSET:
-            field_dict["opacity"] = opacity
-        if projection is not UNSET:
-            field_dict["projection"] = projection
         if relief_contrast is not UNSET:
             field_dict["relief_contrast"] = relief_contrast
-        if road_visibility is not UNSET:
-            field_dict["road_visibility"] = road_visibility
+        if opacity is not UNSET:
+            field_dict["opacity"] = opacity
+        if background_color is not UNSET:
+            field_dict["background_color"] = background_color
         if sublayer_overrides is not UNSET:
             field_dict["sublayer_overrides"] = sublayer_overrides
+        if basemap_position is not UNSET:
+            field_dict["basemap_position"] = basemap_position
+        if projection is not UNSET:
+            field_dict["projection"] = projection
 
         return field_dict
 
@@ -165,32 +165,19 @@ class BasemapConfig:
         )
 
         d = dict(src_dict)
+        _label_mode = d.pop("label_mode", UNSET)
+        label_mode: BasemapLabelMode | Unset
+        if isinstance(_label_mode, Unset):
+            label_mode = UNSET
+        else:
+            label_mode = check_basemap_label_mode(_label_mode)
 
-        def _parse_background_color(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        background_color = _parse_background_color(d.pop("background_color", UNSET))
-
-        def _parse_basemap_position(data: object) -> BasemapPosition | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                basemap_position_type_0 = check_basemap_position(data)
-
-                return basemap_position_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(BasemapPosition | None | Unset, data)
-
-        basemap_position = _parse_basemap_position(d.pop("basemap_position", UNSET))
+        _road_visibility = d.pop("road_visibility", UNSET)
+        road_visibility: BasemapSublayerVisibility | Unset
+        if isinstance(_road_visibility, Unset):
+            road_visibility = UNSET
+        else:
+            road_visibility = check_basemap_sublayer_visibility(_road_visibility)
 
         _boundary_visibility = d.pop("boundary_visibility", UNSET)
         boundary_visibility: BasemapSublayerVisibility | Unset
@@ -203,38 +190,12 @@ class BasemapConfig:
 
         building_visibility = d.pop("building_visibility", UNSET)
 
-        _label_mode = d.pop("label_mode", UNSET)
-        label_mode: BasemapLabelMode | Unset
-        if isinstance(_label_mode, Unset):
-            label_mode = UNSET
-        else:
-            label_mode = check_basemap_label_mode(_label_mode)
-
         _land_water_tone = d.pop("land_water_tone", UNSET)
         land_water_tone: BasemapLandWaterTone | Unset
         if isinstance(_land_water_tone, Unset):
             land_water_tone = UNSET
         else:
             land_water_tone = check_basemap_land_water_tone(_land_water_tone)
-
-        opacity = d.pop("opacity", UNSET)
-
-        def _parse_projection(data: object) -> BasemapProjection | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                projection_type_0 = check_basemap_projection(data)
-
-                return projection_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(BasemapProjection | None | Unset, data)
-
-        projection = _parse_projection(d.pop("projection", UNSET))
 
         def _parse_relief_contrast(
             data: object,
@@ -255,12 +216,16 @@ class BasemapConfig:
 
         relief_contrast = _parse_relief_contrast(d.pop("relief_contrast", UNSET))
 
-        _road_visibility = d.pop("road_visibility", UNSET)
-        road_visibility: BasemapSublayerVisibility | Unset
-        if isinstance(_road_visibility, Unset):
-            road_visibility = UNSET
-        else:
-            road_visibility = check_basemap_sublayer_visibility(_road_visibility)
+        opacity = d.pop("opacity", UNSET)
+
+        def _parse_background_color(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        background_color = _parse_background_color(d.pop("background_color", UNSET))
 
         def _parse_sublayer_overrides(
             data: object,
@@ -285,18 +250,52 @@ class BasemapConfig:
             d.pop("sublayer_overrides", UNSET)
         )
 
+        def _parse_basemap_position(data: object) -> BasemapPosition | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                basemap_position_type_0 = check_basemap_position(data)
+
+                return basemap_position_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(BasemapPosition | None | Unset, data)
+
+        basemap_position = _parse_basemap_position(d.pop("basemap_position", UNSET))
+
+        def _parse_projection(data: object) -> BasemapProjection | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                projection_type_0 = check_basemap_projection(data)
+
+                return projection_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(BasemapProjection | None | Unset, data)
+
+        projection = _parse_projection(d.pop("projection", UNSET))
+
         basemap_config = cls(
-            background_color=background_color,
-            basemap_position=basemap_position,
+            label_mode=label_mode,
+            road_visibility=road_visibility,
             boundary_visibility=boundary_visibility,
             building_visibility=building_visibility,
-            label_mode=label_mode,
             land_water_tone=land_water_tone,
-            opacity=opacity,
-            projection=projection,
             relief_contrast=relief_contrast,
-            road_visibility=road_visibility,
+            opacity=opacity,
+            background_color=background_color,
             sublayer_overrides=sublayer_overrides,
+            basemap_position=basemap_position,
+            projection=projection,
         )
 
         return basemap_config

--- a/sdks/python/geolens/models/basemap_public_response.py
+++ b/sdks/python/geolens/models/basemap_public_response.py
@@ -19,32 +19,32 @@ class BasemapPublicResponse:
     """Public basemap response — excludes api_key.
 
     Attributes:
-        enabled (bool): Whether the basemap is currently selectable.
         id (str): Unique basemap identifier.
-        is_preset (bool): Whether this is a built-in preset.
         label (str): Display label.
         url (str): Tile URL or style JSON URL with API key already substituted (or omitted) for client use.
+        enabled (bool): Whether the basemap is currently selectable.
+        is_preset (bool): Whether this is a built-in preset.
         attribution (None | str | Unset): Attribution string for the basemap source.
     """
 
-    enabled: bool
     id: str
-    is_preset: bool
     label: str
     url: str
+    enabled: bool
+    is_preset: bool
     attribution: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        enabled = self.enabled
-
         id = self.id
-
-        is_preset = self.is_preset
 
         label = self.label
 
         url = self.url
+
+        enabled = self.enabled
+
+        is_preset = self.is_preset
 
         attribution: None | str | Unset
         if isinstance(self.attribution, Unset):
@@ -56,11 +56,11 @@ class BasemapPublicResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "enabled": enabled,
                 "id": id,
-                "is_preset": is_preset,
                 "label": label,
                 "url": url,
+                "enabled": enabled,
+                "is_preset": is_preset,
             }
         )
         if attribution is not UNSET:
@@ -71,15 +71,15 @@ class BasemapPublicResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        enabled = d.pop("enabled")
-
         id = d.pop("id")
-
-        is_preset = d.pop("is_preset")
 
         label = d.pop("label")
 
         url = d.pop("url")
+
+        enabled = d.pop("enabled")
+
+        is_preset = d.pop("is_preset")
 
         def _parse_attribution(data: object) -> None | str | Unset:
             if data is None:
@@ -91,11 +91,11 @@ class BasemapPublicResponse:
         attribution = _parse_attribution(d.pop("attribution", UNSET))
 
         basemap_public_response = cls(
-            enabled=enabled,
             id=id,
-            is_preset=is_preset,
             label=label,
             url=url,
+            enabled=enabled,
+            is_preset=is_preset,
             attribution=attribution,
         )
 

--- a/sdks/python/geolens/models/body_login_auth_login_post.py
+++ b/sdks/python/geolens/models/body_login_auth_login_post.py
@@ -18,26 +18,34 @@ T = TypeVar("T", bound="BodyLoginAuthLoginPost")
 class BodyLoginAuthLoginPost:
     """
     Attributes:
-        password (str):
         username (str):
-        client_id (None | str | Unset):
-        client_secret (None | str | Unset):
+        password (str):
         grant_type (None | str | Unset):
         scope (str | Unset):  Default: ''.
+        client_id (None | str | Unset):
+        client_secret (None | str | Unset):
     """
 
-    password: str
     username: str
-    client_id: None | str | Unset = UNSET
-    client_secret: None | str | Unset = UNSET
+    password: str
     grant_type: None | str | Unset = UNSET
     scope: str | Unset = ""
+    client_id: None | str | Unset = UNSET
+    client_secret: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        username = self.username
+
         password = self.password
 
-        username = self.username
+        grant_type: None | str | Unset
+        if isinstance(self.grant_type, Unset):
+            grant_type = UNSET
+        else:
+            grant_type = self.grant_type
+
+        scope = self.scope
 
         client_id: None | str | Unset
         if isinstance(self.client_id, Unset):
@@ -51,39 +59,42 @@ class BodyLoginAuthLoginPost:
         else:
             client_secret = self.client_secret
 
-        grant_type: None | str | Unset
-        if isinstance(self.grant_type, Unset):
-            grant_type = UNSET
-        else:
-            grant_type = self.grant_type
-
-        scope = self.scope
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "password": password,
                 "username": username,
+                "password": password,
             }
         )
-        if client_id is not UNSET:
-            field_dict["client_id"] = client_id
-        if client_secret is not UNSET:
-            field_dict["client_secret"] = client_secret
         if grant_type is not UNSET:
             field_dict["grant_type"] = grant_type
         if scope is not UNSET:
             field_dict["scope"] = scope
+        if client_id is not UNSET:
+            field_dict["client_id"] = client_id
+        if client_secret is not UNSET:
+            field_dict["client_secret"] = client_secret
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        username = d.pop("username")
+
         password = d.pop("password")
 
-        username = d.pop("username")
+        def _parse_grant_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        grant_type = _parse_grant_type(d.pop("grant_type", UNSET))
+
+        scope = d.pop("scope", UNSET)
 
         def _parse_client_id(data: object) -> None | str | Unset:
             if data is None:
@@ -103,24 +114,13 @@ class BodyLoginAuthLoginPost:
 
         client_secret = _parse_client_secret(d.pop("client_secret", UNSET))
 
-        def _parse_grant_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        grant_type = _parse_grant_type(d.pop("grant_type", UNSET))
-
-        scope = d.pop("scope", UNSET)
-
         body_login_auth_login_post = cls(
-            password=password,
             username=username,
-            client_id=client_id,
-            client_secret=client_secret,
+            password=password,
             grant_type=grant_type,
             scope=scope,
+            client_id=client_id,
+            client_secret=client_secret,
         )
 
         body_login_auth_login_post.additional_properties = d

--- a/sdks/python/geolens/models/bulk_delete_item.py
+++ b/sdks/python/geolens/models/bulk_delete_item.py
@@ -17,25 +17,25 @@ T = TypeVar("T", bound="BulkDeleteItem")
 class BulkDeleteItem:
     """
     Attributes:
-        confirm_title (str):
         dataset_id (UUID):
+        confirm_title (str):
     """
 
-    confirm_title: str
     dataset_id: UUID
+    confirm_title: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        confirm_title = self.confirm_title
-
         dataset_id = str(self.dataset_id)
+
+        confirm_title = self.confirm_title
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "confirm_title": confirm_title,
                 "dataset_id": dataset_id,
+                "confirm_title": confirm_title,
             }
         )
 
@@ -44,13 +44,13 @@ class BulkDeleteItem:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        confirm_title = d.pop("confirm_title")
-
         dataset_id = UUID(d.pop("dataset_id"))
 
+        confirm_title = d.pop("confirm_title")
+
         bulk_delete_item = cls(
-            confirm_title=confirm_title,
             dataset_id=dataset_id,
+            confirm_title=confirm_title,
         )
 
         bulk_delete_item.additional_properties = d

--- a/sdks/python/geolens/models/bulk_register_result.py
+++ b/sdks/python/geolens/models/bulk_register_result.py
@@ -19,24 +19,24 @@ T = TypeVar("T", bound="BulkRegisterResult")
 class BulkRegisterResult:
     """
     Attributes:
-        status (str): Per-row outcome: 'success', 'skipped', or 'error'.
         table_name (str): Source table that was processed.
+        status (str): Per-row outcome: 'success', 'skipped', or 'error'.
         dataset_id (None | Unset | UUID): ID of the created dataset on success.
-        error (None | str | Unset): Error message on failure.
         title (None | str | Unset): Title of the created dataset on success.
+        error (None | str | Unset): Error message on failure.
     """
 
-    status: str
     table_name: str
+    status: str
     dataset_id: None | Unset | UUID = UNSET
-    error: None | str | Unset = UNSET
     title: None | str | Unset = UNSET
+    error: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        status = self.status
-
         table_name = self.table_name
+
+        status = self.status
 
         dataset_id: None | str | Unset
         if isinstance(self.dataset_id, Unset):
@@ -46,41 +46,41 @@ class BulkRegisterResult:
         else:
             dataset_id = self.dataset_id
 
-        error: None | str | Unset
-        if isinstance(self.error, Unset):
-            error = UNSET
-        else:
-            error = self.error
-
         title: None | str | Unset
         if isinstance(self.title, Unset):
             title = UNSET
         else:
             title = self.title
 
+        error: None | str | Unset
+        if isinstance(self.error, Unset):
+            error = UNSET
+        else:
+            error = self.error
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "status": status,
                 "table_name": table_name,
+                "status": status,
             }
         )
         if dataset_id is not UNSET:
             field_dict["dataset_id"] = dataset_id
-        if error is not UNSET:
-            field_dict["error"] = error
         if title is not UNSET:
             field_dict["title"] = title
+        if error is not UNSET:
+            field_dict["error"] = error
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        status = d.pop("status")
-
         table_name = d.pop("table_name")
+
+        status = d.pop("status")
 
         def _parse_dataset_id(data: object) -> None | Unset | UUID:
             if data is None:
@@ -99,15 +99,6 @@ class BulkRegisterResult:
 
         dataset_id = _parse_dataset_id(d.pop("dataset_id", UNSET))
 
-        def _parse_error(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        error = _parse_error(d.pop("error", UNSET))
-
         def _parse_title(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -117,12 +108,21 @@ class BulkRegisterResult:
 
         title = _parse_title(d.pop("title", UNSET))
 
+        def _parse_error(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        error = _parse_error(d.pop("error", UNSET))
+
         bulk_register_result = cls(
-            status=status,
             table_name=table_name,
+            status=status,
             dataset_id=dataset_id,
-            error=error,
             title=title,
+            error=error,
         )
 
         bulk_register_result.additional_properties = d

--- a/sdks/python/geolens/models/catalog_stats_response.py
+++ b/sdks/python/geolens/models/catalog_stats_response.py
@@ -29,61 +29,61 @@ T = TypeVar("T", bound="CatalogStatsResponse")
 class CatalogStatsResponse:
     """
     Attributes:
+        total_datasets (int): Total number of datasets in the catalog.
+        recent_additions (int): Number of datasets added in the last 30 days.
+        total_storage_bytes (int | None): Total storage used by all dataset tables, in bytes. Null if calculation is
+            unavailable.
         datasets_by_geometry_type (CatalogStatsResponseDatasetsByGeometryType): Histogram of datasets keyed by geometry
             type (Point, MultiPolygon, etc.).
         datasets_by_visibility (CatalogStatsResponseDatasetsByVisibility): Histogram of datasets keyed by visibility
             level (private, internal, restricted, public).
-        recent_additions (int): Number of datasets added in the last 30 days.
-        total_datasets (int): Total number of datasets in the catalog.
-        total_storage_bytes (int | None): Total storage used by all dataset tables, in bytes. Null if calculation is
-            unavailable.
-        total_users (int | Unset): Total number of users in the system. Default: 0.
         users_by_status (CatalogStatsResponseUsersByStatus | Unset): Histogram of users keyed by status (active,
             deactivated, pending).
+        total_users (int | Unset): Total number of users in the system. Default: 0.
     """
 
+    total_datasets: int
+    recent_additions: int
+    total_storage_bytes: int | None
     datasets_by_geometry_type: CatalogStatsResponseDatasetsByGeometryType
     datasets_by_visibility: CatalogStatsResponseDatasetsByVisibility
-    recent_additions: int
-    total_datasets: int
-    total_storage_bytes: int | None
-    total_users: int | Unset = 0
     users_by_status: CatalogStatsResponseUsersByStatus | Unset = UNSET
+    total_users: int | Unset = 0
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        datasets_by_geometry_type = self.datasets_by_geometry_type.to_dict()
-
-        datasets_by_visibility = self.datasets_by_visibility.to_dict()
+        total_datasets = self.total_datasets
 
         recent_additions = self.recent_additions
-
-        total_datasets = self.total_datasets
 
         total_storage_bytes: int | None
         total_storage_bytes = self.total_storage_bytes
 
-        total_users = self.total_users
+        datasets_by_geometry_type = self.datasets_by_geometry_type.to_dict()
+
+        datasets_by_visibility = self.datasets_by_visibility.to_dict()
 
         users_by_status: dict[str, Any] | Unset = UNSET
         if not isinstance(self.users_by_status, Unset):
             users_by_status = self.users_by_status.to_dict()
 
+        total_users = self.total_users
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "total_datasets": total_datasets,
+                "recent_additions": recent_additions,
+                "total_storage_bytes": total_storage_bytes,
                 "datasets_by_geometry_type": datasets_by_geometry_type,
                 "datasets_by_visibility": datasets_by_visibility,
-                "recent_additions": recent_additions,
-                "total_datasets": total_datasets,
-                "total_storage_bytes": total_storage_bytes,
             }
         )
-        if total_users is not UNSET:
-            field_dict["total_users"] = total_users
         if users_by_status is not UNSET:
             field_dict["users_by_status"] = users_by_status
+        if total_users is not UNSET:
+            field_dict["total_users"] = total_users
 
         return field_dict
 
@@ -100,6 +100,17 @@ class CatalogStatsResponse:
         )
 
         d = dict(src_dict)
+        total_datasets = d.pop("total_datasets")
+
+        recent_additions = d.pop("recent_additions")
+
+        def _parse_total_storage_bytes(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        total_storage_bytes = _parse_total_storage_bytes(d.pop("total_storage_bytes"))
+
         datasets_by_geometry_type = (
             CatalogStatsResponseDatasetsByGeometryType.from_dict(
                 d.pop("datasets_by_geometry_type")
@@ -110,19 +121,6 @@ class CatalogStatsResponse:
             d.pop("datasets_by_visibility")
         )
 
-        recent_additions = d.pop("recent_additions")
-
-        total_datasets = d.pop("total_datasets")
-
-        def _parse_total_storage_bytes(data: object) -> int | None:
-            if data is None:
-                return data
-            return cast(int | None, data)
-
-        total_storage_bytes = _parse_total_storage_bytes(d.pop("total_storage_bytes"))
-
-        total_users = d.pop("total_users", UNSET)
-
         _users_by_status = d.pop("users_by_status", UNSET)
         users_by_status: CatalogStatsResponseUsersByStatus | Unset
         if isinstance(_users_by_status, Unset):
@@ -132,14 +130,16 @@ class CatalogStatsResponse:
                 _users_by_status
             )
 
+        total_users = d.pop("total_users", UNSET)
+
         catalog_stats_response = cls(
+            total_datasets=total_datasets,
+            recent_additions=recent_additions,
+            total_storage_bytes=total_storage_bytes,
             datasets_by_geometry_type=datasets_by_geometry_type,
             datasets_by_visibility=datasets_by_visibility,
-            recent_additions=recent_additions,
-            total_datasets=total_datasets,
-            total_storage_bytes=total_storage_bytes,
-            total_users=total_users,
             users_by_status=users_by_status,
+            total_users=total_users,
         )
 
         catalog_stats_response.additional_properties = d

--- a/sdks/python/geolens/models/chat_action.py
+++ b/sdks/python/geolens/models/chat_action.py
@@ -27,47 +27,47 @@ class ChatAction:
     """
     Attributes:
         type_ (ChatActionType):
-        bbox (list[float] | None | Unset):
+        layer_id (None | str | Unset):
+        expression (list[Any] | None | Unset):
+        paint (ChatActionPaintType0 | None | Unset):
         clear_paint (list[str] | None | Unset):
-        columns (list[str] | None | Unset):
+        replace_paint (bool | None | Unset):
+        style_config (ChatActionStyleConfigType0 | None | Unset):
+        label_config (ChatActionLabelConfigType0 | None | Unset):
         dataset_id (None | str | Unset):
         dataset_name (None | str | Unset):
-        distance_meters (float | None | Unset):
-        expression (list[Any] | None | Unset):
-        geojson (GeoJSONFeatureCollection | None | Unset):
-        label_config (ChatActionLabelConfigType0 | None | Unset):
-        layer_id (None | str | Unset):
-        opacity (float | None | Unset):
-        operation (None | str | Unset):
-        paint (ChatActionPaintType0 | None | Unset):
-        replace_paint (bool | None | Unset):
-        row_count (int | None | Unset):
-        rows (list[list[Any]] | None | Unset):
-        style_config (ChatActionStyleConfigType0 | None | Unset):
-        truncated (bool | None | Unset):
         visible (bool | None | Unset):
+        opacity (float | None | Unset):
+        geojson (GeoJSONFeatureCollection | None | Unset):
+        bbox (list[float] | None | Unset):
+        rows (list[list[Any]] | None | Unset):
+        columns (list[str] | None | Unset):
+        row_count (int | None | Unset):
+        truncated (bool | None | Unset):
+        operation (None | str | Unset):
+        distance_meters (float | None | Unset):
     """
 
     type_: ChatActionType
-    bbox: list[float] | None | Unset = UNSET
+    layer_id: None | str | Unset = UNSET
+    expression: list[Any] | None | Unset = UNSET
+    paint: ChatActionPaintType0 | None | Unset = UNSET
     clear_paint: list[str] | None | Unset = UNSET
-    columns: list[str] | None | Unset = UNSET
+    replace_paint: bool | None | Unset = UNSET
+    style_config: ChatActionStyleConfigType0 | None | Unset = UNSET
+    label_config: ChatActionLabelConfigType0 | None | Unset = UNSET
     dataset_id: None | str | Unset = UNSET
     dataset_name: None | str | Unset = UNSET
-    distance_meters: float | None | Unset = UNSET
-    expression: list[Any] | None | Unset = UNSET
-    geojson: GeoJSONFeatureCollection | None | Unset = UNSET
-    label_config: ChatActionLabelConfigType0 | None | Unset = UNSET
-    layer_id: None | str | Unset = UNSET
-    opacity: float | None | Unset = UNSET
-    operation: None | str | Unset = UNSET
-    paint: ChatActionPaintType0 | None | Unset = UNSET
-    replace_paint: bool | None | Unset = UNSET
-    row_count: int | None | Unset = UNSET
-    rows: list[list[Any]] | None | Unset = UNSET
-    style_config: ChatActionStyleConfigType0 | None | Unset = UNSET
-    truncated: bool | None | Unset = UNSET
     visible: bool | None | Unset = UNSET
+    opacity: float | None | Unset = UNSET
+    geojson: GeoJSONFeatureCollection | None | Unset = UNSET
+    bbox: list[float] | None | Unset = UNSET
+    rows: list[list[Any]] | None | Unset = UNSET
+    columns: list[str] | None | Unset = UNSET
+    row_count: int | None | Unset = UNSET
+    truncated: bool | None | Unset = UNSET
+    operation: None | str | Unset = UNSET
+    distance_meters: float | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -78,14 +78,28 @@ class ChatAction:
 
         type_: str = self.type_
 
-        bbox: list[float] | None | Unset
-        if isinstance(self.bbox, Unset):
-            bbox = UNSET
-        elif isinstance(self.bbox, list):
-            bbox = self.bbox
+        layer_id: None | str | Unset
+        if isinstance(self.layer_id, Unset):
+            layer_id = UNSET
+        else:
+            layer_id = self.layer_id
+
+        expression: list[Any] | None | Unset
+        if isinstance(self.expression, Unset):
+            expression = UNSET
+        elif isinstance(self.expression, list):
+            expression = self.expression
 
         else:
-            bbox = self.bbox
+            expression = self.expression
+
+        paint: dict[str, Any] | None | Unset
+        if isinstance(self.paint, Unset):
+            paint = UNSET
+        elif isinstance(self.paint, ChatActionPaintType0):
+            paint = self.paint.to_dict()
+        else:
+            paint = self.paint
 
         clear_paint: list[str] | None | Unset
         if isinstance(self.clear_paint, Unset):
@@ -96,14 +110,27 @@ class ChatAction:
         else:
             clear_paint = self.clear_paint
 
-        columns: list[str] | None | Unset
-        if isinstance(self.columns, Unset):
-            columns = UNSET
-        elif isinstance(self.columns, list):
-            columns = self.columns
-
+        replace_paint: bool | None | Unset
+        if isinstance(self.replace_paint, Unset):
+            replace_paint = UNSET
         else:
-            columns = self.columns
+            replace_paint = self.replace_paint
+
+        style_config: dict[str, Any] | None | Unset
+        if isinstance(self.style_config, Unset):
+            style_config = UNSET
+        elif isinstance(self.style_config, ChatActionStyleConfigType0):
+            style_config = self.style_config.to_dict()
+        else:
+            style_config = self.style_config
+
+        label_config: dict[str, Any] | None | Unset
+        if isinstance(self.label_config, Unset):
+            label_config = UNSET
+        elif isinstance(self.label_config, ChatActionLabelConfigType0):
+            label_config = self.label_config.to_dict()
+        else:
+            label_config = self.label_config
 
         dataset_id: None | str | Unset
         if isinstance(self.dataset_id, Unset):
@@ -117,20 +144,17 @@ class ChatAction:
         else:
             dataset_name = self.dataset_name
 
-        distance_meters: float | None | Unset
-        if isinstance(self.distance_meters, Unset):
-            distance_meters = UNSET
+        visible: bool | None | Unset
+        if isinstance(self.visible, Unset):
+            visible = UNSET
         else:
-            distance_meters = self.distance_meters
+            visible = self.visible
 
-        expression: list[Any] | None | Unset
-        if isinstance(self.expression, Unset):
-            expression = UNSET
-        elif isinstance(self.expression, list):
-            expression = self.expression
-
+        opacity: float | None | Unset
+        if isinstance(self.opacity, Unset):
+            opacity = UNSET
         else:
-            expression = self.expression
+            opacity = self.opacity
 
         geojson: dict[str, Any] | None | Unset
         if isinstance(self.geojson, Unset):
@@ -140,51 +164,14 @@ class ChatAction:
         else:
             geojson = self.geojson
 
-        label_config: dict[str, Any] | None | Unset
-        if isinstance(self.label_config, Unset):
-            label_config = UNSET
-        elif isinstance(self.label_config, ChatActionLabelConfigType0):
-            label_config = self.label_config.to_dict()
-        else:
-            label_config = self.label_config
+        bbox: list[float] | None | Unset
+        if isinstance(self.bbox, Unset):
+            bbox = UNSET
+        elif isinstance(self.bbox, list):
+            bbox = self.bbox
 
-        layer_id: None | str | Unset
-        if isinstance(self.layer_id, Unset):
-            layer_id = UNSET
         else:
-            layer_id = self.layer_id
-
-        opacity: float | None | Unset
-        if isinstance(self.opacity, Unset):
-            opacity = UNSET
-        else:
-            opacity = self.opacity
-
-        operation: None | str | Unset
-        if isinstance(self.operation, Unset):
-            operation = UNSET
-        else:
-            operation = self.operation
-
-        paint: dict[str, Any] | None | Unset
-        if isinstance(self.paint, Unset):
-            paint = UNSET
-        elif isinstance(self.paint, ChatActionPaintType0):
-            paint = self.paint.to_dict()
-        else:
-            paint = self.paint
-
-        replace_paint: bool | None | Unset
-        if isinstance(self.replace_paint, Unset):
-            replace_paint = UNSET
-        else:
-            replace_paint = self.replace_paint
-
-        row_count: int | None | Unset
-        if isinstance(self.row_count, Unset):
-            row_count = UNSET
-        else:
-            row_count = self.row_count
+            bbox = self.bbox
 
         rows: list[list[Any]] | None | Unset
         if isinstance(self.rows, Unset):
@@ -199,13 +186,20 @@ class ChatAction:
         else:
             rows = self.rows
 
-        style_config: dict[str, Any] | None | Unset
-        if isinstance(self.style_config, Unset):
-            style_config = UNSET
-        elif isinstance(self.style_config, ChatActionStyleConfigType0):
-            style_config = self.style_config.to_dict()
+        columns: list[str] | None | Unset
+        if isinstance(self.columns, Unset):
+            columns = UNSET
+        elif isinstance(self.columns, list):
+            columns = self.columns
+
         else:
-            style_config = self.style_config
+            columns = self.columns
+
+        row_count: int | None | Unset
+        if isinstance(self.row_count, Unset):
+            row_count = UNSET
+        else:
+            row_count = self.row_count
 
         truncated: bool | None | Unset
         if isinstance(self.truncated, Unset):
@@ -213,11 +207,17 @@ class ChatAction:
         else:
             truncated = self.truncated
 
-        visible: bool | None | Unset
-        if isinstance(self.visible, Unset):
-            visible = UNSET
+        operation: None | str | Unset
+        if isinstance(self.operation, Unset):
+            operation = UNSET
         else:
-            visible = self.visible
+            operation = self.operation
+
+        distance_meters: float | None | Unset
+        if isinstance(self.distance_meters, Unset):
+            distance_meters = UNSET
+        else:
+            distance_meters = self.distance_meters
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -226,44 +226,44 @@ class ChatAction:
                 "type": type_,
             }
         )
-        if bbox is not UNSET:
-            field_dict["bbox"] = bbox
+        if layer_id is not UNSET:
+            field_dict["layer_id"] = layer_id
+        if expression is not UNSET:
+            field_dict["expression"] = expression
+        if paint is not UNSET:
+            field_dict["paint"] = paint
         if clear_paint is not UNSET:
             field_dict["clear_paint"] = clear_paint
-        if columns is not UNSET:
-            field_dict["columns"] = columns
+        if replace_paint is not UNSET:
+            field_dict["replace_paint"] = replace_paint
+        if style_config is not UNSET:
+            field_dict["style_config"] = style_config
+        if label_config is not UNSET:
+            field_dict["label_config"] = label_config
         if dataset_id is not UNSET:
             field_dict["dataset_id"] = dataset_id
         if dataset_name is not UNSET:
             field_dict["dataset_name"] = dataset_name
-        if distance_meters is not UNSET:
-            field_dict["distance_meters"] = distance_meters
-        if expression is not UNSET:
-            field_dict["expression"] = expression
-        if geojson is not UNSET:
-            field_dict["geojson"] = geojson
-        if label_config is not UNSET:
-            field_dict["label_config"] = label_config
-        if layer_id is not UNSET:
-            field_dict["layer_id"] = layer_id
-        if opacity is not UNSET:
-            field_dict["opacity"] = opacity
-        if operation is not UNSET:
-            field_dict["operation"] = operation
-        if paint is not UNSET:
-            field_dict["paint"] = paint
-        if replace_paint is not UNSET:
-            field_dict["replace_paint"] = replace_paint
-        if row_count is not UNSET:
-            field_dict["row_count"] = row_count
-        if rows is not UNSET:
-            field_dict["rows"] = rows
-        if style_config is not UNSET:
-            field_dict["style_config"] = style_config
-        if truncated is not UNSET:
-            field_dict["truncated"] = truncated
         if visible is not UNSET:
             field_dict["visible"] = visible
+        if opacity is not UNSET:
+            field_dict["opacity"] = opacity
+        if geojson is not UNSET:
+            field_dict["geojson"] = geojson
+        if bbox is not UNSET:
+            field_dict["bbox"] = bbox
+        if rows is not UNSET:
+            field_dict["rows"] = rows
+        if columns is not UNSET:
+            field_dict["columns"] = columns
+        if row_count is not UNSET:
+            field_dict["row_count"] = row_count
+        if truncated is not UNSET:
+            field_dict["truncated"] = truncated
+        if operation is not UNSET:
+            field_dict["operation"] = operation
+        if distance_meters is not UNSET:
+            field_dict["distance_meters"] = distance_meters
 
         return field_dict
 
@@ -277,83 +277,14 @@ class ChatAction:
         d = dict(src_dict)
         type_ = check_chat_action_type(d.pop("type"))
 
-        def _parse_bbox(data: object) -> list[float] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                bbox_type_0 = cast(list[float], data)
-
-                return bbox_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[float] | None | Unset, data)
-
-        bbox = _parse_bbox(d.pop("bbox", UNSET))
-
-        def _parse_clear_paint(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                clear_paint_type_0 = cast(list[str], data)
-
-                return clear_paint_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        clear_paint = _parse_clear_paint(d.pop("clear_paint", UNSET))
-
-        def _parse_columns(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                columns_type_0 = cast(list[str], data)
-
-                return columns_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        columns = _parse_columns(d.pop("columns", UNSET))
-
-        def _parse_dataset_id(data: object) -> None | str | Unset:
+        def _parse_layer_id(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        dataset_id = _parse_dataset_id(d.pop("dataset_id", UNSET))
-
-        def _parse_dataset_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        dataset_name = _parse_dataset_name(d.pop("dataset_name", UNSET))
-
-        def _parse_distance_meters(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        distance_meters = _parse_distance_meters(d.pop("distance_meters", UNSET))
+        layer_id = _parse_layer_id(d.pop("layer_id", UNSET))
 
         def _parse_expression(data: object) -> list[Any] | None | Unset:
             if data is None:
@@ -372,7 +303,7 @@ class ChatAction:
 
         expression = _parse_expression(d.pop("expression", UNSET))
 
-        def _parse_geojson(data: object) -> GeoJSONFeatureCollection | None | Unset:
+        def _parse_paint(data: object) -> ChatActionPaintType0 | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -380,14 +311,59 @@ class ChatAction:
             try:
                 if not isinstance(data, dict):
                     raise TypeError()
-                geojson_type_0 = GeoJSONFeatureCollection.from_dict(data)
+                paint_type_0 = ChatActionPaintType0.from_dict(data)
 
-                return geojson_type_0
+                return paint_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(GeoJSONFeatureCollection | None | Unset, data)
+            return cast(ChatActionPaintType0 | None | Unset, data)
 
-        geojson = _parse_geojson(d.pop("geojson", UNSET))
+        paint = _parse_paint(d.pop("paint", UNSET))
+
+        def _parse_clear_paint(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                clear_paint_type_0 = cast(list[str], data)
+
+                return clear_paint_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        clear_paint = _parse_clear_paint(d.pop("clear_paint", UNSET))
+
+        def _parse_replace_paint(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        replace_paint = _parse_replace_paint(d.pop("replace_paint", UNSET))
+
+        def _parse_style_config(
+            data: object,
+        ) -> ChatActionStyleConfigType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                style_config_type_0 = ChatActionStyleConfigType0.from_dict(data)
+
+                return style_config_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(ChatActionStyleConfigType0 | None | Unset, data)
+
+        style_config = _parse_style_config(d.pop("style_config", UNSET))
 
         def _parse_label_config(
             data: object,
@@ -408,14 +384,32 @@ class ChatAction:
 
         label_config = _parse_label_config(d.pop("label_config", UNSET))
 
-        def _parse_layer_id(data: object) -> None | str | Unset:
+        def _parse_dataset_id(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        layer_id = _parse_layer_id(d.pop("layer_id", UNSET))
+        dataset_id = _parse_dataset_id(d.pop("dataset_id", UNSET))
+
+        def _parse_dataset_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        dataset_name = _parse_dataset_name(d.pop("dataset_name", UNSET))
+
+        def _parse_visible(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        visible = _parse_visible(d.pop("visible", UNSET))
 
         def _parse_opacity(data: object) -> float | None | Unset:
             if data is None:
@@ -426,16 +420,7 @@ class ChatAction:
 
         opacity = _parse_opacity(d.pop("opacity", UNSET))
 
-        def _parse_operation(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        operation = _parse_operation(d.pop("operation", UNSET))
-
-        def _parse_paint(data: object) -> ChatActionPaintType0 | None | Unset:
+        def _parse_geojson(data: object) -> GeoJSONFeatureCollection | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -443,32 +428,31 @@ class ChatAction:
             try:
                 if not isinstance(data, dict):
                     raise TypeError()
-                paint_type_0 = ChatActionPaintType0.from_dict(data)
+                geojson_type_0 = GeoJSONFeatureCollection.from_dict(data)
 
-                return paint_type_0
+                return geojson_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(ChatActionPaintType0 | None | Unset, data)
+            return cast(GeoJSONFeatureCollection | None | Unset, data)
 
-        paint = _parse_paint(d.pop("paint", UNSET))
+        geojson = _parse_geojson(d.pop("geojson", UNSET))
 
-        def _parse_replace_paint(data: object) -> bool | None | Unset:
+        def _parse_bbox(data: object) -> list[float] | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(bool | None | Unset, data)
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                bbox_type_0 = cast(list[float], data)
 
-        replace_paint = _parse_replace_paint(d.pop("replace_paint", UNSET))
+                return bbox_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[float] | None | Unset, data)
 
-        def _parse_row_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        row_count = _parse_row_count(d.pop("row_count", UNSET))
+        bbox = _parse_bbox(d.pop("bbox", UNSET))
 
         def _parse_rows(data: object) -> list[list[Any]] | None | Unset:
             if data is None:
@@ -492,24 +476,31 @@ class ChatAction:
 
         rows = _parse_rows(d.pop("rows", UNSET))
 
-        def _parse_style_config(
-            data: object,
-        ) -> ChatActionStyleConfigType0 | None | Unset:
+        def _parse_columns(data: object) -> list[str] | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             try:
-                if not isinstance(data, dict):
+                if not isinstance(data, list):
                     raise TypeError()
-                style_config_type_0 = ChatActionStyleConfigType0.from_dict(data)
+                columns_type_0 = cast(list[str], data)
 
-                return style_config_type_0
+                return columns_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(ChatActionStyleConfigType0 | None | Unset, data)
+            return cast(list[str] | None | Unset, data)
 
-        style_config = _parse_style_config(d.pop("style_config", UNSET))
+        columns = _parse_columns(d.pop("columns", UNSET))
+
+        def _parse_row_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        row_count = _parse_row_count(d.pop("row_count", UNSET))
 
         def _parse_truncated(data: object) -> bool | None | Unset:
             if data is None:
@@ -520,36 +511,45 @@ class ChatAction:
 
         truncated = _parse_truncated(d.pop("truncated", UNSET))
 
-        def _parse_visible(data: object) -> bool | None | Unset:
+        def _parse_operation(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(bool | None | Unset, data)
+            return cast(None | str | Unset, data)
 
-        visible = _parse_visible(d.pop("visible", UNSET))
+        operation = _parse_operation(d.pop("operation", UNSET))
+
+        def _parse_distance_meters(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        distance_meters = _parse_distance_meters(d.pop("distance_meters", UNSET))
 
         chat_action = cls(
             type_=type_,
-            bbox=bbox,
+            layer_id=layer_id,
+            expression=expression,
+            paint=paint,
             clear_paint=clear_paint,
-            columns=columns,
+            replace_paint=replace_paint,
+            style_config=style_config,
+            label_config=label_config,
             dataset_id=dataset_id,
             dataset_name=dataset_name,
-            distance_meters=distance_meters,
-            expression=expression,
-            geojson=geojson,
-            label_config=label_config,
-            layer_id=layer_id,
-            opacity=opacity,
-            operation=operation,
-            paint=paint,
-            replace_paint=replace_paint,
-            row_count=row_count,
-            rows=rows,
-            style_config=style_config,
-            truncated=truncated,
             visible=visible,
+            opacity=opacity,
+            geojson=geojson,
+            bbox=bbox,
+            rows=rows,
+            columns=columns,
+            row_count=row_count,
+            truncated=truncated,
+            operation=operation,
+            distance_meters=distance_meters,
         )
 
         chat_action.additional_properties = d

--- a/sdks/python/geolens/models/chat_history_message.py
+++ b/sdks/python/geolens/models/chat_history_message.py
@@ -19,25 +19,25 @@ class ChatHistoryMessage:
     """A single message in the conversation history.
 
     Attributes:
-        content (str):
         role (ChatHistoryMessageRole):
+        content (str):
     """
 
-    content: str
     role: ChatHistoryMessageRole
+    content: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        content = self.content
-
         role: str = self.role
+
+        content = self.content
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "content": content,
                 "role": role,
+                "content": content,
             }
         )
 
@@ -46,13 +46,13 @@ class ChatHistoryMessage:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        content = d.pop("content")
-
         role = check_chat_history_message_role(d.pop("role"))
 
+        content = d.pop("content")
+
         chat_history_message = cls(
-            content=content,
             role=role,
+            content=content,
         )
 
         chat_history_message.additional_properties = d

--- a/sdks/python/geolens/models/chat_map_layer.py
+++ b/sdks/python/geolens/models/chat_map_layer.py
@@ -31,38 +31,38 @@ class ChatMapLayer:
     """Layer state sent from frontend for chat context.
 
     Attributes:
-        dataset_id (str):
-        dataset_table_name (str):
         id (str):
         name (str):
+        dataset_id (str):
+        dataset_table_name (str):
+        geometry_type (None | str | Unset):
+        layer_type (None | str | Unset):
         column_info (list[ChatMapLayerColumnInfoType0Item] | None | Unset):
         dataset_title (None | str | Unset):
         feature_count (int | None | Unset):
-        filter_ (ChatMapLayerFilterType1 | list[Any] | None | Unset):
-        geometry_type (None | str | Unset):
-        label_config (ChatMapLayerLabelConfigType0 | None | Unset):
-        layer_type (None | str | Unset):
-        paint (ChatMapLayerPaintType0 | None | Unset):
         sample_values (ChatMapLayerSampleValuesType0 | None | Unset):
-        style_config (ChatMapLayerStyleConfigType0 | None | Unset):
         visible (bool | Unset):  Default: True.
+        filter_ (ChatMapLayerFilterType1 | list[Any] | None | Unset):
+        label_config (ChatMapLayerLabelConfigType0 | None | Unset):
+        style_config (ChatMapLayerStyleConfigType0 | None | Unset):
+        paint (ChatMapLayerPaintType0 | None | Unset):
     """
 
-    dataset_id: str
-    dataset_table_name: str
     id: str
     name: str
+    dataset_id: str
+    dataset_table_name: str
+    geometry_type: None | str | Unset = UNSET
+    layer_type: None | str | Unset = UNSET
     column_info: list[ChatMapLayerColumnInfoType0Item] | None | Unset = UNSET
     dataset_title: None | str | Unset = UNSET
     feature_count: int | None | Unset = UNSET
-    filter_: ChatMapLayerFilterType1 | list[Any] | None | Unset = UNSET
-    geometry_type: None | str | Unset = UNSET
-    label_config: ChatMapLayerLabelConfigType0 | None | Unset = UNSET
-    layer_type: None | str | Unset = UNSET
-    paint: ChatMapLayerPaintType0 | None | Unset = UNSET
     sample_values: ChatMapLayerSampleValuesType0 | None | Unset = UNSET
-    style_config: ChatMapLayerStyleConfigType0 | None | Unset = UNSET
     visible: bool | Unset = True
+    filter_: ChatMapLayerFilterType1 | list[Any] | None | Unset = UNSET
+    label_config: ChatMapLayerLabelConfigType0 | None | Unset = UNSET
+    style_config: ChatMapLayerStyleConfigType0 | None | Unset = UNSET
+    paint: ChatMapLayerPaintType0 | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -78,13 +78,25 @@ class ChatMapLayer:
             ChatMapLayerStyleConfigType0,
         )
 
+        id = self.id
+
+        name = self.name
+
         dataset_id = self.dataset_id
 
         dataset_table_name = self.dataset_table_name
 
-        id = self.id
+        geometry_type: None | str | Unset
+        if isinstance(self.geometry_type, Unset):
+            geometry_type = UNSET
+        else:
+            geometry_type = self.geometry_type
 
-        name = self.name
+        layer_type: None | str | Unset
+        if isinstance(self.layer_type, Unset):
+            layer_type = UNSET
+        else:
+            layer_type = self.layer_type
 
         column_info: list[dict[str, Any]] | None | Unset
         if isinstance(self.column_info, Unset):
@@ -110,6 +122,16 @@ class ChatMapLayer:
         else:
             feature_count = self.feature_count
 
+        sample_values: dict[str, Any] | None | Unset
+        if isinstance(self.sample_values, Unset):
+            sample_values = UNSET
+        elif isinstance(self.sample_values, ChatMapLayerSampleValuesType0):
+            sample_values = self.sample_values.to_dict()
+        else:
+            sample_values = self.sample_values
+
+        visible = self.visible
+
         filter_: dict[str, Any] | list[Any] | None | Unset
         if isinstance(self.filter_, Unset):
             filter_ = UNSET
@@ -121,12 +143,6 @@ class ChatMapLayer:
         else:
             filter_ = self.filter_
 
-        geometry_type: None | str | Unset
-        if isinstance(self.geometry_type, Unset):
-            geometry_type = UNSET
-        else:
-            geometry_type = self.geometry_type
-
         label_config: dict[str, Any] | None | Unset
         if isinstance(self.label_config, Unset):
             label_config = UNSET
@@ -134,28 +150,6 @@ class ChatMapLayer:
             label_config = self.label_config.to_dict()
         else:
             label_config = self.label_config
-
-        layer_type: None | str | Unset
-        if isinstance(self.layer_type, Unset):
-            layer_type = UNSET
-        else:
-            layer_type = self.layer_type
-
-        paint: dict[str, Any] | None | Unset
-        if isinstance(self.paint, Unset):
-            paint = UNSET
-        elif isinstance(self.paint, ChatMapLayerPaintType0):
-            paint = self.paint.to_dict()
-        else:
-            paint = self.paint
-
-        sample_values: dict[str, Any] | None | Unset
-        if isinstance(self.sample_values, Unset):
-            sample_values = UNSET
-        elif isinstance(self.sample_values, ChatMapLayerSampleValuesType0):
-            sample_values = self.sample_values.to_dict()
-        else:
-            sample_values = self.sample_values
 
         style_config: dict[str, Any] | None | Unset
         if isinstance(self.style_config, Unset):
@@ -165,40 +159,46 @@ class ChatMapLayer:
         else:
             style_config = self.style_config
 
-        visible = self.visible
+        paint: dict[str, Any] | None | Unset
+        if isinstance(self.paint, Unset):
+            paint = UNSET
+        elif isinstance(self.paint, ChatMapLayerPaintType0):
+            paint = self.paint.to_dict()
+        else:
+            paint = self.paint
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "dataset_id": dataset_id,
-                "dataset_table_name": dataset_table_name,
                 "id": id,
                 "name": name,
+                "dataset_id": dataset_id,
+                "dataset_table_name": dataset_table_name,
             }
         )
+        if geometry_type is not UNSET:
+            field_dict["geometry_type"] = geometry_type
+        if layer_type is not UNSET:
+            field_dict["layer_type"] = layer_type
         if column_info is not UNSET:
             field_dict["column_info"] = column_info
         if dataset_title is not UNSET:
             field_dict["dataset_title"] = dataset_title
         if feature_count is not UNSET:
             field_dict["feature_count"] = feature_count
-        if filter_ is not UNSET:
-            field_dict["filter"] = filter_
-        if geometry_type is not UNSET:
-            field_dict["geometry_type"] = geometry_type
-        if label_config is not UNSET:
-            field_dict["label_config"] = label_config
-        if layer_type is not UNSET:
-            field_dict["layer_type"] = layer_type
-        if paint is not UNSET:
-            field_dict["paint"] = paint
         if sample_values is not UNSET:
             field_dict["sample_values"] = sample_values
-        if style_config is not UNSET:
-            field_dict["style_config"] = style_config
         if visible is not UNSET:
             field_dict["visible"] = visible
+        if filter_ is not UNSET:
+            field_dict["filter"] = filter_
+        if label_config is not UNSET:
+            field_dict["label_config"] = label_config
+        if style_config is not UNSET:
+            field_dict["style_config"] = style_config
+        if paint is not UNSET:
+            field_dict["paint"] = paint
 
         return field_dict
 
@@ -220,13 +220,31 @@ class ChatMapLayer:
         )
 
         d = dict(src_dict)
+        id = d.pop("id")
+
+        name = d.pop("name")
+
         dataset_id = d.pop("dataset_id")
 
         dataset_table_name = d.pop("dataset_table_name")
 
-        id = d.pop("id")
+        def _parse_geometry_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
 
-        name = d.pop("name")
+        geometry_type = _parse_geometry_type(d.pop("geometry_type", UNSET))
+
+        def _parse_layer_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        layer_type = _parse_layer_type(d.pop("layer_type", UNSET))
 
         def _parse_column_info(
             data: object,
@@ -272,6 +290,27 @@ class ChatMapLayer:
 
         feature_count = _parse_feature_count(d.pop("feature_count", UNSET))
 
+        def _parse_sample_values(
+            data: object,
+        ) -> ChatMapLayerSampleValuesType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                sample_values_type_0 = ChatMapLayerSampleValuesType0.from_dict(data)
+
+                return sample_values_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(ChatMapLayerSampleValuesType0 | None | Unset, data)
+
+        sample_values = _parse_sample_values(d.pop("sample_values", UNSET))
+
+        visible = d.pop("visible", UNSET)
+
         def _parse_filter_(
             data: object,
         ) -> ChatMapLayerFilterType1 | list[Any] | None | Unset:
@@ -299,15 +338,6 @@ class ChatMapLayer:
 
         filter_ = _parse_filter_(d.pop("filter", UNSET))
 
-        def _parse_geometry_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        geometry_type = _parse_geometry_type(d.pop("geometry_type", UNSET))
-
         def _parse_label_config(
             data: object,
         ) -> ChatMapLayerLabelConfigType0 | None | Unset:
@@ -326,51 +356,6 @@ class ChatMapLayer:
             return cast(ChatMapLayerLabelConfigType0 | None | Unset, data)
 
         label_config = _parse_label_config(d.pop("label_config", UNSET))
-
-        def _parse_layer_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        layer_type = _parse_layer_type(d.pop("layer_type", UNSET))
-
-        def _parse_paint(data: object) -> ChatMapLayerPaintType0 | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                paint_type_0 = ChatMapLayerPaintType0.from_dict(data)
-
-                return paint_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(ChatMapLayerPaintType0 | None | Unset, data)
-
-        paint = _parse_paint(d.pop("paint", UNSET))
-
-        def _parse_sample_values(
-            data: object,
-        ) -> ChatMapLayerSampleValuesType0 | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                sample_values_type_0 = ChatMapLayerSampleValuesType0.from_dict(data)
-
-                return sample_values_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(ChatMapLayerSampleValuesType0 | None | Unset, data)
-
-        sample_values = _parse_sample_values(d.pop("sample_values", UNSET))
 
         def _parse_style_config(
             data: object,
@@ -391,24 +376,39 @@ class ChatMapLayer:
 
         style_config = _parse_style_config(d.pop("style_config", UNSET))
 
-        visible = d.pop("visible", UNSET)
+        def _parse_paint(data: object) -> ChatMapLayerPaintType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                paint_type_0 = ChatMapLayerPaintType0.from_dict(data)
+
+                return paint_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(ChatMapLayerPaintType0 | None | Unset, data)
+
+        paint = _parse_paint(d.pop("paint", UNSET))
 
         chat_map_layer = cls(
-            dataset_id=dataset_id,
-            dataset_table_name=dataset_table_name,
             id=id,
             name=name,
+            dataset_id=dataset_id,
+            dataset_table_name=dataset_table_name,
+            geometry_type=geometry_type,
+            layer_type=layer_type,
             column_info=column_info,
             dataset_title=dataset_title,
             feature_count=feature_count,
-            filter_=filter_,
-            geometry_type=geometry_type,
-            label_config=label_config,
-            layer_type=layer_type,
-            paint=paint,
             sample_values=sample_values,
-            style_config=style_config,
             visible=visible,
+            filter_=filter_,
+            label_config=label_config,
+            style_config=style_config,
+            paint=paint,
         )
 
         chat_map_layer.additional_properties = d

--- a/sdks/python/geolens/models/chat_request.py
+++ b/sdks/python/geolens/models/chat_request.py
@@ -22,29 +22,35 @@ T = TypeVar("T", bound="ChatRequest")
 class ChatRequest:
     """
     Attributes:
-        layers (list[ChatMapLayer]):
-        map_id (str):
         message (str):
-        history (list[ChatHistoryMessage] | Unset):
+        map_id (str):
+        layers (list[ChatMapLayer]):
         language (None | str | Unset):
+        history (list[ChatHistoryMessage] | Unset):
     """
 
-    layers: list[ChatMapLayer]
-    map_id: str
     message: str
-    history: list[ChatHistoryMessage] | Unset = UNSET
+    map_id: str
+    layers: list[ChatMapLayer]
     language: None | str | Unset = UNSET
+    history: list[ChatHistoryMessage] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        message = self.message
+
+        map_id = self.map_id
+
         layers = []
         for layers_item_data in self.layers:
             layers_item = layers_item_data.to_dict()
             layers.append(layers_item)
 
-        map_id = self.map_id
-
-        message = self.message
+        language: None | str | Unset
+        if isinstance(self.language, Unset):
+            language = UNSET
+        else:
+            language = self.language
 
         history: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.history, Unset):
@@ -53,25 +59,19 @@ class ChatRequest:
                 history_item = history_item_data.to_dict()
                 history.append(history_item)
 
-        language: None | str | Unset
-        if isinstance(self.language, Unset):
-            language = UNSET
-        else:
-            language = self.language
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "layers": layers,
-                "map_id": map_id,
                 "message": message,
+                "map_id": map_id,
+                "layers": layers,
             }
         )
-        if history is not UNSET:
-            field_dict["history"] = history
         if language is not UNSET:
             field_dict["language"] = language
+        if history is not UNSET:
+            field_dict["history"] = history
 
         return field_dict
 
@@ -81,25 +81,16 @@ class ChatRequest:
         from ..models.chat_map_layer import ChatMapLayer
 
         d = dict(src_dict)
+        message = d.pop("message")
+
+        map_id = d.pop("map_id")
+
         layers = []
         _layers = d.pop("layers")
         for layers_item_data in _layers:
             layers_item = ChatMapLayer.from_dict(layers_item_data)
 
             layers.append(layers_item)
-
-        map_id = d.pop("map_id")
-
-        message = d.pop("message")
-
-        _history = d.pop("history", UNSET)
-        history: list[ChatHistoryMessage] | Unset = UNSET
-        if _history is not UNSET:
-            history = []
-            for history_item_data in _history:
-                history_item = ChatHistoryMessage.from_dict(history_item_data)
-
-                history.append(history_item)
 
         def _parse_language(data: object) -> None | str | Unset:
             if data is None:
@@ -110,12 +101,21 @@ class ChatRequest:
 
         language = _parse_language(d.pop("language", UNSET))
 
+        _history = d.pop("history", UNSET)
+        history: list[ChatHistoryMessage] | Unset = UNSET
+        if _history is not UNSET:
+            history = []
+            for history_item_data in _history:
+                history_item = ChatHistoryMessage.from_dict(history_item_data)
+
+                history.append(history_item)
+
         chat_request = cls(
-            layers=layers,
-            map_id=map_id,
             message=message,
-            history=history,
+            map_id=map_id,
+            layers=layers,
             language=language,
+            history=history,
         )
 
         chat_request.additional_properties = d

--- a/sdks/python/geolens/models/chat_response.py
+++ b/sdks/python/geolens/models/chat_response.py
@@ -18,28 +18,28 @@ T = TypeVar("T", bound="ChatResponse")
 class ChatResponse:
     """
     Attributes:
-        actions (list[ChatAction]):
         explanation (str):
+        actions (list[ChatAction]):
     """
 
-    actions: list[ChatAction]
     explanation: str
+    actions: list[ChatAction]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        explanation = self.explanation
+
         actions = []
         for actions_item_data in self.actions:
             actions_item = actions_item_data.to_dict()
             actions.append(actions_item)
 
-        explanation = self.explanation
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "actions": actions,
                 "explanation": explanation,
+                "actions": actions,
             }
         )
 
@@ -50,6 +50,8 @@ class ChatResponse:
         from ..models.chat_action import ChatAction
 
         d = dict(src_dict)
+        explanation = d.pop("explanation")
+
         actions = []
         _actions = d.pop("actions")
         for actions_item_data in _actions:
@@ -57,11 +59,9 @@ class ChatResponse:
 
             actions.append(actions_item)
 
-        explanation = d.pop("explanation")
-
         chat_response = cls(
-            actions=actions,
             explanation=explanation,
+            actions=actions,
         )
 
         chat_response.additional_properties = d

--- a/sdks/python/geolens/models/collection_facet_item.py
+++ b/sdks/python/geolens/models/collection_facet_item.py
@@ -15,30 +15,30 @@ class CollectionFacetItem:
     """A collection facet entry.
 
     Attributes:
-        dataset_count (int):
         id (str):
         name (str):
+        dataset_count (int):
     """
 
-    dataset_count: int
     id: str
     name: str
+    dataset_count: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        dataset_count = self.dataset_count
-
         id = self.id
 
         name = self.name
+
+        dataset_count = self.dataset_count
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "dataset_count": dataset_count,
                 "id": id,
                 "name": name,
+                "dataset_count": dataset_count,
             }
         )
 
@@ -47,16 +47,16 @@ class CollectionFacetItem:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        dataset_count = d.pop("dataset_count")
-
         id = d.pop("id")
 
         name = d.pop("name")
 
+        dataset_count = d.pop("dataset_count")
+
         collection_facet_item = cls(
-            dataset_count=dataset_count,
             id=id,
             name=name,
+            dataset_count=dataset_count,
         )
 
         collection_facet_item.additional_properties = d

--- a/sdks/python/geolens/models/collection_response.py
+++ b/sdks/python/geolens/models/collection_response.py
@@ -21,32 +21,37 @@ T = TypeVar("T", bound="CollectionResponse")
 class CollectionResponse:
     """
     Attributes:
-        created_at (datetime.datetime):
-        created_by (None | UUID):
-        dataset_count (int):
-        description (None | str):
         id (UUID):
         name (str):
+        description (None | str):
+        created_by (None | UUID):
+        created_at (datetime.datetime):
         updated_at (datetime.datetime):
+        dataset_count (int):
         extent_bbox (list[float] | None | Unset):
-        temporal_end (datetime.date | None | Unset):
         temporal_start (datetime.date | None | Unset):
+        temporal_end (datetime.date | None | Unset):
     """
 
-    created_at: datetime.datetime
-    created_by: None | UUID
-    dataset_count: int
-    description: None | str
     id: UUID
     name: str
+    description: None | str
+    created_by: None | UUID
+    created_at: datetime.datetime
     updated_at: datetime.datetime
+    dataset_count: int
     extent_bbox: list[float] | None | Unset = UNSET
-    temporal_end: datetime.date | None | Unset = UNSET
     temporal_start: datetime.date | None | Unset = UNSET
+    temporal_end: datetime.date | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
+        id = str(self.id)
+
+        name = self.name
+
+        description: None | str
+        description = self.description
 
         created_by: None | str
         if isinstance(self.created_by, UUID):
@@ -54,16 +59,11 @@ class CollectionResponse:
         else:
             created_by = self.created_by
 
-        dataset_count = self.dataset_count
-
-        description: None | str
-        description = self.description
-
-        id = str(self.id)
-
-        name = self.name
+        created_at = self.created_at.isoformat()
 
         updated_at = self.updated_at.isoformat()
+
+        dataset_count = self.dataset_count
 
         extent_bbox: list[float] | None | Unset
         if isinstance(self.extent_bbox, Unset):
@@ -74,14 +74,6 @@ class CollectionResponse:
         else:
             extent_bbox = self.extent_bbox
 
-        temporal_end: None | str | Unset
-        if isinstance(self.temporal_end, Unset):
-            temporal_end = UNSET
-        elif isinstance(self.temporal_end, datetime.date):
-            temporal_end = self.temporal_end.isoformat()
-        else:
-            temporal_end = self.temporal_end
-
         temporal_start: None | str | Unset
         if isinstance(self.temporal_start, Unset):
             temporal_start = UNSET
@@ -90,32 +82,49 @@ class CollectionResponse:
         else:
             temporal_start = self.temporal_start
 
+        temporal_end: None | str | Unset
+        if isinstance(self.temporal_end, Unset):
+            temporal_end = UNSET
+        elif isinstance(self.temporal_end, datetime.date):
+            temporal_end = self.temporal_end.isoformat()
+        else:
+            temporal_end = self.temporal_end
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "created_by": created_by,
-                "dataset_count": dataset_count,
-                "description": description,
                 "id": id,
                 "name": name,
+                "description": description,
+                "created_by": created_by,
+                "created_at": created_at,
                 "updated_at": updated_at,
+                "dataset_count": dataset_count,
             }
         )
         if extent_bbox is not UNSET:
             field_dict["extent_bbox"] = extent_bbox
-        if temporal_end is not UNSET:
-            field_dict["temporal_end"] = temporal_end
         if temporal_start is not UNSET:
             field_dict["temporal_start"] = temporal_start
+        if temporal_end is not UNSET:
+            field_dict["temporal_end"] = temporal_end
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
+        id = UUID(d.pop("id"))
+
+        name = d.pop("name")
+
+        def _parse_description(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        description = _parse_description(d.pop("description"))
 
         def _parse_created_by(data: object) -> None | UUID:
             if data is None:
@@ -132,20 +141,11 @@ class CollectionResponse:
 
         created_by = _parse_created_by(d.pop("created_by"))
 
-        dataset_count = d.pop("dataset_count")
-
-        def _parse_description(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        description = _parse_description(d.pop("description"))
-
-        id = UUID(d.pop("id"))
-
-        name = d.pop("name")
+        created_at = isoparse(d.pop("created_at"))
 
         updated_at = isoparse(d.pop("updated_at"))
+
+        dataset_count = d.pop("dataset_count")
 
         def _parse_extent_bbox(data: object) -> list[float] | None | Unset:
             if data is None:
@@ -164,23 +164,6 @@ class CollectionResponse:
 
         extent_bbox = _parse_extent_bbox(d.pop("extent_bbox", UNSET))
 
-        def _parse_temporal_end(data: object) -> datetime.date | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                temporal_end_type_0 = isoparse(data).date()
-
-                return temporal_end_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.date | None | Unset, data)
-
-        temporal_end = _parse_temporal_end(d.pop("temporal_end", UNSET))
-
         def _parse_temporal_start(data: object) -> datetime.date | None | Unset:
             if data is None:
                 return data
@@ -198,17 +181,34 @@ class CollectionResponse:
 
         temporal_start = _parse_temporal_start(d.pop("temporal_start", UNSET))
 
+        def _parse_temporal_end(data: object) -> datetime.date | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                temporal_end_type_0 = isoparse(data).date()
+
+                return temporal_end_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.date | None | Unset, data)
+
+        temporal_end = _parse_temporal_end(d.pop("temporal_end", UNSET))
+
         collection_response = cls(
-            created_at=created_at,
-            created_by=created_by,
-            dataset_count=dataset_count,
-            description=description,
             id=id,
             name=name,
+            description=description,
+            created_by=created_by,
+            created_at=created_at,
             updated_at=updated_at,
+            dataset_count=dataset_count,
             extent_bbox=extent_bbox,
-            temporal_end=temporal_end,
             temporal_start=temporal_start,
+            temporal_end=temporal_end,
         )
 
         collection_response.additional_properties = d

--- a/sdks/python/geolens/models/collection_update.py
+++ b/sdks/python/geolens/models/collection_update.py
@@ -18,49 +18,40 @@ T = TypeVar("T", bound="CollectionUpdate")
 class CollectionUpdate:
     """
     Attributes:
-        description (None | str | Unset): Updated description
         name (None | str | Unset): Updated display name
+        description (None | str | Unset): Updated description
     """
 
-    description: None | str | Unset = UNSET
     name: None | str | Unset = UNSET
+    description: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        description: None | str | Unset
-        if isinstance(self.description, Unset):
-            description = UNSET
-        else:
-            description = self.description
-
         name: None | str | Unset
         if isinstance(self.name, Unset):
             name = UNSET
         else:
             name = self.name
 
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if description is not UNSET:
-            field_dict["description"] = description
         if name is not UNSET:
             field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
-        def _parse_description(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        description = _parse_description(d.pop("description", UNSET))
 
         def _parse_name(data: object) -> None | str | Unset:
             if data is None:
@@ -71,9 +62,18 @@ class CollectionUpdate:
 
         name = _parse_name(d.pop("name", UNSET))
 
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
         collection_update = cls(
-            description=description,
             name=name,
+            description=description,
         )
 
         collection_update.additional_properties = d

--- a/sdks/python/geolens/models/column_ddl_feed_response.py
+++ b/sdks/python/geolens/models/column_ddl_feed_response.py
@@ -20,15 +20,15 @@ class ColumnDdlFeedResponse:
 
     Attributes:
         items (list[ColumnDdlEntry]):
+        total (int):
         limit (int):
         offset (int):
-        total (int):
     """
 
     items: list[ColumnDdlEntry]
+    total: int
     limit: int
     offset: int
-    total: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -37,20 +37,20 @@ class ColumnDdlFeedResponse:
             items_item = items_item_data.to_dict()
             items.append(items_item)
 
+        total = self.total
+
         limit = self.limit
 
         offset = self.offset
-
-        total = self.total
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "items": items,
+                "total": total,
                 "limit": limit,
                 "offset": offset,
-                "total": total,
             }
         )
 
@@ -68,17 +68,17 @@ class ColumnDdlFeedResponse:
 
             items.append(items_item)
 
+        total = d.pop("total")
+
         limit = d.pop("limit")
 
         offset = d.pop("offset")
 
-        total = d.pop("total")
-
         column_ddl_feed_response = cls(
             items=items,
+            total=total,
             limit=limit,
             offset=offset,
-            total=total,
         )
 
         column_ddl_feed_response.additional_properties = d

--- a/sdks/python/geolens/models/column_info.py
+++ b/sdks/python/geolens/models/column_info.py
@@ -24,17 +24,17 @@ class ColumnInfo:
     Attributes:
         name (str):
         type_ (str):
+        semantic_role (None | str | Unset):
         domain_type (None | str | Unset):
         sample_values (list[Any] | None | Unset):
-        semantic_role (None | str | Unset):
         stats (ColumnInfoStatsType0 | None | Unset):
     """
 
     name: str
     type_: str
+    semantic_role: None | str | Unset = UNSET
     domain_type: None | str | Unset = UNSET
     sample_values: list[Any] | None | Unset = UNSET
-    semantic_role: None | str | Unset = UNSET
     stats: ColumnInfoStatsType0 | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -44,6 +44,12 @@ class ColumnInfo:
         name = self.name
 
         type_ = self.type_
+
+        semantic_role: None | str | Unset
+        if isinstance(self.semantic_role, Unset):
+            semantic_role = UNSET
+        else:
+            semantic_role = self.semantic_role
 
         domain_type: None | str | Unset
         if isinstance(self.domain_type, Unset):
@@ -59,12 +65,6 @@ class ColumnInfo:
 
         else:
             sample_values = self.sample_values
-
-        semantic_role: None | str | Unset
-        if isinstance(self.semantic_role, Unset):
-            semantic_role = UNSET
-        else:
-            semantic_role = self.semantic_role
 
         stats: dict[str, Any] | None | Unset
         if isinstance(self.stats, Unset):
@@ -82,12 +82,12 @@ class ColumnInfo:
                 "type": type_,
             }
         )
+        if semantic_role is not UNSET:
+            field_dict["semantic_role"] = semantic_role
         if domain_type is not UNSET:
             field_dict["domain_type"] = domain_type
         if sample_values is not UNSET:
             field_dict["sample_values"] = sample_values
-        if semantic_role is not UNSET:
-            field_dict["semantic_role"] = semantic_role
         if stats is not UNSET:
             field_dict["stats"] = stats
 
@@ -101,6 +101,15 @@ class ColumnInfo:
         name = d.pop("name")
 
         type_ = d.pop("type")
+
+        def _parse_semantic_role(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        semantic_role = _parse_semantic_role(d.pop("semantic_role", UNSET))
 
         def _parse_domain_type(data: object) -> None | str | Unset:
             if data is None:
@@ -128,15 +137,6 @@ class ColumnInfo:
 
         sample_values = _parse_sample_values(d.pop("sample_values", UNSET))
 
-        def _parse_semantic_role(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        semantic_role = _parse_semantic_role(d.pop("semantic_role", UNSET))
-
         def _parse_stats(data: object) -> ColumnInfoStatsType0 | None | Unset:
             if data is None:
                 return data
@@ -157,9 +157,9 @@ class ColumnInfo:
         column_info = cls(
             name=name,
             type_=type_,
+            semantic_role=semantic_role,
             domain_type=domain_type,
             sample_values=sample_values,
-            semantic_role=semantic_role,
             stats=stats,
         )
 

--- a/sdks/python/geolens/models/column_stats_response.py
+++ b/sdks/python/geolens/models/column_stats_response.py
@@ -18,28 +18,56 @@ T = TypeVar("T", bound="ColumnStatsResponse")
 class ColumnStatsResponse:
     """
     Attributes:
-        count (int | Unset):  Default: 0.
-        data_type (None | str | Unset): 'categorical' for non-numeric columns; null for numeric.
-        distinct_count (int | None | Unset): Distinct non-null value count (categorical columns only).
-        max_ (float | None | Unset):
-        mean (float | None | Unset):
         min_ (float | None | Unset):
+        max_ (float | None | Unset):
+        count (int | Unset):  Default: 0.
+        mean (float | None | Unset):
         quantiles (list[float] | Unset):
         stddev (float | None | Unset):
+        data_type (None | str | Unset): 'categorical' for non-numeric columns; null for numeric.
+        distinct_count (int | None | Unset): Distinct non-null value count (categorical columns only).
     """
 
-    count: int | Unset = 0
-    data_type: None | str | Unset = UNSET
-    distinct_count: int | None | Unset = UNSET
-    max_: float | None | Unset = UNSET
-    mean: float | None | Unset = UNSET
     min_: float | None | Unset = UNSET
+    max_: float | None | Unset = UNSET
+    count: int | Unset = 0
+    mean: float | None | Unset = UNSET
     quantiles: list[float] | Unset = UNSET
     stddev: float | None | Unset = UNSET
+    data_type: None | str | Unset = UNSET
+    distinct_count: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        min_: float | None | Unset
+        if isinstance(self.min_, Unset):
+            min_ = UNSET
+        else:
+            min_ = self.min_
+
+        max_: float | None | Unset
+        if isinstance(self.max_, Unset):
+            max_ = UNSET
+        else:
+            max_ = self.max_
+
         count = self.count
+
+        mean: float | None | Unset
+        if isinstance(self.mean, Unset):
+            mean = UNSET
+        else:
+            mean = self.mean
+
+        quantiles: list[float] | Unset = UNSET
+        if not isinstance(self.quantiles, Unset):
+            quantiles = self.quantiles
+
+        stddev: float | None | Unset
+        if isinstance(self.stddev, Unset):
+            stddev = UNSET
+        else:
+            stddev = self.stddev
 
         data_type: None | str | Unset
         if isinstance(self.data_type, Unset):
@@ -53,60 +81,71 @@ class ColumnStatsResponse:
         else:
             distinct_count = self.distinct_count
 
-        max_: float | None | Unset
-        if isinstance(self.max_, Unset):
-            max_ = UNSET
-        else:
-            max_ = self.max_
-
-        mean: float | None | Unset
-        if isinstance(self.mean, Unset):
-            mean = UNSET
-        else:
-            mean = self.mean
-
-        min_: float | None | Unset
-        if isinstance(self.min_, Unset):
-            min_ = UNSET
-        else:
-            min_ = self.min_
-
-        quantiles: list[float] | Unset = UNSET
-        if not isinstance(self.quantiles, Unset):
-            quantiles = self.quantiles
-
-        stddev: float | None | Unset
-        if isinstance(self.stddev, Unset):
-            stddev = UNSET
-        else:
-            stddev = self.stddev
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if count is not UNSET:
-            field_dict["count"] = count
-        if data_type is not UNSET:
-            field_dict["data_type"] = data_type
-        if distinct_count is not UNSET:
-            field_dict["distinct_count"] = distinct_count
-        if max_ is not UNSET:
-            field_dict["max"] = max_
-        if mean is not UNSET:
-            field_dict["mean"] = mean
         if min_ is not UNSET:
             field_dict["min"] = min_
+        if max_ is not UNSET:
+            field_dict["max"] = max_
+        if count is not UNSET:
+            field_dict["count"] = count
+        if mean is not UNSET:
+            field_dict["mean"] = mean
         if quantiles is not UNSET:
             field_dict["quantiles"] = quantiles
         if stddev is not UNSET:
             field_dict["stddev"] = stddev
+        if data_type is not UNSET:
+            field_dict["data_type"] = data_type
+        if distinct_count is not UNSET:
+            field_dict["distinct_count"] = distinct_count
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+
+        def _parse_min_(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        min_ = _parse_min_(d.pop("min", UNSET))
+
+        def _parse_max_(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        max_ = _parse_max_(d.pop("max", UNSET))
+
         count = d.pop("count", UNSET)
+
+        def _parse_mean(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        mean = _parse_mean(d.pop("mean", UNSET))
+
+        quantiles = cast(list[float], d.pop("quantiles", UNSET))
+
+        def _parse_stddev(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        stddev = _parse_stddev(d.pop("stddev", UNSET))
 
         def _parse_data_type(data: object) -> None | str | Unset:
             if data is None:
@@ -126,53 +165,15 @@ class ColumnStatsResponse:
 
         distinct_count = _parse_distinct_count(d.pop("distinct_count", UNSET))
 
-        def _parse_max_(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        max_ = _parse_max_(d.pop("max", UNSET))
-
-        def _parse_mean(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        mean = _parse_mean(d.pop("mean", UNSET))
-
-        def _parse_min_(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        min_ = _parse_min_(d.pop("min", UNSET))
-
-        quantiles = cast(list[float], d.pop("quantiles", UNSET))
-
-        def _parse_stddev(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        stddev = _parse_stddev(d.pop("stddev", UNSET))
-
         column_stats_response = cls(
-            count=count,
-            data_type=data_type,
-            distinct_count=distinct_count,
-            max_=max_,
-            mean=mean,
             min_=min_,
+            max_=max_,
+            count=count,
+            mean=mean,
             quantiles=quantiles,
             stddev=stddev,
+            data_type=data_type,
+            distinct_count=distinct_count,
         )
 
         column_stats_response.additional_properties = d

--- a/sdks/python/geolens/models/column_values_response.py
+++ b/sdks/python/geolens/models/column_values_response.py
@@ -17,29 +17,29 @@ T = TypeVar("T", bound="ColumnValuesResponse")
 class ColumnValuesResponse:
     """
     Attributes:
-        count (int):
         values (list[float | int | None | str]):
+        count (int):
     """
 
-    count: int
     values: list[float | int | None | str]
+    count: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        count = self.count
-
         values = []
         for values_item_data in self.values:
             values_item: float | int | None | str
             values_item = values_item_data
             values.append(values_item)
 
+        count = self.count
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "count": count,
                 "values": values,
+                "count": count,
             }
         )
 
@@ -48,8 +48,6 @@ class ColumnValuesResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        count = d.pop("count")
-
         values = []
         _values = d.pop("values")
         for values_item_data in _values:
@@ -63,9 +61,11 @@ class ColumnValuesResponse:
 
             values.append(values_item)
 
+        count = d.pop("count")
+
         column_values_response = cls(
-            count=count,
             values=values,
+            count=count,
         )
 
         column_values_response.additional_properties = d

--- a/sdks/python/geolens/models/commit_request.py
+++ b/sdks/python/geolens/models/commit_request.py
@@ -39,80 +39,44 @@ class CommitRequest:
 
         Attributes:
             title (str): Human-readable dataset title.
-            compression (None | str | Unset): Raster only: target compression for COG output (e.g. 'LZW', 'DEFLATE').
-            geom_column (None | str | Unset): CSV/Excel only: name of the WKT geometry column (alternative to
-                x_column/y_column).
-            layer_name (None | str | Unset): Multi-layer source only: name of the specific layer to ingest.
-            nodata_override (float | None | str | Unset): Raster only: nodata value to use when source has none defined.
-            resampling (None | str | Unset): Raster only: resampling method for COG conversion (e.g. 'nearest', 'bilinear',
-                'cubic').
-            srid_override (int | None | Unset): EPSG code to use when source CRS is missing or incorrect. Forces
-                reprojection during ingestion.
             summary (None | str | Unset): Optional dataset description shown in the catalog.
-            temporal_end (datetime.datetime | None | Unset): ISO 8601 end of the dataset's temporal extent.
-            temporal_start (datetime.datetime | None | Unset): ISO 8601 start of the dataset's temporal extent.
-            token (None | str | Unset): Optional confirmation token returned by the preview step. Required for some
-                workflows.
             visibility (CommitRequestVisibility | Unset): Dataset visibility level: 'private' (owner-only), 'restricted'
                 (RBAC-controlled), 'internal' (all users), 'public' (anonymous access). Default: 'private'.
+            srid_override (int | None | Unset): EPSG code to use when source CRS is missing or incorrect. Forces
+                reprojection during ingestion.
+            token (None | str | Unset): Optional confirmation token returned by the preview step. Required for some
+                workflows.
+            temporal_start (datetime.datetime | None | Unset): ISO 8601 start of the dataset's temporal extent.
+            temporal_end (datetime.datetime | None | Unset): ISO 8601 end of the dataset's temporal extent.
+            compression (None | str | Unset): Raster only: target compression for COG output (e.g. 'LZW', 'DEFLATE').
+            resampling (None | str | Unset): Raster only: resampling method for COG conversion (e.g. 'nearest', 'bilinear',
+                'cubic').
+            nodata_override (float | None | str | Unset): Raster only: nodata value to use when source has none defined.
+            layer_name (None | str | Unset): Multi-layer source only: name of the specific layer to ingest.
             x_column (None | str | Unset): CSV/Excel only: name of the longitude/X coordinate column.
             y_column (None | str | Unset): CSV/Excel only: name of the latitude/Y coordinate column.
+            geom_column (None | str | Unset): CSV/Excel only: name of the WKT geometry column (alternative to
+                x_column/y_column).
     """
 
     title: str
-    compression: None | str | Unset = UNSET
-    geom_column: None | str | Unset = UNSET
-    layer_name: None | str | Unset = UNSET
-    nodata_override: float | None | str | Unset = UNSET
-    resampling: None | str | Unset = UNSET
-    srid_override: int | None | Unset = UNSET
     summary: None | str | Unset = UNSET
-    temporal_end: datetime.datetime | None | Unset = UNSET
-    temporal_start: datetime.datetime | None | Unset = UNSET
-    token: None | str | Unset = UNSET
     visibility: CommitRequestVisibility | Unset = "private"
+    srid_override: int | None | Unset = UNSET
+    token: None | str | Unset = UNSET
+    temporal_start: datetime.datetime | None | Unset = UNSET
+    temporal_end: datetime.datetime | None | Unset = UNSET
+    compression: None | str | Unset = UNSET
+    resampling: None | str | Unset = UNSET
+    nodata_override: float | None | str | Unset = UNSET
+    layer_name: None | str | Unset = UNSET
     x_column: None | str | Unset = UNSET
     y_column: None | str | Unset = UNSET
+    geom_column: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         title = self.title
-
-        compression: None | str | Unset
-        if isinstance(self.compression, Unset):
-            compression = UNSET
-        else:
-            compression = self.compression
-
-        geom_column: None | str | Unset
-        if isinstance(self.geom_column, Unset):
-            geom_column = UNSET
-        else:
-            geom_column = self.geom_column
-
-        layer_name: None | str | Unset
-        if isinstance(self.layer_name, Unset):
-            layer_name = UNSET
-        else:
-            layer_name = self.layer_name
-
-        nodata_override: float | None | str | Unset
-        if isinstance(self.nodata_override, Unset):
-            nodata_override = UNSET
-        else:
-            nodata_override = self.nodata_override
-
-        resampling: None | str | Unset
-        if isinstance(self.resampling, Unset):
-            resampling = UNSET
-        else:
-            resampling = self.resampling
-
-        srid_override: int | None | Unset
-        if isinstance(self.srid_override, Unset):
-            srid_override = UNSET
-        else:
-            srid_override = self.srid_override
 
         summary: None | str | Unset
         if isinstance(self.summary, Unset):
@@ -120,13 +84,21 @@ class CommitRequest:
         else:
             summary = self.summary
 
-        temporal_end: None | str | Unset
-        if isinstance(self.temporal_end, Unset):
-            temporal_end = UNSET
-        elif isinstance(self.temporal_end, datetime.datetime):
-            temporal_end = self.temporal_end.isoformat()
+        visibility: str | Unset = UNSET
+        if not isinstance(self.visibility, Unset):
+            visibility = self.visibility
+
+        srid_override: int | None | Unset
+        if isinstance(self.srid_override, Unset):
+            srid_override = UNSET
         else:
-            temporal_end = self.temporal_end
+            srid_override = self.srid_override
+
+        token: None | str | Unset
+        if isinstance(self.token, Unset):
+            token = UNSET
+        else:
+            token = self.token
 
         temporal_start: None | str | Unset
         if isinstance(self.temporal_start, Unset):
@@ -136,15 +108,37 @@ class CommitRequest:
         else:
             temporal_start = self.temporal_start
 
-        token: None | str | Unset
-        if isinstance(self.token, Unset):
-            token = UNSET
+        temporal_end: None | str | Unset
+        if isinstance(self.temporal_end, Unset):
+            temporal_end = UNSET
+        elif isinstance(self.temporal_end, datetime.datetime):
+            temporal_end = self.temporal_end.isoformat()
         else:
-            token = self.token
+            temporal_end = self.temporal_end
 
-        visibility: str | Unset = UNSET
-        if not isinstance(self.visibility, Unset):
-            visibility = self.visibility
+        compression: None | str | Unset
+        if isinstance(self.compression, Unset):
+            compression = UNSET
+        else:
+            compression = self.compression
+
+        resampling: None | str | Unset
+        if isinstance(self.resampling, Unset):
+            resampling = UNSET
+        else:
+            resampling = self.resampling
+
+        nodata_override: float | None | str | Unset
+        if isinstance(self.nodata_override, Unset):
+            nodata_override = UNSET
+        else:
+            nodata_override = self.nodata_override
+
+        layer_name: None | str | Unset
+        if isinstance(self.layer_name, Unset):
+            layer_name = UNSET
+        else:
+            layer_name = self.layer_name
 
         x_column: None | str | Unset
         if isinstance(self.x_column, Unset):
@@ -158,6 +152,12 @@ class CommitRequest:
         else:
             y_column = self.y_column
 
+        geom_column: None | str | Unset
+        if isinstance(self.geom_column, Unset):
+            geom_column = UNSET
+        else:
+            geom_column = self.geom_column
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -165,32 +165,32 @@ class CommitRequest:
                 "title": title,
             }
         )
-        if compression is not UNSET:
-            field_dict["compression"] = compression
-        if geom_column is not UNSET:
-            field_dict["geom_column"] = geom_column
-        if layer_name is not UNSET:
-            field_dict["layer_name"] = layer_name
-        if nodata_override is not UNSET:
-            field_dict["nodata_override"] = nodata_override
-        if resampling is not UNSET:
-            field_dict["resampling"] = resampling
-        if srid_override is not UNSET:
-            field_dict["srid_override"] = srid_override
         if summary is not UNSET:
             field_dict["summary"] = summary
-        if temporal_end is not UNSET:
-            field_dict["temporal_end"] = temporal_end
-        if temporal_start is not UNSET:
-            field_dict["temporal_start"] = temporal_start
-        if token is not UNSET:
-            field_dict["token"] = token
         if visibility is not UNSET:
             field_dict["visibility"] = visibility
+        if srid_override is not UNSET:
+            field_dict["srid_override"] = srid_override
+        if token is not UNSET:
+            field_dict["token"] = token
+        if temporal_start is not UNSET:
+            field_dict["temporal_start"] = temporal_start
+        if temporal_end is not UNSET:
+            field_dict["temporal_end"] = temporal_end
+        if compression is not UNSET:
+            field_dict["compression"] = compression
+        if resampling is not UNSET:
+            field_dict["resampling"] = resampling
+        if nodata_override is not UNSET:
+            field_dict["nodata_override"] = nodata_override
+        if layer_name is not UNSET:
+            field_dict["layer_name"] = layer_name
         if x_column is not UNSET:
             field_dict["x_column"] = x_column
         if y_column is not UNSET:
             field_dict["y_column"] = y_column
+        if geom_column is not UNSET:
+            field_dict["geom_column"] = geom_column
 
         return field_dict
 
@@ -198,60 +198,6 @@ class CommitRequest:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         title = d.pop("title")
-
-        def _parse_compression(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        compression = _parse_compression(d.pop("compression", UNSET))
-
-        def _parse_geom_column(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        geom_column = _parse_geom_column(d.pop("geom_column", UNSET))
-
-        def _parse_layer_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        layer_name = _parse_layer_name(d.pop("layer_name", UNSET))
-
-        def _parse_nodata_override(data: object) -> float | None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | str | Unset, data)
-
-        nodata_override = _parse_nodata_override(d.pop("nodata_override", UNSET))
-
-        def _parse_resampling(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        resampling = _parse_resampling(d.pop("resampling", UNSET))
-
-        def _parse_srid_override(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        srid_override = _parse_srid_override(d.pop("srid_override", UNSET))
 
         def _parse_summary(data: object) -> None | str | Unset:
             if data is None:
@@ -262,22 +208,30 @@ class CommitRequest:
 
         summary = _parse_summary(d.pop("summary", UNSET))
 
-        def _parse_temporal_end(data: object) -> datetime.datetime | None | Unset:
+        _visibility = d.pop("visibility", UNSET)
+        visibility: CommitRequestVisibility | Unset
+        if isinstance(_visibility, Unset):
+            visibility = UNSET
+        else:
+            visibility = check_commit_request_visibility(_visibility)
+
+        def _parse_srid_override(data: object) -> int | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                temporal_end_type_0 = isoparse(data)
+            return cast(int | None | Unset, data)
 
-                return temporal_end_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None | Unset, data)
+        srid_override = _parse_srid_override(d.pop("srid_override", UNSET))
 
-        temporal_end = _parse_temporal_end(d.pop("temporal_end", UNSET))
+        def _parse_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        token = _parse_token(d.pop("token", UNSET))
 
         def _parse_temporal_start(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -296,21 +250,58 @@ class CommitRequest:
 
         temporal_start = _parse_temporal_start(d.pop("temporal_start", UNSET))
 
-        def _parse_token(data: object) -> None | str | Unset:
+        def _parse_temporal_end(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                temporal_end_type_0 = isoparse(data)
+
+                return temporal_end_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        temporal_end = _parse_temporal_end(d.pop("temporal_end", UNSET))
+
+        def _parse_compression(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        token = _parse_token(d.pop("token", UNSET))
+        compression = _parse_compression(d.pop("compression", UNSET))
 
-        _visibility = d.pop("visibility", UNSET)
-        visibility: CommitRequestVisibility | Unset
-        if isinstance(_visibility, Unset):
-            visibility = UNSET
-        else:
-            visibility = check_commit_request_visibility(_visibility)
+        def _parse_resampling(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        resampling = _parse_resampling(d.pop("resampling", UNSET))
+
+        def _parse_nodata_override(data: object) -> float | None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | str | Unset, data)
+
+        nodata_override = _parse_nodata_override(d.pop("nodata_override", UNSET))
+
+        def _parse_layer_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        layer_name = _parse_layer_name(d.pop("layer_name", UNSET))
 
         def _parse_x_column(data: object) -> None | str | Unset:
             if data is None:
@@ -330,21 +321,30 @@ class CommitRequest:
 
         y_column = _parse_y_column(d.pop("y_column", UNSET))
 
+        def _parse_geom_column(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        geom_column = _parse_geom_column(d.pop("geom_column", UNSET))
+
         commit_request = cls(
             title=title,
-            compression=compression,
-            geom_column=geom_column,
-            layer_name=layer_name,
-            nodata_override=nodata_override,
-            resampling=resampling,
-            srid_override=srid_override,
             summary=summary,
-            temporal_end=temporal_end,
-            temporal_start=temporal_start,
-            token=token,
             visibility=visibility,
+            srid_override=srid_override,
+            token=token,
+            temporal_start=temporal_start,
+            temporal_end=temporal_end,
+            compression=compression,
+            resampling=resampling,
+            nodata_override=nodata_override,
+            layer_name=layer_name,
             x_column=x_column,
             y_column=y_column,
+            geom_column=geom_column,
         )
 
         commit_request.additional_properties = d

--- a/sdks/python/geolens/models/commit_response.py
+++ b/sdks/python/geolens/models/commit_response.py
@@ -18,29 +18,29 @@ class CommitResponse:
     """
     Attributes:
         job_id (UUID): Identifier of the committed ingestion job.
-        message (str): Human-readable commit result.
         status (str): Updated job status after commit.
+        message (str): Human-readable commit result.
     """
 
     job_id: UUID
-    message: str
     status: str
+    message: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         job_id = str(self.job_id)
 
-        message = self.message
-
         status = self.status
+
+        message = self.message
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "job_id": job_id,
-                "message": message,
                 "status": status,
+                "message": message,
             }
         )
 
@@ -51,14 +51,14 @@ class CommitResponse:
         d = dict(src_dict)
         job_id = UUID(d.pop("job_id"))
 
-        message = d.pop("message")
-
         status = d.pop("status")
+
+        message = d.pop("message")
 
         commit_response = cls(
             job_id=job_id,
-            message=message,
             status=status,
+            message=message,
         )
 
         commit_response.additional_properties = d

--- a/sdks/python/geolens/models/config_import_request.py
+++ b/sdks/python/geolens/models/config_import_request.py
@@ -27,22 +27,30 @@ class ConfigImportRequest:
     """Payload for importing configuration.
 
     Attributes:
-        oauth_providers (list[ConfigImportRequestOauthProvidersType0Item] | None | Unset): Optional OAuth providers to
-            import. Client secrets must be re-supplied via the admin UI after import.
         settings (ConfigImportRequestSettingsType0 | None | Unset): Optional settings to import. Omit to import only
             OAuth providers.
+        oauth_providers (list[ConfigImportRequestOauthProvidersType0Item] | None | Unset): Optional OAuth providers to
+            import. Client secrets must be re-supplied via the admin UI after import.
     """
 
+    settings: ConfigImportRequestSettingsType0 | None | Unset = UNSET
     oauth_providers: list[ConfigImportRequestOauthProvidersType0Item] | None | Unset = (
         UNSET
     )
-    settings: ConfigImportRequestSettingsType0 | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.config_import_request_settings_type_0 import (
             ConfigImportRequestSettingsType0,
         )
+
+        settings: dict[str, Any] | None | Unset
+        if isinstance(self.settings, Unset):
+            settings = UNSET
+        elif isinstance(self.settings, ConfigImportRequestSettingsType0):
+            settings = self.settings.to_dict()
+        else:
+            settings = self.settings
 
         oauth_providers: list[dict[str, Any]] | None | Unset
         if isinstance(self.oauth_providers, Unset):
@@ -56,21 +64,13 @@ class ConfigImportRequest:
         else:
             oauth_providers = self.oauth_providers
 
-        settings: dict[str, Any] | None | Unset
-        if isinstance(self.settings, Unset):
-            settings = UNSET
-        elif isinstance(self.settings, ConfigImportRequestSettingsType0):
-            settings = self.settings.to_dict()
-        else:
-            settings = self.settings
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if oauth_providers is not UNSET:
-            field_dict["oauth_providers"] = oauth_providers
         if settings is not UNSET:
             field_dict["settings"] = settings
+        if oauth_providers is not UNSET:
+            field_dict["oauth_providers"] = oauth_providers
 
         return field_dict
 
@@ -84,6 +84,25 @@ class ConfigImportRequest:
         )
 
         d = dict(src_dict)
+
+        def _parse_settings(
+            data: object,
+        ) -> ConfigImportRequestSettingsType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                settings_type_0 = ConfigImportRequestSettingsType0.from_dict(data)
+
+                return settings_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(ConfigImportRequestSettingsType0 | None | Unset, data)
+
+        settings = _parse_settings(d.pop("settings", UNSET))
 
         def _parse_oauth_providers(
             data: object,
@@ -115,28 +134,9 @@ class ConfigImportRequest:
 
         oauth_providers = _parse_oauth_providers(d.pop("oauth_providers", UNSET))
 
-        def _parse_settings(
-            data: object,
-        ) -> ConfigImportRequestSettingsType0 | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                settings_type_0 = ConfigImportRequestSettingsType0.from_dict(data)
-
-                return settings_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(ConfigImportRequestSettingsType0 | None | Unset, data)
-
-        settings = _parse_settings(d.pop("settings", UNSET))
-
         config_import_request = cls(
-            oauth_providers=oauth_providers,
             settings=settings,
+            oauth_providers=oauth_providers,
         )
 
         config_import_request.additional_properties = d

--- a/sdks/python/geolens/models/config_response.py
+++ b/sdks/python/geolens/models/config_response.py
@@ -21,31 +21,31 @@ class ConfigResponse:
         registration_enabled (bool): Whether self-service registration is open
         allow_signup (bool | Unset): Whether self-serve registration is open. Alias for registration_enabled; login UI
             uses this to show/hide the signup link. Default: False.
+        email_verification_required (bool | Unset): When true, new self-registered users must verify their email before
+            logging in. Default false for back-compat-safe parsing by older clients. Default: False.
         auth_methods (list[str] | Unset): Auth methods contributed by the active AuthExtension. Empty by default;
             compatible deployments may add methods such as ['saml']. Login UI can render conditional sign-in options without
             needing admin OAuthProvider access.
-        banner_color (str | Unset): Theme token for the site banner color: warning | info | success | destructive.
-            Default: 'warning'.
+        landing_first (bool | Unset): When true, unauthenticated visits to '/' are redirected to '/login' as the product
+            landing page. Default false (search catalog is the root). Default: False.
         banner_enabled (bool | Unset): When true and banner_text is non-empty, the site-wide announcement banner is
             shown. Default false. Default: False.
         banner_text (str | Unset): Admin-configured site-wide announcement banner text. Empty string means no banner is
             shown. Default: ''.
-        email_verification_required (bool | Unset): When true, new self-registered users must verify their email before
-            logging in. Default false for back-compat-safe parsing by older clients. Default: False.
-        landing_first (bool | Unset): When true, unauthenticated visits to '/' are redirected to '/login' as the product
-            landing page. Default false (search catalog is the root). Default: False.
+        banner_color (str | Unset): Theme token for the site banner color: warning | info | success | destructive.
+            Default: 'warning'.
         password_login_enabled (bool | Unset): When false, password login is disabled for users without manage_settings.
             Default true for back-compat-safe parsing by older clients. Default: True.
     """
 
     registration_enabled: bool
     allow_signup: bool | Unset = False
+    email_verification_required: bool | Unset = False
     auth_methods: list[str] | Unset = UNSET
-    banner_color: str | Unset = "warning"
+    landing_first: bool | Unset = False
     banner_enabled: bool | Unset = False
     banner_text: str | Unset = ""
-    email_verification_required: bool | Unset = False
-    landing_first: bool | Unset = False
+    banner_color: str | Unset = "warning"
     password_login_enabled: bool | Unset = True
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -54,19 +54,19 @@ class ConfigResponse:
 
         allow_signup = self.allow_signup
 
+        email_verification_required = self.email_verification_required
+
         auth_methods: list[str] | Unset = UNSET
         if not isinstance(self.auth_methods, Unset):
             auth_methods = self.auth_methods
 
-        banner_color = self.banner_color
+        landing_first = self.landing_first
 
         banner_enabled = self.banner_enabled
 
         banner_text = self.banner_text
 
-        email_verification_required = self.email_verification_required
-
-        landing_first = self.landing_first
+        banner_color = self.banner_color
 
         password_login_enabled = self.password_login_enabled
 
@@ -79,18 +79,18 @@ class ConfigResponse:
         )
         if allow_signup is not UNSET:
             field_dict["allow_signup"] = allow_signup
+        if email_verification_required is not UNSET:
+            field_dict["email_verification_required"] = email_verification_required
         if auth_methods is not UNSET:
             field_dict["auth_methods"] = auth_methods
-        if banner_color is not UNSET:
-            field_dict["banner_color"] = banner_color
+        if landing_first is not UNSET:
+            field_dict["landing_first"] = landing_first
         if banner_enabled is not UNSET:
             field_dict["banner_enabled"] = banner_enabled
         if banner_text is not UNSET:
             field_dict["banner_text"] = banner_text
-        if email_verification_required is not UNSET:
-            field_dict["email_verification_required"] = email_verification_required
-        if landing_first is not UNSET:
-            field_dict["landing_first"] = landing_first
+        if banner_color is not UNSET:
+            field_dict["banner_color"] = banner_color
         if password_login_enabled is not UNSET:
             field_dict["password_login_enabled"] = password_login_enabled
 
@@ -103,29 +103,29 @@ class ConfigResponse:
 
         allow_signup = d.pop("allow_signup", UNSET)
 
+        email_verification_required = d.pop("email_verification_required", UNSET)
+
         auth_methods = cast(list[str], d.pop("auth_methods", UNSET))
 
-        banner_color = d.pop("banner_color", UNSET)
+        landing_first = d.pop("landing_first", UNSET)
 
         banner_enabled = d.pop("banner_enabled", UNSET)
 
         banner_text = d.pop("banner_text", UNSET)
 
-        email_verification_required = d.pop("email_verification_required", UNSET)
-
-        landing_first = d.pop("landing_first", UNSET)
+        banner_color = d.pop("banner_color", UNSET)
 
         password_login_enabled = d.pop("password_login_enabled", UNSET)
 
         config_response = cls(
             registration_enabled=registration_enabled,
             allow_signup=allow_signup,
+            email_verification_required=email_verification_required,
             auth_methods=auth_methods,
-            banner_color=banner_color,
+            landing_first=landing_first,
             banner_enabled=banner_enabled,
             banner_text=banner_text,
-            email_verification_required=email_verification_required,
-            landing_first=landing_first,
+            banner_color=banner_color,
             password_login_enabled=password_login_enabled,
         )
 

--- a/sdks/python/geolens/models/connectivity_result.py
+++ b/sdks/python/geolens/models/connectivity_result.py
@@ -22,31 +22,31 @@ class ConnectivityResult:
     """Aggregate connectivity validation result.
 
     Attributes:
+        storage (ServiceProbeResult): Result of a single service connectivity probe.
         cache (ServiceProbeResult): Result of a single service connectivity probe.
         oidc_providers (ConnectivityResultOidcProviders): Per-provider OIDC discovery probe results, keyed by provider
             slug.
-        storage (ServiceProbeResult): Result of a single service connectivity probe.
     """
 
+    storage: ServiceProbeResult
     cache: ServiceProbeResult
     oidc_providers: ConnectivityResultOidcProviders
-    storage: ServiceProbeResult
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        storage = self.storage.to_dict()
+
         cache = self.cache.to_dict()
 
         oidc_providers = self.oidc_providers.to_dict()
-
-        storage = self.storage.to_dict()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "storage": storage,
                 "cache": cache,
                 "oidc_providers": oidc_providers,
-                "storage": storage,
             }
         )
 
@@ -60,18 +60,18 @@ class ConnectivityResult:
         from ..models.service_probe_result import ServiceProbeResult
 
         d = dict(src_dict)
+        storage = ServiceProbeResult.from_dict(d.pop("storage"))
+
         cache = ServiceProbeResult.from_dict(d.pop("cache"))
 
         oidc_providers = ConnectivityResultOidcProviders.from_dict(
             d.pop("oidc_providers")
         )
 
-        storage = ServiceProbeResult.from_dict(d.pop("storage"))
-
         connectivity_result = cls(
+            storage=storage,
             cache=cache,
             oidc_providers=oidc_providers,
-            storage=storage,
         )
 
         connectivity_result.additional_properties = d

--- a/sdks/python/geolens/models/connector_definition_response.py
+++ b/sdks/python/geolens/models/connector_definition_response.py
@@ -23,26 +23,26 @@ class ConnectorDefinitionResponse:
     """Public, non-secret connector capabilities advertised by an overlay.
 
     Attributes:
-        config_schema (ConnectorDefinitionResponseConfigSchema):
-        display_name (str):
         name (str):
+        display_name (str):
+        config_schema (ConnectorDefinitionResponseConfigSchema):
         supports_credentials (bool | Unset):  Default: False.
         supports_scheduled_sync (bool | Unset):  Default: False.
     """
 
-    config_schema: ConnectorDefinitionResponseConfigSchema
-    display_name: str
     name: str
+    display_name: str
+    config_schema: ConnectorDefinitionResponseConfigSchema
     supports_credentials: bool | Unset = False
     supports_scheduled_sync: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        config_schema = self.config_schema.to_dict()
+        name = self.name
 
         display_name = self.display_name
 
-        name = self.name
+        config_schema = self.config_schema.to_dict()
 
         supports_credentials = self.supports_credentials
 
@@ -52,9 +52,9 @@ class ConnectorDefinitionResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "config_schema": config_schema,
-                "display_name": display_name,
                 "name": name,
+                "display_name": display_name,
+                "config_schema": config_schema,
             }
         )
         if supports_credentials is not UNSET:
@@ -71,22 +71,22 @@ class ConnectorDefinitionResponse:
         )
 
         d = dict(src_dict)
-        config_schema = ConnectorDefinitionResponseConfigSchema.from_dict(
-            d.pop("config_schema")
-        )
+        name = d.pop("name")
 
         display_name = d.pop("display_name")
 
-        name = d.pop("name")
+        config_schema = ConnectorDefinitionResponseConfigSchema.from_dict(
+            d.pop("config_schema")
+        )
 
         supports_credentials = d.pop("supports_credentials", UNSET)
 
         supports_scheduled_sync = d.pop("supports_scheduled_sync", UNSET)
 
         connector_definition_response = cls(
-            config_schema=config_schema,
-            display_name=display_name,
             name=name,
+            display_name=display_name,
+            config_schema=config_schema,
             supports_credentials=supports_credentials,
             supports_scheduled_sync=supports_scheduled_sync,
         )

--- a/sdks/python/geolens/models/connector_discover_request.py
+++ b/sdks/python/geolens/models/connector_discover_request.py
@@ -23,32 +23,32 @@ T = TypeVar("T", bound="ConnectorDiscoverRequest")
 class ConnectorDiscoverRequest:
     """
     Attributes:
-        config (ConnectorDiscoverRequestConfig | Unset):
         credential_id (None | str | Unset):
+        config (ConnectorDiscoverRequestConfig | Unset):
     """
 
-    config: ConnectorDiscoverRequestConfig | Unset = UNSET
     credential_id: None | str | Unset = UNSET
+    config: ConnectorDiscoverRequestConfig | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        config: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.config, Unset):
-            config = self.config.to_dict()
-
         credential_id: None | str | Unset
         if isinstance(self.credential_id, Unset):
             credential_id = UNSET
         else:
             credential_id = self.credential_id
 
+        config: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.config, Unset):
+            config = self.config.to_dict()
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if config is not UNSET:
-            field_dict["config"] = config
         if credential_id is not UNSET:
             field_dict["credential_id"] = credential_id
+        if config is not UNSET:
+            field_dict["config"] = config
 
         return field_dict
 
@@ -59,12 +59,6 @@ class ConnectorDiscoverRequest:
         )
 
         d = dict(src_dict)
-        _config = d.pop("config", UNSET)
-        config: ConnectorDiscoverRequestConfig | Unset
-        if isinstance(_config, Unset):
-            config = UNSET
-        else:
-            config = ConnectorDiscoverRequestConfig.from_dict(_config)
 
         def _parse_credential_id(data: object) -> None | str | Unset:
             if data is None:
@@ -75,9 +69,16 @@ class ConnectorDiscoverRequest:
 
         credential_id = _parse_credential_id(d.pop("credential_id", UNSET))
 
+        _config = d.pop("config", UNSET)
+        config: ConnectorDiscoverRequestConfig | Unset
+        if isinstance(_config, Unset):
+            config = UNSET
+        else:
+            config = ConnectorDiscoverRequestConfig.from_dict(_config)
+
         connector_discover_request = cls(
-            config=config,
             credential_id=credential_id,
+            config=config,
         )
 
         connector_discover_request.additional_properties = d

--- a/sdks/python/geolens/models/connector_ingest_request.py
+++ b/sdks/python/geolens/models/connector_ingest_request.py
@@ -22,27 +22,27 @@ class ConnectorIngestRequest:
     """
     Attributes:
         resource_id (str): API-safe opaque handle returned by connector discovery.
-        config (ConnectorIngestRequestConfig | Unset):
         credential_id (None | str | Unset):
+        config (ConnectorIngestRequestConfig | Unset):
     """
 
     resource_id: str
-    config: ConnectorIngestRequestConfig | Unset = UNSET
     credential_id: None | str | Unset = UNSET
+    config: ConnectorIngestRequestConfig | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         resource_id = self.resource_id
-
-        config: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.config, Unset):
-            config = self.config.to_dict()
 
         credential_id: None | str | Unset
         if isinstance(self.credential_id, Unset):
             credential_id = UNSET
         else:
             credential_id = self.credential_id
+
+        config: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.config, Unset):
+            config = self.config.to_dict()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -51,10 +51,10 @@ class ConnectorIngestRequest:
                 "resource_id": resource_id,
             }
         )
-        if config is not UNSET:
-            field_dict["config"] = config
         if credential_id is not UNSET:
             field_dict["credential_id"] = credential_id
+        if config is not UNSET:
+            field_dict["config"] = config
 
         return field_dict
 
@@ -67,13 +67,6 @@ class ConnectorIngestRequest:
         d = dict(src_dict)
         resource_id = d.pop("resource_id")
 
-        _config = d.pop("config", UNSET)
-        config: ConnectorIngestRequestConfig | Unset
-        if isinstance(_config, Unset):
-            config = UNSET
-        else:
-            config = ConnectorIngestRequestConfig.from_dict(_config)
-
         def _parse_credential_id(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -83,10 +76,17 @@ class ConnectorIngestRequest:
 
         credential_id = _parse_credential_id(d.pop("credential_id", UNSET))
 
+        _config = d.pop("config", UNSET)
+        config: ConnectorIngestRequestConfig | Unset
+        if isinstance(_config, Unset):
+            config = UNSET
+        else:
+            config = ConnectorIngestRequestConfig.from_dict(_config)
+
         connector_ingest_request = cls(
             resource_id=resource_id,
-            config=config,
             credential_id=credential_id,
+            config=config,
         )
 
         connector_ingest_request.additional_properties = d

--- a/sdks/python/geolens/models/connector_resource_response.py
+++ b/sdks/python/geolens/models/connector_resource_response.py
@@ -23,23 +23,23 @@ class ConnectorResourceResponse:
     """
     Attributes:
         id (str): API-safe opaque resource handle. This is never a provider URL, signed locator, or credential.
-        kind (str):
         name (str):
+        kind (str):
         metadata (ConnectorResourceResponseMetadata | Unset):
     """
 
     id: str
-    kind: str
     name: str
+    kind: str
     metadata: ConnectorResourceResponseMetadata | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         id = self.id
 
-        kind = self.kind
-
         name = self.name
+
+        kind = self.kind
 
         metadata: dict[str, Any] | Unset = UNSET
         if not isinstance(self.metadata, Unset):
@@ -50,8 +50,8 @@ class ConnectorResourceResponse:
         field_dict.update(
             {
                 "id": id,
-                "kind": kind,
                 "name": name,
+                "kind": kind,
             }
         )
         if metadata is not UNSET:
@@ -68,9 +68,9 @@ class ConnectorResourceResponse:
         d = dict(src_dict)
         id = d.pop("id")
 
-        kind = d.pop("kind")
-
         name = d.pop("name")
+
+        kind = d.pop("kind")
 
         _metadata = d.pop("metadata", UNSET)
         metadata: ConnectorResourceResponseMetadata | Unset
@@ -81,8 +81,8 @@ class ConnectorResourceResponse:
 
         connector_resource_response = cls(
             id=id,
-            kind=kind,
             name=name,
+            kind=kind,
             metadata=metadata,
         )
 

--- a/sdks/python/geolens/models/contact_create.py
+++ b/sdks/python/geolens/models/contact_create.py
@@ -22,20 +22,20 @@ class ContactCreate:
     """
     Attributes:
         role (str): ISO CI_RoleCode, e.g. pointOfContact, author
-        email (None | str | Unset):
-        extra_json (ContactCreateExtraJsonType0 | None | Unset): Arbitrary extra fields stored as JSON
         name (None | str | Unset):
+        email (None | str | Unset):
         organization (None | str | Unset):
         phone (None | str | Unset):
+        extra_json (ContactCreateExtraJsonType0 | None | Unset): Arbitrary extra fields stored as JSON
         sort_order (int | Unset): Display ordering (lower first) Default: 0.
     """
 
     role: str
-    email: None | str | Unset = UNSET
-    extra_json: ContactCreateExtraJsonType0 | None | Unset = UNSET
     name: None | str | Unset = UNSET
+    email: None | str | Unset = UNSET
     organization: None | str | Unset = UNSET
     phone: None | str | Unset = UNSET
+    extra_json: ContactCreateExtraJsonType0 | None | Unset = UNSET
     sort_order: int | Unset = 0
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -46,25 +46,17 @@ class ContactCreate:
 
         role = self.role
 
-        email: None | str | Unset
-        if isinstance(self.email, Unset):
-            email = UNSET
-        else:
-            email = self.email
-
-        extra_json: dict[str, Any] | None | Unset
-        if isinstance(self.extra_json, Unset):
-            extra_json = UNSET
-        elif isinstance(self.extra_json, ContactCreateExtraJsonType0):
-            extra_json = self.extra_json.to_dict()
-        else:
-            extra_json = self.extra_json
-
         name: None | str | Unset
         if isinstance(self.name, Unset):
             name = UNSET
         else:
             name = self.name
+
+        email: None | str | Unset
+        if isinstance(self.email, Unset):
+            email = UNSET
+        else:
+            email = self.email
 
         organization: None | str | Unset
         if isinstance(self.organization, Unset):
@@ -78,6 +70,14 @@ class ContactCreate:
         else:
             phone = self.phone
 
+        extra_json: dict[str, Any] | None | Unset
+        if isinstance(self.extra_json, Unset):
+            extra_json = UNSET
+        elif isinstance(self.extra_json, ContactCreateExtraJsonType0):
+            extra_json = self.extra_json.to_dict()
+        else:
+            extra_json = self.extra_json
+
         sort_order = self.sort_order
 
         field_dict: dict[str, Any] = {}
@@ -87,16 +87,16 @@ class ContactCreate:
                 "role": role,
             }
         )
-        if email is not UNSET:
-            field_dict["email"] = email
-        if extra_json is not UNSET:
-            field_dict["extra_json"] = extra_json
         if name is not UNSET:
             field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
         if organization is not UNSET:
             field_dict["organization"] = organization
         if phone is not UNSET:
             field_dict["phone"] = phone
+        if extra_json is not UNSET:
+            field_dict["extra_json"] = extra_json
         if sort_order is not UNSET:
             field_dict["sort_order"] = sort_order
 
@@ -111,6 +111,15 @@ class ContactCreate:
         d = dict(src_dict)
         role = d.pop("role")
 
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
         def _parse_email(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -119,6 +128,24 @@ class ContactCreate:
             return cast(None | str | Unset, data)
 
         email = _parse_email(d.pop("email", UNSET))
+
+        def _parse_organization(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        organization = _parse_organization(d.pop("organization", UNSET))
+
+        def _parse_phone(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        phone = _parse_phone(d.pop("phone", UNSET))
 
         def _parse_extra_json(
             data: object,
@@ -139,42 +166,15 @@ class ContactCreate:
 
         extra_json = _parse_extra_json(d.pop("extra_json", UNSET))
 
-        def _parse_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        name = _parse_name(d.pop("name", UNSET))
-
-        def _parse_organization(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        organization = _parse_organization(d.pop("organization", UNSET))
-
-        def _parse_phone(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        phone = _parse_phone(d.pop("phone", UNSET))
-
         sort_order = d.pop("sort_order", UNSET)
 
         contact_create = cls(
             role=role,
-            email=email,
-            extra_json=extra_json,
             name=name,
+            email=email,
             organization=organization,
             phone=phone,
+            extra_json=extra_json,
             sort_order=sort_order,
         )
 

--- a/sdks/python/geolens/models/contact_response.py
+++ b/sdks/python/geolens/models/contact_response.py
@@ -23,25 +23,25 @@ T = TypeVar("T", bound="ContactResponse")
 class ContactResponse:
     """
     Attributes:
-        email (None | str):
-        extra_json (ContactResponseExtraJsonType0 | None):
         id (UUID):
-        name (None | str):
-        organization (None | str):
-        phone (None | str):
         record_id (UUID):
         role (str):
+        name (None | str):
+        email (None | str):
+        organization (None | str):
+        phone (None | str):
+        extra_json (ContactResponseExtraJsonType0 | None):
         sort_order (int):
     """
 
-    email: None | str
-    extra_json: ContactResponseExtraJsonType0 | None
     id: UUID
-    name: None | str
-    organization: None | str
-    phone: None | str
     record_id: UUID
     role: str
+    name: None | str
+    email: None | str
+    organization: None | str
+    phone: None | str
+    extra_json: ContactResponseExtraJsonType0 | None
     sort_order: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -50,19 +50,17 @@ class ContactResponse:
             ContactResponseExtraJsonType0,
         )
 
-        email: None | str
-        email = self.email
-
-        extra_json: dict[str, Any] | None
-        if isinstance(self.extra_json, ContactResponseExtraJsonType0):
-            extra_json = self.extra_json.to_dict()
-        else:
-            extra_json = self.extra_json
-
         id = str(self.id)
+
+        record_id = str(self.record_id)
+
+        role = self.role
 
         name: None | str
         name = self.name
+
+        email: None | str
+        email = self.email
 
         organization: None | str
         organization = self.organization
@@ -70,9 +68,11 @@ class ContactResponse:
         phone: None | str
         phone = self.phone
 
-        record_id = str(self.record_id)
-
-        role = self.role
+        extra_json: dict[str, Any] | None
+        if isinstance(self.extra_json, ContactResponseExtraJsonType0):
+            extra_json = self.extra_json.to_dict()
+        else:
+            extra_json = self.extra_json
 
         sort_order = self.sort_order
 
@@ -80,14 +80,14 @@ class ContactResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "email": email,
-                "extra_json": extra_json,
                 "id": id,
-                "name": name,
-                "organization": organization,
-                "phone": phone,
                 "record_id": record_id,
                 "role": role,
+                "name": name,
+                "email": email,
+                "organization": organization,
+                "phone": phone,
+                "extra_json": extra_json,
                 "sort_order": sort_order,
             }
         )
@@ -101,6 +101,18 @@ class ContactResponse:
         )
 
         d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        record_id = UUID(d.pop("record_id"))
+
+        role = d.pop("role")
+
+        def _parse_name(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        name = _parse_name(d.pop("name"))
 
         def _parse_email(data: object) -> None | str:
             if data is None:
@@ -108,6 +120,20 @@ class ContactResponse:
             return cast(None | str, data)
 
         email = _parse_email(d.pop("email"))
+
+        def _parse_organization(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        organization = _parse_organization(d.pop("organization"))
+
+        def _parse_phone(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        phone = _parse_phone(d.pop("phone"))
 
         def _parse_extra_json(data: object) -> ContactResponseExtraJsonType0 | None:
             if data is None:
@@ -124,44 +150,17 @@ class ContactResponse:
 
         extra_json = _parse_extra_json(d.pop("extra_json"))
 
-        id = UUID(d.pop("id"))
-
-        def _parse_name(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        name = _parse_name(d.pop("name"))
-
-        def _parse_organization(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        organization = _parse_organization(d.pop("organization"))
-
-        def _parse_phone(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        phone = _parse_phone(d.pop("phone"))
-
-        record_id = UUID(d.pop("record_id"))
-
-        role = d.pop("role")
-
         sort_order = d.pop("sort_order")
 
         contact_response = cls(
-            email=email,
-            extra_json=extra_json,
             id=id,
-            name=name,
-            organization=organization,
-            phone=phone,
             record_id=record_id,
             role=role,
+            name=name,
+            email=email,
+            organization=organization,
+            phone=phone,
+            extra_json=extra_json,
             sort_order=sort_order,
         )
 

--- a/sdks/python/geolens/models/contact_update.py
+++ b/sdks/python/geolens/models/contact_update.py
@@ -21,21 +21,21 @@ T = TypeVar("T", bound="ContactUpdate")
 class ContactUpdate:
     """
     Attributes:
-        email (None | str | Unset):
-        extra_json (ContactUpdateExtraJsonType0 | None | Unset):
+        role (None | str | Unset):
         name (None | str | Unset):
+        email (None | str | Unset):
         organization (None | str | Unset):
         phone (None | str | Unset):
-        role (None | str | Unset):
+        extra_json (ContactUpdateExtraJsonType0 | None | Unset):
         sort_order (int | None | Unset):
     """
 
-    email: None | str | Unset = UNSET
-    extra_json: ContactUpdateExtraJsonType0 | None | Unset = UNSET
+    role: None | str | Unset = UNSET
     name: None | str | Unset = UNSET
+    email: None | str | Unset = UNSET
     organization: None | str | Unset = UNSET
     phone: None | str | Unset = UNSET
-    role: None | str | Unset = UNSET
+    extra_json: ContactUpdateExtraJsonType0 | None | Unset = UNSET
     sort_order: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -44,25 +44,23 @@ class ContactUpdate:
             ContactUpdateExtraJsonType0,
         )
 
-        email: None | str | Unset
-        if isinstance(self.email, Unset):
-            email = UNSET
+        role: None | str | Unset
+        if isinstance(self.role, Unset):
+            role = UNSET
         else:
-            email = self.email
-
-        extra_json: dict[str, Any] | None | Unset
-        if isinstance(self.extra_json, Unset):
-            extra_json = UNSET
-        elif isinstance(self.extra_json, ContactUpdateExtraJsonType0):
-            extra_json = self.extra_json.to_dict()
-        else:
-            extra_json = self.extra_json
+            role = self.role
 
         name: None | str | Unset
         if isinstance(self.name, Unset):
             name = UNSET
         else:
             name = self.name
+
+        email: None | str | Unset
+        if isinstance(self.email, Unset):
+            email = UNSET
+        else:
+            email = self.email
 
         organization: None | str | Unset
         if isinstance(self.organization, Unset):
@@ -76,11 +74,13 @@ class ContactUpdate:
         else:
             phone = self.phone
 
-        role: None | str | Unset
-        if isinstance(self.role, Unset):
-            role = UNSET
+        extra_json: dict[str, Any] | None | Unset
+        if isinstance(self.extra_json, Unset):
+            extra_json = UNSET
+        elif isinstance(self.extra_json, ContactUpdateExtraJsonType0):
+            extra_json = self.extra_json.to_dict()
         else:
-            role = self.role
+            extra_json = self.extra_json
 
         sort_order: int | None | Unset
         if isinstance(self.sort_order, Unset):
@@ -91,18 +91,18 @@ class ContactUpdate:
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if email is not UNSET:
-            field_dict["email"] = email
-        if extra_json is not UNSET:
-            field_dict["extra_json"] = extra_json
+        if role is not UNSET:
+            field_dict["role"] = role
         if name is not UNSET:
             field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
         if organization is not UNSET:
             field_dict["organization"] = organization
         if phone is not UNSET:
             field_dict["phone"] = phone
-        if role is not UNSET:
-            field_dict["role"] = role
+        if extra_json is not UNSET:
+            field_dict["extra_json"] = extra_json
         if sort_order is not UNSET:
             field_dict["sort_order"] = sort_order
 
@@ -116,6 +116,24 @@ class ContactUpdate:
 
         d = dict(src_dict)
 
+        def _parse_role(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        role = _parse_role(d.pop("role", UNSET))
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
         def _parse_email(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -124,6 +142,24 @@ class ContactUpdate:
             return cast(None | str | Unset, data)
 
         email = _parse_email(d.pop("email", UNSET))
+
+        def _parse_organization(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        organization = _parse_organization(d.pop("organization", UNSET))
+
+        def _parse_phone(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        phone = _parse_phone(d.pop("phone", UNSET))
 
         def _parse_extra_json(
             data: object,
@@ -144,42 +180,6 @@ class ContactUpdate:
 
         extra_json = _parse_extra_json(d.pop("extra_json", UNSET))
 
-        def _parse_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        name = _parse_name(d.pop("name", UNSET))
-
-        def _parse_organization(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        organization = _parse_organization(d.pop("organization", UNSET))
-
-        def _parse_phone(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        phone = _parse_phone(d.pop("phone", UNSET))
-
-        def _parse_role(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        role = _parse_role(d.pop("role", UNSET))
-
         def _parse_sort_order(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -190,12 +190,12 @@ class ContactUpdate:
         sort_order = _parse_sort_order(d.pop("sort_order", UNSET))
 
         contact_update = cls(
-            email=email,
-            extra_json=extra_json,
+            role=role,
             name=name,
+            email=email,
             organization=organization,
             phone=phone,
-            role=role,
+            extra_json=extra_json,
             sort_order=sort_order,
         )
 

--- a/sdks/python/geolens/models/create_empty_dataset_request.py
+++ b/sdks/python/geolens/models/create_empty_dataset_request.py
@@ -18,28 +18,28 @@ T = TypeVar("T", bound="CreateEmptyDatasetRequest")
 class CreateEmptyDatasetRequest:
     """
     Attributes:
-        columns (list[ColumnDefinition]):
         title (str):
+        columns (list[ColumnDefinition]):
     """
 
-    columns: list[ColumnDefinition]
     title: str
+    columns: list[ColumnDefinition]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
         columns = []
         for columns_item_data in self.columns:
             columns_item = columns_item_data.to_dict()
             columns.append(columns_item)
 
-        title = self.title
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "columns": columns,
                 "title": title,
+                "columns": columns,
             }
         )
 
@@ -50,6 +50,8 @@ class CreateEmptyDatasetRequest:
         from ..models.column_definition import ColumnDefinition
 
         d = dict(src_dict)
+        title = d.pop("title")
+
         columns = []
         _columns = d.pop("columns")
         for columns_item_data in _columns:
@@ -57,11 +59,9 @@ class CreateEmptyDatasetRequest:
 
             columns.append(columns_item)
 
-        title = d.pop("title")
-
         create_empty_dataset_request = cls(
-            columns=columns,
             title=title,
+            columns=columns,
         )
 
         create_empty_dataset_request.additional_properties = d

--- a/sdks/python/geolens/models/create_feature_datasets_dataset_id_features_post_geo_json_feature.py
+++ b/sdks/python/geolens/models/create_feature_datasets_dataset_id_features_post_geo_json_feature.py
@@ -33,20 +33,20 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeature:
     Attributes:
         id (int):
         properties (CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureProperties):
+        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
         geometry (CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometry |
             CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCollection | None | Unset):
-        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
     """
 
     id: int
     properties: CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureProperties
+    type_: Literal["Feature"] | Unset = "Feature"
     geometry: (
         CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometry
         | CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCollection
         | None
         | Unset
     ) = UNSET
-    type_: Literal["Feature"] | Unset = "Feature"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -60,6 +60,8 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeature:
         id = self.id
 
         properties = self.properties.to_dict()
+
+        type_ = self.type_
 
         geometry: dict[str, Any] | None | Unset
         if isinstance(self.geometry, Unset):
@@ -77,8 +79,6 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeature:
         else:
             geometry = self.geometry
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -87,10 +87,10 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeature:
                 "properties": properties,
             }
         )
-        if geometry is not UNSET:
-            field_dict["geometry"] = geometry
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if geometry is not UNSET:
+            field_dict["geometry"] = geometry
 
         return field_dict
 
@@ -112,6 +112,10 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeature:
         properties = CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureProperties.from_dict(
             d.pop("properties")
         )
+
+        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
+        if type_ != "Feature" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'Feature', got '{type_}'")
 
         def _parse_geometry(
             data: object,
@@ -155,15 +159,11 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeature:
 
         geometry = _parse_geometry(d.pop("geometry", UNSET))
 
-        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
-        if type_ != "Feature" and not isinstance(type_, Unset):
-            raise ValueError(f"type must match const 'Feature', got '{type_}'")
-
         create_feature_datasets_dataset_id_features_post_geo_json_feature = cls(
             id=id,
             properties=properties,
-            geometry=geometry,
             type_=type_,
+            geometry=geometry,
         )
 
         create_feature_datasets_dataset_id_features_post_geo_json_feature.additional_properties = d

--- a/sdks/python/geolens/models/create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry.py
+++ b/sdks/python/geolens/models/create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry.py
@@ -26,25 +26,25 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometry:
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_ (CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -53,15 +53,15 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometry:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry_collection.py
+++ b/sdks/python/geolens/models/create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry_collection.py
@@ -39,31 +39,31 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCol
     database 500. The write schemas add a raw-payload guard for a clear 422.
 
         Attributes:
+            type_ (Literal['GeometryCollection']):
             geometries
                 (list[CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometry]):
-            type_ (Literal['GeometryCollection']):
     """
 
+    type_: Literal["GeometryCollection"]
     geometries: list[
         CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometry
     ]
-    type_: Literal["GeometryCollection"]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
         geometries = []
         for geometries_item_data in self.geometries:
             geometries_item = geometries_item_data.to_dict()
             geometries.append(geometries_item)
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "geometries": geometries,
                 "type": type_,
+                "geometries": geometries,
             }
         )
 
@@ -76,6 +76,12 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCol
         )
 
         d = dict(src_dict)
+        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
+        if type_ != "GeometryCollection":
+            raise ValueError(
+                f"type must match const 'GeometryCollection', got '{type_}'"
+            )
+
         geometries = []
         _geometries = d.pop("geometries")
         for geometries_item_data in _geometries:
@@ -85,15 +91,9 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCol
 
             geometries.append(geometries_item)
 
-        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
-        if type_ != "GeometryCollection":
-            raise ValueError(
-                f"type must match const 'GeometryCollection', got '{type_}'"
-            )
-
         create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry_collection = cls(
-            geometries=geometries,
             type_=type_,
+            geometries=geometries,
         )
 
         create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry_collection.additional_properties = d

--- a/sdks/python/geolens/models/create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.py
+++ b/sdks/python/geolens/models/create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.py
@@ -27,25 +27,25 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCol
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_ (CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -54,15 +54,15 @@ class CreateFeatureDatasetsDatasetIdFeaturesPostGeoJSONFeatureGeoJSONGeometryCol
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry_collection_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry_collection_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         create_feature_datasets_dataset_id_features_post_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/create_layer_request.py
+++ b/sdks/python/geolens/models/create_layer_request.py
@@ -21,23 +21,29 @@ T = TypeVar("T", bound="CreateLayerRequest")
 class CreateLayerRequest:
     """
     Attributes:
+        title (str): Display name for the new layer Example: Survey Points.
         geometry_type (str): OGC geometry type: Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon
             Example: Point.
-        title (str): Display name for the new layer Example: Survey Points.
-        columns (list[ColumnDef] | None | Unset): Optional initial column definitions
         summary (None | str | Unset): Optional text description of the layer
+        columns (list[ColumnDef] | None | Unset): Optional initial column definitions
     """
 
-    geometry_type: str
     title: str
-    columns: list[ColumnDef] | None | Unset = UNSET
+    geometry_type: str
     summary: None | str | Unset = UNSET
+    columns: list[ColumnDef] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
         geometry_type = self.geometry_type
 
-        title = self.title
+        summary: None | str | Unset
+        if isinstance(self.summary, Unset):
+            summary = UNSET
+        else:
+            summary = self.summary
 
         columns: list[dict[str, Any]] | None | Unset
         if isinstance(self.columns, Unset):
@@ -51,24 +57,18 @@ class CreateLayerRequest:
         else:
             columns = self.columns
 
-        summary: None | str | Unset
-        if isinstance(self.summary, Unset):
-            summary = UNSET
-        else:
-            summary = self.summary
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "geometry_type": geometry_type,
                 "title": title,
+                "geometry_type": geometry_type,
             }
         )
-        if columns is not UNSET:
-            field_dict["columns"] = columns
         if summary is not UNSET:
             field_dict["summary"] = summary
+        if columns is not UNSET:
+            field_dict["columns"] = columns
 
         return field_dict
 
@@ -77,9 +77,18 @@ class CreateLayerRequest:
         from ..models.column_def import ColumnDef
 
         d = dict(src_dict)
+        title = d.pop("title")
+
         geometry_type = d.pop("geometry_type")
 
-        title = d.pop("title")
+        def _parse_summary(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        summary = _parse_summary(d.pop("summary", UNSET))
 
         def _parse_columns(data: object) -> list[ColumnDef] | None | Unset:
             if data is None:
@@ -103,20 +112,11 @@ class CreateLayerRequest:
 
         columns = _parse_columns(d.pop("columns", UNSET))
 
-        def _parse_summary(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        summary = _parse_summary(d.pop("summary", UNSET))
-
         create_layer_request = cls(
-            geometry_type=geometry_type,
             title=title,
-            columns=columns,
+            geometry_type=geometry_type,
             summary=summary,
+            columns=columns,
         )
 
         create_layer_request.additional_properties = d

--- a/sdks/python/geolens/models/create_layer_response.py
+++ b/sdks/python/geolens/models/create_layer_response.py
@@ -19,50 +19,50 @@ T = TypeVar("T", bound="CreateLayerResponse")
 class CreateLayerResponse:
     """
     Attributes:
-        created_at (datetime.datetime): Creation timestamp
-        feature_count (int): Number of features (0 for new layers)
-        geometry_type (str): OGC geometry type
         id (UUID): Dataset ID of the created layer
-        table_name (str): PostGIS table name in the data schema
         title (str): Display name
+        table_name (str): PostGIS table name in the data schema
+        geometry_type (str): OGC geometry type
+        feature_count (int): Number of features (0 for new layers)
         visibility (str): Visibility level: private, internal, or public
+        created_at (datetime.datetime): Creation timestamp
     """
 
-    created_at: datetime.datetime
-    feature_count: int
-    geometry_type: str
     id: UUID
-    table_name: str
     title: str
+    table_name: str
+    geometry_type: str
+    feature_count: int
     visibility: str
+    created_at: datetime.datetime
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
-
-        feature_count = self.feature_count
-
-        geometry_type = self.geometry_type
-
         id = str(self.id)
-
-        table_name = self.table_name
 
         title = self.title
 
+        table_name = self.table_name
+
+        geometry_type = self.geometry_type
+
+        feature_count = self.feature_count
+
         visibility = self.visibility
+
+        created_at = self.created_at.isoformat()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "feature_count": feature_count,
-                "geometry_type": geometry_type,
                 "id": id,
-                "table_name": table_name,
                 "title": title,
+                "table_name": table_name,
+                "geometry_type": geometry_type,
+                "feature_count": feature_count,
                 "visibility": visibility,
+                "created_at": created_at,
             }
         )
 
@@ -71,28 +71,28 @@ class CreateLayerResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
-
-        feature_count = d.pop("feature_count")
-
-        geometry_type = d.pop("geometry_type")
-
         id = UUID(d.pop("id"))
-
-        table_name = d.pop("table_name")
 
         title = d.pop("title")
 
+        table_name = d.pop("table_name")
+
+        geometry_type = d.pop("geometry_type")
+
+        feature_count = d.pop("feature_count")
+
         visibility = d.pop("visibility")
 
+        created_at = isoparse(d.pop("created_at"))
+
         create_layer_response = cls(
-            created_at=created_at,
-            feature_count=feature_count,
-            geometry_type=geometry_type,
             id=id,
-            table_name=table_name,
             title=title,
+            table_name=table_name,
+            geometry_type=geometry_type,
+            feature_count=feature_count,
             visibility=visibility,
+            created_at=created_at,
         )
 
         create_layer_response.additional_properties = d

--- a/sdks/python/geolens/models/dataset_chat_request.py
+++ b/sdks/python/geolens/models/dataset_chat_request.py
@@ -25,22 +25,28 @@ class DatasetChatRequest:
     authoritatively from the DB — the client only names the dataset.
 
         Attributes:
-            dataset_id (str):
             message (str):
-            history (list[ChatHistoryMessage] | Unset):
+            dataset_id (str):
             language (None | str | Unset):
+            history (list[ChatHistoryMessage] | Unset):
     """
 
-    dataset_id: str
     message: str
-    history: list[ChatHistoryMessage] | Unset = UNSET
+    dataset_id: str
     language: None | str | Unset = UNSET
+    history: list[ChatHistoryMessage] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        message = self.message
+
         dataset_id = self.dataset_id
 
-        message = self.message
+        language: None | str | Unset
+        if isinstance(self.language, Unset):
+            language = UNSET
+        else:
+            language = self.language
 
         history: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.history, Unset):
@@ -49,24 +55,18 @@ class DatasetChatRequest:
                 history_item = history_item_data.to_dict()
                 history.append(history_item)
 
-        language: None | str | Unset
-        if isinstance(self.language, Unset):
-            language = UNSET
-        else:
-            language = self.language
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "dataset_id": dataset_id,
                 "message": message,
+                "dataset_id": dataset_id,
             }
         )
-        if history is not UNSET:
-            field_dict["history"] = history
         if language is not UNSET:
             field_dict["language"] = language
+        if history is not UNSET:
+            field_dict["history"] = history
 
         return field_dict
 
@@ -75,18 +75,9 @@ class DatasetChatRequest:
         from ..models.chat_history_message import ChatHistoryMessage
 
         d = dict(src_dict)
-        dataset_id = d.pop("dataset_id")
-
         message = d.pop("message")
 
-        _history = d.pop("history", UNSET)
-        history: list[ChatHistoryMessage] | Unset = UNSET
-        if _history is not UNSET:
-            history = []
-            for history_item_data in _history:
-                history_item = ChatHistoryMessage.from_dict(history_item_data)
-
-                history.append(history_item)
+        dataset_id = d.pop("dataset_id")
 
         def _parse_language(data: object) -> None | str | Unset:
             if data is None:
@@ -97,11 +88,20 @@ class DatasetChatRequest:
 
         language = _parse_language(d.pop("language", UNSET))
 
+        _history = d.pop("history", UNSET)
+        history: list[ChatHistoryMessage] | Unset = UNSET
+        if _history is not UNSET:
+            history = []
+            for history_item_data in _history:
+                history_item = ChatHistoryMessage.from_dict(history_item_data)
+
+                history.append(history_item)
+
         dataset_chat_request = cls(
-            dataset_id=dataset_id,
             message=message,
-            history=history,
+            dataset_id=dataset_id,
             language=language,
+            history=history,
         )
 
         dataset_chat_request.additional_properties = d

--- a/sdks/python/geolens/models/dataset_meta.py
+++ b/sdks/python/geolens/models/dataset_meta.py
@@ -26,67 +26,85 @@ class DatasetMeta:
     new backend call sites use the ``DatasetMetaUpdate`` alias below.
 
         Attributes:
-            access_constraints (None | str | Unset):
-            data_vintage_end (datetime.date | None | Unset): End of temporal coverage
-            data_vintage_start (datetime.date | None | Unset): Start of temporal coverage
-            is_dem (bool | None | Unset): Flag raster as a Digital Elevation Model for terrain rendering
-            language (None | str | Unset): BCP 47 primary language tag, e.g. en, fr, or pt-BR
+            title (None | str | Unset):
+            summary (None | str | Unset):
+            visibility (DatasetMetaVisibilityType0 | None | Unset): Access level: private, restricted, internal, or public
             license_ (None | str | Unset):
+            source_organization (None | str | Unset):
+            data_vintage_start (datetime.date | None | Unset): Start of temporal coverage
+            data_vintage_end (datetime.date | None | Unset): End of temporal coverage
             lineage_summary (None | str | Unset): Free-text provenance / lineage statement
-            owner_org (None | str | Unset): Owning organization name
-            quality_statement (None | str | Unset):
+            update_frequency (None | str | Unset): ISO maintenance frequency code
+            usage_constraints (None | str | Unset):
+            access_constraints (None | str | Unset):
+            sensitivity_classification (None | str | Unset): e.g. public, confidential, restricted
+            theme_category (list[str] | None | Unset): ISO topic category codes
             record_status (None | str | Unset): Lifecycle status. Deliberately not pinned to an enum: the values come from
                 the workflow extension's status_order(), so an overlay may define its own. Community default order: draft,
                 ready, internal, published.
-            sensitivity_classification (None | str | Unset): e.g. public, confidential, restricted
-            source_organization (None | str | Unset):
+            owner_org (None | str | Unset): Owning organization name
+            quality_statement (None | str | Unset):
             source_url (None | str | Unset): URL the data was originally fetched from
-            summary (None | str | Unset):
-            theme_category (list[str] | None | Unset): ISO topic category codes
+            language (None | str | Unset): BCP 47 primary language tag, e.g. en, fr, or pt-BR
+            is_dem (bool | None | Unset): Flag raster as a Digital Elevation Model for terrain rendering
             tile_columns (list[str] | None | Unset): Ordered vector-tile property allowlist; null restores zoom defaults, []
                 emits geometry-only tiles, list emits those properties at any zoom.
-            title (None | str | Unset):
-            update_frequency (None | str | Unset): ISO maintenance frequency code
-            usage_constraints (None | str | Unset):
-            visibility (DatasetMetaVisibilityType0 | None | Unset): Access level: private, restricted, internal, or public
     """
 
-    access_constraints: None | str | Unset = UNSET
-    data_vintage_end: datetime.date | None | Unset = UNSET
-    data_vintage_start: datetime.date | None | Unset = UNSET
-    is_dem: bool | None | Unset = UNSET
-    language: None | str | Unset = UNSET
-    license_: None | str | Unset = UNSET
-    lineage_summary: None | str | Unset = UNSET
-    owner_org: None | str | Unset = UNSET
-    quality_statement: None | str | Unset = UNSET
-    record_status: None | str | Unset = UNSET
-    sensitivity_classification: None | str | Unset = UNSET
-    source_organization: None | str | Unset = UNSET
-    source_url: None | str | Unset = UNSET
-    summary: None | str | Unset = UNSET
-    theme_category: list[str] | None | Unset = UNSET
-    tile_columns: list[str] | None | Unset = UNSET
     title: None | str | Unset = UNSET
+    summary: None | str | Unset = UNSET
+    visibility: DatasetMetaVisibilityType0 | None | Unset = UNSET
+    license_: None | str | Unset = UNSET
+    source_organization: None | str | Unset = UNSET
+    data_vintage_start: datetime.date | None | Unset = UNSET
+    data_vintage_end: datetime.date | None | Unset = UNSET
+    lineage_summary: None | str | Unset = UNSET
     update_frequency: None | str | Unset = UNSET
     usage_constraints: None | str | Unset = UNSET
-    visibility: DatasetMetaVisibilityType0 | None | Unset = UNSET
+    access_constraints: None | str | Unset = UNSET
+    sensitivity_classification: None | str | Unset = UNSET
+    theme_category: list[str] | None | Unset = UNSET
+    record_status: None | str | Unset = UNSET
+    owner_org: None | str | Unset = UNSET
+    quality_statement: None | str | Unset = UNSET
+    source_url: None | str | Unset = UNSET
+    language: None | str | Unset = UNSET
+    is_dem: bool | None | Unset = UNSET
+    tile_columns: list[str] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        access_constraints: None | str | Unset
-        if isinstance(self.access_constraints, Unset):
-            access_constraints = UNSET
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
         else:
-            access_constraints = self.access_constraints
+            title = self.title
 
-        data_vintage_end: None | str | Unset
-        if isinstance(self.data_vintage_end, Unset):
-            data_vintage_end = UNSET
-        elif isinstance(self.data_vintage_end, datetime.date):
-            data_vintage_end = self.data_vintage_end.isoformat()
+        summary: None | str | Unset
+        if isinstance(self.summary, Unset):
+            summary = UNSET
         else:
-            data_vintage_end = self.data_vintage_end
+            summary = self.summary
+
+        visibility: None | str | Unset
+        if isinstance(self.visibility, Unset):
+            visibility = UNSET
+        elif isinstance(self.visibility, str):
+            visibility = self.visibility
+        else:
+            visibility = self.visibility
+
+        license_: None | str | Unset
+        if isinstance(self.license_, Unset):
+            license_ = UNSET
+        else:
+            license_ = self.license_
+
+        source_organization: None | str | Unset
+        if isinstance(self.source_organization, Unset):
+            source_organization = UNSET
+        else:
+            source_organization = self.source_organization
 
         data_vintage_start: None | str | Unset
         if isinstance(self.data_vintage_start, Unset):
@@ -96,95 +114,19 @@ class DatasetMeta:
         else:
             data_vintage_start = self.data_vintage_start
 
-        is_dem: bool | None | Unset
-        if isinstance(self.is_dem, Unset):
-            is_dem = UNSET
+        data_vintage_end: None | str | Unset
+        if isinstance(self.data_vintage_end, Unset):
+            data_vintage_end = UNSET
+        elif isinstance(self.data_vintage_end, datetime.date):
+            data_vintage_end = self.data_vintage_end.isoformat()
         else:
-            is_dem = self.is_dem
-
-        language: None | str | Unset
-        if isinstance(self.language, Unset):
-            language = UNSET
-        else:
-            language = self.language
-
-        license_: None | str | Unset
-        if isinstance(self.license_, Unset):
-            license_ = UNSET
-        else:
-            license_ = self.license_
+            data_vintage_end = self.data_vintage_end
 
         lineage_summary: None | str | Unset
         if isinstance(self.lineage_summary, Unset):
             lineage_summary = UNSET
         else:
             lineage_summary = self.lineage_summary
-
-        owner_org: None | str | Unset
-        if isinstance(self.owner_org, Unset):
-            owner_org = UNSET
-        else:
-            owner_org = self.owner_org
-
-        quality_statement: None | str | Unset
-        if isinstance(self.quality_statement, Unset):
-            quality_statement = UNSET
-        else:
-            quality_statement = self.quality_statement
-
-        record_status: None | str | Unset
-        if isinstance(self.record_status, Unset):
-            record_status = UNSET
-        else:
-            record_status = self.record_status
-
-        sensitivity_classification: None | str | Unset
-        if isinstance(self.sensitivity_classification, Unset):
-            sensitivity_classification = UNSET
-        else:
-            sensitivity_classification = self.sensitivity_classification
-
-        source_organization: None | str | Unset
-        if isinstance(self.source_organization, Unset):
-            source_organization = UNSET
-        else:
-            source_organization = self.source_organization
-
-        source_url: None | str | Unset
-        if isinstance(self.source_url, Unset):
-            source_url = UNSET
-        else:
-            source_url = self.source_url
-
-        summary: None | str | Unset
-        if isinstance(self.summary, Unset):
-            summary = UNSET
-        else:
-            summary = self.summary
-
-        theme_category: list[str] | None | Unset
-        if isinstance(self.theme_category, Unset):
-            theme_category = UNSET
-        elif isinstance(self.theme_category, list):
-            theme_category = self.theme_category
-
-        else:
-            theme_category = self.theme_category
-
-        tile_columns: list[str] | None | Unset
-        if isinstance(self.tile_columns, Unset):
-            tile_columns = UNSET
-        elif isinstance(self.tile_columns, list):
-            tile_columns = self.tile_columns
-
-        else:
-            tile_columns = self.tile_columns
-
-        title: None | str | Unset
-        if isinstance(self.title, Unset):
-            title = UNSET
-        else:
-            title = self.title
 
         update_frequency: None | str | Unset
         if isinstance(self.update_frequency, Unset):
@@ -198,247 +140,121 @@ class DatasetMeta:
         else:
             usage_constraints = self.usage_constraints
 
-        visibility: None | str | Unset
-        if isinstance(self.visibility, Unset):
-            visibility = UNSET
-        elif isinstance(self.visibility, str):
-            visibility = self.visibility
+        access_constraints: None | str | Unset
+        if isinstance(self.access_constraints, Unset):
+            access_constraints = UNSET
         else:
-            visibility = self.visibility
+            access_constraints = self.access_constraints
+
+        sensitivity_classification: None | str | Unset
+        if isinstance(self.sensitivity_classification, Unset):
+            sensitivity_classification = UNSET
+        else:
+            sensitivity_classification = self.sensitivity_classification
+
+        theme_category: list[str] | None | Unset
+        if isinstance(self.theme_category, Unset):
+            theme_category = UNSET
+        elif isinstance(self.theme_category, list):
+            theme_category = self.theme_category
+
+        else:
+            theme_category = self.theme_category
+
+        record_status: None | str | Unset
+        if isinstance(self.record_status, Unset):
+            record_status = UNSET
+        else:
+            record_status = self.record_status
+
+        owner_org: None | str | Unset
+        if isinstance(self.owner_org, Unset):
+            owner_org = UNSET
+        else:
+            owner_org = self.owner_org
+
+        quality_statement: None | str | Unset
+        if isinstance(self.quality_statement, Unset):
+            quality_statement = UNSET
+        else:
+            quality_statement = self.quality_statement
+
+        source_url: None | str | Unset
+        if isinstance(self.source_url, Unset):
+            source_url = UNSET
+        else:
+            source_url = self.source_url
+
+        language: None | str | Unset
+        if isinstance(self.language, Unset):
+            language = UNSET
+        else:
+            language = self.language
+
+        is_dem: bool | None | Unset
+        if isinstance(self.is_dem, Unset):
+            is_dem = UNSET
+        else:
+            is_dem = self.is_dem
+
+        tile_columns: list[str] | None | Unset
+        if isinstance(self.tile_columns, Unset):
+            tile_columns = UNSET
+        elif isinstance(self.tile_columns, list):
+            tile_columns = self.tile_columns
+
+        else:
+            tile_columns = self.tile_columns
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if access_constraints is not UNSET:
-            field_dict["access_constraints"] = access_constraints
-        if data_vintage_end is not UNSET:
-            field_dict["data_vintage_end"] = data_vintage_end
-        if data_vintage_start is not UNSET:
-            field_dict["data_vintage_start"] = data_vintage_start
-        if is_dem is not UNSET:
-            field_dict["is_dem"] = is_dem
-        if language is not UNSET:
-            field_dict["language"] = language
-        if license_ is not UNSET:
-            field_dict["license"] = license_
-        if lineage_summary is not UNSET:
-            field_dict["lineage_summary"] = lineage_summary
-        if owner_org is not UNSET:
-            field_dict["owner_org"] = owner_org
-        if quality_statement is not UNSET:
-            field_dict["quality_statement"] = quality_statement
-        if record_status is not UNSET:
-            field_dict["record_status"] = record_status
-        if sensitivity_classification is not UNSET:
-            field_dict["sensitivity_classification"] = sensitivity_classification
-        if source_organization is not UNSET:
-            field_dict["source_organization"] = source_organization
-        if source_url is not UNSET:
-            field_dict["source_url"] = source_url
-        if summary is not UNSET:
-            field_dict["summary"] = summary
-        if theme_category is not UNSET:
-            field_dict["theme_category"] = theme_category
-        if tile_columns is not UNSET:
-            field_dict["tile_columns"] = tile_columns
         if title is not UNSET:
             field_dict["title"] = title
+        if summary is not UNSET:
+            field_dict["summary"] = summary
+        if visibility is not UNSET:
+            field_dict["visibility"] = visibility
+        if license_ is not UNSET:
+            field_dict["license"] = license_
+        if source_organization is not UNSET:
+            field_dict["source_organization"] = source_organization
+        if data_vintage_start is not UNSET:
+            field_dict["data_vintage_start"] = data_vintage_start
+        if data_vintage_end is not UNSET:
+            field_dict["data_vintage_end"] = data_vintage_end
+        if lineage_summary is not UNSET:
+            field_dict["lineage_summary"] = lineage_summary
         if update_frequency is not UNSET:
             field_dict["update_frequency"] = update_frequency
         if usage_constraints is not UNSET:
             field_dict["usage_constraints"] = usage_constraints
-        if visibility is not UNSET:
-            field_dict["visibility"] = visibility
+        if access_constraints is not UNSET:
+            field_dict["access_constraints"] = access_constraints
+        if sensitivity_classification is not UNSET:
+            field_dict["sensitivity_classification"] = sensitivity_classification
+        if theme_category is not UNSET:
+            field_dict["theme_category"] = theme_category
+        if record_status is not UNSET:
+            field_dict["record_status"] = record_status
+        if owner_org is not UNSET:
+            field_dict["owner_org"] = owner_org
+        if quality_statement is not UNSET:
+            field_dict["quality_statement"] = quality_statement
+        if source_url is not UNSET:
+            field_dict["source_url"] = source_url
+        if language is not UNSET:
+            field_dict["language"] = language
+        if is_dem is not UNSET:
+            field_dict["is_dem"] = is_dem
+        if tile_columns is not UNSET:
+            field_dict["tile_columns"] = tile_columns
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
-        def _parse_access_constraints(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        access_constraints = _parse_access_constraints(
-            d.pop("access_constraints", UNSET)
-        )
-
-        def _parse_data_vintage_end(data: object) -> datetime.date | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                data_vintage_end_type_0 = isoparse(data).date()
-
-                return data_vintage_end_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.date | None | Unset, data)
-
-        data_vintage_end = _parse_data_vintage_end(d.pop("data_vintage_end", UNSET))
-
-        def _parse_data_vintage_start(data: object) -> datetime.date | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                data_vintage_start_type_0 = isoparse(data).date()
-
-                return data_vintage_start_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.date | None | Unset, data)
-
-        data_vintage_start = _parse_data_vintage_start(
-            d.pop("data_vintage_start", UNSET)
-        )
-
-        def _parse_is_dem(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        is_dem = _parse_is_dem(d.pop("is_dem", UNSET))
-
-        def _parse_language(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        language = _parse_language(d.pop("language", UNSET))
-
-        def _parse_license_(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        license_ = _parse_license_(d.pop("license", UNSET))
-
-        def _parse_lineage_summary(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        lineage_summary = _parse_lineage_summary(d.pop("lineage_summary", UNSET))
-
-        def _parse_owner_org(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        owner_org = _parse_owner_org(d.pop("owner_org", UNSET))
-
-        def _parse_quality_statement(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        quality_statement = _parse_quality_statement(d.pop("quality_statement", UNSET))
-
-        def _parse_record_status(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        record_status = _parse_record_status(d.pop("record_status", UNSET))
-
-        def _parse_sensitivity_classification(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        sensitivity_classification = _parse_sensitivity_classification(
-            d.pop("sensitivity_classification", UNSET)
-        )
-
-        def _parse_source_organization(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        source_organization = _parse_source_organization(
-            d.pop("source_organization", UNSET)
-        )
-
-        def _parse_source_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        source_url = _parse_source_url(d.pop("source_url", UNSET))
-
-        def _parse_summary(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        summary = _parse_summary(d.pop("summary", UNSET))
-
-        def _parse_theme_category(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                theme_category_type_0 = cast(list[str], data)
-
-                return theme_category_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        theme_category = _parse_theme_category(d.pop("theme_category", UNSET))
-
-        def _parse_tile_columns(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                tile_columns_type_0 = cast(list[str], data)
-
-                return tile_columns_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        tile_columns = _parse_tile_columns(d.pop("tile_columns", UNSET))
 
         def _parse_title(data: object) -> None | str | Unset:
             if data is None:
@@ -449,23 +265,14 @@ class DatasetMeta:
 
         title = _parse_title(d.pop("title", UNSET))
 
-        def _parse_update_frequency(data: object) -> None | str | Unset:
+        def _parse_summary(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        update_frequency = _parse_update_frequency(d.pop("update_frequency", UNSET))
-
-        def _parse_usage_constraints(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        usage_constraints = _parse_usage_constraints(d.pop("usage_constraints", UNSET))
+        summary = _parse_summary(d.pop("summary", UNSET))
 
         def _parse_visibility(
             data: object,
@@ -486,27 +293,220 @@ class DatasetMeta:
 
         visibility = _parse_visibility(d.pop("visibility", UNSET))
 
+        def _parse_license_(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        license_ = _parse_license_(d.pop("license", UNSET))
+
+        def _parse_source_organization(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        source_organization = _parse_source_organization(
+            d.pop("source_organization", UNSET)
+        )
+
+        def _parse_data_vintage_start(data: object) -> datetime.date | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                data_vintage_start_type_0 = isoparse(data).date()
+
+                return data_vintage_start_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.date | None | Unset, data)
+
+        data_vintage_start = _parse_data_vintage_start(
+            d.pop("data_vintage_start", UNSET)
+        )
+
+        def _parse_data_vintage_end(data: object) -> datetime.date | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                data_vintage_end_type_0 = isoparse(data).date()
+
+                return data_vintage_end_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.date | None | Unset, data)
+
+        data_vintage_end = _parse_data_vintage_end(d.pop("data_vintage_end", UNSET))
+
+        def _parse_lineage_summary(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        lineage_summary = _parse_lineage_summary(d.pop("lineage_summary", UNSET))
+
+        def _parse_update_frequency(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        update_frequency = _parse_update_frequency(d.pop("update_frequency", UNSET))
+
+        def _parse_usage_constraints(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        usage_constraints = _parse_usage_constraints(d.pop("usage_constraints", UNSET))
+
+        def _parse_access_constraints(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        access_constraints = _parse_access_constraints(
+            d.pop("access_constraints", UNSET)
+        )
+
+        def _parse_sensitivity_classification(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        sensitivity_classification = _parse_sensitivity_classification(
+            d.pop("sensitivity_classification", UNSET)
+        )
+
+        def _parse_theme_category(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                theme_category_type_0 = cast(list[str], data)
+
+                return theme_category_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        theme_category = _parse_theme_category(d.pop("theme_category", UNSET))
+
+        def _parse_record_status(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        record_status = _parse_record_status(d.pop("record_status", UNSET))
+
+        def _parse_owner_org(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        owner_org = _parse_owner_org(d.pop("owner_org", UNSET))
+
+        def _parse_quality_statement(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        quality_statement = _parse_quality_statement(d.pop("quality_statement", UNSET))
+
+        def _parse_source_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        source_url = _parse_source_url(d.pop("source_url", UNSET))
+
+        def _parse_language(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        language = _parse_language(d.pop("language", UNSET))
+
+        def _parse_is_dem(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_dem = _parse_is_dem(d.pop("is_dem", UNSET))
+
+        def _parse_tile_columns(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                tile_columns_type_0 = cast(list[str], data)
+
+                return tile_columns_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        tile_columns = _parse_tile_columns(d.pop("tile_columns", UNSET))
+
         dataset_meta = cls(
-            access_constraints=access_constraints,
-            data_vintage_end=data_vintage_end,
-            data_vintage_start=data_vintage_start,
-            is_dem=is_dem,
-            language=language,
-            license_=license_,
-            lineage_summary=lineage_summary,
-            owner_org=owner_org,
-            quality_statement=quality_statement,
-            record_status=record_status,
-            sensitivity_classification=sensitivity_classification,
-            source_organization=source_organization,
-            source_url=source_url,
-            summary=summary,
-            theme_category=theme_category,
-            tile_columns=tile_columns,
             title=title,
+            summary=summary,
+            visibility=visibility,
+            license_=license_,
+            source_organization=source_organization,
+            data_vintage_start=data_vintage_start,
+            data_vintage_end=data_vintage_end,
+            lineage_summary=lineage_summary,
             update_frequency=update_frequency,
             usage_constraints=usage_constraints,
-            visibility=visibility,
+            access_constraints=access_constraints,
+            sensitivity_classification=sensitivity_classification,
+            theme_category=theme_category,
+            record_status=record_status,
+            owner_org=owner_org,
+            quality_statement=quality_statement,
+            source_url=source_url,
+            language=language,
+            is_dem=is_dem,
+            tile_columns=tile_columns,
         )
 
         dataset_meta.additional_properties = d

--- a/sdks/python/geolens/models/dataset_relationship_create.py
+++ b/sdks/python/geolens/models/dataset_relationship_create.py
@@ -19,22 +19,24 @@ T = TypeVar("T", bound="DatasetRelationshipCreate")
 class DatasetRelationshipCreate:
     """
     Attributes:
-        source_column (str): Join column in the source dataset
         target_dataset_id (UUID): UUID of the dataset to link to
-        label (None | str | Unset): Optional display label for this relationship
+        source_column (str): Join column in the source dataset
         target_column (str | Unset): Join column in the target dataset Default: 'gid'.
+        label (None | str | Unset): Optional display label for this relationship
     """
 
-    source_column: str
     target_dataset_id: UUID
-    label: None | str | Unset = UNSET
+    source_column: str
     target_column: str | Unset = "gid"
+    label: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        target_dataset_id = str(self.target_dataset_id)
+
         source_column = self.source_column
 
-        target_dataset_id = str(self.target_dataset_id)
+        target_column = self.target_column
 
         label: None | str | Unset
         if isinstance(self.label, Unset):
@@ -42,29 +44,29 @@ class DatasetRelationshipCreate:
         else:
             label = self.label
 
-        target_column = self.target_column
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "source_column": source_column,
                 "target_dataset_id": target_dataset_id,
+                "source_column": source_column,
             }
         )
-        if label is not UNSET:
-            field_dict["label"] = label
         if target_column is not UNSET:
             field_dict["target_column"] = target_column
+        if label is not UNSET:
+            field_dict["label"] = label
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        target_dataset_id = UUID(d.pop("target_dataset_id"))
+
         source_column = d.pop("source_column")
 
-        target_dataset_id = UUID(d.pop("target_dataset_id"))
+        target_column = d.pop("target_column", UNSET)
 
         def _parse_label(data: object) -> None | str | Unset:
             if data is None:
@@ -75,13 +77,11 @@ class DatasetRelationshipCreate:
 
         label = _parse_label(d.pop("label", UNSET))
 
-        target_column = d.pop("target_column", UNSET)
-
         dataset_relationship_create = cls(
-            source_column=source_column,
             target_dataset_id=target_dataset_id,
-            label=label,
+            source_column=source_column,
             target_column=target_column,
+            label=label,
         )
 
         dataset_relationship_create.additional_properties = d

--- a/sdks/python/geolens/models/dataset_relationship_response.py
+++ b/sdks/python/geolens/models/dataset_relationship_response.py
@@ -20,40 +20,40 @@ class DatasetRelationshipResponse:
     """
     Attributes:
         id (UUID):
-        label (None | str):
-        relationship_type (str):
-        source_column (str):
         source_dataset_id (UUID):
-        target_column (str):
         target_dataset_id (UUID):
+        source_column (str):
+        target_column (str):
+        relationship_type (str):
+        label (None | str):
         target_dataset_title (None | str | Unset):
     """
 
     id: UUID
-    label: None | str
-    relationship_type: str
-    source_column: str
     source_dataset_id: UUID
-    target_column: str
     target_dataset_id: UUID
+    source_column: str
+    target_column: str
+    relationship_type: str
+    label: None | str
     target_dataset_title: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         id = str(self.id)
 
-        label: None | str
-        label = self.label
+        source_dataset_id = str(self.source_dataset_id)
 
-        relationship_type = self.relationship_type
+        target_dataset_id = str(self.target_dataset_id)
 
         source_column = self.source_column
 
-        source_dataset_id = str(self.source_dataset_id)
-
         target_column = self.target_column
 
-        target_dataset_id = str(self.target_dataset_id)
+        relationship_type = self.relationship_type
+
+        label: None | str
+        label = self.label
 
         target_dataset_title: None | str | Unset
         if isinstance(self.target_dataset_title, Unset):
@@ -66,12 +66,12 @@ class DatasetRelationshipResponse:
         field_dict.update(
             {
                 "id": id,
-                "label": label,
-                "relationship_type": relationship_type,
-                "source_column": source_column,
                 "source_dataset_id": source_dataset_id,
-                "target_column": target_column,
                 "target_dataset_id": target_dataset_id,
+                "source_column": source_column,
+                "target_column": target_column,
+                "relationship_type": relationship_type,
+                "label": label,
             }
         )
         if target_dataset_title is not UNSET:
@@ -84,22 +84,22 @@ class DatasetRelationshipResponse:
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
+        source_dataset_id = UUID(d.pop("source_dataset_id"))
+
+        target_dataset_id = UUID(d.pop("target_dataset_id"))
+
+        source_column = d.pop("source_column")
+
+        target_column = d.pop("target_column")
+
+        relationship_type = d.pop("relationship_type")
+
         def _parse_label(data: object) -> None | str:
             if data is None:
                 return data
             return cast(None | str, data)
 
         label = _parse_label(d.pop("label"))
-
-        relationship_type = d.pop("relationship_type")
-
-        source_column = d.pop("source_column")
-
-        source_dataset_id = UUID(d.pop("source_dataset_id"))
-
-        target_column = d.pop("target_column")
-
-        target_dataset_id = UUID(d.pop("target_dataset_id"))
 
         def _parse_target_dataset_title(data: object) -> None | str | Unset:
             if data is None:
@@ -114,12 +114,12 @@ class DatasetRelationshipResponse:
 
         dataset_relationship_response = cls(
             id=id,
-            label=label,
-            relationship_type=relationship_type,
-            source_column=source_column,
             source_dataset_id=source_dataset_id,
-            target_column=target_column,
             target_dataset_id=target_dataset_id,
+            source_column=source_column,
+            target_column=target_column,
+            relationship_type=relationship_type,
+            label=label,
             target_dataset_title=target_dataset_title,
         )
 

--- a/sdks/python/geolens/models/dataset_response.py
+++ b/sdks/python/geolens/models/dataset_response.py
@@ -34,148 +34,148 @@ T = TypeVar("T", bound="DatasetResponse")
 class DatasetResponse:
     """
     Attributes:
-        created_at (datetime.datetime):
-        created_by (None | UUID):
-        created_by_display (str):
-        feature_count (int | None):
         id (UUID):
         record_id (UUID): Parent catalog record UUID
-        source_filename (None | str):
-        summary (None | str):
         table_name (str): Internal PostGIS table name
         title (str):
-        updated_at (datetime.datetime):
+        summary (None | str):
+        feature_count (int | None):
+        source_filename (None | str):
         visibility (str): Access level: private, restricted, internal, public
-        access_constraints (None | str | Unset):
-        collections (list[CollectionRef] | None | Unset):
-        column_info (list[ColumnInfo] | None | Unset): Column names, types, and stats
-        current_version (int | Unset): Monotonic version counter Default: 1.
-        data_vintage_end (datetime.date | None | Unset): End of temporal coverage
-        data_vintage_start (datetime.date | None | Unset): Start of temporal coverage
-        derived_from (DerivedFromResponse | None | Unset): Provenance for an analysis output. Null for a dataset that
-            was not derived, and also for a requester who cannot access the source dataset — the two are deliberately
-            indistinguishable.
-        extent_bbox (list[float] | None | Unset): Bounding box [west, south, east, north] per RFC 7946 §5.2. west > east
-            on an antimeridian-crossing extent.
+        created_by (None | UUID):
+        created_by_display (str):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        srid (int | None | Unset): Current EPSG SRID of stored geometry
         geometry_type (None | str | Unset): OGC geometry type, e.g. MultiPolygon
         has_generic_geometry (bool | Unset): True when the underlying column is generic GEOMETRY (created sketch
             datasets): the dataset accepts ANY geometry subtype on write regardless of the display geometry_type above.
             Computed on the detail endpoint only (fix #430 codex r18); list endpoints always report false. Default: False.
         is_3d (bool | None | Unset): True if geometry has Z dimension
-        language (None | str | Unset): ISO 639-1 language code, e.g. en, fr
-        last_checked_at (datetime.datetime | None | Unset): Last time GeoLens contacted the origin at all, whether the
-            attempt succeeded or failed
-        last_edited_at (datetime.datetime | None | Unset):
-        last_edited_by_display (None | str | Unset):
-        last_refreshed_at (datetime.datetime | None | Unset): Last committed successful refresh — not the last attempt
-        license_ (None | str | Unset):
-        lineage_summary (None | str | Unset): Free-text provenance / lineage statement
-        metadata_warnings (list[str] | None | Unset): Advisory warnings produced by a metadata update — e.g. a
-            visibility or status change exposing keywords inherited from an analysis source the new audience cannot open
-            (feat #1070). Only ever set on the PATCH response; the change has already applied.
         n_dims (int | None | Unset): Number of coordinate dimensions (2, 3, or 4)
+        z_min (float | None | Unset): Minimum Z value across all features
+        z_max (float | None | Unset): Maximum Z value across all features
+        extent_bbox (list[float] | None | Unset): Bounding box [west, south, east, north] per RFC 7946 §5.2. west > east
+            on an antimeridian-crossing extent.
+        column_info (list[ColumnInfo] | None | Unset): Column names, types, and stats
+        license_ (None | str | Unset):
+        source_organization (None | str | Unset):
+        data_vintage_start (datetime.date | None | Unset): Start of temporal coverage
+        data_vintage_end (datetime.date | None | Unset): End of temporal coverage
+        quality_detail (None | QualityDetail | Unset): Automated quality assessment results
+        source_format (None | str | Unset): Original file format, e.g. GPKG, SHP
+        tile_columns (list[str] | None | Unset): Ordered vector-tile property allowlist; null uses zoom defaults, []
+            emits geometry-only tiles, list emits those properties at any zoom.
+        original_srid (int | None | Unset): EPSG SRID of the uploaded source file
+        current_version (int | Unset): Monotonic version counter Default: 1.
+        source_url (None | str | Unset): URL the data was originally fetched from
         origin (None | str | Unset): How the data entered the catalog: upload, postgis, service, stac, or created.
             Computed from source_format and record_type, not stored; null for collections and VRTs, which have no origin of
             their own.
-        origin_ref (DatasetResponseOriginRefType0 | None | Unset): Typed per-origin payload with a `kind` discriminator,
-            e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials.
         origin_uri (None | str | Unset): Machine-readable pointer back to the origin, written only by ingest and
             refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created
             datasets.
-        original_srid (int | None | Unset): EPSG SRID of the uploaded source file
-        owner_org (None | str | Unset): Owning organization name
-        published_at (datetime.datetime | None | Unset):
-        quality_detail (None | QualityDetail | Unset): Automated quality assessment results
-        quality_statement (None | str | Unset):
-        raster (None | RasterMetadata | Unset): Raster-specific metadata (null for vectors)
-        record_status (str | Unset): Lifecycle status. Deliberately not pinned to an enum: the values come from the
-            workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready,
-            internal, published. Default: 'draft'.
-        record_type (str | Unset): Record type: 'vector_dataset' (spatial features), 'raster_dataset' (single COG),
-            'vrt_dataset' (VRT mosaic), 'table' (non-spatial tabular), 'map' (saved map), 'service' (catalogued remote
-            service), 'collection' (flat dataset group). Default: 'vector_dataset'.
-        schema_drift_status (str | Unset): none, drifted, or unknown. Set at refresh commit from the schema diff;
-            'unknown' until a refresh has run. Default: 'unknown'.
-        sensitivity_classification (None | str | Unset): e.g. public, confidential, restricted
-        source_format (None | str | Unset): Original file format, e.g. GPKG, SHP
+        origin_ref (DatasetResponseOriginRefType0 | None | Unset): Typed per-origin payload with a `kind` discriminator,
+            e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials.
+        last_refreshed_at (datetime.datetime | None | Unset): Last committed successful refresh — not the last attempt
+        last_checked_at (datetime.datetime | None | Unset): Last time GeoLens contacted the origin at all, whether the
+            attempt succeeded or failed
         source_health (str | Unset): healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an
             origin kind with nothing to probe. Default: 'unknown'.
         source_health_detail (None | str | Unset): Short redacted reason for a non-healthy state
-        source_organization (None | str | Unset):
-        source_url (None | str | Unset): URL the data was originally fetched from
-        srid (int | None | Unset): Current EPSG SRID of stored geometry
+        schema_drift_status (str | Unset): none, drifted, or unknown. Set at refresh commit from the schema diff;
+            'unknown' until a refresh has run. Default: 'unknown'.
+        quality_statement (None | str | Unset):
+        last_edited_by_display (None | str | Unset):
+        last_edited_at (datetime.datetime | None | Unset):
+        collections (list[CollectionRef] | None | Unset):
+        record_status (str | Unset): Lifecycle status. Deliberately not pinned to an enum: the values come from the
+            workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready,
+            internal, published. Default: 'draft'.
+        lineage_summary (None | str | Unset): Free-text provenance / lineage statement
+        derived_from (DerivedFromResponse | None | Unset): Provenance for an analysis output. Null for a dataset that
+            was not derived, and also for a requester who cannot access the source dataset — the two are deliberately
+            indistinguishable.
+        update_frequency (None | str | Unset): ISO maintenance frequency code
+        usage_constraints (None | str | Unset):
+        access_constraints (None | str | Unset):
+        sensitivity_classification (None | str | Unset): e.g. public, confidential, restricted
+        theme_category (list[str] | None | Unset): ISO topic category codes
+        owner_org (None | str | Unset): Owning organization name
+        published_at (datetime.datetime | None | Unset):
+        updated_by (None | Unset | UUID):
+        record_type (str | Unset): Record type: 'vector_dataset' (spatial features), 'raster_dataset' (single COG),
+            'vrt_dataset' (VRT mosaic), 'table' (non-spatial tabular), 'map' (saved map), 'service' (catalogued remote
+            service), 'collection' (flat dataset group). Default: 'vector_dataset'.
+        raster (None | RasterMetadata | Unset): Raster-specific metadata (null for vectors)
         stac_assets (DatasetResponseStacAssetsType0 | None | Unset): STAC-style asset dictionary
         stac_extensions (list[str] | None | Unset):
-        theme_category (list[str] | None | Unset): ISO topic category codes
-        tile_columns (list[str] | None | Unset): Ordered vector-tile property allowlist; null uses zoom defaults, []
-            emits geometry-only tiles, list emits those properties at any zoom.
-        update_frequency (None | str | Unset): ISO maintenance frequency code
-        updated_by (None | Unset | UUID):
-        usage_constraints (None | str | Unset):
-        z_max (float | None | Unset): Maximum Z value across all features
-        z_min (float | None | Unset): Minimum Z value across all features
+        language (None | str | Unset): ISO 639-1 language code, e.g. en, fr
+        metadata_warnings (list[str] | None | Unset): Advisory warnings produced by a metadata update — e.g. a
+            visibility or status change exposing keywords inherited from an analysis source the new audience cannot open
+            (feat #1070). Only ever set on the PATCH response; the change has already applied.
     """
 
-    created_at: datetime.datetime
-    created_by: None | UUID
-    created_by_display: str
-    feature_count: int | None
     id: UUID
     record_id: UUID
-    source_filename: None | str
-    summary: None | str
     table_name: str
     title: str
-    updated_at: datetime.datetime
+    summary: None | str
+    feature_count: int | None
+    source_filename: None | str
     visibility: str
-    access_constraints: None | str | Unset = UNSET
-    collections: list[CollectionRef] | None | Unset = UNSET
-    column_info: list[ColumnInfo] | None | Unset = UNSET
-    current_version: int | Unset = 1
-    data_vintage_end: datetime.date | None | Unset = UNSET
-    data_vintage_start: datetime.date | None | Unset = UNSET
-    derived_from: DerivedFromResponse | None | Unset = UNSET
-    extent_bbox: list[float] | None | Unset = UNSET
+    created_by: None | UUID
+    created_by_display: str
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    srid: int | None | Unset = UNSET
     geometry_type: None | str | Unset = UNSET
     has_generic_geometry: bool | Unset = False
     is_3d: bool | None | Unset = UNSET
-    language: None | str | Unset = UNSET
-    last_checked_at: datetime.datetime | None | Unset = UNSET
-    last_edited_at: datetime.datetime | None | Unset = UNSET
-    last_edited_by_display: None | str | Unset = UNSET
-    last_refreshed_at: datetime.datetime | None | Unset = UNSET
-    license_: None | str | Unset = UNSET
-    lineage_summary: None | str | Unset = UNSET
-    metadata_warnings: list[str] | None | Unset = UNSET
     n_dims: int | None | Unset = UNSET
-    origin: None | str | Unset = UNSET
-    origin_ref: DatasetResponseOriginRefType0 | None | Unset = UNSET
-    origin_uri: None | str | Unset = UNSET
-    original_srid: int | None | Unset = UNSET
-    owner_org: None | str | Unset = UNSET
-    published_at: datetime.datetime | None | Unset = UNSET
+    z_min: float | None | Unset = UNSET
+    z_max: float | None | Unset = UNSET
+    extent_bbox: list[float] | None | Unset = UNSET
+    column_info: list[ColumnInfo] | None | Unset = UNSET
+    license_: None | str | Unset = UNSET
+    source_organization: None | str | Unset = UNSET
+    data_vintage_start: datetime.date | None | Unset = UNSET
+    data_vintage_end: datetime.date | None | Unset = UNSET
     quality_detail: None | QualityDetail | Unset = UNSET
-    quality_statement: None | str | Unset = UNSET
-    raster: None | RasterMetadata | Unset = UNSET
-    record_status: str | Unset = "draft"
-    record_type: str | Unset = "vector_dataset"
-    schema_drift_status: str | Unset = "unknown"
-    sensitivity_classification: None | str | Unset = UNSET
     source_format: None | str | Unset = UNSET
+    tile_columns: list[str] | None | Unset = UNSET
+    original_srid: int | None | Unset = UNSET
+    current_version: int | Unset = 1
+    source_url: None | str | Unset = UNSET
+    origin: None | str | Unset = UNSET
+    origin_uri: None | str | Unset = UNSET
+    origin_ref: DatasetResponseOriginRefType0 | None | Unset = UNSET
+    last_refreshed_at: datetime.datetime | None | Unset = UNSET
+    last_checked_at: datetime.datetime | None | Unset = UNSET
     source_health: str | Unset = "unknown"
     source_health_detail: None | str | Unset = UNSET
-    source_organization: None | str | Unset = UNSET
-    source_url: None | str | Unset = UNSET
-    srid: int | None | Unset = UNSET
+    schema_drift_status: str | Unset = "unknown"
+    quality_statement: None | str | Unset = UNSET
+    last_edited_by_display: None | str | Unset = UNSET
+    last_edited_at: datetime.datetime | None | Unset = UNSET
+    collections: list[CollectionRef] | None | Unset = UNSET
+    record_status: str | Unset = "draft"
+    lineage_summary: None | str | Unset = UNSET
+    derived_from: DerivedFromResponse | None | Unset = UNSET
+    update_frequency: None | str | Unset = UNSET
+    usage_constraints: None | str | Unset = UNSET
+    access_constraints: None | str | Unset = UNSET
+    sensitivity_classification: None | str | Unset = UNSET
+    theme_category: list[str] | None | Unset = UNSET
+    owner_org: None | str | Unset = UNSET
+    published_at: datetime.datetime | None | Unset = UNSET
+    updated_by: None | Unset | UUID = UNSET
+    record_type: str | Unset = "vector_dataset"
+    raster: None | RasterMetadata | Unset = UNSET
     stac_assets: DatasetResponseStacAssetsType0 | None | Unset = UNSET
     stac_extensions: list[str] | None | Unset = UNSET
-    theme_category: list[str] | None | Unset = UNSET
-    tile_columns: list[str] | None | Unset = UNSET
-    update_frequency: None | str | Unset = UNSET
-    updated_by: None | Unset | UUID = UNSET
-    usage_constraints: None | str | Unset = UNSET
-    z_max: float | None | Unset = UNSET
-    z_min: float | None | Unset = UNSET
+    language: None | str | Unset = UNSET
+    metadata_warnings: list[str] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -189,7 +189,24 @@ class DatasetResponse:
         from ..models.quality_detail import QualityDetail
         from ..models.raster_metadata import RasterMetadata
 
-        created_at = self.created_at.isoformat()
+        id = str(self.id)
+
+        record_id = str(self.record_id)
+
+        table_name = self.table_name
+
+        title = self.title
+
+        summary: None | str
+        summary = self.summary
+
+        feature_count: int | None
+        feature_count = self.feature_count
+
+        source_filename: None | str
+        source_filename = self.source_filename
+
+        visibility = self.visibility
 
         created_by: None | str
         if isinstance(self.created_by, UUID):
@@ -199,91 +216,15 @@ class DatasetResponse:
 
         created_by_display = self.created_by_display
 
-        feature_count: int | None
-        feature_count = self.feature_count
-
-        id = str(self.id)
-
-        record_id = str(self.record_id)
-
-        source_filename: None | str
-        source_filename = self.source_filename
-
-        summary: None | str
-        summary = self.summary
-
-        table_name = self.table_name
-
-        title = self.title
+        created_at = self.created_at.isoformat()
 
         updated_at = self.updated_at.isoformat()
 
-        visibility = self.visibility
-
-        access_constraints: None | str | Unset
-        if isinstance(self.access_constraints, Unset):
-            access_constraints = UNSET
+        srid: int | None | Unset
+        if isinstance(self.srid, Unset):
+            srid = UNSET
         else:
-            access_constraints = self.access_constraints
-
-        collections: list[dict[str, Any]] | None | Unset
-        if isinstance(self.collections, Unset):
-            collections = UNSET
-        elif isinstance(self.collections, list):
-            collections = []
-            for collections_type_0_item_data in self.collections:
-                collections_type_0_item = collections_type_0_item_data.to_dict()
-                collections.append(collections_type_0_item)
-
-        else:
-            collections = self.collections
-
-        column_info: list[dict[str, Any]] | None | Unset
-        if isinstance(self.column_info, Unset):
-            column_info = UNSET
-        elif isinstance(self.column_info, list):
-            column_info = []
-            for column_info_type_0_item_data in self.column_info:
-                column_info_type_0_item = column_info_type_0_item_data.to_dict()
-                column_info.append(column_info_type_0_item)
-
-        else:
-            column_info = self.column_info
-
-        current_version = self.current_version
-
-        data_vintage_end: None | str | Unset
-        if isinstance(self.data_vintage_end, Unset):
-            data_vintage_end = UNSET
-        elif isinstance(self.data_vintage_end, datetime.date):
-            data_vintage_end = self.data_vintage_end.isoformat()
-        else:
-            data_vintage_end = self.data_vintage_end
-
-        data_vintage_start: None | str | Unset
-        if isinstance(self.data_vintage_start, Unset):
-            data_vintage_start = UNSET
-        elif isinstance(self.data_vintage_start, datetime.date):
-            data_vintage_start = self.data_vintage_start.isoformat()
-        else:
-            data_vintage_start = self.data_vintage_start
-
-        derived_from: dict[str, Any] | None | Unset
-        if isinstance(self.derived_from, Unset):
-            derived_from = UNSET
-        elif isinstance(self.derived_from, DerivedFromResponse):
-            derived_from = self.derived_from.to_dict()
-        else:
-            derived_from = self.derived_from
-
-        extent_bbox: list[float] | None | Unset
-        if isinstance(self.extent_bbox, Unset):
-            extent_bbox = UNSET
-        elif isinstance(self.extent_bbox, list):
-            extent_bbox = self.extent_bbox
-
-        else:
-            extent_bbox = self.extent_bbox
+            srid = self.srid
 
         geometry_type: None | str | Unset
         if isinstance(self.geometry_type, Unset):
@@ -299,41 +240,44 @@ class DatasetResponse:
         else:
             is_3d = self.is_3d
 
-        language: None | str | Unset
-        if isinstance(self.language, Unset):
-            language = UNSET
+        n_dims: int | None | Unset
+        if isinstance(self.n_dims, Unset):
+            n_dims = UNSET
         else:
-            language = self.language
+            n_dims = self.n_dims
 
-        last_checked_at: None | str | Unset
-        if isinstance(self.last_checked_at, Unset):
-            last_checked_at = UNSET
-        elif isinstance(self.last_checked_at, datetime.datetime):
-            last_checked_at = self.last_checked_at.isoformat()
+        z_min: float | None | Unset
+        if isinstance(self.z_min, Unset):
+            z_min = UNSET
         else:
-            last_checked_at = self.last_checked_at
+            z_min = self.z_min
 
-        last_edited_at: None | str | Unset
-        if isinstance(self.last_edited_at, Unset):
-            last_edited_at = UNSET
-        elif isinstance(self.last_edited_at, datetime.datetime):
-            last_edited_at = self.last_edited_at.isoformat()
+        z_max: float | None | Unset
+        if isinstance(self.z_max, Unset):
+            z_max = UNSET
         else:
-            last_edited_at = self.last_edited_at
+            z_max = self.z_max
 
-        last_edited_by_display: None | str | Unset
-        if isinstance(self.last_edited_by_display, Unset):
-            last_edited_by_display = UNSET
-        else:
-            last_edited_by_display = self.last_edited_by_display
+        extent_bbox: list[float] | None | Unset
+        if isinstance(self.extent_bbox, Unset):
+            extent_bbox = UNSET
+        elif isinstance(self.extent_bbox, list):
+            extent_bbox = self.extent_bbox
 
-        last_refreshed_at: None | str | Unset
-        if isinstance(self.last_refreshed_at, Unset):
-            last_refreshed_at = UNSET
-        elif isinstance(self.last_refreshed_at, datetime.datetime):
-            last_refreshed_at = self.last_refreshed_at.isoformat()
         else:
-            last_refreshed_at = self.last_refreshed_at
+            extent_bbox = self.extent_bbox
+
+        column_info: list[dict[str, Any]] | None | Unset
+        if isinstance(self.column_info, Unset):
+            column_info = UNSET
+        elif isinstance(self.column_info, list):
+            column_info = []
+            for column_info_type_0_item_data in self.column_info:
+                column_info_type_0_item = column_info_type_0_item_data.to_dict()
+                column_info.append(column_info_type_0_item)
+
+        else:
+            column_info = self.column_info
 
         license_: None | str | Unset
         if isinstance(self.license_, Unset):
@@ -341,32 +285,76 @@ class DatasetResponse:
         else:
             license_ = self.license_
 
-        lineage_summary: None | str | Unset
-        if isinstance(self.lineage_summary, Unset):
-            lineage_summary = UNSET
+        source_organization: None | str | Unset
+        if isinstance(self.source_organization, Unset):
+            source_organization = UNSET
         else:
-            lineage_summary = self.lineage_summary
+            source_organization = self.source_organization
 
-        metadata_warnings: list[str] | None | Unset
-        if isinstance(self.metadata_warnings, Unset):
-            metadata_warnings = UNSET
-        elif isinstance(self.metadata_warnings, list):
-            metadata_warnings = self.metadata_warnings
+        data_vintage_start: None | str | Unset
+        if isinstance(self.data_vintage_start, Unset):
+            data_vintage_start = UNSET
+        elif isinstance(self.data_vintage_start, datetime.date):
+            data_vintage_start = self.data_vintage_start.isoformat()
+        else:
+            data_vintage_start = self.data_vintage_start
+
+        data_vintage_end: None | str | Unset
+        if isinstance(self.data_vintage_end, Unset):
+            data_vintage_end = UNSET
+        elif isinstance(self.data_vintage_end, datetime.date):
+            data_vintage_end = self.data_vintage_end.isoformat()
+        else:
+            data_vintage_end = self.data_vintage_end
+
+        quality_detail: dict[str, Any] | None | Unset
+        if isinstance(self.quality_detail, Unset):
+            quality_detail = UNSET
+        elif isinstance(self.quality_detail, QualityDetail):
+            quality_detail = self.quality_detail.to_dict()
+        else:
+            quality_detail = self.quality_detail
+
+        source_format: None | str | Unset
+        if isinstance(self.source_format, Unset):
+            source_format = UNSET
+        else:
+            source_format = self.source_format
+
+        tile_columns: list[str] | None | Unset
+        if isinstance(self.tile_columns, Unset):
+            tile_columns = UNSET
+        elif isinstance(self.tile_columns, list):
+            tile_columns = self.tile_columns
 
         else:
-            metadata_warnings = self.metadata_warnings
+            tile_columns = self.tile_columns
 
-        n_dims: int | None | Unset
-        if isinstance(self.n_dims, Unset):
-            n_dims = UNSET
+        original_srid: int | None | Unset
+        if isinstance(self.original_srid, Unset):
+            original_srid = UNSET
         else:
-            n_dims = self.n_dims
+            original_srid = self.original_srid
+
+        current_version = self.current_version
+
+        source_url: None | str | Unset
+        if isinstance(self.source_url, Unset):
+            source_url = UNSET
+        else:
+            source_url = self.source_url
 
         origin: None | str | Unset
         if isinstance(self.origin, Unset):
             origin = UNSET
         else:
             origin = self.origin
+
+        origin_uri: None | str | Unset
+        if isinstance(self.origin_uri, Unset):
+            origin_uri = UNSET
+        else:
+            origin_uri = self.origin_uri
 
         origin_ref: dict[str, Any] | None | Unset
         if isinstance(self.origin_ref, Unset):
@@ -376,17 +364,112 @@ class DatasetResponse:
         else:
             origin_ref = self.origin_ref
 
-        origin_uri: None | str | Unset
-        if isinstance(self.origin_uri, Unset):
-            origin_uri = UNSET
+        last_refreshed_at: None | str | Unset
+        if isinstance(self.last_refreshed_at, Unset):
+            last_refreshed_at = UNSET
+        elif isinstance(self.last_refreshed_at, datetime.datetime):
+            last_refreshed_at = self.last_refreshed_at.isoformat()
         else:
-            origin_uri = self.origin_uri
+            last_refreshed_at = self.last_refreshed_at
 
-        original_srid: int | None | Unset
-        if isinstance(self.original_srid, Unset):
-            original_srid = UNSET
+        last_checked_at: None | str | Unset
+        if isinstance(self.last_checked_at, Unset):
+            last_checked_at = UNSET
+        elif isinstance(self.last_checked_at, datetime.datetime):
+            last_checked_at = self.last_checked_at.isoformat()
         else:
-            original_srid = self.original_srid
+            last_checked_at = self.last_checked_at
+
+        source_health = self.source_health
+
+        source_health_detail: None | str | Unset
+        if isinstance(self.source_health_detail, Unset):
+            source_health_detail = UNSET
+        else:
+            source_health_detail = self.source_health_detail
+
+        schema_drift_status = self.schema_drift_status
+
+        quality_statement: None | str | Unset
+        if isinstance(self.quality_statement, Unset):
+            quality_statement = UNSET
+        else:
+            quality_statement = self.quality_statement
+
+        last_edited_by_display: None | str | Unset
+        if isinstance(self.last_edited_by_display, Unset):
+            last_edited_by_display = UNSET
+        else:
+            last_edited_by_display = self.last_edited_by_display
+
+        last_edited_at: None | str | Unset
+        if isinstance(self.last_edited_at, Unset):
+            last_edited_at = UNSET
+        elif isinstance(self.last_edited_at, datetime.datetime):
+            last_edited_at = self.last_edited_at.isoformat()
+        else:
+            last_edited_at = self.last_edited_at
+
+        collections: list[dict[str, Any]] | None | Unset
+        if isinstance(self.collections, Unset):
+            collections = UNSET
+        elif isinstance(self.collections, list):
+            collections = []
+            for collections_type_0_item_data in self.collections:
+                collections_type_0_item = collections_type_0_item_data.to_dict()
+                collections.append(collections_type_0_item)
+
+        else:
+            collections = self.collections
+
+        record_status = self.record_status
+
+        lineage_summary: None | str | Unset
+        if isinstance(self.lineage_summary, Unset):
+            lineage_summary = UNSET
+        else:
+            lineage_summary = self.lineage_summary
+
+        derived_from: dict[str, Any] | None | Unset
+        if isinstance(self.derived_from, Unset):
+            derived_from = UNSET
+        elif isinstance(self.derived_from, DerivedFromResponse):
+            derived_from = self.derived_from.to_dict()
+        else:
+            derived_from = self.derived_from
+
+        update_frequency: None | str | Unset
+        if isinstance(self.update_frequency, Unset):
+            update_frequency = UNSET
+        else:
+            update_frequency = self.update_frequency
+
+        usage_constraints: None | str | Unset
+        if isinstance(self.usage_constraints, Unset):
+            usage_constraints = UNSET
+        else:
+            usage_constraints = self.usage_constraints
+
+        access_constraints: None | str | Unset
+        if isinstance(self.access_constraints, Unset):
+            access_constraints = UNSET
+        else:
+            access_constraints = self.access_constraints
+
+        sensitivity_classification: None | str | Unset
+        if isinstance(self.sensitivity_classification, Unset):
+            sensitivity_classification = UNSET
+        else:
+            sensitivity_classification = self.sensitivity_classification
+
+        theme_category: list[str] | None | Unset
+        if isinstance(self.theme_category, Unset):
+            theme_category = UNSET
+        elif isinstance(self.theme_category, list):
+            theme_category = self.theme_category
+
+        else:
+            theme_category = self.theme_category
 
         owner_org: None | str | Unset
         if isinstance(self.owner_org, Unset):
@@ -402,19 +485,15 @@ class DatasetResponse:
         else:
             published_at = self.published_at
 
-        quality_detail: dict[str, Any] | None | Unset
-        if isinstance(self.quality_detail, Unset):
-            quality_detail = UNSET
-        elif isinstance(self.quality_detail, QualityDetail):
-            quality_detail = self.quality_detail.to_dict()
+        updated_by: None | str | Unset
+        if isinstance(self.updated_by, Unset):
+            updated_by = UNSET
+        elif isinstance(self.updated_by, UUID):
+            updated_by = str(self.updated_by)
         else:
-            quality_detail = self.quality_detail
+            updated_by = self.updated_by
 
-        quality_statement: None | str | Unset
-        if isinstance(self.quality_statement, Unset):
-            quality_statement = UNSET
-        else:
-            quality_statement = self.quality_statement
+        record_type = self.record_type
 
         raster: dict[str, Any] | None | Unset
         if isinstance(self.raster, Unset):
@@ -423,50 +502,6 @@ class DatasetResponse:
             raster = self.raster.to_dict()
         else:
             raster = self.raster
-
-        record_status = self.record_status
-
-        record_type = self.record_type
-
-        schema_drift_status = self.schema_drift_status
-
-        sensitivity_classification: None | str | Unset
-        if isinstance(self.sensitivity_classification, Unset):
-            sensitivity_classification = UNSET
-        else:
-            sensitivity_classification = self.sensitivity_classification
-
-        source_format: None | str | Unset
-        if isinstance(self.source_format, Unset):
-            source_format = UNSET
-        else:
-            source_format = self.source_format
-
-        source_health = self.source_health
-
-        source_health_detail: None | str | Unset
-        if isinstance(self.source_health_detail, Unset):
-            source_health_detail = UNSET
-        else:
-            source_health_detail = self.source_health_detail
-
-        source_organization: None | str | Unset
-        if isinstance(self.source_organization, Unset):
-            source_organization = UNSET
-        else:
-            source_organization = self.source_organization
-
-        source_url: None | str | Unset
-        if isinstance(self.source_url, Unset):
-            source_url = UNSET
-        else:
-            source_url = self.source_url
-
-        srid: int | None | Unset
-        if isinstance(self.srid, Unset):
-            srid = UNSET
-        else:
-            srid = self.srid
 
         stac_assets: dict[str, Any] | None | Unset
         if isinstance(self.stac_assets, Unset):
@@ -485,170 +520,135 @@ class DatasetResponse:
         else:
             stac_extensions = self.stac_extensions
 
-        theme_category: list[str] | None | Unset
-        if isinstance(self.theme_category, Unset):
-            theme_category = UNSET
-        elif isinstance(self.theme_category, list):
-            theme_category = self.theme_category
+        language: None | str | Unset
+        if isinstance(self.language, Unset):
+            language = UNSET
+        else:
+            language = self.language
+
+        metadata_warnings: list[str] | None | Unset
+        if isinstance(self.metadata_warnings, Unset):
+            metadata_warnings = UNSET
+        elif isinstance(self.metadata_warnings, list):
+            metadata_warnings = self.metadata_warnings
 
         else:
-            theme_category = self.theme_category
-
-        tile_columns: list[str] | None | Unset
-        if isinstance(self.tile_columns, Unset):
-            tile_columns = UNSET
-        elif isinstance(self.tile_columns, list):
-            tile_columns = self.tile_columns
-
-        else:
-            tile_columns = self.tile_columns
-
-        update_frequency: None | str | Unset
-        if isinstance(self.update_frequency, Unset):
-            update_frequency = UNSET
-        else:
-            update_frequency = self.update_frequency
-
-        updated_by: None | str | Unset
-        if isinstance(self.updated_by, Unset):
-            updated_by = UNSET
-        elif isinstance(self.updated_by, UUID):
-            updated_by = str(self.updated_by)
-        else:
-            updated_by = self.updated_by
-
-        usage_constraints: None | str | Unset
-        if isinstance(self.usage_constraints, Unset):
-            usage_constraints = UNSET
-        else:
-            usage_constraints = self.usage_constraints
-
-        z_max: float | None | Unset
-        if isinstance(self.z_max, Unset):
-            z_max = UNSET
-        else:
-            z_max = self.z_max
-
-        z_min: float | None | Unset
-        if isinstance(self.z_min, Unset):
-            z_min = UNSET
-        else:
-            z_min = self.z_min
+            metadata_warnings = self.metadata_warnings
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "created_by": created_by,
-                "created_by_display": created_by_display,
-                "feature_count": feature_count,
                 "id": id,
                 "record_id": record_id,
-                "source_filename": source_filename,
-                "summary": summary,
                 "table_name": table_name,
                 "title": title,
-                "updated_at": updated_at,
+                "summary": summary,
+                "feature_count": feature_count,
+                "source_filename": source_filename,
                 "visibility": visibility,
+                "created_by": created_by,
+                "created_by_display": created_by_display,
+                "created_at": created_at,
+                "updated_at": updated_at,
             }
         )
-        if access_constraints is not UNSET:
-            field_dict["access_constraints"] = access_constraints
-        if collections is not UNSET:
-            field_dict["collections"] = collections
-        if column_info is not UNSET:
-            field_dict["column_info"] = column_info
-        if current_version is not UNSET:
-            field_dict["current_version"] = current_version
-        if data_vintage_end is not UNSET:
-            field_dict["data_vintage_end"] = data_vintage_end
-        if data_vintage_start is not UNSET:
-            field_dict["data_vintage_start"] = data_vintage_start
-        if derived_from is not UNSET:
-            field_dict["derived_from"] = derived_from
-        if extent_bbox is not UNSET:
-            field_dict["extent_bbox"] = extent_bbox
+        if srid is not UNSET:
+            field_dict["srid"] = srid
         if geometry_type is not UNSET:
             field_dict["geometry_type"] = geometry_type
         if has_generic_geometry is not UNSET:
             field_dict["has_generic_geometry"] = has_generic_geometry
         if is_3d is not UNSET:
             field_dict["is_3d"] = is_3d
-        if language is not UNSET:
-            field_dict["language"] = language
-        if last_checked_at is not UNSET:
-            field_dict["last_checked_at"] = last_checked_at
-        if last_edited_at is not UNSET:
-            field_dict["last_edited_at"] = last_edited_at
-        if last_edited_by_display is not UNSET:
-            field_dict["last_edited_by_display"] = last_edited_by_display
-        if last_refreshed_at is not UNSET:
-            field_dict["last_refreshed_at"] = last_refreshed_at
-        if license_ is not UNSET:
-            field_dict["license"] = license_
-        if lineage_summary is not UNSET:
-            field_dict["lineage_summary"] = lineage_summary
-        if metadata_warnings is not UNSET:
-            field_dict["metadata_warnings"] = metadata_warnings
         if n_dims is not UNSET:
             field_dict["n_dims"] = n_dims
-        if origin is not UNSET:
-            field_dict["origin"] = origin
-        if origin_ref is not UNSET:
-            field_dict["origin_ref"] = origin_ref
-        if origin_uri is not UNSET:
-            field_dict["origin_uri"] = origin_uri
-        if original_srid is not UNSET:
-            field_dict["original_srid"] = original_srid
-        if owner_org is not UNSET:
-            field_dict["owner_org"] = owner_org
-        if published_at is not UNSET:
-            field_dict["published_at"] = published_at
+        if z_min is not UNSET:
+            field_dict["z_min"] = z_min
+        if z_max is not UNSET:
+            field_dict["z_max"] = z_max
+        if extent_bbox is not UNSET:
+            field_dict["extent_bbox"] = extent_bbox
+        if column_info is not UNSET:
+            field_dict["column_info"] = column_info
+        if license_ is not UNSET:
+            field_dict["license"] = license_
+        if source_organization is not UNSET:
+            field_dict["source_organization"] = source_organization
+        if data_vintage_start is not UNSET:
+            field_dict["data_vintage_start"] = data_vintage_start
+        if data_vintage_end is not UNSET:
+            field_dict["data_vintage_end"] = data_vintage_end
         if quality_detail is not UNSET:
             field_dict["quality_detail"] = quality_detail
-        if quality_statement is not UNSET:
-            field_dict["quality_statement"] = quality_statement
-        if raster is not UNSET:
-            field_dict["raster"] = raster
-        if record_status is not UNSET:
-            field_dict["record_status"] = record_status
-        if record_type is not UNSET:
-            field_dict["record_type"] = record_type
-        if schema_drift_status is not UNSET:
-            field_dict["schema_drift_status"] = schema_drift_status
-        if sensitivity_classification is not UNSET:
-            field_dict["sensitivity_classification"] = sensitivity_classification
         if source_format is not UNSET:
             field_dict["source_format"] = source_format
+        if tile_columns is not UNSET:
+            field_dict["tile_columns"] = tile_columns
+        if original_srid is not UNSET:
+            field_dict["original_srid"] = original_srid
+        if current_version is not UNSET:
+            field_dict["current_version"] = current_version
+        if source_url is not UNSET:
+            field_dict["source_url"] = source_url
+        if origin is not UNSET:
+            field_dict["origin"] = origin
+        if origin_uri is not UNSET:
+            field_dict["origin_uri"] = origin_uri
+        if origin_ref is not UNSET:
+            field_dict["origin_ref"] = origin_ref
+        if last_refreshed_at is not UNSET:
+            field_dict["last_refreshed_at"] = last_refreshed_at
+        if last_checked_at is not UNSET:
+            field_dict["last_checked_at"] = last_checked_at
         if source_health is not UNSET:
             field_dict["source_health"] = source_health
         if source_health_detail is not UNSET:
             field_dict["source_health_detail"] = source_health_detail
-        if source_organization is not UNSET:
-            field_dict["source_organization"] = source_organization
-        if source_url is not UNSET:
-            field_dict["source_url"] = source_url
-        if srid is not UNSET:
-            field_dict["srid"] = srid
+        if schema_drift_status is not UNSET:
+            field_dict["schema_drift_status"] = schema_drift_status
+        if quality_statement is not UNSET:
+            field_dict["quality_statement"] = quality_statement
+        if last_edited_by_display is not UNSET:
+            field_dict["last_edited_by_display"] = last_edited_by_display
+        if last_edited_at is not UNSET:
+            field_dict["last_edited_at"] = last_edited_at
+        if collections is not UNSET:
+            field_dict["collections"] = collections
+        if record_status is not UNSET:
+            field_dict["record_status"] = record_status
+        if lineage_summary is not UNSET:
+            field_dict["lineage_summary"] = lineage_summary
+        if derived_from is not UNSET:
+            field_dict["derived_from"] = derived_from
+        if update_frequency is not UNSET:
+            field_dict["update_frequency"] = update_frequency
+        if usage_constraints is not UNSET:
+            field_dict["usage_constraints"] = usage_constraints
+        if access_constraints is not UNSET:
+            field_dict["access_constraints"] = access_constraints
+        if sensitivity_classification is not UNSET:
+            field_dict["sensitivity_classification"] = sensitivity_classification
+        if theme_category is not UNSET:
+            field_dict["theme_category"] = theme_category
+        if owner_org is not UNSET:
+            field_dict["owner_org"] = owner_org
+        if published_at is not UNSET:
+            field_dict["published_at"] = published_at
+        if updated_by is not UNSET:
+            field_dict["updated_by"] = updated_by
+        if record_type is not UNSET:
+            field_dict["record_type"] = record_type
+        if raster is not UNSET:
+            field_dict["raster"] = raster
         if stac_assets is not UNSET:
             field_dict["stac_assets"] = stac_assets
         if stac_extensions is not UNSET:
             field_dict["stac_extensions"] = stac_extensions
-        if theme_category is not UNSET:
-            field_dict["theme_category"] = theme_category
-        if tile_columns is not UNSET:
-            field_dict["tile_columns"] = tile_columns
-        if update_frequency is not UNSET:
-            field_dict["update_frequency"] = update_frequency
-        if updated_by is not UNSET:
-            field_dict["updated_by"] = updated_by
-        if usage_constraints is not UNSET:
-            field_dict["usage_constraints"] = usage_constraints
-        if z_max is not UNSET:
-            field_dict["z_max"] = z_max
-        if z_min is not UNSET:
-            field_dict["z_min"] = z_min
+        if language is not UNSET:
+            field_dict["language"] = language
+        if metadata_warnings is not UNSET:
+            field_dict["metadata_warnings"] = metadata_warnings
 
         return field_dict
 
@@ -667,7 +667,36 @@ class DatasetResponse:
         from ..models.raster_metadata import RasterMetadata
 
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
+        id = UUID(d.pop("id"))
+
+        record_id = UUID(d.pop("record_id"))
+
+        table_name = d.pop("table_name")
+
+        title = d.pop("title")
+
+        def _parse_summary(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        summary = _parse_summary(d.pop("summary"))
+
+        def _parse_feature_count(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        feature_count = _parse_feature_count(d.pop("feature_count"))
+
+        def _parse_source_filename(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        source_filename = _parse_source_filename(d.pop("source_filename"))
+
+        visibility = d.pop("visibility")
 
         def _parse_created_by(data: object) -> None | UUID:
             if data is None:
@@ -686,51 +715,67 @@ class DatasetResponse:
 
         created_by_display = d.pop("created_by_display")
 
-        def _parse_feature_count(data: object) -> int | None:
-            if data is None:
-                return data
-            return cast(int | None, data)
-
-        feature_count = _parse_feature_count(d.pop("feature_count"))
-
-        id = UUID(d.pop("id"))
-
-        record_id = UUID(d.pop("record_id"))
-
-        def _parse_source_filename(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        source_filename = _parse_source_filename(d.pop("source_filename"))
-
-        def _parse_summary(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        summary = _parse_summary(d.pop("summary"))
-
-        table_name = d.pop("table_name")
-
-        title = d.pop("title")
+        created_at = isoparse(d.pop("created_at"))
 
         updated_at = isoparse(d.pop("updated_at"))
 
-        visibility = d.pop("visibility")
+        def _parse_srid(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
 
-        def _parse_access_constraints(data: object) -> None | str | Unset:
+        srid = _parse_srid(d.pop("srid", UNSET))
+
+        def _parse_geometry_type(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        access_constraints = _parse_access_constraints(
-            d.pop("access_constraints", UNSET)
-        )
+        geometry_type = _parse_geometry_type(d.pop("geometry_type", UNSET))
 
-        def _parse_collections(data: object) -> list[CollectionRef] | None | Unset:
+        has_generic_geometry = d.pop("has_generic_geometry", UNSET)
+
+        def _parse_is_3d(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_3d = _parse_is_3d(d.pop("is_3d", UNSET))
+
+        def _parse_n_dims(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        n_dims = _parse_n_dims(d.pop("n_dims", UNSET))
+
+        def _parse_z_min(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        z_min = _parse_z_min(d.pop("z_min", UNSET))
+
+        def _parse_z_max(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        z_max = _parse_z_max(d.pop("z_max", UNSET))
+
+        def _parse_extent_bbox(data: object) -> list[float] | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -738,21 +783,14 @@ class DatasetResponse:
             try:
                 if not isinstance(data, list):
                     raise TypeError()
-                collections_type_0 = []
-                _collections_type_0 = data
-                for collections_type_0_item_data in _collections_type_0:
-                    collections_type_0_item = CollectionRef.from_dict(
-                        collections_type_0_item_data
-                    )
+                extent_bbox_type_0 = cast(list[float], data)
 
-                    collections_type_0.append(collections_type_0_item)
-
-                return collections_type_0
+                return extent_bbox_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(list[CollectionRef] | None | Unset, data)
+            return cast(list[float] | None | Unset, data)
 
-        collections = _parse_collections(d.pop("collections", UNSET))
+        extent_bbox = _parse_extent_bbox(d.pop("extent_bbox", UNSET))
 
         def _parse_column_info(data: object) -> list[ColumnInfo] | None | Unset:
             if data is None:
@@ -778,24 +816,25 @@ class DatasetResponse:
 
         column_info = _parse_column_info(d.pop("column_info", UNSET))
 
-        current_version = d.pop("current_version", UNSET)
-
-        def _parse_data_vintage_end(data: object) -> datetime.date | None | Unset:
+        def _parse_license_(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                data_vintage_end_type_0 = isoparse(data).date()
+            return cast(None | str | Unset, data)
 
-                return data_vintage_end_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.date | None | Unset, data)
+        license_ = _parse_license_(d.pop("license", UNSET))
 
-        data_vintage_end = _parse_data_vintage_end(d.pop("data_vintage_end", UNSET))
+        def _parse_source_organization(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        source_organization = _parse_source_organization(
+            d.pop("source_organization", UNSET)
+        )
 
         def _parse_data_vintage_start(data: object) -> datetime.date | None | Unset:
             if data is None:
@@ -816,7 +855,24 @@ class DatasetResponse:
             d.pop("data_vintage_start", UNSET)
         )
 
-        def _parse_derived_from(data: object) -> DerivedFromResponse | None | Unset:
+        def _parse_data_vintage_end(data: object) -> datetime.date | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                data_vintage_end_type_0 = isoparse(data).date()
+
+                return data_vintage_end_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.date | None | Unset, data)
+
+        data_vintage_end = _parse_data_vintage_end(d.pop("data_vintage_end", UNSET))
+
+        def _parse_quality_detail(data: object) -> None | QualityDetail | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -824,16 +880,25 @@ class DatasetResponse:
             try:
                 if not isinstance(data, dict):
                     raise TypeError()
-                derived_from_type_0 = DerivedFromResponse.from_dict(data)
+                quality_detail_type_0 = QualityDetail.from_dict(data)
 
-                return derived_from_type_0
+                return quality_detail_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(DerivedFromResponse | None | Unset, data)
+            return cast(None | QualityDetail | Unset, data)
 
-        derived_from = _parse_derived_from(d.pop("derived_from", UNSET))
+        quality_detail = _parse_quality_detail(d.pop("quality_detail", UNSET))
 
-        def _parse_extent_bbox(data: object) -> list[float] | None | Unset:
+        def _parse_source_format(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        source_format = _parse_source_format(d.pop("source_format", UNSET))
+
+        def _parse_tile_columns(data: object) -> list[str] | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -841,149 +906,34 @@ class DatasetResponse:
             try:
                 if not isinstance(data, list):
                     raise TypeError()
-                extent_bbox_type_0 = cast(list[float], data)
+                tile_columns_type_0 = cast(list[str], data)
 
-                return extent_bbox_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[float] | None | Unset, data)
-
-        extent_bbox = _parse_extent_bbox(d.pop("extent_bbox", UNSET))
-
-        def _parse_geometry_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        geometry_type = _parse_geometry_type(d.pop("geometry_type", UNSET))
-
-        has_generic_geometry = d.pop("has_generic_geometry", UNSET)
-
-        def _parse_is_3d(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        is_3d = _parse_is_3d(d.pop("is_3d", UNSET))
-
-        def _parse_language(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        language = _parse_language(d.pop("language", UNSET))
-
-        def _parse_last_checked_at(data: object) -> datetime.datetime | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                last_checked_at_type_0 = isoparse(data)
-
-                return last_checked_at_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None | Unset, data)
-
-        last_checked_at = _parse_last_checked_at(d.pop("last_checked_at", UNSET))
-
-        def _parse_last_edited_at(data: object) -> datetime.datetime | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                last_edited_at_type_0 = isoparse(data)
-
-                return last_edited_at_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None | Unset, data)
-
-        last_edited_at = _parse_last_edited_at(d.pop("last_edited_at", UNSET))
-
-        def _parse_last_edited_by_display(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        last_edited_by_display = _parse_last_edited_by_display(
-            d.pop("last_edited_by_display", UNSET)
-        )
-
-        def _parse_last_refreshed_at(data: object) -> datetime.datetime | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                last_refreshed_at_type_0 = isoparse(data)
-
-                return last_refreshed_at_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None | Unset, data)
-
-        last_refreshed_at = _parse_last_refreshed_at(d.pop("last_refreshed_at", UNSET))
-
-        def _parse_license_(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        license_ = _parse_license_(d.pop("license", UNSET))
-
-        def _parse_lineage_summary(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        lineage_summary = _parse_lineage_summary(d.pop("lineage_summary", UNSET))
-
-        def _parse_metadata_warnings(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                metadata_warnings_type_0 = cast(list[str], data)
-
-                return metadata_warnings_type_0
+                return tile_columns_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[str] | None | Unset, data)
 
-        metadata_warnings = _parse_metadata_warnings(d.pop("metadata_warnings", UNSET))
+        tile_columns = _parse_tile_columns(d.pop("tile_columns", UNSET))
 
-        def _parse_n_dims(data: object) -> int | None | Unset:
+        def _parse_original_srid(data: object) -> int | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(int | None | Unset, data)
 
-        n_dims = _parse_n_dims(d.pop("n_dims", UNSET))
+        original_srid = _parse_original_srid(d.pop("original_srid", UNSET))
+
+        current_version = d.pop("current_version", UNSET)
+
+        def _parse_source_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        source_url = _parse_source_url(d.pop("source_url", UNSET))
 
         def _parse_origin(data: object) -> None | str | Unset:
             if data is None:
@@ -993,6 +943,15 @@ class DatasetResponse:
             return cast(None | str | Unset, data)
 
         origin = _parse_origin(d.pop("origin", UNSET))
+
+        def _parse_origin_uri(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        origin_uri = _parse_origin_uri(d.pop("origin_uri", UNSET))
 
         def _parse_origin_ref(
             data: object,
@@ -1013,23 +972,200 @@ class DatasetResponse:
 
         origin_ref = _parse_origin_ref(d.pop("origin_ref", UNSET))
 
-        def _parse_origin_uri(data: object) -> None | str | Unset:
+        def _parse_last_refreshed_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                last_refreshed_at_type_0 = isoparse(data)
+
+                return last_refreshed_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        last_refreshed_at = _parse_last_refreshed_at(d.pop("last_refreshed_at", UNSET))
+
+        def _parse_last_checked_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                last_checked_at_type_0 = isoparse(data)
+
+                return last_checked_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        last_checked_at = _parse_last_checked_at(d.pop("last_checked_at", UNSET))
+
+        source_health = d.pop("source_health", UNSET)
+
+        def _parse_source_health_detail(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        origin_uri = _parse_origin_uri(d.pop("origin_uri", UNSET))
+        source_health_detail = _parse_source_health_detail(
+            d.pop("source_health_detail", UNSET)
+        )
 
-        def _parse_original_srid(data: object) -> int | None | Unset:
+        schema_drift_status = d.pop("schema_drift_status", UNSET)
+
+        def _parse_quality_statement(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(int | None | Unset, data)
+            return cast(None | str | Unset, data)
 
-        original_srid = _parse_original_srid(d.pop("original_srid", UNSET))
+        quality_statement = _parse_quality_statement(d.pop("quality_statement", UNSET))
+
+        def _parse_last_edited_by_display(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        last_edited_by_display = _parse_last_edited_by_display(
+            d.pop("last_edited_by_display", UNSET)
+        )
+
+        def _parse_last_edited_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                last_edited_at_type_0 = isoparse(data)
+
+                return last_edited_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        last_edited_at = _parse_last_edited_at(d.pop("last_edited_at", UNSET))
+
+        def _parse_collections(data: object) -> list[CollectionRef] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                collections_type_0 = []
+                _collections_type_0 = data
+                for collections_type_0_item_data in _collections_type_0:
+                    collections_type_0_item = CollectionRef.from_dict(
+                        collections_type_0_item_data
+                    )
+
+                    collections_type_0.append(collections_type_0_item)
+
+                return collections_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[CollectionRef] | None | Unset, data)
+
+        collections = _parse_collections(d.pop("collections", UNSET))
+
+        record_status = d.pop("record_status", UNSET)
+
+        def _parse_lineage_summary(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        lineage_summary = _parse_lineage_summary(d.pop("lineage_summary", UNSET))
+
+        def _parse_derived_from(data: object) -> DerivedFromResponse | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                derived_from_type_0 = DerivedFromResponse.from_dict(data)
+
+                return derived_from_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(DerivedFromResponse | None | Unset, data)
+
+        derived_from = _parse_derived_from(d.pop("derived_from", UNSET))
+
+        def _parse_update_frequency(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        update_frequency = _parse_update_frequency(d.pop("update_frequency", UNSET))
+
+        def _parse_usage_constraints(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        usage_constraints = _parse_usage_constraints(d.pop("usage_constraints", UNSET))
+
+        def _parse_access_constraints(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        access_constraints = _parse_access_constraints(
+            d.pop("access_constraints", UNSET)
+        )
+
+        def _parse_sensitivity_classification(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        sensitivity_classification = _parse_sensitivity_classification(
+            d.pop("sensitivity_classification", UNSET)
+        )
+
+        def _parse_theme_category(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                theme_category_type_0 = cast(list[str], data)
+
+                return theme_category_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        theme_category = _parse_theme_category(d.pop("theme_category", UNSET))
 
         def _parse_owner_org(data: object) -> None | str | Unset:
             if data is None:
@@ -1057,31 +1193,24 @@ class DatasetResponse:
 
         published_at = _parse_published_at(d.pop("published_at", UNSET))
 
-        def _parse_quality_detail(data: object) -> None | QualityDetail | Unset:
+        def _parse_updated_by(data: object) -> None | Unset | UUID:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             try:
-                if not isinstance(data, dict):
+                if not isinstance(data, str):
                     raise TypeError()
-                quality_detail_type_0 = QualityDetail.from_dict(data)
+                updated_by_type_0 = UUID(data)
 
-                return quality_detail_type_0
+                return updated_by_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(None | QualityDetail | Unset, data)
+            return cast(None | Unset | UUID, data)
 
-        quality_detail = _parse_quality_detail(d.pop("quality_detail", UNSET))
+        updated_by = _parse_updated_by(d.pop("updated_by", UNSET))
 
-        def _parse_quality_statement(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        quality_statement = _parse_quality_statement(d.pop("quality_statement", UNSET))
+        record_type = d.pop("record_type", UNSET)
 
         def _parse_raster(data: object) -> None | RasterMetadata | Unset:
             if data is None:
@@ -1099,74 +1228,6 @@ class DatasetResponse:
             return cast(None | RasterMetadata | Unset, data)
 
         raster = _parse_raster(d.pop("raster", UNSET))
-
-        record_status = d.pop("record_status", UNSET)
-
-        record_type = d.pop("record_type", UNSET)
-
-        schema_drift_status = d.pop("schema_drift_status", UNSET)
-
-        def _parse_sensitivity_classification(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        sensitivity_classification = _parse_sensitivity_classification(
-            d.pop("sensitivity_classification", UNSET)
-        )
-
-        def _parse_source_format(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        source_format = _parse_source_format(d.pop("source_format", UNSET))
-
-        source_health = d.pop("source_health", UNSET)
-
-        def _parse_source_health_detail(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        source_health_detail = _parse_source_health_detail(
-            d.pop("source_health_detail", UNSET)
-        )
-
-        def _parse_source_organization(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        source_organization = _parse_source_organization(
-            d.pop("source_organization", UNSET)
-        )
-
-        def _parse_source_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        source_url = _parse_source_url(d.pop("source_url", UNSET))
-
-        def _parse_srid(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        srid = _parse_srid(d.pop("srid", UNSET))
 
         def _parse_stac_assets(
             data: object,
@@ -1204,7 +1265,16 @@ class DatasetResponse:
 
         stac_extensions = _parse_stac_extensions(d.pop("stac_extensions", UNSET))
 
-        def _parse_theme_category(data: object) -> list[str] | None | Unset:
+        def _parse_language(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        language = _parse_language(d.pop("language", UNSET))
+
+        def _parse_metadata_warnings(data: object) -> list[str] | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -1212,146 +1282,76 @@ class DatasetResponse:
             try:
                 if not isinstance(data, list):
                     raise TypeError()
-                theme_category_type_0 = cast(list[str], data)
+                metadata_warnings_type_0 = cast(list[str], data)
 
-                return theme_category_type_0
+                return metadata_warnings_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[str] | None | Unset, data)
 
-        theme_category = _parse_theme_category(d.pop("theme_category", UNSET))
-
-        def _parse_tile_columns(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                tile_columns_type_0 = cast(list[str], data)
-
-                return tile_columns_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        tile_columns = _parse_tile_columns(d.pop("tile_columns", UNSET))
-
-        def _parse_update_frequency(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        update_frequency = _parse_update_frequency(d.pop("update_frequency", UNSET))
-
-        def _parse_updated_by(data: object) -> None | Unset | UUID:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                updated_by_type_0 = UUID(data)
-
-                return updated_by_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | Unset | UUID, data)
-
-        updated_by = _parse_updated_by(d.pop("updated_by", UNSET))
-
-        def _parse_usage_constraints(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        usage_constraints = _parse_usage_constraints(d.pop("usage_constraints", UNSET))
-
-        def _parse_z_max(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        z_max = _parse_z_max(d.pop("z_max", UNSET))
-
-        def _parse_z_min(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        z_min = _parse_z_min(d.pop("z_min", UNSET))
+        metadata_warnings = _parse_metadata_warnings(d.pop("metadata_warnings", UNSET))
 
         dataset_response = cls(
-            created_at=created_at,
-            created_by=created_by,
-            created_by_display=created_by_display,
-            feature_count=feature_count,
             id=id,
             record_id=record_id,
-            source_filename=source_filename,
-            summary=summary,
             table_name=table_name,
             title=title,
-            updated_at=updated_at,
+            summary=summary,
+            feature_count=feature_count,
+            source_filename=source_filename,
             visibility=visibility,
-            access_constraints=access_constraints,
-            collections=collections,
-            column_info=column_info,
-            current_version=current_version,
-            data_vintage_end=data_vintage_end,
-            data_vintage_start=data_vintage_start,
-            derived_from=derived_from,
-            extent_bbox=extent_bbox,
+            created_by=created_by,
+            created_by_display=created_by_display,
+            created_at=created_at,
+            updated_at=updated_at,
+            srid=srid,
             geometry_type=geometry_type,
             has_generic_geometry=has_generic_geometry,
             is_3d=is_3d,
-            language=language,
-            last_checked_at=last_checked_at,
-            last_edited_at=last_edited_at,
-            last_edited_by_display=last_edited_by_display,
-            last_refreshed_at=last_refreshed_at,
-            license_=license_,
-            lineage_summary=lineage_summary,
-            metadata_warnings=metadata_warnings,
             n_dims=n_dims,
-            origin=origin,
-            origin_ref=origin_ref,
-            origin_uri=origin_uri,
-            original_srid=original_srid,
-            owner_org=owner_org,
-            published_at=published_at,
+            z_min=z_min,
+            z_max=z_max,
+            extent_bbox=extent_bbox,
+            column_info=column_info,
+            license_=license_,
+            source_organization=source_organization,
+            data_vintage_start=data_vintage_start,
+            data_vintage_end=data_vintage_end,
             quality_detail=quality_detail,
-            quality_statement=quality_statement,
-            raster=raster,
-            record_status=record_status,
-            record_type=record_type,
-            schema_drift_status=schema_drift_status,
-            sensitivity_classification=sensitivity_classification,
             source_format=source_format,
+            tile_columns=tile_columns,
+            original_srid=original_srid,
+            current_version=current_version,
+            source_url=source_url,
+            origin=origin,
+            origin_uri=origin_uri,
+            origin_ref=origin_ref,
+            last_refreshed_at=last_refreshed_at,
+            last_checked_at=last_checked_at,
             source_health=source_health,
             source_health_detail=source_health_detail,
-            source_organization=source_organization,
-            source_url=source_url,
-            srid=srid,
+            schema_drift_status=schema_drift_status,
+            quality_statement=quality_statement,
+            last_edited_by_display=last_edited_by_display,
+            last_edited_at=last_edited_at,
+            collections=collections,
+            record_status=record_status,
+            lineage_summary=lineage_summary,
+            derived_from=derived_from,
+            update_frequency=update_frequency,
+            usage_constraints=usage_constraints,
+            access_constraints=access_constraints,
+            sensitivity_classification=sensitivity_classification,
+            theme_category=theme_category,
+            owner_org=owner_org,
+            published_at=published_at,
+            updated_by=updated_by,
+            record_type=record_type,
+            raster=raster,
             stac_assets=stac_assets,
             stac_extensions=stac_extensions,
-            theme_category=theme_category,
-            tile_columns=tile_columns,
-            update_frequency=update_frequency,
-            updated_by=updated_by,
-            usage_constraints=usage_constraints,
-            z_max=z_max,
-            z_min=z_min,
+            language=language,
+            metadata_warnings=metadata_warnings,
         )
 
         dataset_response.additional_properties = d

--- a/sdks/python/geolens/models/dataset_rows_response.py
+++ b/sdks/python/geolens/models/dataset_rows_response.py
@@ -22,21 +22,19 @@ T = TypeVar("T", bound="DatasetRowsResponse")
 class DatasetRowsResponse:
     """
     Attributes:
-        approximate_total (int): Estimated total row count (may use pg stats)
         columns (list[ColumnChange]):
         rows (list[DatasetRowsResponseRowsItem]):
+        approximate_total (int): Estimated total row count (may use pg stats)
         next_cursor (int | None | Unset): Cursor value for the next page, null if last
     """
 
-    approximate_total: int
     columns: list[ColumnChange]
     rows: list[DatasetRowsResponseRowsItem]
+    approximate_total: int
     next_cursor: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        approximate_total = self.approximate_total
-
         columns = []
         for columns_item_data in self.columns:
             columns_item = columns_item_data.to_dict()
@@ -46,6 +44,8 @@ class DatasetRowsResponse:
         for rows_item_data in self.rows:
             rows_item = rows_item_data.to_dict()
             rows.append(rows_item)
+
+        approximate_total = self.approximate_total
 
         next_cursor: int | None | Unset
         if isinstance(self.next_cursor, Unset):
@@ -57,9 +57,9 @@ class DatasetRowsResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "approximate_total": approximate_total,
                 "columns": columns,
                 "rows": rows,
+                "approximate_total": approximate_total,
             }
         )
         if next_cursor is not UNSET:
@@ -73,8 +73,6 @@ class DatasetRowsResponse:
         from ..models.dataset_rows_response_rows_item import DatasetRowsResponseRowsItem
 
         d = dict(src_dict)
-        approximate_total = d.pop("approximate_total")
-
         columns = []
         _columns = d.pop("columns")
         for columns_item_data in _columns:
@@ -89,6 +87,8 @@ class DatasetRowsResponse:
 
             rows.append(rows_item)
 
+        approximate_total = d.pop("approximate_total")
+
         def _parse_next_cursor(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -99,9 +99,9 @@ class DatasetRowsResponse:
         next_cursor = _parse_next_cursor(d.pop("next_cursor", UNSET))
 
         dataset_rows_response = cls(
-            approximate_total=approximate_total,
             columns=columns,
             rows=rows,
+            approximate_total=approximate_total,
             next_cursor=next_cursor,
         )
 

--- a/sdks/python/geolens/models/dataset_version_list_response.py
+++ b/sdks/python/geolens/models/dataset_version_list_response.py
@@ -18,28 +18,28 @@ T = TypeVar("T", bound="DatasetVersionListResponse")
 class DatasetVersionListResponse:
     """
     Attributes:
-        total (int):
         versions (list[DatasetVersionResponse]):
+        total (int):
     """
 
-    total: int
     versions: list[DatasetVersionResponse]
+    total: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        total = self.total
-
         versions = []
         for versions_item_data in self.versions:
             versions_item = versions_item_data.to_dict()
             versions.append(versions_item)
 
+        total = self.total
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "total": total,
                 "versions": versions,
+                "total": total,
             }
         )
 
@@ -50,8 +50,6 @@ class DatasetVersionListResponse:
         from ..models.dataset_version_response import DatasetVersionResponse
 
         d = dict(src_dict)
-        total = d.pop("total")
-
         versions = []
         _versions = d.pop("versions")
         for versions_item_data in _versions:
@@ -59,9 +57,11 @@ class DatasetVersionListResponse:
 
             versions.append(versions_item)
 
+        total = d.pop("total")
+
         dataset_version_list_response = cls(
-            total=total,
             versions=versions,
+            total=total,
         )
 
         dataset_version_list_response.additional_properties = d

--- a/sdks/python/geolens/models/dataset_version_response.py
+++ b/sdks/python/geolens/models/dataset_version_response.py
@@ -20,45 +20,38 @@ T = TypeVar("T", bound="DatasetVersionResponse")
 class DatasetVersionResponse:
     """
     Attributes:
-        dataset_id (UUID):
-        feature_count (int | None):
-        file_hash (None | str):
-        geometry_type (None | str):
         id (UUID):
+        dataset_id (UUID):
+        version_number (int):
         source_filename (None | str):
         source_format (None | str):
+        feature_count (int | None):
         srid (int | None):
-        uploaded_at (datetime.datetime):
+        geometry_type (None | str):
+        file_hash (None | str):
         uploaded_by (None | UUID):
-        version_number (int):
+        uploaded_at (datetime.datetime):
     """
 
-    dataset_id: UUID
-    feature_count: int | None
-    file_hash: None | str
-    geometry_type: None | str
     id: UUID
+    dataset_id: UUID
+    version_number: int
     source_filename: None | str
     source_format: None | str
+    feature_count: int | None
     srid: int | None
-    uploaded_at: datetime.datetime
+    geometry_type: None | str
+    file_hash: None | str
     uploaded_by: None | UUID
-    version_number: int
+    uploaded_at: datetime.datetime
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
         dataset_id = str(self.dataset_id)
 
-        feature_count: int | None
-        feature_count = self.feature_count
-
-        file_hash: None | str
-        file_hash = self.file_hash
-
-        geometry_type: None | str
-        geometry_type = self.geometry_type
-
-        id = str(self.id)
+        version_number = self.version_number
 
         source_filename: None | str
         source_filename = self.source_filename
@@ -66,10 +59,17 @@ class DatasetVersionResponse:
         source_format: None | str
         source_format = self.source_format
 
+        feature_count: int | None
+        feature_count = self.feature_count
+
         srid: int | None
         srid = self.srid
 
-        uploaded_at = self.uploaded_at.isoformat()
+        geometry_type: None | str
+        geometry_type = self.geometry_type
+
+        file_hash: None | str
+        file_hash = self.file_hash
 
         uploaded_by: None | str
         if isinstance(self.uploaded_by, UUID):
@@ -77,23 +77,23 @@ class DatasetVersionResponse:
         else:
             uploaded_by = self.uploaded_by
 
-        version_number = self.version_number
+        uploaded_at = self.uploaded_at.isoformat()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "dataset_id": dataset_id,
-                "feature_count": feature_count,
-                "file_hash": file_hash,
-                "geometry_type": geometry_type,
                 "id": id,
+                "dataset_id": dataset_id,
+                "version_number": version_number,
                 "source_filename": source_filename,
                 "source_format": source_format,
+                "feature_count": feature_count,
                 "srid": srid,
-                "uploaded_at": uploaded_at,
+                "geometry_type": geometry_type,
+                "file_hash": file_hash,
                 "uploaded_by": uploaded_by,
-                "version_number": version_number,
+                "uploaded_at": uploaded_at,
             }
         )
 
@@ -102,30 +102,11 @@ class DatasetVersionResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
         dataset_id = UUID(d.pop("dataset_id"))
 
-        def _parse_feature_count(data: object) -> int | None:
-            if data is None:
-                return data
-            return cast(int | None, data)
-
-        feature_count = _parse_feature_count(d.pop("feature_count"))
-
-        def _parse_file_hash(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        file_hash = _parse_file_hash(d.pop("file_hash"))
-
-        def _parse_geometry_type(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        geometry_type = _parse_geometry_type(d.pop("geometry_type"))
-
-        id = UUID(d.pop("id"))
+        version_number = d.pop("version_number")
 
         def _parse_source_filename(data: object) -> None | str:
             if data is None:
@@ -141,6 +122,13 @@ class DatasetVersionResponse:
 
         source_format = _parse_source_format(d.pop("source_format"))
 
+        def _parse_feature_count(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        feature_count = _parse_feature_count(d.pop("feature_count"))
+
         def _parse_srid(data: object) -> int | None:
             if data is None:
                 return data
@@ -148,7 +136,19 @@ class DatasetVersionResponse:
 
         srid = _parse_srid(d.pop("srid"))
 
-        uploaded_at = isoparse(d.pop("uploaded_at"))
+        def _parse_geometry_type(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        geometry_type = _parse_geometry_type(d.pop("geometry_type"))
+
+        def _parse_file_hash(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        file_hash = _parse_file_hash(d.pop("file_hash"))
 
         def _parse_uploaded_by(data: object) -> None | UUID:
             if data is None:
@@ -165,20 +165,20 @@ class DatasetVersionResponse:
 
         uploaded_by = _parse_uploaded_by(d.pop("uploaded_by"))
 
-        version_number = d.pop("version_number")
+        uploaded_at = isoparse(d.pop("uploaded_at"))
 
         dataset_version_response = cls(
-            dataset_id=dataset_id,
-            feature_count=feature_count,
-            file_hash=file_hash,
-            geometry_type=geometry_type,
             id=id,
+            dataset_id=dataset_id,
+            version_number=version_number,
             source_filename=source_filename,
             source_format=source_format,
+            feature_count=feature_count,
             srid=srid,
-            uploaded_at=uploaded_at,
+            geometry_type=geometry_type,
+            file_hash=file_hash,
             uploaded_by=uploaded_by,
-            version_number=version_number,
+            uploaded_at=uploaded_at,
         )
 
         dataset_version_response.additional_properties = d

--- a/sdks/python/geolens/models/dbf_truncation_collision_warning.py
+++ b/sdks/python/geolens/models/dbf_truncation_collision_warning.py
@@ -20,27 +20,27 @@ T = TypeVar("T", bound="DbfTruncationCollisionWarning")
 class DbfTruncationCollisionWarning:
     """
     Attributes:
-        details (list[DbfTruncationDetail]):
         kind (Literal['dbf_truncation_collision']):
+        details (list[DbfTruncationDetail]):
     """
 
-    details: list[DbfTruncationDetail]
     kind: Literal["dbf_truncation_collision"]
+    details: list[DbfTruncationDetail]
 
     def to_dict(self) -> dict[str, Any]:
+        kind = self.kind
+
         details = []
         for details_item_data in self.details:
             details_item = details_item_data.to_dict()
             details.append(details_item)
 
-        kind = self.kind
-
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
             {
-                "details": details,
                 "kind": kind,
+                "details": details,
             }
         )
 
@@ -51,6 +51,12 @@ class DbfTruncationCollisionWarning:
         from ..models.dbf_truncation_detail import DbfTruncationDetail
 
         d = dict(src_dict)
+        kind = cast(Literal["dbf_truncation_collision"], d.pop("kind"))
+        if kind != "dbf_truncation_collision":
+            raise ValueError(
+                f"kind must match const 'dbf_truncation_collision', got '{kind}'"
+            )
+
         details = []
         _details = d.pop("details")
         for details_item_data in _details:
@@ -58,15 +64,9 @@ class DbfTruncationCollisionWarning:
 
             details.append(details_item)
 
-        kind = cast(Literal["dbf_truncation_collision"], d.pop("kind"))
-        if kind != "dbf_truncation_collision":
-            raise ValueError(
-                f"kind must match const 'dbf_truncation_collision', got '{kind}'"
-            )
-
         dbf_truncation_collision_warning = cls(
-            details=details,
             kind=kind,
+            details=details,
         )
 
         return dbf_truncation_collision_warning

--- a/sdks/python/geolens/models/dbf_truncation_detail.py
+++ b/sdks/python/geolens/models/dbf_truncation_detail.py
@@ -16,24 +16,24 @@ T = TypeVar("T", bound="DbfTruncationDetail")
 class DbfTruncationDetail:
     """
     Attributes:
-        originals (list[str]):
         truncated (str):
+        originals (list[str]):
     """
 
-    originals: list[str]
     truncated: str
+    originals: list[str]
 
     def to_dict(self) -> dict[str, Any]:
-        originals = self.originals
-
         truncated = self.truncated
+
+        originals = self.originals
 
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
             {
-                "originals": originals,
                 "truncated": truncated,
+                "originals": originals,
             }
         )
 
@@ -42,13 +42,13 @@ class DbfTruncationDetail:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        originals = cast(list[str], d.pop("originals"))
-
         truncated = d.pop("truncated")
 
+        originals = cast(list[str], d.pop("originals"))
+
         dbf_truncation_detail = cls(
-            originals=originals,
             truncated=truncated,
+            originals=originals,
         )
 
         return dbf_truncation_detail

--- a/sdks/python/geolens/models/derived_from_response.py
+++ b/sdks/python/geolens/models/derived_from_response.py
@@ -38,36 +38,36 @@ class DerivedFromResponse:
     describe a shape the redaction is free to punch holes in.
 
         Attributes:
-            created_at (datetime.datetime):
             dataset_id (UUID): The dataset this one was derived from
             operation (str): Analysis operation that produced it
             params (DerivedFromResponseParams): Operation parameters, minus any dataset reference the requester cannot
                 access
+            created_at (datetime.datetime):
     """
 
-    created_at: datetime.datetime
     dataset_id: UUID
     operation: str
     params: DerivedFromResponseParams
+    created_at: datetime.datetime
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
-
         dataset_id = str(self.dataset_id)
 
         operation = self.operation
 
         params = self.params.to_dict()
 
+        created_at = self.created_at.isoformat()
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
                 "dataset_id": dataset_id,
                 "operation": operation,
                 "params": params,
+                "created_at": created_at,
             }
         )
 
@@ -78,19 +78,19 @@ class DerivedFromResponse:
         from ..models.derived_from_response_params import DerivedFromResponseParams
 
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
-
         dataset_id = UUID(d.pop("dataset_id"))
 
         operation = d.pop("operation")
 
         params = DerivedFromResponseParams.from_dict(d.pop("params"))
 
+        created_at = isoparse(d.pop("created_at"))
+
         derived_from_response = cls(
-            created_at=created_at,
             dataset_id=dataset_id,
             operation=operation,
             params=params,
+            created_at=created_at,
         )
 
         derived_from_response.additional_properties = d

--- a/sdks/python/geolens/models/discovered_table.py
+++ b/sdks/python/geolens/models/discovered_table.py
@@ -17,21 +17,20 @@ T = TypeVar("T", bound="DiscoveredTable")
 class DiscoveredTable:
     """
     Attributes:
-        estimated_rows (int | None): PostgreSQL row count estimate from `pg_class.reltuples`.
+        table_name (str): PostgreSQL table name in the `data` schema.
         geometry_type (None | str): Detected geometry type, or null for non-spatial tables.
         srid (int | None): Coordinate reference system EPSG code, if defined.
-        table_name (str): PostgreSQL table name in the `data` schema.
+        estimated_rows (int | None): PostgreSQL row count estimate from `pg_class.reltuples`.
     """
 
-    estimated_rows: int | None
+    table_name: str
     geometry_type: None | str
     srid: int | None
-    table_name: str
+    estimated_rows: int | None
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        estimated_rows: int | None
-        estimated_rows = self.estimated_rows
+        table_name = self.table_name
 
         geometry_type: None | str
         geometry_type = self.geometry_type
@@ -39,16 +38,17 @@ class DiscoveredTable:
         srid: int | None
         srid = self.srid
 
-        table_name = self.table_name
+        estimated_rows: int | None
+        estimated_rows = self.estimated_rows
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "estimated_rows": estimated_rows,
+                "table_name": table_name,
                 "geometry_type": geometry_type,
                 "srid": srid,
-                "table_name": table_name,
+                "estimated_rows": estimated_rows,
             }
         )
 
@@ -57,13 +57,7 @@ class DiscoveredTable:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
-        def _parse_estimated_rows(data: object) -> int | None:
-            if data is None:
-                return data
-            return cast(int | None, data)
-
-        estimated_rows = _parse_estimated_rows(d.pop("estimated_rows"))
+        table_name = d.pop("table_name")
 
         def _parse_geometry_type(data: object) -> None | str:
             if data is None:
@@ -79,13 +73,18 @@ class DiscoveredTable:
 
         srid = _parse_srid(d.pop("srid"))
 
-        table_name = d.pop("table_name")
+        def _parse_estimated_rows(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        estimated_rows = _parse_estimated_rows(d.pop("estimated_rows"))
 
         discovered_table = cls(
-            estimated_rows=estimated_rows,
+            table_name=table_name,
             geometry_type=geometry_type,
             srid=srid,
-            table_name=table_name,
+            estimated_rows=estimated_rows,
         )
 
         discovered_table.additional_properties = d

--- a/sdks/python/geolens/models/distribution_create.py
+++ b/sdks/python/geolens/models/distribution_create.py
@@ -21,21 +21,21 @@ class DistributionCreate:
         distribution_type (str): e.g. download, api, ogc_wms, ogc_wfs
         format_ (str): File or service format, e.g. GeoJSON, SHP, WMS
         url (str): Access URL for this distribution
-        description (None | str | Unset):
-        is_primary (bool | Unset): Mark as the preferred distribution Default: False.
-        media_type (None | str | Unset): IANA media type, e.g. application/geo+json
-        protocol (None | str | Unset): Transfer protocol, e.g. HTTPS, OGC:WFS
         title (None | str | Unset):
+        description (None | str | Unset):
+        protocol (None | str | Unset): Transfer protocol, e.g. HTTPS, OGC:WFS
+        media_type (None | str | Unset): IANA media type, e.g. application/geo+json
+        is_primary (bool | Unset): Mark as the preferred distribution Default: False.
     """
 
     distribution_type: str
     format_: str
     url: str
-    description: None | str | Unset = UNSET
-    is_primary: bool | Unset = False
-    media_type: None | str | Unset = UNSET
-    protocol: None | str | Unset = UNSET
     title: None | str | Unset = UNSET
+    description: None | str | Unset = UNSET
+    protocol: None | str | Unset = UNSET
+    media_type: None | str | Unset = UNSET
+    is_primary: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -45,19 +45,17 @@ class DistributionCreate:
 
         url = self.url
 
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
+        else:
+            title = self.title
+
         description: None | str | Unset
         if isinstance(self.description, Unset):
             description = UNSET
         else:
             description = self.description
-
-        is_primary = self.is_primary
-
-        media_type: None | str | Unset
-        if isinstance(self.media_type, Unset):
-            media_type = UNSET
-        else:
-            media_type = self.media_type
 
         protocol: None | str | Unset
         if isinstance(self.protocol, Unset):
@@ -65,11 +63,13 @@ class DistributionCreate:
         else:
             protocol = self.protocol
 
-        title: None | str | Unset
-        if isinstance(self.title, Unset):
-            title = UNSET
+        media_type: None | str | Unset
+        if isinstance(self.media_type, Unset):
+            media_type = UNSET
         else:
-            title = self.title
+            media_type = self.media_type
+
+        is_primary = self.is_primary
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -80,16 +80,16 @@ class DistributionCreate:
                 "url": url,
             }
         )
-        if description is not UNSET:
-            field_dict["description"] = description
-        if is_primary is not UNSET:
-            field_dict["is_primary"] = is_primary
-        if media_type is not UNSET:
-            field_dict["media_type"] = media_type
-        if protocol is not UNSET:
-            field_dict["protocol"] = protocol
         if title is not UNSET:
             field_dict["title"] = title
+        if description is not UNSET:
+            field_dict["description"] = description
+        if protocol is not UNSET:
+            field_dict["protocol"] = protocol
+        if media_type is not UNSET:
+            field_dict["media_type"] = media_type
+        if is_primary is not UNSET:
+            field_dict["is_primary"] = is_primary
 
         return field_dict
 
@@ -102,6 +102,15 @@ class DistributionCreate:
 
         url = d.pop("url")
 
+        def _parse_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        title = _parse_title(d.pop("title", UNSET))
+
         def _parse_description(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -110,17 +119,6 @@ class DistributionCreate:
             return cast(None | str | Unset, data)
 
         description = _parse_description(d.pop("description", UNSET))
-
-        is_primary = d.pop("is_primary", UNSET)
-
-        def _parse_media_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        media_type = _parse_media_type(d.pop("media_type", UNSET))
 
         def _parse_protocol(data: object) -> None | str | Unset:
             if data is None:
@@ -131,24 +129,26 @@ class DistributionCreate:
 
         protocol = _parse_protocol(d.pop("protocol", UNSET))
 
-        def _parse_title(data: object) -> None | str | Unset:
+        def _parse_media_type(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        title = _parse_title(d.pop("title", UNSET))
+        media_type = _parse_media_type(d.pop("media_type", UNSET))
+
+        is_primary = d.pop("is_primary", UNSET)
 
         distribution_create = cls(
             distribution_type=distribution_type,
             format_=format_,
             url=url,
-            description=description,
-            is_primary=is_primary,
-            media_type=media_type,
-            protocol=protocol,
             title=title,
+            description=description,
+            protocol=protocol,
+            media_type=media_type,
+            is_primary=is_primary,
         )
 
         distribution_create.additional_properties = d

--- a/sdks/python/geolens/models/distribution_response.py
+++ b/sdks/python/geolens/models/distribution_response.py
@@ -18,75 +18,75 @@ T = TypeVar("T", bound="DistributionResponse")
 class DistributionResponse:
     """
     Attributes:
-        auto_generated (bool): True if created automatically by the system
-        description (None | str):
+        id (UUID):
+        record_id (UUID):
         distribution_type (str):
         format_ (None | str):
-        id (UUID):
-        is_primary (bool):
-        media_type (None | str):
-        protocol (None | str):
-        record_id (UUID):
-        title (None | str):
         url (str):
+        title (None | str):
+        description (None | str):
+        protocol (None | str):
+        media_type (None | str):
+        is_primary (bool):
+        auto_generated (bool): True if created automatically by the system
     """
 
-    auto_generated: bool
-    description: None | str
+    id: UUID
+    record_id: UUID
     distribution_type: str
     format_: None | str
-    id: UUID
-    is_primary: bool
-    media_type: None | str
-    protocol: None | str
-    record_id: UUID
-    title: None | str
     url: str
+    title: None | str
+    description: None | str
+    protocol: None | str
+    media_type: None | str
+    is_primary: bool
+    auto_generated: bool
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        auto_generated = self.auto_generated
+        id = str(self.id)
 
-        description: None | str
-        description = self.description
+        record_id = str(self.record_id)
 
         distribution_type = self.distribution_type
 
         format_: None | str
         format_ = self.format_
 
-        id = str(self.id)
-
-        is_primary = self.is_primary
-
-        media_type: None | str
-        media_type = self.media_type
-
-        protocol: None | str
-        protocol = self.protocol
-
-        record_id = str(self.record_id)
+        url = self.url
 
         title: None | str
         title = self.title
 
-        url = self.url
+        description: None | str
+        description = self.description
+
+        protocol: None | str
+        protocol = self.protocol
+
+        media_type: None | str
+        media_type = self.media_type
+
+        is_primary = self.is_primary
+
+        auto_generated = self.auto_generated
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "auto_generated": auto_generated,
-                "description": description,
+                "id": id,
+                "record_id": record_id,
                 "distribution_type": distribution_type,
                 "format": format_,
-                "id": id,
-                "is_primary": is_primary,
-                "media_type": media_type,
-                "protocol": protocol,
-                "record_id": record_id,
-                "title": title,
                 "url": url,
+                "title": title,
+                "description": description,
+                "protocol": protocol,
+                "media_type": media_type,
+                "is_primary": is_primary,
+                "auto_generated": auto_generated,
             }
         )
 
@@ -95,14 +95,9 @@ class DistributionResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        auto_generated = d.pop("auto_generated")
+        id = UUID(d.pop("id"))
 
-        def _parse_description(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        description = _parse_description(d.pop("description"))
+        record_id = UUID(d.pop("record_id"))
 
         distribution_type = d.pop("distribution_type")
 
@@ -113,25 +108,7 @@ class DistributionResponse:
 
         format_ = _parse_format_(d.pop("format"))
 
-        id = UUID(d.pop("id"))
-
-        is_primary = d.pop("is_primary")
-
-        def _parse_media_type(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        media_type = _parse_media_type(d.pop("media_type"))
-
-        def _parse_protocol(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        protocol = _parse_protocol(d.pop("protocol"))
-
-        record_id = UUID(d.pop("record_id"))
+        url = d.pop("url")
 
         def _parse_title(data: object) -> None | str:
             if data is None:
@@ -140,20 +117,43 @@ class DistributionResponse:
 
         title = _parse_title(d.pop("title"))
 
-        url = d.pop("url")
+        def _parse_description(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        description = _parse_description(d.pop("description"))
+
+        def _parse_protocol(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        protocol = _parse_protocol(d.pop("protocol"))
+
+        def _parse_media_type(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        media_type = _parse_media_type(d.pop("media_type"))
+
+        is_primary = d.pop("is_primary")
+
+        auto_generated = d.pop("auto_generated")
 
         distribution_response = cls(
-            auto_generated=auto_generated,
-            description=description,
+            id=id,
+            record_id=record_id,
             distribution_type=distribution_type,
             format_=format_,
-            id=id,
-            is_primary=is_primary,
-            media_type=media_type,
-            protocol=protocol,
-            record_id=record_id,
-            title=title,
             url=url,
+            title=title,
+            description=description,
+            protocol=protocol,
+            media_type=media_type,
+            is_primary=is_primary,
+            auto_generated=auto_generated,
         )
 
         distribution_response.additional_properties = d

--- a/sdks/python/geolens/models/distribution_update.py
+++ b/sdks/python/geolens/models/distribution_update.py
@@ -18,33 +18,27 @@ T = TypeVar("T", bound="DistributionUpdate")
 class DistributionUpdate:
     """
     Attributes:
-        description (None | str | Unset):
         distribution_type (None | str | Unset):
         format_ (None | str | Unset):
-        is_primary (bool | None | Unset):
-        media_type (None | str | Unset):
-        protocol (None | str | Unset):
-        title (None | str | Unset):
         url (None | str | Unset):
+        title (None | str | Unset):
+        description (None | str | Unset):
+        protocol (None | str | Unset):
+        media_type (None | str | Unset):
+        is_primary (bool | None | Unset):
     """
 
-    description: None | str | Unset = UNSET
     distribution_type: None | str | Unset = UNSET
     format_: None | str | Unset = UNSET
-    is_primary: bool | None | Unset = UNSET
-    media_type: None | str | Unset = UNSET
-    protocol: None | str | Unset = UNSET
-    title: None | str | Unset = UNSET
     url: None | str | Unset = UNSET
+    title: None | str | Unset = UNSET
+    description: None | str | Unset = UNSET
+    protocol: None | str | Unset = UNSET
+    media_type: None | str | Unset = UNSET
+    is_primary: bool | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        description: None | str | Unset
-        if isinstance(self.description, Unset):
-            description = UNSET
-        else:
-            description = self.description
-
         distribution_type: None | str | Unset
         if isinstance(self.distribution_type, Unset):
             distribution_type = UNSET
@@ -57,23 +51,11 @@ class DistributionUpdate:
         else:
             format_ = self.format_
 
-        is_primary: bool | None | Unset
-        if isinstance(self.is_primary, Unset):
-            is_primary = UNSET
+        url: None | str | Unset
+        if isinstance(self.url, Unset):
+            url = UNSET
         else:
-            is_primary = self.is_primary
-
-        media_type: None | str | Unset
-        if isinstance(self.media_type, Unset):
-            media_type = UNSET
-        else:
-            media_type = self.media_type
-
-        protocol: None | str | Unset
-        if isinstance(self.protocol, Unset):
-            protocol = UNSET
-        else:
-            protocol = self.protocol
+            url = self.url
 
         title: None | str | Unset
         if isinstance(self.title, Unset):
@@ -81,46 +63,55 @@ class DistributionUpdate:
         else:
             title = self.title
 
-        url: None | str | Unset
-        if isinstance(self.url, Unset):
-            url = UNSET
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
         else:
-            url = self.url
+            description = self.description
+
+        protocol: None | str | Unset
+        if isinstance(self.protocol, Unset):
+            protocol = UNSET
+        else:
+            protocol = self.protocol
+
+        media_type: None | str | Unset
+        if isinstance(self.media_type, Unset):
+            media_type = UNSET
+        else:
+            media_type = self.media_type
+
+        is_primary: bool | None | Unset
+        if isinstance(self.is_primary, Unset):
+            is_primary = UNSET
+        else:
+            is_primary = self.is_primary
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if description is not UNSET:
-            field_dict["description"] = description
         if distribution_type is not UNSET:
             field_dict["distribution_type"] = distribution_type
         if format_ is not UNSET:
             field_dict["format"] = format_
-        if is_primary is not UNSET:
-            field_dict["is_primary"] = is_primary
-        if media_type is not UNSET:
-            field_dict["media_type"] = media_type
-        if protocol is not UNSET:
-            field_dict["protocol"] = protocol
-        if title is not UNSET:
-            field_dict["title"] = title
         if url is not UNSET:
             field_dict["url"] = url
+        if title is not UNSET:
+            field_dict["title"] = title
+        if description is not UNSET:
+            field_dict["description"] = description
+        if protocol is not UNSET:
+            field_dict["protocol"] = protocol
+        if media_type is not UNSET:
+            field_dict["media_type"] = media_type
+        if is_primary is not UNSET:
+            field_dict["is_primary"] = is_primary
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
-        def _parse_description(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        description = _parse_description(d.pop("description", UNSET))
 
         def _parse_distribution_type(data: object) -> None | str | Unset:
             if data is None:
@@ -140,32 +131,14 @@ class DistributionUpdate:
 
         format_ = _parse_format_(d.pop("format", UNSET))
 
-        def _parse_is_primary(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        is_primary = _parse_is_primary(d.pop("is_primary", UNSET))
-
-        def _parse_media_type(data: object) -> None | str | Unset:
+        def _parse_url(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        media_type = _parse_media_type(d.pop("media_type", UNSET))
-
-        def _parse_protocol(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        protocol = _parse_protocol(d.pop("protocol", UNSET))
+        url = _parse_url(d.pop("url", UNSET))
 
         def _parse_title(data: object) -> None | str | Unset:
             if data is None:
@@ -176,24 +149,51 @@ class DistributionUpdate:
 
         title = _parse_title(d.pop("title", UNSET))
 
-        def _parse_url(data: object) -> None | str | Unset:
+        def _parse_description(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        url = _parse_url(d.pop("url", UNSET))
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_protocol(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        protocol = _parse_protocol(d.pop("protocol", UNSET))
+
+        def _parse_media_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        media_type = _parse_media_type(d.pop("media_type", UNSET))
+
+        def _parse_is_primary(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_primary = _parse_is_primary(d.pop("is_primary", UNSET))
 
         distribution_update = cls(
-            description=description,
             distribution_type=distribution_type,
             format_=format_,
-            is_primary=is_primary,
-            media_type=media_type,
-            protocol=protocol,
-            title=title,
             url=url,
+            title=title,
+            description=description,
+            protocol=protocol,
+            media_type=media_type,
+            is_primary=is_primary,
         )
 
         distribution_update.additional_properties = d

--- a/sdks/python/geolens/models/dry_run_response.py
+++ b/sdks/python/geolens/models/dry_run_response.py
@@ -23,21 +23,21 @@ class DryRunResponse:
     """Result of a dry-run import showing what would change.
 
     Attributes:
-        oauth_providers (DryRunResponseOauthProviders): Per-provider diff result keyed by slug.
         settings (DryRunResponseSettings): Per-setting diff result keyed by setting name.
+        oauth_providers (DryRunResponseOauthProviders): Per-provider diff result keyed by slug.
         preview_token (None | str | Unset): Short-lived signed confirmation token required to apply an overwrite. Bound
             to the normalized payload, overwrite mode, and current configuration state.
     """
 
-    oauth_providers: DryRunResponseOauthProviders
     settings: DryRunResponseSettings
+    oauth_providers: DryRunResponseOauthProviders
     preview_token: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        oauth_providers = self.oauth_providers.to_dict()
-
         settings = self.settings.to_dict()
+
+        oauth_providers = self.oauth_providers.to_dict()
 
         preview_token: None | str | Unset
         if isinstance(self.preview_token, Unset):
@@ -49,8 +49,8 @@ class DryRunResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "oauth_providers": oauth_providers,
                 "settings": settings,
+                "oauth_providers": oauth_providers,
             }
         )
         if preview_token is not UNSET:
@@ -66,11 +66,11 @@ class DryRunResponse:
         from ..models.dry_run_response_settings import DryRunResponseSettings
 
         d = dict(src_dict)
+        settings = DryRunResponseSettings.from_dict(d.pop("settings"))
+
         oauth_providers = DryRunResponseOauthProviders.from_dict(
             d.pop("oauth_providers")
         )
-
-        settings = DryRunResponseSettings.from_dict(d.pop("settings"))
 
         def _parse_preview_token(data: object) -> None | str | Unset:
             if data is None:
@@ -82,8 +82,8 @@ class DryRunResponse:
         preview_token = _parse_preview_token(d.pop("preview_token", UNSET))
 
         dry_run_response = cls(
-            oauth_providers=oauth_providers,
             settings=settings,
+            oauth_providers=oauth_providers,
             preview_token=preview_token,
         )
 

--- a/sdks/python/geolens/models/duplicate_map_response.py
+++ b/sdks/python/geolens/models/duplicate_map_response.py
@@ -28,79 +28,93 @@ T = TypeVar("T", bound="DuplicateMapResponse")
 class DuplicateMapResponse:
     """
     Attributes:
-        basemap_style (str):
-        bearing (float):
-        center_lat (float | None):
-        center_lng (float | None):
-        created_at (datetime.datetime):
-        created_by (None | UUID):
-        description (None | str):
         id (UUID):
-        layer_count (int):
-        layers (list[MapLayerResponse]):
         name (str):
-        pitch (float):
-        show_basemap_labels (bool):
-        updated_at (datetime.datetime):
-        visibility (MapVisibility):
+        description (None | str):
+        center_lng (float | None):
+        center_lat (float | None):
         zoom (float | None):
-        basemap_config (BasemapConfig | None | Unset):
-        created_by_username (None | str | Unset):
-        excluded_layer_count (int | Unset): Layers skipped due to access restrictions Default: 0.
-        forked_from_id (None | Unset | UUID): Source map UUID if this is a fork
-        forked_from_name (None | str | Unset):
-        legend_title (None | str | Unset):
+        bearing (float):
+        pitch (float):
+        basemap_style (str):
+        show_basemap_labels (bool):
+        visibility (MapVisibility):
+        created_by (None | UUID):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        layers (list[MapLayerResponse]):
+        layer_count (int):
         notes (None | str | Unset):
-        og_image_url (None | str | Unset):
-        plugins (list[str] | None | Unset):
+        basemap_config (BasemapConfig | None | Unset):
         terrain_config (None | TerrainConfig | Unset):
         thumbnail_url (None | str | Unset):
+        og_image_url (None | str | Unset):
+        forked_from_id (None | Unset | UUID): Source map UUID if this is a fork
+        forked_from_name (None | str | Unset):
+        created_by_username (None | str | Unset):
+        plugins (list[str] | None | Unset):
+        legend_title (None | str | Unset):
+        excluded_layer_count (int | Unset): Layers skipped due to access restrictions Default: 0.
     """
 
-    basemap_style: str
-    bearing: float
-    center_lat: float | None
-    center_lng: float | None
-    created_at: datetime.datetime
-    created_by: None | UUID
-    description: None | str
     id: UUID
-    layer_count: int
-    layers: list[MapLayerResponse]
     name: str
-    pitch: float
-    show_basemap_labels: bool
-    updated_at: datetime.datetime
-    visibility: MapVisibility
+    description: None | str
+    center_lng: float | None
+    center_lat: float | None
     zoom: float | None
-    basemap_config: BasemapConfig | None | Unset = UNSET
-    created_by_username: None | str | Unset = UNSET
-    excluded_layer_count: int | Unset = 0
-    forked_from_id: None | Unset | UUID = UNSET
-    forked_from_name: None | str | Unset = UNSET
-    legend_title: None | str | Unset = UNSET
+    bearing: float
+    pitch: float
+    basemap_style: str
+    show_basemap_labels: bool
+    visibility: MapVisibility
+    created_by: None | UUID
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    layers: list[MapLayerResponse]
+    layer_count: int
     notes: None | str | Unset = UNSET
-    og_image_url: None | str | Unset = UNSET
-    plugins: list[str] | None | Unset = UNSET
+    basemap_config: BasemapConfig | None | Unset = UNSET
     terrain_config: None | TerrainConfig | Unset = UNSET
     thumbnail_url: None | str | Unset = UNSET
+    og_image_url: None | str | Unset = UNSET
+    forked_from_id: None | Unset | UUID = UNSET
+    forked_from_name: None | str | Unset = UNSET
+    created_by_username: None | str | Unset = UNSET
+    plugins: list[str] | None | Unset = UNSET
+    legend_title: None | str | Unset = UNSET
+    excluded_layer_count: int | Unset = 0
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.basemap_config import BasemapConfig
         from ..models.terrain_config import TerrainConfig
 
-        basemap_style = self.basemap_style
+        id = str(self.id)
 
-        bearing = self.bearing
+        name = self.name
 
-        center_lat: float | None
-        center_lat = self.center_lat
+        description: None | str
+        description = self.description
 
         center_lng: float | None
         center_lng = self.center_lng
 
-        created_at = self.created_at.isoformat()
+        center_lat: float | None
+        center_lat = self.center_lat
+
+        zoom: float | None
+        zoom = self.zoom
+
+        bearing = self.bearing
+
+        pitch = self.pitch
+
+        basemap_style = self.basemap_style
+
+        show_basemap_labels = self.show_basemap_labels
+
+        visibility: str = self.visibility
 
         created_by: None | str
         if isinstance(self.created_by, UUID):
@@ -108,30 +122,22 @@ class DuplicateMapResponse:
         else:
             created_by = self.created_by
 
-        description: None | str
-        description = self.description
+        created_at = self.created_at.isoformat()
 
-        id = str(self.id)
-
-        layer_count = self.layer_count
+        updated_at = self.updated_at.isoformat()
 
         layers = []
         for layers_item_data in self.layers:
             layers_item = layers_item_data.to_dict()
             layers.append(layers_item)
 
-        name = self.name
+        layer_count = self.layer_count
 
-        pitch = self.pitch
-
-        show_basemap_labels = self.show_basemap_labels
-
-        updated_at = self.updated_at.isoformat()
-
-        visibility: str = self.visibility
-
-        zoom: float | None
-        zoom = self.zoom
+        notes: None | str | Unset
+        if isinstance(self.notes, Unset):
+            notes = UNSET
+        else:
+            notes = self.notes
 
         basemap_config: dict[str, Any] | None | Unset
         if isinstance(self.basemap_config, Unset):
@@ -140,55 +146,6 @@ class DuplicateMapResponse:
             basemap_config = self.basemap_config.to_dict()
         else:
             basemap_config = self.basemap_config
-
-        created_by_username: None | str | Unset
-        if isinstance(self.created_by_username, Unset):
-            created_by_username = UNSET
-        else:
-            created_by_username = self.created_by_username
-
-        excluded_layer_count = self.excluded_layer_count
-
-        forked_from_id: None | str | Unset
-        if isinstance(self.forked_from_id, Unset):
-            forked_from_id = UNSET
-        elif isinstance(self.forked_from_id, UUID):
-            forked_from_id = str(self.forked_from_id)
-        else:
-            forked_from_id = self.forked_from_id
-
-        forked_from_name: None | str | Unset
-        if isinstance(self.forked_from_name, Unset):
-            forked_from_name = UNSET
-        else:
-            forked_from_name = self.forked_from_name
-
-        legend_title: None | str | Unset
-        if isinstance(self.legend_title, Unset):
-            legend_title = UNSET
-        else:
-            legend_title = self.legend_title
-
-        notes: None | str | Unset
-        if isinstance(self.notes, Unset):
-            notes = UNSET
-        else:
-            notes = self.notes
-
-        og_image_url: None | str | Unset
-        if isinstance(self.og_image_url, Unset):
-            og_image_url = UNSET
-        else:
-            og_image_url = self.og_image_url
-
-        plugins: list[str] | None | Unset
-        if isinstance(self.plugins, Unset):
-            plugins = UNSET
-        elif isinstance(self.plugins, list):
-            plugins = self.plugins
-
-        else:
-            plugins = self.plugins
 
         terrain_config: dict[str, Any] | None | Unset
         if isinstance(self.terrain_config, Unset):
@@ -204,50 +161,93 @@ class DuplicateMapResponse:
         else:
             thumbnail_url = self.thumbnail_url
 
+        og_image_url: None | str | Unset
+        if isinstance(self.og_image_url, Unset):
+            og_image_url = UNSET
+        else:
+            og_image_url = self.og_image_url
+
+        forked_from_id: None | str | Unset
+        if isinstance(self.forked_from_id, Unset):
+            forked_from_id = UNSET
+        elif isinstance(self.forked_from_id, UUID):
+            forked_from_id = str(self.forked_from_id)
+        else:
+            forked_from_id = self.forked_from_id
+
+        forked_from_name: None | str | Unset
+        if isinstance(self.forked_from_name, Unset):
+            forked_from_name = UNSET
+        else:
+            forked_from_name = self.forked_from_name
+
+        created_by_username: None | str | Unset
+        if isinstance(self.created_by_username, Unset):
+            created_by_username = UNSET
+        else:
+            created_by_username = self.created_by_username
+
+        plugins: list[str] | None | Unset
+        if isinstance(self.plugins, Unset):
+            plugins = UNSET
+        elif isinstance(self.plugins, list):
+            plugins = self.plugins
+
+        else:
+            plugins = self.plugins
+
+        legend_title: None | str | Unset
+        if isinstance(self.legend_title, Unset):
+            legend_title = UNSET
+        else:
+            legend_title = self.legend_title
+
+        excluded_layer_count = self.excluded_layer_count
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "basemap_style": basemap_style,
-                "bearing": bearing,
-                "center_lat": center_lat,
-                "center_lng": center_lng,
-                "created_at": created_at,
-                "created_by": created_by,
-                "description": description,
                 "id": id,
-                "layer_count": layer_count,
-                "layers": layers,
                 "name": name,
-                "pitch": pitch,
-                "show_basemap_labels": show_basemap_labels,
-                "updated_at": updated_at,
-                "visibility": visibility,
+                "description": description,
+                "center_lng": center_lng,
+                "center_lat": center_lat,
                 "zoom": zoom,
+                "bearing": bearing,
+                "pitch": pitch,
+                "basemap_style": basemap_style,
+                "show_basemap_labels": show_basemap_labels,
+                "visibility": visibility,
+                "created_by": created_by,
+                "created_at": created_at,
+                "updated_at": updated_at,
+                "layers": layers,
+                "layer_count": layer_count,
             }
         )
-        if basemap_config is not UNSET:
-            field_dict["basemap_config"] = basemap_config
-        if created_by_username is not UNSET:
-            field_dict["created_by_username"] = created_by_username
-        if excluded_layer_count is not UNSET:
-            field_dict["excluded_layer_count"] = excluded_layer_count
-        if forked_from_id is not UNSET:
-            field_dict["forked_from_id"] = forked_from_id
-        if forked_from_name is not UNSET:
-            field_dict["forked_from_name"] = forked_from_name
-        if legend_title is not UNSET:
-            field_dict["legend_title"] = legend_title
         if notes is not UNSET:
             field_dict["notes"] = notes
-        if og_image_url is not UNSET:
-            field_dict["og_image_url"] = og_image_url
-        if plugins is not UNSET:
-            field_dict["plugins"] = plugins
+        if basemap_config is not UNSET:
+            field_dict["basemap_config"] = basemap_config
         if terrain_config is not UNSET:
             field_dict["terrain_config"] = terrain_config
         if thumbnail_url is not UNSET:
             field_dict["thumbnail_url"] = thumbnail_url
+        if og_image_url is not UNSET:
+            field_dict["og_image_url"] = og_image_url
+        if forked_from_id is not UNSET:
+            field_dict["forked_from_id"] = forked_from_id
+        if forked_from_name is not UNSET:
+            field_dict["forked_from_name"] = forked_from_name
+        if created_by_username is not UNSET:
+            field_dict["created_by_username"] = created_by_username
+        if plugins is not UNSET:
+            field_dict["plugins"] = plugins
+        if legend_title is not UNSET:
+            field_dict["legend_title"] = legend_title
+        if excluded_layer_count is not UNSET:
+            field_dict["excluded_layer_count"] = excluded_layer_count
 
         return field_dict
 
@@ -258,16 +258,16 @@ class DuplicateMapResponse:
         from ..models.terrain_config import TerrainConfig
 
         d = dict(src_dict)
-        basemap_style = d.pop("basemap_style")
+        id = UUID(d.pop("id"))
 
-        bearing = d.pop("bearing")
+        name = d.pop("name")
 
-        def _parse_center_lat(data: object) -> float | None:
+        def _parse_description(data: object) -> None | str:
             if data is None:
                 return data
-            return cast(float | None, data)
+            return cast(None | str, data)
 
-        center_lat = _parse_center_lat(d.pop("center_lat"))
+        description = _parse_description(d.pop("description"))
 
         def _parse_center_lng(data: object) -> float | None:
             if data is None:
@@ -276,7 +276,29 @@ class DuplicateMapResponse:
 
         center_lng = _parse_center_lng(d.pop("center_lng"))
 
-        created_at = isoparse(d.pop("created_at"))
+        def _parse_center_lat(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        center_lat = _parse_center_lat(d.pop("center_lat"))
+
+        def _parse_zoom(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        zoom = _parse_zoom(d.pop("zoom"))
+
+        bearing = d.pop("bearing")
+
+        pitch = d.pop("pitch")
+
+        basemap_style = d.pop("basemap_style")
+
+        show_basemap_labels = d.pop("show_basemap_labels")
+
+        visibility = check_map_visibility(d.pop("visibility"))
 
         def _parse_created_by(data: object) -> None | UUID:
             if data is None:
@@ -293,16 +315,9 @@ class DuplicateMapResponse:
 
         created_by = _parse_created_by(d.pop("created_by"))
 
-        def _parse_description(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
+        created_at = isoparse(d.pop("created_at"))
 
-        description = _parse_description(d.pop("description"))
-
-        id = UUID(d.pop("id"))
-
-        layer_count = d.pop("layer_count")
+        updated_at = isoparse(d.pop("updated_at"))
 
         layers = []
         _layers = d.pop("layers")
@@ -311,22 +326,16 @@ class DuplicateMapResponse:
 
             layers.append(layers_item)
 
-        name = d.pop("name")
+        layer_count = d.pop("layer_count")
 
-        pitch = d.pop("pitch")
-
-        show_basemap_labels = d.pop("show_basemap_labels")
-
-        updated_at = isoparse(d.pop("updated_at"))
-
-        visibility = check_map_visibility(d.pop("visibility"))
-
-        def _parse_zoom(data: object) -> float | None:
+        def _parse_notes(data: object) -> None | str | Unset:
             if data is None:
                 return data
-            return cast(float | None, data)
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
 
-        zoom = _parse_zoom(d.pop("zoom"))
+        notes = _parse_notes(d.pop("notes", UNSET))
 
         def _parse_basemap_config(data: object) -> BasemapConfig | None | Unset:
             if data is None:
@@ -344,89 +353,6 @@ class DuplicateMapResponse:
             return cast(BasemapConfig | None | Unset, data)
 
         basemap_config = _parse_basemap_config(d.pop("basemap_config", UNSET))
-
-        def _parse_created_by_username(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        created_by_username = _parse_created_by_username(
-            d.pop("created_by_username", UNSET)
-        )
-
-        excluded_layer_count = d.pop("excluded_layer_count", UNSET)
-
-        def _parse_forked_from_id(data: object) -> None | Unset | UUID:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                forked_from_id_type_0 = UUID(data)
-
-                return forked_from_id_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | Unset | UUID, data)
-
-        forked_from_id = _parse_forked_from_id(d.pop("forked_from_id", UNSET))
-
-        def _parse_forked_from_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        forked_from_name = _parse_forked_from_name(d.pop("forked_from_name", UNSET))
-
-        def _parse_legend_title(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        legend_title = _parse_legend_title(d.pop("legend_title", UNSET))
-
-        def _parse_notes(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        notes = _parse_notes(d.pop("notes", UNSET))
-
-        def _parse_og_image_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        og_image_url = _parse_og_image_url(d.pop("og_image_url", UNSET))
-
-        def _parse_plugins(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                plugins_type_0 = cast(list[str], data)
-
-                return plugins_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        plugins = _parse_plugins(d.pop("plugins", UNSET))
 
         def _parse_terrain_config(data: object) -> None | TerrainConfig | Unset:
             if data is None:
@@ -454,34 +380,108 @@ class DuplicateMapResponse:
 
         thumbnail_url = _parse_thumbnail_url(d.pop("thumbnail_url", UNSET))
 
+        def _parse_og_image_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        og_image_url = _parse_og_image_url(d.pop("og_image_url", UNSET))
+
+        def _parse_forked_from_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                forked_from_id_type_0 = UUID(data)
+
+                return forked_from_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        forked_from_id = _parse_forked_from_id(d.pop("forked_from_id", UNSET))
+
+        def _parse_forked_from_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        forked_from_name = _parse_forked_from_name(d.pop("forked_from_name", UNSET))
+
+        def _parse_created_by_username(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        created_by_username = _parse_created_by_username(
+            d.pop("created_by_username", UNSET)
+        )
+
+        def _parse_plugins(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                plugins_type_0 = cast(list[str], data)
+
+                return plugins_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        plugins = _parse_plugins(d.pop("plugins", UNSET))
+
+        def _parse_legend_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        legend_title = _parse_legend_title(d.pop("legend_title", UNSET))
+
+        excluded_layer_count = d.pop("excluded_layer_count", UNSET)
+
         duplicate_map_response = cls(
-            basemap_style=basemap_style,
-            bearing=bearing,
-            center_lat=center_lat,
-            center_lng=center_lng,
-            created_at=created_at,
-            created_by=created_by,
-            description=description,
             id=id,
-            layer_count=layer_count,
-            layers=layers,
             name=name,
-            pitch=pitch,
-            show_basemap_labels=show_basemap_labels,
-            updated_at=updated_at,
-            visibility=visibility,
+            description=description,
+            center_lng=center_lng,
+            center_lat=center_lat,
             zoom=zoom,
-            basemap_config=basemap_config,
-            created_by_username=created_by_username,
-            excluded_layer_count=excluded_layer_count,
-            forked_from_id=forked_from_id,
-            forked_from_name=forked_from_name,
-            legend_title=legend_title,
+            bearing=bearing,
+            pitch=pitch,
+            basemap_style=basemap_style,
+            show_basemap_labels=show_basemap_labels,
+            visibility=visibility,
+            created_by=created_by,
+            created_at=created_at,
+            updated_at=updated_at,
+            layers=layers,
+            layer_count=layer_count,
             notes=notes,
-            og_image_url=og_image_url,
-            plugins=plugins,
+            basemap_config=basemap_config,
             terrain_config=terrain_config,
             thumbnail_url=thumbnail_url,
+            og_image_url=og_image_url,
+            forked_from_id=forked_from_id,
+            forked_from_name=forked_from_name,
+            created_by_username=created_by_username,
+            plugins=plugins,
+            legend_title=legend_title,
+            excluded_layer_count=excluded_layer_count,
         )
 
         duplicate_map_response.additional_properties = d

--- a/sdks/python/geolens/models/embed_token_create.py
+++ b/sdks/python/geolens/models/embed_token_create.py
@@ -18,19 +18,27 @@ T = TypeVar("T", bound="EmbedTokenCreate")
 class EmbedTokenCreate:
     """
     Attributes:
-        allowed_origins (list[str] | None | Unset): Restrict embedding to these origins. Omit or null allows any origin;
-            non-empty origin restrictions require advanced sharing controls. Example: ['https://dashboard.example.com'].
         expires_in_days (int | Unset): Token lifetime in days (1-365). The default 30-day lifetime is always available;
             custom lifetimes require advanced sharing controls. Default: 30. Example: 90.
         name (None | str | Unset): Human-readable label for the token Example: Public dashboard embed.
+        allowed_origins (list[str] | None | Unset): Restrict embedding to these origins. Omit or null allows any origin;
+            non-empty origin restrictions require advanced sharing controls. Example: ['https://dashboard.example.com'].
     """
 
-    allowed_origins: list[str] | None | Unset = UNSET
     expires_in_days: int | Unset = 30
     name: None | str | Unset = UNSET
+    allowed_origins: list[str] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        expires_in_days = self.expires_in_days
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
         allowed_origins: list[str] | None | Unset
         if isinstance(self.allowed_origins, Unset):
             allowed_origins = UNSET
@@ -40,29 +48,31 @@ class EmbedTokenCreate:
         else:
             allowed_origins = self.allowed_origins
 
-        expires_in_days = self.expires_in_days
-
-        name: None | str | Unset
-        if isinstance(self.name, Unset):
-            name = UNSET
-        else:
-            name = self.name
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if allowed_origins is not UNSET:
-            field_dict["allowed_origins"] = allowed_origins
         if expires_in_days is not UNSET:
             field_dict["expires_in_days"] = expires_in_days
         if name is not UNSET:
             field_dict["name"] = name
+        if allowed_origins is not UNSET:
+            field_dict["allowed_origins"] = allowed_origins
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        expires_in_days = d.pop("expires_in_days", UNSET)
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
 
         def _parse_allowed_origins(data: object) -> list[str] | None | Unset:
             if data is None:
@@ -81,21 +91,10 @@ class EmbedTokenCreate:
 
         allowed_origins = _parse_allowed_origins(d.pop("allowed_origins", UNSET))
 
-        expires_in_days = d.pop("expires_in_days", UNSET)
-
-        def _parse_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        name = _parse_name(d.pop("name", UNSET))
-
         embed_token_create = cls(
-            allowed_origins=allowed_origins,
             expires_in_days=expires_in_days,
             name=name,
+            allowed_origins=allowed_origins,
         )
 
         embed_token_create.additional_properties = d

--- a/sdks/python/geolens/models/embed_token_created_response.py
+++ b/sdks/python/geolens/models/embed_token_created_response.py
@@ -21,50 +21,56 @@ T = TypeVar("T", bound="EmbedTokenCreatedResponse")
 class EmbedTokenCreatedResponse:
     """
     Attributes:
-        created_at (datetime.datetime):
-        expires_at (datetime.datetime):
         id (UUID):
-        is_active (bool):
         map_id (UUID):
-        raw_token (str):
-        scoped_dataset_ids (list[str]):
         token_hint (str):
-        allowed_origins (list[str] | None | Unset):
-        last_used_at (datetime.datetime | None | Unset):
+        scoped_dataset_ids (list[str]):
+        expires_at (datetime.datetime):
+        is_active (bool):
+        created_at (datetime.datetime):
+        raw_token (str):
         name (None | str | Unset):
+        allowed_origins (list[str] | None | Unset):
         use_count (int | Unset):  Default: 0.
+        last_used_at (datetime.datetime | None | Unset):
     """
 
-    created_at: datetime.datetime
-    expires_at: datetime.datetime
     id: UUID
-    is_active: bool
     map_id: UUID
-    raw_token: str
-    scoped_dataset_ids: list[str]
     token_hint: str
-    allowed_origins: list[str] | None | Unset = UNSET
-    last_used_at: datetime.datetime | None | Unset = UNSET
+    scoped_dataset_ids: list[str]
+    expires_at: datetime.datetime
+    is_active: bool
+    created_at: datetime.datetime
+    raw_token: str
     name: None | str | Unset = UNSET
+    allowed_origins: list[str] | None | Unset = UNSET
     use_count: int | Unset = 0
+    last_used_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
-
-        expires_at = self.expires_at.isoformat()
-
         id = str(self.id)
-
-        is_active = self.is_active
 
         map_id = str(self.map_id)
 
-        raw_token = self.raw_token
+        token_hint = self.token_hint
 
         scoped_dataset_ids = self.scoped_dataset_ids
 
-        token_hint = self.token_hint
+        expires_at = self.expires_at.isoformat()
+
+        is_active = self.is_active
+
+        created_at = self.created_at.isoformat()
+
+        raw_token = self.raw_token
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
 
         allowed_origins: list[str] | None | Unset
         if isinstance(self.allowed_origins, Unset):
@@ -75,6 +81,8 @@ class EmbedTokenCreatedResponse:
         else:
             allowed_origins = self.allowed_origins
 
+        use_count = self.use_count
+
         last_used_at: None | str | Unset
         if isinstance(self.last_used_at, Unset):
             last_used_at = UNSET
@@ -83,57 +91,58 @@ class EmbedTokenCreatedResponse:
         else:
             last_used_at = self.last_used_at
 
-        name: None | str | Unset
-        if isinstance(self.name, Unset):
-            name = UNSET
-        else:
-            name = self.name
-
-        use_count = self.use_count
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "expires_at": expires_at,
                 "id": id,
-                "is_active": is_active,
                 "map_id": map_id,
-                "raw_token": raw_token,
-                "scoped_dataset_ids": scoped_dataset_ids,
                 "token_hint": token_hint,
+                "scoped_dataset_ids": scoped_dataset_ids,
+                "expires_at": expires_at,
+                "is_active": is_active,
+                "created_at": created_at,
+                "raw_token": raw_token,
             }
         )
-        if allowed_origins is not UNSET:
-            field_dict["allowed_origins"] = allowed_origins
-        if last_used_at is not UNSET:
-            field_dict["last_used_at"] = last_used_at
         if name is not UNSET:
             field_dict["name"] = name
+        if allowed_origins is not UNSET:
+            field_dict["allowed_origins"] = allowed_origins
         if use_count is not UNSET:
             field_dict["use_count"] = use_count
+        if last_used_at is not UNSET:
+            field_dict["last_used_at"] = last_used_at
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
-
-        expires_at = isoparse(d.pop("expires_at"))
-
         id = UUID(d.pop("id"))
-
-        is_active = d.pop("is_active")
 
         map_id = UUID(d.pop("map_id"))
 
-        raw_token = d.pop("raw_token")
+        token_hint = d.pop("token_hint")
 
         scoped_dataset_ids = cast(list[str], d.pop("scoped_dataset_ids"))
 
-        token_hint = d.pop("token_hint")
+        expires_at = isoparse(d.pop("expires_at"))
+
+        is_active = d.pop("is_active")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        raw_token = d.pop("raw_token")
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
 
         def _parse_allowed_origins(data: object) -> list[str] | None | Unset:
             if data is None:
@@ -152,6 +161,8 @@ class EmbedTokenCreatedResponse:
 
         allowed_origins = _parse_allowed_origins(d.pop("allowed_origins", UNSET))
 
+        use_count = d.pop("use_count", UNSET)
+
         def _parse_last_used_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
                 return data
@@ -169,30 +180,19 @@ class EmbedTokenCreatedResponse:
 
         last_used_at = _parse_last_used_at(d.pop("last_used_at", UNSET))
 
-        def _parse_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        name = _parse_name(d.pop("name", UNSET))
-
-        use_count = d.pop("use_count", UNSET)
-
         embed_token_created_response = cls(
-            created_at=created_at,
-            expires_at=expires_at,
             id=id,
-            is_active=is_active,
             map_id=map_id,
-            raw_token=raw_token,
-            scoped_dataset_ids=scoped_dataset_ids,
             token_hint=token_hint,
-            allowed_origins=allowed_origins,
-            last_used_at=last_used_at,
+            scoped_dataset_ids=scoped_dataset_ids,
+            expires_at=expires_at,
+            is_active=is_active,
+            created_at=created_at,
+            raw_token=raw_token,
             name=name,
+            allowed_origins=allowed_origins,
             use_count=use_count,
+            last_used_at=last_used_at,
         )
 
         embed_token_created_response.additional_properties = d

--- a/sdks/python/geolens/models/embed_token_response.py
+++ b/sdks/python/geolens/models/embed_token_response.py
@@ -21,46 +21,52 @@ T = TypeVar("T", bound="EmbedTokenResponse")
 class EmbedTokenResponse:
     """
     Attributes:
-        created_at (datetime.datetime):
-        expires_at (datetime.datetime):
         id (UUID):
-        is_active (bool):
         map_id (UUID):
-        scoped_dataset_ids (list[str]):
         token_hint (str):
-        allowed_origins (list[str] | None | Unset):
-        last_used_at (datetime.datetime | None | Unset):
+        scoped_dataset_ids (list[str]):
+        expires_at (datetime.datetime):
+        is_active (bool):
+        created_at (datetime.datetime):
         name (None | str | Unset):
+        allowed_origins (list[str] | None | Unset):
         use_count (int | Unset):  Default: 0.
+        last_used_at (datetime.datetime | None | Unset):
     """
 
-    created_at: datetime.datetime
-    expires_at: datetime.datetime
     id: UUID
-    is_active: bool
     map_id: UUID
-    scoped_dataset_ids: list[str]
     token_hint: str
-    allowed_origins: list[str] | None | Unset = UNSET
-    last_used_at: datetime.datetime | None | Unset = UNSET
+    scoped_dataset_ids: list[str]
+    expires_at: datetime.datetime
+    is_active: bool
+    created_at: datetime.datetime
     name: None | str | Unset = UNSET
+    allowed_origins: list[str] | None | Unset = UNSET
     use_count: int | Unset = 0
+    last_used_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
-
-        expires_at = self.expires_at.isoformat()
-
         id = str(self.id)
-
-        is_active = self.is_active
 
         map_id = str(self.map_id)
 
+        token_hint = self.token_hint
+
         scoped_dataset_ids = self.scoped_dataset_ids
 
-        token_hint = self.token_hint
+        expires_at = self.expires_at.isoformat()
+
+        is_active = self.is_active
+
+        created_at = self.created_at.isoformat()
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
 
         allowed_origins: list[str] | None | Unset
         if isinstance(self.allowed_origins, Unset):
@@ -71,6 +77,8 @@ class EmbedTokenResponse:
         else:
             allowed_origins = self.allowed_origins
 
+        use_count = self.use_count
+
         last_used_at: None | str | Unset
         if isinstance(self.last_used_at, Unset):
             last_used_at = UNSET
@@ -79,54 +87,55 @@ class EmbedTokenResponse:
         else:
             last_used_at = self.last_used_at
 
-        name: None | str | Unset
-        if isinstance(self.name, Unset):
-            name = UNSET
-        else:
-            name = self.name
-
-        use_count = self.use_count
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "expires_at": expires_at,
                 "id": id,
-                "is_active": is_active,
                 "map_id": map_id,
-                "scoped_dataset_ids": scoped_dataset_ids,
                 "token_hint": token_hint,
+                "scoped_dataset_ids": scoped_dataset_ids,
+                "expires_at": expires_at,
+                "is_active": is_active,
+                "created_at": created_at,
             }
         )
-        if allowed_origins is not UNSET:
-            field_dict["allowed_origins"] = allowed_origins
-        if last_used_at is not UNSET:
-            field_dict["last_used_at"] = last_used_at
         if name is not UNSET:
             field_dict["name"] = name
+        if allowed_origins is not UNSET:
+            field_dict["allowed_origins"] = allowed_origins
         if use_count is not UNSET:
             field_dict["use_count"] = use_count
+        if last_used_at is not UNSET:
+            field_dict["last_used_at"] = last_used_at
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
-
-        expires_at = isoparse(d.pop("expires_at"))
-
         id = UUID(d.pop("id"))
-
-        is_active = d.pop("is_active")
 
         map_id = UUID(d.pop("map_id"))
 
+        token_hint = d.pop("token_hint")
+
         scoped_dataset_ids = cast(list[str], d.pop("scoped_dataset_ids"))
 
-        token_hint = d.pop("token_hint")
+        expires_at = isoparse(d.pop("expires_at"))
+
+        is_active = d.pop("is_active")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
 
         def _parse_allowed_origins(data: object) -> list[str] | None | Unset:
             if data is None:
@@ -145,6 +154,8 @@ class EmbedTokenResponse:
 
         allowed_origins = _parse_allowed_origins(d.pop("allowed_origins", UNSET))
 
+        use_count = d.pop("use_count", UNSET)
+
         def _parse_last_used_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
                 return data
@@ -162,29 +173,18 @@ class EmbedTokenResponse:
 
         last_used_at = _parse_last_used_at(d.pop("last_used_at", UNSET))
 
-        def _parse_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        name = _parse_name(d.pop("name", UNSET))
-
-        use_count = d.pop("use_count", UNSET)
-
         embed_token_response = cls(
-            created_at=created_at,
-            expires_at=expires_at,
             id=id,
-            is_active=is_active,
             map_id=map_id,
-            scoped_dataset_ids=scoped_dataset_ids,
             token_hint=token_hint,
-            allowed_origins=allowed_origins,
-            last_used_at=last_used_at,
+            scoped_dataset_ids=scoped_dataset_ids,
+            expires_at=expires_at,
+            is_active=is_active,
+            created_at=created_at,
             name=name,
+            allowed_origins=allowed_origins,
             use_count=use_count,
+            last_used_at=last_used_at,
         )
 
         embed_token_response.additional_properties = d

--- a/sdks/python/geolens/models/embedding_stats_response.py
+++ b/sdks/python/geolens/models/embedding_stats_response.py
@@ -14,35 +14,35 @@ T = TypeVar("T", bound="EmbeddingStatsResponse")
 class EmbeddingStatsResponse:
     """
     Attributes:
-        coverage_percent (float): Embedding coverage as a percentage (0-100).
+        total_records (int): Total number of records in the catalog.
         embedded_records (int): Number of records that have an embedding stored.
         missing_records (int): Number of records still missing embeddings.
-        total_records (int): Total number of records in the catalog.
+        coverage_percent (float): Embedding coverage as a percentage (0-100).
     """
 
-    coverage_percent: float
+    total_records: int
     embedded_records: int
     missing_records: int
-    total_records: int
+    coverage_percent: float
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coverage_percent = self.coverage_percent
+        total_records = self.total_records
 
         embedded_records = self.embedded_records
 
         missing_records = self.missing_records
 
-        total_records = self.total_records
+        coverage_percent = self.coverage_percent
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coverage_percent": coverage_percent,
+                "total_records": total_records,
                 "embedded_records": embedded_records,
                 "missing_records": missing_records,
-                "total_records": total_records,
+                "coverage_percent": coverage_percent,
             }
         )
 
@@ -51,19 +51,19 @@ class EmbeddingStatsResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coverage_percent = d.pop("coverage_percent")
+        total_records = d.pop("total_records")
 
         embedded_records = d.pop("embedded_records")
 
         missing_records = d.pop("missing_records")
 
-        total_records = d.pop("total_records")
+        coverage_percent = d.pop("coverage_percent")
 
         embedding_stats_response = cls(
-            coverage_percent=coverage_percent,
+            total_records=total_records,
             embedded_records=embedded_records,
             missing_records=missing_records,
-            total_records=total_records,
+            coverage_percent=coverage_percent,
         )
 
         embedding_stats_response.additional_properties = d

--- a/sdks/python/geolens/models/facet_count_response.py
+++ b/sdks/python/geolens/models/facet_count_response.py
@@ -24,28 +24,21 @@ class FacetCountResponse:
 
     Attributes:
         record_type (FacetCountResponseRecordType): Hit counts keyed by record type
-        collections (list[CollectionFacetItem] | Unset): Collections containing matched records
         keywords (list[FacetValueCount] | Unset): Top keyword tags with counts
         source_organization (list[FacetValueCount] | Unset): Top organizations with counts
         srid (list[FacetValueCount] | Unset): Top SRIDs with counts
+        collections (list[CollectionFacetItem] | Unset): Collections containing matched records
     """
 
     record_type: FacetCountResponseRecordType
-    collections: list[CollectionFacetItem] | Unset = UNSET
     keywords: list[FacetValueCount] | Unset = UNSET
     source_organization: list[FacetValueCount] | Unset = UNSET
     srid: list[FacetValueCount] | Unset = UNSET
+    collections: list[CollectionFacetItem] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         record_type = self.record_type.to_dict()
-
-        collections: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.collections, Unset):
-            collections = []
-            for collections_item_data in self.collections:
-                collections_item = collections_item_data.to_dict()
-                collections.append(collections_item)
 
         keywords: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.keywords, Unset):
@@ -68,6 +61,13 @@ class FacetCountResponse:
                 srid_item = srid_item_data.to_dict()
                 srid.append(srid_item)
 
+        collections: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.collections, Unset):
+            collections = []
+            for collections_item_data in self.collections:
+                collections_item = collections_item_data.to_dict()
+                collections.append(collections_item)
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -75,14 +75,14 @@ class FacetCountResponse:
                 "record_type": record_type,
             }
         )
-        if collections is not UNSET:
-            field_dict["collections"] = collections
         if keywords is not UNSET:
             field_dict["keywords"] = keywords
         if source_organization is not UNSET:
             field_dict["source_organization"] = source_organization
         if srid is not UNSET:
             field_dict["srid"] = srid
+        if collections is not UNSET:
+            field_dict["collections"] = collections
 
         return field_dict
 
@@ -96,15 +96,6 @@ class FacetCountResponse:
 
         d = dict(src_dict)
         record_type = FacetCountResponseRecordType.from_dict(d.pop("record_type"))
-
-        _collections = d.pop("collections", UNSET)
-        collections: list[CollectionFacetItem] | Unset = UNSET
-        if _collections is not UNSET:
-            collections = []
-            for collections_item_data in _collections:
-                collections_item = CollectionFacetItem.from_dict(collections_item_data)
-
-                collections.append(collections_item)
 
         _keywords = d.pop("keywords", UNSET)
         keywords: list[FacetValueCount] | Unset = UNSET
@@ -135,12 +126,21 @@ class FacetCountResponse:
 
                 srid.append(srid_item)
 
+        _collections = d.pop("collections", UNSET)
+        collections: list[CollectionFacetItem] | Unset = UNSET
+        if _collections is not UNSET:
+            collections = []
+            for collections_item_data in _collections:
+                collections_item = CollectionFacetItem.from_dict(collections_item_data)
+
+                collections.append(collections_item)
+
         facet_count_response = cls(
             record_type=record_type,
-            collections=collections,
             keywords=keywords,
             source_organization=source_organization,
             srid=srid,
+            collections=collections,
         )
 
         facet_count_response.additional_properties = d

--- a/sdks/python/geolens/models/facet_value_count.py
+++ b/sdks/python/geolens/models/facet_value_count.py
@@ -15,25 +15,25 @@ class FacetValueCount:
     """A single facet value with count.
 
     Attributes:
-        count (int):
         value (str):
+        count (int):
     """
 
-    count: int
     value: str
+    count: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        count = self.count
-
         value = self.value
+
+        count = self.count
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "count": count,
                 "value": value,
+                "count": count,
             }
         )
 
@@ -42,13 +42,13 @@ class FacetValueCount:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        count = d.pop("count")
-
         value = d.pop("value")
 
+        count = d.pop("count")
+
         facet_value_count = cls(
-            count=count,
             value=value,
+            count=count,
         )
 
         facet_value_count.additional_properties = d

--- a/sdks/python/geolens/models/fan_out_layer_result.py
+++ b/sdks/python/geolens/models/fan_out_layer_result.py
@@ -24,23 +24,31 @@ class FanOutLayerResult:
     Attributes:
         layer_name (str): Layer name from the request.
         status (FanOutLayerResultStatus): 'queued' if the task was dispatched; 'failed' if an error occurred.
+        new_job_id (None | Unset | UUID): ID of the cloned IngestJob queued for this layer. Null on failure.
         dataset_id (None | Unset | UUID): ID of the new Dataset record created for this layer. Null on failure.
         error (None | str | Unset): User-safe error description when status='failed'. Never contains internal file
             paths.
-        new_job_id (None | Unset | UUID): ID of the cloned IngestJob queued for this layer. Null on failure.
     """
 
     layer_name: str
     status: FanOutLayerResultStatus
+    new_job_id: None | Unset | UUID = UNSET
     dataset_id: None | Unset | UUID = UNSET
     error: None | str | Unset = UNSET
-    new_job_id: None | Unset | UUID = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         layer_name = self.layer_name
 
         status: str = self.status
+
+        new_job_id: None | str | Unset
+        if isinstance(self.new_job_id, Unset):
+            new_job_id = UNSET
+        elif isinstance(self.new_job_id, UUID):
+            new_job_id = str(self.new_job_id)
+        else:
+            new_job_id = self.new_job_id
 
         dataset_id: None | str | Unset
         if isinstance(self.dataset_id, Unset):
@@ -56,14 +64,6 @@ class FanOutLayerResult:
         else:
             error = self.error
 
-        new_job_id: None | str | Unset
-        if isinstance(self.new_job_id, Unset):
-            new_job_id = UNSET
-        elif isinstance(self.new_job_id, UUID):
-            new_job_id = str(self.new_job_id)
-        else:
-            new_job_id = self.new_job_id
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -72,12 +72,12 @@ class FanOutLayerResult:
                 "status": status,
             }
         )
+        if new_job_id is not UNSET:
+            field_dict["new_job_id"] = new_job_id
         if dataset_id is not UNSET:
             field_dict["dataset_id"] = dataset_id
         if error is not UNSET:
             field_dict["error"] = error
-        if new_job_id is not UNSET:
-            field_dict["new_job_id"] = new_job_id
 
         return field_dict
 
@@ -87,6 +87,23 @@ class FanOutLayerResult:
         layer_name = d.pop("layer_name")
 
         status = check_fan_out_layer_result_status(d.pop("status"))
+
+        def _parse_new_job_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                new_job_id_type_0 = UUID(data)
+
+                return new_job_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        new_job_id = _parse_new_job_id(d.pop("new_job_id", UNSET))
 
         def _parse_dataset_id(data: object) -> None | Unset | UUID:
             if data is None:
@@ -114,29 +131,12 @@ class FanOutLayerResult:
 
         error = _parse_error(d.pop("error", UNSET))
 
-        def _parse_new_job_id(data: object) -> None | Unset | UUID:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                new_job_id_type_0 = UUID(data)
-
-                return new_job_id_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | Unset | UUID, data)
-
-        new_job_id = _parse_new_job_id(d.pop("new_job_id", UNSET))
-
         fan_out_layer_result = cls(
             layer_name=layer_name,
             status=status,
+            new_job_id=new_job_id,
             dataset_id=dataset_id,
             error=error,
-            new_job_id=new_job_id,
         )
 
         fan_out_layer_result.additional_properties = d

--- a/sdks/python/geolens/models/geo_json_feature.py
+++ b/sdks/python/geolens/models/geo_json_feature.py
@@ -25,14 +25,14 @@ class GeoJSONFeature:
     """A GeoJSON Feature.
 
     Attributes:
+        type_ (str | Unset):  Default: 'Feature'.
         geometry (GeoJSONFeatureGeometryType0 | None | Unset):
         properties (GeoJSONFeaturePropertiesType0 | None | Unset):
-        type_ (str | Unset):  Default: 'Feature'.
     """
 
+    type_: str | Unset = "Feature"
     geometry: GeoJSONFeatureGeometryType0 | None | Unset = UNSET
     properties: GeoJSONFeaturePropertiesType0 | None | Unset = UNSET
-    type_: str | Unset = "Feature"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -42,6 +42,8 @@ class GeoJSONFeature:
         from ..models.geo_json_feature_properties_type_0 import (
             GeoJSONFeaturePropertiesType0,
         )
+
+        type_ = self.type_
 
         geometry: dict[str, Any] | None | Unset
         if isinstance(self.geometry, Unset):
@@ -59,17 +61,15 @@ class GeoJSONFeature:
         else:
             properties = self.properties
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
+        if type_ is not UNSET:
+            field_dict["type"] = type_
         if geometry is not UNSET:
             field_dict["geometry"] = geometry
         if properties is not UNSET:
             field_dict["properties"] = properties
-        if type_ is not UNSET:
-            field_dict["type"] = type_
 
         return field_dict
 
@@ -83,6 +83,7 @@ class GeoJSONFeature:
         )
 
         d = dict(src_dict)
+        type_ = d.pop("type", UNSET)
 
         def _parse_geometry(data: object) -> GeoJSONFeatureGeometryType0 | None | Unset:
             if data is None:
@@ -120,12 +121,10 @@ class GeoJSONFeature:
 
         properties = _parse_properties(d.pop("properties", UNSET))
 
-        type_ = d.pop("type", UNSET)
-
         geo_json_feature = cls(
+            type_=type_,
             geometry=geometry,
             properties=properties,
-            type_=type_,
         )
 
         geo_json_feature.additional_properties = d

--- a/sdks/python/geolens/models/geo_json_feature_collection.py
+++ b/sdks/python/geolens/models/geo_json_feature_collection.py
@@ -21,15 +21,17 @@ class GeoJSONFeatureCollection:
     """A GeoJSON FeatureCollection.
 
     Attributes:
-        features (list[GeoJSONFeature] | Unset):
         type_ (str | Unset):  Default: 'FeatureCollection'.
+        features (list[GeoJSONFeature] | Unset):
     """
 
-    features: list[GeoJSONFeature] | Unset = UNSET
     type_: str | Unset = "FeatureCollection"
+    features: list[GeoJSONFeature] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
         features: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.features, Unset):
             features = []
@@ -37,15 +39,13 @@ class GeoJSONFeatureCollection:
                 features_item = features_item_data.to_dict()
                 features.append(features_item)
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if features is not UNSET:
-            field_dict["features"] = features
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if features is not UNSET:
+            field_dict["features"] = features
 
         return field_dict
 
@@ -54,6 +54,8 @@ class GeoJSONFeatureCollection:
         from ..models.geo_json_feature import GeoJSONFeature
 
         d = dict(src_dict)
+        type_ = d.pop("type", UNSET)
+
         _features = d.pop("features", UNSET)
         features: list[GeoJSONFeature] | Unset = UNSET
         if _features is not UNSET:
@@ -63,11 +65,9 @@ class GeoJSONFeatureCollection:
 
                 features.append(features_item)
 
-        type_ = d.pop("type", UNSET)
-
         geo_json_feature_collection = cls(
-            features=features,
             type_=type_,
+            features=features,
         )
 
         geo_json_feature_collection.additional_properties = d

--- a/sdks/python/geolens/models/geo_json_geometry.py
+++ b/sdks/python/geolens/models/geo_json_geometry.py
@@ -20,25 +20,25 @@ class GeoJSONGeometry:
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_ (GeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: GeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -47,13 +47,13 @@ class GeoJSONGeometry:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_geo_json_geometry_type(d.pop("type"))
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/geo_json_geometry_collection.py
+++ b/sdks/python/geolens/models/geo_json_geometry_collection.py
@@ -34,28 +34,28 @@ class GeoJSONGeometryCollection:
     database 500. The write schemas add a raw-payload guard for a clear 422.
 
         Attributes:
-            geometries (list[GeoJSONGeometry]):
             type_ (Literal['GeometryCollection']):
+            geometries (list[GeoJSONGeometry]):
     """
 
-    geometries: list[GeoJSONGeometry]
     type_: Literal["GeometryCollection"]
+    geometries: list[GeoJSONGeometry]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
         geometries = []
         for geometries_item_data in self.geometries:
             geometries_item = geometries_item_data.to_dict()
             geometries.append(geometries_item)
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "geometries": geometries,
                 "type": type_,
+                "geometries": geometries,
             }
         )
 
@@ -66,6 +66,12 @@ class GeoJSONGeometryCollection:
         from ..models.geo_json_geometry import GeoJSONGeometry
 
         d = dict(src_dict)
+        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
+        if type_ != "GeometryCollection":
+            raise ValueError(
+                f"type must match const 'GeometryCollection', got '{type_}'"
+            )
+
         geometries = []
         _geometries = d.pop("geometries")
         for geometries_item_data in _geometries:
@@ -73,15 +79,9 @@ class GeoJSONGeometryCollection:
 
             geometries.append(geometries_item)
 
-        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
-        if type_ != "GeometryCollection":
-            raise ValueError(
-                f"type must match const 'GeometryCollection', got '{type_}'"
-            )
-
         geo_json_geometry_collection = cls(
-            geometries=geometries,
             type_=type_,
+            geometries=geometries,
         )
 
         geo_json_geometry_collection.additional_properties = d

--- a/sdks/python/geolens/models/get_collection_item_feature_collections_dataset_id_items_feature_id_get_ogc_single_feature_response.py
+++ b/sdks/python/geolens/models/get_collection_item_feature_collections_dataset_id_items_feature_id_get_ogc_single_feature_response.py
@@ -34,32 +34,32 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
     """Single GeoJSON Feature response.
 
     Attributes:
+        id (int): Feature identifier within the collection.
         geometry (GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeatureResponseGeoJSONGeometry |
             None): GeoJSON geometry of the feature, or null for geometry-less features.
-        id (int): Feature identifier within the collection.
         properties (GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeatureResponsePropertiesType0
             | None): Feature attributes as a JSON object.
+        type_ (Literal['Feature'] | Unset): GeoJSON object type. Default: 'Feature'.
         links (list[GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeatureResponseOGCLink] |
             Unset): Self-reference and related-resource links.
-        type_ (Literal['Feature'] | Unset): GeoJSON object type. Default: 'Feature'.
     """
 
+    id: int
     geometry: (
         GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeatureResponseGeoJSONGeometry
         | None
     )
-    id: int
     properties: (
         GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeatureResponsePropertiesType0
         | None
     )
+    type_: Literal["Feature"] | Unset = "Feature"
     links: (
         list[
             GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeatureResponseOGCLink
         ]
         | Unset
     ) = UNSET
-    type_: Literal["Feature"] | Unset = "Feature"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -70,6 +70,8 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
             GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeatureResponsePropertiesType0,
         )
 
+        id = self.id
+
         geometry: dict[str, Any] | None
         if isinstance(
             self.geometry,
@@ -78,8 +80,6 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
             geometry = self.geometry.to_dict()
         else:
             geometry = self.geometry
-
-        id = self.id
 
         properties: dict[str, Any] | None
         if isinstance(
@@ -90,6 +90,8 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
         else:
             properties = self.properties
 
+        type_ = self.type_
+
         links: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.links, Unset):
             links = []
@@ -97,21 +99,19 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
                 links_item = links_item_data.to_dict()
                 links.append(links_item)
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "geometry": geometry,
                 "id": id,
+                "geometry": geometry,
                 "properties": properties,
             }
         )
-        if links is not UNSET:
-            field_dict["links"] = links
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if links is not UNSET:
+            field_dict["links"] = links
 
         return field_dict
 
@@ -128,6 +128,7 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
         )
 
         d = dict(src_dict)
+        id = d.pop("id")
 
         def _parse_geometry(
             data: object,
@@ -155,8 +156,6 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
 
         geometry = _parse_geometry(d.pop("geometry"))
 
-        id = d.pop("id")
-
         def _parse_properties(
             data: object,
         ) -> (
@@ -183,6 +182,10 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
 
         properties = _parse_properties(d.pop("properties"))
 
+        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
+        if type_ != "Feature" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'Feature', got '{type_}'")
+
         _links = d.pop("links", UNSET)
         links: (
             list[
@@ -199,16 +202,12 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
 
                 links.append(links_item)
 
-        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
-        if type_ != "Feature" and not isinstance(type_, Unset):
-            raise ValueError(f"type must match const 'Feature', got '{type_}'")
-
         get_collection_item_feature_collections_dataset_id_items_feature_id_get_ogc_single_feature_response = cls(
-            geometry=geometry,
             id=id,
+            geometry=geometry,
             properties=properties,
-            links=links,
             type_=type_,
+            links=links,
         )
 
         get_collection_item_feature_collections_dataset_id_items_feature_id_get_ogc_single_feature_response.additional_properties = d

--- a/sdks/python/geolens/models/get_collection_item_feature_collections_dataset_id_items_feature_id_get_ogc_single_feature_response_geo_json_geometry.py
+++ b/sdks/python/geolens/models/get_collection_item_feature_collections_dataset_id_items_feature_id_get_ogc_single_feature_response_geo_json_geometry.py
@@ -27,26 +27,26 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_
             (GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeatureResponseGeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeatureResponseGeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -55,15 +55,15 @@ class GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetOGCSingleFeat
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_get_collection_item_feature_collections_dataset_id_items_feature_id_get_ogc_single_feature_response_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         get_collection_item_feature_collections_dataset_id_items_feature_id_get_ogc_single_feature_response_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         get_collection_item_feature_collections_dataset_id_items_feature_id_get_ogc_single_feature_response_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/get_collection_items_collections_dataset_id_items_get_ogc_feature_items_response.py
+++ b/sdks/python/geolens/models/get_collection_items_collections_dataset_id_items_get_ogc_feature_items_response.py
@@ -30,29 +30,33 @@ class GetCollectionItemsCollectionsDatasetIdItemsGetOGCFeatureItemsResponse:
     """FeatureCollection response as defined by OGC API - Features.
 
     Attributes:
+        number_matched (int): Total number of features matching the query (across all pages).
+        number_returned (int): Number of features in this response page.
         features (list[GetCollectionItemsCollectionsDatasetIdItemsGetOGCFeatureItemsResponseFeaturesItem]): GeoJSON
             features returned by the query.
         links (list[GetCollectionItemsCollectionsDatasetIdItemsGetOGCFeatureItemsResponseOGCLink]): Pagination and self-
             reference links.
-        number_matched (int): Total number of features matching the query (across all pages).
-        number_returned (int): Number of features in this response page.
-        time_stamp (str | Unset): ISO 8601 timestamp the response was generated.
         type_ (Literal['FeatureCollection'] | Unset): GeoJSON object type. Default: 'FeatureCollection'.
+        time_stamp (str | Unset): ISO 8601 timestamp the response was generated.
     """
 
+    number_matched: int
+    number_returned: int
     features: list[
         GetCollectionItemsCollectionsDatasetIdItemsGetOGCFeatureItemsResponseFeaturesItem
     ]
     links: list[
         GetCollectionItemsCollectionsDatasetIdItemsGetOGCFeatureItemsResponseOGCLink
     ]
-    number_matched: int
-    number_returned: int
-    time_stamp: str | Unset = UNSET
     type_: Literal["FeatureCollection"] | Unset = "FeatureCollection"
+    time_stamp: str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        number_matched = self.number_matched
+
+        number_returned = self.number_returned
+
         features = []
         for features_item_data in self.features:
             features_item = features_item_data.to_dict()
@@ -63,28 +67,24 @@ class GetCollectionItemsCollectionsDatasetIdItemsGetOGCFeatureItemsResponse:
             links_item = links_item_data.to_dict()
             links.append(links_item)
 
-        number_matched = self.number_matched
-
-        number_returned = self.number_returned
+        type_ = self.type_
 
         time_stamp = self.time_stamp
-
-        type_ = self.type_
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "features": features,
-                "links": links,
                 "numberMatched": number_matched,
                 "numberReturned": number_returned,
+                "features": features,
+                "links": links,
             }
         )
-        if time_stamp is not UNSET:
-            field_dict["timeStamp"] = time_stamp
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if time_stamp is not UNSET:
+            field_dict["timeStamp"] = time_stamp
 
         return field_dict
 
@@ -98,6 +98,10 @@ class GetCollectionItemsCollectionsDatasetIdItemsGetOGCFeatureItemsResponse:
         )
 
         d = dict(src_dict)
+        number_matched = d.pop("numberMatched")
+
+        number_returned = d.pop("numberReturned")
+
         features = []
         _features = d.pop("features")
         for features_item_data in _features:
@@ -116,25 +120,21 @@ class GetCollectionItemsCollectionsDatasetIdItemsGetOGCFeatureItemsResponse:
 
             links.append(links_item)
 
-        number_matched = d.pop("numberMatched")
-
-        number_returned = d.pop("numberReturned")
-
-        time_stamp = d.pop("timeStamp", UNSET)
-
         type_ = cast(Literal["FeatureCollection"] | Unset, d.pop("type", UNSET))
         if type_ != "FeatureCollection" and not isinstance(type_, Unset):
             raise ValueError(
                 f"type must match const 'FeatureCollection', got '{type_}'"
             )
 
+        time_stamp = d.pop("timeStamp", UNSET)
+
         get_collection_items_collections_dataset_id_items_get_ogc_feature_items_response = cls(
-            features=features,
-            links=links,
             number_matched=number_matched,
             number_returned=number_returned,
-            time_stamp=time_stamp,
+            features=features,
+            links=links,
             type_=type_,
+            time_stamp=time_stamp,
         )
 
         get_collection_items_collections_dataset_id_items_get_ogc_feature_items_response.additional_properties = d

--- a/sdks/python/geolens/models/get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature.py
+++ b/sdks/python/geolens/models/get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature.py
@@ -33,20 +33,20 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeature:
     Attributes:
         id (int):
         properties (GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureProperties):
+        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
         geometry (GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeometry |
             GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeometryCollection | None | Unset):
-        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
     """
 
     id: int
     properties: GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureProperties
+    type_: Literal["Feature"] | Unset = "Feature"
     geometry: (
         GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeometry
         | GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeometryCollection
         | None
         | Unset
     ) = UNSET
-    type_: Literal["Feature"] | Unset = "Feature"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -60,6 +60,8 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeature:
         id = self.id
 
         properties = self.properties.to_dict()
+
+        type_ = self.type_
 
         geometry: dict[str, Any] | None | Unset
         if isinstance(self.geometry, Unset):
@@ -77,8 +79,6 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeature:
         else:
             geometry = self.geometry
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -87,10 +87,10 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeature:
                 "properties": properties,
             }
         )
-        if geometry is not UNSET:
-            field_dict["geometry"] = geometry
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if geometry is not UNSET:
+            field_dict["geometry"] = geometry
 
         return field_dict
 
@@ -112,6 +112,10 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeature:
         properties = GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureProperties.from_dict(
             d.pop("properties")
         )
+
+        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
+        if type_ != "Feature" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'Feature', got '{type_}'")
 
         def _parse_geometry(
             data: object,
@@ -155,15 +159,11 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeature:
 
         geometry = _parse_geometry(d.pop("geometry", UNSET))
 
-        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
-        if type_ != "Feature" and not isinstance(type_, Unset):
-            raise ValueError(f"type must match const 'Feature', got '{type_}'")
-
         get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature = cls(
             id=id,
             properties=properties,
-            geometry=geometry,
             type_=type_,
+            geometry=geometry,
         )
 
         get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature.additional_properties = d

--- a/sdks/python/geolens/models/get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry.py
+++ b/sdks/python/geolens/models/get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry.py
@@ -27,27 +27,27 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeomet
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_ (GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: (
         GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeometryType
     )
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -56,15 +56,15 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeomet
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry_collection.py
+++ b/sdks/python/geolens/models/get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry_collection.py
@@ -39,31 +39,31 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeomet
     database 500. The write schemas add a raw-payload guard for a clear 422.
 
         Attributes:
+            type_ (Literal['GeometryCollection']):
             geometries
                 (list[GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometry]):
-            type_ (Literal['GeometryCollection']):
     """
 
+    type_: Literal["GeometryCollection"]
     geometries: list[
         GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometry
     ]
-    type_: Literal["GeometryCollection"]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
         geometries = []
         for geometries_item_data in self.geometries:
             geometries_item = geometries_item_data.to_dict()
             geometries.append(geometries_item)
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "geometries": geometries,
                 "type": type_,
+                "geometries": geometries,
             }
         )
 
@@ -76,6 +76,12 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeomet
         )
 
         d = dict(src_dict)
+        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
+        if type_ != "GeometryCollection":
+            raise ValueError(
+                f"type must match const 'GeometryCollection', got '{type_}'"
+            )
+
         geometries = []
         _geometries = d.pop("geometries")
         for geometries_item_data in _geometries:
@@ -85,15 +91,9 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeomet
 
             geometries.append(geometries_item)
 
-        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
-        if type_ != "GeometryCollection":
-            raise ValueError(
-                f"type must match const 'GeometryCollection', got '{type_}'"
-            )
-
         get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry_collection = cls(
-            geometries=geometries,
             type_=type_,
+            geometries=geometries,
         )
 
         get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry_collection.additional_properties = d

--- a/sdks/python/geolens/models/get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.py
+++ b/sdks/python/geolens/models/get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.py
@@ -27,26 +27,26 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeomet
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_
             (GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -55,15 +55,15 @@ class GetSingleFeatureDatasetsDatasetIdFeaturesGidGetGeoJSONFeatureGeoJSONGeomet
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry_collection_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry_collection_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         get_single_feature_datasets_dataset_id_features_gid_get_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/health_response.py
+++ b/sdks/python/geolens/models/health_response.py
@@ -21,24 +21,24 @@ T = TypeVar("T", bound="HealthResponse")
 class HealthResponse:
     """
     Attributes:
-        providers (HealthResponseProviders):
         status (str):
         version (str):
+        providers (HealthResponseProviders):
         build (None | str | Unset):
     """
 
-    providers: HealthResponseProviders
     status: str
     version: str
+    providers: HealthResponseProviders
     build: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        providers = self.providers.to_dict()
-
         status = self.status
 
         version = self.version
+
+        providers = self.providers.to_dict()
 
         build: None | str | Unset
         if isinstance(self.build, Unset):
@@ -50,9 +50,9 @@ class HealthResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "providers": providers,
                 "status": status,
                 "version": version,
+                "providers": providers,
             }
         )
         if build is not UNSET:
@@ -65,11 +65,11 @@ class HealthResponse:
         from ..models.health_response_providers import HealthResponseProviders
 
         d = dict(src_dict)
-        providers = HealthResponseProviders.from_dict(d.pop("providers"))
-
         status = d.pop("status")
 
         version = d.pop("version")
+
+        providers = HealthResponseProviders.from_dict(d.pop("providers"))
 
         def _parse_build(data: object) -> None | str | Unset:
             if data is None:
@@ -81,9 +81,9 @@ class HealthResponse:
         build = _parse_build(d.pop("build", UNSET))
 
         health_response = cls(
-            providers=providers,
             status=status,
             version=version,
+            providers=providers,
             build=build,
         )
 

--- a/sdks/python/geolens/models/import_result.py
+++ b/sdks/python/geolens/models/import_result.py
@@ -19,89 +19,89 @@ class ImportResult:
     """Summary of what was applied during an import.
 
     Attributes:
-        oauth_created (int): Number of new OAuth providers created.
-        oauth_deleted (int): Number of OAuth providers deleted (overwrite mode only).
-        oauth_updated (int): Number of existing OAuth providers updated.
         settings_applied (int): Number of settings successfully updated.
         settings_skipped (int): Number of settings skipped (no change, unknown key, or restricted key not writable by
             the current runtime).
-        oauth_accounts_deleted (int | Unset): Number of dependent OAuth account links cascade-deleted in overwrite mode.
-            Default: 0.
+        oauth_created (int): Number of new OAuth providers created.
+        oauth_updated (int): Number of existing OAuth providers updated.
+        oauth_deleted (int): Number of OAuth providers deleted (overwrite mode only).
         settings_skipped_restricted (list[str] | Unset): Names of restricted setting keys that were skipped by the
             current runtime.
+        oauth_accounts_deleted (int | Unset): Number of dependent OAuth account links cascade-deleted in overwrite mode.
+            Default: 0.
     """
 
-    oauth_created: int
-    oauth_deleted: int
-    oauth_updated: int
     settings_applied: int
     settings_skipped: int
-    oauth_accounts_deleted: int | Unset = 0
+    oauth_created: int
+    oauth_updated: int
+    oauth_deleted: int
     settings_skipped_restricted: list[str] | Unset = UNSET
+    oauth_accounts_deleted: int | Unset = 0
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        oauth_created = self.oauth_created
-
-        oauth_deleted = self.oauth_deleted
-
-        oauth_updated = self.oauth_updated
-
         settings_applied = self.settings_applied
 
         settings_skipped = self.settings_skipped
 
-        oauth_accounts_deleted = self.oauth_accounts_deleted
+        oauth_created = self.oauth_created
+
+        oauth_updated = self.oauth_updated
+
+        oauth_deleted = self.oauth_deleted
 
         settings_skipped_restricted: list[str] | Unset = UNSET
         if not isinstance(self.settings_skipped_restricted, Unset):
             settings_skipped_restricted = self.settings_skipped_restricted
 
+        oauth_accounts_deleted = self.oauth_accounts_deleted
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "oauth_created": oauth_created,
-                "oauth_deleted": oauth_deleted,
-                "oauth_updated": oauth_updated,
                 "settings_applied": settings_applied,
                 "settings_skipped": settings_skipped,
+                "oauth_created": oauth_created,
+                "oauth_updated": oauth_updated,
+                "oauth_deleted": oauth_deleted,
             }
         )
-        if oauth_accounts_deleted is not UNSET:
-            field_dict["oauth_accounts_deleted"] = oauth_accounts_deleted
         if settings_skipped_restricted is not UNSET:
             field_dict["settings_skipped_restricted"] = settings_skipped_restricted
+        if oauth_accounts_deleted is not UNSET:
+            field_dict["oauth_accounts_deleted"] = oauth_accounts_deleted
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        oauth_created = d.pop("oauth_created")
-
-        oauth_deleted = d.pop("oauth_deleted")
-
-        oauth_updated = d.pop("oauth_updated")
-
         settings_applied = d.pop("settings_applied")
 
         settings_skipped = d.pop("settings_skipped")
 
-        oauth_accounts_deleted = d.pop("oauth_accounts_deleted", UNSET)
+        oauth_created = d.pop("oauth_created")
+
+        oauth_updated = d.pop("oauth_updated")
+
+        oauth_deleted = d.pop("oauth_deleted")
 
         settings_skipped_restricted = cast(
             list[str], d.pop("settings_skipped_restricted", UNSET)
         )
 
+        oauth_accounts_deleted = d.pop("oauth_accounts_deleted", UNSET)
+
         import_result = cls(
-            oauth_created=oauth_created,
-            oauth_deleted=oauth_deleted,
-            oauth_updated=oauth_updated,
             settings_applied=settings_applied,
             settings_skipped=settings_skipped,
-            oauth_accounts_deleted=oauth_accounts_deleted,
+            oauth_created=oauth_created,
+            oauth_updated=oauth_updated,
+            oauth_deleted=oauth_deleted,
             settings_skipped_restricted=settings_skipped_restricted,
+            oauth_accounts_deleted=oauth_accounts_deleted,
         )
 
         import_result.additional_properties = d

--- a/sdks/python/geolens/models/infrastructure_config.py
+++ b/sdks/python/geolens/models/infrastructure_config.py
@@ -14,50 +14,50 @@ T = TypeVar("T", bound="InfrastructureConfig")
 class InfrastructureConfig:
     """
     Attributes:
-        cache_provider (str): Active cache backend ('memory' or 'redis').
-        cdn_configured (bool): Whether a CDN base URL is configured for tile delivery.
-        database_pooler (str): Active connection pooler mode ('sqlalchemy' or 'external').
-        database_type (str): Database flavor (e.g. 'postgres', 'managed-postgres').
         storage_provider (str): Active storage backend ('local' or 's3').
+        cache_provider (str): Active cache backend ('memory' or 'redis').
+        database_type (str): Database flavor (e.g. 'postgres', 'managed-postgres').
+        database_pooler (str): Active connection pooler mode ('sqlalchemy' or 'external').
         tile_cache (str): Tile caching backend in use.
         tile_cache_ttl (int): Tile cache TTL in seconds.
+        cdn_configured (bool): Whether a CDN base URL is configured for tile delivery.
     """
 
-    cache_provider: str
-    cdn_configured: bool
-    database_pooler: str
-    database_type: str
     storage_provider: str
+    cache_provider: str
+    database_type: str
+    database_pooler: str
     tile_cache: str
     tile_cache_ttl: int
+    cdn_configured: bool
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        storage_provider = self.storage_provider
+
         cache_provider = self.cache_provider
-
-        cdn_configured = self.cdn_configured
-
-        database_pooler = self.database_pooler
 
         database_type = self.database_type
 
-        storage_provider = self.storage_provider
+        database_pooler = self.database_pooler
 
         tile_cache = self.tile_cache
 
         tile_cache_ttl = self.tile_cache_ttl
 
+        cdn_configured = self.cdn_configured
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "cache_provider": cache_provider,
-                "cdn_configured": cdn_configured,
-                "database_pooler": database_pooler,
-                "database_type": database_type,
                 "storage_provider": storage_provider,
+                "cache_provider": cache_provider,
+                "database_type": database_type,
+                "database_pooler": database_pooler,
                 "tile_cache": tile_cache,
                 "tile_cache_ttl": tile_cache_ttl,
+                "cdn_configured": cdn_configured,
             }
         )
 
@@ -66,28 +66,28 @@ class InfrastructureConfig:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        storage_provider = d.pop("storage_provider")
+
         cache_provider = d.pop("cache_provider")
-
-        cdn_configured = d.pop("cdn_configured")
-
-        database_pooler = d.pop("database_pooler")
 
         database_type = d.pop("database_type")
 
-        storage_provider = d.pop("storage_provider")
+        database_pooler = d.pop("database_pooler")
 
         tile_cache = d.pop("tile_cache")
 
         tile_cache_ttl = d.pop("tile_cache_ttl")
 
+        cdn_configured = d.pop("cdn_configured")
+
         infrastructure_config = cls(
-            cache_provider=cache_provider,
-            cdn_configured=cdn_configured,
-            database_pooler=database_pooler,
-            database_type=database_type,
             storage_provider=storage_provider,
+            cache_provider=cache_provider,
+            database_type=database_type,
+            database_pooler=database_pooler,
             tile_cache=tile_cache,
             tile_cache_ttl=tile_cache_ttl,
+            cdn_configured=cdn_configured,
         )
 
         infrastructure_config.additional_properties = d

--- a/sdks/python/geolens/models/job_status_response.py
+++ b/sdks/python/geolens/models/job_status_response.py
@@ -37,40 +37,35 @@ T = TypeVar("T", bound="JobStatusResponse")
 class JobStatusResponse:
     """
     Attributes:
+        id (UUID):
+        status (JobStatusResponseStatus):
+        dataset_id (None | UUID):
+        source_filename (None | str):
+        error_message (None | str):
         can_retry (bool):
+        retry_reason (None | str):
+        started_at (datetime.datetime | None):
         completed_at (datetime.datetime | None):
         created_at (datetime.datetime):
-        dataset_id (None | UUID):
-        error_message (None | str):
-        id (UUID):
-        retry_reason (None | str):
-        source_filename (None | str):
-        started_at (datetime.datetime | None):
-        status (JobStatusResponseStatus):
-        archive_failed (bool | Unset):  Default: False.
-        current_step (JobStatusResponseCurrentStepType0 | None | Unset):
-        progress (float | None | Unset):
-        rows_processed (int | None | Unset):
-        temporal_parse_errors (JobStatusResponseTemporalParseErrors | Unset):
         warning_message (None | str | Unset):
         warnings (list[DbfTruncationCollisionWarning | MercatorClipWarning | ReservedRenameWarning] | Unset):
+        progress (float | None | Unset):
+        current_step (JobStatusResponseCurrentStepType0 | None | Unset):
+        rows_processed (int | None | Unset):
+        archive_failed (bool | Unset):  Default: False.
+        temporal_parse_errors (JobStatusResponseTemporalParseErrors | Unset):
     """
 
+    id: UUID
+    status: JobStatusResponseStatus
+    dataset_id: None | UUID
+    source_filename: None | str
+    error_message: None | str
     can_retry: bool
+    retry_reason: None | str
+    started_at: datetime.datetime | None
     completed_at: datetime.datetime | None
     created_at: datetime.datetime
-    dataset_id: None | UUID
-    error_message: None | str
-    id: UUID
-    retry_reason: None | str
-    source_filename: None | str
-    started_at: datetime.datetime | None
-    status: JobStatusResponseStatus
-    archive_failed: bool | Unset = False
-    current_step: JobStatusResponseCurrentStepType0 | None | Unset = UNSET
-    progress: float | None | Unset = UNSET
-    rows_processed: int | None | Unset = UNSET
-    temporal_parse_errors: JobStatusResponseTemporalParseErrors | Unset = UNSET
     warning_message: None | str | Unset = UNSET
     warnings: (
         list[
@@ -78,6 +73,11 @@ class JobStatusResponse:
         ]
         | Unset
     ) = UNSET
+    progress: float | None | Unset = UNSET
+    current_step: JobStatusResponseCurrentStepType0 | None | Unset = UNSET
+    rows_processed: int | None | Unset = UNSET
+    archive_failed: bool | Unset = False
+    temporal_parse_errors: JobStatusResponseTemporalParseErrors | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -86,7 +86,32 @@ class JobStatusResponse:
         )
         from ..models.reserved_rename_warning import ReservedRenameWarning
 
+        id = str(self.id)
+
+        status: str = self.status
+
+        dataset_id: None | str
+        if isinstance(self.dataset_id, UUID):
+            dataset_id = str(self.dataset_id)
+        else:
+            dataset_id = self.dataset_id
+
+        source_filename: None | str
+        source_filename = self.source_filename
+
+        error_message: None | str
+        error_message = self.error_message
+
         can_retry = self.can_retry
+
+        retry_reason: None | str
+        retry_reason = self.retry_reason
+
+        started_at: None | str
+        if isinstance(self.started_at, datetime.datetime):
+            started_at = self.started_at.isoformat()
+        else:
+            started_at = self.started_at
 
         completed_at: None | str
         if isinstance(self.completed_at, datetime.datetime):
@@ -95,57 +120,6 @@ class JobStatusResponse:
             completed_at = self.completed_at
 
         created_at = self.created_at.isoformat()
-
-        dataset_id: None | str
-        if isinstance(self.dataset_id, UUID):
-            dataset_id = str(self.dataset_id)
-        else:
-            dataset_id = self.dataset_id
-
-        error_message: None | str
-        error_message = self.error_message
-
-        id = str(self.id)
-
-        retry_reason: None | str
-        retry_reason = self.retry_reason
-
-        source_filename: None | str
-        source_filename = self.source_filename
-
-        started_at: None | str
-        if isinstance(self.started_at, datetime.datetime):
-            started_at = self.started_at.isoformat()
-        else:
-            started_at = self.started_at
-
-        status: str = self.status
-
-        archive_failed = self.archive_failed
-
-        current_step: None | str | Unset
-        if isinstance(self.current_step, Unset):
-            current_step = UNSET
-        elif isinstance(self.current_step, str):
-            current_step = self.current_step
-        else:
-            current_step = self.current_step
-
-        progress: float | None | Unset
-        if isinstance(self.progress, Unset):
-            progress = UNSET
-        else:
-            progress = self.progress
-
-        rows_processed: int | None | Unset
-        if isinstance(self.rows_processed, Unset):
-            rows_processed = UNSET
-        else:
-            rows_processed = self.rows_processed
-
-        temporal_parse_errors: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.temporal_parse_errors, Unset):
-            temporal_parse_errors = self.temporal_parse_errors.to_dict()
 
         warning_message: None | str | Unset
         if isinstance(self.warning_message, Unset):
@@ -167,36 +141,62 @@ class JobStatusResponse:
 
                 warnings.append(warnings_item)
 
+        progress: float | None | Unset
+        if isinstance(self.progress, Unset):
+            progress = UNSET
+        else:
+            progress = self.progress
+
+        current_step: None | str | Unset
+        if isinstance(self.current_step, Unset):
+            current_step = UNSET
+        elif isinstance(self.current_step, str):
+            current_step = self.current_step
+        else:
+            current_step = self.current_step
+
+        rows_processed: int | None | Unset
+        if isinstance(self.rows_processed, Unset):
+            rows_processed = UNSET
+        else:
+            rows_processed = self.rows_processed
+
+        archive_failed = self.archive_failed
+
+        temporal_parse_errors: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.temporal_parse_errors, Unset):
+            temporal_parse_errors = self.temporal_parse_errors.to_dict()
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "id": id,
+                "status": status,
+                "dataset_id": dataset_id,
+                "source_filename": source_filename,
+                "error_message": error_message,
                 "can_retry": can_retry,
+                "retry_reason": retry_reason,
+                "started_at": started_at,
                 "completed_at": completed_at,
                 "created_at": created_at,
-                "dataset_id": dataset_id,
-                "error_message": error_message,
-                "id": id,
-                "retry_reason": retry_reason,
-                "source_filename": source_filename,
-                "started_at": started_at,
-                "status": status,
             }
         )
-        if archive_failed is not UNSET:
-            field_dict["archive_failed"] = archive_failed
-        if current_step is not UNSET:
-            field_dict["current_step"] = current_step
-        if progress is not UNSET:
-            field_dict["progress"] = progress
-        if rows_processed is not UNSET:
-            field_dict["rows_processed"] = rows_processed
-        if temporal_parse_errors is not UNSET:
-            field_dict["temporal_parse_errors"] = temporal_parse_errors
         if warning_message is not UNSET:
             field_dict["warning_message"] = warning_message
         if warnings is not UNSET:
             field_dict["warnings"] = warnings
+        if progress is not UNSET:
+            field_dict["progress"] = progress
+        if current_step is not UNSET:
+            field_dict["current_step"] = current_step
+        if rows_processed is not UNSET:
+            field_dict["rows_processed"] = rows_processed
+        if archive_failed is not UNSET:
+            field_dict["archive_failed"] = archive_failed
+        if temporal_parse_errors is not UNSET:
+            field_dict["temporal_parse_errors"] = temporal_parse_errors
 
         return field_dict
 
@@ -212,7 +212,62 @@ class JobStatusResponse:
         from ..models.reserved_rename_warning import ReservedRenameWarning
 
         d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        status = check_job_status_response_status(d.pop("status"))
+
+        def _parse_dataset_id(data: object) -> None | UUID:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                dataset_id_type_0 = UUID(data)
+
+                return dataset_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | UUID, data)
+
+        dataset_id = _parse_dataset_id(d.pop("dataset_id"))
+
+        def _parse_source_filename(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        source_filename = _parse_source_filename(d.pop("source_filename"))
+
+        def _parse_error_message(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        error_message = _parse_error_message(d.pop("error_message"))
+
         can_retry = d.pop("can_retry")
+
+        def _parse_retry_reason(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        retry_reason = _parse_retry_reason(d.pop("retry_reason"))
+
+        def _parse_started_at(data: object) -> datetime.datetime | None:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                started_at_type_0 = isoparse(data)
+
+                return started_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None, data)
+
+        started_at = _parse_started_at(d.pop("started_at"))
 
         def _parse_completed_at(data: object) -> datetime.datetime | None:
             if data is None:
@@ -230,111 +285,6 @@ class JobStatusResponse:
         completed_at = _parse_completed_at(d.pop("completed_at"))
 
         created_at = isoparse(d.pop("created_at"))
-
-        def _parse_dataset_id(data: object) -> None | UUID:
-            if data is None:
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                dataset_id_type_0 = UUID(data)
-
-                return dataset_id_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | UUID, data)
-
-        dataset_id = _parse_dataset_id(d.pop("dataset_id"))
-
-        def _parse_error_message(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        error_message = _parse_error_message(d.pop("error_message"))
-
-        id = UUID(d.pop("id"))
-
-        def _parse_retry_reason(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        retry_reason = _parse_retry_reason(d.pop("retry_reason"))
-
-        def _parse_source_filename(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        source_filename = _parse_source_filename(d.pop("source_filename"))
-
-        def _parse_started_at(data: object) -> datetime.datetime | None:
-            if data is None:
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                started_at_type_0 = isoparse(data)
-
-                return started_at_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None, data)
-
-        started_at = _parse_started_at(d.pop("started_at"))
-
-        status = check_job_status_response_status(d.pop("status"))
-
-        archive_failed = d.pop("archive_failed", UNSET)
-
-        def _parse_current_step(
-            data: object,
-        ) -> JobStatusResponseCurrentStepType0 | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                current_step_type_0 = check_job_status_response_current_step_type_0(
-                    data
-                )
-
-                return current_step_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(JobStatusResponseCurrentStepType0 | None | Unset, data)
-
-        current_step = _parse_current_step(d.pop("current_step", UNSET))
-
-        def _parse_progress(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        progress = _parse_progress(d.pop("progress", UNSET))
-
-        def _parse_rows_processed(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        rows_processed = _parse_rows_processed(d.pop("rows_processed", UNSET))
-
-        _temporal_parse_errors = d.pop("temporal_parse_errors", UNSET)
-        temporal_parse_errors: JobStatusResponseTemporalParseErrors | Unset
-        if isinstance(_temporal_parse_errors, Unset):
-            temporal_parse_errors = UNSET
-        else:
-            temporal_parse_errors = JobStatusResponseTemporalParseErrors.from_dict(
-                _temporal_parse_errors
-            )
 
         def _parse_warning_message(data: object) -> None | str | Unset:
             if data is None:
@@ -393,24 +343,74 @@ class JobStatusResponse:
 
                 warnings.append(warnings_item)
 
+        def _parse_progress(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        progress = _parse_progress(d.pop("progress", UNSET))
+
+        def _parse_current_step(
+            data: object,
+        ) -> JobStatusResponseCurrentStepType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                current_step_type_0 = check_job_status_response_current_step_type_0(
+                    data
+                )
+
+                return current_step_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(JobStatusResponseCurrentStepType0 | None | Unset, data)
+
+        current_step = _parse_current_step(d.pop("current_step", UNSET))
+
+        def _parse_rows_processed(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        rows_processed = _parse_rows_processed(d.pop("rows_processed", UNSET))
+
+        archive_failed = d.pop("archive_failed", UNSET)
+
+        _temporal_parse_errors = d.pop("temporal_parse_errors", UNSET)
+        temporal_parse_errors: JobStatusResponseTemporalParseErrors | Unset
+        if isinstance(_temporal_parse_errors, Unset):
+            temporal_parse_errors = UNSET
+        else:
+            temporal_parse_errors = JobStatusResponseTemporalParseErrors.from_dict(
+                _temporal_parse_errors
+            )
+
         job_status_response = cls(
+            id=id,
+            status=status,
+            dataset_id=dataset_id,
+            source_filename=source_filename,
+            error_message=error_message,
             can_retry=can_retry,
+            retry_reason=retry_reason,
+            started_at=started_at,
             completed_at=completed_at,
             created_at=created_at,
-            dataset_id=dataset_id,
-            error_message=error_message,
-            id=id,
-            retry_reason=retry_reason,
-            source_filename=source_filename,
-            started_at=started_at,
-            status=status,
-            archive_failed=archive_failed,
-            current_step=current_step,
-            progress=progress,
-            rows_processed=rows_processed,
-            temporal_parse_errors=temporal_parse_errors,
             warning_message=warning_message,
             warnings=warnings,
+            progress=progress,
+            current_step=current_step,
+            rows_processed=rows_processed,
+            archive_failed=archive_failed,
+            temporal_parse_errors=temporal_parse_errors,
         )
 
         job_status_response.additional_properties = d

--- a/sdks/python/geolens/models/keyword_create.py
+++ b/sdks/python/geolens/models/keyword_create.py
@@ -19,25 +19,25 @@ class KeywordCreate:
     """
     Attributes:
         keyword (str):
-        keyword_type (str | Unset): ISO MD_KeywordTypeCode, e.g. theme, place, discipline Default: 'theme'.
         vocabulary_uri (None | str | Unset): URI of the controlled vocabulary
+        keyword_type (str | Unset): ISO MD_KeywordTypeCode, e.g. theme, place, discipline Default: 'theme'.
     """
 
     keyword: str
-    keyword_type: str | Unset = "theme"
     vocabulary_uri: None | str | Unset = UNSET
+    keyword_type: str | Unset = "theme"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         keyword = self.keyword
-
-        keyword_type = self.keyword_type
 
         vocabulary_uri: None | str | Unset
         if isinstance(self.vocabulary_uri, Unset):
             vocabulary_uri = UNSET
         else:
             vocabulary_uri = self.vocabulary_uri
+
+        keyword_type = self.keyword_type
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -46,10 +46,10 @@ class KeywordCreate:
                 "keyword": keyword,
             }
         )
-        if keyword_type is not UNSET:
-            field_dict["keyword_type"] = keyword_type
         if vocabulary_uri is not UNSET:
             field_dict["vocabulary_uri"] = vocabulary_uri
+        if keyword_type is not UNSET:
+            field_dict["keyword_type"] = keyword_type
 
         return field_dict
 
@@ -57,8 +57,6 @@ class KeywordCreate:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         keyword = d.pop("keyword")
-
-        keyword_type = d.pop("keyword_type", UNSET)
 
         def _parse_vocabulary_uri(data: object) -> None | str | Unset:
             if data is None:
@@ -69,10 +67,12 @@ class KeywordCreate:
 
         vocabulary_uri = _parse_vocabulary_uri(d.pop("vocabulary_uri", UNSET))
 
+        keyword_type = d.pop("keyword_type", UNSET)
+
         keyword_create = cls(
             keyword=keyword,
-            keyword_type=keyword_type,
             vocabulary_uri=vocabulary_uri,
+            keyword_type=keyword_type,
         )
 
         keyword_create.additional_properties = d

--- a/sdks/python/geolens/models/keyword_response.py
+++ b/sdks/python/geolens/models/keyword_response.py
@@ -20,34 +20,34 @@ class KeywordResponse:
     """
     Attributes:
         id (UUID):
-        keyword (str):
-        keyword_type (str):
         record_id (UUID):
+        keyword (str):
         vocabulary_uri (None | str):
+        keyword_type (str):
         inherited (bool | Unset): True when this keyword also exists on the dataset this record was derived from (feat
             #1070). Derived at read time from derived_from; only ever true for a requester who can access that source
             dataset, so everyone else sees false — matching the derived_from redaction. Default: False.
     """
 
     id: UUID
-    keyword: str
-    keyword_type: str
     record_id: UUID
+    keyword: str
     vocabulary_uri: None | str
+    keyword_type: str
     inherited: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         id = str(self.id)
 
-        keyword = self.keyword
-
-        keyword_type = self.keyword_type
-
         record_id = str(self.record_id)
+
+        keyword = self.keyword
 
         vocabulary_uri: None | str
         vocabulary_uri = self.vocabulary_uri
+
+        keyword_type = self.keyword_type
 
         inherited = self.inherited
 
@@ -56,10 +56,10 @@ class KeywordResponse:
         field_dict.update(
             {
                 "id": id,
-                "keyword": keyword,
-                "keyword_type": keyword_type,
                 "record_id": record_id,
+                "keyword": keyword,
                 "vocabulary_uri": vocabulary_uri,
+                "keyword_type": keyword_type,
             }
         )
         if inherited is not UNSET:
@@ -72,11 +72,9 @@ class KeywordResponse:
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
-        keyword = d.pop("keyword")
-
-        keyword_type = d.pop("keyword_type")
-
         record_id = UUID(d.pop("record_id"))
+
+        keyword = d.pop("keyword")
 
         def _parse_vocabulary_uri(data: object) -> None | str:
             if data is None:
@@ -85,14 +83,16 @@ class KeywordResponse:
 
         vocabulary_uri = _parse_vocabulary_uri(d.pop("vocabulary_uri"))
 
+        keyword_type = d.pop("keyword_type")
+
         inherited = d.pop("inherited", UNSET)
 
         keyword_response = cls(
             id=id,
-            keyword=keyword,
-            keyword_type=keyword_type,
             record_id=record_id,
+            keyword=keyword,
             vocabulary_uri=vocabulary_uri,
+            keyword_type=keyword_type,
             inherited=inherited,
         )
 

--- a/sdks/python/geolens/models/landing_page.py
+++ b/sdks/python/geolens/models/landing_page.py
@@ -18,17 +18,19 @@ T = TypeVar("T", bound="LandingPage")
 class LandingPage:
     """
     Attributes:
+        title (str): OGC API landing page title.
         description (str): Human-readable API description.
         links (list[OGCLink]): Top-level navigation links to conformance, collections, and API document.
-        title (str): OGC API landing page title.
     """
 
+    title: str
     description: str
     links: list[OGCLink]
-    title: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
         description = self.description
 
         links = []
@@ -36,15 +38,13 @@ class LandingPage:
             links_item = links_item_data.to_dict()
             links.append(links_item)
 
-        title = self.title
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "title": title,
                 "description": description,
                 "links": links,
-                "title": title,
             }
         )
 
@@ -55,6 +55,8 @@ class LandingPage:
         from ..models.ogc_link import OGCLink
 
         d = dict(src_dict)
+        title = d.pop("title")
+
         description = d.pop("description")
 
         links = []
@@ -64,12 +66,10 @@ class LandingPage:
 
             links.append(links_item)
 
-        title = d.pop("title")
-
         landing_page = cls(
+            title=title,
             description=description,
             links=links,
-            title=title,
         )
 
         landing_page.additional_properties = d

--- a/sdks/python/geolens/models/layer_info.py
+++ b/sdks/python/geolens/models/layer_info.py
@@ -21,37 +21,37 @@ class LayerInfo:
     """
     Attributes:
         name (str): Internal layer identifier used by the source service.
-        feature_count (int | None | Unset): Total feature count if reported by the service.
+        title (None | str | Unset): Human-readable layer title from the service capabilities.
         geometry_type (None | str | Unset): Detected geometry type for the layer.
+        feature_count (int | None | Unset): Total feature count if reported by the service.
+        layer_type (str | Unset): Layer kind: 'layer' (spatial) or 'table' (non-spatial attribute table). Default:
+            'layer'.
+        layer_id (int | None | str | Unset): Numeric or string layer ID used by ArcGIS services.
+        object_id_field (None | str | Unset): ArcGIS object ID field name, used for stable pagination.
         kind (LayerInfoKind | Unset): Backend-classified layer kind. 'vector' = point/line/polygon feature data.
             'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type
             contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image/*. Everything else
             (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'. Default: 'vector'.
-        layer_id (int | None | str | Unset): Numeric or string layer ID used by ArcGIS services.
-        layer_type (str | Unset): Layer kind: 'layer' (spatial) or 'table' (non-spatial attribute table). Default:
-            'layer'.
-        object_id_field (None | str | Unset): ArcGIS object ID field name, used for stable pagination.
-        title (None | str | Unset): Human-readable layer title from the service capabilities.
     """
 
     name: str
-    feature_count: int | None | Unset = UNSET
-    geometry_type: None | str | Unset = UNSET
-    kind: LayerInfoKind | Unset = "vector"
-    layer_id: int | None | str | Unset = UNSET
-    layer_type: str | Unset = "layer"
-    object_id_field: None | str | Unset = UNSET
     title: None | str | Unset = UNSET
+    geometry_type: None | str | Unset = UNSET
+    feature_count: int | None | Unset = UNSET
+    layer_type: str | Unset = "layer"
+    layer_id: int | None | str | Unset = UNSET
+    object_id_field: None | str | Unset = UNSET
+    kind: LayerInfoKind | Unset = "vector"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
 
-        feature_count: int | None | Unset
-        if isinstance(self.feature_count, Unset):
-            feature_count = UNSET
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
         else:
-            feature_count = self.feature_count
+            title = self.title
 
         geometry_type: None | str | Unset
         if isinstance(self.geometry_type, Unset):
@@ -59,9 +59,13 @@ class LayerInfo:
         else:
             geometry_type = self.geometry_type
 
-        kind: str | Unset = UNSET
-        if not isinstance(self.kind, Unset):
-            kind = self.kind
+        feature_count: int | None | Unset
+        if isinstance(self.feature_count, Unset):
+            feature_count = UNSET
+        else:
+            feature_count = self.feature_count
+
+        layer_type = self.layer_type
 
         layer_id: int | None | str | Unset
         if isinstance(self.layer_id, Unset):
@@ -69,19 +73,15 @@ class LayerInfo:
         else:
             layer_id = self.layer_id
 
-        layer_type = self.layer_type
-
         object_id_field: None | str | Unset
         if isinstance(self.object_id_field, Unset):
             object_id_field = UNSET
         else:
             object_id_field = self.object_id_field
 
-        title: None | str | Unset
-        if isinstance(self.title, Unset):
-            title = UNSET
-        else:
-            title = self.title
+        kind: str | Unset = UNSET
+        if not isinstance(self.kind, Unset):
+            kind = self.kind
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -90,20 +90,20 @@ class LayerInfo:
                 "name": name,
             }
         )
-        if feature_count is not UNSET:
-            field_dict["feature_count"] = feature_count
-        if geometry_type is not UNSET:
-            field_dict["geometry_type"] = geometry_type
-        if kind is not UNSET:
-            field_dict["kind"] = kind
-        if layer_id is not UNSET:
-            field_dict["layer_id"] = layer_id
-        if layer_type is not UNSET:
-            field_dict["layer_type"] = layer_type
-        if object_id_field is not UNSET:
-            field_dict["object_id_field"] = object_id_field
         if title is not UNSET:
             field_dict["title"] = title
+        if geometry_type is not UNSET:
+            field_dict["geometry_type"] = geometry_type
+        if feature_count is not UNSET:
+            field_dict["feature_count"] = feature_count
+        if layer_type is not UNSET:
+            field_dict["layer_type"] = layer_type
+        if layer_id is not UNSET:
+            field_dict["layer_id"] = layer_id
+        if object_id_field is not UNSET:
+            field_dict["object_id_field"] = object_id_field
+        if kind is not UNSET:
+            field_dict["kind"] = kind
 
         return field_dict
 
@@ -111,51 +111,6 @@ class LayerInfo:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("name")
-
-        def _parse_feature_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        feature_count = _parse_feature_count(d.pop("feature_count", UNSET))
-
-        def _parse_geometry_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        geometry_type = _parse_geometry_type(d.pop("geometry_type", UNSET))
-
-        _kind = d.pop("kind", UNSET)
-        kind: LayerInfoKind | Unset
-        if isinstance(_kind, Unset):
-            kind = UNSET
-        else:
-            kind = check_layer_info_kind(_kind)
-
-        def _parse_layer_id(data: object) -> int | None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | str | Unset, data)
-
-        layer_id = _parse_layer_id(d.pop("layer_id", UNSET))
-
-        layer_type = d.pop("layer_type", UNSET)
-
-        def _parse_object_id_field(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        object_id_field = _parse_object_id_field(d.pop("object_id_field", UNSET))
 
         def _parse_title(data: object) -> None | str | Unset:
             if data is None:
@@ -166,15 +121,60 @@ class LayerInfo:
 
         title = _parse_title(d.pop("title", UNSET))
 
+        def _parse_geometry_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        geometry_type = _parse_geometry_type(d.pop("geometry_type", UNSET))
+
+        def _parse_feature_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        feature_count = _parse_feature_count(d.pop("feature_count", UNSET))
+
+        layer_type = d.pop("layer_type", UNSET)
+
+        def _parse_layer_id(data: object) -> int | None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | str | Unset, data)
+
+        layer_id = _parse_layer_id(d.pop("layer_id", UNSET))
+
+        def _parse_object_id_field(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        object_id_field = _parse_object_id_field(d.pop("object_id_field", UNSET))
+
+        _kind = d.pop("kind", UNSET)
+        kind: LayerInfoKind | Unset
+        if isinstance(_kind, Unset):
+            kind = UNSET
+        else:
+            kind = check_layer_info_kind(_kind)
+
         layer_info = cls(
             name=name,
-            feature_count=feature_count,
-            geometry_type=geometry_type,
-            kind=kind,
-            layer_id=layer_id,
-            layer_type=layer_type,
-            object_id_field=object_id_field,
             title=title,
+            geometry_type=geometry_type,
+            feature_count=feature_count,
+            layer_type=layer_type,
+            layer_id=layer_id,
+            object_id_field=object_id_field,
+            kind=kind,
         )
 
         layer_info.additional_properties = d

--- a/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection.py
+++ b/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection.py
@@ -30,23 +30,27 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollection:
     """A GeoJSON FeatureCollection with OGC API Features pagination fields.
 
     Attributes:
-        features (list[ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeature]):
-        links (list[ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionLink]):
         number_matched (int):
         number_returned (int):
+        features (list[ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeature]):
+        links (list[ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionLink]):
         type_ (Literal['FeatureCollection'] | Unset):  Default: 'FeatureCollection'.
     """
 
+    number_matched: int
+    number_returned: int
     features: list[
         ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeature
     ]
     links: list[ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionLink]
-    number_matched: int
-    number_returned: int
     type_: Literal["FeatureCollection"] | Unset = "FeatureCollection"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        number_matched = self.number_matched
+
+        number_returned = self.number_returned
+
         features = []
         for features_item_data in self.features:
             features_item = features_item_data.to_dict()
@@ -57,20 +61,16 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollection:
             links_item = links_item_data.to_dict()
             links.append(links_item)
 
-        number_matched = self.number_matched
-
-        number_returned = self.number_returned
-
         type_ = self.type_
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "features": features,
-                "links": links,
                 "numberMatched": number_matched,
                 "numberReturned": number_returned,
+                "features": features,
+                "links": links,
             }
         )
         if type_ is not UNSET:
@@ -88,6 +88,10 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollection:
         )
 
         d = dict(src_dict)
+        number_matched = d.pop("numberMatched")
+
+        number_returned = d.pop("numberReturned")
+
         features = []
         _features = d.pop("features")
         for features_item_data in _features:
@@ -106,10 +110,6 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollection:
 
             links.append(links_item)
 
-        number_matched = d.pop("numberMatched")
-
-        number_returned = d.pop("numberReturned")
-
         type_ = cast(Literal["FeatureCollection"] | Unset, d.pop("type", UNSET))
         if type_ != "FeatureCollection" and not isinstance(type_, Unset):
             raise ValueError(
@@ -118,10 +118,10 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollection:
 
         list_features_datasets_dataset_id_features_get_geo_json_feature_collection = (
             cls(
-                features=features,
-                links=links,
                 number_matched=number_matched,
                 number_returned=number_returned,
+                features=features,
+                links=links,
                 type_=type_,
             )
         )

--- a/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature.py
+++ b/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature.py
@@ -36,21 +36,21 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
     Attributes:
         id (int):
         properties (ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureProperties):
+        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
         geometry (ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometry |
             ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometryCollection | None |
             Unset):
-        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
     """
 
     id: int
     properties: ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureProperties
+    type_: Literal["Feature"] | Unset = "Feature"
     geometry: (
         ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometry
         | ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometryCollection
         | None
         | Unset
     ) = UNSET
-    type_: Literal["Feature"] | Unset = "Feature"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -64,6 +64,8 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
         id = self.id
 
         properties = self.properties.to_dict()
+
+        type_ = self.type_
 
         geometry: dict[str, Any] | None | Unset
         if isinstance(self.geometry, Unset):
@@ -81,8 +83,6 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
         else:
             geometry = self.geometry
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -91,10 +91,10 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
                 "properties": properties,
             }
         )
-        if geometry is not UNSET:
-            field_dict["geometry"] = geometry
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if geometry is not UNSET:
+            field_dict["geometry"] = geometry
 
         return field_dict
 
@@ -116,6 +116,10 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
         properties = ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureProperties.from_dict(
             d.pop("properties")
         )
+
+        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
+        if type_ != "Feature" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'Feature', got '{type_}'")
 
         def _parse_geometry(
             data: object,
@@ -159,15 +163,11 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
 
         geometry = _parse_geometry(d.pop("geometry", UNSET))
 
-        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
-        if type_ != "Feature" and not isinstance(type_, Unset):
-            raise ValueError(f"type must match const 'Feature', got '{type_}'")
-
         list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature = cls(
             id=id,
             properties=properties,
-            geometry=geometry,
             type_=type_,
+            geometry=geometry,
         )
 
         list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature.additional_properties = d

--- a/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry.py
+++ b/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry.py
@@ -27,25 +27,25 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_ (ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -54,15 +54,15 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry_collection.py
+++ b/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry_collection.py
@@ -39,31 +39,31 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
     database 500. The write schemas add a raw-payload guard for a clear 422.
 
         Attributes:
+            type_ (Literal['GeometryCollection']):
             geometries (list[ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometryCo
                 llectionGeoJSONGeometry]):
-            type_ (Literal['GeometryCollection']):
     """
 
+    type_: Literal["GeometryCollection"]
     geometries: list[
         ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometry
     ]
-    type_: Literal["GeometryCollection"]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
         geometries = []
         for geometries_item_data in self.geometries:
             geometries_item = geometries_item_data.to_dict()
             geometries.append(geometries_item)
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "geometries": geometries,
                 "type": type_,
+                "geometries": geometries,
             }
         )
 
@@ -76,6 +76,12 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
         )
 
         d = dict(src_dict)
+        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
+        if type_ != "GeometryCollection":
+            raise ValueError(
+                f"type must match const 'GeometryCollection', got '{type_}'"
+            )
+
         geometries = []
         _geometries = d.pop("geometries")
         for geometries_item_data in _geometries:
@@ -85,15 +91,9 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
 
             geometries.append(geometries_item)
 
-        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
-        if type_ != "GeometryCollection":
-            raise ValueError(
-                f"type must match const 'GeometryCollection', got '{type_}'"
-            )
-
         list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry_collection = cls(
-            geometries=geometries,
             type_=type_,
+            geometries=geometries,
         )
 
         list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry_collection.additional_properties = d

--- a/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.py
+++ b/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.py
@@ -27,26 +27,26 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_ (ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometryCollectionGe
             oJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -55,15 +55,15 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionGeoJSONFea
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry_collection_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry_collection_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         list_features_datasets_dataset_id_features_get_geo_json_feature_collection_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection_link.py
+++ b/sdks/python/geolens/models/list_features_datasets_dataset_id_features_get_geo_json_feature_collection_link.py
@@ -16,20 +16,20 @@ T = TypeVar(
 class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionLink:
     """
     Attributes:
-        href (str):
         rel (str):
+        href (str):
         type_ (str):
     """
 
-    href: str
     rel: str
+    href: str
     type_: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        href = self.href
-
         rel = self.rel
+
+        href = self.href
 
         type_ = self.type_
 
@@ -37,8 +37,8 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionLink:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "href": href,
                 "rel": rel,
+                "href": href,
                 "type": type_,
             }
         )
@@ -48,15 +48,15 @@ class ListFeaturesDatasetsDatasetIdFeaturesGetGeoJSONFeatureCollectionLink:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        href = d.pop("href")
-
         rel = d.pop("rel")
+
+        href = d.pop("href")
 
         type_ = d.pop("type")
 
         list_features_datasets_dataset_id_features_get_geo_json_feature_collection_link = cls(
-            href=href,
             rel=rel,
+            href=href,
             type_=type_,
         )
 

--- a/sdks/python/geolens/models/manifest_apply_entry_result.py
+++ b/sdks/python/geolens/models/manifest_apply_entry_result.py
@@ -23,28 +23,36 @@ T = TypeVar("T", bound="ManifestApplyEntryResult")
 class ManifestApplyEntryResult:
     """
     Attributes:
-        action (ManifestApplyEntryResultAction):
         dataset_key (str):
+        action (ManifestApplyEntryResultAction):
         message (str):
+        job_id (None | Unset | UUID):
         dataset_id (None | Unset | UUID):
         errors (list[str] | Unset):
-        job_id (None | Unset | UUID):
     """
 
-    action: ManifestApplyEntryResultAction
     dataset_key: str
+    action: ManifestApplyEntryResultAction
     message: str
+    job_id: None | Unset | UUID = UNSET
     dataset_id: None | Unset | UUID = UNSET
     errors: list[str] | Unset = UNSET
-    job_id: None | Unset | UUID = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        action: str = self.action
-
         dataset_key = self.dataset_key
 
+        action: str = self.action
+
         message = self.message
+
+        job_id: None | str | Unset
+        if isinstance(self.job_id, Unset):
+            job_id = UNSET
+        elif isinstance(self.job_id, UUID):
+            job_id = str(self.job_id)
+        else:
+            job_id = self.job_id
 
         dataset_id: None | str | Unset
         if isinstance(self.dataset_id, Unset):
@@ -58,40 +66,49 @@ class ManifestApplyEntryResult:
         if not isinstance(self.errors, Unset):
             errors = self.errors
 
-        job_id: None | str | Unset
-        if isinstance(self.job_id, Unset):
-            job_id = UNSET
-        elif isinstance(self.job_id, UUID):
-            job_id = str(self.job_id)
-        else:
-            job_id = self.job_id
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "action": action,
                 "dataset_key": dataset_key,
+                "action": action,
                 "message": message,
             }
         )
+        if job_id is not UNSET:
+            field_dict["job_id"] = job_id
         if dataset_id is not UNSET:
             field_dict["dataset_id"] = dataset_id
         if errors is not UNSET:
             field_dict["errors"] = errors
-        if job_id is not UNSET:
-            field_dict["job_id"] = job_id
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        action = check_manifest_apply_entry_result_action(d.pop("action"))
-
         dataset_key = d.pop("dataset_key")
 
+        action = check_manifest_apply_entry_result_action(d.pop("action"))
+
         message = d.pop("message")
+
+        def _parse_job_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                job_id_type_0 = UUID(data)
+
+                return job_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        job_id = _parse_job_id(d.pop("job_id", UNSET))
 
         def _parse_dataset_id(data: object) -> None | Unset | UUID:
             if data is None:
@@ -112,30 +129,13 @@ class ManifestApplyEntryResult:
 
         errors = cast(list[str], d.pop("errors", UNSET))
 
-        def _parse_job_id(data: object) -> None | Unset | UUID:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                job_id_type_0 = UUID(data)
-
-                return job_id_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | Unset | UUID, data)
-
-        job_id = _parse_job_id(d.pop("job_id", UNSET))
-
         manifest_apply_entry_result = cls(
-            action=action,
             dataset_key=dataset_key,
+            action=action,
             message=message,
+            job_id=job_id,
             dataset_id=dataset_id,
             errors=errors,
-            job_id=job_id,
         )
 
         manifest_apply_entry_result.additional_properties = d

--- a/sdks/python/geolens/models/manifest_apply_request.py
+++ b/sdks/python/geolens/models/manifest_apply_request.py
@@ -22,18 +22,20 @@ T = TypeVar("T", bound="ManifestApplyRequest")
 class ManifestApplyRequest:
     """
     Attributes:
+        manifest_version (Literal['1']):
         catalog (ManifestCatalog):
         datasets (list[ManifestDataset]):
-        manifest_version (Literal['1']):
         dry_run (bool | Unset):  Default: False.
     """
 
+    manifest_version: Literal["1"]
     catalog: ManifestCatalog
     datasets: list[ManifestDataset]
-    manifest_version: Literal["1"]
     dry_run: bool | Unset = False
 
     def to_dict(self) -> dict[str, Any]:
+        manifest_version = self.manifest_version
+
         catalog = self.catalog.to_dict()
 
         datasets = []
@@ -41,17 +43,15 @@ class ManifestApplyRequest:
             datasets_item = datasets_item_data.to_dict()
             datasets.append(datasets_item)
 
-        manifest_version = self.manifest_version
-
         dry_run = self.dry_run
 
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
             {
+                "manifest_version": manifest_version,
                 "catalog": catalog,
                 "datasets": datasets,
-                "manifest_version": manifest_version,
             }
         )
         if dry_run is not UNSET:
@@ -65,6 +65,12 @@ class ManifestApplyRequest:
         from ..models.manifest_dataset import ManifestDataset
 
         d = dict(src_dict)
+        manifest_version = cast(Literal["1"], d.pop("manifest_version"))
+        if manifest_version != "1":
+            raise ValueError(
+                f"manifest_version must match const '1', got '{manifest_version}'"
+            )
+
         catalog = ManifestCatalog.from_dict(d.pop("catalog"))
 
         datasets = []
@@ -74,18 +80,12 @@ class ManifestApplyRequest:
 
             datasets.append(datasets_item)
 
-        manifest_version = cast(Literal["1"], d.pop("manifest_version"))
-        if manifest_version != "1":
-            raise ValueError(
-                f"manifest_version must match const '1', got '{manifest_version}'"
-            )
-
         dry_run = d.pop("dry_run", UNSET)
 
         manifest_apply_request = cls(
+            manifest_version=manifest_version,
             catalog=catalog,
             datasets=datasets,
-            manifest_version=manifest_version,
             dry_run=dry_run,
         )
 

--- a/sdks/python/geolens/models/manifest_catalog.py
+++ b/sdks/python/geolens/models/manifest_catalog.py
@@ -21,28 +21,20 @@ class ManifestCatalog:
     """
     Attributes:
         title (str):
-        contact (ManifestContact | None | Unset):
         description (None | str | Unset):
         organization (None | str | Unset):
+        contact (ManifestContact | None | Unset):
     """
 
     title: str
-    contact: ManifestContact | None | Unset = UNSET
     description: None | str | Unset = UNSET
     organization: None | str | Unset = UNSET
+    contact: ManifestContact | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.manifest_contact import ManifestContact
 
         title = self.title
-
-        contact: dict[str, Any] | None | Unset
-        if isinstance(self.contact, Unset):
-            contact = UNSET
-        elif isinstance(self.contact, ManifestContact):
-            contact = self.contact.to_dict()
-        else:
-            contact = self.contact
 
         description: None | str | Unset
         if isinstance(self.description, Unset):
@@ -56,6 +48,14 @@ class ManifestCatalog:
         else:
             organization = self.organization
 
+        contact: dict[str, Any] | None | Unset
+        if isinstance(self.contact, Unset):
+            contact = UNSET
+        elif isinstance(self.contact, ManifestContact):
+            contact = self.contact.to_dict()
+        else:
+            contact = self.contact
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -63,12 +63,12 @@ class ManifestCatalog:
                 "title": title,
             }
         )
-        if contact is not UNSET:
-            field_dict["contact"] = contact
         if description is not UNSET:
             field_dict["description"] = description
         if organization is not UNSET:
             field_dict["organization"] = organization
+        if contact is not UNSET:
+            field_dict["contact"] = contact
 
         return field_dict
 
@@ -78,23 +78,6 @@ class ManifestCatalog:
 
         d = dict(src_dict)
         title = d.pop("title")
-
-        def _parse_contact(data: object) -> ManifestContact | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                contact_type_0 = ManifestContact.from_dict(data)
-
-                return contact_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(ManifestContact | None | Unset, data)
-
-        contact = _parse_contact(d.pop("contact", UNSET))
 
         def _parse_description(data: object) -> None | str | Unset:
             if data is None:
@@ -114,11 +97,28 @@ class ManifestCatalog:
 
         organization = _parse_organization(d.pop("organization", UNSET))
 
+        def _parse_contact(data: object) -> ManifestContact | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                contact_type_0 = ManifestContact.from_dict(data)
+
+                return contact_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(ManifestContact | None | Unset, data)
+
+        contact = _parse_contact(d.pop("contact", UNSET))
+
         manifest_catalog = cls(
             title=title,
-            contact=contact,
             description=description,
             organization=organization,
+            contact=contact,
         )
 
         return manifest_catalog

--- a/sdks/python/geolens/models/manifest_contact.py
+++ b/sdks/python/geolens/models/manifest_contact.py
@@ -17,27 +17,27 @@ T = TypeVar("T", bound="ManifestContact")
 class ManifestContact:
     """
     Attributes:
-        email (None | str | Unset):
         name (None | str | Unset):
+        email (None | str | Unset):
         url (None | str | Unset):
     """
 
-    email: None | str | Unset = UNSET
     name: None | str | Unset = UNSET
+    email: None | str | Unset = UNSET
     url: None | str | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
-        email: None | str | Unset
-        if isinstance(self.email, Unset):
-            email = UNSET
-        else:
-            email = self.email
-
         name: None | str | Unset
         if isinstance(self.name, Unset):
             name = UNSET
         else:
             name = self.name
+
+        email: None | str | Unset
+        if isinstance(self.email, Unset):
+            email = UNSET
+        else:
+            email = self.email
 
         url: None | str | Unset
         if isinstance(self.url, Unset):
@@ -48,10 +48,10 @@ class ManifestContact:
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
-        if email is not UNSET:
-            field_dict["email"] = email
         if name is not UNSET:
             field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
         if url is not UNSET:
             field_dict["url"] = url
 
@@ -61,15 +61,6 @@ class ManifestContact:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
 
-        def _parse_email(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        email = _parse_email(d.pop("email", UNSET))
-
         def _parse_name(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -78,6 +69,15 @@ class ManifestContact:
             return cast(None | str | Unset, data)
 
         name = _parse_name(d.pop("name", UNSET))
+
+        def _parse_email(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        email = _parse_email(d.pop("email", UNSET))
 
         def _parse_url(data: object) -> None | str | Unset:
             if data is None:
@@ -89,8 +89,8 @@ class ManifestContact:
         url = _parse_url(d.pop("url", UNSET))
 
         manifest_contact = cls(
-            email=email,
             name=name,
+            email=email,
             url=url,
         )
 

--- a/sdks/python/geolens/models/manifest_dataset.py
+++ b/sdks/python/geolens/models/manifest_dataset.py
@@ -23,17 +23,17 @@ class ManifestDataset:
     """
     Attributes:
         key (str): Stable dataset identity key used for idempotent apply operations.
-        publication (ManifestPublication):
-        sources (list[ManifestSource]):
         title (str):
+        sources (list[ManifestSource]):
+        publication (ManifestPublication):
         description (None | str | Unset):
         metadata (ManifestMetadata | None | Unset):
     """
 
     key: str
-    publication: ManifestPublication
-    sources: list[ManifestSource]
     title: str
+    sources: list[ManifestSource]
+    publication: ManifestPublication
     description: None | str | Unset = UNSET
     metadata: ManifestMetadata | None | Unset = UNSET
 
@@ -42,14 +42,14 @@ class ManifestDataset:
 
         key = self.key
 
-        publication = self.publication.to_dict()
+        title = self.title
 
         sources = []
         for sources_item_data in self.sources:
             sources_item = sources_item_data.to_dict()
             sources.append(sources_item)
 
-        title = self.title
+        publication = self.publication.to_dict()
 
         description: None | str | Unset
         if isinstance(self.description, Unset):
@@ -70,9 +70,9 @@ class ManifestDataset:
         field_dict.update(
             {
                 "key": key,
-                "publication": publication,
-                "sources": sources,
                 "title": title,
+                "sources": sources,
+                "publication": publication,
             }
         )
         if description is not UNSET:
@@ -91,7 +91,7 @@ class ManifestDataset:
         d = dict(src_dict)
         key = d.pop("key")
 
-        publication = ManifestPublication.from_dict(d.pop("publication"))
+        title = d.pop("title")
 
         sources = []
         _sources = d.pop("sources")
@@ -100,7 +100,7 @@ class ManifestDataset:
 
             sources.append(sources_item)
 
-        title = d.pop("title")
+        publication = ManifestPublication.from_dict(d.pop("publication"))
 
         def _parse_description(data: object) -> None | str | Unset:
             if data is None:
@@ -130,9 +130,9 @@ class ManifestDataset:
 
         manifest_dataset = cls(
             key=key,
-            publication=publication,
-            sources=sources,
             title=title,
+            sources=sources,
+            publication=publication,
             description=description,
             metadata=metadata,
         )

--- a/sdks/python/geolens/models/manifest_metadata.py
+++ b/sdks/python/geolens/models/manifest_metadata.py
@@ -17,22 +17,49 @@ T = TypeVar("T", bound="ManifestMetadata")
 class ManifestMetadata:
     """
     Attributes:
-        attribution (None | str | Unset):
-        bbox (list[float] | None | Unset):
+        tags (list[str] | None | Unset):
+        organization (None | str | Unset):
         crs (None | str | Unset):
         license_ (None | str | Unset):
-        organization (None | str | Unset):
-        tags (list[str] | None | Unset):
+        attribution (None | str | Unset):
+        bbox (list[float] | None | Unset):
     """
 
-    attribution: None | str | Unset = UNSET
-    bbox: list[float] | None | Unset = UNSET
+    tags: list[str] | None | Unset = UNSET
+    organization: None | str | Unset = UNSET
     crs: None | str | Unset = UNSET
     license_: None | str | Unset = UNSET
-    organization: None | str | Unset = UNSET
-    tags: list[str] | None | Unset = UNSET
+    attribution: None | str | Unset = UNSET
+    bbox: list[float] | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
+        tags: list[str] | None | Unset
+        if isinstance(self.tags, Unset):
+            tags = UNSET
+        elif isinstance(self.tags, list):
+            tags = self.tags
+
+        else:
+            tags = self.tags
+
+        organization: None | str | Unset
+        if isinstance(self.organization, Unset):
+            organization = UNSET
+        else:
+            organization = self.organization
+
+        crs: None | str | Unset
+        if isinstance(self.crs, Unset):
+            crs = UNSET
+        else:
+            crs = self.crs
+
+        license_: None | str | Unset
+        if isinstance(self.license_, Unset):
+            license_ = UNSET
+        else:
+            license_ = self.license_
+
         attribution: None | str | Unset
         if isinstance(self.attribution, Unset):
             attribution = UNSET
@@ -48,54 +75,71 @@ class ManifestMetadata:
         else:
             bbox = self.bbox
 
-        crs: None | str | Unset
-        if isinstance(self.crs, Unset):
-            crs = UNSET
-        else:
-            crs = self.crs
-
-        license_: None | str | Unset
-        if isinstance(self.license_, Unset):
-            license_ = UNSET
-        else:
-            license_ = self.license_
-
-        organization: None | str | Unset
-        if isinstance(self.organization, Unset):
-            organization = UNSET
-        else:
-            organization = self.organization
-
-        tags: list[str] | None | Unset
-        if isinstance(self.tags, Unset):
-            tags = UNSET
-        elif isinstance(self.tags, list):
-            tags = self.tags
-
-        else:
-            tags = self.tags
-
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
-        if attribution is not UNSET:
-            field_dict["attribution"] = attribution
-        if bbox is not UNSET:
-            field_dict["bbox"] = bbox
+        if tags is not UNSET:
+            field_dict["tags"] = tags
+        if organization is not UNSET:
+            field_dict["organization"] = organization
         if crs is not UNSET:
             field_dict["crs"] = crs
         if license_ is not UNSET:
             field_dict["license"] = license_
-        if organization is not UNSET:
-            field_dict["organization"] = organization
-        if tags is not UNSET:
-            field_dict["tags"] = tags
+        if attribution is not UNSET:
+            field_dict["attribution"] = attribution
+        if bbox is not UNSET:
+            field_dict["bbox"] = bbox
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+
+        def _parse_tags(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                tags_type_0 = cast(list[str], data)
+
+                return tags_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        tags = _parse_tags(d.pop("tags", UNSET))
+
+        def _parse_organization(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        organization = _parse_organization(d.pop("organization", UNSET))
+
+        def _parse_crs(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        crs = _parse_crs(d.pop("crs", UNSET))
+
+        def _parse_license_(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        license_ = _parse_license_(d.pop("license", UNSET))
 
         def _parse_attribution(data: object) -> None | str | Unset:
             if data is None:
@@ -123,57 +167,13 @@ class ManifestMetadata:
 
         bbox = _parse_bbox(d.pop("bbox", UNSET))
 
-        def _parse_crs(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        crs = _parse_crs(d.pop("crs", UNSET))
-
-        def _parse_license_(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        license_ = _parse_license_(d.pop("license", UNSET))
-
-        def _parse_organization(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        organization = _parse_organization(d.pop("organization", UNSET))
-
-        def _parse_tags(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                tags_type_0 = cast(list[str], data)
-
-                return tags_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        tags = _parse_tags(d.pop("tags", UNSET))
-
         manifest_metadata = cls(
-            attribution=attribution,
-            bbox=bbox,
+            tags=tags,
+            organization=organization,
             crs=crs,
             license_=license_,
-            organization=organization,
-            tags=tags,
+            attribution=attribution,
+            bbox=bbox,
         )
 
         return manifest_metadata

--- a/sdks/python/geolens/models/manifest_source.py
+++ b/sdks/python/geolens/models/manifest_source.py
@@ -22,23 +22,29 @@ class ManifestSource:
         type_ (ManifestSourceType): Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, or xls;
             raster_cog sources require tif or tiff.
         uri (str): Relative path (no `..` traversal), HTTP(S) URL, or storage URI.
+        title (None | str | Unset):
         description (None | str | Unset):
         format_ (None | str | Unset):
         layer (None | str | Unset):
-        title (None | str | Unset):
     """
 
     type_: ManifestSourceType
     uri: str
+    title: None | str | Unset = UNSET
     description: None | str | Unset = UNSET
     format_: None | str | Unset = UNSET
     layer: None | str | Unset = UNSET
-    title: None | str | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         type_: str = self.type_
 
         uri = self.uri
+
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
+        else:
+            title = self.title
 
         description: None | str | Unset
         if isinstance(self.description, Unset):
@@ -58,12 +64,6 @@ class ManifestSource:
         else:
             layer = self.layer
 
-        title: None | str | Unset
-        if isinstance(self.title, Unset):
-            title = UNSET
-        else:
-            title = self.title
-
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -72,14 +72,14 @@ class ManifestSource:
                 "uri": uri,
             }
         )
+        if title is not UNSET:
+            field_dict["title"] = title
         if description is not UNSET:
             field_dict["description"] = description
         if format_ is not UNSET:
             field_dict["format"] = format_
         if layer is not UNSET:
             field_dict["layer"] = layer
-        if title is not UNSET:
-            field_dict["title"] = title
 
         return field_dict
 
@@ -89,6 +89,15 @@ class ManifestSource:
         type_ = check_manifest_source_type(d.pop("type"))
 
         uri = d.pop("uri")
+
+        def _parse_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        title = _parse_title(d.pop("title", UNSET))
 
         def _parse_description(data: object) -> None | str | Unset:
             if data is None:
@@ -117,22 +126,13 @@ class ManifestSource:
 
         layer = _parse_layer(d.pop("layer", UNSET))
 
-        def _parse_title(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        title = _parse_title(d.pop("title", UNSET))
-
         manifest_source = cls(
             type_=type_,
             uri=uri,
+            title=title,
             description=description,
             format_=format_,
             layer=layer,
-            title=title,
         )
 
         return manifest_source

--- a/sdks/python/geolens/models/map_access_response.py
+++ b/sdks/python/geolens/models/map_access_response.py
@@ -14,25 +14,25 @@ T = TypeVar("T", bound="MapAccessResponse")
 class MapAccessResponse:
     """
     Attributes:
-        can_edit (bool): True when the current request may open the map builder
         can_view (bool): True when the current request may read the map
+        can_edit (bool): True when the current request may open the map builder
     """
 
-    can_edit: bool
     can_view: bool
+    can_edit: bool
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        can_edit = self.can_edit
-
         can_view = self.can_view
+
+        can_edit = self.can_edit
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "can_edit": can_edit,
                 "can_view": can_view,
+                "can_edit": can_edit,
             }
         )
 
@@ -41,13 +41,13 @@ class MapAccessResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        can_edit = d.pop("can_edit")
-
         can_view = d.pop("can_view")
 
+        can_edit = d.pop("can_edit")
+
         map_access_response = cls(
-            can_edit=can_edit,
             can_view=can_view,
+            can_edit=can_edit,
         )
 
         map_access_response.additional_properties = d

--- a/sdks/python/geolens/models/map_create.py
+++ b/sdks/python/geolens/models/map_create.py
@@ -23,18 +23,18 @@ class MapCreate:
     """
     Attributes:
         name (str): Map display name Example: NYC Infrastructure.
-        basemap_config (BasemapConfig | None | Unset): Curated map-level basemap appearance preferences
         description (None | str | Unset): Short description for sharing Example: Buildings, parks, and transit routes in
             Manhattan.
         notes (None | str | Unset): Private notes (not shown publicly)
         terrain_config (None | TerrainConfig | Unset): Map-level terrain source and exaggeration preferences
+        basemap_config (BasemapConfig | None | Unset): Curated map-level basemap appearance preferences
     """
 
     name: str
-    basemap_config: BasemapConfig | None | Unset = UNSET
     description: None | str | Unset = UNSET
     notes: None | str | Unset = UNSET
     terrain_config: None | TerrainConfig | Unset = UNSET
+    basemap_config: BasemapConfig | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -42,14 +42,6 @@ class MapCreate:
         from ..models.terrain_config import TerrainConfig
 
         name = self.name
-
-        basemap_config: dict[str, Any] | None | Unset
-        if isinstance(self.basemap_config, Unset):
-            basemap_config = UNSET
-        elif isinstance(self.basemap_config, BasemapConfig):
-            basemap_config = self.basemap_config.to_dict()
-        else:
-            basemap_config = self.basemap_config
 
         description: None | str | Unset
         if isinstance(self.description, Unset):
@@ -71,6 +63,14 @@ class MapCreate:
         else:
             terrain_config = self.terrain_config
 
+        basemap_config: dict[str, Any] | None | Unset
+        if isinstance(self.basemap_config, Unset):
+            basemap_config = UNSET
+        elif isinstance(self.basemap_config, BasemapConfig):
+            basemap_config = self.basemap_config.to_dict()
+        else:
+            basemap_config = self.basemap_config
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -78,14 +78,14 @@ class MapCreate:
                 "name": name,
             }
         )
-        if basemap_config is not UNSET:
-            field_dict["basemap_config"] = basemap_config
         if description is not UNSET:
             field_dict["description"] = description
         if notes is not UNSET:
             field_dict["notes"] = notes
         if terrain_config is not UNSET:
             field_dict["terrain_config"] = terrain_config
+        if basemap_config is not UNSET:
+            field_dict["basemap_config"] = basemap_config
 
         return field_dict
 
@@ -96,23 +96,6 @@ class MapCreate:
 
         d = dict(src_dict)
         name = d.pop("name")
-
-        def _parse_basemap_config(data: object) -> BasemapConfig | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                basemap_config_type_0 = BasemapConfig.from_dict(data)
-
-                return basemap_config_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(BasemapConfig | None | Unset, data)
-
-        basemap_config = _parse_basemap_config(d.pop("basemap_config", UNSET))
 
         def _parse_description(data: object) -> None | str | Unset:
             if data is None:
@@ -149,12 +132,29 @@ class MapCreate:
 
         terrain_config = _parse_terrain_config(d.pop("terrain_config", UNSET))
 
+        def _parse_basemap_config(data: object) -> BasemapConfig | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                basemap_config_type_0 = BasemapConfig.from_dict(data)
+
+                return basemap_config_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(BasemapConfig | None | Unset, data)
+
+        basemap_config = _parse_basemap_config(d.pop("basemap_config", UNSET))
+
         map_create = cls(
             name=name,
-            basemap_config=basemap_config,
             description=description,
             notes=notes,
             terrain_config=terrain_config,
+            basemap_config=basemap_config,
         )
 
         map_create.additional_properties = d

--- a/sdks/python/geolens/models/map_generate_response.py
+++ b/sdks/python/geolens/models/map_generate_response.py
@@ -17,35 +17,35 @@ T = TypeVar("T", bound="MapGenerateResponse")
 class MapGenerateResponse:
     """
     Attributes:
-        datasets_used (list[str]):
-        explanation (str):
         map_id (str):
         map_name (str):
+        explanation (str):
+        datasets_used (list[str]):
     """
 
-    datasets_used: list[str]
-    explanation: str
     map_id: str
     map_name: str
+    explanation: str
+    datasets_used: list[str]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        datasets_used = self.datasets_used
-
-        explanation = self.explanation
-
         map_id = self.map_id
 
         map_name = self.map_name
+
+        explanation = self.explanation
+
+        datasets_used = self.datasets_used
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "datasets_used": datasets_used,
-                "explanation": explanation,
                 "map_id": map_id,
                 "map_name": map_name,
+                "explanation": explanation,
+                "datasets_used": datasets_used,
             }
         )
 
@@ -54,19 +54,19 @@ class MapGenerateResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        datasets_used = cast(list[str], d.pop("datasets_used"))
-
-        explanation = d.pop("explanation")
-
         map_id = d.pop("map_id")
 
         map_name = d.pop("map_name")
 
+        explanation = d.pop("explanation")
+
+        datasets_used = cast(list[str], d.pop("datasets_used"))
+
         map_generate_response = cls(
-            datasets_used=datasets_used,
-            explanation=explanation,
             map_id=map_id,
             map_name=map_name,
+            explanation=explanation,
+            datasets_used=datasets_used,
         )
 
         map_generate_response.additional_properties = d

--- a/sdks/python/geolens/models/map_history_event_response.py
+++ b/sdks/python/geolens/models/map_history_event_response.py
@@ -26,44 +26,44 @@ T = TypeVar("T", bound="MapHistoryEventResponse")
 class MapHistoryEventResponse:
     """
     Attributes:
-        action (str):
-        created_at (datetime.datetime):
         id (UUID):
         map_id (UUID):
-        summary (str):
         target_type (str):
+        action (str):
+        summary (str):
+        created_at (datetime.datetime):
         actor_id (None | Unset | UUID):
         actor_username (None | str | Unset):
-        details (MapHistoryEventResponseDetails | Unset):
         target_id (None | Unset | UUID):
         target_name (None | str | Unset):
+        details (MapHistoryEventResponseDetails | Unset):
     """
 
-    action: str
-    created_at: datetime.datetime
     id: UUID
     map_id: UUID
-    summary: str
     target_type: str
+    action: str
+    summary: str
+    created_at: datetime.datetime
     actor_id: None | Unset | UUID = UNSET
     actor_username: None | str | Unset = UNSET
-    details: MapHistoryEventResponseDetails | Unset = UNSET
     target_id: None | Unset | UUID = UNSET
     target_name: None | str | Unset = UNSET
+    details: MapHistoryEventResponseDetails | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        action = self.action
-
-        created_at = self.created_at.isoformat()
-
         id = str(self.id)
 
         map_id = str(self.map_id)
 
+        target_type = self.target_type
+
+        action = self.action
+
         summary = self.summary
 
-        target_type = self.target_type
+        created_at = self.created_at.isoformat()
 
         actor_id: None | str | Unset
         if isinstance(self.actor_id, Unset):
@@ -79,10 +79,6 @@ class MapHistoryEventResponse:
         else:
             actor_username = self.actor_username
 
-        details: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.details, Unset):
-            details = self.details.to_dict()
-
         target_id: None | str | Unset
         if isinstance(self.target_id, Unset):
             target_id = UNSET
@@ -97,28 +93,32 @@ class MapHistoryEventResponse:
         else:
             target_name = self.target_name
 
+        details: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.details, Unset):
+            details = self.details.to_dict()
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "action": action,
-                "created_at": created_at,
                 "id": id,
                 "map_id": map_id,
-                "summary": summary,
                 "target_type": target_type,
+                "action": action,
+                "summary": summary,
+                "created_at": created_at,
             }
         )
         if actor_id is not UNSET:
             field_dict["actor_id"] = actor_id
         if actor_username is not UNSET:
             field_dict["actor_username"] = actor_username
-        if details is not UNSET:
-            field_dict["details"] = details
         if target_id is not UNSET:
             field_dict["target_id"] = target_id
         if target_name is not UNSET:
             field_dict["target_name"] = target_name
+        if details is not UNSET:
+            field_dict["details"] = details
 
         return field_dict
 
@@ -129,17 +129,17 @@ class MapHistoryEventResponse:
         )
 
         d = dict(src_dict)
-        action = d.pop("action")
-
-        created_at = isoparse(d.pop("created_at"))
-
         id = UUID(d.pop("id"))
 
         map_id = UUID(d.pop("map_id"))
 
+        target_type = d.pop("target_type")
+
+        action = d.pop("action")
+
         summary = d.pop("summary")
 
-        target_type = d.pop("target_type")
+        created_at = isoparse(d.pop("created_at"))
 
         def _parse_actor_id(data: object) -> None | Unset | UUID:
             if data is None:
@@ -167,13 +167,6 @@ class MapHistoryEventResponse:
 
         actor_username = _parse_actor_username(d.pop("actor_username", UNSET))
 
-        _details = d.pop("details", UNSET)
-        details: MapHistoryEventResponseDetails | Unset
-        if isinstance(_details, Unset):
-            details = UNSET
-        else:
-            details = MapHistoryEventResponseDetails.from_dict(_details)
-
         def _parse_target_id(data: object) -> None | Unset | UUID:
             if data is None:
                 return data
@@ -200,18 +193,25 @@ class MapHistoryEventResponse:
 
         target_name = _parse_target_name(d.pop("target_name", UNSET))
 
+        _details = d.pop("details", UNSET)
+        details: MapHistoryEventResponseDetails | Unset
+        if isinstance(_details, Unset):
+            details = UNSET
+        else:
+            details = MapHistoryEventResponseDetails.from_dict(_details)
+
         map_history_event_response = cls(
-            action=action,
-            created_at=created_at,
             id=id,
             map_id=map_id,
-            summary=summary,
             target_type=target_type,
+            action=action,
+            summary=summary,
+            created_at=created_at,
             actor_id=actor_id,
             actor_username=actor_username,
-            details=details,
             target_id=target_id,
             target_name=target_name,
+            details=details,
         )
 
         map_history_event_response.additional_properties = d

--- a/sdks/python/geolens/models/map_history_list_response.py
+++ b/sdks/python/geolens/models/map_history_list_response.py
@@ -19,15 +19,15 @@ class MapHistoryListResponse:
     """
     Attributes:
         events (list[MapHistoryEventResponse]):
-        limit (int):
-        skip (int):
         total (int):
+        skip (int):
+        limit (int):
     """
 
     events: list[MapHistoryEventResponse]
-    limit: int
-    skip: int
     total: int
+    skip: int
+    limit: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -36,20 +36,20 @@ class MapHistoryListResponse:
             events_item = events_item_data.to_dict()
             events.append(events_item)
 
-        limit = self.limit
+        total = self.total
 
         skip = self.skip
 
-        total = self.total
+        limit = self.limit
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "events": events,
-                "limit": limit,
-                "skip": skip,
                 "total": total,
+                "skip": skip,
+                "limit": limit,
             }
         )
 
@@ -67,17 +67,17 @@ class MapHistoryListResponse:
 
             events.append(events_item)
 
-        limit = d.pop("limit")
+        total = d.pop("total")
 
         skip = d.pop("skip")
 
-        total = d.pop("total")
+        limit = d.pop("limit")
 
         map_history_list_response = cls(
             events=events,
-            limit=limit,
-            skip=skip,
             total=total,
+            skip=skip,
+            limit=limit,
         )
 
         map_history_list_response.additional_properties = d

--- a/sdks/python/geolens/models/map_icon_response.py
+++ b/sdks/python/geolens/models/map_icon_response.py
@@ -19,39 +19,37 @@ class MapIconResponse:
     """
     Attributes:
         id (str):
-        media_type (str):
         name (str):
         slug (str):
-        sprite_id (str):
+        media_type (str):
         url (str):
-        builtin (bool | Unset):  Default: False.
+        sprite_id (str):
         size_bytes (int | None | Unset):
+        builtin (bool | Unset):  Default: False.
     """
 
     id: str
-    media_type: str
     name: str
     slug: str
-    sprite_id: str
+    media_type: str
     url: str
-    builtin: bool | Unset = False
+    sprite_id: str
     size_bytes: int | None | Unset = UNSET
+    builtin: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         id = self.id
 
-        media_type = self.media_type
-
         name = self.name
 
         slug = self.slug
 
-        sprite_id = self.sprite_id
+        media_type = self.media_type
 
         url = self.url
 
-        builtin = self.builtin
+        sprite_id = self.sprite_id
 
         size_bytes: int | None | Unset
         if isinstance(self.size_bytes, Unset):
@@ -59,22 +57,24 @@ class MapIconResponse:
         else:
             size_bytes = self.size_bytes
 
+        builtin = self.builtin
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "id": id,
-                "media_type": media_type,
                 "name": name,
                 "slug": slug,
-                "sprite_id": sprite_id,
+                "media_type": media_type,
                 "url": url,
+                "sprite_id": sprite_id,
             }
         )
-        if builtin is not UNSET:
-            field_dict["builtin"] = builtin
         if size_bytes is not UNSET:
             field_dict["size_bytes"] = size_bytes
+        if builtin is not UNSET:
+            field_dict["builtin"] = builtin
 
         return field_dict
 
@@ -83,17 +83,15 @@ class MapIconResponse:
         d = dict(src_dict)
         id = d.pop("id")
 
-        media_type = d.pop("media_type")
-
         name = d.pop("name")
 
         slug = d.pop("slug")
 
-        sprite_id = d.pop("sprite_id")
+        media_type = d.pop("media_type")
 
         url = d.pop("url")
 
-        builtin = d.pop("builtin", UNSET)
+        sprite_id = d.pop("sprite_id")
 
         def _parse_size_bytes(data: object) -> int | None | Unset:
             if data is None:
@@ -104,15 +102,17 @@ class MapIconResponse:
 
         size_bytes = _parse_size_bytes(d.pop("size_bytes", UNSET))
 
+        builtin = d.pop("builtin", UNSET)
+
         map_icon_response = cls(
             id=id,
-            media_type=media_type,
             name=name,
             slug=slug,
-            sprite_id=sprite_id,
+            media_type=media_type,
             url=url,
-            builtin=builtin,
+            sprite_id=sprite_id,
             size_bytes=size_bytes,
+            builtin=builtin,
         )
 
         map_icon_response.additional_properties = d

--- a/sdks/python/geolens/models/map_layer_diff_request.py
+++ b/sdks/python/geolens/models/map_layer_diff_request.py
@@ -24,17 +24,17 @@ class MapLayerDiffRequest:
     """
     Attributes:
         added (list[MapLayerInput] | Unset): Layers to append (max 200)
-        fallback_full_replace (bool | Unset): Client hint only; PATCH never performs full replacement Default: False.
-        order (list[UUID] | None | Unset): Optional stable layer ID order for existing layers
-        removed (list[UUID] | Unset):
         updated (list[MapLayerPatch] | Unset):
+        removed (list[UUID] | Unset):
+        order (list[UUID] | None | Unset): Optional stable layer ID order for existing layers
+        fallback_full_replace (bool | Unset): Client hint only; PATCH never performs full replacement Default: False.
     """
 
     added: list[MapLayerInput] | Unset = UNSET
-    fallback_full_replace: bool | Unset = False
-    order: list[UUID] | None | Unset = UNSET
-    removed: list[UUID] | Unset = UNSET
     updated: list[MapLayerPatch] | Unset = UNSET
+    removed: list[UUID] | Unset = UNSET
+    order: list[UUID] | None | Unset = UNSET
+    fallback_full_replace: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -45,7 +45,19 @@ class MapLayerDiffRequest:
                 added_item = added_item_data.to_dict()
                 added.append(added_item)
 
-        fallback_full_replace = self.fallback_full_replace
+        updated: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.updated, Unset):
+            updated = []
+            for updated_item_data in self.updated:
+                updated_item = updated_item_data.to_dict()
+                updated.append(updated_item)
+
+        removed: list[str] | Unset = UNSET
+        if not isinstance(self.removed, Unset):
+            removed = []
+            for removed_item_data in self.removed:
+                removed_item = str(removed_item_data)
+                removed.append(removed_item)
 
         order: list[str] | None | Unset
         if isinstance(self.order, Unset):
@@ -59,33 +71,21 @@ class MapLayerDiffRequest:
         else:
             order = self.order
 
-        removed: list[str] | Unset = UNSET
-        if not isinstance(self.removed, Unset):
-            removed = []
-            for removed_item_data in self.removed:
-                removed_item = str(removed_item_data)
-                removed.append(removed_item)
-
-        updated: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.updated, Unset):
-            updated = []
-            for updated_item_data in self.updated:
-                updated_item = updated_item_data.to_dict()
-                updated.append(updated_item)
+        fallback_full_replace = self.fallback_full_replace
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if added is not UNSET:
             field_dict["added"] = added
-        if fallback_full_replace is not UNSET:
-            field_dict["fallback_full_replace"] = fallback_full_replace
-        if order is not UNSET:
-            field_dict["order"] = order
-        if removed is not UNSET:
-            field_dict["removed"] = removed
         if updated is not UNSET:
             field_dict["updated"] = updated
+        if removed is not UNSET:
+            field_dict["removed"] = removed
+        if order is not UNSET:
+            field_dict["order"] = order
+        if fallback_full_replace is not UNSET:
+            field_dict["fallback_full_replace"] = fallback_full_replace
 
         return field_dict
 
@@ -104,7 +104,23 @@ class MapLayerDiffRequest:
 
                 added.append(added_item)
 
-        fallback_full_replace = d.pop("fallback_full_replace", UNSET)
+        _updated = d.pop("updated", UNSET)
+        updated: list[MapLayerPatch] | Unset = UNSET
+        if _updated is not UNSET:
+            updated = []
+            for updated_item_data in _updated:
+                updated_item = MapLayerPatch.from_dict(updated_item_data)
+
+                updated.append(updated_item)
+
+        _removed = d.pop("removed", UNSET)
+        removed: list[UUID] | Unset = UNSET
+        if _removed is not UNSET:
+            removed = []
+            for removed_item_data in _removed:
+                removed_item = UUID(removed_item_data)
+
+                removed.append(removed_item)
 
         def _parse_order(data: object) -> list[UUID] | None | Unset:
             if data is None:
@@ -128,30 +144,14 @@ class MapLayerDiffRequest:
 
         order = _parse_order(d.pop("order", UNSET))
 
-        _removed = d.pop("removed", UNSET)
-        removed: list[UUID] | Unset = UNSET
-        if _removed is not UNSET:
-            removed = []
-            for removed_item_data in _removed:
-                removed_item = UUID(removed_item_data)
-
-                removed.append(removed_item)
-
-        _updated = d.pop("updated", UNSET)
-        updated: list[MapLayerPatch] | Unset = UNSET
-        if _updated is not UNSET:
-            updated = []
-            for updated_item_data in _updated:
-                updated_item = MapLayerPatch.from_dict(updated_item_data)
-
-                updated.append(updated_item)
+        fallback_full_replace = d.pop("fallback_full_replace", UNSET)
 
         map_layer_diff_request = cls(
             added=added,
-            fallback_full_replace=fallback_full_replace,
-            order=order,
-            removed=removed,
             updated=updated,
+            removed=removed,
+            order=order,
+            fallback_full_replace=fallback_full_replace,
         )
 
         map_layer_diff_request.additional_properties = d

--- a/sdks/python/geolens/models/map_layer_input.py
+++ b/sdks/python/geolens/models/map_layer_input.py
@@ -31,37 +31,37 @@ class MapLayerInput:
     """
     Attributes:
         dataset_id (UUID):
-        display_name (None | str | Unset): Label shown in the layer list
-        filter_ (list[Any] | None | Unset): MapLibre filter expression
         id (None | Unset | UUID): Existing layer id to update in place (full-save reconcile)
-        label_config (MapLayerInputLabelConfigType0 | None | Unset): Text label configuration
-        layer_type (None | str | Unset): Auto-detected from record_type if omitted
-        layout (MapLayerInputLayoutType0 | None | Unset): MapLibre layout properties override
+        sort_order (int | Unset): Draw order (lower draws first) Default: 0.
+        visible (bool | Unset):  Default: True.
         opacity (float | Unset): Layer opacity 0.0-1.0 Default: 1.0.
         paint (MapLayerInputPaintType0 | None | Unset): MapLibre paint properties override
+        layout (MapLayerInputLayoutType0 | None | Unset): MapLibre layout properties override
+        display_name (None | str | Unset): Label shown in the layer list
+        filter_ (list[Any] | None | Unset): MapLibre filter expression
+        label_config (MapLayerInputLabelConfigType0 | None | Unset): Text label configuration
         popup_config (None | PopupConfig | Unset): Popup configuration: {enabled, expression, visible_fields}
-        show_in_legend (bool | Unset): Whether to include in the map legend Default: True.
-        sort_order (int | Unset): Draw order (lower draws first) Default: 0.
         style_config (MapLayerInputStyleConfigType0 | None | Unset): Data-driven and builder UI style configuration.
             Builder-only state lives under builder, e.g. fill_disabled, stroke_disabled, outline settings, heatmap metadata,
             and height_column.
-        visible (bool | Unset):  Default: True.
+        layer_type (None | str | Unset): Auto-detected from record_type if omitted
+        show_in_legend (bool | Unset): Whether to include in the map legend Default: True.
     """
 
     dataset_id: UUID
-    display_name: None | str | Unset = UNSET
-    filter_: list[Any] | None | Unset = UNSET
     id: None | Unset | UUID = UNSET
-    label_config: MapLayerInputLabelConfigType0 | None | Unset = UNSET
-    layer_type: None | str | Unset = UNSET
-    layout: MapLayerInputLayoutType0 | None | Unset = UNSET
+    sort_order: int | Unset = 0
+    visible: bool | Unset = True
     opacity: float | Unset = 1.0
     paint: MapLayerInputPaintType0 | None | Unset = UNSET
+    layout: MapLayerInputLayoutType0 | None | Unset = UNSET
+    display_name: None | str | Unset = UNSET
+    filter_: list[Any] | None | Unset = UNSET
+    label_config: MapLayerInputLabelConfigType0 | None | Unset = UNSET
     popup_config: None | PopupConfig | Unset = UNSET
-    show_in_legend: bool | Unset = True
-    sort_order: int | Unset = 0
     style_config: MapLayerInputStyleConfigType0 | None | Unset = UNSET
-    visible: bool | Unset = True
+    layer_type: None | str | Unset = UNSET
+    show_in_legend: bool | Unset = True
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -76,6 +76,36 @@ class MapLayerInput:
         from ..models.popup_config import PopupConfig
 
         dataset_id = str(self.dataset_id)
+
+        id: None | str | Unset
+        if isinstance(self.id, Unset):
+            id = UNSET
+        elif isinstance(self.id, UUID):
+            id = str(self.id)
+        else:
+            id = self.id
+
+        sort_order = self.sort_order
+
+        visible = self.visible
+
+        opacity = self.opacity
+
+        paint: dict[str, Any] | None | Unset
+        if isinstance(self.paint, Unset):
+            paint = UNSET
+        elif isinstance(self.paint, MapLayerInputPaintType0):
+            paint = self.paint.to_dict()
+        else:
+            paint = self.paint
+
+        layout: dict[str, Any] | None | Unset
+        if isinstance(self.layout, Unset):
+            layout = UNSET
+        elif isinstance(self.layout, MapLayerInputLayoutType0):
+            layout = self.layout.to_dict()
+        else:
+            layout = self.layout
 
         display_name: None | str | Unset
         if isinstance(self.display_name, Unset):
@@ -92,14 +122,6 @@ class MapLayerInput:
         else:
             filter_ = self.filter_
 
-        id: None | str | Unset
-        if isinstance(self.id, Unset):
-            id = UNSET
-        elif isinstance(self.id, UUID):
-            id = str(self.id)
-        else:
-            id = self.id
-
         label_config: dict[str, Any] | None | Unset
         if isinstance(self.label_config, Unset):
             label_config = UNSET
@@ -107,30 +129,6 @@ class MapLayerInput:
             label_config = self.label_config.to_dict()
         else:
             label_config = self.label_config
-
-        layer_type: None | str | Unset
-        if isinstance(self.layer_type, Unset):
-            layer_type = UNSET
-        else:
-            layer_type = self.layer_type
-
-        layout: dict[str, Any] | None | Unset
-        if isinstance(self.layout, Unset):
-            layout = UNSET
-        elif isinstance(self.layout, MapLayerInputLayoutType0):
-            layout = self.layout.to_dict()
-        else:
-            layout = self.layout
-
-        opacity = self.opacity
-
-        paint: dict[str, Any] | None | Unset
-        if isinstance(self.paint, Unset):
-            paint = UNSET
-        elif isinstance(self.paint, MapLayerInputPaintType0):
-            paint = self.paint.to_dict()
-        else:
-            paint = self.paint
 
         popup_config: dict[str, Any] | None | Unset
         if isinstance(self.popup_config, Unset):
@@ -140,10 +138,6 @@ class MapLayerInput:
         else:
             popup_config = self.popup_config
 
-        show_in_legend = self.show_in_legend
-
-        sort_order = self.sort_order
-
         style_config: dict[str, Any] | None | Unset
         if isinstance(self.style_config, Unset):
             style_config = UNSET
@@ -152,7 +146,13 @@ class MapLayerInput:
         else:
             style_config = self.style_config
 
-        visible = self.visible
+        layer_type: None | str | Unset
+        if isinstance(self.layer_type, Unset):
+            layer_type = UNSET
+        else:
+            layer_type = self.layer_type
+
+        show_in_legend = self.show_in_legend
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -161,32 +161,32 @@ class MapLayerInput:
                 "dataset_id": dataset_id,
             }
         )
-        if display_name is not UNSET:
-            field_dict["display_name"] = display_name
-        if filter_ is not UNSET:
-            field_dict["filter"] = filter_
         if id is not UNSET:
             field_dict["id"] = id
-        if label_config is not UNSET:
-            field_dict["label_config"] = label_config
-        if layer_type is not UNSET:
-            field_dict["layer_type"] = layer_type
-        if layout is not UNSET:
-            field_dict["layout"] = layout
+        if sort_order is not UNSET:
+            field_dict["sort_order"] = sort_order
+        if visible is not UNSET:
+            field_dict["visible"] = visible
         if opacity is not UNSET:
             field_dict["opacity"] = opacity
         if paint is not UNSET:
             field_dict["paint"] = paint
+        if layout is not UNSET:
+            field_dict["layout"] = layout
+        if display_name is not UNSET:
+            field_dict["display_name"] = display_name
+        if filter_ is not UNSET:
+            field_dict["filter"] = filter_
+        if label_config is not UNSET:
+            field_dict["label_config"] = label_config
         if popup_config is not UNSET:
             field_dict["popup_config"] = popup_config
-        if show_in_legend is not UNSET:
-            field_dict["show_in_legend"] = show_in_legend
-        if sort_order is not UNSET:
-            field_dict["sort_order"] = sort_order
         if style_config is not UNSET:
             field_dict["style_config"] = style_config
-        if visible is not UNSET:
-            field_dict["visible"] = visible
+        if layer_type is not UNSET:
+            field_dict["layer_type"] = layer_type
+        if show_in_legend is not UNSET:
+            field_dict["show_in_legend"] = show_in_legend
 
         return field_dict
 
@@ -204,6 +204,63 @@ class MapLayerInput:
 
         d = dict(src_dict)
         dataset_id = UUID(d.pop("dataset_id"))
+
+        def _parse_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                id_type_0 = UUID(data)
+
+                return id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        id = _parse_id(d.pop("id", UNSET))
+
+        sort_order = d.pop("sort_order", UNSET)
+
+        visible = d.pop("visible", UNSET)
+
+        opacity = d.pop("opacity", UNSET)
+
+        def _parse_paint(data: object) -> MapLayerInputPaintType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                paint_type_0 = MapLayerInputPaintType0.from_dict(data)
+
+                return paint_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(MapLayerInputPaintType0 | None | Unset, data)
+
+        paint = _parse_paint(d.pop("paint", UNSET))
+
+        def _parse_layout(data: object) -> MapLayerInputLayoutType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                layout_type_0 = MapLayerInputLayoutType0.from_dict(data)
+
+                return layout_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(MapLayerInputLayoutType0 | None | Unset, data)
+
+        layout = _parse_layout(d.pop("layout", UNSET))
 
         def _parse_display_name(data: object) -> None | str | Unset:
             if data is None:
@@ -231,23 +288,6 @@ class MapLayerInput:
 
         filter_ = _parse_filter_(d.pop("filter", UNSET))
 
-        def _parse_id(data: object) -> None | Unset | UUID:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                id_type_0 = UUID(data)
-
-                return id_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | Unset | UUID, data)
-
-        id = _parse_id(d.pop("id", UNSET))
-
         def _parse_label_config(
             data: object,
         ) -> MapLayerInputLabelConfigType0 | None | Unset:
@@ -267,51 +307,6 @@ class MapLayerInput:
 
         label_config = _parse_label_config(d.pop("label_config", UNSET))
 
-        def _parse_layer_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        layer_type = _parse_layer_type(d.pop("layer_type", UNSET))
-
-        def _parse_layout(data: object) -> MapLayerInputLayoutType0 | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                layout_type_0 = MapLayerInputLayoutType0.from_dict(data)
-
-                return layout_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(MapLayerInputLayoutType0 | None | Unset, data)
-
-        layout = _parse_layout(d.pop("layout", UNSET))
-
-        opacity = d.pop("opacity", UNSET)
-
-        def _parse_paint(data: object) -> MapLayerInputPaintType0 | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                paint_type_0 = MapLayerInputPaintType0.from_dict(data)
-
-                return paint_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(MapLayerInputPaintType0 | None | Unset, data)
-
-        paint = _parse_paint(d.pop("paint", UNSET))
-
         def _parse_popup_config(data: object) -> None | PopupConfig | Unset:
             if data is None:
                 return data
@@ -328,10 +323,6 @@ class MapLayerInput:
             return cast(None | PopupConfig | Unset, data)
 
         popup_config = _parse_popup_config(d.pop("popup_config", UNSET))
-
-        show_in_legend = d.pop("show_in_legend", UNSET)
-
-        sort_order = d.pop("sort_order", UNSET)
 
         def _parse_style_config(
             data: object,
@@ -352,23 +343,32 @@ class MapLayerInput:
 
         style_config = _parse_style_config(d.pop("style_config", UNSET))
 
-        visible = d.pop("visible", UNSET)
+        def _parse_layer_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        layer_type = _parse_layer_type(d.pop("layer_type", UNSET))
+
+        show_in_legend = d.pop("show_in_legend", UNSET)
 
         map_layer_input = cls(
             dataset_id=dataset_id,
-            display_name=display_name,
-            filter_=filter_,
             id=id,
-            label_config=label_config,
-            layer_type=layer_type,
-            layout=layout,
+            sort_order=sort_order,
+            visible=visible,
             opacity=opacity,
             paint=paint,
+            layout=layout,
+            display_name=display_name,
+            filter_=filter_,
+            label_config=label_config,
             popup_config=popup_config,
-            show_in_legend=show_in_legend,
-            sort_order=sort_order,
             style_config=style_config,
-            visible=visible,
+            layer_type=layer_type,
+            show_in_legend=show_in_legend,
         )
 
         map_layer_input.additional_properties = d

--- a/sdks/python/geolens/models/map_layer_patch.py
+++ b/sdks/python/geolens/models/map_layer_patch.py
@@ -31,33 +31,33 @@ class MapLayerPatch:
     """
     Attributes:
         id (UUID):
+        sort_order (int | None | Unset):
+        visible (bool | None | Unset):
+        opacity (float | None | Unset):
+        paint (MapLayerPatchPaintType0 | None | Unset): MapLibre paint properties override
+        layout (MapLayerPatchLayoutType0 | None | Unset): MapLibre layout properties override
         display_name (None | str | Unset):
         filter_ (list[Any] | None | Unset): MapLibre filter expression
         label_config (MapLayerPatchLabelConfigType0 | None | Unset): Text label configuration
-        layer_type (None | str | Unset):
-        layout (MapLayerPatchLayoutType0 | None | Unset): MapLibre layout properties override
-        opacity (float | None | Unset):
-        paint (MapLayerPatchPaintType0 | None | Unset): MapLibre paint properties override
         popup_config (None | PopupConfig | Unset):
-        show_in_legend (bool | None | Unset):
-        sort_order (int | None | Unset):
         style_config (MapLayerPatchStyleConfigType0 | None | Unset):
-        visible (bool | None | Unset):
+        layer_type (None | str | Unset):
+        show_in_legend (bool | None | Unset):
     """
 
     id: UUID
+    sort_order: int | None | Unset = UNSET
+    visible: bool | None | Unset = UNSET
+    opacity: float | None | Unset = UNSET
+    paint: MapLayerPatchPaintType0 | None | Unset = UNSET
+    layout: MapLayerPatchLayoutType0 | None | Unset = UNSET
     display_name: None | str | Unset = UNSET
     filter_: list[Any] | None | Unset = UNSET
     label_config: MapLayerPatchLabelConfigType0 | None | Unset = UNSET
-    layer_type: None | str | Unset = UNSET
-    layout: MapLayerPatchLayoutType0 | None | Unset = UNSET
-    opacity: float | None | Unset = UNSET
-    paint: MapLayerPatchPaintType0 | None | Unset = UNSET
     popup_config: None | PopupConfig | Unset = UNSET
-    show_in_legend: bool | None | Unset = UNSET
-    sort_order: int | None | Unset = UNSET
     style_config: MapLayerPatchStyleConfigType0 | None | Unset = UNSET
-    visible: bool | None | Unset = UNSET
+    layer_type: None | str | Unset = UNSET
+    show_in_legend: bool | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -72,6 +72,40 @@ class MapLayerPatch:
         from ..models.popup_config import PopupConfig
 
         id = str(self.id)
+
+        sort_order: int | None | Unset
+        if isinstance(self.sort_order, Unset):
+            sort_order = UNSET
+        else:
+            sort_order = self.sort_order
+
+        visible: bool | None | Unset
+        if isinstance(self.visible, Unset):
+            visible = UNSET
+        else:
+            visible = self.visible
+
+        opacity: float | None | Unset
+        if isinstance(self.opacity, Unset):
+            opacity = UNSET
+        else:
+            opacity = self.opacity
+
+        paint: dict[str, Any] | None | Unset
+        if isinstance(self.paint, Unset):
+            paint = UNSET
+        elif isinstance(self.paint, MapLayerPatchPaintType0):
+            paint = self.paint.to_dict()
+        else:
+            paint = self.paint
+
+        layout: dict[str, Any] | None | Unset
+        if isinstance(self.layout, Unset):
+            layout = UNSET
+        elif isinstance(self.layout, MapLayerPatchLayoutType0):
+            layout = self.layout.to_dict()
+        else:
+            layout = self.layout
 
         display_name: None | str | Unset
         if isinstance(self.display_name, Unset):
@@ -96,34 +130,6 @@ class MapLayerPatch:
         else:
             label_config = self.label_config
 
-        layer_type: None | str | Unset
-        if isinstance(self.layer_type, Unset):
-            layer_type = UNSET
-        else:
-            layer_type = self.layer_type
-
-        layout: dict[str, Any] | None | Unset
-        if isinstance(self.layout, Unset):
-            layout = UNSET
-        elif isinstance(self.layout, MapLayerPatchLayoutType0):
-            layout = self.layout.to_dict()
-        else:
-            layout = self.layout
-
-        opacity: float | None | Unset
-        if isinstance(self.opacity, Unset):
-            opacity = UNSET
-        else:
-            opacity = self.opacity
-
-        paint: dict[str, Any] | None | Unset
-        if isinstance(self.paint, Unset):
-            paint = UNSET
-        elif isinstance(self.paint, MapLayerPatchPaintType0):
-            paint = self.paint.to_dict()
-        else:
-            paint = self.paint
-
         popup_config: dict[str, Any] | None | Unset
         if isinstance(self.popup_config, Unset):
             popup_config = UNSET
@@ -131,18 +137,6 @@ class MapLayerPatch:
             popup_config = self.popup_config.to_dict()
         else:
             popup_config = self.popup_config
-
-        show_in_legend: bool | None | Unset
-        if isinstance(self.show_in_legend, Unset):
-            show_in_legend = UNSET
-        else:
-            show_in_legend = self.show_in_legend
-
-        sort_order: int | None | Unset
-        if isinstance(self.sort_order, Unset):
-            sort_order = UNSET
-        else:
-            sort_order = self.sort_order
 
         style_config: dict[str, Any] | None | Unset
         if isinstance(self.style_config, Unset):
@@ -152,11 +146,17 @@ class MapLayerPatch:
         else:
             style_config = self.style_config
 
-        visible: bool | None | Unset
-        if isinstance(self.visible, Unset):
-            visible = UNSET
+        layer_type: None | str | Unset
+        if isinstance(self.layer_type, Unset):
+            layer_type = UNSET
         else:
-            visible = self.visible
+            layer_type = self.layer_type
+
+        show_in_legend: bool | None | Unset
+        if isinstance(self.show_in_legend, Unset):
+            show_in_legend = UNSET
+        else:
+            show_in_legend = self.show_in_legend
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -165,30 +165,30 @@ class MapLayerPatch:
                 "id": id,
             }
         )
+        if sort_order is not UNSET:
+            field_dict["sort_order"] = sort_order
+        if visible is not UNSET:
+            field_dict["visible"] = visible
+        if opacity is not UNSET:
+            field_dict["opacity"] = opacity
+        if paint is not UNSET:
+            field_dict["paint"] = paint
+        if layout is not UNSET:
+            field_dict["layout"] = layout
         if display_name is not UNSET:
             field_dict["display_name"] = display_name
         if filter_ is not UNSET:
             field_dict["filter"] = filter_
         if label_config is not UNSET:
             field_dict["label_config"] = label_config
-        if layer_type is not UNSET:
-            field_dict["layer_type"] = layer_type
-        if layout is not UNSET:
-            field_dict["layout"] = layout
-        if opacity is not UNSET:
-            field_dict["opacity"] = opacity
-        if paint is not UNSET:
-            field_dict["paint"] = paint
         if popup_config is not UNSET:
             field_dict["popup_config"] = popup_config
-        if show_in_legend is not UNSET:
-            field_dict["show_in_legend"] = show_in_legend
-        if sort_order is not UNSET:
-            field_dict["sort_order"] = sort_order
         if style_config is not UNSET:
             field_dict["style_config"] = style_config
-        if visible is not UNSET:
-            field_dict["visible"] = visible
+        if layer_type is not UNSET:
+            field_dict["layer_type"] = layer_type
+        if show_in_legend is not UNSET:
+            field_dict["show_in_legend"] = show_in_legend
 
         return field_dict
 
@@ -206,6 +206,67 @@ class MapLayerPatch:
 
         d = dict(src_dict)
         id = UUID(d.pop("id"))
+
+        def _parse_sort_order(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        sort_order = _parse_sort_order(d.pop("sort_order", UNSET))
+
+        def _parse_visible(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        visible = _parse_visible(d.pop("visible", UNSET))
+
+        def _parse_opacity(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        opacity = _parse_opacity(d.pop("opacity", UNSET))
+
+        def _parse_paint(data: object) -> MapLayerPatchPaintType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                paint_type_0 = MapLayerPatchPaintType0.from_dict(data)
+
+                return paint_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(MapLayerPatchPaintType0 | None | Unset, data)
+
+        paint = _parse_paint(d.pop("paint", UNSET))
+
+        def _parse_layout(data: object) -> MapLayerPatchLayoutType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                layout_type_0 = MapLayerPatchLayoutType0.from_dict(data)
+
+                return layout_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(MapLayerPatchLayoutType0 | None | Unset, data)
+
+        layout = _parse_layout(d.pop("layout", UNSET))
 
         def _parse_display_name(data: object) -> None | str | Unset:
             if data is None:
@@ -252,58 +313,6 @@ class MapLayerPatch:
 
         label_config = _parse_label_config(d.pop("label_config", UNSET))
 
-        def _parse_layer_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        layer_type = _parse_layer_type(d.pop("layer_type", UNSET))
-
-        def _parse_layout(data: object) -> MapLayerPatchLayoutType0 | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                layout_type_0 = MapLayerPatchLayoutType0.from_dict(data)
-
-                return layout_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(MapLayerPatchLayoutType0 | None | Unset, data)
-
-        layout = _parse_layout(d.pop("layout", UNSET))
-
-        def _parse_opacity(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        opacity = _parse_opacity(d.pop("opacity", UNSET))
-
-        def _parse_paint(data: object) -> MapLayerPatchPaintType0 | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                paint_type_0 = MapLayerPatchPaintType0.from_dict(data)
-
-                return paint_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(MapLayerPatchPaintType0 | None | Unset, data)
-
-        paint = _parse_paint(d.pop("paint", UNSET))
-
         def _parse_popup_config(data: object) -> None | PopupConfig | Unset:
             if data is None:
                 return data
@@ -320,24 +329,6 @@ class MapLayerPatch:
             return cast(None | PopupConfig | Unset, data)
 
         popup_config = _parse_popup_config(d.pop("popup_config", UNSET))
-
-        def _parse_show_in_legend(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        show_in_legend = _parse_show_in_legend(d.pop("show_in_legend", UNSET))
-
-        def _parse_sort_order(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        sort_order = _parse_sort_order(d.pop("sort_order", UNSET))
 
         def _parse_style_config(
             data: object,
@@ -358,29 +349,38 @@ class MapLayerPatch:
 
         style_config = _parse_style_config(d.pop("style_config", UNSET))
 
-        def _parse_visible(data: object) -> bool | None | Unset:
+        def _parse_layer_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        layer_type = _parse_layer_type(d.pop("layer_type", UNSET))
+
+        def _parse_show_in_legend(data: object) -> bool | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(bool | None | Unset, data)
 
-        visible = _parse_visible(d.pop("visible", UNSET))
+        show_in_legend = _parse_show_in_legend(d.pop("show_in_legend", UNSET))
 
         map_layer_patch = cls(
             id=id,
+            sort_order=sort_order,
+            visible=visible,
+            opacity=opacity,
+            paint=paint,
+            layout=layout,
             display_name=display_name,
             filter_=filter_,
             label_config=label_config,
-            layer_type=layer_type,
-            layout=layout,
-            opacity=opacity,
-            paint=paint,
             popup_config=popup_config,
-            show_in_legend=show_in_legend,
-            sort_order=sort_order,
             style_config=style_config,
-            visible=visible,
+            layer_type=layer_type,
+            show_in_legend=show_in_legend,
         )
 
         map_layer_patch.additional_properties = d

--- a/sdks/python/geolens/models/map_layer_response.py
+++ b/sdks/python/geolens/models/map_layer_response.py
@@ -36,70 +36,70 @@ T = TypeVar("T", bound="MapLayerResponse")
 class MapLayerResponse:
     """
     Attributes:
-        dataset_extent_bbox (list[float] | None):
-        dataset_geometry_type (None | str):
+        id (UUID):
         dataset_id (UUID):
         dataset_name (str):
+        dataset_geometry_type (None | str):
         dataset_table_name (str):
-        id (UUID):
-        layout (MapLayerResponseLayout):
-        opacity (float):
-        paint (MapLayerResponsePaint):
+        dataset_extent_bbox (list[float] | None):
         sort_order (int):
         visible (bool):
-        band_count (int | None | Unset):
+        opacity (float):
+        paint (MapLayerResponsePaint):
+        layout (MapLayerResponseLayout):
         dataset_column_info (list[MapLayerResponseDatasetColumnInfoType0Item] | None | Unset):
         dataset_feature_count (int | None | Unset):
-        dataset_record_type (None | str | Unset):
         dataset_sample_values (MapLayerResponseDatasetSampleValuesType0 | None | Unset):
-        dataset_status (None | str | Unset):
-        dataset_visibility (None | str | Unset):
-        dem_vertical_units (None | str | Unset):
         display_name (None | str | Unset):
+        layer_type (str | Unset):  Default: 'vector_geolens'.
+        dataset_record_type (None | str | Unset):
         filter_ (list[Any] | None | Unset):
+        label_config (MapLayerResponseLabelConfigType0 | None | Unset):
+        popup_config (None | PopupConfig | Unset):
+        style_config (MapLayerResponseStyleConfigType0 | None | Unset):
+        show_in_legend (bool | Unset):  Default: True.
         is_3d (bool | None | Unset):
         is_dem (bool | None | Unset):
-        label_config (MapLayerResponseLabelConfigType0 | None | Unset):
-        layer_type (str | Unset):  Default: 'vector_geolens'.
-        popup_config (None | PopupConfig | Unset):
-        show_in_legend (bool | Unset):  Default: True.
-        style_config (MapLayerResponseStyleConfigType0 | None | Unset):
+        dem_vertical_units (None | str | Unset):
+        band_count (int | None | Unset):
         tile_version (int | None | Unset):
+        dataset_visibility (None | str | Unset):
+        dataset_status (None | str | Unset):
     """
 
-    dataset_extent_bbox: list[float] | None
-    dataset_geometry_type: None | str
+    id: UUID
     dataset_id: UUID
     dataset_name: str
+    dataset_geometry_type: None | str
     dataset_table_name: str
-    id: UUID
-    layout: MapLayerResponseLayout
-    opacity: float
-    paint: MapLayerResponsePaint
+    dataset_extent_bbox: list[float] | None
     sort_order: int
     visible: bool
-    band_count: int | None | Unset = UNSET
+    opacity: float
+    paint: MapLayerResponsePaint
+    layout: MapLayerResponseLayout
     dataset_column_info: (
         list[MapLayerResponseDatasetColumnInfoType0Item] | None | Unset
     ) = UNSET
     dataset_feature_count: int | None | Unset = UNSET
-    dataset_record_type: None | str | Unset = UNSET
     dataset_sample_values: MapLayerResponseDatasetSampleValuesType0 | None | Unset = (
         UNSET
     )
-    dataset_status: None | str | Unset = UNSET
-    dataset_visibility: None | str | Unset = UNSET
-    dem_vertical_units: None | str | Unset = UNSET
     display_name: None | str | Unset = UNSET
+    layer_type: str | Unset = "vector_geolens"
+    dataset_record_type: None | str | Unset = UNSET
     filter_: list[Any] | None | Unset = UNSET
+    label_config: MapLayerResponseLabelConfigType0 | None | Unset = UNSET
+    popup_config: None | PopupConfig | Unset = UNSET
+    style_config: MapLayerResponseStyleConfigType0 | None | Unset = UNSET
+    show_in_legend: bool | Unset = True
     is_3d: bool | None | Unset = UNSET
     is_dem: bool | None | Unset = UNSET
-    label_config: MapLayerResponseLabelConfigType0 | None | Unset = UNSET
-    layer_type: str | Unset = "vector_geolens"
-    popup_config: None | PopupConfig | Unset = UNSET
-    show_in_legend: bool | Unset = True
-    style_config: MapLayerResponseStyleConfigType0 | None | Unset = UNSET
+    dem_vertical_units: None | str | Unset = UNSET
+    band_count: int | None | Unset = UNSET
     tile_version: int | None | Unset = UNSET
+    dataset_visibility: None | str | Unset = UNSET
+    dataset_status: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -114,6 +114,17 @@ class MapLayerResponse:
         )
         from ..models.popup_config import PopupConfig
 
+        id = str(self.id)
+
+        dataset_id = str(self.dataset_id)
+
+        dataset_name = self.dataset_name
+
+        dataset_geometry_type: None | str
+        dataset_geometry_type = self.dataset_geometry_type
+
+        dataset_table_name = self.dataset_table_name
+
         dataset_extent_bbox: list[float] | None
         if isinstance(self.dataset_extent_bbox, list):
             dataset_extent_bbox = self.dataset_extent_bbox
@@ -121,32 +132,15 @@ class MapLayerResponse:
         else:
             dataset_extent_bbox = self.dataset_extent_bbox
 
-        dataset_geometry_type: None | str
-        dataset_geometry_type = self.dataset_geometry_type
+        sort_order = self.sort_order
 
-        dataset_id = str(self.dataset_id)
-
-        dataset_name = self.dataset_name
-
-        dataset_table_name = self.dataset_table_name
-
-        id = str(self.id)
-
-        layout = self.layout.to_dict()
+        visible = self.visible
 
         opacity = self.opacity
 
         paint = self.paint.to_dict()
 
-        sort_order = self.sort_order
-
-        visible = self.visible
-
-        band_count: int | None | Unset
-        if isinstance(self.band_count, Unset):
-            band_count = UNSET
-        else:
-            band_count = self.band_count
+        layout = self.layout.to_dict()
 
         dataset_column_info: list[dict[str, Any]] | None | Unset
         if isinstance(self.dataset_column_info, Unset):
@@ -168,12 +162,6 @@ class MapLayerResponse:
         else:
             dataset_feature_count = self.dataset_feature_count
 
-        dataset_record_type: None | str | Unset
-        if isinstance(self.dataset_record_type, Unset):
-            dataset_record_type = UNSET
-        else:
-            dataset_record_type = self.dataset_record_type
-
         dataset_sample_values: dict[str, Any] | None | Unset
         if isinstance(self.dataset_sample_values, Unset):
             dataset_sample_values = UNSET
@@ -184,29 +172,19 @@ class MapLayerResponse:
         else:
             dataset_sample_values = self.dataset_sample_values
 
-        dataset_status: None | str | Unset
-        if isinstance(self.dataset_status, Unset):
-            dataset_status = UNSET
-        else:
-            dataset_status = self.dataset_status
-
-        dataset_visibility: None | str | Unset
-        if isinstance(self.dataset_visibility, Unset):
-            dataset_visibility = UNSET
-        else:
-            dataset_visibility = self.dataset_visibility
-
-        dem_vertical_units: None | str | Unset
-        if isinstance(self.dem_vertical_units, Unset):
-            dem_vertical_units = UNSET
-        else:
-            dem_vertical_units = self.dem_vertical_units
-
         display_name: None | str | Unset
         if isinstance(self.display_name, Unset):
             display_name = UNSET
         else:
             display_name = self.display_name
+
+        layer_type = self.layer_type
+
+        dataset_record_type: None | str | Unset
+        if isinstance(self.dataset_record_type, Unset):
+            dataset_record_type = UNSET
+        else:
+            dataset_record_type = self.dataset_record_type
 
         filter_: list[Any] | None | Unset
         if isinstance(self.filter_, Unset):
@@ -216,6 +194,32 @@ class MapLayerResponse:
 
         else:
             filter_ = self.filter_
+
+        label_config: dict[str, Any] | None | Unset
+        if isinstance(self.label_config, Unset):
+            label_config = UNSET
+        elif isinstance(self.label_config, MapLayerResponseLabelConfigType0):
+            label_config = self.label_config.to_dict()
+        else:
+            label_config = self.label_config
+
+        popup_config: dict[str, Any] | None | Unset
+        if isinstance(self.popup_config, Unset):
+            popup_config = UNSET
+        elif isinstance(self.popup_config, PopupConfig):
+            popup_config = self.popup_config.to_dict()
+        else:
+            popup_config = self.popup_config
+
+        style_config: dict[str, Any] | None | Unset
+        if isinstance(self.style_config, Unset):
+            style_config = UNSET
+        elif isinstance(self.style_config, MapLayerResponseStyleConfigType0):
+            style_config = self.style_config.to_dict()
+        else:
+            style_config = self.style_config
+
+        show_in_legend = self.show_in_legend
 
         is_3d: bool | None | Unset
         if isinstance(self.is_3d, Unset):
@@ -229,33 +233,17 @@ class MapLayerResponse:
         else:
             is_dem = self.is_dem
 
-        label_config: dict[str, Any] | None | Unset
-        if isinstance(self.label_config, Unset):
-            label_config = UNSET
-        elif isinstance(self.label_config, MapLayerResponseLabelConfigType0):
-            label_config = self.label_config.to_dict()
+        dem_vertical_units: None | str | Unset
+        if isinstance(self.dem_vertical_units, Unset):
+            dem_vertical_units = UNSET
         else:
-            label_config = self.label_config
+            dem_vertical_units = self.dem_vertical_units
 
-        layer_type = self.layer_type
-
-        popup_config: dict[str, Any] | None | Unset
-        if isinstance(self.popup_config, Unset):
-            popup_config = UNSET
-        elif isinstance(self.popup_config, PopupConfig):
-            popup_config = self.popup_config.to_dict()
+        band_count: int | None | Unset
+        if isinstance(self.band_count, Unset):
+            band_count = UNSET
         else:
-            popup_config = self.popup_config
-
-        show_in_legend = self.show_in_legend
-
-        style_config: dict[str, Any] | None | Unset
-        if isinstance(self.style_config, Unset):
-            style_config = UNSET
-        elif isinstance(self.style_config, MapLayerResponseStyleConfigType0):
-            style_config = self.style_config.to_dict()
-        else:
-            style_config = self.style_config
+            band_count = self.band_count
 
         tile_version: int | None | Unset
         if isinstance(self.tile_version, Unset):
@@ -263,59 +251,71 @@ class MapLayerResponse:
         else:
             tile_version = self.tile_version
 
+        dataset_visibility: None | str | Unset
+        if isinstance(self.dataset_visibility, Unset):
+            dataset_visibility = UNSET
+        else:
+            dataset_visibility = self.dataset_visibility
+
+        dataset_status: None | str | Unset
+        if isinstance(self.dataset_status, Unset):
+            dataset_status = UNSET
+        else:
+            dataset_status = self.dataset_status
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "dataset_extent_bbox": dataset_extent_bbox,
-                "dataset_geometry_type": dataset_geometry_type,
+                "id": id,
                 "dataset_id": dataset_id,
                 "dataset_name": dataset_name,
+                "dataset_geometry_type": dataset_geometry_type,
                 "dataset_table_name": dataset_table_name,
-                "id": id,
-                "layout": layout,
-                "opacity": opacity,
-                "paint": paint,
+                "dataset_extent_bbox": dataset_extent_bbox,
                 "sort_order": sort_order,
                 "visible": visible,
+                "opacity": opacity,
+                "paint": paint,
+                "layout": layout,
             }
         )
-        if band_count is not UNSET:
-            field_dict["band_count"] = band_count
         if dataset_column_info is not UNSET:
             field_dict["dataset_column_info"] = dataset_column_info
         if dataset_feature_count is not UNSET:
             field_dict["dataset_feature_count"] = dataset_feature_count
-        if dataset_record_type is not UNSET:
-            field_dict["dataset_record_type"] = dataset_record_type
         if dataset_sample_values is not UNSET:
             field_dict["dataset_sample_values"] = dataset_sample_values
-        if dataset_status is not UNSET:
-            field_dict["dataset_status"] = dataset_status
-        if dataset_visibility is not UNSET:
-            field_dict["dataset_visibility"] = dataset_visibility
-        if dem_vertical_units is not UNSET:
-            field_dict["dem_vertical_units"] = dem_vertical_units
         if display_name is not UNSET:
             field_dict["display_name"] = display_name
+        if layer_type is not UNSET:
+            field_dict["layer_type"] = layer_type
+        if dataset_record_type is not UNSET:
+            field_dict["dataset_record_type"] = dataset_record_type
         if filter_ is not UNSET:
             field_dict["filter"] = filter_
+        if label_config is not UNSET:
+            field_dict["label_config"] = label_config
+        if popup_config is not UNSET:
+            field_dict["popup_config"] = popup_config
+        if style_config is not UNSET:
+            field_dict["style_config"] = style_config
+        if show_in_legend is not UNSET:
+            field_dict["show_in_legend"] = show_in_legend
         if is_3d is not UNSET:
             field_dict["is_3d"] = is_3d
         if is_dem is not UNSET:
             field_dict["is_dem"] = is_dem
-        if label_config is not UNSET:
-            field_dict["label_config"] = label_config
-        if layer_type is not UNSET:
-            field_dict["layer_type"] = layer_type
-        if popup_config is not UNSET:
-            field_dict["popup_config"] = popup_config
-        if show_in_legend is not UNSET:
-            field_dict["show_in_legend"] = show_in_legend
-        if style_config is not UNSET:
-            field_dict["style_config"] = style_config
+        if dem_vertical_units is not UNSET:
+            field_dict["dem_vertical_units"] = dem_vertical_units
+        if band_count is not UNSET:
+            field_dict["band_count"] = band_count
         if tile_version is not UNSET:
             field_dict["tile_version"] = tile_version
+        if dataset_visibility is not UNSET:
+            field_dict["dataset_visibility"] = dataset_visibility
+        if dataset_status is not UNSET:
+            field_dict["dataset_status"] = dataset_status
 
         return field_dict
 
@@ -338,6 +338,22 @@ class MapLayerResponse:
         from ..models.popup_config import PopupConfig
 
         d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        dataset_id = UUID(d.pop("dataset_id"))
+
+        dataset_name = d.pop("dataset_name")
+
+        def _parse_dataset_geometry_type(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        dataset_geometry_type = _parse_dataset_geometry_type(
+            d.pop("dataset_geometry_type")
+        )
+
+        dataset_table_name = d.pop("dataset_table_name")
 
         def _parse_dataset_extent_bbox(data: object) -> list[float] | None:
             if data is None:
@@ -354,41 +370,15 @@ class MapLayerResponse:
 
         dataset_extent_bbox = _parse_dataset_extent_bbox(d.pop("dataset_extent_bbox"))
 
-        def _parse_dataset_geometry_type(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
+        sort_order = d.pop("sort_order")
 
-        dataset_geometry_type = _parse_dataset_geometry_type(
-            d.pop("dataset_geometry_type")
-        )
-
-        dataset_id = UUID(d.pop("dataset_id"))
-
-        dataset_name = d.pop("dataset_name")
-
-        dataset_table_name = d.pop("dataset_table_name")
-
-        id = UUID(d.pop("id"))
-
-        layout = MapLayerResponseLayout.from_dict(d.pop("layout"))
+        visible = d.pop("visible")
 
         opacity = d.pop("opacity")
 
         paint = MapLayerResponsePaint.from_dict(d.pop("paint"))
 
-        sort_order = d.pop("sort_order")
-
-        visible = d.pop("visible")
-
-        def _parse_band_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        band_count = _parse_band_count(d.pop("band_count", UNSET))
+        layout = MapLayerResponseLayout.from_dict(d.pop("layout"))
 
         def _parse_dataset_column_info(
             data: object,
@@ -433,17 +423,6 @@ class MapLayerResponse:
             d.pop("dataset_feature_count", UNSET)
         )
 
-        def _parse_dataset_record_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        dataset_record_type = _parse_dataset_record_type(
-            d.pop("dataset_record_type", UNSET)
-        )
-
         def _parse_dataset_sample_values(
             data: object,
         ) -> MapLayerResponseDatasetSampleValuesType0 | None | Unset:
@@ -467,37 +446,6 @@ class MapLayerResponse:
             d.pop("dataset_sample_values", UNSET)
         )
 
-        def _parse_dataset_status(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        dataset_status = _parse_dataset_status(d.pop("dataset_status", UNSET))
-
-        def _parse_dataset_visibility(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        dataset_visibility = _parse_dataset_visibility(
-            d.pop("dataset_visibility", UNSET)
-        )
-
-        def _parse_dem_vertical_units(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        dem_vertical_units = _parse_dem_vertical_units(
-            d.pop("dem_vertical_units", UNSET)
-        )
-
         def _parse_display_name(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -506,6 +454,19 @@ class MapLayerResponse:
             return cast(None | str | Unset, data)
 
         display_name = _parse_display_name(d.pop("display_name", UNSET))
+
+        layer_type = d.pop("layer_type", UNSET)
+
+        def _parse_dataset_record_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        dataset_record_type = _parse_dataset_record_type(
+            d.pop("dataset_record_type", UNSET)
+        )
 
         def _parse_filter_(data: object) -> list[Any] | None | Unset:
             if data is None:
@@ -523,24 +484,6 @@ class MapLayerResponse:
             return cast(list[Any] | None | Unset, data)
 
         filter_ = _parse_filter_(d.pop("filter", UNSET))
-
-        def _parse_is_3d(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        is_3d = _parse_is_3d(d.pop("is_3d", UNSET))
-
-        def _parse_is_dem(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        is_dem = _parse_is_dem(d.pop("is_dem", UNSET))
 
         def _parse_label_config(
             data: object,
@@ -561,8 +504,6 @@ class MapLayerResponse:
 
         label_config = _parse_label_config(d.pop("label_config", UNSET))
 
-        layer_type = d.pop("layer_type", UNSET)
-
         def _parse_popup_config(data: object) -> None | PopupConfig | Unset:
             if data is None:
                 return data
@@ -579,8 +520,6 @@ class MapLayerResponse:
             return cast(None | PopupConfig | Unset, data)
 
         popup_config = _parse_popup_config(d.pop("popup_config", UNSET))
-
-        show_in_legend = d.pop("show_in_legend", UNSET)
 
         def _parse_style_config(
             data: object,
@@ -601,6 +540,46 @@ class MapLayerResponse:
 
         style_config = _parse_style_config(d.pop("style_config", UNSET))
 
+        show_in_legend = d.pop("show_in_legend", UNSET)
+
+        def _parse_is_3d(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_3d = _parse_is_3d(d.pop("is_3d", UNSET))
+
+        def _parse_is_dem(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_dem = _parse_is_dem(d.pop("is_dem", UNSET))
+
+        def _parse_dem_vertical_units(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        dem_vertical_units = _parse_dem_vertical_units(
+            d.pop("dem_vertical_units", UNSET)
+        )
+
+        def _parse_band_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        band_count = _parse_band_count(d.pop("band_count", UNSET))
+
         def _parse_tile_version(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -610,36 +589,56 @@ class MapLayerResponse:
 
         tile_version = _parse_tile_version(d.pop("tile_version", UNSET))
 
+        def _parse_dataset_visibility(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        dataset_visibility = _parse_dataset_visibility(
+            d.pop("dataset_visibility", UNSET)
+        )
+
+        def _parse_dataset_status(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        dataset_status = _parse_dataset_status(d.pop("dataset_status", UNSET))
+
         map_layer_response = cls(
-            dataset_extent_bbox=dataset_extent_bbox,
-            dataset_geometry_type=dataset_geometry_type,
+            id=id,
             dataset_id=dataset_id,
             dataset_name=dataset_name,
+            dataset_geometry_type=dataset_geometry_type,
             dataset_table_name=dataset_table_name,
-            id=id,
-            layout=layout,
-            opacity=opacity,
-            paint=paint,
+            dataset_extent_bbox=dataset_extent_bbox,
             sort_order=sort_order,
             visible=visible,
-            band_count=band_count,
+            opacity=opacity,
+            paint=paint,
+            layout=layout,
             dataset_column_info=dataset_column_info,
             dataset_feature_count=dataset_feature_count,
-            dataset_record_type=dataset_record_type,
             dataset_sample_values=dataset_sample_values,
-            dataset_status=dataset_status,
-            dataset_visibility=dataset_visibility,
-            dem_vertical_units=dem_vertical_units,
             display_name=display_name,
+            layer_type=layer_type,
+            dataset_record_type=dataset_record_type,
             filter_=filter_,
+            label_config=label_config,
+            popup_config=popup_config,
+            style_config=style_config,
+            show_in_legend=show_in_legend,
             is_3d=is_3d,
             is_dem=is_dem,
-            label_config=label_config,
-            layer_type=layer_type,
-            popup_config=popup_config,
-            show_in_legend=show_in_legend,
-            style_config=style_config,
+            dem_vertical_units=dem_vertical_units,
+            band_count=band_count,
             tile_version=tile_version,
+            dataset_visibility=dataset_visibility,
+            dataset_status=dataset_status,
         )
 
         map_layer_response.additional_properties = d

--- a/sdks/python/geolens/models/map_response.py
+++ b/sdks/python/geolens/models/map_response.py
@@ -28,77 +28,91 @@ T = TypeVar("T", bound="MapResponse")
 class MapResponse:
     """
     Attributes:
-        basemap_style (str):
-        bearing (float):
-        center_lat (float | None):
-        center_lng (float | None):
-        created_at (datetime.datetime):
-        created_by (None | UUID):
-        description (None | str):
         id (UUID):
-        layer_count (int):
-        layers (list[MapLayerResponse]):
         name (str):
-        pitch (float):
-        show_basemap_labels (bool):
-        updated_at (datetime.datetime):
-        visibility (MapVisibility):
+        description (None | str):
+        center_lng (float | None):
+        center_lat (float | None):
         zoom (float | None):
-        basemap_config (BasemapConfig | None | Unset):
-        created_by_username (None | str | Unset):
-        forked_from_id (None | Unset | UUID): Source map UUID if this is a fork
-        forked_from_name (None | str | Unset):
-        legend_title (None | str | Unset):
+        bearing (float):
+        pitch (float):
+        basemap_style (str):
+        show_basemap_labels (bool):
+        visibility (MapVisibility):
+        created_by (None | UUID):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        layers (list[MapLayerResponse]):
+        layer_count (int):
         notes (None | str | Unset):
-        og_image_url (None | str | Unset):
-        plugins (list[str] | None | Unset):
+        basemap_config (BasemapConfig | None | Unset):
         terrain_config (None | TerrainConfig | Unset):
         thumbnail_url (None | str | Unset):
+        og_image_url (None | str | Unset):
+        forked_from_id (None | Unset | UUID): Source map UUID if this is a fork
+        forked_from_name (None | str | Unset):
+        created_by_username (None | str | Unset):
+        plugins (list[str] | None | Unset):
+        legend_title (None | str | Unset):
     """
 
-    basemap_style: str
-    bearing: float
-    center_lat: float | None
-    center_lng: float | None
-    created_at: datetime.datetime
-    created_by: None | UUID
-    description: None | str
     id: UUID
-    layer_count: int
-    layers: list[MapLayerResponse]
     name: str
-    pitch: float
-    show_basemap_labels: bool
-    updated_at: datetime.datetime
-    visibility: MapVisibility
+    description: None | str
+    center_lng: float | None
+    center_lat: float | None
     zoom: float | None
-    basemap_config: BasemapConfig | None | Unset = UNSET
-    created_by_username: None | str | Unset = UNSET
-    forked_from_id: None | Unset | UUID = UNSET
-    forked_from_name: None | str | Unset = UNSET
-    legend_title: None | str | Unset = UNSET
+    bearing: float
+    pitch: float
+    basemap_style: str
+    show_basemap_labels: bool
+    visibility: MapVisibility
+    created_by: None | UUID
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    layers: list[MapLayerResponse]
+    layer_count: int
     notes: None | str | Unset = UNSET
-    og_image_url: None | str | Unset = UNSET
-    plugins: list[str] | None | Unset = UNSET
+    basemap_config: BasemapConfig | None | Unset = UNSET
     terrain_config: None | TerrainConfig | Unset = UNSET
     thumbnail_url: None | str | Unset = UNSET
+    og_image_url: None | str | Unset = UNSET
+    forked_from_id: None | Unset | UUID = UNSET
+    forked_from_name: None | str | Unset = UNSET
+    created_by_username: None | str | Unset = UNSET
+    plugins: list[str] | None | Unset = UNSET
+    legend_title: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.basemap_config import BasemapConfig
         from ..models.terrain_config import TerrainConfig
 
-        basemap_style = self.basemap_style
+        id = str(self.id)
 
-        bearing = self.bearing
+        name = self.name
 
-        center_lat: float | None
-        center_lat = self.center_lat
+        description: None | str
+        description = self.description
 
         center_lng: float | None
         center_lng = self.center_lng
 
-        created_at = self.created_at.isoformat()
+        center_lat: float | None
+        center_lat = self.center_lat
+
+        zoom: float | None
+        zoom = self.zoom
+
+        bearing = self.bearing
+
+        pitch = self.pitch
+
+        basemap_style = self.basemap_style
+
+        show_basemap_labels = self.show_basemap_labels
+
+        visibility: str = self.visibility
 
         created_by: None | str
         if isinstance(self.created_by, UUID):
@@ -106,30 +120,22 @@ class MapResponse:
         else:
             created_by = self.created_by
 
-        description: None | str
-        description = self.description
+        created_at = self.created_at.isoformat()
 
-        id = str(self.id)
-
-        layer_count = self.layer_count
+        updated_at = self.updated_at.isoformat()
 
         layers = []
         for layers_item_data in self.layers:
             layers_item = layers_item_data.to_dict()
             layers.append(layers_item)
 
-        name = self.name
+        layer_count = self.layer_count
 
-        pitch = self.pitch
-
-        show_basemap_labels = self.show_basemap_labels
-
-        updated_at = self.updated_at.isoformat()
-
-        visibility: str = self.visibility
-
-        zoom: float | None
-        zoom = self.zoom
+        notes: None | str | Unset
+        if isinstance(self.notes, Unset):
+            notes = UNSET
+        else:
+            notes = self.notes
 
         basemap_config: dict[str, Any] | None | Unset
         if isinstance(self.basemap_config, Unset):
@@ -138,53 +144,6 @@ class MapResponse:
             basemap_config = self.basemap_config.to_dict()
         else:
             basemap_config = self.basemap_config
-
-        created_by_username: None | str | Unset
-        if isinstance(self.created_by_username, Unset):
-            created_by_username = UNSET
-        else:
-            created_by_username = self.created_by_username
-
-        forked_from_id: None | str | Unset
-        if isinstance(self.forked_from_id, Unset):
-            forked_from_id = UNSET
-        elif isinstance(self.forked_from_id, UUID):
-            forked_from_id = str(self.forked_from_id)
-        else:
-            forked_from_id = self.forked_from_id
-
-        forked_from_name: None | str | Unset
-        if isinstance(self.forked_from_name, Unset):
-            forked_from_name = UNSET
-        else:
-            forked_from_name = self.forked_from_name
-
-        legend_title: None | str | Unset
-        if isinstance(self.legend_title, Unset):
-            legend_title = UNSET
-        else:
-            legend_title = self.legend_title
-
-        notes: None | str | Unset
-        if isinstance(self.notes, Unset):
-            notes = UNSET
-        else:
-            notes = self.notes
-
-        og_image_url: None | str | Unset
-        if isinstance(self.og_image_url, Unset):
-            og_image_url = UNSET
-        else:
-            og_image_url = self.og_image_url
-
-        plugins: list[str] | None | Unset
-        if isinstance(self.plugins, Unset):
-            plugins = UNSET
-        elif isinstance(self.plugins, list):
-            plugins = self.plugins
-
-        else:
-            plugins = self.plugins
 
         terrain_config: dict[str, Any] | None | Unset
         if isinstance(self.terrain_config, Unset):
@@ -200,48 +159,89 @@ class MapResponse:
         else:
             thumbnail_url = self.thumbnail_url
 
+        og_image_url: None | str | Unset
+        if isinstance(self.og_image_url, Unset):
+            og_image_url = UNSET
+        else:
+            og_image_url = self.og_image_url
+
+        forked_from_id: None | str | Unset
+        if isinstance(self.forked_from_id, Unset):
+            forked_from_id = UNSET
+        elif isinstance(self.forked_from_id, UUID):
+            forked_from_id = str(self.forked_from_id)
+        else:
+            forked_from_id = self.forked_from_id
+
+        forked_from_name: None | str | Unset
+        if isinstance(self.forked_from_name, Unset):
+            forked_from_name = UNSET
+        else:
+            forked_from_name = self.forked_from_name
+
+        created_by_username: None | str | Unset
+        if isinstance(self.created_by_username, Unset):
+            created_by_username = UNSET
+        else:
+            created_by_username = self.created_by_username
+
+        plugins: list[str] | None | Unset
+        if isinstance(self.plugins, Unset):
+            plugins = UNSET
+        elif isinstance(self.plugins, list):
+            plugins = self.plugins
+
+        else:
+            plugins = self.plugins
+
+        legend_title: None | str | Unset
+        if isinstance(self.legend_title, Unset):
+            legend_title = UNSET
+        else:
+            legend_title = self.legend_title
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "basemap_style": basemap_style,
-                "bearing": bearing,
-                "center_lat": center_lat,
-                "center_lng": center_lng,
-                "created_at": created_at,
-                "created_by": created_by,
-                "description": description,
                 "id": id,
-                "layer_count": layer_count,
-                "layers": layers,
                 "name": name,
-                "pitch": pitch,
-                "show_basemap_labels": show_basemap_labels,
-                "updated_at": updated_at,
-                "visibility": visibility,
+                "description": description,
+                "center_lng": center_lng,
+                "center_lat": center_lat,
                 "zoom": zoom,
+                "bearing": bearing,
+                "pitch": pitch,
+                "basemap_style": basemap_style,
+                "show_basemap_labels": show_basemap_labels,
+                "visibility": visibility,
+                "created_by": created_by,
+                "created_at": created_at,
+                "updated_at": updated_at,
+                "layers": layers,
+                "layer_count": layer_count,
             }
         )
-        if basemap_config is not UNSET:
-            field_dict["basemap_config"] = basemap_config
-        if created_by_username is not UNSET:
-            field_dict["created_by_username"] = created_by_username
-        if forked_from_id is not UNSET:
-            field_dict["forked_from_id"] = forked_from_id
-        if forked_from_name is not UNSET:
-            field_dict["forked_from_name"] = forked_from_name
-        if legend_title is not UNSET:
-            field_dict["legend_title"] = legend_title
         if notes is not UNSET:
             field_dict["notes"] = notes
-        if og_image_url is not UNSET:
-            field_dict["og_image_url"] = og_image_url
-        if plugins is not UNSET:
-            field_dict["plugins"] = plugins
+        if basemap_config is not UNSET:
+            field_dict["basemap_config"] = basemap_config
         if terrain_config is not UNSET:
             field_dict["terrain_config"] = terrain_config
         if thumbnail_url is not UNSET:
             field_dict["thumbnail_url"] = thumbnail_url
+        if og_image_url is not UNSET:
+            field_dict["og_image_url"] = og_image_url
+        if forked_from_id is not UNSET:
+            field_dict["forked_from_id"] = forked_from_id
+        if forked_from_name is not UNSET:
+            field_dict["forked_from_name"] = forked_from_name
+        if created_by_username is not UNSET:
+            field_dict["created_by_username"] = created_by_username
+        if plugins is not UNSET:
+            field_dict["plugins"] = plugins
+        if legend_title is not UNSET:
+            field_dict["legend_title"] = legend_title
 
         return field_dict
 
@@ -252,16 +252,16 @@ class MapResponse:
         from ..models.terrain_config import TerrainConfig
 
         d = dict(src_dict)
-        basemap_style = d.pop("basemap_style")
+        id = UUID(d.pop("id"))
 
-        bearing = d.pop("bearing")
+        name = d.pop("name")
 
-        def _parse_center_lat(data: object) -> float | None:
+        def _parse_description(data: object) -> None | str:
             if data is None:
                 return data
-            return cast(float | None, data)
+            return cast(None | str, data)
 
-        center_lat = _parse_center_lat(d.pop("center_lat"))
+        description = _parse_description(d.pop("description"))
 
         def _parse_center_lng(data: object) -> float | None:
             if data is None:
@@ -270,7 +270,29 @@ class MapResponse:
 
         center_lng = _parse_center_lng(d.pop("center_lng"))
 
-        created_at = isoparse(d.pop("created_at"))
+        def _parse_center_lat(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        center_lat = _parse_center_lat(d.pop("center_lat"))
+
+        def _parse_zoom(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        zoom = _parse_zoom(d.pop("zoom"))
+
+        bearing = d.pop("bearing")
+
+        pitch = d.pop("pitch")
+
+        basemap_style = d.pop("basemap_style")
+
+        show_basemap_labels = d.pop("show_basemap_labels")
+
+        visibility = check_map_visibility(d.pop("visibility"))
 
         def _parse_created_by(data: object) -> None | UUID:
             if data is None:
@@ -287,16 +309,9 @@ class MapResponse:
 
         created_by = _parse_created_by(d.pop("created_by"))
 
-        def _parse_description(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
+        created_at = isoparse(d.pop("created_at"))
 
-        description = _parse_description(d.pop("description"))
-
-        id = UUID(d.pop("id"))
-
-        layer_count = d.pop("layer_count")
+        updated_at = isoparse(d.pop("updated_at"))
 
         layers = []
         _layers = d.pop("layers")
@@ -305,22 +320,16 @@ class MapResponse:
 
             layers.append(layers_item)
 
-        name = d.pop("name")
+        layer_count = d.pop("layer_count")
 
-        pitch = d.pop("pitch")
-
-        show_basemap_labels = d.pop("show_basemap_labels")
-
-        updated_at = isoparse(d.pop("updated_at"))
-
-        visibility = check_map_visibility(d.pop("visibility"))
-
-        def _parse_zoom(data: object) -> float | None:
+        def _parse_notes(data: object) -> None | str | Unset:
             if data is None:
                 return data
-            return cast(float | None, data)
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
 
-        zoom = _parse_zoom(d.pop("zoom"))
+        notes = _parse_notes(d.pop("notes", UNSET))
 
         def _parse_basemap_config(data: object) -> BasemapConfig | None | Unset:
             if data is None:
@@ -338,87 +347,6 @@ class MapResponse:
             return cast(BasemapConfig | None | Unset, data)
 
         basemap_config = _parse_basemap_config(d.pop("basemap_config", UNSET))
-
-        def _parse_created_by_username(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        created_by_username = _parse_created_by_username(
-            d.pop("created_by_username", UNSET)
-        )
-
-        def _parse_forked_from_id(data: object) -> None | Unset | UUID:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                forked_from_id_type_0 = UUID(data)
-
-                return forked_from_id_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | Unset | UUID, data)
-
-        forked_from_id = _parse_forked_from_id(d.pop("forked_from_id", UNSET))
-
-        def _parse_forked_from_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        forked_from_name = _parse_forked_from_name(d.pop("forked_from_name", UNSET))
-
-        def _parse_legend_title(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        legend_title = _parse_legend_title(d.pop("legend_title", UNSET))
-
-        def _parse_notes(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        notes = _parse_notes(d.pop("notes", UNSET))
-
-        def _parse_og_image_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        og_image_url = _parse_og_image_url(d.pop("og_image_url", UNSET))
-
-        def _parse_plugins(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                plugins_type_0 = cast(list[str], data)
-
-                return plugins_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        plugins = _parse_plugins(d.pop("plugins", UNSET))
 
         def _parse_terrain_config(data: object) -> None | TerrainConfig | Unset:
             if data is None:
@@ -446,33 +374,105 @@ class MapResponse:
 
         thumbnail_url = _parse_thumbnail_url(d.pop("thumbnail_url", UNSET))
 
+        def _parse_og_image_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        og_image_url = _parse_og_image_url(d.pop("og_image_url", UNSET))
+
+        def _parse_forked_from_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                forked_from_id_type_0 = UUID(data)
+
+                return forked_from_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        forked_from_id = _parse_forked_from_id(d.pop("forked_from_id", UNSET))
+
+        def _parse_forked_from_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        forked_from_name = _parse_forked_from_name(d.pop("forked_from_name", UNSET))
+
+        def _parse_created_by_username(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        created_by_username = _parse_created_by_username(
+            d.pop("created_by_username", UNSET)
+        )
+
+        def _parse_plugins(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                plugins_type_0 = cast(list[str], data)
+
+                return plugins_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        plugins = _parse_plugins(d.pop("plugins", UNSET))
+
+        def _parse_legend_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        legend_title = _parse_legend_title(d.pop("legend_title", UNSET))
+
         map_response = cls(
-            basemap_style=basemap_style,
-            bearing=bearing,
-            center_lat=center_lat,
-            center_lng=center_lng,
-            created_at=created_at,
-            created_by=created_by,
-            description=description,
             id=id,
-            layer_count=layer_count,
-            layers=layers,
             name=name,
-            pitch=pitch,
-            show_basemap_labels=show_basemap_labels,
-            updated_at=updated_at,
-            visibility=visibility,
+            description=description,
+            center_lng=center_lng,
+            center_lat=center_lat,
             zoom=zoom,
-            basemap_config=basemap_config,
-            created_by_username=created_by_username,
-            forked_from_id=forked_from_id,
-            forked_from_name=forked_from_name,
-            legend_title=legend_title,
+            bearing=bearing,
+            pitch=pitch,
+            basemap_style=basemap_style,
+            show_basemap_labels=show_basemap_labels,
+            visibility=visibility,
+            created_by=created_by,
+            created_at=created_at,
+            updated_at=updated_at,
+            layers=layers,
+            layer_count=layer_count,
             notes=notes,
-            og_image_url=og_image_url,
-            plugins=plugins,
+            basemap_config=basemap_config,
             terrain_config=terrain_config,
             thumbnail_url=thumbnail_url,
+            og_image_url=og_image_url,
+            forked_from_id=forked_from_id,
+            forked_from_name=forked_from_name,
+            created_by_username=created_by_username,
+            plugins=plugins,
+            legend_title=legend_title,
         )
 
         map_response.additional_properties = d

--- a/sdks/python/geolens/models/map_style_import_request.py
+++ b/sdks/python/geolens/models/map_style_import_request.py
@@ -43,33 +43,33 @@ class MapStyleImportRequest:
     openapi-python-client generate a navigable named model class.
 
         Attributes:
-            bearing (float | None | Unset):
-            center (list[float] | None | Unset): [longitude, latitude] map center
-            glyphs (None | str | Unset):
-            layers (list[MapStyleImportRequestLayersType0Item] | None | Unset): MapLibre layer specifications
+            version (int | None | Unset): MapLibre style version (always 8 in current spec)
+            name (None | str | Unset): Display name for the imported map
             metadata (MapStyleImportRequestMetadataType0 | None | Unset): Free-form metadata bag (used by GeoLens for
                 center/zoom/basemap hints)
-            name (None | str | Unset): Display name for the imported map
+            center (list[float] | None | Unset): [longitude, latitude] map center
+            zoom (float | None | Unset):
+            bearing (float | None | Unset):
             pitch (float | None | Unset):
             sources (MapStyleImportRequestSourcesType0 | None | Unset): MapLibre sources object keyed by source id
             sprite (None | str | Unset):
+            glyphs (None | str | Unset):
             terrain (MapStyleImportRequestTerrainType0 | None | Unset): MapLibre terrain config (source + exaggeration)
-            version (int | None | Unset): MapLibre style version (always 8 in current spec)
-            zoom (float | None | Unset):
+            layers (list[MapStyleImportRequestLayersType0Item] | None | Unset): MapLibre layer specifications
     """
 
-    bearing: float | None | Unset = UNSET
-    center: list[float] | None | Unset = UNSET
-    glyphs: None | str | Unset = UNSET
-    layers: list[MapStyleImportRequestLayersType0Item] | None | Unset = UNSET
-    metadata: MapStyleImportRequestMetadataType0 | None | Unset = UNSET
+    version: int | None | Unset = UNSET
     name: None | str | Unset = UNSET
+    metadata: MapStyleImportRequestMetadataType0 | None | Unset = UNSET
+    center: list[float] | None | Unset = UNSET
+    zoom: float | None | Unset = UNSET
+    bearing: float | None | Unset = UNSET
     pitch: float | None | Unset = UNSET
     sources: MapStyleImportRequestSourcesType0 | None | Unset = UNSET
     sprite: None | str | Unset = UNSET
+    glyphs: None | str | Unset = UNSET
     terrain: MapStyleImportRequestTerrainType0 | None | Unset = UNSET
-    version: int | None | Unset = UNSET
-    zoom: float | None | Unset = UNSET
+    layers: list[MapStyleImportRequestLayersType0Item] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -83,11 +83,25 @@ class MapStyleImportRequest:
             MapStyleImportRequestTerrainType0,
         )
 
-        bearing: float | None | Unset
-        if isinstance(self.bearing, Unset):
-            bearing = UNSET
+        version: int | None | Unset
+        if isinstance(self.version, Unset):
+            version = UNSET
         else:
-            bearing = self.bearing
+            version = self.version
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, MapStyleImportRequestMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
 
         center: list[float] | None | Unset
         if isinstance(self.center, Unset):
@@ -98,37 +112,17 @@ class MapStyleImportRequest:
         else:
             center = self.center
 
-        glyphs: None | str | Unset
-        if isinstance(self.glyphs, Unset):
-            glyphs = UNSET
+        zoom: float | None | Unset
+        if isinstance(self.zoom, Unset):
+            zoom = UNSET
         else:
-            glyphs = self.glyphs
+            zoom = self.zoom
 
-        layers: list[dict[str, Any]] | None | Unset
-        if isinstance(self.layers, Unset):
-            layers = UNSET
-        elif isinstance(self.layers, list):
-            layers = []
-            for layers_type_0_item_data in self.layers:
-                layers_type_0_item = layers_type_0_item_data.to_dict()
-                layers.append(layers_type_0_item)
-
+        bearing: float | None | Unset
+        if isinstance(self.bearing, Unset):
+            bearing = UNSET
         else:
-            layers = self.layers
-
-        metadata: dict[str, Any] | None | Unset
-        if isinstance(self.metadata, Unset):
-            metadata = UNSET
-        elif isinstance(self.metadata, MapStyleImportRequestMetadataType0):
-            metadata = self.metadata.to_dict()
-        else:
-            metadata = self.metadata
-
-        name: None | str | Unset
-        if isinstance(self.name, Unset):
-            name = UNSET
-        else:
-            name = self.name
+            bearing = self.bearing
 
         pitch: float | None | Unset
         if isinstance(self.pitch, Unset):
@@ -150,6 +144,12 @@ class MapStyleImportRequest:
         else:
             sprite = self.sprite
 
+        glyphs: None | str | Unset
+        if isinstance(self.glyphs, Unset):
+            glyphs = UNSET
+        else:
+            glyphs = self.glyphs
+
         terrain: dict[str, Any] | None | Unset
         if isinstance(self.terrain, Unset):
             terrain = UNSET
@@ -158,45 +158,45 @@ class MapStyleImportRequest:
         else:
             terrain = self.terrain
 
-        version: int | None | Unset
-        if isinstance(self.version, Unset):
-            version = UNSET
-        else:
-            version = self.version
+        layers: list[dict[str, Any]] | None | Unset
+        if isinstance(self.layers, Unset):
+            layers = UNSET
+        elif isinstance(self.layers, list):
+            layers = []
+            for layers_type_0_item_data in self.layers:
+                layers_type_0_item = layers_type_0_item_data.to_dict()
+                layers.append(layers_type_0_item)
 
-        zoom: float | None | Unset
-        if isinstance(self.zoom, Unset):
-            zoom = UNSET
         else:
-            zoom = self.zoom
+            layers = self.layers
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if bearing is not UNSET:
-            field_dict["bearing"] = bearing
-        if center is not UNSET:
-            field_dict["center"] = center
-        if glyphs is not UNSET:
-            field_dict["glyphs"] = glyphs
-        if layers is not UNSET:
-            field_dict["layers"] = layers
-        if metadata is not UNSET:
-            field_dict["metadata"] = metadata
+        if version is not UNSET:
+            field_dict["version"] = version
         if name is not UNSET:
             field_dict["name"] = name
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if center is not UNSET:
+            field_dict["center"] = center
+        if zoom is not UNSET:
+            field_dict["zoom"] = zoom
+        if bearing is not UNSET:
+            field_dict["bearing"] = bearing
         if pitch is not UNSET:
             field_dict["pitch"] = pitch
         if sources is not UNSET:
             field_dict["sources"] = sources
         if sprite is not UNSET:
             field_dict["sprite"] = sprite
+        if glyphs is not UNSET:
+            field_dict["glyphs"] = glyphs
         if terrain is not UNSET:
             field_dict["terrain"] = terrain
-        if version is not UNSET:
-            field_dict["version"] = version
-        if zoom is not UNSET:
-            field_dict["zoom"] = zoom
+        if layers is not UNSET:
+            field_dict["layers"] = layers
 
         return field_dict
 
@@ -217,66 +217,23 @@ class MapStyleImportRequest:
 
         d = dict(src_dict)
 
-        def _parse_bearing(data: object) -> float | None | Unset:
+        def _parse_version(data: object) -> int | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(float | None | Unset, data)
+            return cast(int | None | Unset, data)
 
-        bearing = _parse_bearing(d.pop("bearing", UNSET))
+        version = _parse_version(d.pop("version", UNSET))
 
-        def _parse_center(data: object) -> list[float] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                center_type_0 = cast(list[float], data)
-
-                return center_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[float] | None | Unset, data)
-
-        center = _parse_center(d.pop("center", UNSET))
-
-        def _parse_glyphs(data: object) -> None | str | Unset:
+        def _parse_name(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        glyphs = _parse_glyphs(d.pop("glyphs", UNSET))
-
-        def _parse_layers(
-            data: object,
-        ) -> list[MapStyleImportRequestLayersType0Item] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                layers_type_0 = []
-                _layers_type_0 = data
-                for layers_type_0_item_data in _layers_type_0:
-                    layers_type_0_item = MapStyleImportRequestLayersType0Item.from_dict(
-                        layers_type_0_item_data
-                    )
-
-                    layers_type_0.append(layers_type_0_item)
-
-                return layers_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[MapStyleImportRequestLayersType0Item] | None | Unset, data)
-
-        layers = _parse_layers(d.pop("layers", UNSET))
+        name = _parse_name(d.pop("name", UNSET))
 
         def _parse_metadata(
             data: object,
@@ -297,14 +254,40 @@ class MapStyleImportRequest:
 
         metadata = _parse_metadata(d.pop("metadata", UNSET))
 
-        def _parse_name(data: object) -> None | str | Unset:
+        def _parse_center(data: object) -> list[float] | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(None | str | Unset, data)
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                center_type_0 = cast(list[float], data)
 
-        name = _parse_name(d.pop("name", UNSET))
+                return center_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[float] | None | Unset, data)
+
+        center = _parse_center(d.pop("center", UNSET))
+
+        def _parse_zoom(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        zoom = _parse_zoom(d.pop("zoom", UNSET))
+
+        def _parse_bearing(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        bearing = _parse_bearing(d.pop("bearing", UNSET))
 
         def _parse_pitch(data: object) -> float | None | Unset:
             if data is None:
@@ -343,6 +326,15 @@ class MapStyleImportRequest:
 
         sprite = _parse_sprite(d.pop("sprite", UNSET))
 
+        def _parse_glyphs(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        glyphs = _parse_glyphs(d.pop("glyphs", UNSET))
+
         def _parse_terrain(
             data: object,
         ) -> MapStyleImportRequestTerrainType0 | None | Unset:
@@ -362,37 +354,45 @@ class MapStyleImportRequest:
 
         terrain = _parse_terrain(d.pop("terrain", UNSET))
 
-        def _parse_version(data: object) -> int | None | Unset:
+        def _parse_layers(
+            data: object,
+        ) -> list[MapStyleImportRequestLayersType0Item] | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(int | None | Unset, data)
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                layers_type_0 = []
+                _layers_type_0 = data
+                for layers_type_0_item_data in _layers_type_0:
+                    layers_type_0_item = MapStyleImportRequestLayersType0Item.from_dict(
+                        layers_type_0_item_data
+                    )
 
-        version = _parse_version(d.pop("version", UNSET))
+                    layers_type_0.append(layers_type_0_item)
 
-        def _parse_zoom(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
+                return layers_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[MapStyleImportRequestLayersType0Item] | None | Unset, data)
 
-        zoom = _parse_zoom(d.pop("zoom", UNSET))
+        layers = _parse_layers(d.pop("layers", UNSET))
 
         map_style_import_request = cls(
-            bearing=bearing,
-            center=center,
-            glyphs=glyphs,
-            layers=layers,
-            metadata=metadata,
+            version=version,
             name=name,
+            metadata=metadata,
+            center=center,
+            zoom=zoom,
+            bearing=bearing,
             pitch=pitch,
             sources=sources,
             sprite=sprite,
+            glyphs=glyphs,
             terrain=terrain,
-            version=version,
-            zoom=zoom,
+            layers=layers,
         )
 
         map_style_import_request.additional_properties = d

--- a/sdks/python/geolens/models/map_style_import_summary.py
+++ b/sdks/python/geolens/models/map_style_import_summary.py
@@ -20,28 +20,28 @@ T = TypeVar("T", bound="MapStyleImportSummary")
 class MapStyleImportSummary:
     """
     Attributes:
-        layers_imported (int | Unset):  Default: 0.
-        layers_skipped (int | Unset):  Default: 0.
         sources_matched (int | Unset):  Default: 0.
         sources_unsupported (int | Unset):  Default: 0.
+        layers_imported (int | Unset):  Default: 0.
+        layers_skipped (int | Unset):  Default: 0.
         warnings (list[MapStyleImportWarning] | Unset):
     """
 
-    layers_imported: int | Unset = 0
-    layers_skipped: int | Unset = 0
     sources_matched: int | Unset = 0
     sources_unsupported: int | Unset = 0
+    layers_imported: int | Unset = 0
+    layers_skipped: int | Unset = 0
     warnings: list[MapStyleImportWarning] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        layers_imported = self.layers_imported
-
-        layers_skipped = self.layers_skipped
-
         sources_matched = self.sources_matched
 
         sources_unsupported = self.sources_unsupported
+
+        layers_imported = self.layers_imported
+
+        layers_skipped = self.layers_skipped
 
         warnings: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.warnings, Unset):
@@ -53,14 +53,14 @@ class MapStyleImportSummary:
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if layers_imported is not UNSET:
-            field_dict["layers_imported"] = layers_imported
-        if layers_skipped is not UNSET:
-            field_dict["layers_skipped"] = layers_skipped
         if sources_matched is not UNSET:
             field_dict["sources_matched"] = sources_matched
         if sources_unsupported is not UNSET:
             field_dict["sources_unsupported"] = sources_unsupported
+        if layers_imported is not UNSET:
+            field_dict["layers_imported"] = layers_imported
+        if layers_skipped is not UNSET:
+            field_dict["layers_skipped"] = layers_skipped
         if warnings is not UNSET:
             field_dict["warnings"] = warnings
 
@@ -71,13 +71,13 @@ class MapStyleImportSummary:
         from ..models.map_style_import_warning import MapStyleImportWarning
 
         d = dict(src_dict)
-        layers_imported = d.pop("layers_imported", UNSET)
-
-        layers_skipped = d.pop("layers_skipped", UNSET)
-
         sources_matched = d.pop("sources_matched", UNSET)
 
         sources_unsupported = d.pop("sources_unsupported", UNSET)
+
+        layers_imported = d.pop("layers_imported", UNSET)
+
+        layers_skipped = d.pop("layers_skipped", UNSET)
 
         _warnings = d.pop("warnings", UNSET)
         warnings: list[MapStyleImportWarning] | Unset = UNSET
@@ -89,10 +89,10 @@ class MapStyleImportSummary:
                 warnings.append(warnings_item)
 
         map_style_import_summary = cls(
-            layers_imported=layers_imported,
-            layers_skipped=layers_skipped,
             sources_matched=sources_matched,
             sources_unsupported=sources_unsupported,
+            layers_imported=layers_imported,
+            layers_skipped=layers_skipped,
             warnings=warnings,
         )
 

--- a/sdks/python/geolens/models/map_style_import_warning.py
+++ b/sdks/python/geolens/models/map_style_import_warning.py
@@ -20,14 +20,14 @@ class MapStyleImportWarning:
     Attributes:
         code (str):
         message (str):
-        layer_id (None | str | Unset):
         source_id (None | str | Unset):
+        layer_id (None | str | Unset):
     """
 
     code: str
     message: str
-    layer_id: None | str | Unset = UNSET
     source_id: None | str | Unset = UNSET
+    layer_id: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -35,17 +35,17 @@ class MapStyleImportWarning:
 
         message = self.message
 
-        layer_id: None | str | Unset
-        if isinstance(self.layer_id, Unset):
-            layer_id = UNSET
-        else:
-            layer_id = self.layer_id
-
         source_id: None | str | Unset
         if isinstance(self.source_id, Unset):
             source_id = UNSET
         else:
             source_id = self.source_id
+
+        layer_id: None | str | Unset
+        if isinstance(self.layer_id, Unset):
+            layer_id = UNSET
+        else:
+            layer_id = self.layer_id
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -55,10 +55,10 @@ class MapStyleImportWarning:
                 "message": message,
             }
         )
-        if layer_id is not UNSET:
-            field_dict["layer_id"] = layer_id
         if source_id is not UNSET:
             field_dict["source_id"] = source_id
+        if layer_id is not UNSET:
+            field_dict["layer_id"] = layer_id
 
         return field_dict
 
@@ -69,15 +69,6 @@ class MapStyleImportWarning:
 
         message = d.pop("message")
 
-        def _parse_layer_id(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        layer_id = _parse_layer_id(d.pop("layer_id", UNSET))
-
         def _parse_source_id(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -87,11 +78,20 @@ class MapStyleImportWarning:
 
         source_id = _parse_source_id(d.pop("source_id", UNSET))
 
+        def _parse_layer_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        layer_id = _parse_layer_id(d.pop("layer_id", UNSET))
+
         map_style_import_warning = cls(
             code=code,
             message=message,
-            layer_id=layer_id,
             source_id=source_id,
+            layer_id=layer_id,
         )
 
         map_style_import_warning.additional_properties = d

--- a/sdks/python/geolens/models/map_summary_response.py
+++ b/sdks/python/geolens/models/map_summary_response.py
@@ -23,51 +23,51 @@ T = TypeVar("T", bound="MapSummaryResponse")
 class MapSummaryResponse:
     """
     Attributes:
-        created_at (datetime.datetime):
-        description (None | str):
         id (UUID):
-        layer_count (int):
         name (str):
-        updated_at (datetime.datetime):
+        description (None | str):
         visibility (MapVisibility):
-        created_by_username (None | str | Unset):
-        thumbnail_updated_at (datetime.datetime | None | Unset):
+        layer_count (int):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
         thumbnail_url (None | str | Unset):
+        thumbnail_updated_at (datetime.datetime | None | Unset):
+        created_by_username (None | str | Unset):
     """
 
-    created_at: datetime.datetime
-    description: None | str
     id: UUID
-    layer_count: int
     name: str
-    updated_at: datetime.datetime
+    description: None | str
     visibility: MapVisibility
-    created_by_username: None | str | Unset = UNSET
-    thumbnail_updated_at: datetime.datetime | None | Unset = UNSET
+    layer_count: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
     thumbnail_url: None | str | Unset = UNSET
+    thumbnail_updated_at: datetime.datetime | None | Unset = UNSET
+    created_by_username: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
+        id = str(self.id)
+
+        name = self.name
 
         description: None | str
         description = self.description
 
-        id = str(self.id)
+        visibility: str = self.visibility
 
         layer_count = self.layer_count
 
-        name = self.name
+        created_at = self.created_at.isoformat()
 
         updated_at = self.updated_at.isoformat()
 
-        visibility: str = self.visibility
-
-        created_by_username: None | str | Unset
-        if isinstance(self.created_by_username, Unset):
-            created_by_username = UNSET
+        thumbnail_url: None | str | Unset
+        if isinstance(self.thumbnail_url, Unset):
+            thumbnail_url = UNSET
         else:
-            created_by_username = self.created_by_username
+            thumbnail_url = self.thumbnail_url
 
         thumbnail_updated_at: None | str | Unset
         if isinstance(self.thumbnail_updated_at, Unset):
@@ -77,38 +77,40 @@ class MapSummaryResponse:
         else:
             thumbnail_updated_at = self.thumbnail_updated_at
 
-        thumbnail_url: None | str | Unset
-        if isinstance(self.thumbnail_url, Unset):
-            thumbnail_url = UNSET
+        created_by_username: None | str | Unset
+        if isinstance(self.created_by_username, Unset):
+            created_by_username = UNSET
         else:
-            thumbnail_url = self.thumbnail_url
+            created_by_username = self.created_by_username
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "description": description,
                 "id": id,
-                "layer_count": layer_count,
                 "name": name,
-                "updated_at": updated_at,
+                "description": description,
                 "visibility": visibility,
+                "layer_count": layer_count,
+                "created_at": created_at,
+                "updated_at": updated_at,
             }
         )
-        if created_by_username is not UNSET:
-            field_dict["created_by_username"] = created_by_username
-        if thumbnail_updated_at is not UNSET:
-            field_dict["thumbnail_updated_at"] = thumbnail_updated_at
         if thumbnail_url is not UNSET:
             field_dict["thumbnail_url"] = thumbnail_url
+        if thumbnail_updated_at is not UNSET:
+            field_dict["thumbnail_updated_at"] = thumbnail_updated_at
+        if created_by_username is not UNSET:
+            field_dict["created_by_username"] = created_by_username
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
+        id = UUID(d.pop("id"))
+
+        name = d.pop("name")
 
         def _parse_description(data: object) -> None | str:
             if data is None:
@@ -117,26 +119,22 @@ class MapSummaryResponse:
 
         description = _parse_description(d.pop("description"))
 
-        id = UUID(d.pop("id"))
+        visibility = check_map_visibility(d.pop("visibility"))
 
         layer_count = d.pop("layer_count")
 
-        name = d.pop("name")
+        created_at = isoparse(d.pop("created_at"))
 
         updated_at = isoparse(d.pop("updated_at"))
 
-        visibility = check_map_visibility(d.pop("visibility"))
-
-        def _parse_created_by_username(data: object) -> None | str | Unset:
+        def _parse_thumbnail_url(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        created_by_username = _parse_created_by_username(
-            d.pop("created_by_username", UNSET)
-        )
+        thumbnail_url = _parse_thumbnail_url(d.pop("thumbnail_url", UNSET))
 
         def _parse_thumbnail_updated_at(
             data: object,
@@ -159,26 +157,28 @@ class MapSummaryResponse:
             d.pop("thumbnail_updated_at", UNSET)
         )
 
-        def _parse_thumbnail_url(data: object) -> None | str | Unset:
+        def _parse_created_by_username(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        thumbnail_url = _parse_thumbnail_url(d.pop("thumbnail_url", UNSET))
+        created_by_username = _parse_created_by_username(
+            d.pop("created_by_username", UNSET)
+        )
 
         map_summary_response = cls(
-            created_at=created_at,
-            description=description,
             id=id,
-            layer_count=layer_count,
             name=name,
-            updated_at=updated_at,
+            description=description,
             visibility=visibility,
-            created_by_username=created_by_username,
-            thumbnail_updated_at=thumbnail_updated_at,
+            layer_count=layer_count,
+            created_at=created_at,
+            updated_at=updated_at,
             thumbnail_url=thumbnail_url,
+            thumbnail_updated_at=thumbnail_updated_at,
+            created_by_username=created_by_username,
         )
 
         map_summary_response.additional_properties = d

--- a/sdks/python/geolens/models/map_update.py
+++ b/sdks/python/geolens/models/map_update.py
@@ -25,46 +25,106 @@ T = TypeVar("T", bound="MapUpdate")
 class MapUpdate:
     """
     Attributes:
-        basemap_config (BasemapConfig | None | Unset): Curated map-level basemap appearance preferences
-        basemap_style (None | str | Unset): Basemap style ID or URL
-        bearing (float | None | Unset): Map rotation in degrees
-        center_lat (float | None | Unset): Map center latitude
-        center_lng (float | None | Unset): Map center longitude
-        description (None | str | Unset):
-        layers (list[MapLayerInput] | None | Unset): Full replacement layer list (max 200 layers)
-        legend_title (None | str | Unset): Custom map-level legend title. Null/empty leaves the legend without a heading
-            override (ENH-06).
         name (None | str | Unset):
+        description (None | str | Unset):
         notes (None | str | Unset):
+        center_lng (float | None | Unset): Map center longitude
+        center_lat (float | None | Unset): Map center latitude
+        zoom (float | None | Unset): Map zoom level
+        bearing (float | None | Unset): Map rotation in degrees
         pitch (float | None | Unset): Map tilt in degrees (0-85)
-        plugins (list[str] | None | Unset): Enabled plugin IDs, e.g. ['measurement']
+        basemap_style (None | str | Unset): Basemap style ID or URL
         show_basemap_labels (bool | None | Unset):
+        basemap_config (BasemapConfig | None | Unset): Curated map-level basemap appearance preferences
         terrain_config (None | TerrainConfig | Unset): Map-level terrain source and exaggeration preferences
         visibility (MapVisibility | None | Unset): private, internal, or public
-        zoom (float | None | Unset): Map zoom level
+        layers (list[MapLayerInput] | None | Unset): Full replacement layer list (max 200 layers)
+        plugins (list[str] | None | Unset): Enabled plugin IDs, e.g. ['measurement']
+        legend_title (None | str | Unset): Custom map-level legend title. Null/empty leaves the legend without a heading
+            override (ENH-06).
     """
 
-    basemap_config: BasemapConfig | None | Unset = UNSET
-    basemap_style: None | str | Unset = UNSET
-    bearing: float | None | Unset = UNSET
-    center_lat: float | None | Unset = UNSET
-    center_lng: float | None | Unset = UNSET
-    description: None | str | Unset = UNSET
-    layers: list[MapLayerInput] | None | Unset = UNSET
-    legend_title: None | str | Unset = UNSET
     name: None | str | Unset = UNSET
+    description: None | str | Unset = UNSET
     notes: None | str | Unset = UNSET
+    center_lng: float | None | Unset = UNSET
+    center_lat: float | None | Unset = UNSET
+    zoom: float | None | Unset = UNSET
+    bearing: float | None | Unset = UNSET
     pitch: float | None | Unset = UNSET
-    plugins: list[str] | None | Unset = UNSET
+    basemap_style: None | str | Unset = UNSET
     show_basemap_labels: bool | None | Unset = UNSET
+    basemap_config: BasemapConfig | None | Unset = UNSET
     terrain_config: None | TerrainConfig | Unset = UNSET
     visibility: MapVisibility | None | Unset = UNSET
-    zoom: float | None | Unset = UNSET
+    layers: list[MapLayerInput] | None | Unset = UNSET
+    plugins: list[str] | None | Unset = UNSET
+    legend_title: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.basemap_config import BasemapConfig
         from ..models.terrain_config import TerrainConfig
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        notes: None | str | Unset
+        if isinstance(self.notes, Unset):
+            notes = UNSET
+        else:
+            notes = self.notes
+
+        center_lng: float | None | Unset
+        if isinstance(self.center_lng, Unset):
+            center_lng = UNSET
+        else:
+            center_lng = self.center_lng
+
+        center_lat: float | None | Unset
+        if isinstance(self.center_lat, Unset):
+            center_lat = UNSET
+        else:
+            center_lat = self.center_lat
+
+        zoom: float | None | Unset
+        if isinstance(self.zoom, Unset):
+            zoom = UNSET
+        else:
+            zoom = self.zoom
+
+        bearing: float | None | Unset
+        if isinstance(self.bearing, Unset):
+            bearing = UNSET
+        else:
+            bearing = self.bearing
+
+        pitch: float | None | Unset
+        if isinstance(self.pitch, Unset):
+            pitch = UNSET
+        else:
+            pitch = self.pitch
+
+        basemap_style: None | str | Unset
+        if isinstance(self.basemap_style, Unset):
+            basemap_style = UNSET
+        else:
+            basemap_style = self.basemap_style
+
+        show_basemap_labels: bool | None | Unset
+        if isinstance(self.show_basemap_labels, Unset):
+            show_basemap_labels = UNSET
+        else:
+            show_basemap_labels = self.show_basemap_labels
 
         basemap_config: dict[str, Any] | None | Unset
         if isinstance(self.basemap_config, Unset):
@@ -73,87 +133,6 @@ class MapUpdate:
             basemap_config = self.basemap_config.to_dict()
         else:
             basemap_config = self.basemap_config
-
-        basemap_style: None | str | Unset
-        if isinstance(self.basemap_style, Unset):
-            basemap_style = UNSET
-        else:
-            basemap_style = self.basemap_style
-
-        bearing: float | None | Unset
-        if isinstance(self.bearing, Unset):
-            bearing = UNSET
-        else:
-            bearing = self.bearing
-
-        center_lat: float | None | Unset
-        if isinstance(self.center_lat, Unset):
-            center_lat = UNSET
-        else:
-            center_lat = self.center_lat
-
-        center_lng: float | None | Unset
-        if isinstance(self.center_lng, Unset):
-            center_lng = UNSET
-        else:
-            center_lng = self.center_lng
-
-        description: None | str | Unset
-        if isinstance(self.description, Unset):
-            description = UNSET
-        else:
-            description = self.description
-
-        layers: list[dict[str, Any]] | None | Unset
-        if isinstance(self.layers, Unset):
-            layers = UNSET
-        elif isinstance(self.layers, list):
-            layers = []
-            for layers_type_0_item_data in self.layers:
-                layers_type_0_item = layers_type_0_item_data.to_dict()
-                layers.append(layers_type_0_item)
-
-        else:
-            layers = self.layers
-
-        legend_title: None | str | Unset
-        if isinstance(self.legend_title, Unset):
-            legend_title = UNSET
-        else:
-            legend_title = self.legend_title
-
-        name: None | str | Unset
-        if isinstance(self.name, Unset):
-            name = UNSET
-        else:
-            name = self.name
-
-        notes: None | str | Unset
-        if isinstance(self.notes, Unset):
-            notes = UNSET
-        else:
-            notes = self.notes
-
-        pitch: float | None | Unset
-        if isinstance(self.pitch, Unset):
-            pitch = UNSET
-        else:
-            pitch = self.pitch
-
-        plugins: list[str] | None | Unset
-        if isinstance(self.plugins, Unset):
-            plugins = UNSET
-        elif isinstance(self.plugins, list):
-            plugins = self.plugins
-
-        else:
-            plugins = self.plugins
-
-        show_basemap_labels: bool | None | Unset
-        if isinstance(self.show_basemap_labels, Unset):
-            show_basemap_labels = UNSET
-        else:
-            show_basemap_labels = self.show_basemap_labels
 
         terrain_config: dict[str, Any] | None | Unset
         if isinstance(self.terrain_config, Unset):
@@ -171,47 +150,68 @@ class MapUpdate:
         else:
             visibility = self.visibility
 
-        zoom: float | None | Unset
-        if isinstance(self.zoom, Unset):
-            zoom = UNSET
+        layers: list[dict[str, Any]] | None | Unset
+        if isinstance(self.layers, Unset):
+            layers = UNSET
+        elif isinstance(self.layers, list):
+            layers = []
+            for layers_type_0_item_data in self.layers:
+                layers_type_0_item = layers_type_0_item_data.to_dict()
+                layers.append(layers_type_0_item)
+
         else:
-            zoom = self.zoom
+            layers = self.layers
+
+        plugins: list[str] | None | Unset
+        if isinstance(self.plugins, Unset):
+            plugins = UNSET
+        elif isinstance(self.plugins, list):
+            plugins = self.plugins
+
+        else:
+            plugins = self.plugins
+
+        legend_title: None | str | Unset
+        if isinstance(self.legend_title, Unset):
+            legend_title = UNSET
+        else:
+            legend_title = self.legend_title
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if basemap_config is not UNSET:
-            field_dict["basemap_config"] = basemap_config
-        if basemap_style is not UNSET:
-            field_dict["basemap_style"] = basemap_style
-        if bearing is not UNSET:
-            field_dict["bearing"] = bearing
-        if center_lat is not UNSET:
-            field_dict["center_lat"] = center_lat
-        if center_lng is not UNSET:
-            field_dict["center_lng"] = center_lng
-        if description is not UNSET:
-            field_dict["description"] = description
-        if layers is not UNSET:
-            field_dict["layers"] = layers
-        if legend_title is not UNSET:
-            field_dict["legend_title"] = legend_title
         if name is not UNSET:
             field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
         if notes is not UNSET:
             field_dict["notes"] = notes
+        if center_lng is not UNSET:
+            field_dict["center_lng"] = center_lng
+        if center_lat is not UNSET:
+            field_dict["center_lat"] = center_lat
+        if zoom is not UNSET:
+            field_dict["zoom"] = zoom
+        if bearing is not UNSET:
+            field_dict["bearing"] = bearing
         if pitch is not UNSET:
             field_dict["pitch"] = pitch
-        if plugins is not UNSET:
-            field_dict["plugins"] = plugins
+        if basemap_style is not UNSET:
+            field_dict["basemap_style"] = basemap_style
         if show_basemap_labels is not UNSET:
             field_dict["show_basemap_labels"] = show_basemap_labels
+        if basemap_config is not UNSET:
+            field_dict["basemap_config"] = basemap_config
         if terrain_config is not UNSET:
             field_dict["terrain_config"] = terrain_config
         if visibility is not UNSET:
             field_dict["visibility"] = visibility
-        if zoom is not UNSET:
-            field_dict["zoom"] = zoom
+        if layers is not UNSET:
+            field_dict["layers"] = layers
+        if plugins is not UNSET:
+            field_dict["plugins"] = plugins
+        if legend_title is not UNSET:
+            field_dict["legend_title"] = legend_title
 
         return field_dict
 
@@ -222,6 +222,98 @@ class MapUpdate:
         from ..models.terrain_config import TerrainConfig
 
         d = dict(src_dict)
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_notes(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        notes = _parse_notes(d.pop("notes", UNSET))
+
+        def _parse_center_lng(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        center_lng = _parse_center_lng(d.pop("center_lng", UNSET))
+
+        def _parse_center_lat(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        center_lat = _parse_center_lat(d.pop("center_lat", UNSET))
+
+        def _parse_zoom(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        zoom = _parse_zoom(d.pop("zoom", UNSET))
+
+        def _parse_bearing(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        bearing = _parse_bearing(d.pop("bearing", UNSET))
+
+        def _parse_pitch(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        pitch = _parse_pitch(d.pop("pitch", UNSET))
+
+        def _parse_basemap_style(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        basemap_style = _parse_basemap_style(d.pop("basemap_style", UNSET))
+
+        def _parse_show_basemap_labels(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        show_basemap_labels = _parse_show_basemap_labels(
+            d.pop("show_basemap_labels", UNSET)
+        )
 
         def _parse_basemap_config(data: object) -> BasemapConfig | None | Unset:
             if data is None:
@@ -239,139 +331,6 @@ class MapUpdate:
             return cast(BasemapConfig | None | Unset, data)
 
         basemap_config = _parse_basemap_config(d.pop("basemap_config", UNSET))
-
-        def _parse_basemap_style(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        basemap_style = _parse_basemap_style(d.pop("basemap_style", UNSET))
-
-        def _parse_bearing(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        bearing = _parse_bearing(d.pop("bearing", UNSET))
-
-        def _parse_center_lat(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        center_lat = _parse_center_lat(d.pop("center_lat", UNSET))
-
-        def _parse_center_lng(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        center_lng = _parse_center_lng(d.pop("center_lng", UNSET))
-
-        def _parse_description(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        description = _parse_description(d.pop("description", UNSET))
-
-        def _parse_layers(data: object) -> list[MapLayerInput] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                layers_type_0 = []
-                _layers_type_0 = data
-                for layers_type_0_item_data in _layers_type_0:
-                    layers_type_0_item = MapLayerInput.from_dict(
-                        layers_type_0_item_data
-                    )
-
-                    layers_type_0.append(layers_type_0_item)
-
-                return layers_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[MapLayerInput] | None | Unset, data)
-
-        layers = _parse_layers(d.pop("layers", UNSET))
-
-        def _parse_legend_title(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        legend_title = _parse_legend_title(d.pop("legend_title", UNSET))
-
-        def _parse_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        name = _parse_name(d.pop("name", UNSET))
-
-        def _parse_notes(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        notes = _parse_notes(d.pop("notes", UNSET))
-
-        def _parse_pitch(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        pitch = _parse_pitch(d.pop("pitch", UNSET))
-
-        def _parse_plugins(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                plugins_type_0 = cast(list[str], data)
-
-                return plugins_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        plugins = _parse_plugins(d.pop("plugins", UNSET))
-
-        def _parse_show_basemap_labels(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        show_basemap_labels = _parse_show_basemap_labels(
-            d.pop("show_basemap_labels", UNSET)
-        )
 
         def _parse_terrain_config(data: object) -> None | TerrainConfig | Unset:
             if data is None:
@@ -407,32 +366,73 @@ class MapUpdate:
 
         visibility = _parse_visibility(d.pop("visibility", UNSET))
 
-        def _parse_zoom(data: object) -> float | None | Unset:
+        def _parse_layers(data: object) -> list[MapLayerInput] | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(float | None | Unset, data)
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                layers_type_0 = []
+                _layers_type_0 = data
+                for layers_type_0_item_data in _layers_type_0:
+                    layers_type_0_item = MapLayerInput.from_dict(
+                        layers_type_0_item_data
+                    )
 
-        zoom = _parse_zoom(d.pop("zoom", UNSET))
+                    layers_type_0.append(layers_type_0_item)
+
+                return layers_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[MapLayerInput] | None | Unset, data)
+
+        layers = _parse_layers(d.pop("layers", UNSET))
+
+        def _parse_plugins(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                plugins_type_0 = cast(list[str], data)
+
+                return plugins_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        plugins = _parse_plugins(d.pop("plugins", UNSET))
+
+        def _parse_legend_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        legend_title = _parse_legend_title(d.pop("legend_title", UNSET))
 
         map_update = cls(
-            basemap_config=basemap_config,
-            basemap_style=basemap_style,
-            bearing=bearing,
-            center_lat=center_lat,
-            center_lng=center_lng,
-            description=description,
-            layers=layers,
-            legend_title=legend_title,
             name=name,
+            description=description,
             notes=notes,
+            center_lng=center_lng,
+            center_lat=center_lat,
+            zoom=zoom,
+            bearing=bearing,
             pitch=pitch,
-            plugins=plugins,
+            basemap_style=basemap_style,
             show_basemap_labels=show_basemap_labels,
+            basemap_config=basemap_config,
             terrain_config=terrain_config,
             visibility=visibility,
-            zoom=zoom,
+            layers=layers,
+            plugins=plugins,
+            legend_title=legend_title,
         )
 
         map_update.additional_properties = d

--- a/sdks/python/geolens/models/mercator_clip_detail.py
+++ b/sdks/python/geolens/models/mercator_clip_detail.py
@@ -25,19 +25,19 @@ class MercatorClipDetail:
     reduced form.
 
         Attributes:
-            clipped_features (int):
             dropped_features (int):
+            clipped_features (int):
             clip_skipped (bool | Unset):  Default: False.
     """
 
-    clipped_features: int
     dropped_features: int
+    clipped_features: int
     clip_skipped: bool | Unset = False
 
     def to_dict(self) -> dict[str, Any]:
-        clipped_features = self.clipped_features
-
         dropped_features = self.dropped_features
+
+        clipped_features = self.clipped_features
 
         clip_skipped = self.clip_skipped
 
@@ -45,8 +45,8 @@ class MercatorClipDetail:
 
         field_dict.update(
             {
-                "clipped_features": clipped_features,
                 "dropped_features": dropped_features,
+                "clipped_features": clipped_features,
             }
         )
         if clip_skipped is not UNSET:
@@ -57,15 +57,15 @@ class MercatorClipDetail:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        clipped_features = d.pop("clipped_features")
-
         dropped_features = d.pop("dropped_features")
+
+        clipped_features = d.pop("clipped_features")
 
         clip_skipped = d.pop("clip_skipped", UNSET)
 
         mercator_clip_detail = cls(
-            clipped_features=clipped_features,
             dropped_features=dropped_features,
+            clipped_features=clipped_features,
             clip_skipped=clip_skipped,
         )
 

--- a/sdks/python/geolens/models/mercator_clip_warning.py
+++ b/sdks/python/geolens/models/mercator_clip_warning.py
@@ -20,6 +20,7 @@ T = TypeVar("T", bound="MercatorClipWarning")
 class MercatorClipWarning:
     """
     Attributes:
+        kind (Literal['mercator_clip']):
         details (MercatorClipDetail): fix(#888): how much geometry the Web Mercator clamp destroyed.
 
             The clamp is a box, not a latitude cutoff: longitude -180 to 180 and
@@ -30,23 +31,22 @@ class MercatorClipWarning:
             ``dropped_features`` lost their geometry entirely (a valid point at lat
             -89.95 becomes ``MULTIPOINT EMPTY``); ``clipped_features`` survived in
             reduced form.
-        kind (Literal['mercator_clip']):
     """
 
-    details: MercatorClipDetail
     kind: Literal["mercator_clip"]
+    details: MercatorClipDetail
 
     def to_dict(self) -> dict[str, Any]:
-        details = self.details.to_dict()
-
         kind = self.kind
+
+        details = self.details.to_dict()
 
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
             {
-                "details": details,
                 "kind": kind,
+                "details": details,
             }
         )
 
@@ -57,15 +57,15 @@ class MercatorClipWarning:
         from ..models.mercator_clip_detail import MercatorClipDetail
 
         d = dict(src_dict)
-        details = MercatorClipDetail.from_dict(d.pop("details"))
-
         kind = cast(Literal["mercator_clip"], d.pop("kind"))
         if kind != "mercator_clip":
             raise ValueError(f"kind must match const 'mercator_clip', got '{kind}'")
 
+        details = MercatorClipDetail.from_dict(d.pop("details"))
+
         mercator_clip_warning = cls(
-            details=details,
             kind=kind,
+            details=details,
         )
 
         return mercator_clip_warning

--- a/sdks/python/geolens/models/notification_test_response.py
+++ b/sdks/python/geolens/models/notification_test_response.py
@@ -23,18 +23,20 @@ class NotificationTestResponse:
     values (T-1229-09 / NOTIF-05).
 
         Attributes:
+            sent (bool): True if at least one channel successfully delivered the test notification.
             channels (list[NotificationTestChannelResult]): Per-channel delivery results. Empty when no channel is
                 configured.
             message (str): Human-readable summary of the test result.
-            sent (bool): True if at least one channel successfully delivered the test notification.
     """
 
+    sent: bool
     channels: list[NotificationTestChannelResult]
     message: str
-    sent: bool
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        sent = self.sent
+
         channels = []
         for channels_item_data in self.channels:
             channels_item = channels_item_data.to_dict()
@@ -42,15 +44,13 @@ class NotificationTestResponse:
 
         message = self.message
 
-        sent = self.sent
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "sent": sent,
                 "channels": channels,
                 "message": message,
-                "sent": sent,
             }
         )
 
@@ -63,6 +63,8 @@ class NotificationTestResponse:
         )
 
         d = dict(src_dict)
+        sent = d.pop("sent")
+
         channels = []
         _channels = d.pop("channels")
         for channels_item_data in _channels:
@@ -72,12 +74,10 @@ class NotificationTestResponse:
 
         message = d.pop("message")
 
-        sent = d.pop("sent")
-
         notification_test_response = cls(
+            sent=sent,
             channels=channels,
             message=message,
-            sent=sent,
         )
 
         notification_test_response.additional_properties = d

--- a/sdks/python/geolens/models/o_auth_provider_create.py
+++ b/sdks/python/geolens/models/o_auth_provider_create.py
@@ -30,56 +30,56 @@ class OAuthProviderCreate:
     """Schema for creating a new OAuth provider.
 
     Attributes:
+        slug (str): URL-safe identifier used in callback URLs (e.g. 'google', 'azure-ad'). Lowercase, digits, and
+            hyphens only.
         display_name (str): Human-readable label shown on the login page button.
         provider_type (OAuthProviderCreateProviderType): OAuth or SAML provider type. 'google' and 'microsoft' auto-
             populate the discovery URL; 'oidc' is generic OAuth/OIDC; 'github' uses GitHub's fixed OAuth2 endpoints (no
             discovery URL); 'saml' is available only on SAML-enabled deployments.
-        slug (str): URL-safe identifier used in callback URLs (e.g. 'google', 'azure-ad'). Lowercase, digits, and
-            hyphens only.
-        authorize_url (None | str | Unset): Authorization endpoint. Only needed when discovery_url is not set.
         client_id (None | str | Unset): OAuth client ID issued by the IdP. Required for OAuth/OIDC providers; omit for
             SAML.
         client_secret (None | str | Unset): OAuth client secret issued by the IdP. Stored encrypted; never returned in
             responses. Required for OAuth/OIDC providers; omit for SAML.
-        default_role (str | Unset): Role assigned to new users created via this provider: 'viewer', 'editor', or
-            'admin'. Default: 'viewer'.
         discovery_url (None | str | Unset): OIDC discovery URL ending in `.well-known/openid-configuration`. Auto-
             populated for Google and Microsoft.
-        enabled (bool | Unset): Whether the provider button appears on the login page. Default: True.
+        authorize_url (None | str | Unset): Authorization endpoint. Only needed when discovery_url is not set.
+        token_url (None | str | Unset): Token endpoint. Only needed when discovery_url is not set.
+        userinfo_url (None | str | Unset): Userinfo endpoint. Only needed when discovery_url is not set.
+        idp_entity_id (None | str | Unset): SAML IdP entityID. Required for SAML providers.
+        idp_sso_url (None | str | Unset): SAML IdP SSO URL (HTTP-Redirect or HTTP-POST binding). Required for SAML
+            providers.
+        idp_certificate (None | str | Unset): SAML IdP signing certificate (PEM). Required for SAML providers. Stored
+            Fernet-encrypted at rest; never returned in responses.
+        sp_entity_id (None | str | Unset): SP entityID for this provider. Required for SAML providers. Default
+            suggestion: {public_api_url}/auth/saml/{slug}.
+        scopes (str | Unset): Space-separated OAuth scopes. Default: 'openid profile email'.
+        default_role (str | Unset): Role assigned to new users created via this provider: 'viewer', 'editor', or
+            'admin'. Default: 'viewer'.
         group_claim (None | str | Unset): Name of the JWT/userinfo claim (or SAML attribute) that contains group
             memberships. Set to enable group-based role mapping.
         group_role_mapping (None | OAuthProviderCreateGroupRoleMappingType0 | Unset): JSON object mapping IdP group
             names to GeoLens roles. First match wins. Falls back to default_role if no group matches.
-        idp_certificate (None | str | Unset): SAML IdP signing certificate (PEM). Required for SAML providers. Stored
-            Fernet-encrypted at rest; never returned in responses.
-        idp_entity_id (None | str | Unset): SAML IdP entityID. Required for SAML providers.
-        idp_sso_url (None | str | Unset): SAML IdP SSO URL (HTTP-Redirect or HTTP-POST binding). Required for SAML
-            providers.
-        scopes (str | Unset): Space-separated OAuth scopes. Default: 'openid profile email'.
-        sp_entity_id (None | str | Unset): SP entityID for this provider. Required for SAML providers. Default
-            suggestion: {public_api_url}/auth/saml/{slug}.
-        token_url (None | str | Unset): Token endpoint. Only needed when discovery_url is not set.
-        userinfo_url (None | str | Unset): Userinfo endpoint. Only needed when discovery_url is not set.
+        enabled (bool | Unset): Whether the provider button appears on the login page. Default: True.
     """
 
+    slug: str
     display_name: str
     provider_type: OAuthProviderCreateProviderType
-    slug: str
-    authorize_url: None | str | Unset = UNSET
     client_id: None | str | Unset = UNSET
     client_secret: None | str | Unset = UNSET
-    default_role: str | Unset = "viewer"
     discovery_url: None | str | Unset = UNSET
-    enabled: bool | Unset = True
-    group_claim: None | str | Unset = UNSET
-    group_role_mapping: None | OAuthProviderCreateGroupRoleMappingType0 | Unset = UNSET
-    idp_certificate: None | str | Unset = UNSET
-    idp_entity_id: None | str | Unset = UNSET
-    idp_sso_url: None | str | Unset = UNSET
-    scopes: str | Unset = "openid profile email"
-    sp_entity_id: None | str | Unset = UNSET
+    authorize_url: None | str | Unset = UNSET
     token_url: None | str | Unset = UNSET
     userinfo_url: None | str | Unset = UNSET
+    idp_entity_id: None | str | Unset = UNSET
+    idp_sso_url: None | str | Unset = UNSET
+    idp_certificate: None | str | Unset = UNSET
+    sp_entity_id: None | str | Unset = UNSET
+    scopes: str | Unset = "openid profile email"
+    default_role: str | Unset = "viewer"
+    group_claim: None | str | Unset = UNSET
+    group_role_mapping: None | OAuthProviderCreateGroupRoleMappingType0 | Unset = UNSET
+    enabled: bool | Unset = True
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -87,17 +87,11 @@ class OAuthProviderCreate:
             OAuthProviderCreateGroupRoleMappingType0,
         )
 
+        slug = self.slug
+
         display_name = self.display_name
 
         provider_type: str = self.provider_type
-
-        slug = self.slug
-
-        authorize_url: None | str | Unset
-        if isinstance(self.authorize_url, Unset):
-            authorize_url = UNSET
-        else:
-            authorize_url = self.authorize_url
 
         client_id: None | str | Unset
         if isinstance(self.client_id, Unset):
@@ -111,15 +105,57 @@ class OAuthProviderCreate:
         else:
             client_secret = self.client_secret
 
-        default_role = self.default_role
-
         discovery_url: None | str | Unset
         if isinstance(self.discovery_url, Unset):
             discovery_url = UNSET
         else:
             discovery_url = self.discovery_url
 
-        enabled = self.enabled
+        authorize_url: None | str | Unset
+        if isinstance(self.authorize_url, Unset):
+            authorize_url = UNSET
+        else:
+            authorize_url = self.authorize_url
+
+        token_url: None | str | Unset
+        if isinstance(self.token_url, Unset):
+            token_url = UNSET
+        else:
+            token_url = self.token_url
+
+        userinfo_url: None | str | Unset
+        if isinstance(self.userinfo_url, Unset):
+            userinfo_url = UNSET
+        else:
+            userinfo_url = self.userinfo_url
+
+        idp_entity_id: None | str | Unset
+        if isinstance(self.idp_entity_id, Unset):
+            idp_entity_id = UNSET
+        else:
+            idp_entity_id = self.idp_entity_id
+
+        idp_sso_url: None | str | Unset
+        if isinstance(self.idp_sso_url, Unset):
+            idp_sso_url = UNSET
+        else:
+            idp_sso_url = self.idp_sso_url
+
+        idp_certificate: None | str | Unset
+        if isinstance(self.idp_certificate, Unset):
+            idp_certificate = UNSET
+        else:
+            idp_certificate = self.idp_certificate
+
+        sp_entity_id: None | str | Unset
+        if isinstance(self.sp_entity_id, Unset):
+            sp_entity_id = UNSET
+        else:
+            sp_entity_id = self.sp_entity_id
+
+        scopes = self.scopes
+
+        default_role = self.default_role
 
         group_claim: None | str | Unset
         if isinstance(self.group_claim, Unset):
@@ -137,83 +173,47 @@ class OAuthProviderCreate:
         else:
             group_role_mapping = self.group_role_mapping
 
-        idp_certificate: None | str | Unset
-        if isinstance(self.idp_certificate, Unset):
-            idp_certificate = UNSET
-        else:
-            idp_certificate = self.idp_certificate
-
-        idp_entity_id: None | str | Unset
-        if isinstance(self.idp_entity_id, Unset):
-            idp_entity_id = UNSET
-        else:
-            idp_entity_id = self.idp_entity_id
-
-        idp_sso_url: None | str | Unset
-        if isinstance(self.idp_sso_url, Unset):
-            idp_sso_url = UNSET
-        else:
-            idp_sso_url = self.idp_sso_url
-
-        scopes = self.scopes
-
-        sp_entity_id: None | str | Unset
-        if isinstance(self.sp_entity_id, Unset):
-            sp_entity_id = UNSET
-        else:
-            sp_entity_id = self.sp_entity_id
-
-        token_url: None | str | Unset
-        if isinstance(self.token_url, Unset):
-            token_url = UNSET
-        else:
-            token_url = self.token_url
-
-        userinfo_url: None | str | Unset
-        if isinstance(self.userinfo_url, Unset):
-            userinfo_url = UNSET
-        else:
-            userinfo_url = self.userinfo_url
+        enabled = self.enabled
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "slug": slug,
                 "display_name": display_name,
                 "provider_type": provider_type,
-                "slug": slug,
             }
         )
-        if authorize_url is not UNSET:
-            field_dict["authorize_url"] = authorize_url
         if client_id is not UNSET:
             field_dict["client_id"] = client_id
         if client_secret is not UNSET:
             field_dict["client_secret"] = client_secret
-        if default_role is not UNSET:
-            field_dict["default_role"] = default_role
         if discovery_url is not UNSET:
             field_dict["discovery_url"] = discovery_url
-        if enabled is not UNSET:
-            field_dict["enabled"] = enabled
-        if group_claim is not UNSET:
-            field_dict["group_claim"] = group_claim
-        if group_role_mapping is not UNSET:
-            field_dict["group_role_mapping"] = group_role_mapping
-        if idp_certificate is not UNSET:
-            field_dict["idp_certificate"] = idp_certificate
-        if idp_entity_id is not UNSET:
-            field_dict["idp_entity_id"] = idp_entity_id
-        if idp_sso_url is not UNSET:
-            field_dict["idp_sso_url"] = idp_sso_url
-        if scopes is not UNSET:
-            field_dict["scopes"] = scopes
-        if sp_entity_id is not UNSET:
-            field_dict["sp_entity_id"] = sp_entity_id
+        if authorize_url is not UNSET:
+            field_dict["authorize_url"] = authorize_url
         if token_url is not UNSET:
             field_dict["token_url"] = token_url
         if userinfo_url is not UNSET:
             field_dict["userinfo_url"] = userinfo_url
+        if idp_entity_id is not UNSET:
+            field_dict["idp_entity_id"] = idp_entity_id
+        if idp_sso_url is not UNSET:
+            field_dict["idp_sso_url"] = idp_sso_url
+        if idp_certificate is not UNSET:
+            field_dict["idp_certificate"] = idp_certificate
+        if sp_entity_id is not UNSET:
+            field_dict["sp_entity_id"] = sp_entity_id
+        if scopes is not UNSET:
+            field_dict["scopes"] = scopes
+        if default_role is not UNSET:
+            field_dict["default_role"] = default_role
+        if group_claim is not UNSET:
+            field_dict["group_claim"] = group_claim
+        if group_role_mapping is not UNSET:
+            field_dict["group_role_mapping"] = group_role_mapping
+        if enabled is not UNSET:
+            field_dict["enabled"] = enabled
 
         return field_dict
 
@@ -224,22 +224,13 @@ class OAuthProviderCreate:
         )
 
         d = dict(src_dict)
+        slug = d.pop("slug")
+
         display_name = d.pop("display_name")
 
         provider_type = check_o_auth_provider_create_provider_type(
             d.pop("provider_type")
         )
-
-        slug = d.pop("slug")
-
-        def _parse_authorize_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        authorize_url = _parse_authorize_url(d.pop("authorize_url", UNSET))
 
         def _parse_client_id(data: object) -> None | str | Unset:
             if data is None:
@@ -259,8 +250,6 @@ class OAuthProviderCreate:
 
         client_secret = _parse_client_secret(d.pop("client_secret", UNSET))
 
-        default_role = d.pop("default_role", UNSET)
-
         def _parse_discovery_url(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -270,7 +259,72 @@ class OAuthProviderCreate:
 
         discovery_url = _parse_discovery_url(d.pop("discovery_url", UNSET))
 
-        enabled = d.pop("enabled", UNSET)
+        def _parse_authorize_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        authorize_url = _parse_authorize_url(d.pop("authorize_url", UNSET))
+
+        def _parse_token_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        token_url = _parse_token_url(d.pop("token_url", UNSET))
+
+        def _parse_userinfo_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        userinfo_url = _parse_userinfo_url(d.pop("userinfo_url", UNSET))
+
+        def _parse_idp_entity_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        idp_entity_id = _parse_idp_entity_id(d.pop("idp_entity_id", UNSET))
+
+        def _parse_idp_sso_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        idp_sso_url = _parse_idp_sso_url(d.pop("idp_sso_url", UNSET))
+
+        def _parse_idp_certificate(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        idp_certificate = _parse_idp_certificate(d.pop("idp_certificate", UNSET))
+
+        def _parse_sp_entity_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        sp_entity_id = _parse_sp_entity_id(d.pop("sp_entity_id", UNSET))
+
+        scopes = d.pop("scopes", UNSET)
+
+        default_role = d.pop("default_role", UNSET)
 
         def _parse_group_claim(data: object) -> None | str | Unset:
             if data is None:
@@ -304,81 +358,27 @@ class OAuthProviderCreate:
             d.pop("group_role_mapping", UNSET)
         )
 
-        def _parse_idp_certificate(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        idp_certificate = _parse_idp_certificate(d.pop("idp_certificate", UNSET))
-
-        def _parse_idp_entity_id(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        idp_entity_id = _parse_idp_entity_id(d.pop("idp_entity_id", UNSET))
-
-        def _parse_idp_sso_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        idp_sso_url = _parse_idp_sso_url(d.pop("idp_sso_url", UNSET))
-
-        scopes = d.pop("scopes", UNSET)
-
-        def _parse_sp_entity_id(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        sp_entity_id = _parse_sp_entity_id(d.pop("sp_entity_id", UNSET))
-
-        def _parse_token_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        token_url = _parse_token_url(d.pop("token_url", UNSET))
-
-        def _parse_userinfo_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        userinfo_url = _parse_userinfo_url(d.pop("userinfo_url", UNSET))
+        enabled = d.pop("enabled", UNSET)
 
         o_auth_provider_create = cls(
+            slug=slug,
             display_name=display_name,
             provider_type=provider_type,
-            slug=slug,
-            authorize_url=authorize_url,
             client_id=client_id,
             client_secret=client_secret,
-            default_role=default_role,
             discovery_url=discovery_url,
-            enabled=enabled,
-            group_claim=group_claim,
-            group_role_mapping=group_role_mapping,
-            idp_certificate=idp_certificate,
-            idp_entity_id=idp_entity_id,
-            idp_sso_url=idp_sso_url,
-            scopes=scopes,
-            sp_entity_id=sp_entity_id,
+            authorize_url=authorize_url,
             token_url=token_url,
             userinfo_url=userinfo_url,
+            idp_entity_id=idp_entity_id,
+            idp_sso_url=idp_sso_url,
+            idp_certificate=idp_certificate,
+            sp_entity_id=sp_entity_id,
+            scopes=scopes,
+            default_role=default_role,
+            group_claim=group_claim,
+            group_role_mapping=group_role_mapping,
+            enabled=enabled,
         )
 
         o_auth_provider_create.additional_properties = d

--- a/sdks/python/geolens/models/o_auth_provider_public.py
+++ b/sdks/python/geolens/models/o_auth_provider_public.py
@@ -15,30 +15,30 @@ class OAuthProviderPublic:
     """Minimal provider info for the login page (no secrets, no config).
 
     Attributes:
+        slug (str): URL-safe identifier used in the callback URL.
         display_name (str): Label shown on the login page button.
         provider_type (str): Provider type, used by the frontend to pick the right icon.
-        slug (str): URL-safe identifier used in the callback URL.
     """
 
+    slug: str
     display_name: str
     provider_type: str
-    slug: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        slug = self.slug
+
         display_name = self.display_name
 
         provider_type = self.provider_type
-
-        slug = self.slug
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "slug": slug,
                 "display_name": display_name,
                 "provider_type": provider_type,
-                "slug": slug,
             }
         )
 
@@ -47,16 +47,16 @@ class OAuthProviderPublic:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        slug = d.pop("slug")
+
         display_name = d.pop("display_name")
 
         provider_type = d.pop("provider_type")
 
-        slug = d.pop("slug")
-
         o_auth_provider_public = cls(
+            slug=slug,
             display_name=display_name,
             provider_type=provider_type,
-            slug=slug,
         )
 
         o_auth_provider_public.additional_properties = d

--- a/sdks/python/geolens/models/o_auth_provider_response.py
+++ b/sdks/python/geolens/models/o_auth_provider_response.py
@@ -43,49 +43,49 @@ class OAuthProviderResponse:
     that need the values must use ``undefer_group("saml")`` at query time.
 
         Attributes:
-            created_at (datetime.datetime): Timestamp the provider was created.
-            default_role (str): Default role assigned to new users.
-            display_name (str): Label shown on the login page button.
-            enabled (bool): Whether the provider button appears on the login page.
             id (UUID): Unique provider identifier.
+            slug (str): URL-safe identifier used in the callback URL.
+            display_name (str): Label shown on the login page button.
             provider_type (str): Provider type: 'google', 'microsoft', 'oidc', or 'saml'.
             scopes (str): Space-separated OAuth scopes.
-            slug (str): URL-safe identifier used in the callback URL.
+            default_role (str): Default role assigned to new users.
+            enabled (bool): Whether the provider button appears on the login page.
+            created_at (datetime.datetime): Timestamp the provider was created.
             updated_at (datetime.datetime): Timestamp the provider was last updated.
-            authorize_url (None | str | Unset): Authorization endpoint.
             client_id (None | str | Unset): OAuth client ID. Visible to admins; never exposes client_secret. Null for SAML
                 providers.
             discovery_url (None | str | Unset): OIDC discovery URL.
-            group_claim (None | str | Unset): Claim name used for group-based role mapping.
-            group_role_mapping (None | OAuthProviderResponseGroupRoleMappingType0 | Unset): Group-to-role mapping rules.
+            authorize_url (None | str | Unset): Authorization endpoint.
+            token_url (None | str | Unset): Token endpoint.
+            userinfo_url (None | str | Unset): Userinfo endpoint.
             idp_entity_id (None | str | Unset): SAML IdP entityID (SAML providers only).
             idp_sso_url (None | str | Unset): SAML IdP SSO URL (SAML providers only).
             sp_entity_id (None | str | Unset): SP entityID for this SAML provider (SAML providers only).
-            token_url (None | str | Unset): Token endpoint.
-            userinfo_url (None | str | Unset): Userinfo endpoint.
+            group_claim (None | str | Unset): Claim name used for group-based role mapping.
+            group_role_mapping (None | OAuthProviderResponseGroupRoleMappingType0 | Unset): Group-to-role mapping rules.
     """
 
-    created_at: datetime.datetime
-    default_role: str
-    display_name: str
-    enabled: bool
     id: UUID
+    slug: str
+    display_name: str
     provider_type: str
     scopes: str
-    slug: str
+    default_role: str
+    enabled: bool
+    created_at: datetime.datetime
     updated_at: datetime.datetime
-    authorize_url: None | str | Unset = UNSET
     client_id: None | str | Unset = UNSET
     discovery_url: None | str | Unset = UNSET
+    authorize_url: None | str | Unset = UNSET
+    token_url: None | str | Unset = UNSET
+    userinfo_url: None | str | Unset = UNSET
+    idp_entity_id: None | str | Unset = UNSET
+    idp_sso_url: None | str | Unset = UNSET
+    sp_entity_id: None | str | Unset = UNSET
     group_claim: None | str | Unset = UNSET
     group_role_mapping: None | OAuthProviderResponseGroupRoleMappingType0 | Unset = (
         UNSET
     )
-    idp_entity_id: None | str | Unset = UNSET
-    idp_sso_url: None | str | Unset = UNSET
-    sp_entity_id: None | str | Unset = UNSET
-    token_url: None | str | Unset = UNSET
-    userinfo_url: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -93,29 +93,23 @@ class OAuthProviderResponse:
             OAuthProviderResponseGroupRoleMappingType0,
         )
 
-        created_at = self.created_at.isoformat()
+        id = str(self.id)
 
-        default_role = self.default_role
+        slug = self.slug
 
         display_name = self.display_name
-
-        enabled = self.enabled
-
-        id = str(self.id)
 
         provider_type = self.provider_type
 
         scopes = self.scopes
 
-        slug = self.slug
+        default_role = self.default_role
+
+        enabled = self.enabled
+
+        created_at = self.created_at.isoformat()
 
         updated_at = self.updated_at.isoformat()
-
-        authorize_url: None | str | Unset
-        if isinstance(self.authorize_url, Unset):
-            authorize_url = UNSET
-        else:
-            authorize_url = self.authorize_url
 
         client_id: None | str | Unset
         if isinstance(self.client_id, Unset):
@@ -129,21 +123,23 @@ class OAuthProviderResponse:
         else:
             discovery_url = self.discovery_url
 
-        group_claim: None | str | Unset
-        if isinstance(self.group_claim, Unset):
-            group_claim = UNSET
+        authorize_url: None | str | Unset
+        if isinstance(self.authorize_url, Unset):
+            authorize_url = UNSET
         else:
-            group_claim = self.group_claim
+            authorize_url = self.authorize_url
 
-        group_role_mapping: dict[str, Any] | None | Unset
-        if isinstance(self.group_role_mapping, Unset):
-            group_role_mapping = UNSET
-        elif isinstance(
-            self.group_role_mapping, OAuthProviderResponseGroupRoleMappingType0
-        ):
-            group_role_mapping = self.group_role_mapping.to_dict()
+        token_url: None | str | Unset
+        if isinstance(self.token_url, Unset):
+            token_url = UNSET
         else:
-            group_role_mapping = self.group_role_mapping
+            token_url = self.token_url
+
+        userinfo_url: None | str | Unset
+        if isinstance(self.userinfo_url, Unset):
+            userinfo_url = UNSET
+        else:
+            userinfo_url = self.userinfo_url
 
         idp_entity_id: None | str | Unset
         if isinstance(self.idp_entity_id, Unset):
@@ -163,53 +159,57 @@ class OAuthProviderResponse:
         else:
             sp_entity_id = self.sp_entity_id
 
-        token_url: None | str | Unset
-        if isinstance(self.token_url, Unset):
-            token_url = UNSET
+        group_claim: None | str | Unset
+        if isinstance(self.group_claim, Unset):
+            group_claim = UNSET
         else:
-            token_url = self.token_url
+            group_claim = self.group_claim
 
-        userinfo_url: None | str | Unset
-        if isinstance(self.userinfo_url, Unset):
-            userinfo_url = UNSET
+        group_role_mapping: dict[str, Any] | None | Unset
+        if isinstance(self.group_role_mapping, Unset):
+            group_role_mapping = UNSET
+        elif isinstance(
+            self.group_role_mapping, OAuthProviderResponseGroupRoleMappingType0
+        ):
+            group_role_mapping = self.group_role_mapping.to_dict()
         else:
-            userinfo_url = self.userinfo_url
+            group_role_mapping = self.group_role_mapping
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "default_role": default_role,
-                "display_name": display_name,
-                "enabled": enabled,
                 "id": id,
+                "slug": slug,
+                "display_name": display_name,
                 "provider_type": provider_type,
                 "scopes": scopes,
-                "slug": slug,
+                "default_role": default_role,
+                "enabled": enabled,
+                "created_at": created_at,
                 "updated_at": updated_at,
             }
         )
-        if authorize_url is not UNSET:
-            field_dict["authorize_url"] = authorize_url
         if client_id is not UNSET:
             field_dict["client_id"] = client_id
         if discovery_url is not UNSET:
             field_dict["discovery_url"] = discovery_url
-        if group_claim is not UNSET:
-            field_dict["group_claim"] = group_claim
-        if group_role_mapping is not UNSET:
-            field_dict["group_role_mapping"] = group_role_mapping
+        if authorize_url is not UNSET:
+            field_dict["authorize_url"] = authorize_url
+        if token_url is not UNSET:
+            field_dict["token_url"] = token_url
+        if userinfo_url is not UNSET:
+            field_dict["userinfo_url"] = userinfo_url
         if idp_entity_id is not UNSET:
             field_dict["idp_entity_id"] = idp_entity_id
         if idp_sso_url is not UNSET:
             field_dict["idp_sso_url"] = idp_sso_url
         if sp_entity_id is not UNSET:
             field_dict["sp_entity_id"] = sp_entity_id
-        if token_url is not UNSET:
-            field_dict["token_url"] = token_url
-        if userinfo_url is not UNSET:
-            field_dict["userinfo_url"] = userinfo_url
+        if group_claim is not UNSET:
+            field_dict["group_claim"] = group_claim
+        if group_role_mapping is not UNSET:
+            field_dict["group_role_mapping"] = group_role_mapping
 
         return field_dict
 
@@ -220,32 +220,23 @@ class OAuthProviderResponse:
         )
 
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
+        id = UUID(d.pop("id"))
 
-        default_role = d.pop("default_role")
+        slug = d.pop("slug")
 
         display_name = d.pop("display_name")
-
-        enabled = d.pop("enabled")
-
-        id = UUID(d.pop("id"))
 
         provider_type = d.pop("provider_type")
 
         scopes = d.pop("scopes")
 
-        slug = d.pop("slug")
+        default_role = d.pop("default_role")
+
+        enabled = d.pop("enabled")
+
+        created_at = isoparse(d.pop("created_at"))
 
         updated_at = isoparse(d.pop("updated_at"))
-
-        def _parse_authorize_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        authorize_url = _parse_authorize_url(d.pop("authorize_url", UNSET))
 
         def _parse_client_id(data: object) -> None | str | Unset:
             if data is None:
@@ -264,6 +255,60 @@ class OAuthProviderResponse:
             return cast(None | str | Unset, data)
 
         discovery_url = _parse_discovery_url(d.pop("discovery_url", UNSET))
+
+        def _parse_authorize_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        authorize_url = _parse_authorize_url(d.pop("authorize_url", UNSET))
+
+        def _parse_token_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        token_url = _parse_token_url(d.pop("token_url", UNSET))
+
+        def _parse_userinfo_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        userinfo_url = _parse_userinfo_url(d.pop("userinfo_url", UNSET))
+
+        def _parse_idp_entity_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        idp_entity_id = _parse_idp_entity_id(d.pop("idp_entity_id", UNSET))
+
+        def _parse_idp_sso_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        idp_sso_url = _parse_idp_sso_url(d.pop("idp_sso_url", UNSET))
+
+        def _parse_sp_entity_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        sp_entity_id = _parse_sp_entity_id(d.pop("sp_entity_id", UNSET))
 
         def _parse_group_claim(data: object) -> None | str | Unset:
             if data is None:
@@ -297,71 +342,26 @@ class OAuthProviderResponse:
             d.pop("group_role_mapping", UNSET)
         )
 
-        def _parse_idp_entity_id(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        idp_entity_id = _parse_idp_entity_id(d.pop("idp_entity_id", UNSET))
-
-        def _parse_idp_sso_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        idp_sso_url = _parse_idp_sso_url(d.pop("idp_sso_url", UNSET))
-
-        def _parse_sp_entity_id(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        sp_entity_id = _parse_sp_entity_id(d.pop("sp_entity_id", UNSET))
-
-        def _parse_token_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        token_url = _parse_token_url(d.pop("token_url", UNSET))
-
-        def _parse_userinfo_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        userinfo_url = _parse_userinfo_url(d.pop("userinfo_url", UNSET))
-
         o_auth_provider_response = cls(
-            created_at=created_at,
-            default_role=default_role,
-            display_name=display_name,
-            enabled=enabled,
             id=id,
+            slug=slug,
+            display_name=display_name,
             provider_type=provider_type,
             scopes=scopes,
-            slug=slug,
+            default_role=default_role,
+            enabled=enabled,
+            created_at=created_at,
             updated_at=updated_at,
-            authorize_url=authorize_url,
             client_id=client_id,
             discovery_url=discovery_url,
-            group_claim=group_claim,
-            group_role_mapping=group_role_mapping,
+            authorize_url=authorize_url,
+            token_url=token_url,
+            userinfo_url=userinfo_url,
             idp_entity_id=idp_entity_id,
             idp_sso_url=idp_sso_url,
             sp_entity_id=sp_entity_id,
-            token_url=token_url,
-            userinfo_url=userinfo_url,
+            group_claim=group_claim,
+            group_role_mapping=group_role_mapping,
         )
 
         o_auth_provider_response.additional_properties = d

--- a/sdks/python/geolens/models/o_auth_provider_update.py
+++ b/sdks/python/geolens/models/o_auth_provider_update.py
@@ -30,48 +30,48 @@ class OAuthProviderUpdate:
     """Schema for updating an existing OAuth provider. All fields optional.
 
     Attributes:
-        authorize_url (None | str | Unset): Updated authorization endpoint.
+        slug (None | str | Unset): New slug. Changes the callback URL — coordinate with the IdP before updating.
+        display_name (None | str | Unset): New display label.
+        provider_type (None | OAuthProviderUpdateProviderTypeType0 | Unset): New provider type. Rarely changed after
+            creation.
         client_id (None | str | Unset): New client ID. Set when rotating credentials.
         client_secret (None | str | Unset): New client secret. Omit to leave unchanged; setting this rotates the stored
             secret.
-        default_role (None | str | Unset): Updated default role for new users.
         discovery_url (None | str | Unset): Updated OIDC discovery URL.
-        display_name (None | str | Unset): New display label.
-        enabled (bool | None | Unset): Set to false to hide the provider button without deleting the configuration.
+        authorize_url (None | str | Unset): Updated authorization endpoint.
+        token_url (None | str | Unset): Updated token endpoint.
+        userinfo_url (None | str | Unset): Updated userinfo endpoint.
+        idp_entity_id (None | str | Unset): Updated SAML IdP entityID.
+        idp_sso_url (None | str | Unset): Updated SAML IdP SSO URL.
+        idp_certificate (None | str | Unset): Updated SAML IdP signing certificate (PEM). Setting this rotates the
+            stored cert; omit to leave unchanged.
+        sp_entity_id (None | str | Unset): Updated SP entityID.
+        scopes (None | str | Unset): Updated space-separated scopes.
+        default_role (None | str | Unset): Updated default role for new users.
         group_claim (None | str | Unset): Updated group claim name.
         group_role_mapping (None | OAuthProviderUpdateGroupRoleMappingType0 | Unset): Updated group-to-role mapping.
             Pass an empty object to clear.
-        idp_certificate (None | str | Unset): Updated SAML IdP signing certificate (PEM). Setting this rotates the
-            stored cert; omit to leave unchanged.
-        idp_entity_id (None | str | Unset): Updated SAML IdP entityID.
-        idp_sso_url (None | str | Unset): Updated SAML IdP SSO URL.
-        provider_type (None | OAuthProviderUpdateProviderTypeType0 | Unset): New provider type. Rarely changed after
-            creation.
-        scopes (None | str | Unset): Updated space-separated scopes.
-        slug (None | str | Unset): New slug. Changes the callback URL — coordinate with the IdP before updating.
-        sp_entity_id (None | str | Unset): Updated SP entityID.
-        token_url (None | str | Unset): Updated token endpoint.
-        userinfo_url (None | str | Unset): Updated userinfo endpoint.
+        enabled (bool | None | Unset): Set to false to hide the provider button without deleting the configuration.
     """
 
-    authorize_url: None | str | Unset = UNSET
+    slug: None | str | Unset = UNSET
+    display_name: None | str | Unset = UNSET
+    provider_type: None | OAuthProviderUpdateProviderTypeType0 | Unset = UNSET
     client_id: None | str | Unset = UNSET
     client_secret: None | str | Unset = UNSET
-    default_role: None | str | Unset = UNSET
     discovery_url: None | str | Unset = UNSET
-    display_name: None | str | Unset = UNSET
-    enabled: bool | None | Unset = UNSET
-    group_claim: None | str | Unset = UNSET
-    group_role_mapping: None | OAuthProviderUpdateGroupRoleMappingType0 | Unset = UNSET
-    idp_certificate: None | str | Unset = UNSET
-    idp_entity_id: None | str | Unset = UNSET
-    idp_sso_url: None | str | Unset = UNSET
-    provider_type: None | OAuthProviderUpdateProviderTypeType0 | Unset = UNSET
-    scopes: None | str | Unset = UNSET
-    slug: None | str | Unset = UNSET
-    sp_entity_id: None | str | Unset = UNSET
+    authorize_url: None | str | Unset = UNSET
     token_url: None | str | Unset = UNSET
     userinfo_url: None | str | Unset = UNSET
+    idp_entity_id: None | str | Unset = UNSET
+    idp_sso_url: None | str | Unset = UNSET
+    idp_certificate: None | str | Unset = UNSET
+    sp_entity_id: None | str | Unset = UNSET
+    scopes: None | str | Unset = UNSET
+    default_role: None | str | Unset = UNSET
+    group_claim: None | str | Unset = UNSET
+    group_role_mapping: None | OAuthProviderUpdateGroupRoleMappingType0 | Unset = UNSET
+    enabled: bool | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -79,11 +79,25 @@ class OAuthProviderUpdate:
             OAuthProviderUpdateGroupRoleMappingType0,
         )
 
-        authorize_url: None | str | Unset
-        if isinstance(self.authorize_url, Unset):
-            authorize_url = UNSET
+        slug: None | str | Unset
+        if isinstance(self.slug, Unset):
+            slug = UNSET
         else:
-            authorize_url = self.authorize_url
+            slug = self.slug
+
+        display_name: None | str | Unset
+        if isinstance(self.display_name, Unset):
+            display_name = UNSET
+        else:
+            display_name = self.display_name
+
+        provider_type: None | str | Unset
+        if isinstance(self.provider_type, Unset):
+            provider_type = UNSET
+        elif isinstance(self.provider_type, str):
+            provider_type = self.provider_type
+        else:
+            provider_type = self.provider_type
 
         client_id: None | str | Unset
         if isinstance(self.client_id, Unset):
@@ -97,29 +111,65 @@ class OAuthProviderUpdate:
         else:
             client_secret = self.client_secret
 
-        default_role: None | str | Unset
-        if isinstance(self.default_role, Unset):
-            default_role = UNSET
-        else:
-            default_role = self.default_role
-
         discovery_url: None | str | Unset
         if isinstance(self.discovery_url, Unset):
             discovery_url = UNSET
         else:
             discovery_url = self.discovery_url
 
-        display_name: None | str | Unset
-        if isinstance(self.display_name, Unset):
-            display_name = UNSET
+        authorize_url: None | str | Unset
+        if isinstance(self.authorize_url, Unset):
+            authorize_url = UNSET
         else:
-            display_name = self.display_name
+            authorize_url = self.authorize_url
 
-        enabled: bool | None | Unset
-        if isinstance(self.enabled, Unset):
-            enabled = UNSET
+        token_url: None | str | Unset
+        if isinstance(self.token_url, Unset):
+            token_url = UNSET
         else:
-            enabled = self.enabled
+            token_url = self.token_url
+
+        userinfo_url: None | str | Unset
+        if isinstance(self.userinfo_url, Unset):
+            userinfo_url = UNSET
+        else:
+            userinfo_url = self.userinfo_url
+
+        idp_entity_id: None | str | Unset
+        if isinstance(self.idp_entity_id, Unset):
+            idp_entity_id = UNSET
+        else:
+            idp_entity_id = self.idp_entity_id
+
+        idp_sso_url: None | str | Unset
+        if isinstance(self.idp_sso_url, Unset):
+            idp_sso_url = UNSET
+        else:
+            idp_sso_url = self.idp_sso_url
+
+        idp_certificate: None | str | Unset
+        if isinstance(self.idp_certificate, Unset):
+            idp_certificate = UNSET
+        else:
+            idp_certificate = self.idp_certificate
+
+        sp_entity_id: None | str | Unset
+        if isinstance(self.sp_entity_id, Unset):
+            sp_entity_id = UNSET
+        else:
+            sp_entity_id = self.sp_entity_id
+
+        scopes: None | str | Unset
+        if isinstance(self.scopes, Unset):
+            scopes = UNSET
+        else:
+            scopes = self.scopes
+
+        default_role: None | str | Unset
+        if isinstance(self.default_role, Unset):
+            default_role = UNSET
+        else:
+            default_role = self.default_role
 
         group_claim: None | str | Unset
         if isinstance(self.group_claim, Unset):
@@ -137,101 +187,51 @@ class OAuthProviderUpdate:
         else:
             group_role_mapping = self.group_role_mapping
 
-        idp_certificate: None | str | Unset
-        if isinstance(self.idp_certificate, Unset):
-            idp_certificate = UNSET
+        enabled: bool | None | Unset
+        if isinstance(self.enabled, Unset):
+            enabled = UNSET
         else:
-            idp_certificate = self.idp_certificate
-
-        idp_entity_id: None | str | Unset
-        if isinstance(self.idp_entity_id, Unset):
-            idp_entity_id = UNSET
-        else:
-            idp_entity_id = self.idp_entity_id
-
-        idp_sso_url: None | str | Unset
-        if isinstance(self.idp_sso_url, Unset):
-            idp_sso_url = UNSET
-        else:
-            idp_sso_url = self.idp_sso_url
-
-        provider_type: None | str | Unset
-        if isinstance(self.provider_type, Unset):
-            provider_type = UNSET
-        elif isinstance(self.provider_type, str):
-            provider_type = self.provider_type
-        else:
-            provider_type = self.provider_type
-
-        scopes: None | str | Unset
-        if isinstance(self.scopes, Unset):
-            scopes = UNSET
-        else:
-            scopes = self.scopes
-
-        slug: None | str | Unset
-        if isinstance(self.slug, Unset):
-            slug = UNSET
-        else:
-            slug = self.slug
-
-        sp_entity_id: None | str | Unset
-        if isinstance(self.sp_entity_id, Unset):
-            sp_entity_id = UNSET
-        else:
-            sp_entity_id = self.sp_entity_id
-
-        token_url: None | str | Unset
-        if isinstance(self.token_url, Unset):
-            token_url = UNSET
-        else:
-            token_url = self.token_url
-
-        userinfo_url: None | str | Unset
-        if isinstance(self.userinfo_url, Unset):
-            userinfo_url = UNSET
-        else:
-            userinfo_url = self.userinfo_url
+            enabled = self.enabled
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if authorize_url is not UNSET:
-            field_dict["authorize_url"] = authorize_url
+        if slug is not UNSET:
+            field_dict["slug"] = slug
+        if display_name is not UNSET:
+            field_dict["display_name"] = display_name
+        if provider_type is not UNSET:
+            field_dict["provider_type"] = provider_type
         if client_id is not UNSET:
             field_dict["client_id"] = client_id
         if client_secret is not UNSET:
             field_dict["client_secret"] = client_secret
-        if default_role is not UNSET:
-            field_dict["default_role"] = default_role
         if discovery_url is not UNSET:
             field_dict["discovery_url"] = discovery_url
-        if display_name is not UNSET:
-            field_dict["display_name"] = display_name
-        if enabled is not UNSET:
-            field_dict["enabled"] = enabled
-        if group_claim is not UNSET:
-            field_dict["group_claim"] = group_claim
-        if group_role_mapping is not UNSET:
-            field_dict["group_role_mapping"] = group_role_mapping
-        if idp_certificate is not UNSET:
-            field_dict["idp_certificate"] = idp_certificate
-        if idp_entity_id is not UNSET:
-            field_dict["idp_entity_id"] = idp_entity_id
-        if idp_sso_url is not UNSET:
-            field_dict["idp_sso_url"] = idp_sso_url
-        if provider_type is not UNSET:
-            field_dict["provider_type"] = provider_type
-        if scopes is not UNSET:
-            field_dict["scopes"] = scopes
-        if slug is not UNSET:
-            field_dict["slug"] = slug
-        if sp_entity_id is not UNSET:
-            field_dict["sp_entity_id"] = sp_entity_id
+        if authorize_url is not UNSET:
+            field_dict["authorize_url"] = authorize_url
         if token_url is not UNSET:
             field_dict["token_url"] = token_url
         if userinfo_url is not UNSET:
             field_dict["userinfo_url"] = userinfo_url
+        if idp_entity_id is not UNSET:
+            field_dict["idp_entity_id"] = idp_entity_id
+        if idp_sso_url is not UNSET:
+            field_dict["idp_sso_url"] = idp_sso_url
+        if idp_certificate is not UNSET:
+            field_dict["idp_certificate"] = idp_certificate
+        if sp_entity_id is not UNSET:
+            field_dict["sp_entity_id"] = sp_entity_id
+        if scopes is not UNSET:
+            field_dict["scopes"] = scopes
+        if default_role is not UNSET:
+            field_dict["default_role"] = default_role
+        if group_claim is not UNSET:
+            field_dict["group_claim"] = group_claim
+        if group_role_mapping is not UNSET:
+            field_dict["group_role_mapping"] = group_role_mapping
+        if enabled is not UNSET:
+            field_dict["enabled"] = enabled
 
         return field_dict
 
@@ -243,14 +243,44 @@ class OAuthProviderUpdate:
 
         d = dict(src_dict)
 
-        def _parse_authorize_url(data: object) -> None | str | Unset:
+        def _parse_slug(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        authorize_url = _parse_authorize_url(d.pop("authorize_url", UNSET))
+        slug = _parse_slug(d.pop("slug", UNSET))
+
+        def _parse_display_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        display_name = _parse_display_name(d.pop("display_name", UNSET))
+
+        def _parse_provider_type(
+            data: object,
+        ) -> None | OAuthProviderUpdateProviderTypeType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                provider_type_type_0 = (
+                    check_o_auth_provider_update_provider_type_type_0(data)
+                )
+
+                return provider_type_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | OAuthProviderUpdateProviderTypeType0 | Unset, data)
+
+        provider_type = _parse_provider_type(d.pop("provider_type", UNSET))
 
         def _parse_client_id(data: object) -> None | str | Unset:
             if data is None:
@@ -270,15 +300,6 @@ class OAuthProviderUpdate:
 
         client_secret = _parse_client_secret(d.pop("client_secret", UNSET))
 
-        def _parse_default_role(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        default_role = _parse_default_role(d.pop("default_role", UNSET))
-
         def _parse_discovery_url(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -288,23 +309,86 @@ class OAuthProviderUpdate:
 
         discovery_url = _parse_discovery_url(d.pop("discovery_url", UNSET))
 
-        def _parse_display_name(data: object) -> None | str | Unset:
+        def _parse_authorize_url(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        display_name = _parse_display_name(d.pop("display_name", UNSET))
+        authorize_url = _parse_authorize_url(d.pop("authorize_url", UNSET))
 
-        def _parse_enabled(data: object) -> bool | None | Unset:
+        def _parse_token_url(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(bool | None | Unset, data)
+            return cast(None | str | Unset, data)
 
-        enabled = _parse_enabled(d.pop("enabled", UNSET))
+        token_url = _parse_token_url(d.pop("token_url", UNSET))
+
+        def _parse_userinfo_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        userinfo_url = _parse_userinfo_url(d.pop("userinfo_url", UNSET))
+
+        def _parse_idp_entity_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        idp_entity_id = _parse_idp_entity_id(d.pop("idp_entity_id", UNSET))
+
+        def _parse_idp_sso_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        idp_sso_url = _parse_idp_sso_url(d.pop("idp_sso_url", UNSET))
+
+        def _parse_idp_certificate(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        idp_certificate = _parse_idp_certificate(d.pop("idp_certificate", UNSET))
+
+        def _parse_sp_entity_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        sp_entity_id = _parse_sp_entity_id(d.pop("sp_entity_id", UNSET))
+
+        def _parse_scopes(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        scopes = _parse_scopes(d.pop("scopes", UNSET))
+
+        def _parse_default_role(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        default_role = _parse_default_role(d.pop("default_role", UNSET))
 
         def _parse_group_claim(data: object) -> None | str | Unset:
             if data is None:
@@ -338,118 +422,34 @@ class OAuthProviderUpdate:
             d.pop("group_role_mapping", UNSET)
         )
 
-        def _parse_idp_certificate(data: object) -> None | str | Unset:
+        def _parse_enabled(data: object) -> bool | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(None | str | Unset, data)
+            return cast(bool | None | Unset, data)
 
-        idp_certificate = _parse_idp_certificate(d.pop("idp_certificate", UNSET))
-
-        def _parse_idp_entity_id(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        idp_entity_id = _parse_idp_entity_id(d.pop("idp_entity_id", UNSET))
-
-        def _parse_idp_sso_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        idp_sso_url = _parse_idp_sso_url(d.pop("idp_sso_url", UNSET))
-
-        def _parse_provider_type(
-            data: object,
-        ) -> None | OAuthProviderUpdateProviderTypeType0 | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                provider_type_type_0 = (
-                    check_o_auth_provider_update_provider_type_type_0(data)
-                )
-
-                return provider_type_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | OAuthProviderUpdateProviderTypeType0 | Unset, data)
-
-        provider_type = _parse_provider_type(d.pop("provider_type", UNSET))
-
-        def _parse_scopes(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        scopes = _parse_scopes(d.pop("scopes", UNSET))
-
-        def _parse_slug(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        slug = _parse_slug(d.pop("slug", UNSET))
-
-        def _parse_sp_entity_id(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        sp_entity_id = _parse_sp_entity_id(d.pop("sp_entity_id", UNSET))
-
-        def _parse_token_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        token_url = _parse_token_url(d.pop("token_url", UNSET))
-
-        def _parse_userinfo_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        userinfo_url = _parse_userinfo_url(d.pop("userinfo_url", UNSET))
+        enabled = _parse_enabled(d.pop("enabled", UNSET))
 
         o_auth_provider_update = cls(
-            authorize_url=authorize_url,
+            slug=slug,
+            display_name=display_name,
+            provider_type=provider_type,
             client_id=client_id,
             client_secret=client_secret,
-            default_role=default_role,
             discovery_url=discovery_url,
-            display_name=display_name,
-            enabled=enabled,
-            group_claim=group_claim,
-            group_role_mapping=group_role_mapping,
-            idp_certificate=idp_certificate,
-            idp_entity_id=idp_entity_id,
-            idp_sso_url=idp_sso_url,
-            provider_type=provider_type,
-            scopes=scopes,
-            slug=slug,
-            sp_entity_id=sp_entity_id,
+            authorize_url=authorize_url,
             token_url=token_url,
             userinfo_url=userinfo_url,
+            idp_entity_id=idp_entity_id,
+            idp_sso_url=idp_sso_url,
+            idp_certificate=idp_certificate,
+            sp_entity_id=sp_entity_id,
+            scopes=scopes,
+            default_role=default_role,
+            group_claim=group_claim,
+            group_role_mapping=group_role_mapping,
+            enabled=enabled,
         )
 
         o_auth_provider_update.additional_properties = d

--- a/sdks/python/geolens/models/ogc_asset.py
+++ b/sdks/python/geolens/models/ogc_asset.py
@@ -21,20 +21,26 @@ class OGCAsset:
     Attributes:
         href (str):
         type_ (str):
-        roles (list[str] | None | Unset):
         title (None | str | Unset):
+        roles (list[str] | None | Unset):
     """
 
     href: str
     type_: str
-    roles: list[str] | None | Unset = UNSET
     title: None | str | Unset = UNSET
+    roles: list[str] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         href = self.href
 
         type_ = self.type_
+
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
+        else:
+            title = self.title
 
         roles: list[str] | None | Unset
         if isinstance(self.roles, Unset):
@@ -45,12 +51,6 @@ class OGCAsset:
         else:
             roles = self.roles
 
-        title: None | str | Unset
-        if isinstance(self.title, Unset):
-            title = UNSET
-        else:
-            title = self.title
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -59,10 +59,10 @@ class OGCAsset:
                 "type": type_,
             }
         )
-        if roles is not UNSET:
-            field_dict["roles"] = roles
         if title is not UNSET:
             field_dict["title"] = title
+        if roles is not UNSET:
+            field_dict["roles"] = roles
 
         return field_dict
 
@@ -72,6 +72,15 @@ class OGCAsset:
         href = d.pop("href")
 
         type_ = d.pop("type")
+
+        def _parse_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        title = _parse_title(d.pop("title", UNSET))
 
         def _parse_roles(data: object) -> list[str] | None | Unset:
             if data is None:
@@ -90,20 +99,11 @@ class OGCAsset:
 
         roles = _parse_roles(d.pop("roles", UNSET))
 
-        def _parse_title(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        title = _parse_title(d.pop("title", UNSET))
-
         ogc_asset = cls(
             href=href,
             type_=type_,
-            roles=roles,
             title=title,
+            roles=roles,
         )
 
         ogc_asset.additional_properties = d

--- a/sdks/python/geolens/models/ogc_collection_metadata.py
+++ b/sdks/python/geolens/models/ogc_collection_metadata.py
@@ -26,23 +26,23 @@ class OGCCollectionMetadata:
 
     Attributes:
         id (str): Stable collection identifier (typically the dataset ID).
-        links (list[OGCLink]): Collection navigation links (self, items, queryables, etc.).
         title (str): Human-readable collection title.
-        crs (list[str] | Unset): Coordinate reference systems supported for items in this collection.
+        links (list[OGCLink]): Collection navigation links (self, items, queryables, etc.).
         description (None | str | Unset): Collection description.
         extent (None | OGCCollectionMetadataExtentType0 | Unset): Spatial and temporal extent (OGC API Features extent
             object).
         item_type (str | Unset): Type of items in the collection: 'feature' for vector feature collections, 'coverage'
             for raster/VRT collections (which expose tiles instead of feature items). Default: 'feature'.
+        crs (list[str] | Unset): Coordinate reference systems supported for items in this collection.
     """
 
     id: str
-    links: list[OGCLink]
     title: str
-    crs: list[str] | Unset = UNSET
+    links: list[OGCLink]
     description: None | str | Unset = UNSET
     extent: None | OGCCollectionMetadataExtentType0 | Unset = UNSET
     item_type: str | Unset = "feature"
+    crs: list[str] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -52,16 +52,12 @@ class OGCCollectionMetadata:
 
         id = self.id
 
+        title = self.title
+
         links = []
         for links_item_data in self.links:
             links_item = links_item_data.to_dict()
             links.append(links_item)
-
-        title = self.title
-
-        crs: list[str] | Unset = UNSET
-        if not isinstance(self.crs, Unset):
-            crs = self.crs
 
         description: None | str | Unset
         if isinstance(self.description, Unset):
@@ -79,23 +75,27 @@ class OGCCollectionMetadata:
 
         item_type = self.item_type
 
+        crs: list[str] | Unset = UNSET
+        if not isinstance(self.crs, Unset):
+            crs = self.crs
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "id": id,
-                "links": links,
                 "title": title,
+                "links": links,
             }
         )
-        if crs is not UNSET:
-            field_dict["crs"] = crs
         if description is not UNSET:
             field_dict["description"] = description
         if extent is not UNSET:
             field_dict["extent"] = extent
         if item_type is not UNSET:
             field_dict["itemType"] = item_type
+        if crs is not UNSET:
+            field_dict["crs"] = crs
 
         return field_dict
 
@@ -109,16 +109,14 @@ class OGCCollectionMetadata:
         d = dict(src_dict)
         id = d.pop("id")
 
+        title = d.pop("title")
+
         links = []
         _links = d.pop("links")
         for links_item_data in _links:
             links_item = OGCLink.from_dict(links_item_data)
 
             links.append(links_item)
-
-        title = d.pop("title")
-
-        crs = cast(list[str], d.pop("crs", UNSET))
 
         def _parse_description(data: object) -> None | str | Unset:
             if data is None:
@@ -150,14 +148,16 @@ class OGCCollectionMetadata:
 
         item_type = d.pop("itemType", UNSET)
 
+        crs = cast(list[str], d.pop("crs", UNSET))
+
         ogc_collection_metadata = cls(
             id=id,
-            links=links,
             title=title,
-            crs=crs,
+            links=links,
             description=description,
             extent=extent,
             item_type=item_type,
+            crs=crs,
         )
 
         ogc_collection_metadata.additional_properties = d

--- a/sdks/python/geolens/models/ogc_collection_metadata_response.py
+++ b/sdks/python/geolens/models/ogc_collection_metadata_response.py
@@ -30,21 +30,21 @@ class OGCCollectionMetadataResponse:
     """Response for /collections/datasets single collection metadata.
 
     Attributes:
-        description (str):
         id (str):
-        links (list[OGCCollectionMetadataResponseLinksItem]):
         title (str):
-        extent (None | OGCCollectionMetadataResponseExtentType0 | Unset):
+        description (str):
+        links (list[OGCCollectionMetadataResponseLinksItem]):
         item_type (str | Unset):  Default: 'record'.
+        extent (None | OGCCollectionMetadataResponseExtentType0 | Unset):
         summaries (None | OGCCollectionMetadataResponseSummariesType0 | Unset):
     """
 
-    description: str
     id: str
-    links: list[OGCCollectionMetadataResponseLinksItem]
     title: str
-    extent: None | OGCCollectionMetadataResponseExtentType0 | Unset = UNSET
+    description: str
+    links: list[OGCCollectionMetadataResponseLinksItem]
     item_type: str | Unset = "record"
+    extent: None | OGCCollectionMetadataResponseExtentType0 | Unset = UNSET
     summaries: None | OGCCollectionMetadataResponseSummariesType0 | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -56,16 +56,18 @@ class OGCCollectionMetadataResponse:
             OGCCollectionMetadataResponseSummariesType0,
         )
 
-        description = self.description
-
         id = self.id
+
+        title = self.title
+
+        description = self.description
 
         links = []
         for links_item_data in self.links:
             links_item = links_item_data.to_dict()
             links.append(links_item)
 
-        title = self.title
+        item_type = self.item_type
 
         extent: dict[str, Any] | None | Unset
         if isinstance(self.extent, Unset):
@@ -74,8 +76,6 @@ class OGCCollectionMetadataResponse:
             extent = self.extent.to_dict()
         else:
             extent = self.extent
-
-        item_type = self.item_type
 
         summaries: dict[str, Any] | None | Unset
         if isinstance(self.summaries, Unset):
@@ -89,16 +89,16 @@ class OGCCollectionMetadataResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "description": description,
                 "id": id,
-                "links": links,
                 "title": title,
+                "description": description,
+                "links": links,
             }
         )
-        if extent is not UNSET:
-            field_dict["extent"] = extent
         if item_type is not UNSET:
             field_dict["itemType"] = item_type
+        if extent is not UNSET:
+            field_dict["extent"] = extent
         if summaries is not UNSET:
             field_dict["summaries"] = summaries
 
@@ -117,9 +117,11 @@ class OGCCollectionMetadataResponse:
         )
 
         d = dict(src_dict)
-        description = d.pop("description")
-
         id = d.pop("id")
+
+        title = d.pop("title")
+
+        description = d.pop("description")
 
         links = []
         _links = d.pop("links")
@@ -130,7 +132,7 @@ class OGCCollectionMetadataResponse:
 
             links.append(links_item)
 
-        title = d.pop("title")
+        item_type = d.pop("itemType", UNSET)
 
         def _parse_extent(
             data: object,
@@ -150,8 +152,6 @@ class OGCCollectionMetadataResponse:
             return cast(None | OGCCollectionMetadataResponseExtentType0 | Unset, data)
 
         extent = _parse_extent(d.pop("extent", UNSET))
-
-        item_type = d.pop("itemType", UNSET)
 
         def _parse_summaries(
             data: object,
@@ -177,12 +177,12 @@ class OGCCollectionMetadataResponse:
         summaries = _parse_summaries(d.pop("summaries", UNSET))
 
         ogc_collection_metadata_response = cls(
-            description=description,
             id=id,
-            links=links,
             title=title,
-            extent=extent,
+            description=description,
+            links=links,
             item_type=item_type,
+            extent=extent,
             summaries=summaries,
         )
 

--- a/sdks/python/geolens/models/ogc_feature_collection_response.py
+++ b/sdks/python/geolens/models/ogc_feature_collection_response.py
@@ -23,31 +23,39 @@ class OGCFeatureCollectionResponse:
     """OGC API Records FeatureCollection with match counts.
 
     Attributes:
-        features (list[OGCRecordResponse]):
         number_matched (int): Total records matching the query
         number_returned (int): Number of records in this response page
-        links (list[OGCRecordLink] | None | Unset): Pagination and self links
-        time_stamp (None | str | Unset):
+        features (list[OGCRecordResponse]):
         type_ (str | Unset):  Default: 'FeatureCollection'.
+        time_stamp (None | str | Unset):
+        links (list[OGCRecordLink] | None | Unset): Pagination and self links
     """
 
-    features: list[OGCRecordResponse]
     number_matched: int
     number_returned: int
-    links: list[OGCRecordLink] | None | Unset = UNSET
-    time_stamp: None | str | Unset = UNSET
+    features: list[OGCRecordResponse]
     type_: str | Unset = "FeatureCollection"
+    time_stamp: None | str | Unset = UNSET
+    links: list[OGCRecordLink] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        number_matched = self.number_matched
+
+        number_returned = self.number_returned
+
         features = []
         for features_item_data in self.features:
             features_item = features_item_data.to_dict()
             features.append(features_item)
 
-        number_matched = self.number_matched
+        type_ = self.type_
 
-        number_returned = self.number_returned
+        time_stamp: None | str | Unset
+        if isinstance(self.time_stamp, Unset):
+            time_stamp = UNSET
+        else:
+            time_stamp = self.time_stamp
 
         links: list[dict[str, Any]] | None | Unset
         if isinstance(self.links, Unset):
@@ -61,29 +69,21 @@ class OGCFeatureCollectionResponse:
         else:
             links = self.links
 
-        time_stamp: None | str | Unset
-        if isinstance(self.time_stamp, Unset):
-            time_stamp = UNSET
-        else:
-            time_stamp = self.time_stamp
-
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "features": features,
                 "numberMatched": number_matched,
                 "numberReturned": number_returned,
+                "features": features,
             }
         )
-        if links is not UNSET:
-            field_dict["links"] = links
-        if time_stamp is not UNSET:
-            field_dict["timeStamp"] = time_stamp
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if time_stamp is not UNSET:
+            field_dict["timeStamp"] = time_stamp
+        if links is not UNSET:
+            field_dict["links"] = links
 
         return field_dict
 
@@ -93,6 +93,10 @@ class OGCFeatureCollectionResponse:
         from ..models.ogc_record_response import OGCRecordResponse
 
         d = dict(src_dict)
+        number_matched = d.pop("numberMatched")
+
+        number_returned = d.pop("numberReturned")
+
         features = []
         _features = d.pop("features")
         for features_item_data in _features:
@@ -100,9 +104,16 @@ class OGCFeatureCollectionResponse:
 
             features.append(features_item)
 
-        number_matched = d.pop("numberMatched")
+        type_ = d.pop("type", UNSET)
 
-        number_returned = d.pop("numberReturned")
+        def _parse_time_stamp(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        time_stamp = _parse_time_stamp(d.pop("timeStamp", UNSET))
 
         def _parse_links(data: object) -> list[OGCRecordLink] | None | Unset:
             if data is None:
@@ -126,24 +137,13 @@ class OGCFeatureCollectionResponse:
 
         links = _parse_links(d.pop("links", UNSET))
 
-        def _parse_time_stamp(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        time_stamp = _parse_time_stamp(d.pop("timeStamp", UNSET))
-
-        type_ = d.pop("type", UNSET)
-
         ogc_feature_collection_response = cls(
-            features=features,
             number_matched=number_matched,
             number_returned=number_returned,
-            links=links,
-            time_stamp=time_stamp,
+            features=features,
             type_=type_,
+            time_stamp=time_stamp,
+            links=links,
         )
 
         ogc_feature_collection_response.additional_properties = d

--- a/sdks/python/geolens/models/ogc_record_link.py
+++ b/sdks/python/geolens/models/ogc_record_link.py
@@ -15,20 +15,20 @@ class OGCRecordLink:
     """Link object in OGC API Records.
 
     Attributes:
-        href (str):
         rel (str):
+        href (str):
         type_ (str):
     """
 
-    href: str
     rel: str
+    href: str
     type_: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        href = self.href
-
         rel = self.rel
+
+        href = self.href
 
         type_ = self.type_
 
@@ -36,8 +36,8 @@ class OGCRecordLink:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "href": href,
                 "rel": rel,
+                "href": href,
                 "type": type_,
             }
         )
@@ -47,15 +47,15 @@ class OGCRecordLink:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        href = d.pop("href")
-
         rel = d.pop("rel")
+
+        href = d.pop("href")
 
         type_ = d.pop("type")
 
         ogc_record_link = cls(
-            href=href,
             rel=rel,
+            href=href,
             type_=type_,
         )
 

--- a/sdks/python/geolens/models/ogc_record_properties.py
+++ b/sdks/python/geolens/models/ogc_record_properties.py
@@ -37,89 +37,89 @@ class OGCRecordProperties:
     """Properties block of an OGC API Records Feature.
 
     Attributes:
-        contacts (list[OGCRecordPropertiesContactsItem]):
+        title (str):
         description (str):
         keywords (list[str]):
         license_ (str):
         themes (list[OGCRecordPropertiesThemesItem]):
+        contacts (list[OGCRecordPropertiesContactsItem]):
         time (OGCRecordPropertiesTime):
-        title (str):
-        band_count (int | None | Unset):
-        column_count (int | None | Unset): Number of columns in the dataset (populated from column_info length).
-        constraints (None | OGCRecordPropertiesConstraintsType0 | Unset):
-        created (datetime.datetime | None | Unset):
-        crs (None | str | Unset):
-        crs_is_geographic (bool | None | Unset): True when the raster CRS is geographic (gsd/res are degrees, not
-            meters); None when the CRS class is unknown.
-        dataset_count (int | None | Unset):
-        distributions (list[OGCRecordPropertiesDistributionsType0Item] | None | Unset):
-        external_ids (list[str] | Unset): Identifiers assigned by the described resource's source system.
-        feature_count (int | None | Unset):
-        formats (list[str] | None | Unset):
-        geometry_type (None | str | Unset):
-        gsd (float | None | Unset):
-        has_quicklook (bool | Unset):  Default: False.
-        language (None | str | Unset):
-        lineage (None | str | Unset):
-        never_edited (bool | Unset):  Default: False.
-        quality_detail (None | OGCRecordPropertiesQualityDetailType0 | Unset):
-        quality_statement (None | str | Unset):
-        record_status (None | str | Unset):
-        record_type (str | Unset):  Default: 'vector_dataset'.
-        rights (None | str | Unset):
-        row_count (int | None | Unset): Row count for tabular records (alias for feature_count when
-            record_type='table').
-        source_count (int | None | Unset):
-        source_format (None | str | Unset): Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac',
-            'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.
-        source_organization (None | str | Unset):
         type_ (str | Unset):  Default: 'dataset'.
-        update_frequency (None | str | Unset):
+        created (datetime.datetime | None | Unset):
         updated (datetime.datetime | None | Unset):
         updated_by_display (None | str | Unset):
+        never_edited (bool | Unset):  Default: False.
+        crs (None | str | Unset):
+        record_type (str | Unset):  Default: 'vector_dataset'.
+        band_count (int | None | Unset):
+        geometry_type (None | str | Unset):
+        feature_count (int | None | Unset):
+        row_count (int | None | Unset): Row count for tabular records (alias for feature_count when
+            record_type='table').
+        column_count (int | None | Unset): Number of columns in the dataset (populated from column_info length).
+        source_organization (None | str | Unset):
+        source_format (None | str | Unset): Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac',
+            'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.
+        quality_detail (None | OGCRecordPropertiesQualityDetailType0 | Unset):
+        quality_statement (None | str | Unset):
+        formats (list[str] | None | Unset):
+        language (None | str | Unset):
+        external_ids (list[str] | Unset): Identifiers assigned by the described resource's source system.
+        rights (None | str | Unset):
+        lineage (None | str | Unset):
+        update_frequency (None | str | Unset):
+        constraints (None | OGCRecordPropertiesConstraintsType0 | Unset):
+        distributions (list[OGCRecordPropertiesDistributionsType0Item] | None | Unset):
+        record_status (None | str | Unset):
+        has_quicklook (bool | Unset):  Default: False.
+        gsd (float | None | Unset):
+        crs_is_geographic (bool | None | Unset): True when the raster CRS is geographic (gsd/res are degrees, not
+            meters); None when the CRS class is unknown.
         vrt_type (None | str | Unset):
+        source_count (int | None | Unset):
+        dataset_count (int | None | Unset):
     """
 
-    contacts: list[OGCRecordPropertiesContactsItem]
+    title: str
     description: str
     keywords: list[str]
     license_: str
     themes: list[OGCRecordPropertiesThemesItem]
+    contacts: list[OGCRecordPropertiesContactsItem]
     time: OGCRecordPropertiesTime
-    title: str
-    band_count: int | None | Unset = UNSET
-    column_count: int | None | Unset = UNSET
-    constraints: None | OGCRecordPropertiesConstraintsType0 | Unset = UNSET
+    type_: str | Unset = "dataset"
     created: datetime.datetime | None | Unset = UNSET
+    updated: datetime.datetime | None | Unset = UNSET
+    updated_by_display: None | str | Unset = UNSET
+    never_edited: bool | Unset = False
     crs: None | str | Unset = UNSET
-    crs_is_geographic: bool | None | Unset = UNSET
-    dataset_count: int | None | Unset = UNSET
+    record_type: str | Unset = "vector_dataset"
+    band_count: int | None | Unset = UNSET
+    geometry_type: None | str | Unset = UNSET
+    feature_count: int | None | Unset = UNSET
+    row_count: int | None | Unset = UNSET
+    column_count: int | None | Unset = UNSET
+    source_organization: None | str | Unset = UNSET
+    source_format: None | str | Unset = UNSET
+    quality_detail: None | OGCRecordPropertiesQualityDetailType0 | Unset = UNSET
+    quality_statement: None | str | Unset = UNSET
+    formats: list[str] | None | Unset = UNSET
+    language: None | str | Unset = UNSET
+    external_ids: list[str] | Unset = UNSET
+    rights: None | str | Unset = UNSET
+    lineage: None | str | Unset = UNSET
+    update_frequency: None | str | Unset = UNSET
+    constraints: None | OGCRecordPropertiesConstraintsType0 | Unset = UNSET
     distributions: list[OGCRecordPropertiesDistributionsType0Item] | None | Unset = (
         UNSET
     )
-    external_ids: list[str] | Unset = UNSET
-    feature_count: int | None | Unset = UNSET
-    formats: list[str] | None | Unset = UNSET
-    geometry_type: None | str | Unset = UNSET
-    gsd: float | None | Unset = UNSET
-    has_quicklook: bool | Unset = False
-    language: None | str | Unset = UNSET
-    lineage: None | str | Unset = UNSET
-    never_edited: bool | Unset = False
-    quality_detail: None | OGCRecordPropertiesQualityDetailType0 | Unset = UNSET
-    quality_statement: None | str | Unset = UNSET
     record_status: None | str | Unset = UNSET
-    record_type: str | Unset = "vector_dataset"
-    rights: None | str | Unset = UNSET
-    row_count: int | None | Unset = UNSET
-    source_count: int | None | Unset = UNSET
-    source_format: None | str | Unset = UNSET
-    source_organization: None | str | Unset = UNSET
-    type_: str | Unset = "dataset"
-    update_frequency: None | str | Unset = UNSET
-    updated: datetime.datetime | None | Unset = UNSET
-    updated_by_display: None | str | Unset = UNSET
+    has_quicklook: bool | Unset = False
+    gsd: float | None | Unset = UNSET
+    crs_is_geographic: bool | None | Unset = UNSET
     vrt_type: None | str | Unset = UNSET
+    source_count: int | None | Unset = UNSET
+    dataset_count: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -130,10 +130,7 @@ class OGCRecordProperties:
             OGCRecordPropertiesQualityDetailType0,
         )
 
-        contacts = []
-        for contacts_item_data in self.contacts:
-            contacts_item = contacts_item_data.to_dict()
-            contacts.append(contacts_item)
+        title = self.title
 
         description = self.description
 
@@ -146,29 +143,14 @@ class OGCRecordProperties:
             themes_item = themes_item_data.to_dict()
             themes.append(themes_item)
 
+        contacts = []
+        for contacts_item_data in self.contacts:
+            contacts_item = contacts_item_data.to_dict()
+            contacts.append(contacts_item)
+
         time = self.time.to_dict()
 
-        title = self.title
-
-        band_count: int | None | Unset
-        if isinstance(self.band_count, Unset):
-            band_count = UNSET
-        else:
-            band_count = self.band_count
-
-        column_count: int | None | Unset
-        if isinstance(self.column_count, Unset):
-            column_count = UNSET
-        else:
-            column_count = self.column_count
-
-        constraints: dict[str, Any] | None | Unset
-        if isinstance(self.constraints, Unset):
-            constraints = UNSET
-        elif isinstance(self.constraints, OGCRecordPropertiesConstraintsType0):
-            constraints = self.constraints.to_dict()
-        else:
-            constraints = self.constraints
+        type_ = self.type_
 
         created: None | str | Unset
         if isinstance(self.created, Unset):
@@ -177,143 +159,6 @@ class OGCRecordProperties:
             created = self.created.isoformat()
         else:
             created = self.created
-
-        crs: None | str | Unset
-        if isinstance(self.crs, Unset):
-            crs = UNSET
-        else:
-            crs = self.crs
-
-        crs_is_geographic: bool | None | Unset
-        if isinstance(self.crs_is_geographic, Unset):
-            crs_is_geographic = UNSET
-        else:
-            crs_is_geographic = self.crs_is_geographic
-
-        dataset_count: int | None | Unset
-        if isinstance(self.dataset_count, Unset):
-            dataset_count = UNSET
-        else:
-            dataset_count = self.dataset_count
-
-        distributions: list[dict[str, Any]] | None | Unset
-        if isinstance(self.distributions, Unset):
-            distributions = UNSET
-        elif isinstance(self.distributions, list):
-            distributions = []
-            for distributions_type_0_item_data in self.distributions:
-                distributions_type_0_item = distributions_type_0_item_data.to_dict()
-                distributions.append(distributions_type_0_item)
-
-        else:
-            distributions = self.distributions
-
-        external_ids: list[str] | Unset = UNSET
-        if not isinstance(self.external_ids, Unset):
-            external_ids = self.external_ids
-
-        feature_count: int | None | Unset
-        if isinstance(self.feature_count, Unset):
-            feature_count = UNSET
-        else:
-            feature_count = self.feature_count
-
-        formats: list[str] | None | Unset
-        if isinstance(self.formats, Unset):
-            formats = UNSET
-        elif isinstance(self.formats, list):
-            formats = self.formats
-
-        else:
-            formats = self.formats
-
-        geometry_type: None | str | Unset
-        if isinstance(self.geometry_type, Unset):
-            geometry_type = UNSET
-        else:
-            geometry_type = self.geometry_type
-
-        gsd: float | None | Unset
-        if isinstance(self.gsd, Unset):
-            gsd = UNSET
-        else:
-            gsd = self.gsd
-
-        has_quicklook = self.has_quicklook
-
-        language: None | str | Unset
-        if isinstance(self.language, Unset):
-            language = UNSET
-        else:
-            language = self.language
-
-        lineage: None | str | Unset
-        if isinstance(self.lineage, Unset):
-            lineage = UNSET
-        else:
-            lineage = self.lineage
-
-        never_edited = self.never_edited
-
-        quality_detail: dict[str, Any] | None | Unset
-        if isinstance(self.quality_detail, Unset):
-            quality_detail = UNSET
-        elif isinstance(self.quality_detail, OGCRecordPropertiesQualityDetailType0):
-            quality_detail = self.quality_detail.to_dict()
-        else:
-            quality_detail = self.quality_detail
-
-        quality_statement: None | str | Unset
-        if isinstance(self.quality_statement, Unset):
-            quality_statement = UNSET
-        else:
-            quality_statement = self.quality_statement
-
-        record_status: None | str | Unset
-        if isinstance(self.record_status, Unset):
-            record_status = UNSET
-        else:
-            record_status = self.record_status
-
-        record_type = self.record_type
-
-        rights: None | str | Unset
-        if isinstance(self.rights, Unset):
-            rights = UNSET
-        else:
-            rights = self.rights
-
-        row_count: int | None | Unset
-        if isinstance(self.row_count, Unset):
-            row_count = UNSET
-        else:
-            row_count = self.row_count
-
-        source_count: int | None | Unset
-        if isinstance(self.source_count, Unset):
-            source_count = UNSET
-        else:
-            source_count = self.source_count
-
-        source_format: None | str | Unset
-        if isinstance(self.source_format, Unset):
-            source_format = UNSET
-        else:
-            source_format = self.source_format
-
-        source_organization: None | str | Unset
-        if isinstance(self.source_organization, Unset):
-            source_organization = UNSET
-        else:
-            source_organization = self.source_organization
-
-        type_ = self.type_
-
-        update_frequency: None | str | Unset
-        if isinstance(self.update_frequency, Unset):
-            update_frequency = UNSET
-        else:
-            update_frequency = self.update_frequency
 
         updated: None | str | Unset
         if isinstance(self.updated, Unset):
@@ -329,87 +174,242 @@ class OGCRecordProperties:
         else:
             updated_by_display = self.updated_by_display
 
+        never_edited = self.never_edited
+
+        crs: None | str | Unset
+        if isinstance(self.crs, Unset):
+            crs = UNSET
+        else:
+            crs = self.crs
+
+        record_type = self.record_type
+
+        band_count: int | None | Unset
+        if isinstance(self.band_count, Unset):
+            band_count = UNSET
+        else:
+            band_count = self.band_count
+
+        geometry_type: None | str | Unset
+        if isinstance(self.geometry_type, Unset):
+            geometry_type = UNSET
+        else:
+            geometry_type = self.geometry_type
+
+        feature_count: int | None | Unset
+        if isinstance(self.feature_count, Unset):
+            feature_count = UNSET
+        else:
+            feature_count = self.feature_count
+
+        row_count: int | None | Unset
+        if isinstance(self.row_count, Unset):
+            row_count = UNSET
+        else:
+            row_count = self.row_count
+
+        column_count: int | None | Unset
+        if isinstance(self.column_count, Unset):
+            column_count = UNSET
+        else:
+            column_count = self.column_count
+
+        source_organization: None | str | Unset
+        if isinstance(self.source_organization, Unset):
+            source_organization = UNSET
+        else:
+            source_organization = self.source_organization
+
+        source_format: None | str | Unset
+        if isinstance(self.source_format, Unset):
+            source_format = UNSET
+        else:
+            source_format = self.source_format
+
+        quality_detail: dict[str, Any] | None | Unset
+        if isinstance(self.quality_detail, Unset):
+            quality_detail = UNSET
+        elif isinstance(self.quality_detail, OGCRecordPropertiesQualityDetailType0):
+            quality_detail = self.quality_detail.to_dict()
+        else:
+            quality_detail = self.quality_detail
+
+        quality_statement: None | str | Unset
+        if isinstance(self.quality_statement, Unset):
+            quality_statement = UNSET
+        else:
+            quality_statement = self.quality_statement
+
+        formats: list[str] | None | Unset
+        if isinstance(self.formats, Unset):
+            formats = UNSET
+        elif isinstance(self.formats, list):
+            formats = self.formats
+
+        else:
+            formats = self.formats
+
+        language: None | str | Unset
+        if isinstance(self.language, Unset):
+            language = UNSET
+        else:
+            language = self.language
+
+        external_ids: list[str] | Unset = UNSET
+        if not isinstance(self.external_ids, Unset):
+            external_ids = self.external_ids
+
+        rights: None | str | Unset
+        if isinstance(self.rights, Unset):
+            rights = UNSET
+        else:
+            rights = self.rights
+
+        lineage: None | str | Unset
+        if isinstance(self.lineage, Unset):
+            lineage = UNSET
+        else:
+            lineage = self.lineage
+
+        update_frequency: None | str | Unset
+        if isinstance(self.update_frequency, Unset):
+            update_frequency = UNSET
+        else:
+            update_frequency = self.update_frequency
+
+        constraints: dict[str, Any] | None | Unset
+        if isinstance(self.constraints, Unset):
+            constraints = UNSET
+        elif isinstance(self.constraints, OGCRecordPropertiesConstraintsType0):
+            constraints = self.constraints.to_dict()
+        else:
+            constraints = self.constraints
+
+        distributions: list[dict[str, Any]] | None | Unset
+        if isinstance(self.distributions, Unset):
+            distributions = UNSET
+        elif isinstance(self.distributions, list):
+            distributions = []
+            for distributions_type_0_item_data in self.distributions:
+                distributions_type_0_item = distributions_type_0_item_data.to_dict()
+                distributions.append(distributions_type_0_item)
+
+        else:
+            distributions = self.distributions
+
+        record_status: None | str | Unset
+        if isinstance(self.record_status, Unset):
+            record_status = UNSET
+        else:
+            record_status = self.record_status
+
+        has_quicklook = self.has_quicklook
+
+        gsd: float | None | Unset
+        if isinstance(self.gsd, Unset):
+            gsd = UNSET
+        else:
+            gsd = self.gsd
+
+        crs_is_geographic: bool | None | Unset
+        if isinstance(self.crs_is_geographic, Unset):
+            crs_is_geographic = UNSET
+        else:
+            crs_is_geographic = self.crs_is_geographic
+
         vrt_type: None | str | Unset
         if isinstance(self.vrt_type, Unset):
             vrt_type = UNSET
         else:
             vrt_type = self.vrt_type
 
+        source_count: int | None | Unset
+        if isinstance(self.source_count, Unset):
+            source_count = UNSET
+        else:
+            source_count = self.source_count
+
+        dataset_count: int | None | Unset
+        if isinstance(self.dataset_count, Unset):
+            dataset_count = UNSET
+        else:
+            dataset_count = self.dataset_count
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "contacts": contacts,
+                "title": title,
                 "description": description,
                 "keywords": keywords,
                 "license": license_,
                 "themes": themes,
+                "contacts": contacts,
                 "time": time,
-                "title": title,
             }
         )
-        if band_count is not UNSET:
-            field_dict["band_count"] = band_count
-        if column_count is not UNSET:
-            field_dict["column_count"] = column_count
-        if constraints is not UNSET:
-            field_dict["constraints"] = constraints
-        if created is not UNSET:
-            field_dict["created"] = created
-        if crs is not UNSET:
-            field_dict["crs"] = crs
-        if crs_is_geographic is not UNSET:
-            field_dict["crs_is_geographic"] = crs_is_geographic
-        if dataset_count is not UNSET:
-            field_dict["dataset_count"] = dataset_count
-        if distributions is not UNSET:
-            field_dict["distributions"] = distributions
-        if external_ids is not UNSET:
-            field_dict["externalIds"] = external_ids
-        if feature_count is not UNSET:
-            field_dict["feature_count"] = feature_count
-        if formats is not UNSET:
-            field_dict["formats"] = formats
-        if geometry_type is not UNSET:
-            field_dict["geometry_type"] = geometry_type
-        if gsd is not UNSET:
-            field_dict["gsd"] = gsd
-        if has_quicklook is not UNSET:
-            field_dict["has_quicklook"] = has_quicklook
-        if language is not UNSET:
-            field_dict["language"] = language
-        if lineage is not UNSET:
-            field_dict["lineage"] = lineage
-        if never_edited is not UNSET:
-            field_dict["never_edited"] = never_edited
-        if quality_detail is not UNSET:
-            field_dict["quality_detail"] = quality_detail
-        if quality_statement is not UNSET:
-            field_dict["quality_statement"] = quality_statement
-        if record_status is not UNSET:
-            field_dict["record_status"] = record_status
-        if record_type is not UNSET:
-            field_dict["record_type"] = record_type
-        if rights is not UNSET:
-            field_dict["rights"] = rights
-        if row_count is not UNSET:
-            field_dict["row_count"] = row_count
-        if source_count is not UNSET:
-            field_dict["source_count"] = source_count
-        if source_format is not UNSET:
-            field_dict["source_format"] = source_format
-        if source_organization is not UNSET:
-            field_dict["source_organization"] = source_organization
         if type_ is not UNSET:
             field_dict["type"] = type_
-        if update_frequency is not UNSET:
-            field_dict["update_frequency"] = update_frequency
+        if created is not UNSET:
+            field_dict["created"] = created
         if updated is not UNSET:
             field_dict["updated"] = updated
         if updated_by_display is not UNSET:
             field_dict["updated_by_display"] = updated_by_display
+        if never_edited is not UNSET:
+            field_dict["never_edited"] = never_edited
+        if crs is not UNSET:
+            field_dict["crs"] = crs
+        if record_type is not UNSET:
+            field_dict["record_type"] = record_type
+        if band_count is not UNSET:
+            field_dict["band_count"] = band_count
+        if geometry_type is not UNSET:
+            field_dict["geometry_type"] = geometry_type
+        if feature_count is not UNSET:
+            field_dict["feature_count"] = feature_count
+        if row_count is not UNSET:
+            field_dict["row_count"] = row_count
+        if column_count is not UNSET:
+            field_dict["column_count"] = column_count
+        if source_organization is not UNSET:
+            field_dict["source_organization"] = source_organization
+        if source_format is not UNSET:
+            field_dict["source_format"] = source_format
+        if quality_detail is not UNSET:
+            field_dict["quality_detail"] = quality_detail
+        if quality_statement is not UNSET:
+            field_dict["quality_statement"] = quality_statement
+        if formats is not UNSET:
+            field_dict["formats"] = formats
+        if language is not UNSET:
+            field_dict["language"] = language
+        if external_ids is not UNSET:
+            field_dict["externalIds"] = external_ids
+        if rights is not UNSET:
+            field_dict["rights"] = rights
+        if lineage is not UNSET:
+            field_dict["lineage"] = lineage
+        if update_frequency is not UNSET:
+            field_dict["update_frequency"] = update_frequency
+        if constraints is not UNSET:
+            field_dict["constraints"] = constraints
+        if distributions is not UNSET:
+            field_dict["distributions"] = distributions
+        if record_status is not UNSET:
+            field_dict["record_status"] = record_status
+        if has_quicklook is not UNSET:
+            field_dict["has_quicklook"] = has_quicklook
+        if gsd is not UNSET:
+            field_dict["gsd"] = gsd
+        if crs_is_geographic is not UNSET:
+            field_dict["crs_is_geographic"] = crs_is_geographic
         if vrt_type is not UNSET:
             field_dict["vrt_type"] = vrt_type
+        if source_count is not UNSET:
+            field_dict["source_count"] = source_count
+        if dataset_count is not UNSET:
+            field_dict["dataset_count"] = dataset_count
 
         return field_dict
 
@@ -433,14 +433,7 @@ class OGCRecordProperties:
         from ..models.ogc_record_properties_time import OGCRecordPropertiesTime
 
         d = dict(src_dict)
-        contacts = []
-        _contacts = d.pop("contacts")
-        for contacts_item_data in _contacts:
-            contacts_item = OGCRecordPropertiesContactsItem.from_dict(
-                contacts_item_data
-            )
-
-            contacts.append(contacts_item)
+        title = d.pop("title")
 
         description = d.pop("description")
 
@@ -455,46 +448,18 @@ class OGCRecordProperties:
 
             themes.append(themes_item)
 
+        contacts = []
+        _contacts = d.pop("contacts")
+        for contacts_item_data in _contacts:
+            contacts_item = OGCRecordPropertiesContactsItem.from_dict(
+                contacts_item_data
+            )
+
+            contacts.append(contacts_item)
+
         time = OGCRecordPropertiesTime.from_dict(d.pop("time"))
 
-        title = d.pop("title")
-
-        def _parse_band_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        band_count = _parse_band_count(d.pop("band_count", UNSET))
-
-        def _parse_column_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        column_count = _parse_column_count(d.pop("column_count", UNSET))
-
-        def _parse_constraints(
-            data: object,
-        ) -> None | OGCRecordPropertiesConstraintsType0 | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                constraints_type_0 = OGCRecordPropertiesConstraintsType0.from_dict(data)
-
-                return constraints_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | OGCRecordPropertiesConstraintsType0 | Unset, data)
-
-        constraints = _parse_constraints(d.pop("constraints", UNSET))
+        type_ = d.pop("type", UNSET)
 
         def _parse_created(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -513,6 +478,36 @@ class OGCRecordProperties:
 
         created = _parse_created(d.pop("created", UNSET))
 
+        def _parse_updated(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                updated_type_0 = isoparse(data)
+
+                return updated_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        updated = _parse_updated(d.pop("updated", UNSET))
+
+        def _parse_updated_by_display(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        updated_by_display = _parse_updated_by_display(
+            d.pop("updated_by_display", UNSET)
+        )
+
+        never_edited = d.pop("never_edited", UNSET)
+
         def _parse_crs(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -522,81 +517,16 @@ class OGCRecordProperties:
 
         crs = _parse_crs(d.pop("crs", UNSET))
 
-        def _parse_crs_is_geographic(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
+        record_type = d.pop("record_type", UNSET)
 
-        crs_is_geographic = _parse_crs_is_geographic(d.pop("crs_is_geographic", UNSET))
-
-        def _parse_dataset_count(data: object) -> int | None | Unset:
+        def _parse_band_count(data: object) -> int | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(int | None | Unset, data)
 
-        dataset_count = _parse_dataset_count(d.pop("dataset_count", UNSET))
-
-        def _parse_distributions(
-            data: object,
-        ) -> list[OGCRecordPropertiesDistributionsType0Item] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                distributions_type_0 = []
-                _distributions_type_0 = data
-                for distributions_type_0_item_data in _distributions_type_0:
-                    distributions_type_0_item = (
-                        OGCRecordPropertiesDistributionsType0Item.from_dict(
-                            distributions_type_0_item_data
-                        )
-                    )
-
-                    distributions_type_0.append(distributions_type_0_item)
-
-                return distributions_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(
-                list[OGCRecordPropertiesDistributionsType0Item] | None | Unset, data
-            )
-
-        distributions = _parse_distributions(d.pop("distributions", UNSET))
-
-        external_ids = cast(list[str], d.pop("externalIds", UNSET))
-
-        def _parse_feature_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        feature_count = _parse_feature_count(d.pop("feature_count", UNSET))
-
-        def _parse_formats(data: object) -> list[str] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                formats_type_0 = cast(list[str], data)
-
-                return formats_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[str] | None | Unset, data)
-
-        formats = _parse_formats(d.pop("formats", UNSET))
+        band_count = _parse_band_count(d.pop("band_count", UNSET))
 
         def _parse_geometry_type(data: object) -> None | str | Unset:
             if data is None:
@@ -607,36 +537,52 @@ class OGCRecordProperties:
 
         geometry_type = _parse_geometry_type(d.pop("geometry_type", UNSET))
 
-        def _parse_gsd(data: object) -> float | None | Unset:
+        def _parse_feature_count(data: object) -> int | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(float | None | Unset, data)
+            return cast(int | None | Unset, data)
 
-        gsd = _parse_gsd(d.pop("gsd", UNSET))
+        feature_count = _parse_feature_count(d.pop("feature_count", UNSET))
 
-        has_quicklook = d.pop("has_quicklook", UNSET)
+        def _parse_row_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
 
-        def _parse_language(data: object) -> None | str | Unset:
+        row_count = _parse_row_count(d.pop("row_count", UNSET))
+
+        def _parse_column_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        column_count = _parse_column_count(d.pop("column_count", UNSET))
+
+        def _parse_source_organization(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        language = _parse_language(d.pop("language", UNSET))
+        source_organization = _parse_source_organization(
+            d.pop("source_organization", UNSET)
+        )
 
-        def _parse_lineage(data: object) -> None | str | Unset:
+        def _parse_source_format(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        lineage = _parse_lineage(d.pop("lineage", UNSET))
-
-        never_edited = d.pop("never_edited", UNSET)
+        source_format = _parse_source_format(d.pop("source_format", UNSET))
 
         def _parse_quality_detail(
             data: object,
@@ -668,16 +614,33 @@ class OGCRecordProperties:
 
         quality_statement = _parse_quality_statement(d.pop("quality_statement", UNSET))
 
-        def _parse_record_status(data: object) -> None | str | Unset:
+        def _parse_formats(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                formats_type_0 = cast(list[str], data)
+
+                return formats_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        formats = _parse_formats(d.pop("formats", UNSET))
+
+        def _parse_language(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        record_status = _parse_record_status(d.pop("record_status", UNSET))
+        language = _parse_language(d.pop("language", UNSET))
 
-        record_type = d.pop("record_type", UNSET)
+        external_ids = cast(list[str], d.pop("externalIds", UNSET))
 
         def _parse_rights(data: object) -> None | str | Unset:
             if data is None:
@@ -688,45 +651,14 @@ class OGCRecordProperties:
 
         rights = _parse_rights(d.pop("rights", UNSET))
 
-        def _parse_row_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        row_count = _parse_row_count(d.pop("row_count", UNSET))
-
-        def _parse_source_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        source_count = _parse_source_count(d.pop("source_count", UNSET))
-
-        def _parse_source_format(data: object) -> None | str | Unset:
+        def _parse_lineage(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        source_format = _parse_source_format(d.pop("source_format", UNSET))
-
-        def _parse_source_organization(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        source_organization = _parse_source_organization(
-            d.pop("source_organization", UNSET)
-        )
-
-        type_ = d.pop("type", UNSET)
+        lineage = _parse_lineage(d.pop("lineage", UNSET))
 
         def _parse_update_frequency(data: object) -> None | str | Unset:
             if data is None:
@@ -737,33 +669,83 @@ class OGCRecordProperties:
 
         update_frequency = _parse_update_frequency(d.pop("update_frequency", UNSET))
 
-        def _parse_updated(data: object) -> datetime.datetime | None | Unset:
+        def _parse_constraints(
+            data: object,
+        ) -> None | OGCRecordPropertiesConstraintsType0 | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             try:
-                if not isinstance(data, str):
+                if not isinstance(data, dict):
                     raise TypeError()
-                updated_type_0 = isoparse(data)
+                constraints_type_0 = OGCRecordPropertiesConstraintsType0.from_dict(data)
 
-                return updated_type_0
+                return constraints_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(datetime.datetime | None | Unset, data)
+            return cast(None | OGCRecordPropertiesConstraintsType0 | Unset, data)
 
-        updated = _parse_updated(d.pop("updated", UNSET))
+        constraints = _parse_constraints(d.pop("constraints", UNSET))
 
-        def _parse_updated_by_display(data: object) -> None | str | Unset:
+        def _parse_distributions(
+            data: object,
+        ) -> list[OGCRecordPropertiesDistributionsType0Item] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                distributions_type_0 = []
+                _distributions_type_0 = data
+                for distributions_type_0_item_data in _distributions_type_0:
+                    distributions_type_0_item = (
+                        OGCRecordPropertiesDistributionsType0Item.from_dict(
+                            distributions_type_0_item_data
+                        )
+                    )
+
+                    distributions_type_0.append(distributions_type_0_item)
+
+                return distributions_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                list[OGCRecordPropertiesDistributionsType0Item] | None | Unset, data
+            )
+
+        distributions = _parse_distributions(d.pop("distributions", UNSET))
+
+        def _parse_record_status(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        updated_by_display = _parse_updated_by_display(
-            d.pop("updated_by_display", UNSET)
-        )
+        record_status = _parse_record_status(d.pop("record_status", UNSET))
+
+        has_quicklook = d.pop("has_quicklook", UNSET)
+
+        def _parse_gsd(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        gsd = _parse_gsd(d.pop("gsd", UNSET))
+
+        def _parse_crs_is_geographic(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        crs_is_geographic = _parse_crs_is_geographic(d.pop("crs_is_geographic", UNSET))
 
         def _parse_vrt_type(data: object) -> None | str | Unset:
             if data is None:
@@ -774,45 +756,63 @@ class OGCRecordProperties:
 
         vrt_type = _parse_vrt_type(d.pop("vrt_type", UNSET))
 
+        def _parse_source_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        source_count = _parse_source_count(d.pop("source_count", UNSET))
+
+        def _parse_dataset_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        dataset_count = _parse_dataset_count(d.pop("dataset_count", UNSET))
+
         ogc_record_properties = cls(
-            contacts=contacts,
+            title=title,
             description=description,
             keywords=keywords,
             license_=license_,
             themes=themes,
+            contacts=contacts,
             time=time,
-            title=title,
-            band_count=band_count,
-            column_count=column_count,
-            constraints=constraints,
-            created=created,
-            crs=crs,
-            crs_is_geographic=crs_is_geographic,
-            dataset_count=dataset_count,
-            distributions=distributions,
-            external_ids=external_ids,
-            feature_count=feature_count,
-            formats=formats,
-            geometry_type=geometry_type,
-            gsd=gsd,
-            has_quicklook=has_quicklook,
-            language=language,
-            lineage=lineage,
-            never_edited=never_edited,
-            quality_detail=quality_detail,
-            quality_statement=quality_statement,
-            record_status=record_status,
-            record_type=record_type,
-            rights=rights,
-            row_count=row_count,
-            source_count=source_count,
-            source_format=source_format,
-            source_organization=source_organization,
             type_=type_,
-            update_frequency=update_frequency,
+            created=created,
             updated=updated,
             updated_by_display=updated_by_display,
+            never_edited=never_edited,
+            crs=crs,
+            record_type=record_type,
+            band_count=band_count,
+            geometry_type=geometry_type,
+            feature_count=feature_count,
+            row_count=row_count,
+            column_count=column_count,
+            source_organization=source_organization,
+            source_format=source_format,
+            quality_detail=quality_detail,
+            quality_statement=quality_statement,
+            formats=formats,
+            language=language,
+            external_ids=external_ids,
+            rights=rights,
+            lineage=lineage,
+            update_frequency=update_frequency,
+            constraints=constraints,
+            distributions=distributions,
+            record_status=record_status,
+            has_quicklook=has_quicklook,
+            gsd=gsd,
+            crs_is_geographic=crs_is_geographic,
             vrt_type=vrt_type,
+            source_count=source_count,
+            dataset_count=dataset_count,
         )
 
         ogc_record_properties.additional_properties = d

--- a/sdks/python/geolens/models/ogc_record_response.py
+++ b/sdks/python/geolens/models/ogc_record_response.py
@@ -29,25 +29,25 @@ class OGCRecordResponse:
 
     Attributes:
         id (str):
-        links (list[OGCRecordLink]):
-        properties (OGCRecordProperties): Properties block of an OGC API Records Feature.
         time (OGCRecordResponseTime):
-        assets (None | OGCRecordResponseAssetsType0 | Unset):
-        bbox (list[float] | None | Unset):
+        properties (OGCRecordProperties): Properties block of an OGC API Records Feature.
+        links (list[OGCRecordLink]):
+        type_ (str | Unset):  Default: 'Feature'.
         conforms_to (list[str] | None | Unset):
         geometry (None | OGCRecordResponseGeometryType0 | Unset):
-        type_ (str | Unset):  Default: 'Feature'.
+        assets (None | OGCRecordResponseAssetsType0 | Unset):
+        bbox (list[float] | None | Unset):
     """
 
     id: str
-    links: list[OGCRecordLink]
-    properties: OGCRecordProperties
     time: OGCRecordResponseTime
-    assets: None | OGCRecordResponseAssetsType0 | Unset = UNSET
-    bbox: list[float] | None | Unset = UNSET
+    properties: OGCRecordProperties
+    links: list[OGCRecordLink]
+    type_: str | Unset = "Feature"
     conforms_to: list[str] | None | Unset = UNSET
     geometry: None | OGCRecordResponseGeometryType0 | Unset = UNSET
-    type_: str | Unset = "Feature"
+    assets: None | OGCRecordResponseAssetsType0 | Unset = UNSET
+    bbox: list[float] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -60,31 +60,16 @@ class OGCRecordResponse:
 
         id = self.id
 
+        time = self.time.to_dict()
+
+        properties = self.properties.to_dict()
+
         links = []
         for links_item_data in self.links:
             links_item = links_item_data.to_dict()
             links.append(links_item)
 
-        properties = self.properties.to_dict()
-
-        time = self.time.to_dict()
-
-        assets: dict[str, Any] | None | Unset
-        if isinstance(self.assets, Unset):
-            assets = UNSET
-        elif isinstance(self.assets, OGCRecordResponseAssetsType0):
-            assets = self.assets.to_dict()
-        else:
-            assets = self.assets
-
-        bbox: list[float] | None | Unset
-        if isinstance(self.bbox, Unset):
-            bbox = UNSET
-        elif isinstance(self.bbox, list):
-            bbox = self.bbox
-
-        else:
-            bbox = self.bbox
+        type_ = self.type_
 
         conforms_to: list[str] | None | Unset
         if isinstance(self.conforms_to, Unset):
@@ -103,28 +88,43 @@ class OGCRecordResponse:
         else:
             geometry = self.geometry
 
-        type_ = self.type_
+        assets: dict[str, Any] | None | Unset
+        if isinstance(self.assets, Unset):
+            assets = UNSET
+        elif isinstance(self.assets, OGCRecordResponseAssetsType0):
+            assets = self.assets.to_dict()
+        else:
+            assets = self.assets
+
+        bbox: list[float] | None | Unset
+        if isinstance(self.bbox, Unset):
+            bbox = UNSET
+        elif isinstance(self.bbox, list):
+            bbox = self.bbox
+
+        else:
+            bbox = self.bbox
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "id": id,
-                "links": links,
-                "properties": properties,
                 "time": time,
+                "properties": properties,
+                "links": links,
             }
         )
-        if assets is not UNSET:
-            field_dict["assets"] = assets
-        if bbox is not UNSET:
-            field_dict["bbox"] = bbox
+        if type_ is not UNSET:
+            field_dict["type"] = type_
         if conforms_to is not UNSET:
             field_dict["conformsTo"] = conforms_to
         if geometry is not UNSET:
             field_dict["geometry"] = geometry
-        if type_ is not UNSET:
-            field_dict["type"] = type_
+        if assets is not UNSET:
+            field_dict["assets"] = assets
+        if bbox is not UNSET:
+            field_dict["bbox"] = bbox
 
         return field_dict
 
@@ -143,6 +143,10 @@ class OGCRecordResponse:
         d = dict(src_dict)
         id = d.pop("id")
 
+        time = OGCRecordResponseTime.from_dict(d.pop("time"))
+
+        properties = OGCRecordProperties.from_dict(d.pop("properties"))
+
         links = []
         _links = d.pop("links")
         for links_item_data in _links:
@@ -150,43 +154,7 @@ class OGCRecordResponse:
 
             links.append(links_item)
 
-        properties = OGCRecordProperties.from_dict(d.pop("properties"))
-
-        time = OGCRecordResponseTime.from_dict(d.pop("time"))
-
-        def _parse_assets(data: object) -> None | OGCRecordResponseAssetsType0 | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                assets_type_0 = OGCRecordResponseAssetsType0.from_dict(data)
-
-                return assets_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | OGCRecordResponseAssetsType0 | Unset, data)
-
-        assets = _parse_assets(d.pop("assets", UNSET))
-
-        def _parse_bbox(data: object) -> list[float] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                bbox_type_0 = cast(list[float], data)
-
-                return bbox_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[float] | None | Unset, data)
-
-        bbox = _parse_bbox(d.pop("bbox", UNSET))
+        type_ = d.pop("type", UNSET)
 
         def _parse_conforms_to(data: object) -> list[str] | None | Unset:
             if data is None:
@@ -224,18 +192,50 @@ class OGCRecordResponse:
 
         geometry = _parse_geometry(d.pop("geometry", UNSET))
 
-        type_ = d.pop("type", UNSET)
+        def _parse_assets(data: object) -> None | OGCRecordResponseAssetsType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                assets_type_0 = OGCRecordResponseAssetsType0.from_dict(data)
+
+                return assets_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | OGCRecordResponseAssetsType0 | Unset, data)
+
+        assets = _parse_assets(d.pop("assets", UNSET))
+
+        def _parse_bbox(data: object) -> list[float] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                bbox_type_0 = cast(list[float], data)
+
+                return bbox_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[float] | None | Unset, data)
+
+        bbox = _parse_bbox(d.pop("bbox", UNSET))
 
         ogc_record_response = cls(
             id=id,
-            links=links,
-            properties=properties,
             time=time,
-            assets=assets,
-            bbox=bbox,
+            properties=properties,
+            links=links,
+            type_=type_,
             conforms_to=conforms_to,
             geometry=geometry,
-            type_=type_,
+            assets=assets,
+            bbox=bbox,
         )
 
         ogc_record_response.additional_properties = d

--- a/sdks/python/geolens/models/patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature.py
+++ b/sdks/python/geolens/models/patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature.py
@@ -35,22 +35,22 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeature:
     Attributes:
         id (int):
         properties (PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureProperties):
+        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
         geometry (None | PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGeometry |
             PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGeometryCollection | Unset):
-        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
     """
 
     id: int
     properties: (
         PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureProperties
     )
+    type_: Literal["Feature"] | Unset = "Feature"
     geometry: (
         None
         | PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGeometry
         | PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGeometryCollection
         | Unset
     ) = UNSET
-    type_: Literal["Feature"] | Unset = "Feature"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -64,6 +64,8 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeature:
         id = self.id
 
         properties = self.properties.to_dict()
+
+        type_ = self.type_
 
         geometry: dict[str, Any] | None | Unset
         if isinstance(self.geometry, Unset):
@@ -81,8 +83,6 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeature:
         else:
             geometry = self.geometry
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -91,10 +91,10 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeature:
                 "properties": properties,
             }
         )
-        if geometry is not UNSET:
-            field_dict["geometry"] = geometry
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if geometry is not UNSET:
+            field_dict["geometry"] = geometry
 
         return field_dict
 
@@ -116,6 +116,10 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeature:
         properties = PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureProperties.from_dict(
             d.pop("properties")
         )
+
+        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
+        if type_ != "Feature" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'Feature', got '{type_}'")
 
         def _parse_geometry(
             data: object,
@@ -159,16 +163,12 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeature:
 
         geometry = _parse_geometry(d.pop("geometry", UNSET))
 
-        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
-        if type_ != "Feature" and not isinstance(type_, Unset):
-            raise ValueError(f"type must match const 'Feature', got '{type_}'")
-
         patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature = (
             cls(
                 id=id,
                 properties=properties,
-                geometry=geometry,
                 type_=type_,
+                geometry=geometry,
             )
         )
 

--- a/sdks/python/geolens/models/patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry.py
+++ b/sdks/python/geolens/models/patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry.py
@@ -27,25 +27,25 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGe
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_ (PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -54,15 +54,15 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGe
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry_collection.py
+++ b/sdks/python/geolens/models/patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry_collection.py
@@ -39,31 +39,31 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGe
     database 500. The write schemas add a raw-payload guard for a clear 422.
 
         Attributes:
+            type_ (Literal['GeometryCollection']):
             geometries (list[PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGeometryCollectionGeoJS
                 ONGeometry]):
-            type_ (Literal['GeometryCollection']):
     """
 
+    type_: Literal["GeometryCollection"]
     geometries: list[
         PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometry
     ]
-    type_: Literal["GeometryCollection"]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
         geometries = []
         for geometries_item_data in self.geometries:
             geometries_item = geometries_item_data.to_dict()
             geometries.append(geometries_item)
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "geometries": geometries,
                 "type": type_,
+                "geometries": geometries,
             }
         )
 
@@ -76,6 +76,12 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGe
         )
 
         d = dict(src_dict)
+        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
+        if type_ != "GeometryCollection":
+            raise ValueError(
+                f"type must match const 'GeometryCollection', got '{type_}'"
+            )
+
         geometries = []
         _geometries = d.pop("geometries")
         for geometries_item_data in _geometries:
@@ -85,15 +91,9 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGe
 
             geometries.append(geometries_item)
 
-        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
-        if type_ != "GeometryCollection":
-            raise ValueError(
-                f"type must match const 'GeometryCollection', got '{type_}'"
-            )
-
         patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry_collection = cls(
-            geometries=geometries,
             type_=type_,
+            geometries=geometries,
         )
 
         patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry_collection.additional_properties = d

--- a/sdks/python/geolens/models/patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.py
+++ b/sdks/python/geolens/models/patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.py
@@ -27,26 +27,26 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGe
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_
             (PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -55,15 +55,15 @@ class PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchGeoJSONFeatureGeoJSONGe
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry_collection_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry_collection_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         patch_single_feature_datasets_dataset_id_features_gid_patch_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/presigned_upload_request.py
+++ b/sdks/python/geolens/models/presigned_upload_request.py
@@ -16,21 +16,21 @@ T = TypeVar("T", bound="PresignedUploadRequest")
 class PresignedUploadRequest:
     """
     Attributes:
-        file_size (int): Total file size in bytes. Used to decide between single-part and multipart upload.
         filename (str): Original filename being uploaded. Used to determine the file extension and content disposition.
+        file_size (int): Total file size in bytes. Used to decide between single-part and multipart upload.
         content_type (str | Unset): MIME type to associate with the uploaded object. Default: 'application/octet-
             stream'.
     """
 
-    file_size: int
     filename: str
+    file_size: int
     content_type: str | Unset = "application/octet-stream"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        file_size = self.file_size
-
         filename = self.filename
+
+        file_size = self.file_size
 
         content_type = self.content_type
 
@@ -38,8 +38,8 @@ class PresignedUploadRequest:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "file_size": file_size,
                 "filename": filename,
+                "file_size": file_size,
             }
         )
         if content_type is not UNSET:
@@ -50,15 +50,15 @@ class PresignedUploadRequest:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        file_size = d.pop("file_size")
-
         filename = d.pop("filename")
+
+        file_size = d.pop("file_size")
 
         content_type = d.pop("content_type", UNSET)
 
         presigned_upload_request = cls(
-            file_size=file_size,
             filename=filename,
+            file_size=file_size,
             content_type=content_type,
         )
 

--- a/sdks/python/geolens/models/presigned_upload_response.py
+++ b/sdks/python/geolens/models/presigned_upload_response.py
@@ -20,31 +20,25 @@ class PresignedUploadResponse:
     """
     Attributes:
         job_id (UUID): Identifier of the ingestion job created for this upload.
-        s3_key (str): Object key in the S3 bucket where the file will be stored.
         urls (list[str]): One presigned PUT URL per part. Single-element list for single-part uploads.
-        part_size (int | None | Unset): Byte size of each part in a multipart upload.
+        s3_key (str): Object key in the S3 bucket where the file will be stored.
         upload_id (None | str | Unset): S3 multipart upload ID, set only for multipart uploads.
+        part_size (int | None | Unset): Byte size of each part in a multipart upload.
     """
 
     job_id: UUID
-    s3_key: str
     urls: list[str]
-    part_size: int | None | Unset = UNSET
+    s3_key: str
     upload_id: None | str | Unset = UNSET
+    part_size: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         job_id = str(self.job_id)
 
-        s3_key = self.s3_key
-
         urls = self.urls
 
-        part_size: int | None | Unset
-        if isinstance(self.part_size, Unset):
-            part_size = UNSET
-        else:
-            part_size = self.part_size
+        s3_key = self.s3_key
 
         upload_id: None | str | Unset
         if isinstance(self.upload_id, Unset):
@@ -52,19 +46,25 @@ class PresignedUploadResponse:
         else:
             upload_id = self.upload_id
 
+        part_size: int | None | Unset
+        if isinstance(self.part_size, Unset):
+            part_size = UNSET
+        else:
+            part_size = self.part_size
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "job_id": job_id,
-                "s3_key": s3_key,
                 "urls": urls,
+                "s3_key": s3_key,
             }
         )
-        if part_size is not UNSET:
-            field_dict["part_size"] = part_size
         if upload_id is not UNSET:
             field_dict["upload_id"] = upload_id
+        if part_size is not UNSET:
+            field_dict["part_size"] = part_size
 
         return field_dict
 
@@ -73,18 +73,9 @@ class PresignedUploadResponse:
         d = dict(src_dict)
         job_id = UUID(d.pop("job_id"))
 
-        s3_key = d.pop("s3_key")
-
         urls = cast(list[str], d.pop("urls"))
 
-        def _parse_part_size(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        part_size = _parse_part_size(d.pop("part_size", UNSET))
+        s3_key = d.pop("s3_key")
 
         def _parse_upload_id(data: object) -> None | str | Unset:
             if data is None:
@@ -95,12 +86,21 @@ class PresignedUploadResponse:
 
         upload_id = _parse_upload_id(d.pop("upload_id", UNSET))
 
+        def _parse_part_size(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        part_size = _parse_part_size(d.pop("part_size", UNSET))
+
         presigned_upload_response = cls(
             job_id=job_id,
-            s3_key=s3_key,
             urls=urls,
-            part_size=part_size,
+            s3_key=s3_key,
             upload_id=upload_id,
+            part_size=part_size,
         )
 
         presigned_upload_response.additional_properties = d

--- a/sdks/python/geolens/models/preview_response.py
+++ b/sdks/python/geolens/models/preview_response.py
@@ -27,40 +27,45 @@ T = TypeVar("T", bound="PreviewResponse")
 class PreviewResponse:
     """
     Attributes:
+        job_id (UUID): Identifier of the ingestion job being previewed.
+        source_filename (None | str): Original filename of the uploaded file, if known.
         columns (list[ColumnPreview]): Detected attribute columns. Each entry includes name, type, and nullability.
         crs (int | None): Detected coordinate reference system EPSG code, or null if undetermined.
-        feature_count (int | None): Total number of features in the source file, if known.
         geometry_type (None | str): Detected geometry type (Point, LineString, Polygon, MultiPolygon, etc.), or null for
             non-spatial data.
-        job_id (UUID): Identifier of the ingestion job being previewed.
-        layer_name (str): Name of the layer being previewed. Defaults to the source filename for single-layer files.
+        feature_count (int | None): Total number of features in the source file, if known.
         sample_rows (list[PreviewResponseSampleRowsItem]): Up to 5 sample rows from the source file for preview
             purposes.
-        source_filename (None | str): Original filename of the uploaded file, if known.
-        detected_geometry_columns (None | PreviewResponseDetectedGeometryColumnsType0 | Unset): Auto-detected lat/lon or
-            geometry columns for CSV/Excel sources. Null for native geospatial formats.
+        layer_name (str): Name of the layer being previewed. Defaults to the source filename for single-layer files.
         layers (list[LayerPreview] | None | Unset): List of all layers in multi-layer sources (e.g. GeoPackage). Null
             for single-layer files.
+        detected_geometry_columns (None | PreviewResponseDetectedGeometryColumnsType0 | Unset): Auto-detected lat/lon or
+            geometry columns for CSV/Excel sources. Null for native geospatial formats.
     """
 
+    job_id: UUID
+    source_filename: None | str
     columns: list[ColumnPreview]
     crs: int | None
-    feature_count: int | None
     geometry_type: None | str
-    job_id: UUID
-    layer_name: str
+    feature_count: int | None
     sample_rows: list[PreviewResponseSampleRowsItem]
-    source_filename: None | str
+    layer_name: str
+    layers: list[LayerPreview] | None | Unset = UNSET
     detected_geometry_columns: (
         None | PreviewResponseDetectedGeometryColumnsType0 | Unset
     ) = UNSET
-    layers: list[LayerPreview] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.preview_response_detected_geometry_columns_type_0 import (
             PreviewResponseDetectedGeometryColumnsType0,
         )
+
+        job_id = str(self.job_id)
+
+        source_filename: None | str
+        source_filename = self.source_filename
 
         columns = []
         for columns_item_data in self.columns:
@@ -70,33 +75,18 @@ class PreviewResponse:
         crs: int | None
         crs = self.crs
 
-        feature_count: int | None
-        feature_count = self.feature_count
-
         geometry_type: None | str
         geometry_type = self.geometry_type
 
-        job_id = str(self.job_id)
-
-        layer_name = self.layer_name
+        feature_count: int | None
+        feature_count = self.feature_count
 
         sample_rows = []
         for sample_rows_item_data in self.sample_rows:
             sample_rows_item = sample_rows_item_data.to_dict()
             sample_rows.append(sample_rows_item)
 
-        source_filename: None | str
-        source_filename = self.source_filename
-
-        detected_geometry_columns: dict[str, Any] | None | Unset
-        if isinstance(self.detected_geometry_columns, Unset):
-            detected_geometry_columns = UNSET
-        elif isinstance(
-            self.detected_geometry_columns, PreviewResponseDetectedGeometryColumnsType0
-        ):
-            detected_geometry_columns = self.detected_geometry_columns.to_dict()
-        else:
-            detected_geometry_columns = self.detected_geometry_columns
+        layer_name = self.layer_name
 
         layers: list[dict[str, Any]] | None | Unset
         if isinstance(self.layers, Unset):
@@ -110,24 +100,34 @@ class PreviewResponse:
         else:
             layers = self.layers
 
+        detected_geometry_columns: dict[str, Any] | None | Unset
+        if isinstance(self.detected_geometry_columns, Unset):
+            detected_geometry_columns = UNSET
+        elif isinstance(
+            self.detected_geometry_columns, PreviewResponseDetectedGeometryColumnsType0
+        ):
+            detected_geometry_columns = self.detected_geometry_columns.to_dict()
+        else:
+            detected_geometry_columns = self.detected_geometry_columns
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "job_id": job_id,
+                "source_filename": source_filename,
                 "columns": columns,
                 "crs": crs,
-                "feature_count": feature_count,
                 "geometry_type": geometry_type,
-                "job_id": job_id,
-                "layer_name": layer_name,
+                "feature_count": feature_count,
                 "sample_rows": sample_rows,
-                "source_filename": source_filename,
+                "layer_name": layer_name,
             }
         )
-        if detected_geometry_columns is not UNSET:
-            field_dict["detected_geometry_columns"] = detected_geometry_columns
         if layers is not UNSET:
             field_dict["layers"] = layers
+        if detected_geometry_columns is not UNSET:
+            field_dict["detected_geometry_columns"] = detected_geometry_columns
 
         return field_dict
 
@@ -143,6 +143,15 @@ class PreviewResponse:
         )
 
         d = dict(src_dict)
+        job_id = UUID(d.pop("job_id"))
+
+        def _parse_source_filename(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        source_filename = _parse_source_filename(d.pop("source_filename"))
+
         columns = []
         _columns = d.pop("columns")
         for columns_item_data in _columns:
@@ -157,13 +166,6 @@ class PreviewResponse:
 
         crs = _parse_crs(d.pop("crs"))
 
-        def _parse_feature_count(data: object) -> int | None:
-            if data is None:
-                return data
-            return cast(int | None, data)
-
-        feature_count = _parse_feature_count(d.pop("feature_count"))
-
         def _parse_geometry_type(data: object) -> None | str:
             if data is None:
                 return data
@@ -171,9 +173,12 @@ class PreviewResponse:
 
         geometry_type = _parse_geometry_type(d.pop("geometry_type"))
 
-        job_id = UUID(d.pop("job_id"))
+        def _parse_feature_count(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
 
-        layer_name = d.pop("layer_name")
+        feature_count = _parse_feature_count(d.pop("feature_count"))
 
         sample_rows = []
         _sample_rows = d.pop("sample_rows")
@@ -184,12 +189,29 @@ class PreviewResponse:
 
             sample_rows.append(sample_rows_item)
 
-        def _parse_source_filename(data: object) -> None | str:
+        layer_name = d.pop("layer_name")
+
+        def _parse_layers(data: object) -> list[LayerPreview] | None | Unset:
             if data is None:
                 return data
-            return cast(None | str, data)
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                layers_type_0 = []
+                _layers_type_0 = data
+                for layers_type_0_item_data in _layers_type_0:
+                    layers_type_0_item = LayerPreview.from_dict(layers_type_0_item_data)
 
-        source_filename = _parse_source_filename(d.pop("source_filename"))
+                    layers_type_0.append(layers_type_0_item)
+
+                return layers_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[LayerPreview] | None | Unset, data)
+
+        layers = _parse_layers(d.pop("layers", UNSET))
 
         def _parse_detected_geometry_columns(
             data: object,
@@ -216,39 +238,17 @@ class PreviewResponse:
             d.pop("detected_geometry_columns", UNSET)
         )
 
-        def _parse_layers(data: object) -> list[LayerPreview] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                layers_type_0 = []
-                _layers_type_0 = data
-                for layers_type_0_item_data in _layers_type_0:
-                    layers_type_0_item = LayerPreview.from_dict(layers_type_0_item_data)
-
-                    layers_type_0.append(layers_type_0_item)
-
-                return layers_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[LayerPreview] | None | Unset, data)
-
-        layers = _parse_layers(d.pop("layers", UNSET))
-
         preview_response = cls(
+            job_id=job_id,
+            source_filename=source_filename,
             columns=columns,
             crs=crs,
-            feature_count=feature_count,
             geometry_type=geometry_type,
-            job_id=job_id,
-            layer_name=layer_name,
+            feature_count=feature_count,
             sample_rows=sample_rows,
-            source_filename=source_filename,
-            detected_geometry_columns=detected_geometry_columns,
+            layer_name=layer_name,
             layers=layers,
+            detected_geometry_columns=detected_geometry_columns,
         )
 
         preview_response.additional_properties = d

--- a/sdks/python/geolens/models/probe_response.py
+++ b/sdks/python/geolens/models/probe_response.py
@@ -21,28 +21,28 @@ T = TypeVar("T", bound="ProbeResponse")
 class ProbeResponse:
     """
     Attributes:
-        layers (list[LayerInfo]): Layers exposed by the probed service.
         service_type (str): Detected service type, e.g. 'WFS 2.0' or 'ArcGIS FeatureServer'.
         url (str): Normalized service URL after probing.
+        layers (list[LayerInfo]): Layers exposed by the probed service.
         selected_layer_id (int | None | str | Unset): Auto-selected layer ID when the input URL contained a specific
             layer number.
     """
 
-    layers: list[LayerInfo]
     service_type: str
     url: str
+    layers: list[LayerInfo]
     selected_layer_id: int | None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        service_type = self.service_type
+
+        url = self.url
+
         layers = []
         for layers_item_data in self.layers:
             layers_item = layers_item_data.to_dict()
             layers.append(layers_item)
-
-        service_type = self.service_type
-
-        url = self.url
 
         selected_layer_id: int | None | str | Unset
         if isinstance(self.selected_layer_id, Unset):
@@ -54,9 +54,9 @@ class ProbeResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "layers": layers,
                 "service_type": service_type,
                 "url": url,
+                "layers": layers,
             }
         )
         if selected_layer_id is not UNSET:
@@ -69,16 +69,16 @@ class ProbeResponse:
         from ..models.layer_info import LayerInfo
 
         d = dict(src_dict)
+        service_type = d.pop("service_type")
+
+        url = d.pop("url")
+
         layers = []
         _layers = d.pop("layers")
         for layers_item_data in _layers:
             layers_item = LayerInfo.from_dict(layers_item_data)
 
             layers.append(layers_item)
-
-        service_type = d.pop("service_type")
-
-        url = d.pop("url")
 
         def _parse_selected_layer_id(data: object) -> int | None | str | Unset:
             if data is None:
@@ -90,9 +90,9 @@ class ProbeResponse:
         selected_layer_id = _parse_selected_layer_id(d.pop("selected_layer_id", UNSET))
 
         probe_response = cls(
-            layers=layers,
             service_type=service_type,
             url=url,
+            layers=layers,
             selected_layer_id=selected_layer_id,
         )
 

--- a/sdks/python/geolens/models/problem_detail.py
+++ b/sdks/python/geolens/models/problem_detail.py
@@ -21,20 +21,24 @@ T = TypeVar("T", bound="ProblemDetail")
 class ProblemDetail:
     """
     Attributes:
-        detail (list[Any] | ProblemDetailDetailType1 | str):
-        status (int):
         title (str):
+        status (int):
+        detail (list[Any] | ProblemDetailDetailType1 | str):
         type_ (str | Unset):  Default: 'about:blank'.
     """
 
-    detail: list[Any] | ProblemDetailDetailType1 | str
-    status: int
     title: str
+    status: int
+    detail: list[Any] | ProblemDetailDetailType1 | str
     type_: str | Unset = "about:blank"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.problem_detail_detail_type_1 import ProblemDetailDetailType1
+
+        title = self.title
+
+        status = self.status
 
         detail: dict[str, Any] | list[Any] | str
         if isinstance(self.detail, ProblemDetailDetailType1):
@@ -45,19 +49,15 @@ class ProblemDetail:
         else:
             detail = self.detail
 
-        status = self.status
-
-        title = self.title
-
         type_ = self.type_
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "detail": detail,
-                "status": status,
                 "title": title,
+                "status": status,
+                "detail": detail,
             }
         )
         if type_ is not UNSET:
@@ -70,6 +70,9 @@ class ProblemDetail:
         from ..models.problem_detail_detail_type_1 import ProblemDetailDetailType1
 
         d = dict(src_dict)
+        title = d.pop("title")
+
+        status = d.pop("status")
 
         def _parse_detail(data: object) -> list[Any] | ProblemDetailDetailType1 | str:
             try:
@@ -92,16 +95,12 @@ class ProblemDetail:
 
         detail = _parse_detail(d.pop("detail"))
 
-        status = d.pop("status")
-
-        title = d.pop("title")
-
         type_ = d.pop("type", UNSET)
 
         problem_detail = cls(
-            detail=detail,
-            status=status,
             title=title,
+            status=status,
+            detail=detail,
             type_=type_,
         )
 

--- a/sdks/python/geolens/models/provider_health.py
+++ b/sdks/python/geolens/models/provider_health.py
@@ -18,20 +18,20 @@ T = TypeVar("T", bound="ProviderHealth")
 class ProviderHealth:
     """
     Attributes:
-        latency_ms (float): Latency of the most recent health probe in milliseconds.
         status (str): Provider health status: 'ok' or 'error'.
+        latency_ms (float): Latency of the most recent health probe in milliseconds.
         error (None | str | Unset): Error message when status is 'error'.
     """
 
-    latency_ms: float
     status: str
+    latency_ms: float
     error: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        latency_ms = self.latency_ms
-
         status = self.status
+
+        latency_ms = self.latency_ms
 
         error: None | str | Unset
         if isinstance(self.error, Unset):
@@ -43,8 +43,8 @@ class ProviderHealth:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "latency_ms": latency_ms,
                 "status": status,
+                "latency_ms": latency_ms,
             }
         )
         if error is not UNSET:
@@ -55,9 +55,9 @@ class ProviderHealth:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        latency_ms = d.pop("latency_ms")
-
         status = d.pop("status")
+
+        latency_ms = d.pop("latency_ms")
 
         def _parse_error(data: object) -> None | str | Unset:
             if data is None:
@@ -69,8 +69,8 @@ class ProviderHealth:
         error = _parse_error(d.pop("error", UNSET))
 
         provider_health = cls(
-            latency_ms=latency_ms,
             status=status,
+            latency_ms=latency_ms,
             error=error,
         )
 

--- a/sdks/python/geolens/models/quality_detail.py
+++ b/sdks/python/geolens/models/quality_detail.py
@@ -21,28 +21,40 @@ class QualityDetail:
     """Automated quality assessment results.
 
     Attributes:
-        attribute_completeness (float):
-        metadata_completeness (float):
         overall (float):
-        computed_at (datetime.datetime | None | Unset):
-        crs_defined (float | None | Unset):
+        metadata_completeness (float):
+        attribute_completeness (float):
         geometry_validity (float | None | Unset):
+        crs_defined (float | None | Unset):
+        computed_at (datetime.datetime | None | Unset):
     """
 
-    attribute_completeness: float
-    metadata_completeness: float
     overall: float
-    computed_at: datetime.datetime | None | Unset = UNSET
-    crs_defined: float | None | Unset = UNSET
+    metadata_completeness: float
+    attribute_completeness: float
     geometry_validity: float | None | Unset = UNSET
+    crs_defined: float | None | Unset = UNSET
+    computed_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        attribute_completeness = self.attribute_completeness
+        overall = self.overall
 
         metadata_completeness = self.metadata_completeness
 
-        overall = self.overall
+        attribute_completeness = self.attribute_completeness
+
+        geometry_validity: float | None | Unset
+        if isinstance(self.geometry_validity, Unset):
+            geometry_validity = UNSET
+        else:
+            geometry_validity = self.geometry_validity
+
+        crs_defined: float | None | Unset
+        if isinstance(self.crs_defined, Unset):
+            crs_defined = UNSET
+        else:
+            crs_defined = self.crs_defined
 
         computed_at: None | str | Unset
         if isinstance(self.computed_at, Unset):
@@ -52,44 +64,50 @@ class QualityDetail:
         else:
             computed_at = self.computed_at
 
-        crs_defined: float | None | Unset
-        if isinstance(self.crs_defined, Unset):
-            crs_defined = UNSET
-        else:
-            crs_defined = self.crs_defined
-
-        geometry_validity: float | None | Unset
-        if isinstance(self.geometry_validity, Unset):
-            geometry_validity = UNSET
-        else:
-            geometry_validity = self.geometry_validity
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "attribute_completeness": attribute_completeness,
-                "metadata_completeness": metadata_completeness,
                 "overall": overall,
+                "metadata_completeness": metadata_completeness,
+                "attribute_completeness": attribute_completeness,
             }
         )
-        if computed_at is not UNSET:
-            field_dict["computed_at"] = computed_at
-        if crs_defined is not UNSET:
-            field_dict["crs_defined"] = crs_defined
         if geometry_validity is not UNSET:
             field_dict["geometry_validity"] = geometry_validity
+        if crs_defined is not UNSET:
+            field_dict["crs_defined"] = crs_defined
+        if computed_at is not UNSET:
+            field_dict["computed_at"] = computed_at
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        attribute_completeness = d.pop("attribute_completeness")
+        overall = d.pop("overall")
 
         metadata_completeness = d.pop("metadata_completeness")
 
-        overall = d.pop("overall")
+        attribute_completeness = d.pop("attribute_completeness")
+
+        def _parse_geometry_validity(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        geometry_validity = _parse_geometry_validity(d.pop("geometry_validity", UNSET))
+
+        def _parse_crs_defined(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        crs_defined = _parse_crs_defined(d.pop("crs_defined", UNSET))
 
         def _parse_computed_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -108,31 +126,13 @@ class QualityDetail:
 
         computed_at = _parse_computed_at(d.pop("computed_at", UNSET))
 
-        def _parse_crs_defined(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        crs_defined = _parse_crs_defined(d.pop("crs_defined", UNSET))
-
-        def _parse_geometry_validity(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        geometry_validity = _parse_geometry_validity(d.pop("geometry_validity", UNSET))
-
         quality_detail = cls(
-            attribute_completeness=attribute_completeness,
-            metadata_completeness=metadata_completeness,
             overall=overall,
-            computed_at=computed_at,
-            crs_defined=crs_defined,
+            metadata_completeness=metadata_completeness,
+            attribute_completeness=attribute_completeness,
             geometry_validity=geometry_validity,
+            crs_defined=crs_defined,
+            computed_at=computed_at,
         )
 
         quality_detail.additional_properties = d

--- a/sdks/python/geolens/models/raster_band_info.py
+++ b/sdks/python/geolens/models/raster_band_info.py
@@ -18,28 +18,22 @@ T = TypeVar("T", bound="RasterBandInfo")
 class RasterBandInfo:
     """
     Attributes:
-        dtype (str): Pixel data type, e.g. uint8, float32
         index (int): 1-based band index
-        color_interp (None | str | Unset): Color interpretation, e.g. Red, Green, Gray
+        dtype (str): Pixel data type, e.g. uint8, float32
         nodata (None | str | Unset): Nodata sentinel value for this band
+        color_interp (None | str | Unset): Color interpretation, e.g. Red, Green, Gray
     """
 
-    dtype: str
     index: int
-    color_interp: None | str | Unset = UNSET
+    dtype: str
     nodata: None | str | Unset = UNSET
+    color_interp: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        dtype = self.dtype
-
         index = self.index
 
-        color_interp: None | str | Unset
-        if isinstance(self.color_interp, Unset):
-            color_interp = UNSET
-        else:
-            color_interp = self.color_interp
+        dtype = self.dtype
 
         nodata: None | str | Unset
         if isinstance(self.nodata, Unset):
@@ -47,36 +41,33 @@ class RasterBandInfo:
         else:
             nodata = self.nodata
 
+        color_interp: None | str | Unset
+        if isinstance(self.color_interp, Unset):
+            color_interp = UNSET
+        else:
+            color_interp = self.color_interp
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "dtype": dtype,
                 "index": index,
+                "dtype": dtype,
             }
         )
-        if color_interp is not UNSET:
-            field_dict["color_interp"] = color_interp
         if nodata is not UNSET:
             field_dict["nodata"] = nodata
+        if color_interp is not UNSET:
+            field_dict["color_interp"] = color_interp
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        dtype = d.pop("dtype")
-
         index = d.pop("index")
 
-        def _parse_color_interp(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        color_interp = _parse_color_interp(d.pop("color_interp", UNSET))
+        dtype = d.pop("dtype")
 
         def _parse_nodata(data: object) -> None | str | Unset:
             if data is None:
@@ -87,11 +78,20 @@ class RasterBandInfo:
 
         nodata = _parse_nodata(d.pop("nodata", UNSET))
 
+        def _parse_color_interp(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        color_interp = _parse_color_interp(d.pop("color_interp", UNSET))
+
         raster_band_info = cls(
-            dtype=dtype,
             index=index,
-            color_interp=color_interp,
+            dtype=dtype,
             nodata=nodata,
+            color_interp=color_interp,
         )
 
         raster_band_info.additional_properties = d

--- a/sdks/python/geolens/models/raster_metadata.py
+++ b/sdks/python/geolens/models/raster_metadata.py
@@ -22,82 +22,49 @@ T = TypeVar("T", bound="RasterMetadata")
 class RasterMetadata:
     """
     Attributes:
-        band_count (int | None | Unset):
-        bands (list[RasterBandInfo] | Unset):
-        compression (None | str | Unset): Internal compression, e.g. DEFLATE, LZW
-        connect (None | RasterConnect | Unset):
+        epsg (int | None | Unset): EPSG code of the raster CRS
         crs_is_geographic (bool | None | Unset): True when the raster CRS is geographic (res_x/res_y are degrees, not
             meters); None when the CRS class is unknown.
-        epsg (int | None | Unset): EPSG code of the raster CRS
-        height (int | None | Unset): Raster height in pixels
-        is_dem (bool | None | Unset): True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade
-        nodata (None | str | Unset): Global nodata sentinel value
         res_x (float | None | Unset): Pixel resolution in X (CRS units)
         res_y (float | None | Unset): Pixel resolution in Y (CRS units)
-        resolution_strategy (None | str | Unset): VRT resolution strategy, e.g. highest, average
-        size_bytes (int | None | Unset): File size on disk in bytes
-        source_count (int | None | Unset): Number of source rasters in a VRT mosaic
-        status (None | str | Unset): Processing status, e.g. ready, failed
-        tile_url (None | str | Unset): Titiler XYZ tile endpoint
-        vrt_type (None | str | Unset): VRT variant: mosaic or timeseries
+        band_count (int | None | Unset):
+        is_dem (bool | None | Unset): True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade
+        nodata (None | str | Unset): Global nodata sentinel value
+        compression (None | str | Unset): Internal compression, e.g. DEFLATE, LZW
         width (int | None | Unset): Raster width in pixels
+        height (int | None | Unset): Raster height in pixels
+        size_bytes (int | None | Unset): File size on disk in bytes
+        tile_url (None | str | Unset): Titiler XYZ tile endpoint
+        bands (list[RasterBandInfo] | Unset):
+        connect (None | RasterConnect | Unset):
+        status (None | str | Unset): Processing status, e.g. ready, failed
+        vrt_type (None | str | Unset): VRT variant: mosaic or timeseries
+        source_count (int | None | Unset): Number of source rasters in a VRT mosaic
+        resolution_strategy (None | str | Unset): VRT resolution strategy, e.g. highest, average
     """
 
-    band_count: int | None | Unset = UNSET
-    bands: list[RasterBandInfo] | Unset = UNSET
-    compression: None | str | Unset = UNSET
-    connect: None | RasterConnect | Unset = UNSET
-    crs_is_geographic: bool | None | Unset = UNSET
     epsg: int | None | Unset = UNSET
-    height: int | None | Unset = UNSET
-    is_dem: bool | None | Unset = UNSET
-    nodata: None | str | Unset = UNSET
+    crs_is_geographic: bool | None | Unset = UNSET
     res_x: float | None | Unset = UNSET
     res_y: float | None | Unset = UNSET
-    resolution_strategy: None | str | Unset = UNSET
-    size_bytes: int | None | Unset = UNSET
-    source_count: int | None | Unset = UNSET
-    status: None | str | Unset = UNSET
-    tile_url: None | str | Unset = UNSET
-    vrt_type: None | str | Unset = UNSET
+    band_count: int | None | Unset = UNSET
+    is_dem: bool | None | Unset = UNSET
+    nodata: None | str | Unset = UNSET
+    compression: None | str | Unset = UNSET
     width: int | None | Unset = UNSET
+    height: int | None | Unset = UNSET
+    size_bytes: int | None | Unset = UNSET
+    tile_url: None | str | Unset = UNSET
+    bands: list[RasterBandInfo] | Unset = UNSET
+    connect: None | RasterConnect | Unset = UNSET
+    status: None | str | Unset = UNSET
+    vrt_type: None | str | Unset = UNSET
+    source_count: int | None | Unset = UNSET
+    resolution_strategy: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.raster_connect import RasterConnect
-
-        band_count: int | None | Unset
-        if isinstance(self.band_count, Unset):
-            band_count = UNSET
-        else:
-            band_count = self.band_count
-
-        bands: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.bands, Unset):
-            bands = []
-            for bands_item_data in self.bands:
-                bands_item = bands_item_data.to_dict()
-                bands.append(bands_item)
-
-        compression: None | str | Unset
-        if isinstance(self.compression, Unset):
-            compression = UNSET
-        else:
-            compression = self.compression
-
-        connect: dict[str, Any] | None | Unset
-        if isinstance(self.connect, Unset):
-            connect = UNSET
-        elif isinstance(self.connect, RasterConnect):
-            connect = self.connect.to_dict()
-        else:
-            connect = self.connect
-
-        crs_is_geographic: bool | None | Unset
-        if isinstance(self.crs_is_geographic, Unset):
-            crs_is_geographic = UNSET
-        else:
-            crs_is_geographic = self.crs_is_geographic
 
         epsg: int | None | Unset
         if isinstance(self.epsg, Unset):
@@ -105,23 +72,11 @@ class RasterMetadata:
         else:
             epsg = self.epsg
 
-        height: int | None | Unset
-        if isinstance(self.height, Unset):
-            height = UNSET
+        crs_is_geographic: bool | None | Unset
+        if isinstance(self.crs_is_geographic, Unset):
+            crs_is_geographic = UNSET
         else:
-            height = self.height
-
-        is_dem: bool | None | Unset
-        if isinstance(self.is_dem, Unset):
-            is_dem = UNSET
-        else:
-            is_dem = self.is_dem
-
-        nodata: None | str | Unset
-        if isinstance(self.nodata, Unset):
-            nodata = UNSET
-        else:
-            nodata = self.nodata
+            crs_is_geographic = self.crs_is_geographic
 
         res_x: float | None | Unset
         if isinstance(self.res_x, Unset):
@@ -135,41 +90,29 @@ class RasterMetadata:
         else:
             res_y = self.res_y
 
-        resolution_strategy: None | str | Unset
-        if isinstance(self.resolution_strategy, Unset):
-            resolution_strategy = UNSET
+        band_count: int | None | Unset
+        if isinstance(self.band_count, Unset):
+            band_count = UNSET
         else:
-            resolution_strategy = self.resolution_strategy
+            band_count = self.band_count
 
-        size_bytes: int | None | Unset
-        if isinstance(self.size_bytes, Unset):
-            size_bytes = UNSET
+        is_dem: bool | None | Unset
+        if isinstance(self.is_dem, Unset):
+            is_dem = UNSET
         else:
-            size_bytes = self.size_bytes
+            is_dem = self.is_dem
 
-        source_count: int | None | Unset
-        if isinstance(self.source_count, Unset):
-            source_count = UNSET
+        nodata: None | str | Unset
+        if isinstance(self.nodata, Unset):
+            nodata = UNSET
         else:
-            source_count = self.source_count
+            nodata = self.nodata
 
-        status: None | str | Unset
-        if isinstance(self.status, Unset):
-            status = UNSET
+        compression: None | str | Unset
+        if isinstance(self.compression, Unset):
+            compression = UNSET
         else:
-            status = self.status
-
-        tile_url: None | str | Unset
-        if isinstance(self.tile_url, Unset):
-            tile_url = UNSET
-        else:
-            tile_url = self.tile_url
-
-        vrt_type: None | str | Unset
-        if isinstance(self.vrt_type, Unset):
-            vrt_type = UNSET
-        else:
-            vrt_type = self.vrt_type
+            compression = self.compression
 
         width: int | None | Unset
         if isinstance(self.width, Unset):
@@ -177,45 +120,102 @@ class RasterMetadata:
         else:
             width = self.width
 
+        height: int | None | Unset
+        if isinstance(self.height, Unset):
+            height = UNSET
+        else:
+            height = self.height
+
+        size_bytes: int | None | Unset
+        if isinstance(self.size_bytes, Unset):
+            size_bytes = UNSET
+        else:
+            size_bytes = self.size_bytes
+
+        tile_url: None | str | Unset
+        if isinstance(self.tile_url, Unset):
+            tile_url = UNSET
+        else:
+            tile_url = self.tile_url
+
+        bands: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.bands, Unset):
+            bands = []
+            for bands_item_data in self.bands:
+                bands_item = bands_item_data.to_dict()
+                bands.append(bands_item)
+
+        connect: dict[str, Any] | None | Unset
+        if isinstance(self.connect, Unset):
+            connect = UNSET
+        elif isinstance(self.connect, RasterConnect):
+            connect = self.connect.to_dict()
+        else:
+            connect = self.connect
+
+        status: None | str | Unset
+        if isinstance(self.status, Unset):
+            status = UNSET
+        else:
+            status = self.status
+
+        vrt_type: None | str | Unset
+        if isinstance(self.vrt_type, Unset):
+            vrt_type = UNSET
+        else:
+            vrt_type = self.vrt_type
+
+        source_count: int | None | Unset
+        if isinstance(self.source_count, Unset):
+            source_count = UNSET
+        else:
+            source_count = self.source_count
+
+        resolution_strategy: None | str | Unset
+        if isinstance(self.resolution_strategy, Unset):
+            resolution_strategy = UNSET
+        else:
+            resolution_strategy = self.resolution_strategy
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if band_count is not UNSET:
-            field_dict["band_count"] = band_count
-        if bands is not UNSET:
-            field_dict["bands"] = bands
-        if compression is not UNSET:
-            field_dict["compression"] = compression
-        if connect is not UNSET:
-            field_dict["connect"] = connect
-        if crs_is_geographic is not UNSET:
-            field_dict["crs_is_geographic"] = crs_is_geographic
         if epsg is not UNSET:
             field_dict["epsg"] = epsg
-        if height is not UNSET:
-            field_dict["height"] = height
-        if is_dem is not UNSET:
-            field_dict["is_dem"] = is_dem
-        if nodata is not UNSET:
-            field_dict["nodata"] = nodata
+        if crs_is_geographic is not UNSET:
+            field_dict["crs_is_geographic"] = crs_is_geographic
         if res_x is not UNSET:
             field_dict["res_x"] = res_x
         if res_y is not UNSET:
             field_dict["res_y"] = res_y
-        if resolution_strategy is not UNSET:
-            field_dict["resolution_strategy"] = resolution_strategy
-        if size_bytes is not UNSET:
-            field_dict["size_bytes"] = size_bytes
-        if source_count is not UNSET:
-            field_dict["source_count"] = source_count
-        if status is not UNSET:
-            field_dict["status"] = status
-        if tile_url is not UNSET:
-            field_dict["tile_url"] = tile_url
-        if vrt_type is not UNSET:
-            field_dict["vrt_type"] = vrt_type
+        if band_count is not UNSET:
+            field_dict["band_count"] = band_count
+        if is_dem is not UNSET:
+            field_dict["is_dem"] = is_dem
+        if nodata is not UNSET:
+            field_dict["nodata"] = nodata
+        if compression is not UNSET:
+            field_dict["compression"] = compression
         if width is not UNSET:
             field_dict["width"] = width
+        if height is not UNSET:
+            field_dict["height"] = height
+        if size_bytes is not UNSET:
+            field_dict["size_bytes"] = size_bytes
+        if tile_url is not UNSET:
+            field_dict["tile_url"] = tile_url
+        if bands is not UNSET:
+            field_dict["bands"] = bands
+        if connect is not UNSET:
+            field_dict["connect"] = connect
+        if status is not UNSET:
+            field_dict["status"] = status
+        if vrt_type is not UNSET:
+            field_dict["vrt_type"] = vrt_type
+        if source_count is not UNSET:
+            field_dict["source_count"] = source_count
+        if resolution_strategy is not UNSET:
+            field_dict["resolution_strategy"] = resolution_strategy
 
         return field_dict
 
@@ -226,59 +226,6 @@ class RasterMetadata:
 
         d = dict(src_dict)
 
-        def _parse_band_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        band_count = _parse_band_count(d.pop("band_count", UNSET))
-
-        _bands = d.pop("bands", UNSET)
-        bands: list[RasterBandInfo] | Unset = UNSET
-        if _bands is not UNSET:
-            bands = []
-            for bands_item_data in _bands:
-                bands_item = RasterBandInfo.from_dict(bands_item_data)
-
-                bands.append(bands_item)
-
-        def _parse_compression(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        compression = _parse_compression(d.pop("compression", UNSET))
-
-        def _parse_connect(data: object) -> None | RasterConnect | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                connect_type_0 = RasterConnect.from_dict(data)
-
-                return connect_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | RasterConnect | Unset, data)
-
-        connect = _parse_connect(d.pop("connect", UNSET))
-
-        def _parse_crs_is_geographic(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        crs_is_geographic = _parse_crs_is_geographic(d.pop("crs_is_geographic", UNSET))
-
         def _parse_epsg(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -288,32 +235,14 @@ class RasterMetadata:
 
         epsg = _parse_epsg(d.pop("epsg", UNSET))
 
-        def _parse_height(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        height = _parse_height(d.pop("height", UNSET))
-
-        def _parse_is_dem(data: object) -> bool | None | Unset:
+        def _parse_crs_is_geographic(data: object) -> bool | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(bool | None | Unset, data)
 
-        is_dem = _parse_is_dem(d.pop("is_dem", UNSET))
-
-        def _parse_nodata(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        nodata = _parse_nodata(d.pop("nodata", UNSET))
+        crs_is_geographic = _parse_crs_is_geographic(d.pop("crs_is_geographic", UNSET))
 
         def _parse_res_x(data: object) -> float | None | Unset:
             if data is None:
@@ -333,6 +262,131 @@ class RasterMetadata:
 
         res_y = _parse_res_y(d.pop("res_y", UNSET))
 
+        def _parse_band_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        band_count = _parse_band_count(d.pop("band_count", UNSET))
+
+        def _parse_is_dem(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_dem = _parse_is_dem(d.pop("is_dem", UNSET))
+
+        def _parse_nodata(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        nodata = _parse_nodata(d.pop("nodata", UNSET))
+
+        def _parse_compression(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        compression = _parse_compression(d.pop("compression", UNSET))
+
+        def _parse_width(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        width = _parse_width(d.pop("width", UNSET))
+
+        def _parse_height(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        height = _parse_height(d.pop("height", UNSET))
+
+        def _parse_size_bytes(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        size_bytes = _parse_size_bytes(d.pop("size_bytes", UNSET))
+
+        def _parse_tile_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        tile_url = _parse_tile_url(d.pop("tile_url", UNSET))
+
+        _bands = d.pop("bands", UNSET)
+        bands: list[RasterBandInfo] | Unset = UNSET
+        if _bands is not UNSET:
+            bands = []
+            for bands_item_data in _bands:
+                bands_item = RasterBandInfo.from_dict(bands_item_data)
+
+                bands.append(bands_item)
+
+        def _parse_connect(data: object) -> None | RasterConnect | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                connect_type_0 = RasterConnect.from_dict(data)
+
+                return connect_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | RasterConnect | Unset, data)
+
+        connect = _parse_connect(d.pop("connect", UNSET))
+
+        def _parse_status(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        status = _parse_status(d.pop("status", UNSET))
+
+        def _parse_vrt_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        vrt_type = _parse_vrt_type(d.pop("vrt_type", UNSET))
+
+        def _parse_source_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        source_count = _parse_source_count(d.pop("source_count", UNSET))
+
         def _parse_resolution_strategy(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -344,79 +398,25 @@ class RasterMetadata:
             d.pop("resolution_strategy", UNSET)
         )
 
-        def _parse_size_bytes(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        size_bytes = _parse_size_bytes(d.pop("size_bytes", UNSET))
-
-        def _parse_source_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        source_count = _parse_source_count(d.pop("source_count", UNSET))
-
-        def _parse_status(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        status = _parse_status(d.pop("status", UNSET))
-
-        def _parse_tile_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        tile_url = _parse_tile_url(d.pop("tile_url", UNSET))
-
-        def _parse_vrt_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        vrt_type = _parse_vrt_type(d.pop("vrt_type", UNSET))
-
-        def _parse_width(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        width = _parse_width(d.pop("width", UNSET))
-
         raster_metadata = cls(
-            band_count=band_count,
-            bands=bands,
-            compression=compression,
-            connect=connect,
-            crs_is_geographic=crs_is_geographic,
             epsg=epsg,
-            height=height,
-            is_dem=is_dem,
-            nodata=nodata,
+            crs_is_geographic=crs_is_geographic,
             res_x=res_x,
             res_y=res_y,
-            resolution_strategy=resolution_strategy,
-            size_bytes=size_bytes,
-            source_count=source_count,
-            status=status,
-            tile_url=tile_url,
-            vrt_type=vrt_type,
+            band_count=band_count,
+            is_dem=is_dem,
+            nodata=nodata,
+            compression=compression,
             width=width,
+            height=height,
+            size_bytes=size_bytes,
+            tile_url=tile_url,
+            bands=bands,
+            connect=connect,
+            status=status,
+            vrt_type=vrt_type,
+            source_count=source_count,
+            resolution_strategy=resolution_strategy,
         )
 
         raster_metadata.additional_properties = d

--- a/sdks/python/geolens/models/raster_preview_response.py
+++ b/sdks/python/geolens/models/raster_preview_response.py
@@ -21,50 +21,48 @@ T = TypeVar("T", bound="RasterPreviewResponse")
 class RasterPreviewResponse:
     """
     Attributes:
-        band_count (int): Number of raster bands.
-        compliance_reason (str): Explanation of COG compliance status. Lists missing requirements when not compliant.
-        compression (None | str): Existing compression method (e.g. 'LZW', 'DEFLATE'), or null for uncompressed.
+        job_id (UUID): Identifier of the raster ingestion job being previewed.
+        source_filename (None | str): Original filename of the uploaded raster file.
         crs_epsg (int | None): Detected EPSG code for the raster's CRS, if available.
         crs_wkt (None | str): Full WKT representation of the raster's CRS.
-        dtype (str): Pixel data type (e.g. 'uint8', 'float32').
-        file_size_bytes (int | None): Source file size in bytes.
+        band_count (int): Number of raster bands.
+        width (int): Raster width in pixels.
         height (int): Raster height in pixels.
-        is_cog_compliant (bool): Whether the source file is already a Cloud-Optimized GeoTIFF.
-        job_id (UUID): Identifier of the raster ingestion job being previewed.
+        dtype (str): Pixel data type (e.g. 'uint8', 'float32').
         nodata (float | None | str): Nodata value for the raster, if defined.
         res_x (float): Pixel resolution along the X axis in CRS units.
         res_y (float): Pixel resolution along the Y axis in CRS units.
-        source_filename (None | str): Original filename of the uploaded raster file.
-        width (int): Raster width in pixels.
+        compression (None | str): Existing compression method (e.g. 'LZW', 'DEFLATE'), or null for uncompressed.
+        file_size_bytes (int | None): Source file size in bytes.
+        is_cog_compliant (bool): Whether the source file is already a Cloud-Optimized GeoTIFF.
+        compliance_reason (str): Explanation of COG compliance status. Lists missing requirements when not compliant.
         temporal_start (datetime.datetime | None | Unset): ISO 8601 acquisition timestamp parsed from raster metadata,
             if present.
     """
 
-    band_count: int
-    compliance_reason: str
-    compression: None | str
+    job_id: UUID
+    source_filename: None | str
     crs_epsg: int | None
     crs_wkt: None | str
-    dtype: str
-    file_size_bytes: int | None
+    band_count: int
+    width: int
     height: int
-    is_cog_compliant: bool
-    job_id: UUID
+    dtype: str
     nodata: float | None | str
     res_x: float
     res_y: float
-    source_filename: None | str
-    width: int
+    compression: None | str
+    file_size_bytes: int | None
+    is_cog_compliant: bool
+    compliance_reason: str
     temporal_start: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        band_count = self.band_count
+        job_id = str(self.job_id)
 
-        compliance_reason = self.compliance_reason
-
-        compression: None | str
-        compression = self.compression
+        source_filename: None | str
+        source_filename = self.source_filename
 
         crs_epsg: int | None
         crs_epsg = self.crs_epsg
@@ -72,16 +70,13 @@ class RasterPreviewResponse:
         crs_wkt: None | str
         crs_wkt = self.crs_wkt
 
-        dtype = self.dtype
+        band_count = self.band_count
 
-        file_size_bytes: int | None
-        file_size_bytes = self.file_size_bytes
+        width = self.width
 
         height = self.height
 
-        is_cog_compliant = self.is_cog_compliant
-
-        job_id = str(self.job_id)
+        dtype = self.dtype
 
         nodata: float | None | str
         nodata = self.nodata
@@ -90,10 +85,15 @@ class RasterPreviewResponse:
 
         res_y = self.res_y
 
-        source_filename: None | str
-        source_filename = self.source_filename
+        compression: None | str
+        compression = self.compression
 
-        width = self.width
+        file_size_bytes: int | None
+        file_size_bytes = self.file_size_bytes
+
+        is_cog_compliant = self.is_cog_compliant
+
+        compliance_reason = self.compliance_reason
 
         temporal_start: None | str | Unset
         if isinstance(self.temporal_start, Unset):
@@ -107,21 +107,21 @@ class RasterPreviewResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "band_count": band_count,
-                "compliance_reason": compliance_reason,
-                "compression": compression,
+                "job_id": job_id,
+                "source_filename": source_filename,
                 "crs_epsg": crs_epsg,
                 "crs_wkt": crs_wkt,
-                "dtype": dtype,
-                "file_size_bytes": file_size_bytes,
+                "band_count": band_count,
+                "width": width,
                 "height": height,
-                "is_cog_compliant": is_cog_compliant,
-                "job_id": job_id,
+                "dtype": dtype,
                 "nodata": nodata,
                 "res_x": res_x,
                 "res_y": res_y,
-                "source_filename": source_filename,
-                "width": width,
+                "compression": compression,
+                "file_size_bytes": file_size_bytes,
+                "is_cog_compliant": is_cog_compliant,
+                "compliance_reason": compliance_reason,
             }
         )
         if temporal_start is not UNSET:
@@ -132,16 +132,14 @@ class RasterPreviewResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        band_count = d.pop("band_count")
+        job_id = UUID(d.pop("job_id"))
 
-        compliance_reason = d.pop("compliance_reason")
-
-        def _parse_compression(data: object) -> None | str:
+        def _parse_source_filename(data: object) -> None | str:
             if data is None:
                 return data
             return cast(None | str, data)
 
-        compression = _parse_compression(d.pop("compression"))
+        source_filename = _parse_source_filename(d.pop("source_filename"))
 
         def _parse_crs_epsg(data: object) -> int | None:
             if data is None:
@@ -157,20 +155,13 @@ class RasterPreviewResponse:
 
         crs_wkt = _parse_crs_wkt(d.pop("crs_wkt"))
 
-        dtype = d.pop("dtype")
+        band_count = d.pop("band_count")
 
-        def _parse_file_size_bytes(data: object) -> int | None:
-            if data is None:
-                return data
-            return cast(int | None, data)
-
-        file_size_bytes = _parse_file_size_bytes(d.pop("file_size_bytes"))
+        width = d.pop("width")
 
         height = d.pop("height")
 
-        is_cog_compliant = d.pop("is_cog_compliant")
-
-        job_id = UUID(d.pop("job_id"))
+        dtype = d.pop("dtype")
 
         def _parse_nodata(data: object) -> float | None | str:
             if data is None:
@@ -183,14 +174,23 @@ class RasterPreviewResponse:
 
         res_y = d.pop("res_y")
 
-        def _parse_source_filename(data: object) -> None | str:
+        def _parse_compression(data: object) -> None | str:
             if data is None:
                 return data
             return cast(None | str, data)
 
-        source_filename = _parse_source_filename(d.pop("source_filename"))
+        compression = _parse_compression(d.pop("compression"))
 
-        width = d.pop("width")
+        def _parse_file_size_bytes(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        file_size_bytes = _parse_file_size_bytes(d.pop("file_size_bytes"))
+
+        is_cog_compliant = d.pop("is_cog_compliant")
+
+        compliance_reason = d.pop("compliance_reason")
 
         def _parse_temporal_start(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -210,21 +210,21 @@ class RasterPreviewResponse:
         temporal_start = _parse_temporal_start(d.pop("temporal_start", UNSET))
 
         raster_preview_response = cls(
-            band_count=band_count,
-            compliance_reason=compliance_reason,
-            compression=compression,
+            job_id=job_id,
+            source_filename=source_filename,
             crs_epsg=crs_epsg,
             crs_wkt=crs_wkt,
-            dtype=dtype,
-            file_size_bytes=file_size_bytes,
+            band_count=band_count,
+            width=width,
             height=height,
-            is_cog_compliant=is_cog_compliant,
-            job_id=job_id,
+            dtype=dtype,
             nodata=nodata,
             res_x=res_x,
             res_y=res_y,
-            source_filename=source_filename,
-            width=width,
+            compression=compression,
+            file_size_bytes=file_size_bytes,
+            is_cog_compliant=is_cog_compliant,
+            compliance_reason=compliance_reason,
             temporal_start=temporal_start,
         )
 

--- a/sdks/python/geolens/models/raster_tile_token.py
+++ b/sdks/python/geolens/models/raster_tile_token.py
@@ -31,33 +31,45 @@ class RasterTileToken:
     as fields, mirroring `VectorTileToken`, for clients that rebuild the URL.
 
         Attributes:
-            bounds (list[float] | None):
-            exp (int):
-            expires_in (int):
-            format_ (str):
             kind (Literal['raster']):
-            maxzoom (int):
-            minzoom (int):
-            scope (str):
-            sig (str):
-            tile_size (int):
             tile_url (str):
+            sig (str):
+            exp (int):
+            scope (str):
+            expires_in (int):
+            bounds (list[float] | None):
+            minzoom (int):
+            maxzoom (int):
+            tile_size (int):
+            format_ (str):
     """
 
-    bounds: list[float] | None
-    exp: int
-    expires_in: int
-    format_: str
     kind: Literal["raster"]
-    maxzoom: int
-    minzoom: int
-    scope: str
-    sig: str
-    tile_size: int
     tile_url: str
+    sig: str
+    exp: int
+    scope: str
+    expires_in: int
+    bounds: list[float] | None
+    minzoom: int
+    maxzoom: int
+    tile_size: int
+    format_: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        kind = self.kind
+
+        tile_url = self.tile_url
+
+        sig = self.sig
+
+        exp = self.exp
+
+        scope = self.scope
+
+        expires_in = self.expires_in
+
         bounds: list[float] | None
         if isinstance(self.bounds, list):
             bounds = self.bounds
@@ -65,41 +77,29 @@ class RasterTileToken:
         else:
             bounds = self.bounds
 
-        exp = self.exp
-
-        expires_in = self.expires_in
-
-        format_ = self.format_
-
-        kind = self.kind
+        minzoom = self.minzoom
 
         maxzoom = self.maxzoom
 
-        minzoom = self.minzoom
-
-        scope = self.scope
-
-        sig = self.sig
-
         tile_size = self.tile_size
 
-        tile_url = self.tile_url
+        format_ = self.format_
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "bounds": bounds,
-                "exp": exp,
-                "expires_in": expires_in,
-                "format": format_,
                 "kind": kind,
-                "maxzoom": maxzoom,
-                "minzoom": minzoom,
-                "scope": scope,
-                "sig": sig,
-                "tile_size": tile_size,
                 "tile_url": tile_url,
+                "sig": sig,
+                "exp": exp,
+                "scope": scope,
+                "expires_in": expires_in,
+                "bounds": bounds,
+                "minzoom": minzoom,
+                "maxzoom": maxzoom,
+                "tile_size": tile_size,
+                "format": format_,
             }
         )
 
@@ -108,6 +108,19 @@ class RasterTileToken:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        kind = cast(Literal["raster"], d.pop("kind"))
+        if kind != "raster":
+            raise ValueError(f"kind must match const 'raster', got '{kind}'")
+
+        tile_url = d.pop("tile_url")
+
+        sig = d.pop("sig")
+
+        exp = d.pop("exp")
+
+        scope = d.pop("scope")
+
+        expires_in = d.pop("expires_in")
 
         def _parse_bounds(data: object) -> list[float] | None:
             if data is None:
@@ -124,40 +137,26 @@ class RasterTileToken:
 
         bounds = _parse_bounds(d.pop("bounds"))
 
-        exp = d.pop("exp")
-
-        expires_in = d.pop("expires_in")
-
-        format_ = d.pop("format")
-
-        kind = cast(Literal["raster"], d.pop("kind"))
-        if kind != "raster":
-            raise ValueError(f"kind must match const 'raster', got '{kind}'")
+        minzoom = d.pop("minzoom")
 
         maxzoom = d.pop("maxzoom")
 
-        minzoom = d.pop("minzoom")
-
-        scope = d.pop("scope")
-
-        sig = d.pop("sig")
-
         tile_size = d.pop("tile_size")
 
-        tile_url = d.pop("tile_url")
+        format_ = d.pop("format")
 
         raster_tile_token = cls(
-            bounds=bounds,
-            exp=exp,
-            expires_in=expires_in,
-            format_=format_,
             kind=kind,
-            maxzoom=maxzoom,
-            minzoom=minzoom,
-            scope=scope,
-            sig=sig,
-            tile_size=tile_size,
             tile_url=tile_url,
+            sig=sig,
+            exp=exp,
+            scope=scope,
+            expires_in=expires_in,
+            bounds=bounds,
+            minzoom=minzoom,
+            maxzoom=maxzoom,
+            tile_size=tile_size,
+            format_=format_,
         )
 
         raster_tile_token.additional_properties = d

--- a/sdks/python/geolens/models/related_dataset_item.py
+++ b/sdks/python/geolens/models/related_dataset_item.py
@@ -18,45 +18,33 @@ T = TypeVar("T", bound="RelatedDatasetItem")
 class RelatedDatasetItem:
     """
     Attributes:
-        geometry_type (None | str):
         id (str):
         name (str):
+        geometry_type (None | str):
         similarity (float): Cosine similarity score (0-1)
-        band_count (int | None | Unset):
-        feature_count (int | None | Unset):
         record_type (None | str | Unset):
+        feature_count (int | None | Unset):
+        band_count (int | None | Unset):
     """
 
-    geometry_type: None | str
     id: str
     name: str
+    geometry_type: None | str
     similarity: float
-    band_count: int | None | Unset = UNSET
-    feature_count: int | None | Unset = UNSET
     record_type: None | str | Unset = UNSET
+    feature_count: int | None | Unset = UNSET
+    band_count: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        geometry_type: None | str
-        geometry_type = self.geometry_type
-
         id = self.id
 
         name = self.name
 
+        geometry_type: None | str
+        geometry_type = self.geometry_type
+
         similarity = self.similarity
-
-        band_count: int | None | Unset
-        if isinstance(self.band_count, Unset):
-            band_count = UNSET
-        else:
-            band_count = self.band_count
-
-        feature_count: int | None | Unset
-        if isinstance(self.feature_count, Unset):
-            feature_count = UNSET
-        else:
-            feature_count = self.feature_count
 
         record_type: None | str | Unset
         if isinstance(self.record_type, Unset):
@@ -64,28 +52,43 @@ class RelatedDatasetItem:
         else:
             record_type = self.record_type
 
+        feature_count: int | None | Unset
+        if isinstance(self.feature_count, Unset):
+            feature_count = UNSET
+        else:
+            feature_count = self.feature_count
+
+        band_count: int | None | Unset
+        if isinstance(self.band_count, Unset):
+            band_count = UNSET
+        else:
+            band_count = self.band_count
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "geometry_type": geometry_type,
                 "id": id,
                 "name": name,
+                "geometry_type": geometry_type,
                 "similarity": similarity,
             }
         )
-        if band_count is not UNSET:
-            field_dict["band_count"] = band_count
-        if feature_count is not UNSET:
-            field_dict["feature_count"] = feature_count
         if record_type is not UNSET:
             field_dict["record_type"] = record_type
+        if feature_count is not UNSET:
+            field_dict["feature_count"] = feature_count
+        if band_count is not UNSET:
+            field_dict["band_count"] = band_count
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        id = d.pop("id")
+
+        name = d.pop("name")
 
         def _parse_geometry_type(data: object) -> None | str:
             if data is None:
@@ -94,29 +97,7 @@ class RelatedDatasetItem:
 
         geometry_type = _parse_geometry_type(d.pop("geometry_type"))
 
-        id = d.pop("id")
-
-        name = d.pop("name")
-
         similarity = d.pop("similarity")
-
-        def _parse_band_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        band_count = _parse_band_count(d.pop("band_count", UNSET))
-
-        def _parse_feature_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        feature_count = _parse_feature_count(d.pop("feature_count", UNSET))
 
         def _parse_record_type(data: object) -> None | str | Unset:
             if data is None:
@@ -127,14 +108,32 @@ class RelatedDatasetItem:
 
         record_type = _parse_record_type(d.pop("record_type", UNSET))
 
+        def _parse_feature_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        feature_count = _parse_feature_count(d.pop("feature_count", UNSET))
+
+        def _parse_band_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        band_count = _parse_band_count(d.pop("band_count", UNSET))
+
         related_dataset_item = cls(
-            geometry_type=geometry_type,
             id=id,
             name=name,
+            geometry_type=geometry_type,
             similarity=similarity,
-            band_count=band_count,
-            feature_count=feature_count,
             record_type=record_type,
+            feature_count=feature_count,
+            band_count=band_count,
         )
 
         related_dataset_item.additional_properties = d

--- a/sdks/python/geolens/models/replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature.py
+++ b/sdks/python/geolens/models/replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature.py
@@ -35,22 +35,22 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeature:
     Attributes:
         id (int):
         properties (ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureProperties):
+        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
         geometry (None | ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGeometry |
             ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGeometryCollection | Unset):
-        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
     """
 
     id: int
     properties: (
         ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureProperties
     )
+    type_: Literal["Feature"] | Unset = "Feature"
     geometry: (
         None
         | ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGeometry
         | ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGeometryCollection
         | Unset
     ) = UNSET
-    type_: Literal["Feature"] | Unset = "Feature"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -64,6 +64,8 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeature:
         id = self.id
 
         properties = self.properties.to_dict()
+
+        type_ = self.type_
 
         geometry: dict[str, Any] | None | Unset
         if isinstance(self.geometry, Unset):
@@ -81,8 +83,6 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeature:
         else:
             geometry = self.geometry
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -91,10 +91,10 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeature:
                 "properties": properties,
             }
         )
-        if geometry is not UNSET:
-            field_dict["geometry"] = geometry
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if geometry is not UNSET:
+            field_dict["geometry"] = geometry
 
         return field_dict
 
@@ -116,6 +116,10 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeature:
         properties = ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureProperties.from_dict(
             d.pop("properties")
         )
+
+        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
+        if type_ != "Feature" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'Feature', got '{type_}'")
 
         def _parse_geometry(
             data: object,
@@ -159,16 +163,12 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeature:
 
         geometry = _parse_geometry(d.pop("geometry", UNSET))
 
-        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
-        if type_ != "Feature" and not isinstance(type_, Unset):
-            raise ValueError(f"type must match const 'Feature', got '{type_}'")
-
         replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature = (
             cls(
                 id=id,
                 properties=properties,
-                geometry=geometry,
                 type_=type_,
+                geometry=geometry,
             )
         )
 

--- a/sdks/python/geolens/models/replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry.py
+++ b/sdks/python/geolens/models/replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry.py
@@ -27,25 +27,25 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGe
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_ (ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -54,15 +54,15 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGe
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry_collection.py
+++ b/sdks/python/geolens/models/replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry_collection.py
@@ -39,31 +39,31 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGe
     database 500. The write schemas add a raw-payload guard for a clear 422.
 
         Attributes:
+            type_ (Literal['GeometryCollection']):
             geometries (list[ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGeometryCollectionGeoJS
                 ONGeometry]):
-            type_ (Literal['GeometryCollection']):
     """
 
+    type_: Literal["GeometryCollection"]
     geometries: list[
         ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometry
     ]
-    type_: Literal["GeometryCollection"]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
         geometries = []
         for geometries_item_data in self.geometries:
             geometries_item = geometries_item_data.to_dict()
             geometries.append(geometries_item)
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "geometries": geometries,
                 "type": type_,
+                "geometries": geometries,
             }
         )
 
@@ -76,6 +76,12 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGe
         )
 
         d = dict(src_dict)
+        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
+        if type_ != "GeometryCollection":
+            raise ValueError(
+                f"type must match const 'GeometryCollection', got '{type_}'"
+            )
+
         geometries = []
         _geometries = d.pop("geometries")
         for geometries_item_data in _geometries:
@@ -85,15 +91,9 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGe
 
             geometries.append(geometries_item)
 
-        type_ = cast(Literal["GeometryCollection"], d.pop("type"))
-        if type_ != "GeometryCollection":
-            raise ValueError(
-                f"type must match const 'GeometryCollection', got '{type_}'"
-            )
-
         replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry_collection = cls(
-            geometries=geometries,
             type_=type_,
+            geometries=geometries,
         )
 
         replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry_collection.additional_properties = d

--- a/sdks/python/geolens/models/replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.py
+++ b/sdks/python/geolens/models/replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.py
@@ -27,26 +27,26 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGe
     """A GeoJSON geometry object (RFC 7946).
 
     Attributes:
-        coordinates (list[Any]):
         type_
             (ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometryType):
+        coordinates (list[Any]):
     """
 
-    coordinates: list[Any]
     type_: ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGeometryCollectionGeoJSONGeometryType
+    coordinates: list[Any]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        coordinates = self.coordinates
-
         type_: str = self.type_
+
+        coordinates = self.coordinates
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "coordinates": coordinates,
                 "type": type_,
+                "coordinates": coordinates,
             }
         )
 
@@ -55,15 +55,15 @@ class ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutGeoJSONFeatureGeoJSONGe
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        coordinates = cast(list[Any], d.pop("coordinates"))
-
         type_ = check_replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry_collection_geo_json_geometry_type(
             d.pop("type")
         )
 
+        coordinates = cast(list[Any], d.pop("coordinates"))
+
         replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry_collection_geo_json_geometry = cls(
-            coordinates=coordinates,
             type_=type_,
+            coordinates=coordinates,
         )
 
         replace_single_feature_datasets_dataset_id_features_gid_put_geo_json_feature_geo_json_geometry_collection_geo_json_geometry.additional_properties = d

--- a/sdks/python/geolens/models/reserved_rename_warning.py
+++ b/sdks/python/geolens/models/reserved_rename_warning.py
@@ -20,27 +20,27 @@ T = TypeVar("T", bound="ReservedRenameWarning")
 class ReservedRenameWarning:
     """
     Attributes:
-        details (list[ReservedRenameDetail]):
         kind (Literal['reserved_rename']):
+        details (list[ReservedRenameDetail]):
     """
 
-    details: list[ReservedRenameDetail]
     kind: Literal["reserved_rename"]
+    details: list[ReservedRenameDetail]
 
     def to_dict(self) -> dict[str, Any]:
+        kind = self.kind
+
         details = []
         for details_item_data in self.details:
             details_item = details_item_data.to_dict()
             details.append(details_item)
 
-        kind = self.kind
-
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
             {
-                "details": details,
                 "kind": kind,
+                "details": details,
             }
         )
 
@@ -51,6 +51,10 @@ class ReservedRenameWarning:
         from ..models.reserved_rename_detail import ReservedRenameDetail
 
         d = dict(src_dict)
+        kind = cast(Literal["reserved_rename"], d.pop("kind"))
+        if kind != "reserved_rename":
+            raise ValueError(f"kind must match const 'reserved_rename', got '{kind}'")
+
         details = []
         _details = d.pop("details")
         for details_item_data in _details:
@@ -58,13 +62,9 @@ class ReservedRenameWarning:
 
             details.append(details_item)
 
-        kind = cast(Literal["reserved_rename"], d.pop("kind"))
-        if kind != "reserved_rename":
-            raise ValueError(f"kind must match const 'reserved_rename', got '{kind}'")
-
         reserved_rename_warning = cls(
-            details=details,
             kind=kind,
+            details=details,
         )
 
         return reserved_rename_warning

--- a/sdks/python/geolens/models/reupload_commit_request.py
+++ b/sdks/python/geolens/models/reupload_commit_request.py
@@ -18,23 +18,17 @@ T = TypeVar("T", bound="ReuploadCommitRequest")
 class ReuploadCommitRequest:
     """
     Attributes:
-        layer_name (None | str | Unset):
         srid_override (int | None | Unset):
         token (None | str | Unset):
+        layer_name (None | str | Unset):
     """
 
-    layer_name: None | str | Unset = UNSET
     srid_override: int | None | Unset = UNSET
     token: None | str | Unset = UNSET
+    layer_name: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        layer_name: None | str | Unset
-        if isinstance(self.layer_name, Unset):
-            layer_name = UNSET
-        else:
-            layer_name = self.layer_name
-
         srid_override: int | None | Unset
         if isinstance(self.srid_override, Unset):
             srid_override = UNSET
@@ -47,30 +41,27 @@ class ReuploadCommitRequest:
         else:
             token = self.token
 
+        layer_name: None | str | Unset
+        if isinstance(self.layer_name, Unset):
+            layer_name = UNSET
+        else:
+            layer_name = self.layer_name
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if layer_name is not UNSET:
-            field_dict["layer_name"] = layer_name
         if srid_override is not UNSET:
             field_dict["srid_override"] = srid_override
         if token is not UNSET:
             field_dict["token"] = token
+        if layer_name is not UNSET:
+            field_dict["layer_name"] = layer_name
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
-        def _parse_layer_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        layer_name = _parse_layer_name(d.pop("layer_name", UNSET))
 
         def _parse_srid_override(data: object) -> int | None | Unset:
             if data is None:
@@ -90,10 +81,19 @@ class ReuploadCommitRequest:
 
         token = _parse_token(d.pop("token", UNSET))
 
+        def _parse_layer_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        layer_name = _parse_layer_name(d.pop("layer_name", UNSET))
+
         reupload_commit_request = cls(
-            layer_name=layer_name,
             srid_override=srid_override,
             token=token,
+            layer_name=layer_name,
         )
 
         reupload_commit_request.additional_properties = d

--- a/sdks/python/geolens/models/reupload_commit_response.py
+++ b/sdks/python/geolens/models/reupload_commit_response.py
@@ -18,29 +18,29 @@ class ReuploadCommitResponse:
     """
     Attributes:
         job_id (UUID):
-        message (str):
         status (str):
+        message (str):
     """
 
     job_id: UUID
-    message: str
     status: str
+    message: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         job_id = str(self.job_id)
 
-        message = self.message
-
         status = self.status
+
+        message = self.message
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "job_id": job_id,
-                "message": message,
                 "status": status,
+                "message": message,
             }
         )
 
@@ -51,14 +51,14 @@ class ReuploadCommitResponse:
         d = dict(src_dict)
         job_id = UUID(d.pop("job_id"))
 
-        message = d.pop("message")
-
         status = d.pop("status")
+
+        message = d.pop("message")
 
         reupload_commit_response = cls(
             job_id=job_id,
-            message=message,
             status=status,
+            message=message,
         )
 
         reupload_commit_response.additional_properties = d

--- a/sdks/python/geolens/models/reupload_preview_response.py
+++ b/sdks/python/geolens/models/reupload_preview_response.py
@@ -29,33 +29,38 @@ T = TypeVar("T", bound="ReuploadPreviewResponse")
 class ReuploadPreviewResponse:
     """
     Attributes:
+        job_id (UUID):
+        source_filename (None | str):
         columns (list[ColumnChange]):
         crs (int | None):
-        feature_count (int | None):
         geometry_type (None | str):
-        job_id (UUID):
-        layer_name (str):
+        feature_count (int | None):
         sample_rows (list[ReuploadPreviewResponseSampleRowsItem]):
+        layer_name (str):
         schema_diff (SchemaDiff):
-        source_filename (None | str):
         all_layers (list[ReuploadPreviewResponseAllLayersType0Item] | None | Unset):
         previous_source_layer (None | str | Unset):
     """
 
+    job_id: UUID
+    source_filename: None | str
     columns: list[ColumnChange]
     crs: int | None
-    feature_count: int | None
     geometry_type: None | str
-    job_id: UUID
-    layer_name: str
+    feature_count: int | None
     sample_rows: list[ReuploadPreviewResponseSampleRowsItem]
+    layer_name: str
     schema_diff: SchemaDiff
-    source_filename: None | str
     all_layers: list[ReuploadPreviewResponseAllLayersType0Item] | None | Unset = UNSET
     previous_source_layer: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        job_id = str(self.job_id)
+
+        source_filename: None | str
+        source_filename = self.source_filename
+
         columns = []
         for columns_item_data in self.columns:
             columns_item = columns_item_data.to_dict()
@@ -64,25 +69,20 @@ class ReuploadPreviewResponse:
         crs: int | None
         crs = self.crs
 
-        feature_count: int | None
-        feature_count = self.feature_count
-
         geometry_type: None | str
         geometry_type = self.geometry_type
 
-        job_id = str(self.job_id)
-
-        layer_name = self.layer_name
+        feature_count: int | None
+        feature_count = self.feature_count
 
         sample_rows = []
         for sample_rows_item_data in self.sample_rows:
             sample_rows_item = sample_rows_item_data.to_dict()
             sample_rows.append(sample_rows_item)
 
-        schema_diff = self.schema_diff.to_dict()
+        layer_name = self.layer_name
 
-        source_filename: None | str
-        source_filename = self.source_filename
+        schema_diff = self.schema_diff.to_dict()
 
         all_layers: list[dict[str, Any]] | None | Unset
         if isinstance(self.all_layers, Unset):
@@ -106,15 +106,15 @@ class ReuploadPreviewResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "job_id": job_id,
+                "source_filename": source_filename,
                 "columns": columns,
                 "crs": crs,
-                "feature_count": feature_count,
                 "geometry_type": geometry_type,
-                "job_id": job_id,
-                "layer_name": layer_name,
+                "feature_count": feature_count,
                 "sample_rows": sample_rows,
+                "layer_name": layer_name,
                 "schema_diff": schema_diff,
-                "source_filename": source_filename,
             }
         )
         if all_layers is not UNSET:
@@ -136,6 +136,15 @@ class ReuploadPreviewResponse:
         from ..models.schema_diff import SchemaDiff
 
         d = dict(src_dict)
+        job_id = UUID(d.pop("job_id"))
+
+        def _parse_source_filename(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        source_filename = _parse_source_filename(d.pop("source_filename"))
+
         columns = []
         _columns = d.pop("columns")
         for columns_item_data in _columns:
@@ -150,13 +159,6 @@ class ReuploadPreviewResponse:
 
         crs = _parse_crs(d.pop("crs"))
 
-        def _parse_feature_count(data: object) -> int | None:
-            if data is None:
-                return data
-            return cast(int | None, data)
-
-        feature_count = _parse_feature_count(d.pop("feature_count"))
-
         def _parse_geometry_type(data: object) -> None | str:
             if data is None:
                 return data
@@ -164,9 +166,12 @@ class ReuploadPreviewResponse:
 
         geometry_type = _parse_geometry_type(d.pop("geometry_type"))
 
-        job_id = UUID(d.pop("job_id"))
+        def _parse_feature_count(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
 
-        layer_name = d.pop("layer_name")
+        feature_count = _parse_feature_count(d.pop("feature_count"))
 
         sample_rows = []
         _sample_rows = d.pop("sample_rows")
@@ -177,14 +182,9 @@ class ReuploadPreviewResponse:
 
             sample_rows.append(sample_rows_item)
 
+        layer_name = d.pop("layer_name")
+
         schema_diff = SchemaDiff.from_dict(d.pop("schema_diff"))
-
-        def _parse_source_filename(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        source_filename = _parse_source_filename(d.pop("source_filename"))
 
         def _parse_all_layers(
             data: object,
@@ -228,15 +228,15 @@ class ReuploadPreviewResponse:
         )
 
         reupload_preview_response = cls(
+            job_id=job_id,
+            source_filename=source_filename,
             columns=columns,
             crs=crs,
-            feature_count=feature_count,
             geometry_type=geometry_type,
-            job_id=job_id,
-            layer_name=layer_name,
+            feature_count=feature_count,
             sample_rows=sample_rows,
+            layer_name=layer_name,
             schema_diff=schema_diff,
-            source_filename=source_filename,
             all_layers=all_layers,
             previous_source_layer=previous_source_layer,
         )

--- a/sdks/python/geolens/models/reupload_service_preview_request.py
+++ b/sdks/python/geolens/models/reupload_service_preview_request.py
@@ -18,36 +18,30 @@ T = TypeVar("T", bound="ReuploadServicePreviewRequest")
 class ReuploadServicePreviewRequest:
     """
     Attributes:
-        layer_name (str):
-        service_type (str):
         url (str):
-        layer_id (int | None | str | Unset):
+        service_type (str):
+        layer_name (str):
         layer_title (None | str | Unset):
-        object_id_field (None | str | Unset):
+        layer_id (int | None | str | Unset):
         token (None | str | Unset):
+        object_id_field (None | str | Unset):
     """
 
-    layer_name: str
-    service_type: str
     url: str
-    layer_id: int | None | str | Unset = UNSET
+    service_type: str
+    layer_name: str
     layer_title: None | str | Unset = UNSET
-    object_id_field: None | str | Unset = UNSET
+    layer_id: int | None | str | Unset = UNSET
     token: None | str | Unset = UNSET
+    object_id_field: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        layer_name = self.layer_name
+        url = self.url
 
         service_type = self.service_type
 
-        url = self.url
-
-        layer_id: int | None | str | Unset
-        if isinstance(self.layer_id, Unset):
-            layer_id = UNSET
-        else:
-            layer_id = self.layer_id
+        layer_name = self.layer_name
 
         layer_title: None | str | Unset
         if isinstance(self.layer_title, Unset):
@@ -55,11 +49,11 @@ class ReuploadServicePreviewRequest:
         else:
             layer_title = self.layer_title
 
-        object_id_field: None | str | Unset
-        if isinstance(self.object_id_field, Unset):
-            object_id_field = UNSET
+        layer_id: int | None | str | Unset
+        if isinstance(self.layer_id, Unset):
+            layer_id = UNSET
         else:
-            object_id_field = self.object_id_field
+            layer_id = self.layer_id
 
         token: None | str | Unset
         if isinstance(self.token, Unset):
@@ -67,43 +61,40 @@ class ReuploadServicePreviewRequest:
         else:
             token = self.token
 
+        object_id_field: None | str | Unset
+        if isinstance(self.object_id_field, Unset):
+            object_id_field = UNSET
+        else:
+            object_id_field = self.object_id_field
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "layer_name": layer_name,
-                "service_type": service_type,
                 "url": url,
+                "service_type": service_type,
+                "layer_name": layer_name,
             }
         )
-        if layer_id is not UNSET:
-            field_dict["layer_id"] = layer_id
         if layer_title is not UNSET:
             field_dict["layer_title"] = layer_title
-        if object_id_field is not UNSET:
-            field_dict["object_id_field"] = object_id_field
+        if layer_id is not UNSET:
+            field_dict["layer_id"] = layer_id
         if token is not UNSET:
             field_dict["token"] = token
+        if object_id_field is not UNSET:
+            field_dict["object_id_field"] = object_id_field
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        layer_name = d.pop("layer_name")
+        url = d.pop("url")
 
         service_type = d.pop("service_type")
 
-        url = d.pop("url")
-
-        def _parse_layer_id(data: object) -> int | None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | str | Unset, data)
-
-        layer_id = _parse_layer_id(d.pop("layer_id", UNSET))
+        layer_name = d.pop("layer_name")
 
         def _parse_layer_title(data: object) -> None | str | Unset:
             if data is None:
@@ -114,14 +105,14 @@ class ReuploadServicePreviewRequest:
 
         layer_title = _parse_layer_title(d.pop("layer_title", UNSET))
 
-        def _parse_object_id_field(data: object) -> None | str | Unset:
+        def _parse_layer_id(data: object) -> int | None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(None | str | Unset, data)
+            return cast(int | None | str | Unset, data)
 
-        object_id_field = _parse_object_id_field(d.pop("object_id_field", UNSET))
+        layer_id = _parse_layer_id(d.pop("layer_id", UNSET))
 
         def _parse_token(data: object) -> None | str | Unset:
             if data is None:
@@ -132,14 +123,23 @@ class ReuploadServicePreviewRequest:
 
         token = _parse_token(d.pop("token", UNSET))
 
+        def _parse_object_id_field(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        object_id_field = _parse_object_id_field(d.pop("object_id_field", UNSET))
+
         reupload_service_preview_request = cls(
-            layer_name=layer_name,
-            service_type=service_type,
             url=url,
-            layer_id=layer_id,
+            service_type=service_type,
+            layer_name=layer_name,
             layer_title=layer_title,
-            object_id_field=object_id_field,
+            layer_id=layer_id,
             token=token,
+            object_id_field=object_id_field,
         )
 
         reupload_service_preview_request.additional_properties = d

--- a/sdks/python/geolens/models/saved_search_response.py
+++ b/sdks/python/geolens/models/saved_search_response.py
@@ -23,28 +23,28 @@ class SavedSearchResponse:
     """Response for a single saved search.
 
     Attributes:
-        created_at (datetime.datetime):
         id (UUID):
         name (str):
         params (SavedSearchResponseParams):
+        created_at (datetime.datetime):
         updated_at (datetime.datetime):
     """
 
-    created_at: datetime.datetime
     id: UUID
     name: str
     params: SavedSearchResponseParams
+    created_at: datetime.datetime
     updated_at: datetime.datetime
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created_at = self.created_at.isoformat()
-
         id = str(self.id)
 
         name = self.name
 
         params = self.params.to_dict()
+
+        created_at = self.created_at.isoformat()
 
         updated_at = self.updated_at.isoformat()
 
@@ -52,10 +52,10 @@ class SavedSearchResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
                 "id": id,
                 "name": name,
                 "params": params,
+                "created_at": created_at,
                 "updated_at": updated_at,
             }
         )
@@ -67,21 +67,21 @@ class SavedSearchResponse:
         from ..models.saved_search_response_params import SavedSearchResponseParams
 
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
-
         id = UUID(d.pop("id"))
 
         name = d.pop("name")
 
         params = SavedSearchResponseParams.from_dict(d.pop("params"))
 
+        created_at = isoparse(d.pop("created_at"))
+
         updated_at = isoparse(d.pop("updated_at"))
 
         saved_search_response = cls(
-            created_at=created_at,
             id=id,
             name=name,
             params=params,
+            created_at=created_at,
             updated_at=updated_at,
         )
 

--- a/sdks/python/geolens/models/schema_diff.py
+++ b/sdks/python/geolens/models/schema_diff.py
@@ -23,18 +23,18 @@ class SchemaDiff:
     Attributes:
         columns_added (list[ColumnChange]): Columns present in new but not old schema
         columns_removed (list[ColumnChange]): Columns present in old but not new schema
-        row_count_delta (int): row_count_new minus row_count_old
-        row_count_new (int | None):
-        row_count_old (int | None):
         type_changes (list[TypeChange]): Columns whose data type changed
+        row_count_old (int | None):
+        row_count_new (int | None):
+        row_count_delta (int): row_count_new minus row_count_old
     """
 
     columns_added: list[ColumnChange]
     columns_removed: list[ColumnChange]
-    row_count_delta: int
-    row_count_new: int | None
-    row_count_old: int | None
     type_changes: list[TypeChange]
+    row_count_old: int | None
+    row_count_new: int | None
+    row_count_delta: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -48,18 +48,18 @@ class SchemaDiff:
             columns_removed_item = columns_removed_item_data.to_dict()
             columns_removed.append(columns_removed_item)
 
-        row_count_delta = self.row_count_delta
-
-        row_count_new: int | None
-        row_count_new = self.row_count_new
-
-        row_count_old: int | None
-        row_count_old = self.row_count_old
-
         type_changes = []
         for type_changes_item_data in self.type_changes:
             type_changes_item = type_changes_item_data.to_dict()
             type_changes.append(type_changes_item)
+
+        row_count_old: int | None
+        row_count_old = self.row_count_old
+
+        row_count_new: int | None
+        row_count_new = self.row_count_new
+
+        row_count_delta = self.row_count_delta
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -67,10 +67,10 @@ class SchemaDiff:
             {
                 "columns_added": columns_added,
                 "columns_removed": columns_removed,
-                "row_count_delta": row_count_delta,
-                "row_count_new": row_count_new,
-                "row_count_old": row_count_old,
                 "type_changes": type_changes,
+                "row_count_old": row_count_old,
+                "row_count_new": row_count_new,
+                "row_count_delta": row_count_delta,
             }
         )
 
@@ -96,14 +96,12 @@ class SchemaDiff:
 
             columns_removed.append(columns_removed_item)
 
-        row_count_delta = d.pop("row_count_delta")
+        type_changes = []
+        _type_changes = d.pop("type_changes")
+        for type_changes_item_data in _type_changes:
+            type_changes_item = TypeChange.from_dict(type_changes_item_data)
 
-        def _parse_row_count_new(data: object) -> int | None:
-            if data is None:
-                return data
-            return cast(int | None, data)
-
-        row_count_new = _parse_row_count_new(d.pop("row_count_new"))
+            type_changes.append(type_changes_item)
 
         def _parse_row_count_old(data: object) -> int | None:
             if data is None:
@@ -112,20 +110,22 @@ class SchemaDiff:
 
         row_count_old = _parse_row_count_old(d.pop("row_count_old"))
 
-        type_changes = []
-        _type_changes = d.pop("type_changes")
-        for type_changes_item_data in _type_changes:
-            type_changes_item = TypeChange.from_dict(type_changes_item_data)
+        def _parse_row_count_new(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
 
-            type_changes.append(type_changes_item)
+        row_count_new = _parse_row_count_new(d.pop("row_count_new"))
+
+        row_count_delta = d.pop("row_count_delta")
 
         schema_diff = cls(
             columns_added=columns_added,
             columns_removed=columns_removed,
-            row_count_delta=row_count_delta,
-            row_count_new=row_count_new,
-            row_count_old=row_count_old,
             type_changes=type_changes,
+            row_count_old=row_count_old,
+            row_count_new=row_count_new,
+            row_count_delta=row_count_delta,
         )
 
         schema_diff.additional_properties = d

--- a/sdks/python/geolens/models/service_health.py
+++ b/sdks/python/geolens/models/service_health.py
@@ -19,29 +19,29 @@ class ServiceHealth:
     """
     Attributes:
         status (str):
-        error (None | str | Unset):
         latency_ms (float | None | Unset):
+        error (None | str | Unset):
     """
 
     status: str
-    error: None | str | Unset = UNSET
     latency_ms: float | None | Unset = UNSET
+    error: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         status = self.status
-
-        error: None | str | Unset
-        if isinstance(self.error, Unset):
-            error = UNSET
-        else:
-            error = self.error
 
         latency_ms: float | None | Unset
         if isinstance(self.latency_ms, Unset):
             latency_ms = UNSET
         else:
             latency_ms = self.latency_ms
+
+        error: None | str | Unset
+        if isinstance(self.error, Unset):
+            error = UNSET
+        else:
+            error = self.error
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -50,10 +50,10 @@ class ServiceHealth:
                 "status": status,
             }
         )
-        if error is not UNSET:
-            field_dict["error"] = error
         if latency_ms is not UNSET:
             field_dict["latency_ms"] = latency_ms
+        if error is not UNSET:
+            field_dict["error"] = error
 
         return field_dict
 
@@ -61,15 +61,6 @@ class ServiceHealth:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         status = d.pop("status")
-
-        def _parse_error(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        error = _parse_error(d.pop("error", UNSET))
 
         def _parse_latency_ms(data: object) -> float | None | Unset:
             if data is None:
@@ -80,10 +71,19 @@ class ServiceHealth:
 
         latency_ms = _parse_latency_ms(d.pop("latency_ms", UNSET))
 
+        def _parse_error(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        error = _parse_error(d.pop("error", UNSET))
+
         service_health = cls(
             status=status,
-            error=error,
             latency_ms=latency_ms,
+            error=error,
         )
 
         service_health.additional_properties = d

--- a/sdks/python/geolens/models/service_preview_request.py
+++ b/sdks/python/geolens/models/service_preview_request.py
@@ -18,36 +18,30 @@ T = TypeVar("T", bound="ServicePreviewRequest")
 class ServicePreviewRequest:
     """
     Attributes:
-        layer_name (str): Name of the specific layer to preview, from the probe layers list.
-        service_type (str): Service type from the probe response, e.g. 'WFS 2.0.0' or 'ArcGIS FeatureServer'.
         url (str): Normalized service URL from a previous probe response.
-        layer_id (int | None | str | Unset): ArcGIS layer ID, when applicable.
+        service_type (str): Service type from the probe response, e.g. 'WFS 2.0.0' or 'ArcGIS FeatureServer'.
+        layer_name (str): Name of the specific layer to preview, from the probe layers list.
         layer_title (None | str | Unset): Human-readable layer title from the probe LayerInfo.
-        object_id_field (None | str | Unset): ArcGIS OID field name used for orderByFields during preview pagination.
+        layer_id (int | None | str | Unset): ArcGIS layer ID, when applicable.
         token (None | str | Unset): Optional auth token for protected services.
+        object_id_field (None | str | Unset): ArcGIS OID field name used for orderByFields during preview pagination.
     """
 
-    layer_name: str
-    service_type: str
     url: str
-    layer_id: int | None | str | Unset = UNSET
+    service_type: str
+    layer_name: str
     layer_title: None | str | Unset = UNSET
-    object_id_field: None | str | Unset = UNSET
+    layer_id: int | None | str | Unset = UNSET
     token: None | str | Unset = UNSET
+    object_id_field: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        layer_name = self.layer_name
+        url = self.url
 
         service_type = self.service_type
 
-        url = self.url
-
-        layer_id: int | None | str | Unset
-        if isinstance(self.layer_id, Unset):
-            layer_id = UNSET
-        else:
-            layer_id = self.layer_id
+        layer_name = self.layer_name
 
         layer_title: None | str | Unset
         if isinstance(self.layer_title, Unset):
@@ -55,11 +49,11 @@ class ServicePreviewRequest:
         else:
             layer_title = self.layer_title
 
-        object_id_field: None | str | Unset
-        if isinstance(self.object_id_field, Unset):
-            object_id_field = UNSET
+        layer_id: int | None | str | Unset
+        if isinstance(self.layer_id, Unset):
+            layer_id = UNSET
         else:
-            object_id_field = self.object_id_field
+            layer_id = self.layer_id
 
         token: None | str | Unset
         if isinstance(self.token, Unset):
@@ -67,43 +61,40 @@ class ServicePreviewRequest:
         else:
             token = self.token
 
+        object_id_field: None | str | Unset
+        if isinstance(self.object_id_field, Unset):
+            object_id_field = UNSET
+        else:
+            object_id_field = self.object_id_field
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "layer_name": layer_name,
-                "service_type": service_type,
                 "url": url,
+                "service_type": service_type,
+                "layer_name": layer_name,
             }
         )
-        if layer_id is not UNSET:
-            field_dict["layer_id"] = layer_id
         if layer_title is not UNSET:
             field_dict["layer_title"] = layer_title
-        if object_id_field is not UNSET:
-            field_dict["object_id_field"] = object_id_field
+        if layer_id is not UNSET:
+            field_dict["layer_id"] = layer_id
         if token is not UNSET:
             field_dict["token"] = token
+        if object_id_field is not UNSET:
+            field_dict["object_id_field"] = object_id_field
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        layer_name = d.pop("layer_name")
+        url = d.pop("url")
 
         service_type = d.pop("service_type")
 
-        url = d.pop("url")
-
-        def _parse_layer_id(data: object) -> int | None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | str | Unset, data)
-
-        layer_id = _parse_layer_id(d.pop("layer_id", UNSET))
+        layer_name = d.pop("layer_name")
 
         def _parse_layer_title(data: object) -> None | str | Unset:
             if data is None:
@@ -114,14 +105,14 @@ class ServicePreviewRequest:
 
         layer_title = _parse_layer_title(d.pop("layer_title", UNSET))
 
-        def _parse_object_id_field(data: object) -> None | str | Unset:
+        def _parse_layer_id(data: object) -> int | None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(None | str | Unset, data)
+            return cast(int | None | str | Unset, data)
 
-        object_id_field = _parse_object_id_field(d.pop("object_id_field", UNSET))
+        layer_id = _parse_layer_id(d.pop("layer_id", UNSET))
 
         def _parse_token(data: object) -> None | str | Unset:
             if data is None:
@@ -132,14 +123,23 @@ class ServicePreviewRequest:
 
         token = _parse_token(d.pop("token", UNSET))
 
+        def _parse_object_id_field(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        object_id_field = _parse_object_id_field(d.pop("object_id_field", UNSET))
+
         service_preview_request = cls(
-            layer_name=layer_name,
-            service_type=service_type,
             url=url,
-            layer_id=layer_id,
+            service_type=service_type,
+            layer_name=layer_name,
             layer_title=layer_title,
-            object_id_field=object_id_field,
+            layer_id=layer_id,
             token=token,
+            object_id_field=object_id_field,
         )
 
         service_preview_request.additional_properties = d

--- a/sdks/python/geolens/models/service_preview_response.py
+++ b/sdks/python/geolens/models/service_preview_response.py
@@ -26,28 +26,33 @@ T = TypeVar("T", bound="ServicePreviewResponse")
 class ServicePreviewResponse:
     """
     Attributes:
+        job_id (UUID): IngestJob ID for the preview. Use this to commit the import.
+        source_filename (None | str): Layer name acting as a source filename for downstream ingestion logic.
         columns (list[ServicePreviewResponseColumnsItem]): Detected attribute columns: [{'name': str, 'type': str},
             ...].
         crs (int | None): Detected EPSG code for the layer's CRS.
-        feature_count (int | None): Total feature count if reported by the source service.
         geometry_type (None | str): Detected geometry type.
-        job_id (UUID): IngestJob ID for the preview. Use this to commit the import.
-        layer_name (str): Layer name as it appears in the remote service.
+        feature_count (int | None): Total feature count if reported by the source service.
         sample_rows (list[ServicePreviewResponseSampleRowsItem]): Up to 5 sample rows for preview display.
-        source_filename (None | str): Layer name acting as a source filename for downstream ingestion logic.
+        layer_name (str): Layer name as it appears in the remote service.
     """
 
+    job_id: UUID
+    source_filename: None | str
     columns: list[ServicePreviewResponseColumnsItem]
     crs: int | None
-    feature_count: int | None
     geometry_type: None | str
-    job_id: UUID
-    layer_name: str
+    feature_count: int | None
     sample_rows: list[ServicePreviewResponseSampleRowsItem]
-    source_filename: None | str
+    layer_name: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        job_id = str(self.job_id)
+
+        source_filename: None | str
+        source_filename = self.source_filename
+
         columns = []
         for columns_item_data in self.columns:
             columns_item = columns_item_data.to_dict()
@@ -56,36 +61,31 @@ class ServicePreviewResponse:
         crs: int | None
         crs = self.crs
 
-        feature_count: int | None
-        feature_count = self.feature_count
-
         geometry_type: None | str
         geometry_type = self.geometry_type
 
-        job_id = str(self.job_id)
-
-        layer_name = self.layer_name
+        feature_count: int | None
+        feature_count = self.feature_count
 
         sample_rows = []
         for sample_rows_item_data in self.sample_rows:
             sample_rows_item = sample_rows_item_data.to_dict()
             sample_rows.append(sample_rows_item)
 
-        source_filename: None | str
-        source_filename = self.source_filename
+        layer_name = self.layer_name
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "job_id": job_id,
+                "source_filename": source_filename,
                 "columns": columns,
                 "crs": crs,
-                "feature_count": feature_count,
                 "geometry_type": geometry_type,
-                "job_id": job_id,
-                "layer_name": layer_name,
+                "feature_count": feature_count,
                 "sample_rows": sample_rows,
-                "source_filename": source_filename,
+                "layer_name": layer_name,
             }
         )
 
@@ -101,6 +101,15 @@ class ServicePreviewResponse:
         )
 
         d = dict(src_dict)
+        job_id = UUID(d.pop("job_id"))
+
+        def _parse_source_filename(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        source_filename = _parse_source_filename(d.pop("source_filename"))
+
         columns = []
         _columns = d.pop("columns")
         for columns_item_data in _columns:
@@ -117,13 +126,6 @@ class ServicePreviewResponse:
 
         crs = _parse_crs(d.pop("crs"))
 
-        def _parse_feature_count(data: object) -> int | None:
-            if data is None:
-                return data
-            return cast(int | None, data)
-
-        feature_count = _parse_feature_count(d.pop("feature_count"))
-
         def _parse_geometry_type(data: object) -> None | str:
             if data is None:
                 return data
@@ -131,9 +133,12 @@ class ServicePreviewResponse:
 
         geometry_type = _parse_geometry_type(d.pop("geometry_type"))
 
-        job_id = UUID(d.pop("job_id"))
+        def _parse_feature_count(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
 
-        layer_name = d.pop("layer_name")
+        feature_count = _parse_feature_count(d.pop("feature_count"))
 
         sample_rows = []
         _sample_rows = d.pop("sample_rows")
@@ -144,22 +149,17 @@ class ServicePreviewResponse:
 
             sample_rows.append(sample_rows_item)
 
-        def _parse_source_filename(data: object) -> None | str:
-            if data is None:
-                return data
-            return cast(None | str, data)
-
-        source_filename = _parse_source_filename(d.pop("source_filename"))
+        layer_name = d.pop("layer_name")
 
         service_preview_response = cls(
+            job_id=job_id,
+            source_filename=source_filename,
             columns=columns,
             crs=crs,
-            feature_count=feature_count,
             geometry_type=geometry_type,
-            job_id=job_id,
-            layer_name=layer_name,
+            feature_count=feature_count,
             sample_rows=sample_rows,
-            source_filename=source_filename,
+            layer_name=layer_name,
         )
 
         service_preview_response.additional_properties = d

--- a/sdks/python/geolens/models/service_probe_result.py
+++ b/sdks/python/geolens/models/service_probe_result.py
@@ -21,24 +21,24 @@ class ServiceProbeResult:
     """Result of a single service connectivity probe.
 
     Attributes:
-        latency_ms (float): Round-trip latency in milliseconds.
         name (str): Service name (e.g. 'storage', 'cache', 'oidc:google').
         status (ServiceProbeResultStatus): Probe outcome.
+        latency_ms (float): Round-trip latency in milliseconds.
         error (None | str | Unset): Error message when status is 'error'.
     """
 
-    latency_ms: float
     name: str
     status: ServiceProbeResultStatus
+    latency_ms: float
     error: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        latency_ms = self.latency_ms
-
         name = self.name
 
         status: str = self.status
+
+        latency_ms = self.latency_ms
 
         error: None | str | Unset
         if isinstance(self.error, Unset):
@@ -50,9 +50,9 @@ class ServiceProbeResult:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "latency_ms": latency_ms,
                 "name": name,
                 "status": status,
+                "latency_ms": latency_ms,
             }
         )
         if error is not UNSET:
@@ -63,11 +63,11 @@ class ServiceProbeResult:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        latency_ms = d.pop("latency_ms")
-
         name = d.pop("name")
 
         status = check_service_probe_result_status(d.pop("status"))
+
+        latency_ms = d.pop("latency_ms")
 
         def _parse_error(data: object) -> None | str | Unset:
             if data is None:
@@ -79,9 +79,9 @@ class ServiceProbeResult:
         error = _parse_error(d.pop("error", UNSET))
 
         service_probe_result = cls(
-            latency_ms=latency_ms,
             name=name,
             status=status,
+            latency_ms=latency_ms,
             error=error,
         )
 

--- a/sdks/python/geolens/models/setting_item.py
+++ b/sdks/python/geolens/models/setting_item.py
@@ -16,35 +16,35 @@ class SettingItem:
 
     Attributes:
         key (str): Setting key (e.g. 'login_rate_limit', 'basemaps').
-        label (str): Human-readable label for display in the admin UI.
+        value (Any): Current value. Type depends on the setting.
         source (str): Where the value came from: 'default' (built-in default), 'overridden' (admin set via UI), or
             'env_only' (configured via environment variable, read-only).
-        value (Any): Current value. Type depends on the setting.
+        label (str): Human-readable label for display in the admin UI.
     """
 
     key: str
-    label: str
-    source: str
     value: Any
+    source: str
+    label: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         key = self.key
 
-        label = self.label
+        value = self.value
 
         source = self.source
 
-        value = self.value
+        label = self.label
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "key": key,
-                "label": label,
-                "source": source,
                 "value": value,
+                "source": source,
+                "label": label,
             }
         )
 
@@ -55,17 +55,17 @@ class SettingItem:
         d = dict(src_dict)
         key = d.pop("key")
 
-        label = d.pop("label")
+        value = d.pop("value")
 
         source = d.pop("source")
 
-        value = d.pop("value")
+        label = d.pop("label")
 
         setting_item = cls(
             key=key,
-            label=label,
-            source=source,
             value=value,
+            source=source,
+            label=label,
         )
 
         setting_item.additional_properties = d

--- a/sdks/python/geolens/models/share_token_response.py
+++ b/sdks/python/geolens/models/share_token_response.py
@@ -21,19 +21,25 @@ class ShareTokenResponse:
     """
     Attributes:
         token (str): Raw token on create, hint on retrieve
+        share_url (None | str | Unset): Full shareable URL — only returned on create
         expires_at (datetime.datetime | None | Unset):
         is_active (bool | Unset):  Default: True.
-        share_url (None | str | Unset): Full shareable URL — only returned on create
     """
 
     token: str
+    share_url: None | str | Unset = UNSET
     expires_at: datetime.datetime | None | Unset = UNSET
     is_active: bool | Unset = True
-    share_url: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         token = self.token
+
+        share_url: None | str | Unset
+        if isinstance(self.share_url, Unset):
+            share_url = UNSET
+        else:
+            share_url = self.share_url
 
         expires_at: None | str | Unset
         if isinstance(self.expires_at, Unset):
@@ -45,12 +51,6 @@ class ShareTokenResponse:
 
         is_active = self.is_active
 
-        share_url: None | str | Unset
-        if isinstance(self.share_url, Unset):
-            share_url = UNSET
-        else:
-            share_url = self.share_url
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -58,12 +58,12 @@ class ShareTokenResponse:
                 "token": token,
             }
         )
+        if share_url is not UNSET:
+            field_dict["share_url"] = share_url
         if expires_at is not UNSET:
             field_dict["expires_at"] = expires_at
         if is_active is not UNSET:
             field_dict["is_active"] = is_active
-        if share_url is not UNSET:
-            field_dict["share_url"] = share_url
 
         return field_dict
 
@@ -71,6 +71,15 @@ class ShareTokenResponse:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         token = d.pop("token")
+
+        def _parse_share_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        share_url = _parse_share_url(d.pop("share_url", UNSET))
 
         def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -91,20 +100,11 @@ class ShareTokenResponse:
 
         is_active = d.pop("is_active", UNSET)
 
-        def _parse_share_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        share_url = _parse_share_url(d.pop("share_url", UNSET))
-
         share_token_response = cls(
             token=token,
+            share_url=share_url,
             expires_at=expires_at,
             is_active=is_active,
-            share_url=share_url,
         )
 
         share_token_response.additional_properties = d

--- a/sdks/python/geolens/models/shared_layer_response.py
+++ b/sdks/python/geolens/models/shared_layer_response.py
@@ -32,57 +32,57 @@ T = TypeVar("T", bound="SharedLayerResponse")
 class SharedLayerResponse:
     """
     Attributes:
+        id (str):
         dataset_id (str):
         dataset_name (str):
+        table_name (str):
         geometry_type (None | str):
-        id (str):
-        layout (SharedLayerResponseLayout):
+        sort_order (int):
+        visible (bool):
         opacity (float):
         paint (SharedLayerResponsePaint):
-        sort_order (int):
-        table_name (str):
+        layout (SharedLayerResponseLayout):
         tile_url (str):
-        visible (bool):
-        column_info (list[SharedLayerResponseColumnInfoType0Item] | None | Unset):
-        dataset_record_type (None | str | Unset):
-        dem_vertical_units (None | str | Unset):
         display_name (None | str | Unset):
-        feature_count (int | None | Unset):
-        filter_ (list[Any] | None | Unset):
-        is_3d (bool | None | Unset):
-        is_dem (bool | None | Unset):
-        label_config (None | SharedLayerResponseLabelConfigType0 | Unset):
+        column_info (list[SharedLayerResponseColumnInfoType0Item] | None | Unset):
         layer_type (str | Unset):  Default: 'vector_geolens'.
+        dataset_record_type (None | str | Unset):
+        filter_ (list[Any] | None | Unset):
+        label_config (None | SharedLayerResponseLabelConfigType0 | Unset):
         popup_config (None | PopupConfig | Unset):
-        show_in_legend (bool | Unset):  Default: True.
         style_config (None | SharedLayerResponseStyleConfigType0 | Unset):
+        show_in_legend (bool | Unset):  Default: True.
+        is_dem (bool | None | Unset):
+        dem_vertical_units (None | str | Unset):
+        is_3d (bool | None | Unset):
+        feature_count (int | None | Unset):
         tile_version (int | None | Unset):
     """
 
+    id: str
     dataset_id: str
     dataset_name: str
+    table_name: str
     geometry_type: None | str
-    id: str
-    layout: SharedLayerResponseLayout
+    sort_order: int
+    visible: bool
     opacity: float
     paint: SharedLayerResponsePaint
-    sort_order: int
-    table_name: str
+    layout: SharedLayerResponseLayout
     tile_url: str
-    visible: bool
-    column_info: list[SharedLayerResponseColumnInfoType0Item] | None | Unset = UNSET
-    dataset_record_type: None | str | Unset = UNSET
-    dem_vertical_units: None | str | Unset = UNSET
     display_name: None | str | Unset = UNSET
-    feature_count: int | None | Unset = UNSET
-    filter_: list[Any] | None | Unset = UNSET
-    is_3d: bool | None | Unset = UNSET
-    is_dem: bool | None | Unset = UNSET
-    label_config: None | SharedLayerResponseLabelConfigType0 | Unset = UNSET
+    column_info: list[SharedLayerResponseColumnInfoType0Item] | None | Unset = UNSET
     layer_type: str | Unset = "vector_geolens"
+    dataset_record_type: None | str | Unset = UNSET
+    filter_: list[Any] | None | Unset = UNSET
+    label_config: None | SharedLayerResponseLabelConfigType0 | Unset = UNSET
     popup_config: None | PopupConfig | Unset = UNSET
-    show_in_legend: bool | Unset = True
     style_config: None | SharedLayerResponseStyleConfigType0 | Unset = UNSET
+    show_in_legend: bool | Unset = True
+    is_dem: bool | None | Unset = UNSET
+    dem_vertical_units: None | str | Unset = UNSET
+    is_3d: bool | None | Unset = UNSET
+    feature_count: int | None | Unset = UNSET
     tile_version: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -95,28 +95,34 @@ class SharedLayerResponse:
             SharedLayerResponseStyleConfigType0,
         )
 
+        id = self.id
+
         dataset_id = self.dataset_id
 
         dataset_name = self.dataset_name
 
+        table_name = self.table_name
+
         geometry_type: None | str
         geometry_type = self.geometry_type
 
-        id = self.id
+        sort_order = self.sort_order
 
-        layout = self.layout.to_dict()
+        visible = self.visible
 
         opacity = self.opacity
 
         paint = self.paint.to_dict()
 
-        sort_order = self.sort_order
-
-        table_name = self.table_name
+        layout = self.layout.to_dict()
 
         tile_url = self.tile_url
 
-        visible = self.visible
+        display_name: None | str | Unset
+        if isinstance(self.display_name, Unset):
+            display_name = UNSET
+        else:
+            display_name = self.display_name
 
         column_info: list[dict[str, Any]] | None | Unset
         if isinstance(self.column_info, Unset):
@@ -130,29 +136,13 @@ class SharedLayerResponse:
         else:
             column_info = self.column_info
 
+        layer_type = self.layer_type
+
         dataset_record_type: None | str | Unset
         if isinstance(self.dataset_record_type, Unset):
             dataset_record_type = UNSET
         else:
             dataset_record_type = self.dataset_record_type
-
-        dem_vertical_units: None | str | Unset
-        if isinstance(self.dem_vertical_units, Unset):
-            dem_vertical_units = UNSET
-        else:
-            dem_vertical_units = self.dem_vertical_units
-
-        display_name: None | str | Unset
-        if isinstance(self.display_name, Unset):
-            display_name = UNSET
-        else:
-            display_name = self.display_name
-
-        feature_count: int | None | Unset
-        if isinstance(self.feature_count, Unset):
-            feature_count = UNSET
-        else:
-            feature_count = self.feature_count
 
         filter_: list[Any] | None | Unset
         if isinstance(self.filter_, Unset):
@@ -163,18 +153,6 @@ class SharedLayerResponse:
         else:
             filter_ = self.filter_
 
-        is_3d: bool | None | Unset
-        if isinstance(self.is_3d, Unset):
-            is_3d = UNSET
-        else:
-            is_3d = self.is_3d
-
-        is_dem: bool | None | Unset
-        if isinstance(self.is_dem, Unset):
-            is_dem = UNSET
-        else:
-            is_dem = self.is_dem
-
         label_config: dict[str, Any] | None | Unset
         if isinstance(self.label_config, Unset):
             label_config = UNSET
@@ -182,8 +160,6 @@ class SharedLayerResponse:
             label_config = self.label_config.to_dict()
         else:
             label_config = self.label_config
-
-        layer_type = self.layer_type
 
         popup_config: dict[str, Any] | None | Unset
         if isinstance(self.popup_config, Unset):
@@ -193,8 +169,6 @@ class SharedLayerResponse:
         else:
             popup_config = self.popup_config
 
-        show_in_legend = self.show_in_legend
-
         style_config: dict[str, Any] | None | Unset
         if isinstance(self.style_config, Unset):
             style_config = UNSET
@@ -202,6 +176,32 @@ class SharedLayerResponse:
             style_config = self.style_config.to_dict()
         else:
             style_config = self.style_config
+
+        show_in_legend = self.show_in_legend
+
+        is_dem: bool | None | Unset
+        if isinstance(self.is_dem, Unset):
+            is_dem = UNSET
+        else:
+            is_dem = self.is_dem
+
+        dem_vertical_units: None | str | Unset
+        if isinstance(self.dem_vertical_units, Unset):
+            dem_vertical_units = UNSET
+        else:
+            dem_vertical_units = self.dem_vertical_units
+
+        is_3d: bool | None | Unset
+        if isinstance(self.is_3d, Unset):
+            is_3d = UNSET
+        else:
+            is_3d = self.is_3d
+
+        feature_count: int | None | Unset
+        if isinstance(self.feature_count, Unset):
+            feature_count = UNSET
+        else:
+            feature_count = self.feature_count
 
         tile_version: int | None | Unset
         if isinstance(self.tile_version, Unset):
@@ -213,45 +213,45 @@ class SharedLayerResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "id": id,
                 "dataset_id": dataset_id,
                 "dataset_name": dataset_name,
+                "table_name": table_name,
                 "geometry_type": geometry_type,
-                "id": id,
-                "layout": layout,
+                "sort_order": sort_order,
+                "visible": visible,
                 "opacity": opacity,
                 "paint": paint,
-                "sort_order": sort_order,
-                "table_name": table_name,
+                "layout": layout,
                 "tile_url": tile_url,
-                "visible": visible,
             }
         )
-        if column_info is not UNSET:
-            field_dict["column_info"] = column_info
-        if dataset_record_type is not UNSET:
-            field_dict["dataset_record_type"] = dataset_record_type
-        if dem_vertical_units is not UNSET:
-            field_dict["dem_vertical_units"] = dem_vertical_units
         if display_name is not UNSET:
             field_dict["display_name"] = display_name
-        if feature_count is not UNSET:
-            field_dict["feature_count"] = feature_count
-        if filter_ is not UNSET:
-            field_dict["filter"] = filter_
-        if is_3d is not UNSET:
-            field_dict["is_3d"] = is_3d
-        if is_dem is not UNSET:
-            field_dict["is_dem"] = is_dem
-        if label_config is not UNSET:
-            field_dict["label_config"] = label_config
+        if column_info is not UNSET:
+            field_dict["column_info"] = column_info
         if layer_type is not UNSET:
             field_dict["layer_type"] = layer_type
+        if dataset_record_type is not UNSET:
+            field_dict["dataset_record_type"] = dataset_record_type
+        if filter_ is not UNSET:
+            field_dict["filter"] = filter_
+        if label_config is not UNSET:
+            field_dict["label_config"] = label_config
         if popup_config is not UNSET:
             field_dict["popup_config"] = popup_config
-        if show_in_legend is not UNSET:
-            field_dict["show_in_legend"] = show_in_legend
         if style_config is not UNSET:
             field_dict["style_config"] = style_config
+        if show_in_legend is not UNSET:
+            field_dict["show_in_legend"] = show_in_legend
+        if is_dem is not UNSET:
+            field_dict["is_dem"] = is_dem
+        if dem_vertical_units is not UNSET:
+            field_dict["dem_vertical_units"] = dem_vertical_units
+        if is_3d is not UNSET:
+            field_dict["is_3d"] = is_3d
+        if feature_count is not UNSET:
+            field_dict["feature_count"] = feature_count
         if tile_version is not UNSET:
             field_dict["tile_version"] = tile_version
 
@@ -273,9 +273,13 @@ class SharedLayerResponse:
         )
 
         d = dict(src_dict)
+        id = d.pop("id")
+
         dataset_id = d.pop("dataset_id")
 
         dataset_name = d.pop("dataset_name")
+
+        table_name = d.pop("table_name")
 
         def _parse_geometry_type(data: object) -> None | str:
             if data is None:
@@ -284,21 +288,26 @@ class SharedLayerResponse:
 
         geometry_type = _parse_geometry_type(d.pop("geometry_type"))
 
-        id = d.pop("id")
+        sort_order = d.pop("sort_order")
 
-        layout = SharedLayerResponseLayout.from_dict(d.pop("layout"))
+        visible = d.pop("visible")
 
         opacity = d.pop("opacity")
 
         paint = SharedLayerResponsePaint.from_dict(d.pop("paint"))
 
-        sort_order = d.pop("sort_order")
-
-        table_name = d.pop("table_name")
+        layout = SharedLayerResponseLayout.from_dict(d.pop("layout"))
 
         tile_url = d.pop("tile_url")
 
-        visible = d.pop("visible")
+        def _parse_display_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        display_name = _parse_display_name(d.pop("display_name", UNSET))
 
         def _parse_column_info(
             data: object,
@@ -330,6 +339,8 @@ class SharedLayerResponse:
 
         column_info = _parse_column_info(d.pop("column_info", UNSET))
 
+        layer_type = d.pop("layer_type", UNSET)
+
         def _parse_dataset_record_type(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -340,35 +351,6 @@ class SharedLayerResponse:
         dataset_record_type = _parse_dataset_record_type(
             d.pop("dataset_record_type", UNSET)
         )
-
-        def _parse_dem_vertical_units(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        dem_vertical_units = _parse_dem_vertical_units(
-            d.pop("dem_vertical_units", UNSET)
-        )
-
-        def _parse_display_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        display_name = _parse_display_name(d.pop("display_name", UNSET))
-
-        def _parse_feature_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        feature_count = _parse_feature_count(d.pop("feature_count", UNSET))
 
         def _parse_filter_(data: object) -> list[Any] | None | Unset:
             if data is None:
@@ -386,24 +368,6 @@ class SharedLayerResponse:
             return cast(list[Any] | None | Unset, data)
 
         filter_ = _parse_filter_(d.pop("filter", UNSET))
-
-        def _parse_is_3d(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        is_3d = _parse_is_3d(d.pop("is_3d", UNSET))
-
-        def _parse_is_dem(data: object) -> bool | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(bool | None | Unset, data)
-
-        is_dem = _parse_is_dem(d.pop("is_dem", UNSET))
 
         def _parse_label_config(
             data: object,
@@ -426,8 +390,6 @@ class SharedLayerResponse:
 
         label_config = _parse_label_config(d.pop("label_config", UNSET))
 
-        layer_type = d.pop("layer_type", UNSET)
-
         def _parse_popup_config(data: object) -> None | PopupConfig | Unset:
             if data is None:
                 return data
@@ -444,8 +406,6 @@ class SharedLayerResponse:
             return cast(None | PopupConfig | Unset, data)
 
         popup_config = _parse_popup_config(d.pop("popup_config", UNSET))
-
-        show_in_legend = d.pop("show_in_legend", UNSET)
 
         def _parse_style_config(
             data: object,
@@ -468,6 +428,46 @@ class SharedLayerResponse:
 
         style_config = _parse_style_config(d.pop("style_config", UNSET))
 
+        show_in_legend = d.pop("show_in_legend", UNSET)
+
+        def _parse_is_dem(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_dem = _parse_is_dem(d.pop("is_dem", UNSET))
+
+        def _parse_dem_vertical_units(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        dem_vertical_units = _parse_dem_vertical_units(
+            d.pop("dem_vertical_units", UNSET)
+        )
+
+        def _parse_is_3d(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        is_3d = _parse_is_3d(d.pop("is_3d", UNSET))
+
+        def _parse_feature_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        feature_count = _parse_feature_count(d.pop("feature_count", UNSET))
+
         def _parse_tile_version(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -478,30 +478,30 @@ class SharedLayerResponse:
         tile_version = _parse_tile_version(d.pop("tile_version", UNSET))
 
         shared_layer_response = cls(
+            id=id,
             dataset_id=dataset_id,
             dataset_name=dataset_name,
+            table_name=table_name,
             geometry_type=geometry_type,
-            id=id,
-            layout=layout,
+            sort_order=sort_order,
+            visible=visible,
             opacity=opacity,
             paint=paint,
-            sort_order=sort_order,
-            table_name=table_name,
+            layout=layout,
             tile_url=tile_url,
-            visible=visible,
-            column_info=column_info,
-            dataset_record_type=dataset_record_type,
-            dem_vertical_units=dem_vertical_units,
             display_name=display_name,
-            feature_count=feature_count,
-            filter_=filter_,
-            is_3d=is_3d,
-            is_dem=is_dem,
-            label_config=label_config,
+            column_info=column_info,
             layer_type=layer_type,
+            dataset_record_type=dataset_record_type,
+            filter_=filter_,
+            label_config=label_config,
             popup_config=popup_config,
-            show_in_legend=show_in_legend,
             style_config=style_config,
+            show_in_legend=show_in_legend,
+            is_dem=is_dem,
+            dem_vertical_units=dem_vertical_units,
+            is_3d=is_3d,
+            feature_count=feature_count,
             tile_version=tile_version,
         )
 

--- a/sdks/python/geolens/models/shared_map_response.py
+++ b/sdks/python/geolens/models/shared_map_response.py
@@ -23,63 +23,65 @@ T = TypeVar("T", bound="SharedMapResponse")
 class SharedMapResponse:
     """
     Attributes:
-        basemap_style (str):
-        bearing (float):
-        center_lat (float):
-        center_lng (float):
-        description (None | str):
-        layers (list[SharedLayerResponse]):
         name (str):
-        pitch (float):
+        description (None | str):
+        center_lng (float):
+        center_lat (float):
         zoom (float):
+        bearing (float):
+        pitch (float):
+        basemap_style (str):
+        layers (list[SharedLayerResponse]):
+        show_basemap_labels (bool | Unset):  Default: True.
         basemap_config (BasemapConfig | None | Unset):
+        terrain_config (None | TerrainConfig | Unset):
         has_non_public_layers (bool | Unset):  Default: False.
         legend_title (None | str | Unset):
-        show_basemap_labels (bool | Unset):  Default: True.
-        terrain_config (None | TerrainConfig | Unset):
     """
 
-    basemap_style: str
-    bearing: float
-    center_lat: float
-    center_lng: float
-    description: None | str
-    layers: list[SharedLayerResponse]
     name: str
-    pitch: float
+    description: None | str
+    center_lng: float
+    center_lat: float
     zoom: float
+    bearing: float
+    pitch: float
+    basemap_style: str
+    layers: list[SharedLayerResponse]
+    show_basemap_labels: bool | Unset = True
     basemap_config: BasemapConfig | None | Unset = UNSET
+    terrain_config: None | TerrainConfig | Unset = UNSET
     has_non_public_layers: bool | Unset = False
     legend_title: None | str | Unset = UNSET
-    show_basemap_labels: bool | Unset = True
-    terrain_config: None | TerrainConfig | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.basemap_config import BasemapConfig
         from ..models.terrain_config import TerrainConfig
 
-        basemap_style = self.basemap_style
-
-        bearing = self.bearing
-
-        center_lat = self.center_lat
-
-        center_lng = self.center_lng
+        name = self.name
 
         description: None | str
         description = self.description
+
+        center_lng = self.center_lng
+
+        center_lat = self.center_lat
+
+        zoom = self.zoom
+
+        bearing = self.bearing
+
+        pitch = self.pitch
+
+        basemap_style = self.basemap_style
 
         layers = []
         for layers_item_data in self.layers:
             layers_item = layers_item_data.to_dict()
             layers.append(layers_item)
 
-        name = self.name
-
-        pitch = self.pitch
-
-        zoom = self.zoom
+        show_basemap_labels = self.show_basemap_labels
 
         basemap_config: dict[str, Any] | None | Unset
         if isinstance(self.basemap_config, Unset):
@@ -89,16 +91,6 @@ class SharedMapResponse:
         else:
             basemap_config = self.basemap_config
 
-        has_non_public_layers = self.has_non_public_layers
-
-        legend_title: None | str | Unset
-        if isinstance(self.legend_title, Unset):
-            legend_title = UNSET
-        else:
-            legend_title = self.legend_title
-
-        show_basemap_labels = self.show_basemap_labels
-
         terrain_config: dict[str, Any] | None | Unset
         if isinstance(self.terrain_config, Unset):
             terrain_config = UNSET
@@ -107,31 +99,39 @@ class SharedMapResponse:
         else:
             terrain_config = self.terrain_config
 
+        has_non_public_layers = self.has_non_public_layers
+
+        legend_title: None | str | Unset
+        if isinstance(self.legend_title, Unset):
+            legend_title = UNSET
+        else:
+            legend_title = self.legend_title
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "basemap_style": basemap_style,
-                "bearing": bearing,
-                "center_lat": center_lat,
-                "center_lng": center_lng,
-                "description": description,
-                "layers": layers,
                 "name": name,
-                "pitch": pitch,
+                "description": description,
+                "center_lng": center_lng,
+                "center_lat": center_lat,
                 "zoom": zoom,
+                "bearing": bearing,
+                "pitch": pitch,
+                "basemap_style": basemap_style,
+                "layers": layers,
             }
         )
+        if show_basemap_labels is not UNSET:
+            field_dict["show_basemap_labels"] = show_basemap_labels
         if basemap_config is not UNSET:
             field_dict["basemap_config"] = basemap_config
+        if terrain_config is not UNSET:
+            field_dict["terrain_config"] = terrain_config
         if has_non_public_layers is not UNSET:
             field_dict["has_non_public_layers"] = has_non_public_layers
         if legend_title is not UNSET:
             field_dict["legend_title"] = legend_title
-        if show_basemap_labels is not UNSET:
-            field_dict["show_basemap_labels"] = show_basemap_labels
-        if terrain_config is not UNSET:
-            field_dict["terrain_config"] = terrain_config
 
         return field_dict
 
@@ -142,13 +142,7 @@ class SharedMapResponse:
         from ..models.terrain_config import TerrainConfig
 
         d = dict(src_dict)
-        basemap_style = d.pop("basemap_style")
-
-        bearing = d.pop("bearing")
-
-        center_lat = d.pop("center_lat")
-
-        center_lng = d.pop("center_lng")
+        name = d.pop("name")
 
         def _parse_description(data: object) -> None | str:
             if data is None:
@@ -157,6 +151,18 @@ class SharedMapResponse:
 
         description = _parse_description(d.pop("description"))
 
+        center_lng = d.pop("center_lng")
+
+        center_lat = d.pop("center_lat")
+
+        zoom = d.pop("zoom")
+
+        bearing = d.pop("bearing")
+
+        pitch = d.pop("pitch")
+
+        basemap_style = d.pop("basemap_style")
+
         layers = []
         _layers = d.pop("layers")
         for layers_item_data in _layers:
@@ -164,11 +170,7 @@ class SharedMapResponse:
 
             layers.append(layers_item)
 
-        name = d.pop("name")
-
-        pitch = d.pop("pitch")
-
-        zoom = d.pop("zoom")
+        show_basemap_labels = d.pop("show_basemap_labels", UNSET)
 
         def _parse_basemap_config(data: object) -> BasemapConfig | None | Unset:
             if data is None:
@@ -187,19 +189,6 @@ class SharedMapResponse:
 
         basemap_config = _parse_basemap_config(d.pop("basemap_config", UNSET))
 
-        has_non_public_layers = d.pop("has_non_public_layers", UNSET)
-
-        def _parse_legend_title(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        legend_title = _parse_legend_title(d.pop("legend_title", UNSET))
-
-        show_basemap_labels = d.pop("show_basemap_labels", UNSET)
-
         def _parse_terrain_config(data: object) -> None | TerrainConfig | Unset:
             if data is None:
                 return data
@@ -217,21 +206,32 @@ class SharedMapResponse:
 
         terrain_config = _parse_terrain_config(d.pop("terrain_config", UNSET))
 
+        has_non_public_layers = d.pop("has_non_public_layers", UNSET)
+
+        def _parse_legend_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        legend_title = _parse_legend_title(d.pop("legend_title", UNSET))
+
         shared_map_response = cls(
-            basemap_style=basemap_style,
-            bearing=bearing,
-            center_lat=center_lat,
-            center_lng=center_lng,
-            description=description,
-            layers=layers,
             name=name,
-            pitch=pitch,
+            description=description,
+            center_lng=center_lng,
+            center_lat=center_lat,
             zoom=zoom,
+            bearing=bearing,
+            pitch=pitch,
+            basemap_style=basemap_style,
+            layers=layers,
+            show_basemap_labels=show_basemap_labels,
             basemap_config=basemap_config,
+            terrain_config=terrain_config,
             has_non_public_layers=has_non_public_layers,
             legend_title=legend_title,
-            show_basemap_labels=show_basemap_labels,
-            terrain_config=terrain_config,
         )
 
         shared_map_response.additional_properties = d

--- a/sdks/python/geolens/models/sse_actions_event.py
+++ b/sdks/python/geolens/models/sse_actions_event.py
@@ -22,28 +22,28 @@ class SSEActionsEvent:
     """Validated map-edit actions produced by streaming chat.
 
     Attributes:
-        actions (list[ChatAction]):
         type_ (Literal['actions']):
+        actions (list[ChatAction]):
     """
 
-    actions: list[ChatAction]
     type_: Literal["actions"]
+    actions: list[ChatAction]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
         actions = []
         for actions_item_data in self.actions:
             actions_item = actions_item_data.to_dict()
             actions.append(actions_item)
 
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "actions": actions,
                 "type": type_,
+                "actions": actions,
             }
         )
 
@@ -54,6 +54,10 @@ class SSEActionsEvent:
         from ..models.chat_action import ChatAction
 
         d = dict(src_dict)
+        type_ = cast(Literal["actions"], d.pop("type"))
+        if type_ != "actions":
+            raise ValueError(f"type must match const 'actions', got '{type_}'")
+
         actions = []
         _actions = d.pop("actions")
         for actions_item_data in _actions:
@@ -61,13 +65,9 @@ class SSEActionsEvent:
 
             actions.append(actions_item)
 
-        type_ = cast(Literal["actions"], d.pop("type"))
-        if type_ != "actions":
-            raise ValueError(f"type must match const 'actions', got '{type_}'")
-
         sse_actions_event = cls(
-            actions=actions,
             type_=type_,
+            actions=actions,
         )
 
         sse_actions_event.additional_properties = d

--- a/sdks/python/geolens/models/sse_chat_done_event.py
+++ b/sdks/python/geolens/models/sse_chat_done_event.py
@@ -18,25 +18,25 @@ class SSEChatDoneEvent:
     """Terminal payload for a successful streaming chat request.
 
     Attributes:
-        explanation (str):
         type_ (Literal['done']):
+        explanation (str):
     """
 
-    explanation: str
     type_: Literal["done"]
+    explanation: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        explanation = self.explanation
-
         type_ = self.type_
+
+        explanation = self.explanation
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "explanation": explanation,
                 "type": type_,
+                "explanation": explanation,
             }
         )
 
@@ -45,15 +45,15 @@ class SSEChatDoneEvent:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        explanation = d.pop("explanation")
-
         type_ = cast(Literal["done"], d.pop("type"))
         if type_ != "done":
             raise ValueError(f"type must match const 'done', got '{type_}'")
 
+        explanation = d.pop("explanation")
+
         sse_chat_done_event = cls(
-            explanation=explanation,
             type_=type_,
+            explanation=explanation,
         )
 
         sse_chat_done_event.additional_properties = d

--- a/sdks/python/geolens/models/sse_error_event.py
+++ b/sdks/python/geolens/models/sse_error_event.py
@@ -23,19 +23,21 @@ class SSEErrorEvent:
     """Error payload carried inside an already-open SSE response.
 
     Attributes:
-        message (list[Any] | SSEErrorEventMessageType1 | str):
         type_ (Literal['error']):
+        message (list[Any] | SSEErrorEventMessageType1 | str):
         status (int | None | Unset): HTTP-equivalent status for router-level failures; provider and model errors raised
             inside the stream may omit it.
     """
 
-    message: list[Any] | SSEErrorEventMessageType1 | str
     type_: Literal["error"]
+    message: list[Any] | SSEErrorEventMessageType1 | str
     status: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.sse_error_event_message_type_1 import SSEErrorEventMessageType1
+
+        type_ = self.type_
 
         message: dict[str, Any] | list[Any] | str
         if isinstance(self.message, SSEErrorEventMessageType1):
@@ -45,8 +47,6 @@ class SSEErrorEvent:
 
         else:
             message = self.message
-
-        type_ = self.type_
 
         status: int | None | Unset
         if isinstance(self.status, Unset):
@@ -58,8 +58,8 @@ class SSEErrorEvent:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "message": message,
                 "type": type_,
+                "message": message,
             }
         )
         if status is not UNSET:
@@ -72,6 +72,9 @@ class SSEErrorEvent:
         from ..models.sse_error_event_message_type_1 import SSEErrorEventMessageType1
 
         d = dict(src_dict)
+        type_ = cast(Literal["error"], d.pop("type"))
+        if type_ != "error":
+            raise ValueError(f"type must match const 'error', got '{type_}'")
 
         def _parse_message(data: object) -> list[Any] | SSEErrorEventMessageType1 | str:
             try:
@@ -94,10 +97,6 @@ class SSEErrorEvent:
 
         message = _parse_message(d.pop("message"))
 
-        type_ = cast(Literal["error"], d.pop("type"))
-        if type_ != "error":
-            raise ValueError(f"type must match const 'error', got '{type_}'")
-
         def _parse_status(data: object) -> int | None | Unset:
             if data is None:
                 return data
@@ -108,8 +107,8 @@ class SSEErrorEvent:
         status = _parse_status(d.pop("status", UNSET))
 
         sse_error_event = cls(
-            message=message,
             type_=type_,
+            message=message,
             status=status,
         )
 

--- a/sdks/python/geolens/models/sse_map_done_event.py
+++ b/sdks/python/geolens/models/sse_map_done_event.py
@@ -19,40 +19,40 @@ class SSEMapDoneEvent:
     """Terminal payload for a successful streaming map-generation request.
 
     Attributes:
-        datasets_used (list[str]):
-        explanation (str):
+        type_ (Literal['done']):
         map_id (str):
         map_name (str):
-        type_ (Literal['done']):
+        explanation (str):
+        datasets_used (list[str]):
     """
 
-    datasets_used: list[str]
-    explanation: str
+    type_: Literal["done"]
     map_id: str
     map_name: str
-    type_: Literal["done"]
+    explanation: str
+    datasets_used: list[str]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        datasets_used = self.datasets_used
-
-        explanation = self.explanation
+        type_ = self.type_
 
         map_id = self.map_id
 
         map_name = self.map_name
 
-        type_ = self.type_
+        explanation = self.explanation
+
+        datasets_used = self.datasets_used
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "datasets_used": datasets_used,
-                "explanation": explanation,
+                "type": type_,
                 "map_id": map_id,
                 "map_name": map_name,
-                "type": type_,
+                "explanation": explanation,
+                "datasets_used": datasets_used,
             }
         )
 
@@ -61,24 +61,24 @@ class SSEMapDoneEvent:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        datasets_used = cast(list[str], d.pop("datasets_used"))
-
-        explanation = d.pop("explanation")
+        type_ = cast(Literal["done"], d.pop("type"))
+        if type_ != "done":
+            raise ValueError(f"type must match const 'done', got '{type_}'")
 
         map_id = d.pop("map_id")
 
         map_name = d.pop("map_name")
 
-        type_ = cast(Literal["done"], d.pop("type"))
-        if type_ != "done":
-            raise ValueError(f"type must match const 'done', got '{type_}'")
+        explanation = d.pop("explanation")
+
+        datasets_used = cast(list[str], d.pop("datasets_used"))
 
         sse_map_done_event = cls(
-            datasets_used=datasets_used,
-            explanation=explanation,
+            type_=type_,
             map_id=map_id,
             map_name=map_name,
-            type_=type_,
+            explanation=explanation,
+            datasets_used=datasets_used,
         )
 
         sse_map_done_event.additional_properties = d

--- a/sdks/python/geolens/models/sse_token_event.py
+++ b/sdks/python/geolens/models/sse_token_event.py
@@ -18,25 +18,25 @@ class SSETokenEvent:
     """Token payload carried by a ``token`` server-sent event.
 
     Attributes:
-        text (str):
         type_ (Literal['token']):
+        text (str):
     """
 
-    text: str
     type_: Literal["token"]
+    text: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        text = self.text
-
         type_ = self.type_
+
+        text = self.text
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "text": text,
                 "type": type_,
+                "text": text,
             }
         )
 
@@ -45,15 +45,15 @@ class SSETokenEvent:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        text = d.pop("text")
-
         type_ = cast(Literal["token"], d.pop("type"))
         if type_ != "token":
             raise ValueError(f"type must match const 'token', got '{type_}'")
 
+        text = d.pop("text")
+
         sse_token_event = cls(
-            text=text,
             type_=type_,
+            text=text,
         )
 
         sse_token_event.additional_properties = d

--- a/sdks/python/geolens/models/sse_tool_result_event.py
+++ b/sdks/python/geolens/models/sse_tool_result_event.py
@@ -18,30 +18,30 @@ class SSEToolResultEvent:
     """Progress payload emitted when an AI tool finishes.
 
     Attributes:
-        success (bool):
-        tool (str):
         type_ (Literal['tool_result']):
+        tool (str):
+        success (bool):
     """
 
-    success: bool
-    tool: str
     type_: Literal["tool_result"]
+    tool: str
+    success: bool
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        success = self.success
+        type_ = self.type_
 
         tool = self.tool
 
-        type_ = self.type_
+        success = self.success
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "success": success,
-                "tool": tool,
                 "type": type_,
+                "tool": tool,
+                "success": success,
             }
         )
 
@@ -50,18 +50,18 @@ class SSEToolResultEvent:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        success = d.pop("success")
-
-        tool = d.pop("tool")
-
         type_ = cast(Literal["tool_result"], d.pop("type"))
         if type_ != "tool_result":
             raise ValueError(f"type must match const 'tool_result', got '{type_}'")
 
+        tool = d.pop("tool")
+
+        success = d.pop("success")
+
         sse_tool_result_event = cls(
-            success=success,
-            tool=tool,
             type_=type_,
+            tool=tool,
+            success=success,
         )
 
         sse_tool_result_event.additional_properties = d

--- a/sdks/python/geolens/models/sse_tool_start_event.py
+++ b/sdks/python/geolens/models/sse_tool_start_event.py
@@ -18,30 +18,30 @@ class SSEToolStartEvent:
     """Progress payload emitted when an AI tool starts.
 
     Attributes:
-        label (str):
-        tool (str):
         type_ (Literal['tool_start']):
+        tool (str):
+        label (str):
     """
 
-    label: str
-    tool: str
     type_: Literal["tool_start"]
+    tool: str
+    label: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        label = self.label
+        type_ = self.type_
 
         tool = self.tool
 
-        type_ = self.type_
+        label = self.label
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "label": label,
-                "tool": tool,
                 "type": type_,
+                "tool": tool,
+                "label": label,
             }
         )
 
@@ -50,18 +50,18 @@ class SSEToolStartEvent:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        label = d.pop("label")
-
-        tool = d.pop("tool")
-
         type_ = cast(Literal["tool_start"], d.pop("type"))
         if type_ != "tool_start":
             raise ValueError(f"type must match const 'tool_start', got '{type_}'")
 
+        tool = d.pop("tool")
+
+        label = d.pop("label")
+
         sse_tool_start_event = cls(
-            label=label,
-            tool=tool,
             type_=type_,
+            tool=tool,
+            label=label,
         )
 
         sse_tool_start_event.additional_properties = d

--- a/sdks/python/geolens/models/stac_asset.py
+++ b/sdks/python/geolens/models/stac_asset.py
@@ -19,23 +19,35 @@ class StacAsset:
     """
     Attributes:
         href (str):
+        type_ (None | str | Unset):
+        title (None | str | Unset):
         description (None | str | Unset):
         roles (list[str] | None | Unset):
         size_bytes (int | None | Unset):
-        title (None | str | Unset):
-        type_ (None | str | Unset):
     """
 
     href: str
+    type_: None | str | Unset = UNSET
+    title: None | str | Unset = UNSET
     description: None | str | Unset = UNSET
     roles: list[str] | None | Unset = UNSET
     size_bytes: int | None | Unset = UNSET
-    title: None | str | Unset = UNSET
-    type_: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         href = self.href
+
+        type_: None | str | Unset
+        if isinstance(self.type_, Unset):
+            type_ = UNSET
+        else:
+            type_ = self.type_
+
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
+        else:
+            title = self.title
 
         description: None | str | Unset
         if isinstance(self.description, Unset):
@@ -58,18 +70,6 @@ class StacAsset:
         else:
             size_bytes = self.size_bytes
 
-        title: None | str | Unset
-        if isinstance(self.title, Unset):
-            title = UNSET
-        else:
-            title = self.title
-
-        type_: None | str | Unset
-        if isinstance(self.type_, Unset):
-            type_ = UNSET
-        else:
-            type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -77,16 +77,16 @@ class StacAsset:
                 "href": href,
             }
         )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if title is not UNSET:
+            field_dict["title"] = title
         if description is not UNSET:
             field_dict["description"] = description
         if roles is not UNSET:
             field_dict["roles"] = roles
         if size_bytes is not UNSET:
             field_dict["size_bytes"] = size_bytes
-        if title is not UNSET:
-            field_dict["title"] = title
-        if type_ is not UNSET:
-            field_dict["type"] = type_
 
         return field_dict
 
@@ -94,6 +94,24 @@ class StacAsset:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         href = d.pop("href")
+
+        def _parse_type_(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        type_ = _parse_type_(d.pop("type", UNSET))
+
+        def _parse_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        title = _parse_title(d.pop("title", UNSET))
 
         def _parse_description(data: object) -> None | str | Unset:
             if data is None:
@@ -130,31 +148,13 @@ class StacAsset:
 
         size_bytes = _parse_size_bytes(d.pop("size_bytes", UNSET))
 
-        def _parse_title(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        title = _parse_title(d.pop("title", UNSET))
-
-        def _parse_type_(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        type_ = _parse_type_(d.pop("type", UNSET))
-
         stac_asset = cls(
             href=href,
+            type_=type_,
+            title=title,
             description=description,
             roles=roles,
             size_bytes=size_bytes,
-            title=title,
-            type_=type_,
         )
 
         stac_asset.additional_properties = d

--- a/sdks/python/geolens/models/stac_catalog.py
+++ b/sdks/python/geolens/models/stac_catalog.py
@@ -22,58 +22,58 @@ class StacCatalog:
     """STAC Catalog / landing page response.
 
     Attributes:
+        id (str): Stable identifier for the catalog.
+        title (str): Catalog title.
+        description (str): Human-readable catalog description.
         conforms_to (list[str]): List of conformance URIs declaring which STAC and OGC API standards the catalog
             implements.
-        description (str): Human-readable catalog description.
-        id (str): Stable identifier for the catalog.
         links (list[StacLink]): Catalog navigation links (self, root, search, collections, etc.).
-        title (str): Catalog title.
-        stac_version (str | Unset): STAC specification version implemented. Default: '1.0.0'.
         type_ (str | Unset): STAC object type. Always 'Catalog' for the landing page. Default: 'Catalog'.
+        stac_version (str | Unset): STAC specification version implemented. Default: '1.0.0'.
     """
 
-    conforms_to: list[str]
-    description: str
     id: str
-    links: list[StacLink]
     title: str
-    stac_version: str | Unset = "1.0.0"
+    description: str
+    conforms_to: list[str]
+    links: list[StacLink]
     type_: str | Unset = "Catalog"
+    stac_version: str | Unset = "1.0.0"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        conforms_to = self.conforms_to
+        id = self.id
+
+        title = self.title
 
         description = self.description
 
-        id = self.id
+        conforms_to = self.conforms_to
 
         links = []
         for links_item_data in self.links:
             links_item = links_item_data.to_dict()
             links.append(links_item)
 
-        title = self.title
+        type_ = self.type_
 
         stac_version = self.stac_version
-
-        type_ = self.type_
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "conformsTo": conforms_to,
-                "description": description,
                 "id": id,
-                "links": links,
                 "title": title,
+                "description": description,
+                "conformsTo": conforms_to,
+                "links": links,
             }
         )
-        if stac_version is not UNSET:
-            field_dict["stac_version"] = stac_version
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if stac_version is not UNSET:
+            field_dict["stac_version"] = stac_version
 
         return field_dict
 
@@ -82,11 +82,13 @@ class StacCatalog:
         from ..models.stac_link import StacLink
 
         d = dict(src_dict)
-        conforms_to = cast(list[str], d.pop("conformsTo"))
+        id = d.pop("id")
+
+        title = d.pop("title")
 
         description = d.pop("description")
 
-        id = d.pop("id")
+        conforms_to = cast(list[str], d.pop("conformsTo"))
 
         links = []
         _links = d.pop("links")
@@ -95,20 +97,18 @@ class StacCatalog:
 
             links.append(links_item)
 
-        title = d.pop("title")
+        type_ = d.pop("type", UNSET)
 
         stac_version = d.pop("stac_version", UNSET)
 
-        type_ = d.pop("type", UNSET)
-
         stac_catalog = cls(
-            conforms_to=conforms_to,
-            description=description,
             id=id,
-            links=links,
             title=title,
-            stac_version=stac_version,
+            description=description,
+            conforms_to=conforms_to,
+            links=links,
             type_=type_,
+            stac_version=stac_version,
         )
 
         stac_catalog.additional_properties = d

--- a/sdks/python/geolens/models/stac_collection.py
+++ b/sdks/python/geolens/models/stac_collection.py
@@ -23,39 +23,37 @@ class StacCollection:
     """A single STAC Collection response (permissive — allows extra STAC fields).
 
     Attributes:
-        extent (StacCollectionExtent): Spatial and temporal extent of items in the collection.
         id (str): Stable collection identifier.
+        extent (StacCollectionExtent): Spatial and temporal extent of items in the collection.
         links (list[StacLink]): Collection navigation links.
-        description (str | Unset): Collection description. Default: ''.
-        license_ (str | Unset): SPDX license identifier or 'proprietary'. Default: 'proprietary'.
+        type_ (str | Unset): STAC object type. Default: 'Collection'.
         stac_version (str | Unset): STAC specification version. Default: '1.0.0'.
         title (None | str | Unset): Human-readable collection title.
-        type_ (str | Unset): STAC object type. Default: 'Collection'.
+        description (str | Unset): Collection description. Default: ''.
+        license_ (str | Unset): SPDX license identifier or 'proprietary'. Default: 'proprietary'.
     """
 
-    extent: StacCollectionExtent
     id: str
+    extent: StacCollectionExtent
     links: list[StacLink]
-    description: str | Unset = ""
-    license_: str | Unset = "proprietary"
+    type_: str | Unset = "Collection"
     stac_version: str | Unset = "1.0.0"
     title: None | str | Unset = UNSET
-    type_: str | Unset = "Collection"
+    description: str | Unset = ""
+    license_: str | Unset = "proprietary"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        extent = self.extent.to_dict()
-
         id = self.id
+
+        extent = self.extent.to_dict()
 
         links = []
         for links_item_data in self.links:
             links_item = links_item_data.to_dict()
             links.append(links_item)
 
-        description = self.description
-
-        license_ = self.license_
+        type_ = self.type_
 
         stac_version = self.stac_version
 
@@ -65,27 +63,29 @@ class StacCollection:
         else:
             title = self.title
 
-        type_ = self.type_
+        description = self.description
+
+        license_ = self.license_
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "extent": extent,
                 "id": id,
+                "extent": extent,
                 "links": links,
             }
         )
-        if description is not UNSET:
-            field_dict["description"] = description
-        if license_ is not UNSET:
-            field_dict["license"] = license_
+        if type_ is not UNSET:
+            field_dict["type"] = type_
         if stac_version is not UNSET:
             field_dict["stac_version"] = stac_version
         if title is not UNSET:
             field_dict["title"] = title
-        if type_ is not UNSET:
-            field_dict["type"] = type_
+        if description is not UNSET:
+            field_dict["description"] = description
+        if license_ is not UNSET:
+            field_dict["license"] = license_
 
         return field_dict
 
@@ -95,9 +95,9 @@ class StacCollection:
         from ..models.stac_link import StacLink
 
         d = dict(src_dict)
-        extent = StacCollectionExtent.from_dict(d.pop("extent"))
-
         id = d.pop("id")
+
+        extent = StacCollectionExtent.from_dict(d.pop("extent"))
 
         links = []
         _links = d.pop("links")
@@ -106,9 +106,7 @@ class StacCollection:
 
             links.append(links_item)
 
-        description = d.pop("description", UNSET)
-
-        license_ = d.pop("license", UNSET)
+        type_ = d.pop("type", UNSET)
 
         stac_version = d.pop("stac_version", UNSET)
 
@@ -121,17 +119,19 @@ class StacCollection:
 
         title = _parse_title(d.pop("title", UNSET))
 
-        type_ = d.pop("type", UNSET)
+        description = d.pop("description", UNSET)
+
+        license_ = d.pop("license", UNSET)
 
         stac_collection = cls(
-            extent=extent,
             id=id,
+            extent=extent,
             links=links,
-            description=description,
-            license_=license_,
+            type_=type_,
             stac_version=stac_version,
             title=title,
-            type_=type_,
+            description=description,
+            license_=license_,
         )
 
         stac_collection.additional_properties = d

--- a/sdks/python/geolens/models/stac_collection_summary.py
+++ b/sdks/python/geolens/models/stac_collection_summary.py
@@ -18,34 +18,44 @@ T = TypeVar("T", bound="StacCollectionSummary")
 class StacCollectionSummary:
     """
     Attributes:
-        description (str): Collection description.
         id (str): Collection identifier.
         title (str): Collection title.
-        bbox (list[float] | None | Unset): Spatial extent as [west, south, east, north].
-        item_count (int | None | Unset): Number of items if reported by the API.
-        keywords (list[str] | Unset): Collection keywords.
+        description (str): Collection description.
         license_ (None | str | Unset): SPDX license identifier.
-        temporal_end (None | str | Unset): End of temporal extent (ISO 8601).
+        keywords (list[str] | Unset): Collection keywords.
+        bbox (list[float] | None | Unset): Spatial extent as [west, south, east, north].
         temporal_start (None | str | Unset): Start of temporal extent (ISO 8601).
+        temporal_end (None | str | Unset): End of temporal extent (ISO 8601).
+        item_count (int | None | Unset): Number of items if reported by the API.
     """
 
-    description: str
     id: str
     title: str
-    bbox: list[float] | None | Unset = UNSET
-    item_count: int | None | Unset = UNSET
-    keywords: list[str] | Unset = UNSET
+    description: str
     license_: None | str | Unset = UNSET
-    temporal_end: None | str | Unset = UNSET
+    keywords: list[str] | Unset = UNSET
+    bbox: list[float] | None | Unset = UNSET
     temporal_start: None | str | Unset = UNSET
+    temporal_end: None | str | Unset = UNSET
+    item_count: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        description = self.description
-
         id = self.id
 
         title = self.title
+
+        description = self.description
+
+        license_: None | str | Unset
+        if isinstance(self.license_, Unset):
+            license_ = UNSET
+        else:
+            license_ = self.license_
+
+        keywords: list[str] | Unset = UNSET
+        if not isinstance(self.keywords, Unset):
+            keywords = self.keywords
 
         bbox: list[float] | None | Unset
         if isinstance(self.bbox, Unset):
@@ -56,21 +66,11 @@ class StacCollectionSummary:
         else:
             bbox = self.bbox
 
-        item_count: int | None | Unset
-        if isinstance(self.item_count, Unset):
-            item_count = UNSET
+        temporal_start: None | str | Unset
+        if isinstance(self.temporal_start, Unset):
+            temporal_start = UNSET
         else:
-            item_count = self.item_count
-
-        keywords: list[str] | Unset = UNSET
-        if not isinstance(self.keywords, Unset):
-            keywords = self.keywords
-
-        license_: None | str | Unset
-        if isinstance(self.license_, Unset):
-            license_ = UNSET
-        else:
-            license_ = self.license_
+            temporal_start = self.temporal_start
 
         temporal_end: None | str | Unset
         if isinstance(self.temporal_end, Unset):
@@ -78,44 +78,55 @@ class StacCollectionSummary:
         else:
             temporal_end = self.temporal_end
 
-        temporal_start: None | str | Unset
-        if isinstance(self.temporal_start, Unset):
-            temporal_start = UNSET
+        item_count: int | None | Unset
+        if isinstance(self.item_count, Unset):
+            item_count = UNSET
         else:
-            temporal_start = self.temporal_start
+            item_count = self.item_count
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "description": description,
                 "id": id,
                 "title": title,
+                "description": description,
             }
         )
-        if bbox is not UNSET:
-            field_dict["bbox"] = bbox
-        if item_count is not UNSET:
-            field_dict["item_count"] = item_count
-        if keywords is not UNSET:
-            field_dict["keywords"] = keywords
         if license_ is not UNSET:
             field_dict["license"] = license_
-        if temporal_end is not UNSET:
-            field_dict["temporal_end"] = temporal_end
+        if keywords is not UNSET:
+            field_dict["keywords"] = keywords
+        if bbox is not UNSET:
+            field_dict["bbox"] = bbox
         if temporal_start is not UNSET:
             field_dict["temporal_start"] = temporal_start
+        if temporal_end is not UNSET:
+            field_dict["temporal_end"] = temporal_end
+        if item_count is not UNSET:
+            field_dict["item_count"] = item_count
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        description = d.pop("description")
-
         id = d.pop("id")
 
         title = d.pop("title")
+
+        description = d.pop("description")
+
+        def _parse_license_(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        license_ = _parse_license_(d.pop("license", UNSET))
+
+        keywords = cast(list[str], d.pop("keywords", UNSET))
 
         def _parse_bbox(data: object) -> list[float] | None | Unset:
             if data is None:
@@ -134,25 +145,14 @@ class StacCollectionSummary:
 
         bbox = _parse_bbox(d.pop("bbox", UNSET))
 
-        def _parse_item_count(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        item_count = _parse_item_count(d.pop("item_count", UNSET))
-
-        keywords = cast(list[str], d.pop("keywords", UNSET))
-
-        def _parse_license_(data: object) -> None | str | Unset:
+        def _parse_temporal_start(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        license_ = _parse_license_(d.pop("license", UNSET))
+        temporal_start = _parse_temporal_start(d.pop("temporal_start", UNSET))
 
         def _parse_temporal_end(data: object) -> None | str | Unset:
             if data is None:
@@ -163,25 +163,25 @@ class StacCollectionSummary:
 
         temporal_end = _parse_temporal_end(d.pop("temporal_end", UNSET))
 
-        def _parse_temporal_start(data: object) -> None | str | Unset:
+        def _parse_item_count(data: object) -> int | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(None | str | Unset, data)
+            return cast(int | None | Unset, data)
 
-        temporal_start = _parse_temporal_start(d.pop("temporal_start", UNSET))
+        item_count = _parse_item_count(d.pop("item_count", UNSET))
 
         stac_collection_summary = cls(
-            description=description,
             id=id,
             title=title,
-            bbox=bbox,
-            item_count=item_count,
-            keywords=keywords,
+            description=description,
             license_=license_,
-            temporal_end=temporal_end,
+            keywords=keywords,
+            bbox=bbox,
             temporal_start=temporal_start,
+            temporal_end=temporal_end,
+            item_count=item_count,
         )
 
         stac_collection_summary.additional_properties = d

--- a/sdks/python/geolens/models/stac_collections_response.py
+++ b/sdks/python/geolens/models/stac_collections_response.py
@@ -18,28 +18,28 @@ T = TypeVar("T", bound="StacCollectionsResponse")
 class StacCollectionsResponse:
     """
     Attributes:
-        collections (list[StacCollectionSummary]): Available collections.
         url (str): STAC API URL that was queried.
+        collections (list[StacCollectionSummary]): Available collections.
     """
 
-    collections: list[StacCollectionSummary]
     url: str
+    collections: list[StacCollectionSummary]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        url = self.url
+
         collections = []
         for collections_item_data in self.collections:
             collections_item = collections_item_data.to_dict()
             collections.append(collections_item)
 
-        url = self.url
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "collections": collections,
                 "url": url,
+                "collections": collections,
             }
         )
 
@@ -50,6 +50,8 @@ class StacCollectionsResponse:
         from ..models.stac_collection_summary import StacCollectionSummary
 
         d = dict(src_dict)
+        url = d.pop("url")
+
         collections = []
         _collections = d.pop("collections")
         for collections_item_data in _collections:
@@ -57,11 +59,9 @@ class StacCollectionsResponse:
 
             collections.append(collections_item)
 
-        url = d.pop("url")
-
         stac_collections_response = cls(
-            collections=collections,
             url=url,
+            collections=collections,
         )
 
         stac_collections_response.additional_properties = d

--- a/sdks/python/geolens/models/stac_connect_response.py
+++ b/sdks/python/geolens/models/stac_connect_response.py
@@ -14,40 +14,40 @@ T = TypeVar("T", bound="StacConnectResponse")
 class StacConnectResponse:
     """
     Attributes:
+        url (str): Normalized STAC API URL.
         catalog_id (str): Catalog identifier from the landing page.
+        title (str): Catalog title.
         description (str): Catalog description.
         stac_version (str): STAC specification version.
-        title (str): Catalog title.
-        url (str): Normalized STAC API URL.
     """
 
+    url: str
     catalog_id: str
+    title: str
     description: str
     stac_version: str
-    title: str
-    url: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        url = self.url
+
         catalog_id = self.catalog_id
+
+        title = self.title
 
         description = self.description
 
         stac_version = self.stac_version
 
-        title = self.title
-
-        url = self.url
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "url": url,
                 "catalog_id": catalog_id,
+                "title": title,
                 "description": description,
                 "stac_version": stac_version,
-                "title": title,
-                "url": url,
             }
         )
 
@@ -56,22 +56,22 @@ class StacConnectResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        url = d.pop("url")
+
         catalog_id = d.pop("catalog_id")
+
+        title = d.pop("title")
 
         description = d.pop("description")
 
         stac_version = d.pop("stac_version")
 
-        title = d.pop("title")
-
-        url = d.pop("url")
-
         stac_connect_response = cls(
+            url=url,
             catalog_id=catalog_id,
+            title=title,
             description=description,
             stac_version=stac_version,
-            title=title,
-            url=url,
         )
 
         stac_connect_response.additional_properties = d

--- a/sdks/python/geolens/models/stac_context.py
+++ b/sdks/python/geolens/models/stac_context.py
@@ -16,29 +16,29 @@ class StacContext:
 
     Attributes:
         limit (int):
-        matched (int):
         returned (int):
+        matched (int):
     """
 
     limit: int
-    matched: int
     returned: int
+    matched: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         limit = self.limit
 
-        matched = self.matched
-
         returned = self.returned
+
+        matched = self.matched
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "limit": limit,
-                "matched": matched,
                 "returned": returned,
+                "matched": matched,
             }
         )
 
@@ -49,14 +49,14 @@ class StacContext:
         d = dict(src_dict)
         limit = d.pop("limit")
 
-        matched = d.pop("matched")
-
         returned = d.pop("returned")
+
+        matched = d.pop("matched")
 
         stac_context = cls(
             limit=limit,
-            matched=matched,
             returned=returned,
+            matched=matched,
         )
 
         stac_context.additional_properties = d

--- a/sdks/python/geolens/models/stac_import_item.py
+++ b/sdks/python/geolens/models/stac_import_item.py
@@ -18,34 +18,40 @@ T = TypeVar("T", bound="StacImportItem")
 class StacImportItem:
     """
     Attributes:
-        data_asset_href (str): URL of the COG asset to reference.
         id (str): STAC item ID.
         title (str): Title to use for the GeoLens dataset.
-        bbox (list[float] | None | Unset): Item bounding box.
+        data_asset_href (str): URL of the COG asset to reference.
         collection (None | str | Unset): Parent collection ID.
-        datetime_end (None | str | Unset): Temporal end.
-        datetime_start (None | str | Unset): Temporal start.
+        bbox (list[float] | None | Unset): Item bounding box.
         epsg (int | None | Unset): EPSG code.
+        datetime_start (None | str | Unset): Temporal start.
+        datetime_end (None | str | Unset): Temporal end.
         keywords (list[str] | Unset): Keywords from STAC collection.
     """
 
-    data_asset_href: str
     id: str
     title: str
-    bbox: list[float] | None | Unset = UNSET
+    data_asset_href: str
     collection: None | str | Unset = UNSET
-    datetime_end: None | str | Unset = UNSET
-    datetime_start: None | str | Unset = UNSET
+    bbox: list[float] | None | Unset = UNSET
     epsg: int | None | Unset = UNSET
+    datetime_start: None | str | Unset = UNSET
+    datetime_end: None | str | Unset = UNSET
     keywords: list[str] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        data_asset_href = self.data_asset_href
-
         id = self.id
 
         title = self.title
+
+        data_asset_href = self.data_asset_href
+
+        collection: None | str | Unset
+        if isinstance(self.collection, Unset):
+            collection = UNSET
+        else:
+            collection = self.collection
 
         bbox: list[float] | None | Unset
         if isinstance(self.bbox, Unset):
@@ -56,17 +62,11 @@ class StacImportItem:
         else:
             bbox = self.bbox
 
-        collection: None | str | Unset
-        if isinstance(self.collection, Unset):
-            collection = UNSET
+        epsg: int | None | Unset
+        if isinstance(self.epsg, Unset):
+            epsg = UNSET
         else:
-            collection = self.collection
-
-        datetime_end: None | str | Unset
-        if isinstance(self.datetime_end, Unset):
-            datetime_end = UNSET
-        else:
-            datetime_end = self.datetime_end
+            epsg = self.epsg
 
         datetime_start: None | str | Unset
         if isinstance(self.datetime_start, Unset):
@@ -74,11 +74,11 @@ class StacImportItem:
         else:
             datetime_start = self.datetime_start
 
-        epsg: int | None | Unset
-        if isinstance(self.epsg, Unset):
-            epsg = UNSET
+        datetime_end: None | str | Unset
+        if isinstance(self.datetime_end, Unset):
+            datetime_end = UNSET
         else:
-            epsg = self.epsg
+            datetime_end = self.datetime_end
 
         keywords: list[str] | Unset = UNSET
         if not isinstance(self.keywords, Unset):
@@ -88,21 +88,21 @@ class StacImportItem:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "data_asset_href": data_asset_href,
                 "id": id,
                 "title": title,
+                "data_asset_href": data_asset_href,
             }
         )
-        if bbox is not UNSET:
-            field_dict["bbox"] = bbox
         if collection is not UNSET:
             field_dict["collection"] = collection
-        if datetime_end is not UNSET:
-            field_dict["datetime_end"] = datetime_end
-        if datetime_start is not UNSET:
-            field_dict["datetime_start"] = datetime_start
+        if bbox is not UNSET:
+            field_dict["bbox"] = bbox
         if epsg is not UNSET:
             field_dict["epsg"] = epsg
+        if datetime_start is not UNSET:
+            field_dict["datetime_start"] = datetime_start
+        if datetime_end is not UNSET:
+            field_dict["datetime_end"] = datetime_end
         if keywords is not UNSET:
             field_dict["keywords"] = keywords
 
@@ -111,11 +111,20 @@ class StacImportItem:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        data_asset_href = d.pop("data_asset_href")
-
         id = d.pop("id")
 
         title = d.pop("title")
+
+        data_asset_href = d.pop("data_asset_href")
+
+        def _parse_collection(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        collection = _parse_collection(d.pop("collection", UNSET))
 
         def _parse_bbox(data: object) -> list[float] | None | Unset:
             if data is None:
@@ -134,23 +143,14 @@ class StacImportItem:
 
         bbox = _parse_bbox(d.pop("bbox", UNSET))
 
-        def _parse_collection(data: object) -> None | str | Unset:
+        def _parse_epsg(data: object) -> int | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(None | str | Unset, data)
+            return cast(int | None | Unset, data)
 
-        collection = _parse_collection(d.pop("collection", UNSET))
-
-        def _parse_datetime_end(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        datetime_end = _parse_datetime_end(d.pop("datetime_end", UNSET))
+        epsg = _parse_epsg(d.pop("epsg", UNSET))
 
         def _parse_datetime_start(data: object) -> None | str | Unset:
             if data is None:
@@ -161,26 +161,26 @@ class StacImportItem:
 
         datetime_start = _parse_datetime_start(d.pop("datetime_start", UNSET))
 
-        def _parse_epsg(data: object) -> int | None | Unset:
+        def _parse_datetime_end(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(int | None | Unset, data)
+            return cast(None | str | Unset, data)
 
-        epsg = _parse_epsg(d.pop("epsg", UNSET))
+        datetime_end = _parse_datetime_end(d.pop("datetime_end", UNSET))
 
         keywords = cast(list[str], d.pop("keywords", UNSET))
 
         stac_import_item = cls(
-            data_asset_href=data_asset_href,
             id=id,
             title=title,
-            bbox=bbox,
+            data_asset_href=data_asset_href,
             collection=collection,
-            datetime_end=datetime_end,
-            datetime_start=datetime_start,
+            bbox=bbox,
             epsg=epsg,
+            datetime_start=datetime_start,
+            datetime_end=datetime_end,
             keywords=keywords,
         )
 

--- a/sdks/python/geolens/models/stac_import_request.py
+++ b/sdks/python/geolens/models/stac_import_request.py
@@ -22,23 +22,23 @@ T = TypeVar("T", bound="StacImportRequest")
 class StacImportRequest:
     """
     Attributes:
-        items (list[StacImportItem]): Items to import (max 50 per request).
         url (str): STAC API URL for provenance.
+        items (list[StacImportItem]): Items to import (max 50 per request).
         visibility (StacImportRequestVisibility | Unset): Visibility for imported datasets. Default: 'private'.
     """
 
-    items: list[StacImportItem]
     url: str
+    items: list[StacImportItem]
     visibility: StacImportRequestVisibility | Unset = "private"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        url = self.url
+
         items = []
         for items_item_data in self.items:
             items_item = items_item_data.to_dict()
             items.append(items_item)
-
-        url = self.url
 
         visibility: str | Unset = UNSET
         if not isinstance(self.visibility, Unset):
@@ -48,8 +48,8 @@ class StacImportRequest:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "items": items,
                 "url": url,
+                "items": items,
             }
         )
         if visibility is not UNSET:
@@ -62,14 +62,14 @@ class StacImportRequest:
         from ..models.stac_import_item import StacImportItem
 
         d = dict(src_dict)
+        url = d.pop("url")
+
         items = []
         _items = d.pop("items")
         for items_item_data in _items:
             items_item = StacImportItem.from_dict(items_item_data)
 
             items.append(items_item)
-
-        url = d.pop("url")
 
         _visibility = d.pop("visibility", UNSET)
         visibility: StacImportRequestVisibility | Unset
@@ -79,8 +79,8 @@ class StacImportRequest:
             visibility = check_stac_import_request_visibility(_visibility)
 
         stac_import_request = cls(
-            items=items,
             url=url,
+            items=items,
             visibility=visibility,
         )
 

--- a/sdks/python/geolens/models/stac_import_response.py
+++ b/sdks/python/geolens/models/stac_import_response.py
@@ -18,38 +18,38 @@ T = TypeVar("T", bound="StacImportResponse")
 class StacImportResponse:
     """
     Attributes:
-        created (int): Number of datasets created.
-        errors (int): Number of items that failed.
         results (list[StacImportResult]): Per-item import results.
+        created (int): Number of datasets created.
         skipped (int): Number of items skipped (duplicates).
+        errors (int): Number of items that failed.
     """
 
-    created: int
-    errors: int
     results: list[StacImportResult]
+    created: int
     skipped: int
+    errors: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        created = self.created
-
-        errors = self.errors
-
         results = []
         for results_item_data in self.results:
             results_item = results_item_data.to_dict()
             results.append(results_item)
 
+        created = self.created
+
         skipped = self.skipped
+
+        errors = self.errors
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created": created,
-                "errors": errors,
                 "results": results,
+                "created": created,
                 "skipped": skipped,
+                "errors": errors,
             }
         )
 
@@ -60,10 +60,6 @@ class StacImportResponse:
         from ..models.stac_import_result import StacImportResult
 
         d = dict(src_dict)
-        created = d.pop("created")
-
-        errors = d.pop("errors")
-
         results = []
         _results = d.pop("results")
         for results_item_data in _results:
@@ -71,13 +67,17 @@ class StacImportResponse:
 
             results.append(results_item)
 
+        created = d.pop("created")
+
         skipped = d.pop("skipped")
 
+        errors = d.pop("errors")
+
         stac_import_response = cls(
-            created=created,
-            errors=errors,
             results=results,
+            created=created,
             skipped=skipped,
+            errors=errors,
         )
 
         stac_import_response.additional_properties = d

--- a/sdks/python/geolens/models/stac_item_asset.py
+++ b/sdks/python/geolens/models/stac_item_asset.py
@@ -20,21 +20,33 @@ class StacItemAsset:
 
     Attributes:
         href (str): URL of the asset resource.
+        type_ (None | str | Unset): Asset media type.
+        title (None | str | Unset): Human-readable asset title.
         description (None | str | Unset): Human-readable asset description.
         roles (list[str] | None | Unset): Semantic roles such as data or visual.
-        title (None | str | Unset): Human-readable asset title.
-        type_ (None | str | Unset): Asset media type.
     """
 
     href: str
+    type_: None | str | Unset = UNSET
+    title: None | str | Unset = UNSET
     description: None | str | Unset = UNSET
     roles: list[str] | None | Unset = UNSET
-    title: None | str | Unset = UNSET
-    type_: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         href = self.href
+
+        type_: None | str | Unset
+        if isinstance(self.type_, Unset):
+            type_ = UNSET
+        else:
+            type_ = self.type_
+
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
+        else:
+            title = self.title
 
         description: None | str | Unset
         if isinstance(self.description, Unset):
@@ -51,18 +63,6 @@ class StacItemAsset:
         else:
             roles = self.roles
 
-        title: None | str | Unset
-        if isinstance(self.title, Unset):
-            title = UNSET
-        else:
-            title = self.title
-
-        type_: None | str | Unset
-        if isinstance(self.type_, Unset):
-            type_ = UNSET
-        else:
-            type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -70,14 +70,14 @@ class StacItemAsset:
                 "href": href,
             }
         )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if title is not UNSET:
+            field_dict["title"] = title
         if description is not UNSET:
             field_dict["description"] = description
         if roles is not UNSET:
             field_dict["roles"] = roles
-        if title is not UNSET:
-            field_dict["title"] = title
-        if type_ is not UNSET:
-            field_dict["type"] = type_
 
         return field_dict
 
@@ -85,6 +85,24 @@ class StacItemAsset:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         href = d.pop("href")
+
+        def _parse_type_(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        type_ = _parse_type_(d.pop("type", UNSET))
+
+        def _parse_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        title = _parse_title(d.pop("title", UNSET))
 
         def _parse_description(data: object) -> None | str | Unset:
             if data is None:
@@ -112,30 +130,12 @@ class StacItemAsset:
 
         roles = _parse_roles(d.pop("roles", UNSET))
 
-        def _parse_title(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        title = _parse_title(d.pop("title", UNSET))
-
-        def _parse_type_(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        type_ = _parse_type_(d.pop("type", UNSET))
-
         stac_item_asset = cls(
             href=href,
+            type_=type_,
+            title=title,
             description=description,
             roles=roles,
-            title=title,
-            type_=type_,
         )
 
         stac_item_asset.additional_properties = d

--- a/sdks/python/geolens/models/stac_item_collection_response.py
+++ b/sdks/python/geolens/models/stac_item_collection_response.py
@@ -25,25 +25,23 @@ class StacItemCollectionResponse:
     """Typed OpenAPI representation of a STAC ItemCollection.
 
     Attributes:
-        context (StacContext): Paging metadata emitted with STAC ItemCollections.
         features (list[StacItemResponse]):
         links (list[StacLink]):
         number_matched (int):
         number_returned (int):
+        context (StacContext): Paging metadata emitted with STAC ItemCollections.
         type_ (Literal['FeatureCollection'] | Unset):  Default: 'FeatureCollection'.
     """
 
-    context: StacContext
     features: list[StacItemResponse]
     links: list[StacLink]
     number_matched: int
     number_returned: int
+    context: StacContext
     type_: Literal["FeatureCollection"] | Unset = "FeatureCollection"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        context = self.context.to_dict()
-
         features = []
         for features_item_data in self.features:
             features_item = features_item_data.to_dict()
@@ -58,17 +56,19 @@ class StacItemCollectionResponse:
 
         number_returned = self.number_returned
 
+        context = self.context.to_dict()
+
         type_ = self.type_
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "context": context,
                 "features": features,
                 "links": links,
                 "numberMatched": number_matched,
                 "numberReturned": number_returned,
+                "context": context,
             }
         )
         if type_ is not UNSET:
@@ -83,8 +83,6 @@ class StacItemCollectionResponse:
         from ..models.stac_link import StacLink
 
         d = dict(src_dict)
-        context = StacContext.from_dict(d.pop("context"))
-
         features = []
         _features = d.pop("features")
         for features_item_data in _features:
@@ -103,6 +101,8 @@ class StacItemCollectionResponse:
 
         number_returned = d.pop("numberReturned")
 
+        context = StacContext.from_dict(d.pop("context"))
+
         type_ = cast(Literal["FeatureCollection"] | Unset, d.pop("type", UNSET))
         if type_ != "FeatureCollection" and not isinstance(type_, Unset):
             raise ValueError(
@@ -110,11 +110,11 @@ class StacItemCollectionResponse:
             )
 
         stac_item_collection_response = cls(
-            context=context,
             features=features,
             links=links,
             number_matched=number_matched,
             number_returned=number_returned,
+            context=context,
             type_=type_,
         )
 

--- a/sdks/python/geolens/models/stac_item_properties.py
+++ b/sdks/python/geolens/models/stac_item_properties.py
@@ -20,34 +20,22 @@ class StacItemProperties:
 
     Attributes:
         datetime_ (None | str): Item timestamp, or null when a temporal interval is supplied.
-        description (None | str | Unset): Human-readable item description.
-        end_datetime (None | str | Unset): End of the item's temporal interval.
         start_datetime (None | str | Unset): Start of the item's temporal interval.
+        end_datetime (None | str | Unset): End of the item's temporal interval.
         title (None | str | Unset): Human-readable item title.
+        description (None | str | Unset): Human-readable item description.
     """
 
     datetime_: None | str
-    description: None | str | Unset = UNSET
-    end_datetime: None | str | Unset = UNSET
     start_datetime: None | str | Unset = UNSET
+    end_datetime: None | str | Unset = UNSET
     title: None | str | Unset = UNSET
+    description: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         datetime_: None | str
         datetime_ = self.datetime_
-
-        description: None | str | Unset
-        if isinstance(self.description, Unset):
-            description = UNSET
-        else:
-            description = self.description
-
-        end_datetime: None | str | Unset
-        if isinstance(self.end_datetime, Unset):
-            end_datetime = UNSET
-        else:
-            end_datetime = self.end_datetime
 
         start_datetime: None | str | Unset
         if isinstance(self.start_datetime, Unset):
@@ -55,11 +43,23 @@ class StacItemProperties:
         else:
             start_datetime = self.start_datetime
 
+        end_datetime: None | str | Unset
+        if isinstance(self.end_datetime, Unset):
+            end_datetime = UNSET
+        else:
+            end_datetime = self.end_datetime
+
         title: None | str | Unset
         if isinstance(self.title, Unset):
             title = UNSET
         else:
             title = self.title
+
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -68,14 +68,14 @@ class StacItemProperties:
                 "datetime": datetime_,
             }
         )
-        if description is not UNSET:
-            field_dict["description"] = description
-        if end_datetime is not UNSET:
-            field_dict["end_datetime"] = end_datetime
         if start_datetime is not UNSET:
             field_dict["start_datetime"] = start_datetime
+        if end_datetime is not UNSET:
+            field_dict["end_datetime"] = end_datetime
         if title is not UNSET:
             field_dict["title"] = title
+        if description is not UNSET:
+            field_dict["description"] = description
 
         return field_dict
 
@@ -90,14 +90,14 @@ class StacItemProperties:
 
         datetime_ = _parse_datetime_(d.pop("datetime"))
 
-        def _parse_description(data: object) -> None | str | Unset:
+        def _parse_start_datetime(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(None | str | Unset, data)
 
-        description = _parse_description(d.pop("description", UNSET))
+        start_datetime = _parse_start_datetime(d.pop("start_datetime", UNSET))
 
         def _parse_end_datetime(data: object) -> None | str | Unset:
             if data is None:
@@ -108,15 +108,6 @@ class StacItemProperties:
 
         end_datetime = _parse_end_datetime(d.pop("end_datetime", UNSET))
 
-        def _parse_start_datetime(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        start_datetime = _parse_start_datetime(d.pop("start_datetime", UNSET))
-
         def _parse_title(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -126,12 +117,21 @@ class StacItemProperties:
 
         title = _parse_title(d.pop("title", UNSET))
 
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
         stac_item_properties = cls(
             datetime_=datetime_,
-            description=description,
-            end_datetime=end_datetime,
             start_datetime=start_datetime,
+            end_datetime=end_datetime,
             title=title,
+            description=description,
         )
 
         stac_item_properties.additional_properties = d

--- a/sdks/python/geolens/models/stac_item_response.py
+++ b/sdks/python/geolens/models/stac_item_response.py
@@ -27,36 +27,38 @@ class StacItemResponse:
     """A GeoJSON Feature conforming to the STAC Item specification.
 
     Attributes:
-        assets (StacItemResponseAssets):
+        stac_version (str): STAC specification version.
+        id (str): Stable item identifier.
         geometry (GeoJSONGeometry | GeoJSONGeometryCollection | None): Item footprint as GeoJSON, or null when
             unavailable.
-        id (str): Stable item identifier.
-        links (list[StacLink]):
         properties (StacItemProperties): Core STAC Item properties plus extension-defined fields.
-        stac_version (str): STAC specification version.
+        links (list[StacLink]):
+        assets (StacItemResponseAssets):
+        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
+        stac_extensions (list[str] | Unset): STAC extension schema URIs in use.
         bbox (list[float] | None | Unset): Item bounding box with exactly four 2D or six 3D coordinates.
         collection (None | str | Unset): Identifier of the containing STAC Collection.
-        stac_extensions (list[str] | Unset): STAC extension schema URIs in use.
-        type_ (Literal['Feature'] | Unset):  Default: 'Feature'.
     """
 
-    assets: StacItemResponseAssets
-    geometry: GeoJSONGeometry | GeoJSONGeometryCollection | None
-    id: str
-    links: list[StacLink]
-    properties: StacItemProperties
     stac_version: str
+    id: str
+    geometry: GeoJSONGeometry | GeoJSONGeometryCollection | None
+    properties: StacItemProperties
+    links: list[StacLink]
+    assets: StacItemResponseAssets
+    type_: Literal["Feature"] | Unset = "Feature"
+    stac_extensions: list[str] | Unset = UNSET
     bbox: list[float] | None | Unset = UNSET
     collection: None | str | Unset = UNSET
-    stac_extensions: list[str] | Unset = UNSET
-    type_: Literal["Feature"] | Unset = "Feature"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.geo_json_geometry import GeoJSONGeometry
         from ..models.geo_json_geometry_collection import GeoJSONGeometryCollection
 
-        assets = self.assets.to_dict()
+        stac_version = self.stac_version
+
+        id = self.id
 
         geometry: dict[str, Any] | None
         if isinstance(self.geometry, GeoJSONGeometryCollection):
@@ -66,16 +68,20 @@ class StacItemResponse:
         else:
             geometry = self.geometry
 
-        id = self.id
+        properties = self.properties.to_dict()
 
         links = []
         for links_item_data in self.links:
             links_item = links_item_data.to_dict()
             links.append(links_item)
 
-        properties = self.properties.to_dict()
+        assets = self.assets.to_dict()
 
-        stac_version = self.stac_version
+        type_ = self.type_
+
+        stac_extensions: list[str] | Unset = UNSET
+        if not isinstance(self.stac_extensions, Unset):
+            stac_extensions = self.stac_extensions
 
         bbox: list[float] | None | Unset
         if isinstance(self.bbox, Unset):
@@ -96,32 +102,26 @@ class StacItemResponse:
         else:
             collection = self.collection
 
-        stac_extensions: list[str] | Unset = UNSET
-        if not isinstance(self.stac_extensions, Unset):
-            stac_extensions = self.stac_extensions
-
-        type_ = self.type_
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "assets": assets,
-                "geometry": geometry,
-                "id": id,
-                "links": links,
-                "properties": properties,
                 "stac_version": stac_version,
+                "id": id,
+                "geometry": geometry,
+                "properties": properties,
+                "links": links,
+                "assets": assets,
             }
         )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if stac_extensions is not UNSET:
+            field_dict["stac_extensions"] = stac_extensions
         if bbox is not UNSET:
             field_dict["bbox"] = bbox
         if collection is not UNSET:
             field_dict["collection"] = collection
-        if stac_extensions is not UNSET:
-            field_dict["stac_extensions"] = stac_extensions
-        if type_ is not UNSET:
-            field_dict["type"] = type_
 
         return field_dict
 
@@ -134,7 +134,9 @@ class StacItemResponse:
         from ..models.stac_link import StacLink
 
         d = dict(src_dict)
-        assets = StacItemResponseAssets.from_dict(d.pop("assets"))
+        stac_version = d.pop("stac_version")
+
+        id = d.pop("id")
 
         def _parse_geometry(
             data: object,
@@ -161,7 +163,7 @@ class StacItemResponse:
 
         geometry = _parse_geometry(d.pop("geometry"))
 
-        id = d.pop("id")
+        properties = StacItemProperties.from_dict(d.pop("properties"))
 
         links = []
         _links = d.pop("links")
@@ -170,9 +172,13 @@ class StacItemResponse:
 
             links.append(links_item)
 
-        properties = StacItemProperties.from_dict(d.pop("properties"))
+        assets = StacItemResponseAssets.from_dict(d.pop("assets"))
 
-        stac_version = d.pop("stac_version")
+        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
+        if type_ != "Feature" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'Feature', got '{type_}'")
+
+        stac_extensions = cast(list[str], d.pop("stac_extensions", UNSET))
 
         def _parse_bbox(data: object) -> list[float] | None | Unset:
             if data is None:
@@ -209,23 +215,17 @@ class StacItemResponse:
 
         collection = _parse_collection(d.pop("collection", UNSET))
 
-        stac_extensions = cast(list[str], d.pop("stac_extensions", UNSET))
-
-        type_ = cast(Literal["Feature"] | Unset, d.pop("type", UNSET))
-        if type_ != "Feature" and not isinstance(type_, Unset):
-            raise ValueError(f"type must match const 'Feature', got '{type_}'")
-
         stac_item_response = cls(
-            assets=assets,
-            geometry=geometry,
-            id=id,
-            links=links,
-            properties=properties,
             stac_version=stac_version,
+            id=id,
+            geometry=geometry,
+            properties=properties,
+            links=links,
+            assets=assets,
+            type_=type_,
+            stac_extensions=stac_extensions,
             bbox=bbox,
             collection=collection,
-            stac_extensions=stac_extensions,
-            type_=type_,
         )
 
         stac_item_response.additional_properties = d

--- a/sdks/python/geolens/models/stac_item_summary.py
+++ b/sdks/python/geolens/models/stac_item_summary.py
@@ -18,47 +18,53 @@ T = TypeVar("T", bound="StacItemSummary")
 class StacItemSummary:
     """
     Attributes:
-        asset_count (int): Number of assets on this item.
         id (str): Item identifier.
         title (str): Item title (falls back to ID).
-        bbox (list[float] | None | Unset): Item bounding box.
-        cloud_cover (float | None | Unset): Cloud cover percentage (eo extension).
+        asset_count (int): Number of assets on this item.
         collection (None | str | Unset): Parent collection ID.
-        data_asset_href (None | str | Unset): URL of the primary data asset (COG).
-        data_asset_size_bytes (int | None | Unset): Size of the primary data asset in bytes (from STAC file:size). None
-            when not in manifest.
-        data_asset_type (None | str | Unset): Media type of the data asset.
+        bbox (list[float] | None | Unset): Item bounding box.
         datetime_ (None | str | Unset): Primary datetime (ISO 8601).
-        datetime_end (None | str | Unset): End datetime for ranges.
         datetime_start (None | str | Unset): Start datetime for ranges.
+        datetime_end (None | str | Unset): End datetime for ranges.
         epsg (int | None | Unset): EPSG code from proj extension.
         gsd (float | None | Unset): Ground sample distance in meters.
+        cloud_cover (float | None | Unset): Cloud cover percentage (eo extension).
+        data_asset_href (None | str | Unset): URL of the primary data asset (COG).
+        data_asset_type (None | str | Unset): Media type of the data asset.
+        data_asset_size_bytes (int | None | Unset): Size of the primary data asset in bytes (from STAC file:size). None
+            when not in manifest.
         thumbnail_href (None | str | Unset): Thumbnail URL if available.
     """
 
-    asset_count: int
     id: str
     title: str
-    bbox: list[float] | None | Unset = UNSET
-    cloud_cover: float | None | Unset = UNSET
+    asset_count: int
     collection: None | str | Unset = UNSET
-    data_asset_href: None | str | Unset = UNSET
-    data_asset_size_bytes: int | None | Unset = UNSET
-    data_asset_type: None | str | Unset = UNSET
+    bbox: list[float] | None | Unset = UNSET
     datetime_: None | str | Unset = UNSET
-    datetime_end: None | str | Unset = UNSET
     datetime_start: None | str | Unset = UNSET
+    datetime_end: None | str | Unset = UNSET
     epsg: int | None | Unset = UNSET
     gsd: float | None | Unset = UNSET
+    cloud_cover: float | None | Unset = UNSET
+    data_asset_href: None | str | Unset = UNSET
+    data_asset_type: None | str | Unset = UNSET
+    data_asset_size_bytes: int | None | Unset = UNSET
     thumbnail_href: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        asset_count = self.asset_count
-
         id = self.id
 
         title = self.title
+
+        asset_count = self.asset_count
+
+        collection: None | str | Unset
+        if isinstance(self.collection, Unset):
+            collection = UNSET
+        else:
+            collection = self.collection
 
         bbox: list[float] | None | Unset
         if isinstance(self.bbox, Unset):
@@ -69,53 +75,23 @@ class StacItemSummary:
         else:
             bbox = self.bbox
 
-        cloud_cover: float | None | Unset
-        if isinstance(self.cloud_cover, Unset):
-            cloud_cover = UNSET
-        else:
-            cloud_cover = self.cloud_cover
-
-        collection: None | str | Unset
-        if isinstance(self.collection, Unset):
-            collection = UNSET
-        else:
-            collection = self.collection
-
-        data_asset_href: None | str | Unset
-        if isinstance(self.data_asset_href, Unset):
-            data_asset_href = UNSET
-        else:
-            data_asset_href = self.data_asset_href
-
-        data_asset_size_bytes: int | None | Unset
-        if isinstance(self.data_asset_size_bytes, Unset):
-            data_asset_size_bytes = UNSET
-        else:
-            data_asset_size_bytes = self.data_asset_size_bytes
-
-        data_asset_type: None | str | Unset
-        if isinstance(self.data_asset_type, Unset):
-            data_asset_type = UNSET
-        else:
-            data_asset_type = self.data_asset_type
-
         datetime_: None | str | Unset
         if isinstance(self.datetime_, Unset):
             datetime_ = UNSET
         else:
             datetime_ = self.datetime_
 
-        datetime_end: None | str | Unset
-        if isinstance(self.datetime_end, Unset):
-            datetime_end = UNSET
-        else:
-            datetime_end = self.datetime_end
-
         datetime_start: None | str | Unset
         if isinstance(self.datetime_start, Unset):
             datetime_start = UNSET
         else:
             datetime_start = self.datetime_start
+
+        datetime_end: None | str | Unset
+        if isinstance(self.datetime_end, Unset):
+            datetime_end = UNSET
+        else:
+            datetime_end = self.datetime_end
 
         epsg: int | None | Unset
         if isinstance(self.epsg, Unset):
@@ -129,6 +105,30 @@ class StacItemSummary:
         else:
             gsd = self.gsd
 
+        cloud_cover: float | None | Unset
+        if isinstance(self.cloud_cover, Unset):
+            cloud_cover = UNSET
+        else:
+            cloud_cover = self.cloud_cover
+
+        data_asset_href: None | str | Unset
+        if isinstance(self.data_asset_href, Unset):
+            data_asset_href = UNSET
+        else:
+            data_asset_href = self.data_asset_href
+
+        data_asset_type: None | str | Unset
+        if isinstance(self.data_asset_type, Unset):
+            data_asset_type = UNSET
+        else:
+            data_asset_type = self.data_asset_type
+
+        data_asset_size_bytes: int | None | Unset
+        if isinstance(self.data_asset_size_bytes, Unset):
+            data_asset_size_bytes = UNSET
+        else:
+            data_asset_size_bytes = self.data_asset_size_bytes
+
         thumbnail_href: None | str | Unset
         if isinstance(self.thumbnail_href, Unset):
             thumbnail_href = UNSET
@@ -139,33 +139,33 @@ class StacItemSummary:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "asset_count": asset_count,
                 "id": id,
                 "title": title,
+                "asset_count": asset_count,
             }
         )
-        if bbox is not UNSET:
-            field_dict["bbox"] = bbox
-        if cloud_cover is not UNSET:
-            field_dict["cloud_cover"] = cloud_cover
         if collection is not UNSET:
             field_dict["collection"] = collection
-        if data_asset_href is not UNSET:
-            field_dict["data_asset_href"] = data_asset_href
-        if data_asset_size_bytes is not UNSET:
-            field_dict["data_asset_size_bytes"] = data_asset_size_bytes
-        if data_asset_type is not UNSET:
-            field_dict["data_asset_type"] = data_asset_type
+        if bbox is not UNSET:
+            field_dict["bbox"] = bbox
         if datetime_ is not UNSET:
             field_dict["datetime"] = datetime_
-        if datetime_end is not UNSET:
-            field_dict["datetime_end"] = datetime_end
         if datetime_start is not UNSET:
             field_dict["datetime_start"] = datetime_start
+        if datetime_end is not UNSET:
+            field_dict["datetime_end"] = datetime_end
         if epsg is not UNSET:
             field_dict["epsg"] = epsg
         if gsd is not UNSET:
             field_dict["gsd"] = gsd
+        if cloud_cover is not UNSET:
+            field_dict["cloud_cover"] = cloud_cover
+        if data_asset_href is not UNSET:
+            field_dict["data_asset_href"] = data_asset_href
+        if data_asset_type is not UNSET:
+            field_dict["data_asset_type"] = data_asset_type
+        if data_asset_size_bytes is not UNSET:
+            field_dict["data_asset_size_bytes"] = data_asset_size_bytes
         if thumbnail_href is not UNSET:
             field_dict["thumbnail_href"] = thumbnail_href
 
@@ -174,11 +174,20 @@ class StacItemSummary:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        asset_count = d.pop("asset_count")
-
         id = d.pop("id")
 
         title = d.pop("title")
+
+        asset_count = d.pop("asset_count")
+
+        def _parse_collection(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        collection = _parse_collection(d.pop("collection", UNSET))
 
         def _parse_bbox(data: object) -> list[float] | None | Unset:
             if data is None:
@@ -197,53 +206,6 @@ class StacItemSummary:
 
         bbox = _parse_bbox(d.pop("bbox", UNSET))
 
-        def _parse_cloud_cover(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        cloud_cover = _parse_cloud_cover(d.pop("cloud_cover", UNSET))
-
-        def _parse_collection(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        collection = _parse_collection(d.pop("collection", UNSET))
-
-        def _parse_data_asset_href(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        data_asset_href = _parse_data_asset_href(d.pop("data_asset_href", UNSET))
-
-        def _parse_data_asset_size_bytes(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        data_asset_size_bytes = _parse_data_asset_size_bytes(
-            d.pop("data_asset_size_bytes", UNSET)
-        )
-
-        def _parse_data_asset_type(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        data_asset_type = _parse_data_asset_type(d.pop("data_asset_type", UNSET))
-
         def _parse_datetime_(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -253,15 +215,6 @@ class StacItemSummary:
 
         datetime_ = _parse_datetime_(d.pop("datetime", UNSET))
 
-        def _parse_datetime_end(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        datetime_end = _parse_datetime_end(d.pop("datetime_end", UNSET))
-
         def _parse_datetime_start(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -270,6 +223,15 @@ class StacItemSummary:
             return cast(None | str | Unset, data)
 
         datetime_start = _parse_datetime_start(d.pop("datetime_start", UNSET))
+
+        def _parse_datetime_end(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        datetime_end = _parse_datetime_end(d.pop("datetime_end", UNSET))
 
         def _parse_epsg(data: object) -> int | None | Unset:
             if data is None:
@@ -289,6 +251,44 @@ class StacItemSummary:
 
         gsd = _parse_gsd(d.pop("gsd", UNSET))
 
+        def _parse_cloud_cover(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        cloud_cover = _parse_cloud_cover(d.pop("cloud_cover", UNSET))
+
+        def _parse_data_asset_href(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        data_asset_href = _parse_data_asset_href(d.pop("data_asset_href", UNSET))
+
+        def _parse_data_asset_type(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        data_asset_type = _parse_data_asset_type(d.pop("data_asset_type", UNSET))
+
+        def _parse_data_asset_size_bytes(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        data_asset_size_bytes = _parse_data_asset_size_bytes(
+            d.pop("data_asset_size_bytes", UNSET)
+        )
+
         def _parse_thumbnail_href(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -299,20 +299,20 @@ class StacItemSummary:
         thumbnail_href = _parse_thumbnail_href(d.pop("thumbnail_href", UNSET))
 
         stac_item_summary = cls(
-            asset_count=asset_count,
             id=id,
             title=title,
-            bbox=bbox,
-            cloud_cover=cloud_cover,
+            asset_count=asset_count,
             collection=collection,
-            data_asset_href=data_asset_href,
-            data_asset_size_bytes=data_asset_size_bytes,
-            data_asset_type=data_asset_type,
+            bbox=bbox,
             datetime_=datetime_,
-            datetime_end=datetime_end,
             datetime_start=datetime_start,
+            datetime_end=datetime_end,
             epsg=epsg,
             gsd=gsd,
+            cloud_cover=cloud_cover,
+            data_asset_href=data_asset_href,
+            data_asset_type=data_asset_type,
+            data_asset_size_bytes=data_asset_size_bytes,
             thumbnail_href=thumbnail_href,
         )
 

--- a/sdks/python/geolens/models/stac_link.py
+++ b/sdks/python/geolens/models/stac_link.py
@@ -21,14 +21,14 @@ class StacLink:
     Attributes:
         href (str): Target URL of the link.
         rel (str): Link relation type (e.g. 'self', 'root', 'parent', 'item', 'data').
-        method (None | str | Unset): HTTP method to use (defaults to GET).
         type_ (None | str | Unset): Media type of the linked resource (e.g. 'application/json').
+        method (None | str | Unset): HTTP method to use (defaults to GET).
     """
 
     href: str
     rel: str
-    method: None | str | Unset = UNSET
     type_: None | str | Unset = UNSET
+    method: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -36,17 +36,17 @@ class StacLink:
 
         rel = self.rel
 
-        method: None | str | Unset
-        if isinstance(self.method, Unset):
-            method = UNSET
-        else:
-            method = self.method
-
         type_: None | str | Unset
         if isinstance(self.type_, Unset):
             type_ = UNSET
         else:
             type_ = self.type_
+
+        method: None | str | Unset
+        if isinstance(self.method, Unset):
+            method = UNSET
+        else:
+            method = self.method
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -56,10 +56,10 @@ class StacLink:
                 "rel": rel,
             }
         )
-        if method is not UNSET:
-            field_dict["method"] = method
         if type_ is not UNSET:
             field_dict["type"] = type_
+        if method is not UNSET:
+            field_dict["method"] = method
 
         return field_dict
 
@@ -70,15 +70,6 @@ class StacLink:
 
         rel = d.pop("rel")
 
-        def _parse_method(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        method = _parse_method(d.pop("method", UNSET))
-
         def _parse_type_(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -88,11 +79,20 @@ class StacLink:
 
         type_ = _parse_type_(d.pop("type", UNSET))
 
+        def _parse_method(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        method = _parse_method(d.pop("method", UNSET))
+
         stac_link = cls(
             href=href,
             rel=rel,
-            method=method,
             type_=type_,
+            method=method,
         )
 
         stac_link.additional_properties = d

--- a/sdks/python/geolens/models/stac_search_body.py
+++ b/sdks/python/geolens/models/stac_search_body.py
@@ -25,8 +25,8 @@ class StacSearchBody:
 
     Attributes:
         bbox (list[float] | None | Unset):
-        collections (list[str] | None | Unset):
         datetime_ (None | str | Unset):
+        collections (list[str] | None | Unset):
         ids (list[str] | None | Unset):
         intersects (None | StacSearchBodyIntersectsType0 | Unset):
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to 200. Default: 10.
@@ -34,8 +34,8 @@ class StacSearchBody:
     """
 
     bbox: list[float] | None | Unset = UNSET
-    collections: list[str] | None | Unset = UNSET
     datetime_: None | str | Unset = UNSET
+    collections: list[str] | None | Unset = UNSET
     ids: list[str] | None | Unset = UNSET
     intersects: None | StacSearchBodyIntersectsType0 | Unset = UNSET
     limit: int | Unset = 10
@@ -56,6 +56,12 @@ class StacSearchBody:
         else:
             bbox = self.bbox
 
+        datetime_: None | str | Unset
+        if isinstance(self.datetime_, Unset):
+            datetime_ = UNSET
+        else:
+            datetime_ = self.datetime_
+
         collections: list[str] | None | Unset
         if isinstance(self.collections, Unset):
             collections = UNSET
@@ -64,12 +70,6 @@ class StacSearchBody:
 
         else:
             collections = self.collections
-
-        datetime_: None | str | Unset
-        if isinstance(self.datetime_, Unset):
-            datetime_ = UNSET
-        else:
-            datetime_ = self.datetime_
 
         ids: list[str] | None | Unset
         if isinstance(self.ids, Unset):
@@ -97,10 +97,10 @@ class StacSearchBody:
         field_dict.update({})
         if bbox is not UNSET:
             field_dict["bbox"] = bbox
-        if collections is not UNSET:
-            field_dict["collections"] = collections
         if datetime_ is not UNSET:
             field_dict["datetime"] = datetime_
+        if collections is not UNSET:
+            field_dict["collections"] = collections
         if ids is not UNSET:
             field_dict["ids"] = ids
         if intersects is not UNSET:
@@ -137,6 +137,15 @@ class StacSearchBody:
 
         bbox = _parse_bbox(d.pop("bbox", UNSET))
 
+        def _parse_datetime_(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        datetime_ = _parse_datetime_(d.pop("datetime", UNSET))
+
         def _parse_collections(data: object) -> list[str] | None | Unset:
             if data is None:
                 return data
@@ -153,15 +162,6 @@ class StacSearchBody:
             return cast(list[str] | None | Unset, data)
 
         collections = _parse_collections(d.pop("collections", UNSET))
-
-        def _parse_datetime_(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        datetime_ = _parse_datetime_(d.pop("datetime", UNSET))
 
         def _parse_ids(data: object) -> list[str] | None | Unset:
             if data is None:
@@ -205,8 +205,8 @@ class StacSearchBody:
 
         stac_search_body = cls(
             bbox=bbox,
-            collections=collections,
             datetime_=datetime_,
+            collections=collections,
             ids=ids,
             intersects=intersects,
             limit=limit,

--- a/sdks/python/geolens/models/stac_search_request.py
+++ b/sdks/python/geolens/models/stac_search_request.py
@@ -19,30 +19,21 @@ class StacSearchRequest:
     """
     Attributes:
         url (str): STAC API root URL.
-        bbox (list[float] | None | Unset): Bounding box filter as [west, south, east, north].
         collections (list[str] | None | Unset): Filter by collection IDs.
+        bbox (list[float] | None | Unset): Bounding box filter as [west, south, east, north].
         datetime_range (None | str | Unset): Temporal filter in STAC datetime format (e.g. '2023-01-01/2023-12-31').
         limit (int | Unset): Maximum items to return. Default: 20.
     """
 
     url: str
-    bbox: list[float] | None | Unset = UNSET
     collections: list[str] | None | Unset = UNSET
+    bbox: list[float] | None | Unset = UNSET
     datetime_range: None | str | Unset = UNSET
     limit: int | Unset = 20
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         url = self.url
-
-        bbox: list[float] | None | Unset
-        if isinstance(self.bbox, Unset):
-            bbox = UNSET
-        elif isinstance(self.bbox, list):
-            bbox = self.bbox
-
-        else:
-            bbox = self.bbox
 
         collections: list[str] | None | Unset
         if isinstance(self.collections, Unset):
@@ -52,6 +43,15 @@ class StacSearchRequest:
 
         else:
             collections = self.collections
+
+        bbox: list[float] | None | Unset
+        if isinstance(self.bbox, Unset):
+            bbox = UNSET
+        elif isinstance(self.bbox, list):
+            bbox = self.bbox
+
+        else:
+            bbox = self.bbox
 
         datetime_range: None | str | Unset
         if isinstance(self.datetime_range, Unset):
@@ -68,10 +68,10 @@ class StacSearchRequest:
                 "url": url,
             }
         )
-        if bbox is not UNSET:
-            field_dict["bbox"] = bbox
         if collections is not UNSET:
             field_dict["collections"] = collections
+        if bbox is not UNSET:
+            field_dict["bbox"] = bbox
         if datetime_range is not UNSET:
             field_dict["datetime_range"] = datetime_range
         if limit is not UNSET:
@@ -83,23 +83,6 @@ class StacSearchRequest:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         url = d.pop("url")
-
-        def _parse_bbox(data: object) -> list[float] | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, list):
-                    raise TypeError()
-                bbox_type_0 = cast(list[float], data)
-
-                return bbox_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(list[float] | None | Unset, data)
-
-        bbox = _parse_bbox(d.pop("bbox", UNSET))
 
         def _parse_collections(data: object) -> list[str] | None | Unset:
             if data is None:
@@ -118,6 +101,23 @@ class StacSearchRequest:
 
         collections = _parse_collections(d.pop("collections", UNSET))
 
+        def _parse_bbox(data: object) -> list[float] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                bbox_type_0 = cast(list[float], data)
+
+                return bbox_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[float] | None | Unset, data)
+
+        bbox = _parse_bbox(d.pop("bbox", UNSET))
+
         def _parse_datetime_range(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -131,8 +131,8 @@ class StacSearchRequest:
 
         stac_search_request = cls(
             url=url,
-            bbox=bbox,
             collections=collections,
+            bbox=bbox,
             datetime_range=datetime_range,
             limit=limit,
         )

--- a/sdks/python/geolens/models/stale_cleanup_response.py
+++ b/sdks/python/geolens/models/stale_cleanup_response.py
@@ -14,52 +14,38 @@ T = TypeVar("T", bound="StaleCleanupResponse")
 class StaleCleanupResponse:
     """
     Attributes:
-        local_files_reaped (int):
         pending_failed (int):
         running_failed (int):
-        staged_cleanup_failures (int):
-        staged_paths_considered (int):
-        staged_paths_skipped (int):
-        storage_objects_reaped (int):
-        terminal_jobs_purged (int):
-        total_affected (int):
         total_cleaned (int):
         vrt_assets_recovered (int):
         vrt_generations_failed (int):
+        terminal_jobs_purged (int):
+        staged_paths_considered (int):
+        local_files_reaped (int):
+        storage_objects_reaped (int):
+        staged_paths_skipped (int):
+        staged_cleanup_failures (int):
+        total_affected (int):
     """
 
-    local_files_reaped: int
     pending_failed: int
     running_failed: int
-    staged_cleanup_failures: int
-    staged_paths_considered: int
-    staged_paths_skipped: int
-    storage_objects_reaped: int
-    terminal_jobs_purged: int
-    total_affected: int
     total_cleaned: int
     vrt_assets_recovered: int
     vrt_generations_failed: int
+    terminal_jobs_purged: int
+    staged_paths_considered: int
+    local_files_reaped: int
+    storage_objects_reaped: int
+    staged_paths_skipped: int
+    staged_cleanup_failures: int
+    total_affected: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        local_files_reaped = self.local_files_reaped
-
         pending_failed = self.pending_failed
 
         running_failed = self.running_failed
-
-        staged_cleanup_failures = self.staged_cleanup_failures
-
-        staged_paths_considered = self.staged_paths_considered
-
-        staged_paths_skipped = self.staged_paths_skipped
-
-        storage_objects_reaped = self.storage_objects_reaped
-
-        terminal_jobs_purged = self.terminal_jobs_purged
-
-        total_affected = self.total_affected
 
         total_cleaned = self.total_cleaned
 
@@ -67,22 +53,36 @@ class StaleCleanupResponse:
 
         vrt_generations_failed = self.vrt_generations_failed
 
+        terminal_jobs_purged = self.terminal_jobs_purged
+
+        staged_paths_considered = self.staged_paths_considered
+
+        local_files_reaped = self.local_files_reaped
+
+        storage_objects_reaped = self.storage_objects_reaped
+
+        staged_paths_skipped = self.staged_paths_skipped
+
+        staged_cleanup_failures = self.staged_cleanup_failures
+
+        total_affected = self.total_affected
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "local_files_reaped": local_files_reaped,
                 "pending_failed": pending_failed,
                 "running_failed": running_failed,
-                "staged_cleanup_failures": staged_cleanup_failures,
-                "staged_paths_considered": staged_paths_considered,
-                "staged_paths_skipped": staged_paths_skipped,
-                "storage_objects_reaped": storage_objects_reaped,
-                "terminal_jobs_purged": terminal_jobs_purged,
-                "total_affected": total_affected,
                 "total_cleaned": total_cleaned,
                 "vrt_assets_recovered": vrt_assets_recovered,
                 "vrt_generations_failed": vrt_generations_failed,
+                "terminal_jobs_purged": terminal_jobs_purged,
+                "staged_paths_considered": staged_paths_considered,
+                "local_files_reaped": local_files_reaped,
+                "storage_objects_reaped": storage_objects_reaped,
+                "staged_paths_skipped": staged_paths_skipped,
+                "staged_cleanup_failures": staged_cleanup_failures,
+                "total_affected": total_affected,
             }
         )
 
@@ -91,23 +91,9 @@ class StaleCleanupResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        local_files_reaped = d.pop("local_files_reaped")
-
         pending_failed = d.pop("pending_failed")
 
         running_failed = d.pop("running_failed")
-
-        staged_cleanup_failures = d.pop("staged_cleanup_failures")
-
-        staged_paths_considered = d.pop("staged_paths_considered")
-
-        staged_paths_skipped = d.pop("staged_paths_skipped")
-
-        storage_objects_reaped = d.pop("storage_objects_reaped")
-
-        terminal_jobs_purged = d.pop("terminal_jobs_purged")
-
-        total_affected = d.pop("total_affected")
 
         total_cleaned = d.pop("total_cleaned")
 
@@ -115,19 +101,33 @@ class StaleCleanupResponse:
 
         vrt_generations_failed = d.pop("vrt_generations_failed")
 
+        terminal_jobs_purged = d.pop("terminal_jobs_purged")
+
+        staged_paths_considered = d.pop("staged_paths_considered")
+
+        local_files_reaped = d.pop("local_files_reaped")
+
+        storage_objects_reaped = d.pop("storage_objects_reaped")
+
+        staged_paths_skipped = d.pop("staged_paths_skipped")
+
+        staged_cleanup_failures = d.pop("staged_cleanup_failures")
+
+        total_affected = d.pop("total_affected")
+
         stale_cleanup_response = cls(
-            local_files_reaped=local_files_reaped,
             pending_failed=pending_failed,
             running_failed=running_failed,
-            staged_cleanup_failures=staged_cleanup_failures,
-            staged_paths_considered=staged_paths_considered,
-            staged_paths_skipped=staged_paths_skipped,
-            storage_objects_reaped=storage_objects_reaped,
-            terminal_jobs_purged=terminal_jobs_purged,
-            total_affected=total_affected,
             total_cleaned=total_cleaned,
             vrt_assets_recovered=vrt_assets_recovered,
             vrt_generations_failed=vrt_generations_failed,
+            terminal_jobs_purged=terminal_jobs_purged,
+            staged_paths_considered=staged_paths_considered,
+            local_files_reaped=local_files_reaped,
+            storage_objects_reaped=storage_objects_reaped,
+            staged_paths_skipped=staged_paths_skipped,
+            staged_cleanup_failures=staged_cleanup_failures,
+            total_affected=total_affected,
         )
 
         stale_cleanup_response.additional_properties = d

--- a/sdks/python/geolens/models/sublayer_override.py
+++ b/sdks/python/geolens/models/sublayer_override.py
@@ -31,60 +31,30 @@ class SublayerOverride:
         validation time (T-1059A-03).
 
         Attributes:
+            stroke_color (None | str | Unset): Stroke color in #RRGGBB hex format, or null to use the basemap default.
+            stroke_width (float | None | Unset): Stroke width in pixels (0-20), or null to use the basemap default.
             casing_color (None | str | Unset): Casing color in #RRGGBB hex format, or null to use the basemap default.
             casing_width (float | None | Unset): Casing width in pixels (0-20), or null to use the basemap default.
-            max_zoom (float | None | Unset): Maximum zoom level at which the sublayer is visible (0-24), or null for
-                default.
             min_zoom (float | None | Unset): Minimum zoom level at which the sublayer is visible (0-24), or null for
+                default.
+            max_zoom (float | None | Unset): Maximum zoom level at which the sublayer is visible (0-24), or null for
                 default.
             opacity (float | None | Unset): Per-sublayer opacity (0-1), or null to use the basemap default. Composes on top
                 of BasemapConfig.opacity (the whole-basemap master opacity): the rendered opacity is override.opacity *
                 master_opacity (builder-audit #338 CORR-01). The UI opacity slider in BasemapSublayerEditorScene persists
                 through this field: MapBuilderPage.handleSublayerOpacityChange -> setBasemapSublayerOpacity ->
                 updateBasemapSublayerOverride writes config.sublayer_overrides[key].opacity.
-            stroke_color (None | str | Unset): Stroke color in #RRGGBB hex format, or null to use the basemap default.
-            stroke_width (float | None | Unset): Stroke width in pixels (0-20), or null to use the basemap default.
     """
 
-    casing_color: None | str | Unset = UNSET
-    casing_width: float | None | Unset = UNSET
-    max_zoom: float | None | Unset = UNSET
-    min_zoom: float | None | Unset = UNSET
-    opacity: float | None | Unset = UNSET
     stroke_color: None | str | Unset = UNSET
     stroke_width: float | None | Unset = UNSET
+    casing_color: None | str | Unset = UNSET
+    casing_width: float | None | Unset = UNSET
+    min_zoom: float | None | Unset = UNSET
+    max_zoom: float | None | Unset = UNSET
+    opacity: float | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
-        casing_color: None | str | Unset
-        if isinstance(self.casing_color, Unset):
-            casing_color = UNSET
-        else:
-            casing_color = self.casing_color
-
-        casing_width: float | None | Unset
-        if isinstance(self.casing_width, Unset):
-            casing_width = UNSET
-        else:
-            casing_width = self.casing_width
-
-        max_zoom: float | None | Unset
-        if isinstance(self.max_zoom, Unset):
-            max_zoom = UNSET
-        else:
-            max_zoom = self.max_zoom
-
-        min_zoom: float | None | Unset
-        if isinstance(self.min_zoom, Unset):
-            min_zoom = UNSET
-        else:
-            min_zoom = self.min_zoom
-
-        opacity: float | None | Unset
-        if isinstance(self.opacity, Unset):
-            opacity = UNSET
-        else:
-            opacity = self.opacity
-
         stroke_color: None | str | Unset
         if isinstance(self.stroke_color, Unset):
             stroke_color = UNSET
@@ -97,74 +67,59 @@ class SublayerOverride:
         else:
             stroke_width = self.stroke_width
 
+        casing_color: None | str | Unset
+        if isinstance(self.casing_color, Unset):
+            casing_color = UNSET
+        else:
+            casing_color = self.casing_color
+
+        casing_width: float | None | Unset
+        if isinstance(self.casing_width, Unset):
+            casing_width = UNSET
+        else:
+            casing_width = self.casing_width
+
+        min_zoom: float | None | Unset
+        if isinstance(self.min_zoom, Unset):
+            min_zoom = UNSET
+        else:
+            min_zoom = self.min_zoom
+
+        max_zoom: float | None | Unset
+        if isinstance(self.max_zoom, Unset):
+            max_zoom = UNSET
+        else:
+            max_zoom = self.max_zoom
+
+        opacity: float | None | Unset
+        if isinstance(self.opacity, Unset):
+            opacity = UNSET
+        else:
+            opacity = self.opacity
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
-        if casing_color is not UNSET:
-            field_dict["casing_color"] = casing_color
-        if casing_width is not UNSET:
-            field_dict["casing_width"] = casing_width
-        if max_zoom is not UNSET:
-            field_dict["max_zoom"] = max_zoom
-        if min_zoom is not UNSET:
-            field_dict["min_zoom"] = min_zoom
-        if opacity is not UNSET:
-            field_dict["opacity"] = opacity
         if stroke_color is not UNSET:
             field_dict["stroke_color"] = stroke_color
         if stroke_width is not UNSET:
             field_dict["stroke_width"] = stroke_width
+        if casing_color is not UNSET:
+            field_dict["casing_color"] = casing_color
+        if casing_width is not UNSET:
+            field_dict["casing_width"] = casing_width
+        if min_zoom is not UNSET:
+            field_dict["min_zoom"] = min_zoom
+        if max_zoom is not UNSET:
+            field_dict["max_zoom"] = max_zoom
+        if opacity is not UNSET:
+            field_dict["opacity"] = opacity
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
-        def _parse_casing_color(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        casing_color = _parse_casing_color(d.pop("casing_color", UNSET))
-
-        def _parse_casing_width(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        casing_width = _parse_casing_width(d.pop("casing_width", UNSET))
-
-        def _parse_max_zoom(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        max_zoom = _parse_max_zoom(d.pop("max_zoom", UNSET))
-
-        def _parse_min_zoom(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        min_zoom = _parse_min_zoom(d.pop("min_zoom", UNSET))
-
-        def _parse_opacity(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        opacity = _parse_opacity(d.pop("opacity", UNSET))
 
         def _parse_stroke_color(data: object) -> None | str | Unset:
             if data is None:
@@ -184,14 +139,59 @@ class SublayerOverride:
 
         stroke_width = _parse_stroke_width(d.pop("stroke_width", UNSET))
 
+        def _parse_casing_color(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        casing_color = _parse_casing_color(d.pop("casing_color", UNSET))
+
+        def _parse_casing_width(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        casing_width = _parse_casing_width(d.pop("casing_width", UNSET))
+
+        def _parse_min_zoom(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        min_zoom = _parse_min_zoom(d.pop("min_zoom", UNSET))
+
+        def _parse_max_zoom(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        max_zoom = _parse_max_zoom(d.pop("max_zoom", UNSET))
+
+        def _parse_opacity(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        opacity = _parse_opacity(d.pop("opacity", UNSET))
+
         sublayer_override = cls(
-            casing_color=casing_color,
-            casing_width=casing_width,
-            max_zoom=max_zoom,
-            min_zoom=min_zoom,
-            opacity=opacity,
             stroke_color=stroke_color,
             stroke_width=stroke_width,
+            casing_color=casing_color,
+            casing_width=casing_width,
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+            opacity=opacity,
         )
 
         return sublayer_override

--- a/sdks/python/geolens/models/table_register_response.py
+++ b/sdks/python/geolens/models/table_register_response.py
@@ -18,29 +18,29 @@ class TableRegisterResponse:
     """
     Attributes:
         dataset_id (UUID): Identifier of the newly registered dataset.
-        table_name (str): Source PostgreSQL table that was registered.
         title (str): Title of the registered dataset.
+        table_name (str): Source PostgreSQL table that was registered.
     """
 
     dataset_id: UUID
-    table_name: str
     title: str
+    table_name: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         dataset_id = str(self.dataset_id)
 
-        table_name = self.table_name
-
         title = self.title
+
+        table_name = self.table_name
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "dataset_id": dataset_id,
-                "table_name": table_name,
                 "title": title,
+                "table_name": table_name,
             }
         )
 
@@ -51,14 +51,14 @@ class TableRegisterResponse:
         d = dict(src_dict)
         dataset_id = UUID(d.pop("dataset_id"))
 
-        table_name = d.pop("table_name")
-
         title = d.pop("title")
+
+        table_name = d.pop("table_name")
 
         table_register_response = cls(
             dataset_id=dataset_id,
-            table_name=table_name,
             title=title,
+            table_name=table_name,
         )
 
         table_register_response.additional_properties = d

--- a/sdks/python/geolens/models/terrain_config.py
+++ b/sdks/python/geolens/models/terrain_config.py
@@ -19,18 +19,16 @@ class TerrainConfig:
     """
     Attributes:
         enabled (bool | Unset):  Default: False.
-        exaggeration (float | Unset):  Default: 1.0.
         source_dataset_id (None | Unset | UUID):
+        exaggeration (float | Unset):  Default: 1.0.
     """
 
     enabled: bool | Unset = False
-    exaggeration: float | Unset = 1.0
     source_dataset_id: None | Unset | UUID = UNSET
+    exaggeration: float | Unset = 1.0
 
     def to_dict(self) -> dict[str, Any]:
         enabled = self.enabled
-
-        exaggeration = self.exaggeration
 
         source_dataset_id: None | str | Unset
         if isinstance(self.source_dataset_id, Unset):
@@ -40,15 +38,17 @@ class TerrainConfig:
         else:
             source_dataset_id = self.source_dataset_id
 
+        exaggeration = self.exaggeration
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
         if enabled is not UNSET:
             field_dict["enabled"] = enabled
-        if exaggeration is not UNSET:
-            field_dict["exaggeration"] = exaggeration
         if source_dataset_id is not UNSET:
             field_dict["source_dataset_id"] = source_dataset_id
+        if exaggeration is not UNSET:
+            field_dict["exaggeration"] = exaggeration
 
         return field_dict
 
@@ -56,8 +56,6 @@ class TerrainConfig:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         enabled = d.pop("enabled", UNSET)
-
-        exaggeration = d.pop("exaggeration", UNSET)
 
         def _parse_source_dataset_id(data: object) -> None | Unset | UUID:
             if data is None:
@@ -76,10 +74,12 @@ class TerrainConfig:
 
         source_dataset_id = _parse_source_dataset_id(d.pop("source_dataset_id", UNSET))
 
+        exaggeration = d.pop("exaggeration", UNSET)
+
         terrain_config = cls(
             enabled=enabled,
-            exaggeration=exaggeration,
             source_dataset_id=source_dataset_id,
+            exaggeration=exaggeration,
         )
 
         return terrain_config

--- a/sdks/python/geolens/models/tile_config_response.py
+++ b/sdks/python/geolens/models/tile_config_response.py
@@ -19,18 +19,18 @@ class TileConfigResponse:
     """
     Attributes:
         cdn_base_url (None | str | Unset): CDN origin URL for tile delivery, if configured.
+        public_app_url (None | str | Unset): Browser-facing app URL used for share links and OAuth redirects.
+        public_api_url (None | str | Unset): Externally-reachable API base URL used in OGC self-links.
+        public_base_url (None | str | Unset): Deprecated alias for public_api_url. Will be removed in a future release.
         mvt_source_layer_prefix (None | str | Unset): Schema prefix emitted inside vector-tile source-layer names. Null
             when a multi-tenant request has no resolved tenant context. Default: 'data'.
-        public_api_url (None | str | Unset): Externally-reachable API base URL used in OGC self-links.
-        public_app_url (None | str | Unset): Browser-facing app URL used for share links and OAuth redirects.
-        public_base_url (None | str | Unset): Deprecated alias for public_api_url. Will be removed in a future release.
     """
 
     cdn_base_url: None | str | Unset = UNSET
-    mvt_source_layer_prefix: None | str | Unset = "data"
-    public_api_url: None | str | Unset = UNSET
     public_app_url: None | str | Unset = UNSET
+    public_api_url: None | str | Unset = UNSET
     public_base_url: None | str | Unset = UNSET
+    mvt_source_layer_prefix: None | str | Unset = "data"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -40,11 +40,11 @@ class TileConfigResponse:
         else:
             cdn_base_url = self.cdn_base_url
 
-        mvt_source_layer_prefix: None | str | Unset
-        if isinstance(self.mvt_source_layer_prefix, Unset):
-            mvt_source_layer_prefix = UNSET
+        public_app_url: None | str | Unset
+        if isinstance(self.public_app_url, Unset):
+            public_app_url = UNSET
         else:
-            mvt_source_layer_prefix = self.mvt_source_layer_prefix
+            public_app_url = self.public_app_url
 
         public_api_url: None | str | Unset
         if isinstance(self.public_api_url, Unset):
@@ -52,31 +52,31 @@ class TileConfigResponse:
         else:
             public_api_url = self.public_api_url
 
-        public_app_url: None | str | Unset
-        if isinstance(self.public_app_url, Unset):
-            public_app_url = UNSET
-        else:
-            public_app_url = self.public_app_url
-
         public_base_url: None | str | Unset
         if isinstance(self.public_base_url, Unset):
             public_base_url = UNSET
         else:
             public_base_url = self.public_base_url
 
+        mvt_source_layer_prefix: None | str | Unset
+        if isinstance(self.mvt_source_layer_prefix, Unset):
+            mvt_source_layer_prefix = UNSET
+        else:
+            mvt_source_layer_prefix = self.mvt_source_layer_prefix
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if cdn_base_url is not UNSET:
             field_dict["cdn_base_url"] = cdn_base_url
-        if mvt_source_layer_prefix is not UNSET:
-            field_dict["mvt_source_layer_prefix"] = mvt_source_layer_prefix
-        if public_api_url is not UNSET:
-            field_dict["public_api_url"] = public_api_url
         if public_app_url is not UNSET:
             field_dict["public_app_url"] = public_app_url
+        if public_api_url is not UNSET:
+            field_dict["public_api_url"] = public_api_url
         if public_base_url is not UNSET:
             field_dict["public_base_url"] = public_base_url
+        if mvt_source_layer_prefix is not UNSET:
+            field_dict["mvt_source_layer_prefix"] = mvt_source_layer_prefix
 
         return field_dict
 
@@ -93,6 +93,33 @@ class TileConfigResponse:
 
         cdn_base_url = _parse_cdn_base_url(d.pop("cdn_base_url", UNSET))
 
+        def _parse_public_app_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        public_app_url = _parse_public_app_url(d.pop("public_app_url", UNSET))
+
+        def _parse_public_api_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        public_api_url = _parse_public_api_url(d.pop("public_api_url", UNSET))
+
+        def _parse_public_base_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        public_base_url = _parse_public_base_url(d.pop("public_base_url", UNSET))
+
         def _parse_mvt_source_layer_prefix(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -104,39 +131,12 @@ class TileConfigResponse:
             d.pop("mvt_source_layer_prefix", UNSET)
         )
 
-        def _parse_public_api_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        public_api_url = _parse_public_api_url(d.pop("public_api_url", UNSET))
-
-        def _parse_public_app_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        public_app_url = _parse_public_app_url(d.pop("public_app_url", UNSET))
-
-        def _parse_public_base_url(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        public_base_url = _parse_public_base_url(d.pop("public_base_url", UNSET))
-
         tile_config_response = cls(
             cdn_base_url=cdn_base_url,
-            mvt_source_layer_prefix=mvt_source_layer_prefix,
-            public_api_url=public_api_url,
             public_app_url=public_app_url,
+            public_api_url=public_api_url,
             public_base_url=public_base_url,
+            mvt_source_layer_prefix=mvt_source_layer_prefix,
         )
 
         tile_config_response.additional_properties = d

--- a/sdks/python/geolens/models/token_response.py
+++ b/sdks/python/geolens/models/token_response.py
@@ -17,23 +17,23 @@ class TokenResponse:
     """
     Attributes:
         access_token (str): JWT access token for Authorization header
-        expires_in (int): Seconds until the access token expires
         refresh_token (str): Opaque token used to obtain a new access token
+        expires_in (int): Seconds until the access token expires
         token_type (str | Unset):  Default: 'bearer'.
     """
 
     access_token: str
-    expires_in: int
     refresh_token: str
+    expires_in: int
     token_type: str | Unset = "bearer"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         access_token = self.access_token
 
-        expires_in = self.expires_in
-
         refresh_token = self.refresh_token
+
+        expires_in = self.expires_in
 
         token_type = self.token_type
 
@@ -42,8 +42,8 @@ class TokenResponse:
         field_dict.update(
             {
                 "access_token": access_token,
-                "expires_in": expires_in,
                 "refresh_token": refresh_token,
+                "expires_in": expires_in,
             }
         )
         if token_type is not UNSET:
@@ -56,16 +56,16 @@ class TokenResponse:
         d = dict(src_dict)
         access_token = d.pop("access_token")
 
-        expires_in = d.pop("expires_in")
-
         refresh_token = d.pop("refresh_token")
+
+        expires_in = d.pop("expires_in")
 
         token_type = d.pop("token_type", UNSET)
 
         token_response = cls(
             access_token=access_token,
-            expires_in=expires_in,
             refresh_token=refresh_token,
+            expires_in=expires_in,
             token_type=token_type,
         )
 

--- a/sdks/python/geolens/models/translation_list_response.py
+++ b/sdks/python/geolens/models/translation_list_response.py
@@ -18,28 +18,28 @@ T = TypeVar("T", bound="TranslationListResponse")
 class TranslationListResponse:
     """
     Attributes:
-        total (int):
         translations (list[TranslationResponse]):
+        total (int):
     """
 
-    total: int
     translations: list[TranslationResponse]
+    total: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        total = self.total
-
         translations = []
         for translations_item_data in self.translations:
             translations_item = translations_item_data.to_dict()
             translations.append(translations_item)
 
+        total = self.total
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "total": total,
                 "translations": translations,
+                "total": total,
             }
         )
 
@@ -50,8 +50,6 @@ class TranslationListResponse:
         from ..models.translation_response import TranslationResponse
 
         d = dict(src_dict)
-        total = d.pop("total")
-
         translations = []
         _translations = d.pop("translations")
         for translations_item_data in _translations:
@@ -59,9 +57,11 @@ class TranslationListResponse:
 
             translations.append(translations_item)
 
+        total = d.pop("total")
+
         translation_list_response = cls(
-            total=total,
             translations=translations,
+            total=total,
         )
 
         translation_list_response.additional_properties = d

--- a/sdks/python/geolens/models/translation_response.py
+++ b/sdks/python/geolens/models/translation_response.py
@@ -18,36 +18,36 @@ T = TypeVar("T", bound="TranslationResponse")
 class TranslationResponse:
     """
     Attributes:
-        language (str):
         record_id (UUID):
-        summary (None | str):
+        language (str):
         title (str):
+        summary (None | str):
     """
 
-    language: str
     record_id: UUID
-    summary: None | str
+    language: str
     title: str
+    summary: None | str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        record_id = str(self.record_id)
+
         language = self.language
 
-        record_id = str(self.record_id)
+        title = self.title
 
         summary: None | str
         summary = self.summary
-
-        title = self.title
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "language": language,
                 "record_id": record_id,
-                "summary": summary,
+                "language": language,
                 "title": title,
+                "summary": summary,
             }
         )
 
@@ -56,9 +56,11 @@ class TranslationResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+        record_id = UUID(d.pop("record_id"))
+
         language = d.pop("language")
 
-        record_id = UUID(d.pop("record_id"))
+        title = d.pop("title")
 
         def _parse_summary(data: object) -> None | str:
             if data is None:
@@ -67,13 +69,11 @@ class TranslationResponse:
 
         summary = _parse_summary(d.pop("summary"))
 
-        title = d.pop("title")
-
         translation_response = cls(
-            language=language,
             record_id=record_id,
-            summary=summary,
+            language=language,
             title=title,
+            summary=summary,
         )
 
         translation_response.additional_properties = d

--- a/sdks/python/geolens/models/type_change.py
+++ b/sdks/python/geolens/models/type_change.py
@@ -15,29 +15,29 @@ class TypeChange:
     """
     Attributes:
         name (str):
-        new_type (str):
         old_type (str):
+        new_type (str):
     """
 
     name: str
-    new_type: str
     old_type: str
+    new_type: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
 
-        new_type = self.new_type
-
         old_type = self.old_type
+
+        new_type = self.new_type
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "name": name,
-                "new_type": new_type,
                 "old_type": old_type,
+                "new_type": new_type,
             }
         )
 
@@ -48,14 +48,14 @@ class TypeChange:
         d = dict(src_dict)
         name = d.pop("name")
 
-        new_type = d.pop("new_type")
-
         old_type = d.pop("old_type")
+
+        new_type = d.pop("new_type")
 
         type_change = cls(
             name=name,
-            new_type=new_type,
             old_type=old_type,
+            new_type=new_type,
         )
 
         type_change.additional_properties = d

--- a/sdks/python/geolens/models/upload_config_response.py
+++ b/sdks/python/geolens/models/upload_config_response.py
@@ -18,30 +18,30 @@ T = TypeVar("T", bound="UploadConfigResponse")
 class UploadConfigResponse:
     """
     Attributes:
-        allowed_extensions (str): Comma-separated list of allowed file extensions.
-        max_file_size_bytes (int): Maximum allowed upload size in bytes.
-        presigned_threshold_bytes (int): File size threshold (bytes) above which multipart presigned URLs are used.
         presigned_uploads (bool): Whether presigned S3 uploads are enabled (requires `STORAGE_PROVIDER=s3`).
+        presigned_threshold_bytes (int): File size threshold (bytes) above which multipart presigned URLs are used.
+        max_file_size_bytes (int): Maximum allowed upload size in bytes.
+        allowed_extensions (str): Comma-separated list of allowed file extensions.
         remaining_dataset_quota (int | None | Unset): Datasets the caller may still create before hitting the per-user
             count cap, or null when no count cap is configured (unlimited). Advisory UX hint only — the cap is enforced
             server-side at upload.
     """
 
-    allowed_extensions: str
-    max_file_size_bytes: int
-    presigned_threshold_bytes: int
     presigned_uploads: bool
+    presigned_threshold_bytes: int
+    max_file_size_bytes: int
+    allowed_extensions: str
     remaining_dataset_quota: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        allowed_extensions = self.allowed_extensions
-
-        max_file_size_bytes = self.max_file_size_bytes
+        presigned_uploads = self.presigned_uploads
 
         presigned_threshold_bytes = self.presigned_threshold_bytes
 
-        presigned_uploads = self.presigned_uploads
+        max_file_size_bytes = self.max_file_size_bytes
+
+        allowed_extensions = self.allowed_extensions
 
         remaining_dataset_quota: int | None | Unset
         if isinstance(self.remaining_dataset_quota, Unset):
@@ -53,10 +53,10 @@ class UploadConfigResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "allowed_extensions": allowed_extensions,
-                "max_file_size_bytes": max_file_size_bytes,
-                "presigned_threshold_bytes": presigned_threshold_bytes,
                 "presigned_uploads": presigned_uploads,
+                "presigned_threshold_bytes": presigned_threshold_bytes,
+                "max_file_size_bytes": max_file_size_bytes,
+                "allowed_extensions": allowed_extensions,
             }
         )
         if remaining_dataset_quota is not UNSET:
@@ -67,13 +67,13 @@ class UploadConfigResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        allowed_extensions = d.pop("allowed_extensions")
-
-        max_file_size_bytes = d.pop("max_file_size_bytes")
+        presigned_uploads = d.pop("presigned_uploads")
 
         presigned_threshold_bytes = d.pop("presigned_threshold_bytes")
 
-        presigned_uploads = d.pop("presigned_uploads")
+        max_file_size_bytes = d.pop("max_file_size_bytes")
+
+        allowed_extensions = d.pop("allowed_extensions")
 
         def _parse_remaining_dataset_quota(data: object) -> int | None | Unset:
             if data is None:
@@ -87,10 +87,10 @@ class UploadConfigResponse:
         )
 
         upload_config_response = cls(
-            allowed_extensions=allowed_extensions,
-            max_file_size_bytes=max_file_size_bytes,
-            presigned_threshold_bytes=presigned_threshold_bytes,
             presigned_uploads=presigned_uploads,
+            presigned_threshold_bytes=presigned_threshold_bytes,
+            max_file_size_bytes=max_file_size_bytes,
+            allowed_extensions=allowed_extensions,
             remaining_dataset_quota=remaining_dataset_quota,
         )
 

--- a/sdks/python/geolens/models/user_create.py
+++ b/sdks/python/geolens/models/user_create.py
@@ -18,20 +18,20 @@ T = TypeVar("T", bound="UserCreate")
 class UserCreate:
     """
     Attributes:
-        password (str): Plaintext password (policy: min 12 chars, 3+ character classes) Example: securePass123!.
         username (str): Unique login name Example: jdoe.
+        password (str): Plaintext password (policy: min 12 chars, 3+ character classes) Example: securePass123!.
         email (None | str | Unset): Optional email address Example: jdoe@example.com.
     """
 
-    password: str
     username: str
+    password: str
     email: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        password = self.password
-
         username = self.username
+
+        password = self.password
 
         email: None | str | Unset
         if isinstance(self.email, Unset):
@@ -43,8 +43,8 @@ class UserCreate:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "password": password,
                 "username": username,
+                "password": password,
             }
         )
         if email is not UNSET:
@@ -55,9 +55,9 @@ class UserCreate:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        password = d.pop("password")
-
         username = d.pop("username")
+
+        password = d.pop("password")
 
         def _parse_email(data: object) -> None | str | Unset:
             if data is None:
@@ -69,8 +69,8 @@ class UserCreate:
         email = _parse_email(d.pop("email", UNSET))
 
         user_create = cls(
-            password=password,
             username=username,
+            password=password,
             email=email,
         )
 

--- a/sdks/python/geolens/models/user_list_response.py
+++ b/sdks/python/geolens/models/user_list_response.py
@@ -18,28 +18,28 @@ T = TypeVar("T", bound="UserListResponse")
 class UserListResponse:
     """
     Attributes:
-        total (int): Total number of users matching the query (across all pages).
         users (list[UserResponse]): Page of users matching the query.
+        total (int): Total number of users matching the query (across all pages).
     """
 
-    total: int
     users: list[UserResponse]
+    total: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        total = self.total
-
         users = []
         for users_item_data in self.users:
             users_item = users_item_data.to_dict()
             users.append(users_item)
 
+        total = self.total
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "total": total,
                 "users": users,
+                "total": total,
             }
         )
 
@@ -50,8 +50,6 @@ class UserListResponse:
         from ..models.user_response import UserResponse
 
         d = dict(src_dict)
-        total = d.pop("total")
-
         users = []
         _users = d.pop("users")
         for users_item_data in _users:
@@ -59,9 +57,11 @@ class UserListResponse:
 
             users.append(users_item)
 
+        total = d.pop("total")
+
         user_list_response = cls(
-            total=total,
             users=users,
+            total=total,
         )
 
         user_list_response.additional_properties = d

--- a/sdks/python/geolens/models/user_quota_usage.py
+++ b/sdks/python/geolens/models/user_quota_usage.py
@@ -16,34 +16,34 @@ class UserQuotaUsage:
 
     Attributes:
         bytes_used (int):
-        count_cap (int):
         dataset_count (int):
         storage_cap (int):
+        count_cap (int):
     """
 
     bytes_used: int
-    count_cap: int
     dataset_count: int
     storage_cap: int
+    count_cap: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         bytes_used = self.bytes_used
 
-        count_cap = self.count_cap
-
         dataset_count = self.dataset_count
 
         storage_cap = self.storage_cap
+
+        count_cap = self.count_cap
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "bytes_used": bytes_used,
-                "count_cap": count_cap,
                 "dataset_count": dataset_count,
                 "storage_cap": storage_cap,
+                "count_cap": count_cap,
             }
         )
 
@@ -54,17 +54,17 @@ class UserQuotaUsage:
         d = dict(src_dict)
         bytes_used = d.pop("bytes_used")
 
-        count_cap = d.pop("count_cap")
-
         dataset_count = d.pop("dataset_count")
 
         storage_cap = d.pop("storage_cap")
 
+        count_cap = d.pop("count_cap")
+
         user_quota_usage = cls(
             bytes_used=bytes_used,
-            count_cap=count_cap,
             dataset_count=dataset_count,
             storage_cap=storage_cap,
+            count_cap=count_cap,
         )
 
         user_quota_usage.additional_properties = d

--- a/sdks/python/geolens/models/user_response.py
+++ b/sdks/python/geolens/models/user_response.py
@@ -26,40 +26,42 @@ T = TypeVar("T", bound="UserResponse")
 class UserResponse:
     """
     Attributes:
-        created_at (datetime.datetime):
-        email (None | str):
         id (UUID):
-        is_active (bool):
-        last_login_at (datetime.datetime | None):
-        roles (list[str]): Assigned role names, e.g. ['admin', 'editor']
-        status (UserResponseStatus): Account status: active, pending, suspended, or deactivated.
         username (str):
+        email (None | str):
+        is_active (bool):
+        status (UserResponseStatus): Account status: active, pending, suspended, or deactivated.
+        last_login_at (datetime.datetime | None):
+        created_at (datetime.datetime):
+        roles (list[str]): Assigned role names, e.g. ['admin', 'editor']
         quota_usage (None | Unset | UserQuotaUsage): Per-user storage quota usage. Populated only on admin list
             responses; None when the caller did not load usage (e.g. /auth/me, single-user GET).
     """
 
-    created_at: datetime.datetime
-    email: None | str
     id: UUID
-    is_active: bool
-    last_login_at: datetime.datetime | None
-    roles: list[str]
-    status: UserResponseStatus
     username: str
+    email: None | str
+    is_active: bool
+    status: UserResponseStatus
+    last_login_at: datetime.datetime | None
+    created_at: datetime.datetime
+    roles: list[str]
     quota_usage: None | Unset | UserQuotaUsage = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.user_quota_usage import UserQuotaUsage
 
-        created_at = self.created_at.isoformat()
+        id = str(self.id)
+
+        username = self.username
 
         email: None | str
         email = self.email
 
-        id = str(self.id)
-
         is_active = self.is_active
+
+        status: str = self.status
 
         last_login_at: None | str
         if isinstance(self.last_login_at, datetime.datetime):
@@ -67,11 +69,9 @@ class UserResponse:
         else:
             last_login_at = self.last_login_at
 
+        created_at = self.created_at.isoformat()
+
         roles = self.roles
-
-        status: str = self.status
-
-        username = self.username
 
         quota_usage: dict[str, Any] | None | Unset
         if isinstance(self.quota_usage, Unset):
@@ -85,14 +85,14 @@ class UserResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "created_at": created_at,
-                "email": email,
                 "id": id,
-                "is_active": is_active,
-                "last_login_at": last_login_at,
-                "roles": roles,
-                "status": status,
                 "username": username,
+                "email": email,
+                "is_active": is_active,
+                "status": status,
+                "last_login_at": last_login_at,
+                "created_at": created_at,
+                "roles": roles,
             }
         )
         if quota_usage is not UNSET:
@@ -105,7 +105,9 @@ class UserResponse:
         from ..models.user_quota_usage import UserQuotaUsage
 
         d = dict(src_dict)
-        created_at = isoparse(d.pop("created_at"))
+        id = UUID(d.pop("id"))
+
+        username = d.pop("username")
 
         def _parse_email(data: object) -> None | str:
             if data is None:
@@ -114,9 +116,9 @@ class UserResponse:
 
         email = _parse_email(d.pop("email"))
 
-        id = UUID(d.pop("id"))
-
         is_active = d.pop("is_active")
+
+        status = check_user_response_status(d.pop("status"))
 
         def _parse_last_login_at(data: object) -> datetime.datetime | None:
             if data is None:
@@ -133,11 +135,9 @@ class UserResponse:
 
         last_login_at = _parse_last_login_at(d.pop("last_login_at"))
 
+        created_at = isoparse(d.pop("created_at"))
+
         roles = cast(list[str], d.pop("roles"))
-
-        status = check_user_response_status(d.pop("status"))
-
-        username = d.pop("username")
 
         def _parse_quota_usage(data: object) -> None | Unset | UserQuotaUsage:
             if data is None:
@@ -157,14 +157,14 @@ class UserResponse:
         quota_usage = _parse_quota_usage(d.pop("quota_usage", UNSET))
 
         user_response = cls(
-            created_at=created_at,
-            email=email,
             id=id,
-            is_active=is_active,
-            last_login_at=last_login_at,
-            roles=roles,
-            status=status,
             username=username,
+            email=email,
+            is_active=is_active,
+            status=status,
+            last_login_at=last_login_at,
+            created_at=created_at,
+            roles=roles,
             quota_usage=quota_usage,
         )
 

--- a/sdks/python/geolens/models/user_update.py
+++ b/sdks/python/geolens/models/user_update.py
@@ -23,15 +23,15 @@ class UserUpdate:
         email (None | str | Unset): New email address. Set to update; omit to leave unchanged.
         is_active (bool | None | Unset): Legacy account-state toggle. False maps to 'deactivated' and true maps to
             'active'. Prefer the explicit status field.
-        role (None | str | Unset): New role: 'admin', 'editor', or 'viewer'. Omit to leave unchanged.
         status (None | Unset | UserUpdateStatusType0): Explicit account lifecycle state. Pending registrations must use
             the approve/reject endpoints.
+        role (None | str | Unset): New role: 'admin', 'editor', or 'viewer'. Omit to leave unchanged.
     """
 
     email: None | str | Unset = UNSET
     is_active: bool | None | Unset = UNSET
-    role: None | str | Unset = UNSET
     status: None | Unset | UserUpdateStatusType0 = UNSET
+    role: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -47,12 +47,6 @@ class UserUpdate:
         else:
             is_active = self.is_active
 
-        role: None | str | Unset
-        if isinstance(self.role, Unset):
-            role = UNSET
-        else:
-            role = self.role
-
         status: None | str | Unset
         if isinstance(self.status, Unset):
             status = UNSET
@@ -61,6 +55,12 @@ class UserUpdate:
         else:
             status = self.status
 
+        role: None | str | Unset
+        if isinstance(self.role, Unset):
+            role = UNSET
+        else:
+            role = self.role
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -68,10 +68,10 @@ class UserUpdate:
             field_dict["email"] = email
         if is_active is not UNSET:
             field_dict["is_active"] = is_active
-        if role is not UNSET:
-            field_dict["role"] = role
         if status is not UNSET:
             field_dict["status"] = status
+        if role is not UNSET:
+            field_dict["role"] = role
 
         return field_dict
 
@@ -97,15 +97,6 @@ class UserUpdate:
 
         is_active = _parse_is_active(d.pop("is_active", UNSET))
 
-        def _parse_role(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        role = _parse_role(d.pop("role", UNSET))
-
         def _parse_status(data: object) -> None | Unset | UserUpdateStatusType0:
             if data is None:
                 return data
@@ -123,11 +114,20 @@ class UserUpdate:
 
         status = _parse_status(d.pop("status", UNSET))
 
+        def _parse_role(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        role = _parse_role(d.pop("role", UNSET))
+
         user_update = cls(
             email=email,
             is_active=is_active,
-            role=role,
             status=status,
+            role=role,
         )
 
         user_update.additional_properties = d

--- a/sdks/python/geolens/models/validation_error.py
+++ b/sdks/python/geolens/models/validation_error.py
@@ -24,15 +24,15 @@ class ValidationError:
         loc (list[int | str]):
         msg (str):
         type_ (str):
-        ctx (ValidationErrorContext | Unset):
         input_ (Any | Unset):
+        ctx (ValidationErrorContext | Unset):
     """
 
     loc: list[int | str]
     msg: str
     type_: str
-    ctx: ValidationErrorContext | Unset = UNSET
     input_: Any | Unset = UNSET
+    ctx: ValidationErrorContext | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -46,11 +46,11 @@ class ValidationError:
 
         type_ = self.type_
 
+        input_ = self.input_
+
         ctx: dict[str, Any] | Unset = UNSET
         if not isinstance(self.ctx, Unset):
             ctx = self.ctx.to_dict()
-
-        input_ = self.input_
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -61,10 +61,10 @@ class ValidationError:
                 "type": type_,
             }
         )
-        if ctx is not UNSET:
-            field_dict["ctx"] = ctx
         if input_ is not UNSET:
             field_dict["input"] = input_
+        if ctx is not UNSET:
+            field_dict["ctx"] = ctx
 
         return field_dict
 
@@ -88,6 +88,8 @@ class ValidationError:
 
         type_ = d.pop("type")
 
+        input_ = d.pop("input", UNSET)
+
         _ctx = d.pop("ctx", UNSET)
         ctx: ValidationErrorContext | Unset
         if isinstance(_ctx, Unset):
@@ -95,14 +97,12 @@ class ValidationError:
         else:
             ctx = ValidationErrorContext.from_dict(_ctx)
 
-        input_ = d.pop("input", UNSET)
-
         validation_error = cls(
             loc=loc,
             msg=msg,
             type_=type_,
-            ctx=ctx,
             input_=input_,
+            ctx=ctx,
         )
 
         validation_error.additional_properties = d

--- a/sdks/python/geolens/models/validation_result_response.py
+++ b/sdks/python/geolens/models/validation_result_response.py
@@ -24,14 +24,14 @@ T = TypeVar("T", bound="ValidationResultResponse")
 class ValidationResultResponse:
     """
     Attributes:
-        errors (list[ValidationIssue]):
         is_valid (bool):
+        errors (list[ValidationIssue]):
         warnings (list[ValidationIssue]):
         quality_score (None | Unset | ValidationResultResponseQualityScoreType0):
     """
 
-    errors: list[ValidationIssue]
     is_valid: bool
+    errors: list[ValidationIssue]
     warnings: list[ValidationIssue]
     quality_score: None | Unset | ValidationResultResponseQualityScoreType0 = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -41,12 +41,12 @@ class ValidationResultResponse:
             ValidationResultResponseQualityScoreType0,
         )
 
+        is_valid = self.is_valid
+
         errors = []
         for errors_item_data in self.errors:
             errors_item = errors_item_data.to_dict()
             errors.append(errors_item)
-
-        is_valid = self.is_valid
 
         warnings = []
         for warnings_item_data in self.warnings:
@@ -65,8 +65,8 @@ class ValidationResultResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "errors": errors,
                 "is_valid": is_valid,
+                "errors": errors,
                 "warnings": warnings,
             }
         )
@@ -83,14 +83,14 @@ class ValidationResultResponse:
         )
 
         d = dict(src_dict)
+        is_valid = d.pop("is_valid")
+
         errors = []
         _errors = d.pop("errors")
         for errors_item_data in _errors:
             errors_item = ValidationIssue.from_dict(errors_item_data)
 
             errors.append(errors_item)
-
-        is_valid = d.pop("is_valid")
 
         warnings = []
         _warnings = d.pop("warnings")
@@ -121,8 +121,8 @@ class ValidationResultResponse:
         quality_score = _parse_quality_score(d.pop("quality_score", UNSET))
 
         validation_result_response = cls(
-            errors=errors,
             is_valid=is_valid,
+            errors=errors,
             warnings=warnings,
             quality_score=quality_score,
         )

--- a/sdks/python/geolens/models/vector_tile_token.py
+++ b/sdks/python/geolens/models/vector_tile_token.py
@@ -17,40 +17,40 @@ T = TypeVar("T", bound="VectorTileToken")
 class VectorTileToken:
     """
     Attributes:
-        exp (int):
-        expires_in (int):
         kind (Literal['vector']):
-        scope (str):
         sig (str):
+        exp (int):
+        scope (str):
+        expires_in (int):
     """
 
-    exp: int
-    expires_in: int
     kind: Literal["vector"]
-    scope: str
     sig: str
+    exp: int
+    scope: str
+    expires_in: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        exp = self.exp
-
-        expires_in = self.expires_in
-
         kind = self.kind
+
+        sig = self.sig
+
+        exp = self.exp
 
         scope = self.scope
 
-        sig = self.sig
+        expires_in = self.expires_in
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "exp": exp,
-                "expires_in": expires_in,
                 "kind": kind,
-                "scope": scope,
                 "sig": sig,
+                "exp": exp,
+                "scope": scope,
+                "expires_in": expires_in,
             }
         )
 
@@ -59,24 +59,24 @@ class VectorTileToken:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        exp = d.pop("exp")
-
-        expires_in = d.pop("expires_in")
-
         kind = cast(Literal["vector"], d.pop("kind"))
         if kind != "vector":
             raise ValueError(f"kind must match const 'vector', got '{kind}'")
 
-        scope = d.pop("scope")
-
         sig = d.pop("sig")
 
+        exp = d.pop("exp")
+
+        scope = d.pop("scope")
+
+        expires_in = d.pop("expires_in")
+
         vector_tile_token = cls(
-            exp=exp,
-            expires_in=expires_in,
             kind=kind,
-            scope=scope,
             sig=sig,
+            exp=exp,
+            scope=scope,
+            expires_in=expires_in,
         )
 
         vector_tile_token.additional_properties = d

--- a/sdks/python/geolens/models/visibility_check_response.py
+++ b/sdks/python/geolens/models/visibility_check_response.py
@@ -17,25 +17,25 @@ T = TypeVar("T", bound="VisibilityCheckResponse")
 class VisibilityCheckResponse:
     """
     Attributes:
-        has_non_public (bool): True if any layer references a non-public dataset
         non_public_datasets (list[str]): Titles of datasets not publicly visible
+        has_non_public (bool): True if any layer references a non-public dataset
     """
 
-    has_non_public: bool
     non_public_datasets: list[str]
+    has_non_public: bool
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        has_non_public = self.has_non_public
-
         non_public_datasets = self.non_public_datasets
+
+        has_non_public = self.has_non_public
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "has_non_public": has_non_public,
                 "non_public_datasets": non_public_datasets,
+                "has_non_public": has_non_public,
             }
         )
 
@@ -44,13 +44,13 @@ class VisibilityCheckResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        has_non_public = d.pop("has_non_public")
-
         non_public_datasets = cast(list[str], d.pop("non_public_datasets"))
 
+        has_non_public = d.pop("has_non_public")
+
         visibility_check_response = cls(
-            has_non_public=has_non_public,
             non_public_datasets=non_public_datasets,
+            has_non_public=has_non_public,
         )
 
         visibility_check_response.additional_properties = d

--- a/sdks/python/geolens/models/vrt_active_generation.py
+++ b/sdks/python/geolens/models/vrt_active_generation.py
@@ -19,30 +19,30 @@ T = TypeVar("T", bound="VrtActiveGeneration")
 class VrtActiveGeneration:
     """
     Attributes:
-        elapsed_seconds (float):
         generation_id (UUID):
         started_at (datetime.datetime):
+        elapsed_seconds (float):
     """
 
-    elapsed_seconds: float
     generation_id: UUID
     started_at: datetime.datetime
+    elapsed_seconds: float
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        elapsed_seconds = self.elapsed_seconds
-
         generation_id = str(self.generation_id)
 
         started_at = self.started_at.isoformat()
+
+        elapsed_seconds = self.elapsed_seconds
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "elapsed_seconds": elapsed_seconds,
                 "generation_id": generation_id,
                 "started_at": started_at,
+                "elapsed_seconds": elapsed_seconds,
             }
         )
 
@@ -51,16 +51,16 @@ class VrtActiveGeneration:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        elapsed_seconds = d.pop("elapsed_seconds")
-
         generation_id = UUID(d.pop("generation_id"))
 
         started_at = isoparse(d.pop("started_at"))
 
+        elapsed_seconds = d.pop("elapsed_seconds")
+
         vrt_active_generation = cls(
-            elapsed_seconds=elapsed_seconds,
             generation_id=generation_id,
             started_at=started_at,
+            elapsed_seconds=elapsed_seconds,
         )
 
         vrt_active_generation.additional_properties = d

--- a/sdks/python/geolens/models/vrt_create_request.py
+++ b/sdks/python/geolens/models/vrt_create_request.py
@@ -29,36 +29,36 @@ T = TypeVar("T", bound="VrtCreateRequest")
 class VrtCreateRequest:
     """
     Attributes:
-        resolution_strategy (VrtCreateRequestResolutionStrategy): How to resolve mismatched source resolutions: 'finest'
-            uses the highest, 'coarsest' uses the lowest, 'average' computes the mean.
         source_dataset_ids (list[UUID]): Source raster dataset IDs to include in the VRT mosaic or band stack (1-500).
-        title (str): Human-readable title for the resulting VRT dataset.
         vrt_type (VrtCreateRequestVrtType): Type of VRT to create. 'mosaic' tiles sources spatially; 'band_stack' aligns
             same-extent sources as multi-band output.
+        resolution_strategy (VrtCreateRequestResolutionStrategy): How to resolve mismatched source resolutions: 'finest'
+            uses the highest, 'coarsest' uses the lowest, 'average' computes the mean.
+        title (str): Human-readable title for the resulting VRT dataset.
         summary (None | str | Unset): Optional description for the VRT dataset.
         visibility (VrtCreateRequestVisibility | Unset): Visibility level for the resulting VRT dataset. Default:
             'private'.
     """
 
-    resolution_strategy: VrtCreateRequestResolutionStrategy
     source_dataset_ids: list[UUID]
-    title: str
     vrt_type: VrtCreateRequestVrtType
+    resolution_strategy: VrtCreateRequestResolutionStrategy
+    title: str
     summary: None | str | Unset = UNSET
     visibility: VrtCreateRequestVisibility | Unset = "private"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        resolution_strategy: str = self.resolution_strategy
-
         source_dataset_ids = []
         for source_dataset_ids_item_data in self.source_dataset_ids:
             source_dataset_ids_item = str(source_dataset_ids_item_data)
             source_dataset_ids.append(source_dataset_ids_item)
 
-        title = self.title
-
         vrt_type: str = self.vrt_type
+
+        resolution_strategy: str = self.resolution_strategy
+
+        title = self.title
 
         summary: None | str | Unset
         if isinstance(self.summary, Unset):
@@ -74,10 +74,10 @@ class VrtCreateRequest:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "resolution_strategy": resolution_strategy,
                 "source_dataset_ids": source_dataset_ids,
-                "title": title,
                 "vrt_type": vrt_type,
+                "resolution_strategy": resolution_strategy,
+                "title": title,
             }
         )
         if summary is not UNSET:
@@ -90,10 +90,6 @@ class VrtCreateRequest:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        resolution_strategy = check_vrt_create_request_resolution_strategy(
-            d.pop("resolution_strategy")
-        )
-
         source_dataset_ids = []
         _source_dataset_ids = d.pop("source_dataset_ids")
         for source_dataset_ids_item_data in _source_dataset_ids:
@@ -101,9 +97,13 @@ class VrtCreateRequest:
 
             source_dataset_ids.append(source_dataset_ids_item)
 
-        title = d.pop("title")
-
         vrt_type = check_vrt_create_request_vrt_type(d.pop("vrt_type"))
+
+        resolution_strategy = check_vrt_create_request_resolution_strategy(
+            d.pop("resolution_strategy")
+        )
+
+        title = d.pop("title")
 
         def _parse_summary(data: object) -> None | str | Unset:
             if data is None:
@@ -122,10 +122,10 @@ class VrtCreateRequest:
             visibility = check_vrt_create_request_visibility(_visibility)
 
         vrt_create_request = cls(
-            resolution_strategy=resolution_strategy,
             source_dataset_ids=source_dataset_ids,
-            title=title,
             vrt_type=vrt_type,
+            resolution_strategy=resolution_strategy,
+            title=title,
             summary=summary,
             visibility=visibility,
         )

--- a/sdks/python/geolens/models/vrt_generation_item.py
+++ b/sdks/python/geolens/models/vrt_generation_item.py
@@ -23,21 +23,21 @@ class VrtGenerationItem:
     Attributes:
         id (UUID):
         status (str):
+        started_at (datetime.datetime | None | Unset):
         completed_at (datetime.datetime | None | Unset):
         duration_seconds (float | None | Unset):
         error_message (None | str | Unset):
         source_count (int | None | Unset):
-        started_at (datetime.datetime | None | Unset):
         triggered_by (None | str | Unset):
     """
 
     id: UUID
     status: str
+    started_at: datetime.datetime | None | Unset = UNSET
     completed_at: datetime.datetime | None | Unset = UNSET
     duration_seconds: float | None | Unset = UNSET
     error_message: None | str | Unset = UNSET
     source_count: int | None | Unset = UNSET
-    started_at: datetime.datetime | None | Unset = UNSET
     triggered_by: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -45,6 +45,14 @@ class VrtGenerationItem:
         id = str(self.id)
 
         status = self.status
+
+        started_at: None | str | Unset
+        if isinstance(self.started_at, Unset):
+            started_at = UNSET
+        elif isinstance(self.started_at, datetime.datetime):
+            started_at = self.started_at.isoformat()
+        else:
+            started_at = self.started_at
 
         completed_at: None | str | Unset
         if isinstance(self.completed_at, Unset):
@@ -72,14 +80,6 @@ class VrtGenerationItem:
         else:
             source_count = self.source_count
 
-        started_at: None | str | Unset
-        if isinstance(self.started_at, Unset):
-            started_at = UNSET
-        elif isinstance(self.started_at, datetime.datetime):
-            started_at = self.started_at.isoformat()
-        else:
-            started_at = self.started_at
-
         triggered_by: None | str | Unset
         if isinstance(self.triggered_by, Unset):
             triggered_by = UNSET
@@ -94,6 +94,8 @@ class VrtGenerationItem:
                 "status": status,
             }
         )
+        if started_at is not UNSET:
+            field_dict["started_at"] = started_at
         if completed_at is not UNSET:
             field_dict["completed_at"] = completed_at
         if duration_seconds is not UNSET:
@@ -102,8 +104,6 @@ class VrtGenerationItem:
             field_dict["error_message"] = error_message
         if source_count is not UNSET:
             field_dict["source_count"] = source_count
-        if started_at is not UNSET:
-            field_dict["started_at"] = started_at
         if triggered_by is not UNSET:
             field_dict["triggered_by"] = triggered_by
 
@@ -115,6 +115,23 @@ class VrtGenerationItem:
         id = UUID(d.pop("id"))
 
         status = d.pop("status")
+
+        def _parse_started_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                started_at_type_0 = isoparse(data)
+
+                return started_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        started_at = _parse_started_at(d.pop("started_at", UNSET))
 
         def _parse_completed_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -160,23 +177,6 @@ class VrtGenerationItem:
 
         source_count = _parse_source_count(d.pop("source_count", UNSET))
 
-        def _parse_started_at(data: object) -> datetime.datetime | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                started_at_type_0 = isoparse(data)
-
-                return started_at_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None | Unset, data)
-
-        started_at = _parse_started_at(d.pop("started_at", UNSET))
-
         def _parse_triggered_by(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -189,11 +189,11 @@ class VrtGenerationItem:
         vrt_generation_item = cls(
             id=id,
             status=status,
+            started_at=started_at,
             completed_at=completed_at,
             duration_seconds=duration_seconds,
             error_message=error_message,
             source_count=source_count,
-            started_at=started_at,
             triggered_by=triggered_by,
         )
 

--- a/sdks/python/geolens/models/vrt_source_health.py
+++ b/sdks/python/geolens/models/vrt_source_health.py
@@ -20,29 +20,29 @@ class VrtSourceHealth:
     """
     Attributes:
         dataset_id (UUID):
-        status (VrtSourceHealthStatus):
         title (str):
+        status (VrtSourceHealthStatus):
     """
 
     dataset_id: UUID
-    status: VrtSourceHealthStatus
     title: str
+    status: VrtSourceHealthStatus
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         dataset_id = str(self.dataset_id)
 
-        status: str = self.status
-
         title = self.title
+
+        status: str = self.status
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "dataset_id": dataset_id,
-                "status": status,
                 "title": title,
+                "status": status,
             }
         )
 
@@ -53,14 +53,14 @@ class VrtSourceHealth:
         d = dict(src_dict)
         dataset_id = UUID(d.pop("dataset_id"))
 
-        status = check_vrt_source_health_status(d.pop("status"))
-
         title = d.pop("title")
+
+        status = check_vrt_source_health_status(d.pop("status"))
 
         vrt_source_health = cls(
             dataset_id=dataset_id,
-            status=status,
             title=title,
+            status=status,
         )
 
         vrt_source_health.additional_properties = d

--- a/sdks/python/geolens/models/vrt_source_item.py
+++ b/sdks/python/geolens/models/vrt_source_item.py
@@ -20,37 +20,49 @@ class VrtSourceItem:
     """
     Attributes:
         dataset_id (UUID):
-        position (int):
         title (str):
+        position (int):
         band_count (int | None | Unset):
-        crs_epsg (int | None | Unset):
-        extent_bbox (list[float] | None | Unset):
         resolution_x (float | None | Unset):
         resolution_y (float | None | Unset):
+        crs_epsg (int | None | Unset):
+        extent_bbox (list[float] | None | Unset):
     """
 
     dataset_id: UUID
-    position: int
     title: str
+    position: int
     band_count: int | None | Unset = UNSET
-    crs_epsg: int | None | Unset = UNSET
-    extent_bbox: list[float] | None | Unset = UNSET
     resolution_x: float | None | Unset = UNSET
     resolution_y: float | None | Unset = UNSET
+    crs_epsg: int | None | Unset = UNSET
+    extent_bbox: list[float] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         dataset_id = str(self.dataset_id)
 
-        position = self.position
-
         title = self.title
+
+        position = self.position
 
         band_count: int | None | Unset
         if isinstance(self.band_count, Unset):
             band_count = UNSET
         else:
             band_count = self.band_count
+
+        resolution_x: float | None | Unset
+        if isinstance(self.resolution_x, Unset):
+            resolution_x = UNSET
+        else:
+            resolution_x = self.resolution_x
+
+        resolution_y: float | None | Unset
+        if isinstance(self.resolution_y, Unset):
+            resolution_y = UNSET
+        else:
+            resolution_y = self.resolution_y
 
         crs_epsg: int | None | Unset
         if isinstance(self.crs_epsg, Unset):
@@ -67,37 +79,25 @@ class VrtSourceItem:
         else:
             extent_bbox = self.extent_bbox
 
-        resolution_x: float | None | Unset
-        if isinstance(self.resolution_x, Unset):
-            resolution_x = UNSET
-        else:
-            resolution_x = self.resolution_x
-
-        resolution_y: float | None | Unset
-        if isinstance(self.resolution_y, Unset):
-            resolution_y = UNSET
-        else:
-            resolution_y = self.resolution_y
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "dataset_id": dataset_id,
-                "position": position,
                 "title": title,
+                "position": position,
             }
         )
         if band_count is not UNSET:
             field_dict["band_count"] = band_count
-        if crs_epsg is not UNSET:
-            field_dict["crs_epsg"] = crs_epsg
-        if extent_bbox is not UNSET:
-            field_dict["extent_bbox"] = extent_bbox
         if resolution_x is not UNSET:
             field_dict["resolution_x"] = resolution_x
         if resolution_y is not UNSET:
             field_dict["resolution_y"] = resolution_y
+        if crs_epsg is not UNSET:
+            field_dict["crs_epsg"] = crs_epsg
+        if extent_bbox is not UNSET:
+            field_dict["extent_bbox"] = extent_bbox
 
         return field_dict
 
@@ -106,9 +106,9 @@ class VrtSourceItem:
         d = dict(src_dict)
         dataset_id = UUID(d.pop("dataset_id"))
 
-        position = d.pop("position")
-
         title = d.pop("title")
+
+        position = d.pop("position")
 
         def _parse_band_count(data: object) -> int | None | Unset:
             if data is None:
@@ -118,6 +118,24 @@ class VrtSourceItem:
             return cast(int | None | Unset, data)
 
         band_count = _parse_band_count(d.pop("band_count", UNSET))
+
+        def _parse_resolution_x(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        resolution_x = _parse_resolution_x(d.pop("resolution_x", UNSET))
+
+        def _parse_resolution_y(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        resolution_y = _parse_resolution_y(d.pop("resolution_y", UNSET))
 
         def _parse_crs_epsg(data: object) -> int | None | Unset:
             if data is None:
@@ -145,33 +163,15 @@ class VrtSourceItem:
 
         extent_bbox = _parse_extent_bbox(d.pop("extent_bbox", UNSET))
 
-        def _parse_resolution_x(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        resolution_x = _parse_resolution_x(d.pop("resolution_x", UNSET))
-
-        def _parse_resolution_y(data: object) -> float | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(float | None | Unset, data)
-
-        resolution_y = _parse_resolution_y(d.pop("resolution_y", UNSET))
-
         vrt_source_item = cls(
             dataset_id=dataset_id,
-            position=position,
             title=title,
+            position=position,
             band_count=band_count,
-            crs_epsg=crs_epsg,
-            extent_bbox=extent_bbox,
             resolution_x=resolution_x,
             resolution_y=resolution_y,
+            crs_epsg=crs_epsg,
+            extent_bbox=extent_bbox,
         )
 
         vrt_source_item.additional_properties = d

--- a/sdks/python/geolens/models/vrt_status_response.py
+++ b/sdks/python/geolens/models/vrt_status_response.py
@@ -26,22 +26,24 @@ T = TypeVar("T", bound="VrtStatusResponse")
 class VrtStatusResponse:
     """
     Attributes:
+        status (VrtStatusResponseStatus):
         source_count (int):
         source_health (list[VrtSourceHealth]):
-        status (VrtStatusResponseStatus):
-        active_generation (None | Unset | VrtActiveGeneration):
         last_generation_at (datetime.datetime | None | Unset):
+        active_generation (None | Unset | VrtActiveGeneration):
     """
 
+    status: VrtStatusResponseStatus
     source_count: int
     source_health: list[VrtSourceHealth]
-    status: VrtStatusResponseStatus
-    active_generation: None | Unset | VrtActiveGeneration = UNSET
     last_generation_at: datetime.datetime | None | Unset = UNSET
+    active_generation: None | Unset | VrtActiveGeneration = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.vrt_active_generation import VrtActiveGeneration
+
+        status: str = self.status
 
         source_count = self.source_count
 
@@ -49,16 +51,6 @@ class VrtStatusResponse:
         for source_health_item_data in self.source_health:
             source_health_item = source_health_item_data.to_dict()
             source_health.append(source_health_item)
-
-        status: str = self.status
-
-        active_generation: dict[str, Any] | None | Unset
-        if isinstance(self.active_generation, Unset):
-            active_generation = UNSET
-        elif isinstance(self.active_generation, VrtActiveGeneration):
-            active_generation = self.active_generation.to_dict()
-        else:
-            active_generation = self.active_generation
 
         last_generation_at: None | str | Unset
         if isinstance(self.last_generation_at, Unset):
@@ -68,19 +60,27 @@ class VrtStatusResponse:
         else:
             last_generation_at = self.last_generation_at
 
+        active_generation: dict[str, Any] | None | Unset
+        if isinstance(self.active_generation, Unset):
+            active_generation = UNSET
+        elif isinstance(self.active_generation, VrtActiveGeneration):
+            active_generation = self.active_generation.to_dict()
+        else:
+            active_generation = self.active_generation
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "status": status,
                 "source_count": source_count,
                 "source_health": source_health,
-                "status": status,
             }
         )
-        if active_generation is not UNSET:
-            field_dict["active_generation"] = active_generation
         if last_generation_at is not UNSET:
             field_dict["last_generation_at"] = last_generation_at
+        if active_generation is not UNSET:
+            field_dict["active_generation"] = active_generation
 
         return field_dict
 
@@ -90,6 +90,8 @@ class VrtStatusResponse:
         from ..models.vrt_source_health import VrtSourceHealth
 
         d = dict(src_dict)
+        status = check_vrt_status_response_status(d.pop("status"))
+
         source_count = d.pop("source_count")
 
         source_health = []
@@ -98,27 +100,6 @@ class VrtStatusResponse:
             source_health_item = VrtSourceHealth.from_dict(source_health_item_data)
 
             source_health.append(source_health_item)
-
-        status = check_vrt_status_response_status(d.pop("status"))
-
-        def _parse_active_generation(
-            data: object,
-        ) -> None | Unset | VrtActiveGeneration:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                active_generation_type_0 = VrtActiveGeneration.from_dict(data)
-
-                return active_generation_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | Unset | VrtActiveGeneration, data)
-
-        active_generation = _parse_active_generation(d.pop("active_generation", UNSET))
 
         def _parse_last_generation_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -139,12 +120,31 @@ class VrtStatusResponse:
             d.pop("last_generation_at", UNSET)
         )
 
+        def _parse_active_generation(
+            data: object,
+        ) -> None | Unset | VrtActiveGeneration:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                active_generation_type_0 = VrtActiveGeneration.from_dict(data)
+
+                return active_generation_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | VrtActiveGeneration, data)
+
+        active_generation = _parse_active_generation(d.pop("active_generation", UNSET))
+
         vrt_status_response = cls(
+            status=status,
             source_count=source_count,
             source_health=source_health,
-            status=status,
-            active_generation=active_generation,
             last_generation_at=last_generation_at,
+            active_generation=active_generation,
         )
 
         vrt_status_response.additional_properties = d

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -34,12 +34,6 @@ export type AiProbeCheck = {
      */
     configured: boolean;
     /**
-     * Error
-     *
-     * Short sanitized failure reason. Never contains the key or raw provider error bodies.
-     */
-    error?: string | null;
-    /**
      * Ok
      *
      * Whether the live provider call succeeded. None when not configured (no call was made).
@@ -51,6 +45,12 @@ export type AiProbeCheck = {
      * HTTP status returned by the provider on failure, when available.
      */
     status?: number | null;
+    /**
+     * Error
+     *
+     * Short sanitized failure reason. Never contains the key or raw provider error bodies.
+     */
+    error?: string | null;
 };
 
 /**
@@ -68,23 +68,11 @@ export type AiProbeReport = {
  */
 export type AiStatusResponse = {
     /**
-     * Configured
+     * Provider
      *
-     * Whether an API key is configured. AI features require both 'enabled' and 'configured'.
+     * Active AI provider name (e.g. 'anthropic', 'openai').
      */
-    configured: boolean;
-    /**
-     * Enabled
-     *
-     * Whether AI features are enabled for this instance.
-     */
-    enabled: boolean;
-    /**
-     * Has Embeddings
-     *
-     * Whether at least one record has embeddings stored.
-     */
-    has_embeddings?: boolean;
+    provider: string | null;
     /**
      * Model
      *
@@ -92,21 +80,33 @@ export type AiStatusResponse = {
      */
     model: string | null;
     /**
-     * Live provider probe results. Only present when the request opted in via ?probe=true.
-     */
-    probe?: AiProbeReport | null;
-    /**
-     * Provider
+     * Enabled
      *
-     * Active AI provider name (e.g. 'anthropic', 'openai').
+     * Whether AI features are enabled for this instance.
      */
-    provider: string | null;
+    enabled: boolean;
+    /**
+     * Configured
+     *
+     * Whether an API key is configured. AI features require both 'enabled' and 'configured'.
+     */
+    configured: boolean;
     /**
      * Semantic Search Enabled
      *
      * Whether pgvector-backed semantic search is enabled.
      */
     semantic_search_enabled?: boolean;
+    /**
+     * Has Embeddings
+     *
+     * Whether at least one record has embeddings stored.
+     */
+    has_embeddings?: boolean;
+    /**
+     * Live provider probe results. Only present when the request opted in via ?probe=true.
+     */
+    probe?: AiProbeReport | null;
 };
 
 /**
@@ -143,11 +143,11 @@ export type AddDatasetsResponse = {
  */
 export type AdminApiKeyCreateRequest = {
     /**
-     * Expires At
+     * User Id
      *
-     * Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
+     * ID of the user the new API key will belong to.
      */
-    expires_at?: string | null;
+    user_id: string;
     /**
      * Name
      *
@@ -155,17 +155,17 @@ export type AdminApiKeyCreateRequest = {
      */
     name: string;
     /**
+     * Expires At
+     *
+     * Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
+     */
+    expires_at?: string | null;
+    /**
      * Scope
      *
      * Privilege scope (#875). 'full' impersonates the owner completely, the pre-existing behavior. 'read_only' authenticates GET, HEAD and OPTIONS requests only; any other method is refused with 403. A service-account key minted for an application is the usual case for 'read_only'.
      */
     scope?: 'full' | 'read_only';
-    /**
-     * User Id
-     *
-     * ID of the user the new API key will belong to.
-     */
-    user_id: string;
 };
 
 /**
@@ -173,41 +173,17 @@ export type AdminApiKeyCreateRequest = {
  */
 export type AdminApiKeyListItem = {
     /**
-     * Created At
-     *
-     * Timestamp when the key was created.
-     */
-    created_at: string;
-    /**
-     * Expires At
-     *
-     * Expiry timestamp; null means the key does not expire.
-     */
-    expires_at?: string | null;
-    /**
-     * Fingerprint
-     *
-     * Non-secret key identifier; null for legacy keys.
-     */
-    fingerprint: string | null;
-    /**
      * Id
      *
      * Unique API key identifier.
      */
     id: string;
     /**
-     * Is Active
+     * User Id
      *
-     * Whether the key is active. Inactive keys cannot authenticate.
+     * Owning user's ID.
      */
-    is_active: boolean;
-    /**
-     * Last Used At
-     *
-     * Timestamp of the most recent successful authentication using this key.
-     */
-    last_used_at: string | null;
+    user_id: string;
     /**
      * Name
      *
@@ -215,17 +191,41 @@ export type AdminApiKeyListItem = {
      */
     name: string;
     /**
+     * Fingerprint
+     *
+     * Non-secret key identifier; null for legacy keys.
+     */
+    fingerprint: string | null;
+    /**
+     * Is Active
+     *
+     * Whether the key is active. Inactive keys cannot authenticate.
+     */
+    is_active: boolean;
+    /**
+     * Expires At
+     *
+     * Expiry timestamp; null means the key does not expire.
+     */
+    expires_at?: string | null;
+    /**
      * Scope
      *
      * Privilege scope: 'full' or 'read_only' (#875).
      */
     scope: string;
     /**
-     * User Id
+     * Created At
      *
-     * Owning user's ID.
+     * Timestamp when the key was created.
      */
-    user_id: string;
+    created_at: string;
+    /**
+     * Last Used At
+     *
+     * Timestamp of the most recent successful authentication using this key.
+     */
+    last_used_at: string | null;
 };
 
 /**
@@ -265,57 +265,57 @@ export type AdminEmbedTokenListResponse = {
  */
 export type AdminEmbedTokenResponse = {
     /**
-     * Allowed Origins
-     */
-    allowed_origins?: Array<string> | null;
-    /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Creator Username
-     */
-    creator_username?: string | null;
-    /**
-     * Expires At
-     */
-    expires_at: string;
-    /**
      * Id
      */
     id: string;
-    /**
-     * Is Active
-     */
-    is_active: boolean;
-    /**
-     * Last Used At
-     */
-    last_used_at?: string | null;
     /**
      * Map Id
      */
     map_id: string;
     /**
-     * Map Name
-     */
-    map_name?: string | null;
-    /**
      * Name
      */
     name?: string | null;
-    /**
-     * Scoped Dataset Ids
-     */
-    scoped_dataset_ids: Array<string>;
     /**
      * Token Hint
      */
     token_hint: string;
     /**
+     * Scoped Dataset Ids
+     */
+    scoped_dataset_ids: Array<string>;
+    /**
+     * Allowed Origins
+     */
+    allowed_origins?: Array<string> | null;
+    /**
+     * Expires At
+     */
+    expires_at: string;
+    /**
+     * Is Active
+     */
+    is_active: boolean;
+    /**
      * Use Count
      */
     use_count?: number;
+    /**
+     * Last Used At
+     */
+    last_used_at?: string | null;
+    /**
+     * Created At
+     */
+    created_at: string;
+    /**
+     * Map Name
+     */
+    map_name?: string | null;
+    /**
+     * Creator Username
+     */
+    creator_username?: string | null;
 };
 
 /**
@@ -341,29 +341,23 @@ export type AdminJobListResponse = {
  */
 export type AdminJobResponse = {
     /**
-     * Can Retry
+     * Id
      *
-     * Whether the failed job can be retried with its retained source.
+     * Unique ingestion job identifier.
      */
-    can_retry: boolean;
+    id: string;
     /**
-     * Completed At
+     * Status
      *
-     * Timestamp when the job finished (success or failure).
+     * Current job status: 'pending', 'running', 'complete', 'failed', or 'cancelled'.
      */
-    completed_at: string | null;
+    status: 'pending' | 'running' | 'complete' | 'failed' | 'cancelled' | 'fanned_out';
     /**
-     * Created At
+     * Source Filename
      *
-     * Timestamp when the job was queued.
+     * Original filename of the uploaded file, if applicable.
      */
-    created_at: string;
-    /**
-     * Created By
-     *
-     * ID of the user who initiated the job.
-     */
-    created_by: string | null;
+    source_filename: string | null;
     /**
      * Dataset Id
      *
@@ -377,35 +371,17 @@ export type AdminJobResponse = {
      */
     error_message: string | null;
     /**
-     * Id
+     * Can Retry
      *
-     * Unique ingestion job identifier.
+     * Whether the failed job can be retried with its retained source.
      */
-    id: string;
+    can_retry: boolean;
     /**
      * Retry Reason
      *
      * Why the job cannot be retried, when retry is unavailable.
      */
     retry_reason: string | null;
-    /**
-     * Source Filename
-     *
-     * Original filename of the uploaded file, if applicable.
-     */
-    source_filename: string | null;
-    /**
-     * Started At
-     *
-     * Timestamp when the worker began processing the job.
-     */
-    started_at: string | null;
-    /**
-     * Status
-     *
-     * Current job status: 'pending', 'running', 'complete', 'failed', or 'cancelled'.
-     */
-    status: 'pending' | 'running' | 'complete' | 'failed' | 'cancelled' | 'fanned_out';
     /**
      * User Metadata
      *
@@ -415,11 +391,35 @@ export type AdminJobResponse = {
         [key: string]: unknown;
     } | null;
     /**
+     * Created By
+     *
+     * ID of the user who initiated the job.
+     */
+    created_by: string | null;
+    /**
      * Username
      *
      * Username of the user who initiated the job.
      */
     username: string | null;
+    /**
+     * Started At
+     *
+     * Timestamp when the worker began processing the job.
+     */
+    started_at: string | null;
+    /**
+     * Completed At
+     *
+     * Timestamp when the job finished (success or failure).
+     */
+    completed_at: string | null;
+    /**
+     * Created At
+     *
+     * Timestamp when the job was queued.
+     */
+    created_at: string;
 };
 
 /**
@@ -441,29 +441,9 @@ export type AdminShareTokenListResponse = {
  */
 export type AdminShareTokenResponse = {
     /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Created By
-     */
-    created_by: string | null;
-    /**
-     * Embed Token Count
-     */
-    embed_token_count?: number;
-    /**
-     * Expires At
-     */
-    expires_at?: string | null;
-    /**
      * Id
      */
     id?: string | null;
-    /**
-     * Is Active
-     */
-    is_active?: boolean | null;
     /**
      * Map Id
      */
@@ -476,6 +456,26 @@ export type AdminShareTokenResponse = {
      * Token
      */
     token?: string | null;
+    /**
+     * Is Active
+     */
+    is_active?: boolean | null;
+    /**
+     * Expires At
+     */
+    expires_at?: string | null;
+    /**
+     * Created At
+     */
+    created_at: string;
+    /**
+     * Created By
+     */
+    created_by: string | null;
+    /**
+     * Embed Token Count
+     */
+    embed_token_count?: number;
 };
 
 /**
@@ -483,11 +483,11 @@ export type AdminShareTokenResponse = {
  */
 export type AdminUserCreate = {
     /**
-     * Email
+     * Username
      *
-     * Optional email address. Used for OAuth account linking and notifications.
+     * Login username (3-150 chars). Must be unique across the system.
      */
-    email?: string | null;
+    username: string;
     /**
      * Password
      *
@@ -495,17 +495,17 @@ export type AdminUserCreate = {
      */
     password: string;
     /**
+     * Email
+     *
+     * Optional email address. Used for OAuth account linking and notifications.
+     */
+    email?: string | null;
+    /**
      * Role
      *
      * User role: 'admin', 'editor', or 'viewer'. Defaults to 'viewer'.
      */
     role?: string;
-    /**
-     * Username
-     *
-     * Login username (3-150 chars). Must be unique across the system.
-     */
-    username: string;
 };
 
 /**
@@ -527,29 +527,19 @@ export type AlterColumnTypeRequest = {
  */
 export type AnalysisMaterializeRequest = {
     /**
-     * By Field
-     *
-     * Optional group-by column for dissolve
+     * Operation
      */
-    by_field?: string | null;
+    operation: 'buffer' | 'centroid' | 'clip' | 'dissolve' | 'spatial_join' | 'measure' | 'select_by_location' | 'intersect';
+    /**
+     * Title
+     */
+    title: string;
     /**
      * Distance Meters
      *
      * Buffer distance in meters (buffer only)
      */
     distance_meters?: number | null;
-    /**
-     * Join Dataset Id
-     *
-     * Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
-     */
-    join_dataset_id?: string | null;
-    /**
-     * Join Fields
-     *
-     * Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
-     */
-    join_fields?: Array<string> | null;
     /**
      * Mask
      *
@@ -565,13 +555,23 @@ export type AnalysisMaterializeRequest = {
      */
     mask_dataset_id?: string | null;
     /**
-     * Operation
+     * By Field
+     *
+     * Optional group-by column for dissolve
      */
-    operation: 'buffer' | 'centroid' | 'clip' | 'dissolve' | 'spatial_join' | 'measure' | 'select_by_location' | 'intersect';
+    by_field?: string | null;
     /**
-     * Title
+     * Join Dataset Id
+     *
+     * Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
      */
-    title: string;
+    join_dataset_id?: string | null;
+    /**
+     * Join Fields
+     *
+     * Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
+     */
+    join_fields?: Array<string> | null;
 };
 
 /**
@@ -600,29 +600,15 @@ export type AnalysisMaterializeResponse = {
  */
 export type AnalysisPreviewRequest = {
     /**
-     * Bbox
-     *
-     * [minx, miny, maxx, maxy] in EPSG:4326, typically the map's current viewport. When present, only source features intersecting the envelope are considered before the preview's row cap applies, so a capped result reflects what is on screen rather than an arbitrary sample in ingest order (fix(#727)). Applies to every operation, not just one, so it is deliberately absent from _ANALYSIS_PARAM_OWNERS — omit it to preview the whole dataset, unchanged from before this field existed.
+     * Operation
      */
-    bbox?: Array<number> | null;
+    operation: 'buffer' | 'centroid' | 'clip' | 'spatial_join' | 'measure' | 'select_by_location' | 'intersect';
     /**
      * Distance Meters
      *
      * Buffer distance in meters (buffer only)
      */
     distance_meters?: number | null;
-    /**
-     * Join Dataset Id
-     *
-     * Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
-     */
-    join_dataset_id?: string | null;
-    /**
-     * Join Fields
-     *
-     * Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
-     */
-    join_fields?: Array<string> | null;
     /**
      * Mask
      *
@@ -638,9 +624,23 @@ export type AnalysisPreviewRequest = {
      */
     mask_dataset_id?: string | null;
     /**
-     * Operation
+     * Join Dataset Id
+     *
+     * Dataset to join against; each source feature gains a count of the features from it that intersect (spatial_join only)
      */
-    operation: 'buffer' | 'centroid' | 'clip' | 'spatial_join' | 'measure' | 'select_by_location' | 'intersect';
+    join_dataset_id?: string | null;
+    /**
+     * Join Fields
+     *
+     * Columns to copy from the intersecting join feature, prefixed 'join_' in the output. Ties break on the lowest join-layer gid (spatial_join only)
+     */
+    join_fields?: Array<string> | null;
+    /**
+     * Bbox
+     *
+     * [minx, miny, maxx, maxy] in EPSG:4326, typically the map's current viewport. When present, only source features intersecting the envelope are considered before the preview's row cap applies, so a capped result reflects what is on screen rather than an arbitrary sample in ingest order (fix(#727)). Applies to every operation, not just one, so it is deliberately absent from _ANALYSIS_PARAM_OWNERS — omit it to preview the whole dataset, unchanged from before this field existed.
+     */
+    bbox?: Array<number> | null;
 };
 
 /**
@@ -650,25 +650,23 @@ export type AnalysisPreviewRequest = {
  */
 export type AnalysisPreviewResponse = {
     /**
-     * Bbox
-     */
-    bbox?: Array<number> | null;
-    /**
-     * Feature Count
-     */
-    feature_count: number;
-    /**
      * Geojson
      */
     geojson: {
         [key: string]: unknown;
     };
     /**
-     * Match Count
-     *
-     * Exact total across the WHOLE source, not just the previewed features — WHOLE meaning the request's bbox when one was sent, the same sense source_feature_count uses that word. What it counts is per-operation, so read it against the operation you sent rather than as one number: select_by_location gives the selected source features and intersect gives the output pieces, and for both of those it IS the output total; spatial_join gives intersecting source/join PAIRS, which is NOT the output total, because the join keeps every source row (use source_feature_count for that operation). intersect and spatial_join both scope this total to a bbox on the request; select_by_location's count is a separate uncapped query the request's bbox does not reach, so it stays unscoped even though its preview rows are viewport-limited too. Null for operations that report no such total, and when the count could not be computed within the query budget
+     * Feature Count
      */
-    match_count?: number | null;
+    feature_count: number;
+    /**
+     * Truncated
+     */
+    truncated: boolean;
+    /**
+     * Bbox
+     */
+    bbox?: Array<number> | null;
     /**
      * Source Feature Count
      *
@@ -676,9 +674,11 @@ export type AnalysisPreviewResponse = {
      */
     source_feature_count?: number | null;
     /**
-     * Truncated
+     * Match Count
+     *
+     * Exact total across the WHOLE source, not just the previewed features — WHOLE meaning the request's bbox when one was sent, the same sense source_feature_count uses that word. What it counts is per-operation, so read it against the operation you sent rather than as one number: select_by_location gives the selected source features and intersect gives the output pieces, and for both of those it IS the output total; spatial_join gives intersecting source/join PAIRS, which is NOT the output total, because the join keeps every source row (use source_feature_count for that operation). intersect and spatial_join both scope this total to a bbox on the request; select_by_location's count is a separate uncapped query the request's bbox does not reach, so it stays unscoped even though its preview rows are viewport-limited too. Null for operations that report no such total, and when the count could not be computed within the query budget
      */
-    truncated: boolean;
+    match_count?: number | null;
 };
 
 /**
@@ -686,17 +686,17 @@ export type AnalysisPreviewResponse = {
  */
 export type ApiKeyCreateRequest = {
     /**
-     * Expires At
-     *
-     * Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
-     */
-    expires_at?: string | null;
-    /**
      * Name
      *
      * Human-readable label for the API key
      */
     name: string;
+    /**
+     * Expires At
+     *
+     * Optional expiry timestamp (RFC 3339, timezone-aware). Omit or null for a non-expiring key; expired keys stop authenticating.
+     */
+    expires_at?: string | null;
     /**
      * Scope
      *
@@ -710,22 +710,6 @@ export type ApiKeyCreateRequest = {
  */
 export type ApiKeyCreateResponse = {
     /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Expires At
-     *
-     * Expiry timestamp; null means the key does not expire
-     */
-    expires_at?: string | null;
-    /**
-     * Fingerprint
-     *
-     * Non-secret key identifier (prefix and last four characters)
-     */
-    fingerprint: string;
-    /**
      * Id
      */
     id: string;
@@ -736,25 +720,15 @@ export type ApiKeyCreateResponse = {
      */
     key: string;
     /**
+     * Fingerprint
+     *
+     * Non-secret key identifier (prefix and last four characters)
+     */
+    fingerprint: string;
+    /**
      * Name
      */
     name: string;
-    /**
-     * Scope
-     *
-     * Privilege scope: 'full' or 'read_only' (#875)
-     */
-    scope: string;
-};
-
-/**
- * ApiKeyListItem
- */
-export type ApiKeyListItem = {
-    /**
-     * Created At
-     */
-    created_at: string;
     /**
      * Expires At
      *
@@ -762,33 +736,59 @@ export type ApiKeyListItem = {
      */
     expires_at?: string | null;
     /**
+     * Scope
+     *
+     * Privilege scope: 'full' or 'read_only' (#875)
+     */
+    scope: string;
+    /**
+     * Created At
+     */
+    created_at: string;
+};
+
+/**
+ * ApiKeyListItem
+ */
+export type ApiKeyListItem = {
+    /**
+     * Id
+     */
+    id: string;
+    /**
+     * Name
+     */
+    name: string;
+    /**
      * Fingerprint
      *
      * Non-secret key identifier; null for keys created before fingerprint support
      */
     fingerprint: string | null;
     /**
-     * Id
-     */
-    id: string;
-    /**
      * Is Active
      */
     is_active: boolean;
     /**
-     * Last Used At
+     * Expires At
+     *
+     * Expiry timestamp; null means the key does not expire
      */
-    last_used_at: string | null;
-    /**
-     * Name
-     */
-    name: string;
+    expires_at?: string | null;
     /**
      * Scope
      *
      * Privilege scope: 'full' or 'read_only' (#875)
      */
     scope: string;
+    /**
+     * Created At
+     */
+    created_at: string;
+    /**
+     * Last Used At
+     */
+    last_used_at: string | null;
 };
 
 /**
@@ -856,51 +856,37 @@ export type AttributeMetadataListResponse = {
  */
 export type AttributeMetadataResponse = {
     /**
-     * Data Type
+     * Id
      */
-    data_type: string | null;
+    id: string;
     /**
      * Dataset Id
      */
     dataset_id: string;
     /**
-     * Description
-     */
-    description: string | null;
-    /**
-     * Domain Type
-     */
-    domain_type: string | null;
-    /**
-     * Example Values
-     *
-     * Sample values from the column
-     */
-    example_values?: Array<unknown> | null;
-    /**
      * Field Name
      */
     field_name: string;
     /**
-     * Id
+     * Title
      */
-    id: string;
+    title: string | null;
     /**
-     * Is Current
-     *
-     * False if column was removed in a later version
+     * Description
      */
-    is_current: boolean;
+    description: string | null;
     /**
-     * Is Nullable
+     * Data Type
      */
-    is_nullable?: boolean | null;
+    data_type: string | null;
     /**
-     * Ordinal Position
-     *
-     * Column position in the table (1-based)
+     * Units
      */
-    ordinal_position?: number | null;
+    units: string | null;
+    /**
+     * Domain Type
+     */
+    domain_type: string | null;
     /**
      * Semantic Role
      *
@@ -908,13 +894,27 @@ export type AttributeMetadataResponse = {
      */
     semantic_role?: string | null;
     /**
-     * Title
+     * Example Values
+     *
+     * Sample values from the column
      */
-    title: string | null;
+    example_values?: Array<unknown> | null;
     /**
-     * Units
+     * Ordinal Position
+     *
+     * Column position in the table (1-based)
      */
-    units: string | null;
+    ordinal_position?: number | null;
+    /**
+     * Is Nullable
+     */
+    is_nullable?: boolean | null;
+    /**
+     * Is Current
+     *
+     * False if column was removed in a later version
+     */
+    is_current: boolean;
     /**
      * User Modified Fields
      *
@@ -928,15 +928,21 @@ export type AttributeMetadataResponse = {
  */
 export type AttributeMetadataUpdate = {
     /**
+     * Title
+     *
+     * Human-friendly column display name
+     */
+    title?: string | null;
+    /**
      * Description
      */
     description?: string | null;
     /**
-     * Domain Type
+     * Units
      *
-     * Value domain: continuous, categorical, coded, etc.
+     * Measurement units, e.g. meters, kg
      */
-    domain_type?: 'continuous' | 'discrete' | 'categorical' | 'coded' | 'codedValue' | 'boolean' | 'text' | 'date' | 'temporal' | 'geometry' | 'range' | null;
+    units?: string | null;
     /**
      * Semantic Role
      *
@@ -944,17 +950,11 @@ export type AttributeMetadataUpdate = {
      */
     semantic_role?: 'geometry' | 'identifier' | 'measure' | 'temporal' | 'categorical' | 'category' | 'label' | 'foreign_key' | 'other' | null;
     /**
-     * Title
+     * Domain Type
      *
-     * Human-friendly column display name
+     * Value domain: continuous, categorical, coded, etc.
      */
-    title?: string | null;
-    /**
-     * Units
-     *
-     * Measurement units, e.g. meters, kg
-     */
-    units?: string | null;
+    domain_type?: 'continuous' | 'discrete' | 'categorical' | 'coded' | 'codedValue' | 'boolean' | 'text' | 'date' | 'temporal' | 'geometry' | 'range' | null;
 };
 
 /**
@@ -976,27 +976,25 @@ export type AuditLogListResponse = {
  */
 export type AuditLogResponse = {
     /**
-     * Action
-     */
-    action: string;
-    /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Details
-     */
-    details: {
-        [key: string]: unknown;
-    } | null;
-    /**
      * Id
      */
     id: string;
     /**
-     * Ip Address
+     * User Id
      */
-    ip_address: string | null;
+    user_id: string | null;
+    /**
+     * Username
+     */
+    username?: string | null;
+    /**
+     * Action
+     */
+    action: string;
+    /**
+     * Resource Type
+     */
+    resource_type: string;
     /**
      * Resource Id
      */
@@ -1006,17 +1004,19 @@ export type AuditLogResponse = {
      */
     resource_name?: string | null;
     /**
-     * Resource Type
+     * Details
      */
-    resource_type: string;
+    details: {
+        [key: string]: unknown;
+    } | null;
     /**
-     * User Id
+     * Ip Address
      */
-    user_id: string | null;
+    ip_address: string | null;
     /**
-     * Username
+     * Created At
      */
-    username?: string | null;
+    created_at: string;
 };
 
 /**
@@ -1024,29 +1024,29 @@ export type AuditLogResponse = {
  */
 export type BackfillResponse = {
     /**
-     * Created
-     *
-     * Number of new embeddings created.
-     */
-    created: number;
-    /**
-     * Errors
-     *
-     * Number of records that failed during embedding generation.
-     */
-    errors: number;
-    /**
      * Processed
      *
      * Number of records processed in this backfill batch.
      */
     processed: number;
     /**
+     * Created
+     *
+     * Number of new embeddings created.
+     */
+    created: number;
+    /**
      * Skipped
      *
      * Number of records skipped because an embedding already existed.
      */
     skipped: number;
+    /**
+     * Errors
+     *
+     * Number of records that failed during embedding generation.
+     */
+    errors: number;
 };
 
 /**
@@ -1054,15 +1054,13 @@ export type BackfillResponse = {
  */
 export type BasemapConfig = {
     /**
-     * Background Color
-     *
-     * Map canvas background color in #RRGGBB hex format, or null to use the basemap default.
+     * Basemap label prominence.
      */
-    background_color?: string | null;
+    label_mode?: BasemapLabelMode;
     /**
-     * Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no migration).
+     * Road and transit sublayer visibility where supported.
      */
-    basemap_position?: BasemapPosition | null;
+    road_visibility?: BasemapSublayerVisibility;
     /**
      * Administrative boundary sublayer visibility where supported.
      */
@@ -1074,13 +1072,13 @@ export type BasemapConfig = {
      */
     building_visibility?: boolean;
     /**
-     * Basemap label prominence.
-     */
-    label_mode?: BasemapLabelMode;
-    /**
      * Land and water color treatment where supported.
      */
     land_water_tone?: BasemapLandWaterTone;
+    /**
+     * Optional contrast hint for relief-oriented basemap styling.
+     */
+    relief_contrast?: BasemapReliefContrast | null;
     /**
      * Opacity
      *
@@ -1088,17 +1086,11 @@ export type BasemapConfig = {
      */
     opacity?: number;
     /**
-     * Map projection: 'mercator' (default) or experimental 'globe'. null/undefined loads as 'mercator' on the client.
+     * Background Color
+     *
+     * Map canvas background color in #RRGGBB hex format, or null to use the basemap default.
      */
-    projection?: BasemapProjection | null;
-    /**
-     * Optional contrast hint for relief-oriented basemap styling.
-     */
-    relief_contrast?: BasemapReliefContrast | null;
-    /**
-     * Road and transit sublayer visibility where supported.
-     */
-    road_visibility?: BasemapSublayerVisibility;
+    background_color?: string | null;
     /**
      * Sublayer Overrides
      *
@@ -1107,6 +1099,14 @@ export type BasemapConfig = {
     sublayer_overrides?: {
         [key: string]: SublayerOverride;
     } | null;
+    /**
+     * Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no migration).
+     */
+    basemap_position?: BasemapPosition | null;
+    /**
+     * Map projection: 'mercator' (default) or experimental 'globe'. null/undefined loads as 'mercator' on the client.
+     */
+    projection?: BasemapProjection | null;
 };
 
 /**
@@ -1140,29 +1140,11 @@ export type BasemapProjection = 'mercator' | 'globe';
  */
 export type BasemapPublicResponse = {
     /**
-     * Attribution
-     *
-     * Attribution string for the basemap source.
-     */
-    attribution?: string | null;
-    /**
-     * Enabled
-     *
-     * Whether the basemap is currently selectable.
-     */
-    enabled: boolean;
-    /**
      * Id
      *
      * Unique basemap identifier.
      */
     id: string;
-    /**
-     * Is Preset
-     *
-     * Whether this is a built-in preset.
-     */
-    is_preset: boolean;
     /**
      * Label
      *
@@ -1175,6 +1157,24 @@ export type BasemapPublicResponse = {
      * Tile URL or style JSON URL with API key already substituted (or omitted) for client use.
      */
     url: string;
+    /**
+     * Enabled
+     *
+     * Whether the basemap is currently selectable.
+     */
+    enabled: boolean;
+    /**
+     * Is Preset
+     *
+     * Whether this is a built-in preset.
+     */
+    is_preset: boolean;
+    /**
+     * Attribution
+     *
+     * Attribution string for the basemap source.
+     */
+    attribution?: string | null;
 };
 
 /**
@@ -1192,17 +1192,13 @@ export type BasemapSublayerVisibility = 'full' | 'subtle' | 'hidden';
  */
 export type BodyLoginAuthLoginPost = {
     /**
-     * Client Id
-     */
-    client_id?: string | null;
-    /**
-     * Client Secret
-     */
-    client_secret?: string | null;
-    /**
      * Grant Type
      */
     grant_type?: string | null;
+    /**
+     * Username
+     */
+    username: string;
     /**
      * Password
      */
@@ -1212,9 +1208,13 @@ export type BodyLoginAuthLoginPost = {
      */
     scope?: string;
     /**
-     * Username
+     * Client Id
      */
-    username: string;
+    client_id?: string | null;
+    /**
+     * Client Secret
+     */
+    client_secret?: string | null;
 };
 
 /**
@@ -1266,13 +1266,13 @@ export type BrandingResponse = {
  */
 export type BulkDeleteItem = {
     /**
-     * Confirm Title
-     */
-    confirm_title: string;
-    /**
      * Dataset Id
      */
     dataset_id: string;
+    /**
+     * Confirm Title
+     */
+    confirm_title: string;
 };
 
 /**
@@ -1360,25 +1360,19 @@ export type BulkDeleteResultItem = {
      */
     dataset_id: string;
     /**
-     * Detail
-     */
-    detail?: string | null;
-    /**
      * Status
      */
     status: string;
+    /**
+     * Detail
+     */
+    detail?: string | null;
 };
 
 /**
  * BulkRegisterItem
  */
 export type BulkRegisterItem = {
-    /**
-     * Summary
-     *
-     * Optional dataset description.
-     */
-    summary?: string | null;
     /**
      * Table Name
      *
@@ -1391,6 +1385,12 @@ export type BulkRegisterItem = {
      * Human-readable dataset title.
      */
     title: string;
+    /**
+     * Summary
+     *
+     * Optional dataset description.
+     */
+    summary?: string | null;
     /**
      * Visibility
      *
@@ -1428,17 +1428,11 @@ export type BulkRegisterResponse = {
  */
 export type BulkRegisterResult = {
     /**
-     * Dataset Id
+     * Table Name
      *
-     * ID of the created dataset on success.
+     * Source table that was processed.
      */
-    dataset_id?: string | null;
-    /**
-     * Error
-     *
-     * Error message on failure.
-     */
-    error?: string | null;
+    table_name: string;
     /**
      * Status
      *
@@ -1446,17 +1440,23 @@ export type BulkRegisterResult = {
      */
     status: string;
     /**
-     * Table Name
+     * Dataset Id
      *
-     * Source table that was processed.
+     * ID of the created dataset on success.
      */
-    table_name: string;
+    dataset_id?: string | null;
     /**
      * Title
      *
      * Title of the created dataset on success.
      */
     title?: string | null;
+    /**
+     * Error
+     *
+     * Error message on failure.
+     */
+    error?: string | null;
 };
 
 /**
@@ -1484,6 +1484,24 @@ export type BulkRevokeResponse = {
  */
 export type CatalogStatsResponse = {
     /**
+     * Total Datasets
+     *
+     * Total number of datasets in the catalog.
+     */
+    total_datasets: number;
+    /**
+     * Recent Additions
+     *
+     * Number of datasets added in the last 30 days.
+     */
+    recent_additions: number;
+    /**
+     * Total Storage Bytes
+     *
+     * Total storage used by all dataset tables, in bytes. Null if calculation is unavailable.
+     */
+    total_storage_bytes: number | null;
+    /**
      * Datasets By Geometry Type
      *
      * Histogram of datasets keyed by geometry type (Point, MultiPolygon, etc.).
@@ -1500,30 +1518,6 @@ export type CatalogStatsResponse = {
         [key: string]: number;
     };
     /**
-     * Recent Additions
-     *
-     * Number of datasets added in the last 30 days.
-     */
-    recent_additions: number;
-    /**
-     * Total Datasets
-     *
-     * Total number of datasets in the catalog.
-     */
-    total_datasets: number;
-    /**
-     * Total Storage Bytes
-     *
-     * Total storage used by all dataset tables, in bytes. Null if calculation is unavailable.
-     */
-    total_storage_bytes: number | null;
-    /**
-     * Total Users
-     *
-     * Total number of users in the system.
-     */
-    total_users?: number;
-    /**
      * Users By Status
      *
      * Histogram of users keyed by status (active, deactivated, pending).
@@ -1531,6 +1525,12 @@ export type CatalogStatsResponse = {
     users_by_status?: {
         [key: string]: number;
     };
+    /**
+     * Total Users
+     *
+     * Total number of users in the system.
+     */
+    total_users?: number;
 };
 
 /**
@@ -1554,17 +1554,43 @@ export type ChangePasswordRequest = {
  */
 export type ChatAction = {
     /**
-     * Bbox
+     * Type
      */
-    bbox?: Array<number> | null;
+    type: 'set_filter' | 'set_style' | 'set_data_driven_style' | 'set_label' | 'toggle_visibility' | 'add_layer' | 'remove_layer' | 'show_query_result' | 'set_opacity';
+    /**
+     * Layer Id
+     */
+    layer_id?: string | null;
+    /**
+     * Expression
+     */
+    expression?: Array<unknown> | null;
+    /**
+     * Paint
+     */
+    paint?: {
+        [key: string]: unknown;
+    } | null;
     /**
      * Clear Paint
      */
     clear_paint?: Array<string> | null;
     /**
-     * Columns
+     * Replace Paint
      */
-    columns?: Array<string> | null;
+    replace_paint?: boolean | null;
+    /**
+     * Style Config
+     */
+    style_config?: {
+        [key: string]: unknown;
+    } | null;
+    /**
+     * Label Config
+     */
+    label_config?: {
+        [key: string]: unknown;
+    } | null;
     /**
      * Dataset Id
      */
@@ -1574,68 +1600,42 @@ export type ChatAction = {
      */
     dataset_name?: string | null;
     /**
-     * Distance Meters
+     * Visible
      */
-    distance_meters?: number | null;
-    /**
-     * Expression
-     */
-    expression?: Array<unknown> | null;
-    geojson?: GeoJsonFeatureCollection | null;
-    /**
-     * Label Config
-     */
-    label_config?: {
-        [key: string]: unknown;
-    } | null;
-    /**
-     * Layer Id
-     */
-    layer_id?: string | null;
+    visible?: boolean | null;
     /**
      * Opacity
      */
     opacity?: number | null;
+    geojson?: GeoJsonFeatureCollection | null;
     /**
-     * Operation
+     * Bbox
      */
-    operation?: string | null;
-    /**
-     * Paint
-     */
-    paint?: {
-        [key: string]: unknown;
-    } | null;
-    /**
-     * Replace Paint
-     */
-    replace_paint?: boolean | null;
-    /**
-     * Row Count
-     */
-    row_count?: number | null;
+    bbox?: Array<number> | null;
     /**
      * Rows
      */
     rows?: Array<Array<unknown>> | null;
     /**
-     * Style Config
+     * Columns
      */
-    style_config?: {
-        [key: string]: unknown;
-    } | null;
+    columns?: Array<string> | null;
+    /**
+     * Row Count
+     */
+    row_count?: number | null;
     /**
      * Truncated
      */
     truncated?: boolean | null;
     /**
-     * Type
+     * Operation
      */
-    type: 'set_filter' | 'set_style' | 'set_data_driven_style' | 'set_label' | 'toggle_visibility' | 'add_layer' | 'remove_layer' | 'show_query_result' | 'set_opacity';
+    operation?: string | null;
     /**
-     * Visible
+     * Distance Meters
      */
-    visible?: boolean | null;
+    distance_meters?: number | null;
 };
 
 /**
@@ -1645,13 +1645,13 @@ export type ChatAction = {
  */
 export type ChatHistoryMessage = {
     /**
-     * Content
-     */
-    content: string;
-    /**
      * Role
      */
     role: 'user' | 'assistant';
+    /**
+     * Content
+     */
+    content: string;
 };
 
 /**
@@ -1661,11 +1661,13 @@ export type ChatHistoryMessage = {
  */
 export type ChatMapLayer = {
     /**
-     * Column Info
+     * Id
      */
-    column_info?: Array<{
-        [key: string]: unknown;
-    }> | null;
+    id: string;
+    /**
+     * Name
+     */
+    name: string;
     /**
      * Dataset Id
      */
@@ -1675,6 +1677,20 @@ export type ChatMapLayer = {
      */
     dataset_table_name: string;
     /**
+     * Geometry Type
+     */
+    geometry_type?: string | null;
+    /**
+     * Layer Type
+     */
+    layer_type?: string | null;
+    /**
+     * Column Info
+     */
+    column_info?: Array<{
+        [key: string]: unknown;
+    }> | null;
+    /**
      * Dataset Title
      */
     dataset_title?: string | null;
@@ -1683,43 +1699,25 @@ export type ChatMapLayer = {
      */
     feature_count?: number | null;
     /**
+     * Sample Values
+     */
+    sample_values?: {
+        [key: string]: unknown;
+    } | null;
+    /**
+     * Visible
+     */
+    visible?: boolean;
+    /**
      * Filter
      */
     filter?: Array<unknown> | {
         [key: string]: unknown;
     } | null;
     /**
-     * Geometry Type
-     */
-    geometry_type?: string | null;
-    /**
-     * Id
-     */
-    id: string;
-    /**
      * Label Config
      */
     label_config?: {
-        [key: string]: unknown;
-    } | null;
-    /**
-     * Layer Type
-     */
-    layer_type?: string | null;
-    /**
-     * Name
-     */
-    name: string;
-    /**
-     * Paint
-     */
-    paint?: {
-        [key: string]: unknown;
-    } | null;
-    /**
-     * Sample Values
-     */
-    sample_values?: {
         [key: string]: unknown;
     } | null;
     /**
@@ -1729,9 +1727,11 @@ export type ChatMapLayer = {
         [key: string]: unknown;
     } | null;
     /**
-     * Visible
+     * Paint
      */
-    visible?: boolean;
+    paint?: {
+        [key: string]: unknown;
+    } | null;
 };
 
 /**
@@ -1739,25 +1739,25 @@ export type ChatMapLayer = {
  */
 export type ChatRequest = {
     /**
-     * History
+     * Message
      */
-    history?: Array<ChatHistoryMessage>;
-    /**
-     * Language
-     */
-    language?: string | null;
-    /**
-     * Layers
-     */
-    layers: Array<ChatMapLayer>;
+    message: string;
     /**
      * Map Id
      */
     map_id: string;
     /**
-     * Message
+     * Layers
      */
-    message: string;
+    layers: Array<ChatMapLayer>;
+    /**
+     * Language
+     */
+    language?: string | null;
+    /**
+     * History
+     */
+    history?: Array<ChatHistoryMessage>;
 };
 
 /**
@@ -1765,13 +1765,13 @@ export type ChatRequest = {
  */
 export type ChatResponse = {
     /**
-     * Actions
-     */
-    actions: Array<ChatAction>;
-    /**
      * Explanation
      */
     explanation: string;
+    /**
+     * Actions
+     */
+    actions: Array<ChatAction>;
 };
 
 /**
@@ -1791,17 +1791,17 @@ export type CollectionAddDatasetsRequest = {
  */
 export type CollectionCreate = {
     /**
-     * Description
-     *
-     * Optional text description
-     */
-    description?: string | null;
-    /**
      * Name
      *
      * Display name for the collection
      */
     name: string;
+    /**
+     * Description
+     *
+     * Optional text description
+     */
+    description?: string | null;
 };
 
 /**
@@ -1811,10 +1811,6 @@ export type CollectionCreate = {
  */
 export type CollectionFacetItem = {
     /**
-     * Dataset Count
-     */
-    dataset_count: number;
-    /**
      * Id
      */
     id: string;
@@ -1822,6 +1818,10 @@ export type CollectionFacetItem = {
      * Name
      */
     name: string;
+    /**
+     * Dataset Count
+     */
+    dataset_count: number;
 };
 
 /**
@@ -1859,26 +1859,6 @@ export type CollectionRef = {
  */
 export type CollectionResponse = {
     /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Created By
-     */
-    created_by: string | null;
-    /**
-     * Dataset Count
-     */
-    dataset_count: number;
-    /**
-     * Description
-     */
-    description: string | null;
-    /**
-     * Extent Bbox
-     */
-    extent_bbox?: Array<number> | null;
-    /**
      * Id
      */
     id: string;
@@ -1887,17 +1867,37 @@ export type CollectionResponse = {
      */
     name: string;
     /**
-     * Temporal End
+     * Description
      */
-    temporal_end?: string | null;
+    description: string | null;
+    /**
+     * Created By
+     */
+    created_by: string | null;
+    /**
+     * Created At
+     */
+    created_at: string;
+    /**
+     * Updated At
+     */
+    updated_at: string;
+    /**
+     * Dataset Count
+     */
+    dataset_count: number;
+    /**
+     * Extent Bbox
+     */
+    extent_bbox?: Array<number> | null;
     /**
      * Temporal Start
      */
     temporal_start?: string | null;
     /**
-     * Updated At
+     * Temporal End
      */
-    updated_at: string;
+    temporal_end?: string | null;
 };
 
 /**
@@ -1905,17 +1905,17 @@ export type CollectionResponse = {
  */
 export type CollectionUpdate = {
     /**
-     * Description
-     *
-     * Updated description
-     */
-    description?: string | null;
-    /**
      * Name
      *
      * Updated display name
      */
     name?: string | null;
+    /**
+     * Description
+     *
+     * Updated description
+     */
+    description?: string | null;
 };
 
 /**
@@ -1976,6 +1976,10 @@ export type ColumnDdlFeedResponse = {
      */
     items: Array<ColumnDdlEntry>;
     /**
+     * Total
+     */
+    total: number;
+    /**
      * Limit
      */
     limit: number;
@@ -1983,10 +1987,6 @@ export type ColumnDdlFeedResponse = {
      * Offset
      */
     offset: number;
-    /**
-     * Total
-     */
-    total: number;
 };
 
 /**
@@ -2024,31 +2024,31 @@ export type ColumnDefinition = {
  */
 export type ColumnInfo = {
     /**
-     * Domain Type
-     */
-    domain_type?: string | null;
-    /**
      * Name
      */
     name: string;
     /**
-     * Sample Values
+     * Type
      */
-    sample_values?: Array<unknown> | null;
+    type: string;
     /**
      * Semantic Role
      */
     semantic_role?: string | null;
+    /**
+     * Domain Type
+     */
+    domain_type?: string | null;
+    /**
+     * Sample Values
+     */
+    sample_values?: Array<unknown> | null;
     /**
      * Stats
      */
     stats?: {
         [key: string]: unknown;
     } | null;
-    /**
-     * Type
-     */
-    type: string;
 };
 
 /**
@@ -2096,9 +2096,29 @@ export type ColumnReferencesResponse = {
  */
 export type ColumnStatsResponse = {
     /**
+     * Min
+     */
+    min?: number | null;
+    /**
+     * Max
+     */
+    max?: number | null;
+    /**
      * Count
      */
     count?: number;
+    /**
+     * Mean
+     */
+    mean?: number | null;
+    /**
+     * Quantiles
+     */
+    quantiles?: Array<number>;
+    /**
+     * Stddev
+     */
+    stddev?: number | null;
     /**
      * Data Type
      *
@@ -2111,26 +2131,6 @@ export type ColumnStatsResponse = {
      * Distinct non-null value count (categorical columns only).
      */
     distinct_count?: number | null;
-    /**
-     * Max
-     */
-    max?: number | null;
-    /**
-     * Mean
-     */
-    mean?: number | null;
-    /**
-     * Min
-     */
-    min?: number | null;
-    /**
-     * Quantiles
-     */
-    quantiles?: Array<number>;
-    /**
-     * Stddev
-     */
-    stddev?: number | null;
 };
 
 /**
@@ -2138,13 +2138,13 @@ export type ColumnStatsResponse = {
  */
 export type ColumnValuesResponse = {
     /**
-     * Count
-     */
-    count: number;
-    /**
      * Values
      */
     values: Array<string | number | number | null>;
+    /**
+     * Count
+     */
+    count: number;
 };
 
 /**
@@ -2169,41 +2169,11 @@ export type ColumnValuesResponse = {
  */
 export type CommitRequest = {
     /**
-     * Compression
+     * Title
      *
-     * Raster only: target compression for COG output (e.g. 'LZW', 'DEFLATE').
+     * Human-readable dataset title.
      */
-    compression?: string | null;
-    /**
-     * Geom Column
-     *
-     * CSV/Excel only: name of the WKT geometry column (alternative to x_column/y_column).
-     */
-    geom_column?: string | null;
-    /**
-     * Layer Name
-     *
-     * Multi-layer source only: name of the specific layer to ingest.
-     */
-    layer_name?: string | null;
-    /**
-     * Nodata Override
-     *
-     * Raster only: nodata value to use when source has none defined.
-     */
-    nodata_override?: number | string | null;
-    /**
-     * Resampling
-     *
-     * Raster only: resampling method for COG conversion (e.g. 'nearest', 'bilinear', 'cubic').
-     */
-    resampling?: string | null;
-    /**
-     * Srid Override
-     *
-     * EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.
-     */
-    srid_override?: number | null;
+    title: string;
     /**
      * Summary
      *
@@ -2211,23 +2181,17 @@ export type CommitRequest = {
      */
     summary?: string | null;
     /**
-     * Temporal End
+     * Visibility
      *
-     * ISO 8601 end of the dataset's temporal extent.
+     * Dataset visibility level: 'private' (owner-only), 'restricted' (RBAC-controlled), 'internal' (all users), 'public' (anonymous access).
      */
-    temporal_end?: string | null;
+    visibility?: 'private' | 'restricted' | 'internal' | 'public';
     /**
-     * Temporal Start
+     * Srid Override
      *
-     * ISO 8601 start of the dataset's temporal extent.
+     * EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.
      */
-    temporal_start?: string | null;
-    /**
-     * Title
-     *
-     * Human-readable dataset title.
-     */
-    title: string;
+    srid_override?: number | null;
     /**
      * Token
      *
@@ -2235,11 +2199,41 @@ export type CommitRequest = {
      */
     token?: string | null;
     /**
-     * Visibility
+     * Temporal Start
      *
-     * Dataset visibility level: 'private' (owner-only), 'restricted' (RBAC-controlled), 'internal' (all users), 'public' (anonymous access).
+     * ISO 8601 start of the dataset's temporal extent.
      */
-    visibility?: 'private' | 'restricted' | 'internal' | 'public';
+    temporal_start?: string | null;
+    /**
+     * Temporal End
+     *
+     * ISO 8601 end of the dataset's temporal extent.
+     */
+    temporal_end?: string | null;
+    /**
+     * Compression
+     *
+     * Raster only: target compression for COG output (e.g. 'LZW', 'DEFLATE').
+     */
+    compression?: string | null;
+    /**
+     * Resampling
+     *
+     * Raster only: resampling method for COG conversion (e.g. 'nearest', 'bilinear', 'cubic').
+     */
+    resampling?: string | null;
+    /**
+     * Nodata Override
+     *
+     * Raster only: nodata value to use when source has none defined.
+     */
+    nodata_override?: number | string | null;
+    /**
+     * Layer Name
+     *
+     * Multi-layer source only: name of the specific layer to ingest.
+     */
+    layer_name?: string | null;
     /**
      * X Column
      *
@@ -2252,6 +2246,12 @@ export type CommitRequest = {
      * CSV/Excel only: name of the latitude/Y coordinate column.
      */
     y_column?: string | null;
+    /**
+     * Geom Column
+     *
+     * CSV/Excel only: name of the WKT geometry column (alternative to x_column/y_column).
+     */
+    geom_column?: string | null;
 };
 
 /**
@@ -2265,17 +2265,17 @@ export type CommitResponse = {
      */
     job_id: string;
     /**
-     * Message
-     *
-     * Human-readable commit result.
-     */
-    message: string;
-    /**
      * Status
      *
      * Updated job status after commit.
      */
     status: string;
+    /**
+     * Message
+     *
+     * Human-readable commit result.
+     */
+    message: string;
 };
 
 /**
@@ -2285,14 +2285,6 @@ export type CommitResponse = {
  */
 export type ConfigImportRequest = {
     /**
-     * Oauth Providers
-     *
-     * Optional OAuth providers to import. Client secrets must be re-supplied via the admin UI after import.
-     */
-    oauth_providers?: Array<{
-        [key: string]: unknown;
-    }> | null;
-    /**
      * Settings
      *
      * Optional settings to import. Omit to import only OAuth providers.
@@ -2300,6 +2292,14 @@ export type ConfigImportRequest = {
     settings?: {
         [key: string]: unknown;
     } | null;
+    /**
+     * Oauth Providers
+     *
+     * Optional OAuth providers to import. Client secrets must be re-supplied via the admin UI after import.
+     */
+    oauth_providers?: Array<{
+        [key: string]: unknown;
+    }> | null;
 };
 
 /**
@@ -2321,11 +2321,23 @@ export type ConfigModeResponse = {
  */
 export type ConfigResponse = {
     /**
+     * Registration Enabled
+     *
+     * Whether self-service registration is open
+     */
+    registration_enabled: boolean;
+    /**
      * Allow Signup
      *
      * Whether self-serve registration is open. Alias for registration_enabled; login UI uses this to show/hide the signup link.
      */
     allow_signup?: boolean;
+    /**
+     * Email Verification Required
+     *
+     * When true, new self-registered users must verify their email before logging in. Default false for back-compat-safe parsing by older clients.
+     */
+    email_verification_required?: boolean;
     /**
      * Auth Methods
      *
@@ -2333,11 +2345,11 @@ export type ConfigResponse = {
      */
     auth_methods?: Array<string>;
     /**
-     * Banner Color
+     * Landing First
      *
-     * Theme token for the site banner color: warning | info | success | destructive.
+     * When true, unauthenticated visits to '/' are redirected to '/login' as the product landing page. Default false (search catalog is the root).
      */
-    banner_color?: string;
+    landing_first?: boolean;
     /**
      * Banner Enabled
      *
@@ -2351,29 +2363,17 @@ export type ConfigResponse = {
      */
     banner_text?: string;
     /**
-     * Email Verification Required
+     * Banner Color
      *
-     * When true, new self-registered users must verify their email before logging in. Default false for back-compat-safe parsing by older clients.
+     * Theme token for the site banner color: warning | info | success | destructive.
      */
-    email_verification_required?: boolean;
-    /**
-     * Landing First
-     *
-     * When true, unauthenticated visits to '/' are redirected to '/login' as the product landing page. Default false (search catalog is the root).
-     */
-    landing_first?: boolean;
+    banner_color?: string;
     /**
      * Password Login Enabled
      *
      * When false, password login is disabled for users without manage_settings. Default true for back-compat-safe parsing by older clients.
      */
     password_login_enabled?: boolean;
-    /**
-     * Registration Enabled
-     *
-     * Whether self-service registration is open
-     */
-    registration_enabled: boolean;
 };
 
 /**
@@ -2395,6 +2395,10 @@ export type ConformanceResponse = {
  */
 export type ConnectivityResult = {
     /**
+     * Object storage probe result.
+     */
+    storage: ServiceProbeResult;
+    /**
      * Cache backend probe result.
      */
     cache: ServiceProbeResult;
@@ -2406,10 +2410,6 @@ export type ConnectivityResult = {
     oidc_providers: {
         [key: string]: ServiceProbeResult;
     };
-    /**
-     * Object storage probe result.
-     */
-    storage: ServiceProbeResult;
 };
 
 /**
@@ -2419,19 +2419,19 @@ export type ConnectivityResult = {
  */
 export type ConnectorDefinitionResponse = {
     /**
-     * Config Schema
+     * Name
      */
-    config_schema: {
-        [key: string]: unknown;
-    };
+    name: string;
     /**
      * Display Name
      */
     display_name: string;
     /**
-     * Name
+     * Config Schema
      */
-    name: string;
+    config_schema: {
+        [key: string]: unknown;
+    };
     /**
      * Supports Credentials
      */
@@ -2447,15 +2447,15 @@ export type ConnectorDefinitionResponse = {
  */
 export type ConnectorDiscoverRequest = {
     /**
+     * Credential Id
+     */
+    credential_id?: string | null;
+    /**
      * Config
      */
     config?: {
         [key: string]: unknown;
     };
-    /**
-     * Credential Id
-     */
-    credential_id?: string | null;
 };
 
 /**
@@ -2473,15 +2473,15 @@ export type ConnectorDiscoverResponse = {
  */
 export type ConnectorIngestRequest = {
     /**
+     * Credential Id
+     */
+    credential_id?: string | null;
+    /**
      * Config
      */
     config?: {
         [key: string]: unknown;
     };
-    /**
-     * Credential Id
-     */
-    credential_id?: string | null;
     /**
      * Resource Id
      *
@@ -2527,6 +2527,10 @@ export type ConnectorResourceResponse = {
      */
     id: string;
     /**
+     * Name
+     */
+    name: string;
+    /**
      * Kind
      */
     kind: string;
@@ -2536,10 +2540,6 @@ export type ConnectorResourceResponse = {
     metadata?: {
         [key: string]: unknown;
     };
-    /**
-     * Name
-     */
-    name: string;
 };
 
 /**
@@ -2547,21 +2547,19 @@ export type ConnectorResourceResponse = {
  */
 export type ContactCreate = {
     /**
-     * Email
-     */
-    email?: string | null;
-    /**
-     * Extra Json
+     * Role
      *
-     * Arbitrary extra fields stored as JSON
+     * ISO CI_RoleCode, e.g. pointOfContact, author
      */
-    extra_json?: {
-        [key: string]: unknown;
-    } | null;
+    role: string;
     /**
      * Name
      */
     name?: string | null;
+    /**
+     * Email
+     */
+    email?: string | null;
     /**
      * Organization
      */
@@ -2571,11 +2569,13 @@ export type ContactCreate = {
      */
     phone?: string | null;
     /**
-     * Role
+     * Extra Json
      *
-     * ISO CI_RoleCode, e.g. pointOfContact, author
+     * Arbitrary extra fields stored as JSON
      */
-    role: string;
+    extra_json?: {
+        [key: string]: unknown;
+    } | null;
     /**
      * Sort Order
      *
@@ -2603,23 +2603,25 @@ export type ContactListResponse = {
  */
 export type ContactResponse = {
     /**
-     * Email
-     */
-    email: string | null;
-    /**
-     * Extra Json
-     */
-    extra_json: {
-        [key: string]: unknown;
-    } | null;
-    /**
      * Id
      */
     id: string;
     /**
+     * Record Id
+     */
+    record_id: string;
+    /**
+     * Role
+     */
+    role: string;
+    /**
      * Name
      */
     name: string | null;
+    /**
+     * Email
+     */
+    email: string | null;
     /**
      * Organization
      */
@@ -2629,13 +2631,11 @@ export type ContactResponse = {
      */
     phone: string | null;
     /**
-     * Record Id
+     * Extra Json
      */
-    record_id: string;
-    /**
-     * Role
-     */
-    role: string;
+    extra_json: {
+        [key: string]: unknown;
+    } | null;
     /**
      * Sort Order
      */
@@ -2647,19 +2647,17 @@ export type ContactResponse = {
  */
 export type ContactUpdate = {
     /**
-     * Email
+     * Role
      */
-    email?: string | null;
-    /**
-     * Extra Json
-     */
-    extra_json?: {
-        [key: string]: unknown;
-    } | null;
+    role?: string | null;
     /**
      * Name
      */
     name?: string | null;
+    /**
+     * Email
+     */
+    email?: string | null;
     /**
      * Organization
      */
@@ -2669,9 +2667,11 @@ export type ContactUpdate = {
      */
     phone?: string | null;
     /**
-     * Role
+     * Extra Json
      */
-    role?: string | null;
+    extra_json?: {
+        [key: string]: unknown;
+    } | null;
     /**
      * Sort Order
      */
@@ -2683,13 +2683,13 @@ export type ContactUpdate = {
  */
 export type CreateEmptyDatasetRequest = {
     /**
-     * Columns
-     */
-    columns: Array<ColumnDefinition>;
-    /**
      * Title
      */
     title: string;
+    /**
+     * Columns
+     */
+    columns: Array<ColumnDefinition>;
 };
 
 /**
@@ -2697,11 +2697,11 @@ export type CreateEmptyDatasetRequest = {
  */
 export type CreateLayerRequest = {
     /**
-     * Columns
+     * Title
      *
-     * Optional initial column definitions
+     * Display name for the new layer
      */
-    columns?: Array<ColumnDef> | null;
+    title: string;
     /**
      * Geometry Type
      *
@@ -2715,11 +2715,11 @@ export type CreateLayerRequest = {
      */
     summary?: string | null;
     /**
-     * Title
+     * Columns
      *
-     * Display name for the new layer
+     * Optional initial column definitions
      */
-    title: string;
+    columns?: Array<ColumnDef> | null;
 };
 
 /**
@@ -2727,35 +2727,11 @@ export type CreateLayerRequest = {
  */
 export type CreateLayerResponse = {
     /**
-     * Created At
-     *
-     * Creation timestamp
-     */
-    created_at: string;
-    /**
-     * Feature Count
-     *
-     * Number of features (0 for new layers)
-     */
-    feature_count: number;
-    /**
-     * Geometry Type
-     *
-     * OGC geometry type
-     */
-    geometry_type: string;
-    /**
      * Id
      *
      * Dataset ID of the created layer
      */
     id: string;
-    /**
-     * Table Name
-     *
-     * PostGIS table name in the data schema
-     */
-    table_name: string;
     /**
      * Title
      *
@@ -2763,11 +2739,35 @@ export type CreateLayerResponse = {
      */
     title: string;
     /**
+     * Table Name
+     *
+     * PostGIS table name in the data schema
+     */
+    table_name: string;
+    /**
+     * Geometry Type
+     *
+     * OGC geometry type
+     */
+    geometry_type: string;
+    /**
+     * Feature Count
+     *
+     * Number of features (0 for new layers)
+     */
+    feature_count: number;
+    /**
      * Visibility
      *
      * Visibility level: private, internal, or public
      */
     visibility: string;
+    /**
+     * Created At
+     *
+     * Creation timestamp
+     */
+    created_at: string;
 };
 
 /**
@@ -2780,21 +2780,21 @@ export type CreateLayerResponse = {
  */
 export type DatasetChatRequest = {
     /**
+     * Message
+     */
+    message: string;
+    /**
      * Dataset Id
      */
     dataset_id: string;
-    /**
-     * History
-     */
-    history?: Array<ChatHistoryMessage>;
     /**
      * Language
      */
     language?: string | null;
     /**
-     * Message
+     * History
      */
-    message: string;
+    history?: Array<ChatHistoryMessage>;
 };
 
 /**
@@ -2833,15 +2833,27 @@ export type DatasetListResponse = {
  */
 export type DatasetMeta = {
     /**
-     * Access Constraints
+     * Title
      */
-    access_constraints?: string | null;
+    title?: string | null;
     /**
-     * Data Vintage End
-     *
-     * End of temporal coverage
+     * Summary
      */
-    data_vintage_end?: string | null;
+    summary?: string | null;
+    /**
+     * Visibility
+     *
+     * Access level: private, restricted, internal, or public
+     */
+    visibility?: 'private' | 'restricted' | 'internal' | 'public' | null;
+    /**
+     * License
+     */
+    license?: string | null;
+    /**
+     * Source Organization
+     */
+    source_organization?: string | null;
     /**
      * Data Vintage Start
      *
@@ -2849,79 +2861,17 @@ export type DatasetMeta = {
      */
     data_vintage_start?: string | null;
     /**
-     * Is Dem
+     * Data Vintage End
      *
-     * Flag raster as a Digital Elevation Model for terrain rendering
+     * End of temporal coverage
      */
-    is_dem?: boolean | null;
-    /**
-     * Language
-     *
-     * BCP 47 primary language tag, e.g. en, fr, or pt-BR
-     */
-    language?: string | null;
-    /**
-     * License
-     */
-    license?: string | null;
+    data_vintage_end?: string | null;
     /**
      * Lineage Summary
      *
      * Free-text provenance / lineage statement
      */
     lineage_summary?: string | null;
-    /**
-     * Owner Org
-     *
-     * Owning organization name
-     */
-    owner_org?: string | null;
-    /**
-     * Quality Statement
-     */
-    quality_statement?: string | null;
-    /**
-     * Record Status
-     *
-     * Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
-     */
-    record_status?: string | null;
-    /**
-     * Sensitivity Classification
-     *
-     * e.g. public, confidential, restricted
-     */
-    sensitivity_classification?: string | null;
-    /**
-     * Source Organization
-     */
-    source_organization?: string | null;
-    /**
-     * Source Url
-     *
-     * URL the data was originally fetched from
-     */
-    source_url?: string | null;
-    /**
-     * Summary
-     */
-    summary?: string | null;
-    /**
-     * Theme Category
-     *
-     * ISO topic category codes
-     */
-    theme_category?: Array<string> | null;
-    /**
-     * Tile Columns
-     *
-     * Ordered vector-tile property allowlist; null restores zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.
-     */
-    tile_columns?: Array<string> | null;
-    /**
-     * Title
-     */
-    title?: string | null;
     /**
      * Update Frequency
      *
@@ -2933,11 +2883,61 @@ export type DatasetMeta = {
      */
     usage_constraints?: string | null;
     /**
-     * Visibility
-     *
-     * Access level: private, restricted, internal, or public
+     * Access Constraints
      */
-    visibility?: 'private' | 'restricted' | 'internal' | 'public' | null;
+    access_constraints?: string | null;
+    /**
+     * Sensitivity Classification
+     *
+     * e.g. public, confidential, restricted
+     */
+    sensitivity_classification?: string | null;
+    /**
+     * Theme Category
+     *
+     * ISO topic category codes
+     */
+    theme_category?: Array<string> | null;
+    /**
+     * Record Status
+     *
+     * Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
+     */
+    record_status?: string | null;
+    /**
+     * Owner Org
+     *
+     * Owning organization name
+     */
+    owner_org?: string | null;
+    /**
+     * Quality Statement
+     */
+    quality_statement?: string | null;
+    /**
+     * Source Url
+     *
+     * URL the data was originally fetched from
+     */
+    source_url?: string | null;
+    /**
+     * Language
+     *
+     * BCP 47 primary language tag, e.g. en, fr, or pt-BR
+     */
+    language?: string | null;
+    /**
+     * Is Dem
+     *
+     * Flag raster as a Digital Elevation Model for terrain rendering
+     */
+    is_dem?: boolean | null;
+    /**
+     * Tile Columns
+     *
+     * Ordered vector-tile property allowlist; null restores zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.
+     */
+    tile_columns?: Array<string> | null;
 };
 
 /**
@@ -2945,11 +2945,11 @@ export type DatasetMeta = {
  */
 export type DatasetRelationshipCreate = {
     /**
-     * Label
+     * Target Dataset Id
      *
-     * Optional display label for this relationship
+     * UUID of the dataset to link to
      */
-    label?: string | null;
+    target_dataset_id: string;
     /**
      * Source Column
      *
@@ -2963,11 +2963,11 @@ export type DatasetRelationshipCreate = {
      */
     target_column?: string;
     /**
-     * Target Dataset Id
+     * Label
      *
-     * UUID of the dataset to link to
+     * Optional display label for this relationship
      */
-    target_dataset_id: string;
+    label?: string | null;
 };
 
 /**
@@ -3000,29 +3000,29 @@ export type DatasetRelationshipResponse = {
      */
     id: string;
     /**
-     * Label
+     * Source Dataset Id
      */
-    label: string | null;
+    source_dataset_id: string;
     /**
-     * Relationship Type
+     * Target Dataset Id
      */
-    relationship_type: string;
+    target_dataset_id: string;
     /**
      * Source Column
      */
     source_column: string;
     /**
-     * Source Dataset Id
-     */
-    source_dataset_id: string;
-    /**
      * Target Column
      */
     target_column: string;
     /**
-     * Target Dataset Id
+     * Relationship Type
      */
-    target_dataset_id: string;
+    relationship_type: string;
+    /**
+     * Label
+     */
+    label: string | null;
     /**
      * Target Dataset Title
      */
@@ -3034,63 +3034,35 @@ export type DatasetRelationshipResponse = {
  */
 export type DatasetResponse = {
     /**
-     * Access Constraints
+     * Id
      */
-    access_constraints?: string | null;
+    id: string;
     /**
-     * Collections
-     */
-    collections?: Array<CollectionRef> | null;
-    /**
-     * Column Info
+     * Record Id
      *
-     * Column names, types, and stats
+     * Parent catalog record UUID
      */
-    column_info?: Array<ColumnInfo> | null;
+    record_id: string;
     /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Created By
-     */
-    created_by: string | null;
-    /**
-     * Created By Display
-     */
-    created_by_display: string;
-    /**
-     * Current Version
+     * Table Name
      *
-     * Monotonic version counter
+     * Internal PostGIS table name
      */
-    current_version?: number;
+    table_name: string;
     /**
-     * Data Vintage End
+     * Title
+     */
+    title: string;
+    /**
+     * Summary
+     */
+    summary: string | null;
+    /**
+     * Srid
      *
-     * End of temporal coverage
+     * Current EPSG SRID of stored geometry
      */
-    data_vintage_end?: string | null;
-    /**
-     * Data Vintage Start
-     *
-     * Start of temporal coverage
-     */
-    data_vintage_start?: string | null;
-    /**
-     * Provenance for an analysis output. Null for a dataset that was not derived, and also for a requester who cannot access the source dataset — the two are deliberately indistinguishable.
-     */
-    derived_from?: DerivedFromResponse | null;
-    /**
-     * Extent Bbox
-     *
-     * Bounding box [west, south, east, north] per RFC 7946 §5.2. west > east on an antimeridian-crossing extent.
-     */
-    extent_bbox?: Array<number> | null;
-    /**
-     * Feature Count
-     */
-    feature_count: number | null;
+    srid?: number | null;
     /**
      * Geometry Type
      *
@@ -3104,57 +3076,11 @@ export type DatasetResponse = {
      */
     has_generic_geometry?: boolean;
     /**
-     * Id
-     */
-    id: string;
-    /**
      * Is 3D
      *
      * True if geometry has Z dimension
      */
     is_3d?: boolean | null;
-    /**
-     * Language
-     *
-     * ISO 639-1 language code, e.g. en, fr
-     */
-    language?: string | null;
-    /**
-     * Last Checked At
-     *
-     * Last time GeoLens contacted the origin at all, whether the attempt succeeded or failed
-     */
-    last_checked_at?: string | null;
-    /**
-     * Last Edited At
-     */
-    last_edited_at?: string | null;
-    /**
-     * Last Edited By Display
-     */
-    last_edited_by_display?: string | null;
-    /**
-     * Last Refreshed At
-     *
-     * Last committed successful refresh — not the last attempt
-     */
-    last_refreshed_at?: string | null;
-    /**
-     * License
-     */
-    license?: string | null;
-    /**
-     * Lineage Summary
-     *
-     * Free-text provenance / lineage statement
-     */
-    lineage_summary?: string | null;
-    /**
-     * Metadata Warnings
-     *
-     * Advisory warnings produced by a metadata update — e.g. a visibility or status change exposing keywords inherited from an analysis source the new audience cannot open (feat #1070). Only ever set on the PATCH response; the change has already applied.
-     */
-    metadata_warnings?: Array<string> | null;
     /**
      * N Dims
      *
@@ -3162,11 +3088,103 @@ export type DatasetResponse = {
      */
     n_dims?: number | null;
     /**
+     * Z Min
+     *
+     * Minimum Z value across all features
+     */
+    z_min?: number | null;
+    /**
+     * Z Max
+     *
+     * Maximum Z value across all features
+     */
+    z_max?: number | null;
+    /**
+     * Feature Count
+     */
+    feature_count: number | null;
+    /**
+     * Extent Bbox
+     *
+     * Bounding box [west, south, east, north] per RFC 7946 §5.2. west > east on an antimeridian-crossing extent.
+     */
+    extent_bbox?: Array<number> | null;
+    /**
+     * Column Info
+     *
+     * Column names, types, and stats
+     */
+    column_info?: Array<ColumnInfo> | null;
+    /**
+     * License
+     */
+    license?: string | null;
+    /**
+     * Source Organization
+     */
+    source_organization?: string | null;
+    /**
+     * Data Vintage Start
+     *
+     * Start of temporal coverage
+     */
+    data_vintage_start?: string | null;
+    /**
+     * Data Vintage End
+     *
+     * End of temporal coverage
+     */
+    data_vintage_end?: string | null;
+    /**
+     * Automated quality assessment results
+     */
+    quality_detail?: QualityDetail | null;
+    /**
+     * Source Format
+     *
+     * Original file format, e.g. GPKG, SHP
+     */
+    source_format?: string | null;
+    /**
+     * Source Filename
+     */
+    source_filename: string | null;
+    /**
+     * Tile Columns
+     *
+     * Ordered vector-tile property allowlist; null uses zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.
+     */
+    tile_columns?: Array<string> | null;
+    /**
+     * Original Srid
+     *
+     * EPSG SRID of the uploaded source file
+     */
+    original_srid?: number | null;
+    /**
+     * Current Version
+     *
+     * Monotonic version counter
+     */
+    current_version?: number;
+    /**
+     * Source Url
+     *
+     * URL the data was originally fetched from
+     */
+    source_url?: string | null;
+    /**
      * Origin
      *
      * How the data entered the catalog: upload, postgis, service, stac, or created. Computed from source_format and record_type, not stored; null for collections and VRTs, which have no origin of their own.
      */
     origin?: string | null;
+    /**
+     * Origin Uri
+     *
+     * Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.
+     */
+    origin_uri?: string | null;
     /**
      * Origin Ref
      *
@@ -3176,79 +3194,17 @@ export type DatasetResponse = {
         [key: string]: unknown;
     } | null;
     /**
-     * Origin Uri
+     * Last Refreshed At
      *
-     * Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.
+     * Last committed successful refresh — not the last attempt
      */
-    origin_uri?: string | null;
+    last_refreshed_at?: string | null;
     /**
-     * Original Srid
+     * Last Checked At
      *
-     * EPSG SRID of the uploaded source file
+     * Last time GeoLens contacted the origin at all, whether the attempt succeeded or failed
      */
-    original_srid?: number | null;
-    /**
-     * Owner Org
-     *
-     * Owning organization name
-     */
-    owner_org?: string | null;
-    /**
-     * Published At
-     */
-    published_at?: string | null;
-    /**
-     * Automated quality assessment results
-     */
-    quality_detail?: QualityDetail | null;
-    /**
-     * Quality Statement
-     */
-    quality_statement?: string | null;
-    /**
-     * Raster-specific metadata (null for vectors)
-     */
-    raster?: RasterMetadata | null;
-    /**
-     * Record Id
-     *
-     * Parent catalog record UUID
-     */
-    record_id: string;
-    /**
-     * Record Status
-     *
-     * Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
-     */
-    record_status?: string;
-    /**
-     * Record Type
-     *
-     * Record type: 'vector_dataset' (spatial features), 'raster_dataset' (single COG), 'vrt_dataset' (VRT mosaic), 'table' (non-spatial tabular), 'map' (saved map), 'service' (catalogued remote service), 'collection' (flat dataset group).
-     */
-    record_type?: string;
-    /**
-     * Schema Drift Status
-     *
-     * none, drifted, or unknown. Set at refresh commit from the schema diff; 'unknown' until a refresh has run.
-     */
-    schema_drift_status?: string;
-    /**
-     * Sensitivity Classification
-     *
-     * e.g. public, confidential, restricted
-     */
-    sensitivity_classification?: string | null;
-    /**
-     * Source Filename
-     */
-    source_filename: string | null;
-    /**
-     * Source Format
-     *
-     * Original file format, e.g. GPKG, SHP
-     */
-    source_format?: string | null;
+    last_checked_at?: string | null;
     /**
      * Source Health
      *
@@ -3262,21 +3218,115 @@ export type DatasetResponse = {
      */
     source_health_detail?: string | null;
     /**
-     * Source Organization
-     */
-    source_organization?: string | null;
-    /**
-     * Source Url
+     * Schema Drift Status
      *
-     * URL the data was originally fetched from
+     * none, drifted, or unknown. Set at refresh commit from the schema diff; 'unknown' until a refresh has run.
      */
-    source_url?: string | null;
+    schema_drift_status?: string;
     /**
-     * Srid
-     *
-     * Current EPSG SRID of stored geometry
+     * Quality Statement
      */
-    srid?: number | null;
+    quality_statement?: string | null;
+    /**
+     * Visibility
+     *
+     * Access level: private, restricted, internal, public
+     */
+    visibility: string;
+    /**
+     * Created By
+     */
+    created_by: string | null;
+    /**
+     * Created By Display
+     */
+    created_by_display: string;
+    /**
+     * Created At
+     */
+    created_at: string;
+    /**
+     * Updated At
+     */
+    updated_at: string;
+    /**
+     * Last Edited By Display
+     */
+    last_edited_by_display?: string | null;
+    /**
+     * Last Edited At
+     */
+    last_edited_at?: string | null;
+    /**
+     * Collections
+     */
+    collections?: Array<CollectionRef> | null;
+    /**
+     * Record Status
+     *
+     * Lifecycle status. Deliberately not pinned to an enum: the values come from the workflow extension's status_order(), so an overlay may define its own. Community default order: draft, ready, internal, published.
+     */
+    record_status?: string;
+    /**
+     * Lineage Summary
+     *
+     * Free-text provenance / lineage statement
+     */
+    lineage_summary?: string | null;
+    /**
+     * Provenance for an analysis output. Null for a dataset that was not derived, and also for a requester who cannot access the source dataset — the two are deliberately indistinguishable.
+     */
+    derived_from?: DerivedFromResponse | null;
+    /**
+     * Update Frequency
+     *
+     * ISO maintenance frequency code
+     */
+    update_frequency?: string | null;
+    /**
+     * Usage Constraints
+     */
+    usage_constraints?: string | null;
+    /**
+     * Access Constraints
+     */
+    access_constraints?: string | null;
+    /**
+     * Sensitivity Classification
+     *
+     * e.g. public, confidential, restricted
+     */
+    sensitivity_classification?: string | null;
+    /**
+     * Theme Category
+     *
+     * ISO topic category codes
+     */
+    theme_category?: Array<string> | null;
+    /**
+     * Owner Org
+     *
+     * Owning organization name
+     */
+    owner_org?: string | null;
+    /**
+     * Published At
+     */
+    published_at?: string | null;
+    /**
+     * Updated By
+     */
+    updated_by?: string | null;
+    /**
+     * Record Type
+     *
+     * Record type: 'vector_dataset' (spatial features), 'raster_dataset' (single COG), 'vrt_dataset' (VRT mosaic), 'table' (non-spatial tabular), 'map' (saved map), 'service' (catalogued remote service), 'collection' (flat dataset group).
+     */
+    record_type?: string;
+    /**
+     * Raster-specific metadata (null for vectors)
+     */
+    raster?: RasterMetadata | null;
     /**
      * Stac Assets
      *
@@ -3290,67 +3340,17 @@ export type DatasetResponse = {
      */
     stac_extensions?: Array<string> | null;
     /**
-     * Summary
-     */
-    summary: string | null;
-    /**
-     * Table Name
+     * Language
      *
-     * Internal PostGIS table name
+     * ISO 639-1 language code, e.g. en, fr
      */
-    table_name: string;
+    language?: string | null;
     /**
-     * Theme Category
+     * Metadata Warnings
      *
-     * ISO topic category codes
+     * Advisory warnings produced by a metadata update — e.g. a visibility or status change exposing keywords inherited from an analysis source the new audience cannot open (feat #1070). Only ever set on the PATCH response; the change has already applied.
      */
-    theme_category?: Array<string> | null;
-    /**
-     * Tile Columns
-     *
-     * Ordered vector-tile property allowlist; null uses zoom defaults, [] emits geometry-only tiles, list emits those properties at any zoom.
-     */
-    tile_columns?: Array<string> | null;
-    /**
-     * Title
-     */
-    title: string;
-    /**
-     * Update Frequency
-     *
-     * ISO maintenance frequency code
-     */
-    update_frequency?: string | null;
-    /**
-     * Updated At
-     */
-    updated_at: string;
-    /**
-     * Updated By
-     */
-    updated_by?: string | null;
-    /**
-     * Usage Constraints
-     */
-    usage_constraints?: string | null;
-    /**
-     * Visibility
-     *
-     * Access level: private, restricted, internal, public
-     */
-    visibility: string;
-    /**
-     * Z Max
-     *
-     * Maximum Z value across all features
-     */
-    z_max?: number | null;
-    /**
-     * Z Min
-     *
-     * Minimum Z value across all features
-     */
-    z_min?: number | null;
+    metadata_warnings?: Array<string> | null;
 };
 
 /**
@@ -3358,27 +3358,27 @@ export type DatasetResponse = {
  */
 export type DatasetRowsResponse = {
     /**
-     * Approximate Total
-     *
-     * Estimated total row count (may use pg stats)
-     */
-    approximate_total: number;
-    /**
      * Columns
      */
     columns: Array<ColumnChange>;
-    /**
-     * Next Cursor
-     *
-     * Cursor value for the next page, null if last
-     */
-    next_cursor?: number | null;
     /**
      * Rows
      */
     rows: Array<{
         [key: string]: unknown;
     }>;
+    /**
+     * Approximate Total
+     *
+     * Estimated total row count (may use pg stats)
+     */
+    approximate_total: number;
+    /**
+     * Next Cursor
+     *
+     * Cursor value for the next page, null if last
+     */
+    next_cursor?: number | null;
 };
 
 /**
@@ -3386,13 +3386,13 @@ export type DatasetRowsResponse = {
  */
 export type DatasetVersionListResponse = {
     /**
-     * Total
-     */
-    total: number;
-    /**
      * Versions
      */
     versions: Array<DatasetVersionResponse>;
+    /**
+     * Total
+     */
+    total: number;
 };
 
 /**
@@ -3400,25 +3400,17 @@ export type DatasetVersionListResponse = {
  */
 export type DatasetVersionResponse = {
     /**
+     * Id
+     */
+    id: string;
+    /**
      * Dataset Id
      */
     dataset_id: string;
     /**
-     * Feature Count
+     * Version Number
      */
-    feature_count: number | null;
-    /**
-     * File Hash
-     */
-    file_hash: string | null;
-    /**
-     * Geometry Type
-     */
-    geometry_type: string | null;
-    /**
-     * Id
-     */
-    id: string;
+    version_number: number;
     /**
      * Source Filename
      */
@@ -3428,21 +3420,29 @@ export type DatasetVersionResponse = {
      */
     source_format: string | null;
     /**
+     * Feature Count
+     */
+    feature_count: number | null;
+    /**
      * Srid
      */
     srid: number | null;
     /**
-     * Uploaded At
+     * Geometry Type
      */
-    uploaded_at: string;
+    geometry_type: string | null;
+    /**
+     * File Hash
+     */
+    file_hash: string | null;
     /**
      * Uploaded By
      */
     uploaded_by: string | null;
     /**
-     * Version Number
+     * Uploaded At
      */
-    version_number: number;
+    uploaded_at: string;
 };
 
 /**
@@ -3450,13 +3450,13 @@ export type DatasetVersionResponse = {
  */
 export type DbfTruncationCollisionWarning = {
     /**
-     * Details
-     */
-    details: Array<DbfTruncationDetail>;
-    /**
      * Kind
      */
     kind: 'dbf_truncation_collision';
+    /**
+     * Details
+     */
+    details: Array<DbfTruncationDetail>;
 };
 
 /**
@@ -3464,13 +3464,13 @@ export type DbfTruncationCollisionWarning = {
  */
 export type DbfTruncationDetail = {
     /**
-     * Originals
-     */
-    originals: Array<string>;
-    /**
      * Truncated
      */
     truncated: string;
+    /**
+     * Originals
+     */
+    originals: Array<string>;
 };
 
 /**
@@ -3495,10 +3495,6 @@ export type DbfTruncationDetail = {
  */
 export type DerivedFromResponse = {
     /**
-     * Created At
-     */
-    created_at: string;
-    /**
      * Dataset Id
      *
      * The dataset this one was derived from
@@ -3518,6 +3514,10 @@ export type DerivedFromResponse = {
     params: {
         [key: string]: unknown;
     };
+    /**
+     * Created At
+     */
+    created_at: string;
 };
 
 /**
@@ -3551,11 +3551,11 @@ export type DiscoverResponse = {
  */
 export type DiscoveredTable = {
     /**
-     * Estimated Rows
+     * Table Name
      *
-     * PostgreSQL row count estimate from `pg_class.reltuples`.
+     * PostgreSQL table name in the `data` schema.
      */
-    estimated_rows: number | null;
+    table_name: string;
     /**
      * Geometry Type
      *
@@ -3569,21 +3569,17 @@ export type DiscoveredTable = {
      */
     srid: number | null;
     /**
-     * Table Name
+     * Estimated Rows
      *
-     * PostgreSQL table name in the `data` schema.
+     * PostgreSQL row count estimate from `pg_class.reltuples`.
      */
-    table_name: string;
+    estimated_rows: number | null;
 };
 
 /**
  * DistributionCreate
  */
 export type DistributionCreate = {
-    /**
-     * Description
-     */
-    description?: string | null;
     /**
      * Distribution Type
      *
@@ -3597,17 +3593,19 @@ export type DistributionCreate = {
      */
     format: string;
     /**
-     * Is Primary
+     * Url
      *
-     * Mark as the preferred distribution
+     * Access URL for this distribution
      */
-    is_primary?: boolean;
+    url: string;
     /**
-     * Media Type
-     *
-     * IANA media type, e.g. application/geo+json
+     * Title
      */
-    media_type?: string | null;
+    title?: string | null;
+    /**
+     * Description
+     */
+    description?: string | null;
     /**
      * Protocol
      *
@@ -3615,15 +3613,17 @@ export type DistributionCreate = {
      */
     protocol?: string | null;
     /**
-     * Title
-     */
-    title?: string | null;
-    /**
-     * Url
+     * Media Type
      *
-     * Access URL for this distribution
+     * IANA media type, e.g. application/geo+json
      */
-    url: string;
+    media_type?: string | null;
+    /**
+     * Is Primary
+     *
+     * Mark as the preferred distribution
+     */
+    is_primary?: boolean;
 };
 
 /**
@@ -3645,15 +3645,13 @@ export type DistributionListResponse = {
  */
 export type DistributionResponse = {
     /**
-     * Auto Generated
-     *
-     * True if created automatically by the system
+     * Id
      */
-    auto_generated: boolean;
+    id: string;
     /**
-     * Description
+     * Record Id
      */
-    description: string | null;
+    record_id: string;
     /**
      * Distribution Type
      */
@@ -3663,43 +3661,41 @@ export type DistributionResponse = {
      */
     format: string | null;
     /**
-     * Id
+     * Url
      */
-    id: string;
-    /**
-     * Is Primary
-     */
-    is_primary: boolean;
-    /**
-     * Media Type
-     */
-    media_type: string | null;
-    /**
-     * Protocol
-     */
-    protocol: string | null;
-    /**
-     * Record Id
-     */
-    record_id: string;
+    url: string;
     /**
      * Title
      */
     title: string | null;
     /**
-     * Url
+     * Description
      */
-    url: string;
+    description: string | null;
+    /**
+     * Protocol
+     */
+    protocol: string | null;
+    /**
+     * Media Type
+     */
+    media_type: string | null;
+    /**
+     * Is Primary
+     */
+    is_primary: boolean;
+    /**
+     * Auto Generated
+     *
+     * True if created automatically by the system
+     */
+    auto_generated: boolean;
 };
 
 /**
  * DistributionUpdate
  */
 export type DistributionUpdate = {
-    /**
-     * Description
-     */
-    description?: string | null;
     /**
      * Distribution Type
      */
@@ -3709,25 +3705,29 @@ export type DistributionUpdate = {
      */
     format?: string | null;
     /**
-     * Is Primary
+     * Url
      */
-    is_primary?: boolean | null;
-    /**
-     * Media Type
-     */
-    media_type?: string | null;
-    /**
-     * Protocol
-     */
-    protocol?: string | null;
+    url?: string | null;
     /**
      * Title
      */
     title?: string | null;
     /**
-     * Url
+     * Description
      */
-    url?: string | null;
+    description?: string | null;
+    /**
+     * Protocol
+     */
+    protocol?: string | null;
+    /**
+     * Media Type
+     */
+    media_type?: string | null;
+    /**
+     * Is Primary
+     */
+    is_primary?: boolean | null;
 };
 
 /**
@@ -3735,17 +3735,17 @@ export type DistributionUpdate = {
  */
 export type DownloadTokenResponse = {
     /**
-     * Expires In
-     *
-     * Seconds until the download token expires
-     */
-    expires_in?: number;
-    /**
      * Token
      *
      * Short-lived download-scoped JWT (typ='download', TTL ≤ 120s)
      */
     token: string;
+    /**
+     * Expires In
+     *
+     * Seconds until the download token expires
+     */
+    expires_in?: number;
 };
 
 /**
@@ -3754,6 +3754,14 @@ export type DownloadTokenResponse = {
  * Result of a dry-run import showing what would change.
  */
 export type DryRunResponse = {
+    /**
+     * Settings
+     *
+     * Per-setting diff result keyed by setting name.
+     */
+    settings: {
+        [key: string]: unknown;
+    };
     /**
      * Oauth Providers
      *
@@ -3768,59 +3776,67 @@ export type DryRunResponse = {
      * Short-lived signed confirmation token required to apply an overwrite. Bound to the normalized payload, overwrite mode, and current configuration state.
      */
     preview_token?: string | null;
-    /**
-     * Settings
-     *
-     * Per-setting diff result keyed by setting name.
-     */
-    settings: {
-        [key: string]: unknown;
-    };
 };
 
 /**
  * DuplicateMapResponse
  */
 export type DuplicateMapResponse = {
-    basemap_config?: BasemapConfig | null;
     /**
-     * Basemap Style
+     * Id
      */
-    basemap_style: string;
+    id: string;
     /**
-     * Bearing
+     * Name
      */
-    bearing: number;
-    /**
-     * Center Lat
-     */
-    center_lat: number | null;
-    /**
-     * Center Lng
-     */
-    center_lng: number | null;
-    /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Created By
-     */
-    created_by: string | null;
-    /**
-     * Created By Username
-     */
-    created_by_username?: string | null;
+    name: string;
     /**
      * Description
      */
     description: string | null;
     /**
-     * Excluded Layer Count
-     *
-     * Layers skipped due to access restrictions
+     * Notes
      */
-    excluded_layer_count?: number;
+    notes?: string | null;
+    /**
+     * Center Lng
+     */
+    center_lng: number | null;
+    /**
+     * Center Lat
+     */
+    center_lat: number | null;
+    /**
+     * Zoom
+     */
+    zoom: number | null;
+    /**
+     * Bearing
+     */
+    bearing: number;
+    /**
+     * Pitch
+     */
+    pitch: number;
+    /**
+     * Basemap Style
+     */
+    basemap_style: string;
+    /**
+     * Show Basemap Labels
+     */
+    show_basemap_labels: boolean;
+    basemap_config?: BasemapConfig | null;
+    terrain_config?: TerrainConfig | null;
+    visibility: MapVisibility;
+    /**
+     * Thumbnail Url
+     */
+    thumbnail_url?: string | null;
+    /**
+     * Og Image Url
+     */
+    og_image_url?: string | null;
     /**
      * Forked From Id
      *
@@ -3832,59 +3848,43 @@ export type DuplicateMapResponse = {
      */
     forked_from_name?: string | null;
     /**
-     * Id
+     * Created By
      */
-    id: string;
+    created_by: string | null;
     /**
-     * Layer Count
+     * Created By Username
      */
-    layer_count: number;
+    created_by_username?: string | null;
+    /**
+     * Created At
+     */
+    created_at: string;
+    /**
+     * Updated At
+     */
+    updated_at: string;
     /**
      * Layers
      */
     layers: Array<MapLayerResponse>;
     /**
-     * Legend Title
+     * Layer Count
      */
-    legend_title?: string | null;
-    /**
-     * Name
-     */
-    name: string;
-    /**
-     * Notes
-     */
-    notes?: string | null;
-    /**
-     * Og Image Url
-     */
-    og_image_url?: string | null;
-    /**
-     * Pitch
-     */
-    pitch: number;
+    layer_count: number;
     /**
      * Plugins
      */
     plugins?: Array<string> | null;
     /**
-     * Show Basemap Labels
+     * Legend Title
      */
-    show_basemap_labels: boolean;
-    terrain_config?: TerrainConfig | null;
+    legend_title?: string | null;
     /**
-     * Thumbnail Url
+     * Excluded Layer Count
+     *
+     * Layers skipped due to access restrictions
      */
-    thumbnail_url?: string | null;
-    /**
-     * Updated At
-     */
-    updated_at: string;
-    visibility: MapVisibility;
-    /**
-     * Zoom
-     */
-    zoom: number | null;
+    excluded_layer_count?: number;
 };
 
 /**
@@ -3918,12 +3918,6 @@ export type EditionInfoResponse = {
  */
 export type EmbedTokenCreate = {
     /**
-     * Allowed Origins
-     *
-     * Restrict embedding to these origins. Omit or null allows any origin; non-empty origin restrictions require advanced sharing controls.
-     */
-    allowed_origins?: Array<string> | null;
-    /**
      * Expires In Days
      *
      * Token lifetime in days (1-365). The default 30-day lifetime is always available; custom lifetimes require advanced sharing controls.
@@ -3935,6 +3929,12 @@ export type EmbedTokenCreate = {
      * Human-readable label for the token
      */
     name?: string | null;
+    /**
+     * Allowed Origins
+     *
+     * Restrict embedding to these origins. Omit or null allows any origin; non-empty origin restrictions require advanced sharing controls.
+     */
+    allowed_origins?: Array<string> | null;
 };
 
 /**
@@ -3942,29 +3942,9 @@ export type EmbedTokenCreate = {
  */
 export type EmbedTokenCreatedResponse = {
     /**
-     * Allowed Origins
-     */
-    allowed_origins?: Array<string> | null;
-    /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Expires At
-     */
-    expires_at: string;
-    /**
      * Id
      */
     id: string;
-    /**
-     * Is Active
-     */
-    is_active: boolean;
-    /**
-     * Last Used At
-     */
-    last_used_at?: string | null;
     /**
      * Map Id
      */
@@ -3974,21 +3954,41 @@ export type EmbedTokenCreatedResponse = {
      */
     name?: string | null;
     /**
-     * Raw Token
+     * Token Hint
      */
-    raw_token: string;
+    token_hint: string;
     /**
      * Scoped Dataset Ids
      */
     scoped_dataset_ids: Array<string>;
     /**
-     * Token Hint
+     * Allowed Origins
      */
-    token_hint: string;
+    allowed_origins?: Array<string> | null;
+    /**
+     * Expires At
+     */
+    expires_at: string;
+    /**
+     * Is Active
+     */
+    is_active: boolean;
     /**
      * Use Count
      */
     use_count?: number;
+    /**
+     * Last Used At
+     */
+    last_used_at?: string | null;
+    /**
+     * Created At
+     */
+    created_at: string;
+    /**
+     * Raw Token
+     */
+    raw_token: string;
 };
 
 /**
@@ -4010,29 +4010,9 @@ export type EmbedTokenListResponse = {
  */
 export type EmbedTokenResponse = {
     /**
-     * Allowed Origins
-     */
-    allowed_origins?: Array<string> | null;
-    /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Expires At
-     */
-    expires_at: string;
-    /**
      * Id
      */
     id: string;
-    /**
-     * Is Active
-     */
-    is_active: boolean;
-    /**
-     * Last Used At
-     */
-    last_used_at?: string | null;
     /**
      * Map Id
      */
@@ -4042,17 +4022,37 @@ export type EmbedTokenResponse = {
      */
     name?: string | null;
     /**
-     * Scoped Dataset Ids
-     */
-    scoped_dataset_ids: Array<string>;
-    /**
      * Token Hint
      */
     token_hint: string;
     /**
+     * Scoped Dataset Ids
+     */
+    scoped_dataset_ids: Array<string>;
+    /**
+     * Allowed Origins
+     */
+    allowed_origins?: Array<string> | null;
+    /**
+     * Expires At
+     */
+    expires_at: string;
+    /**
+     * Is Active
+     */
+    is_active: boolean;
+    /**
      * Use Count
      */
     use_count?: number;
+    /**
+     * Last Used At
+     */
+    last_used_at?: string | null;
+    /**
+     * Created At
+     */
+    created_at: string;
 };
 
 /**
@@ -4072,11 +4072,11 @@ export type EmbedTokenUpdate = {
  */
 export type EmbeddingStatsResponse = {
     /**
-     * Coverage Percent
+     * Total Records
      *
-     * Embedding coverage as a percentage (0-100).
+     * Total number of records in the catalog.
      */
-    coverage_percent: number;
+    total_records: number;
     /**
      * Embedded Records
      *
@@ -4090,11 +4090,11 @@ export type EmbeddingStatsResponse = {
      */
     missing_records: number;
     /**
-     * Total Records
+     * Coverage Percent
      *
-     * Total number of records in the catalog.
+     * Embedding coverage as a percentage (0-100).
      */
-    total_records: number;
+    coverage_percent: number;
 };
 
 /**
@@ -4123,18 +4123,6 @@ export type ExportFormat = 'gpkg' | 'geojson' | 'shp' | 'csv' | 'parquet';
  */
 export type FacetCountResponse = {
     /**
-     * Collections
-     *
-     * Collections containing matched records
-     */
-    collections?: Array<CollectionFacetItem>;
-    /**
-     * Keywords
-     *
-     * Top keyword tags with counts
-     */
-    keywords?: Array<FacetValueCount>;
-    /**
      * Record Type
      *
      * Hit counts keyed by record type
@@ -4142,6 +4130,12 @@ export type FacetCountResponse = {
     record_type: {
         [key: string]: number;
     };
+    /**
+     * Keywords
+     *
+     * Top keyword tags with counts
+     */
+    keywords?: Array<FacetValueCount>;
     /**
      * Source Organization
      *
@@ -4154,6 +4148,12 @@ export type FacetCountResponse = {
      * Top SRIDs with counts
      */
     srid?: Array<FacetValueCount>;
+    /**
+     * Collections
+     *
+     * Collections containing matched records
+     */
+    collections?: Array<CollectionFacetItem>;
 };
 
 /**
@@ -4163,13 +4163,13 @@ export type FacetCountResponse = {
  */
 export type FacetValueCount = {
     /**
-     * Count
-     */
-    count: number;
-    /**
      * Value
      */
     value: string;
+    /**
+     * Count
+     */
+    count: number;
 };
 
 /**
@@ -4236,18 +4236,6 @@ export type FanOutLayerRequest = {
  */
 export type FanOutLayerResult = {
     /**
-     * Dataset Id
-     *
-     * ID of the new Dataset record created for this layer. Null on failure.
-     */
-    dataset_id?: string | null;
-    /**
-     * Error
-     *
-     * User-safe error description when status='failed'. Never contains internal file paths.
-     */
-    error?: string | null;
-    /**
      * Layer Name
      *
      * Layer name from the request.
@@ -4260,11 +4248,23 @@ export type FanOutLayerResult = {
      */
     new_job_id?: string | null;
     /**
+     * Dataset Id
+     *
+     * ID of the new Dataset record created for this layer. Null on failure.
+     */
+    dataset_id?: string | null;
+    /**
      * Status
      *
      * 'queued' if the task was dispatched; 'failed' if an error occurred.
      */
     status: 'queued' | 'failed';
+    /**
+     * Error
+     *
+     * User-safe error description when status='failed'. Never contains internal file paths.
+     */
+    error?: string | null;
 };
 
 /**
@@ -4344,6 +4344,10 @@ export type FeatureUpdate = {
  */
 export type GeoJsonFeature = {
     /**
+     * Type
+     */
+    type?: string;
+    /**
      * Geometry
      */
     geometry?: {
@@ -4355,10 +4359,6 @@ export type GeoJsonFeature = {
     properties?: {
         [key: string]: unknown;
     } | null;
-    /**
-     * Type
-     */
-    type?: string;
     [key: string]: unknown;
 };
 
@@ -4369,13 +4369,13 @@ export type GeoJsonFeature = {
  */
 export type GeoJsonFeatureCollection = {
     /**
-     * Features
-     */
-    features?: Array<GeoJsonFeature>;
-    /**
      * Type
      */
     type?: string;
+    /**
+     * Features
+     */
+    features?: Array<GeoJsonFeature>;
     [key: string]: unknown;
 };
 
@@ -4386,13 +4386,13 @@ export type GeoJsonFeatureCollection = {
  */
 export type GeoJsonGeometry = {
     /**
-     * Coordinates
-     */
-    coordinates: Array<unknown>;
-    /**
      * Type
      */
     type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+    /**
+     * Coordinates
+     */
+    coordinates: Array<unknown>;
 };
 
 /**
@@ -4414,13 +4414,13 @@ export type GeoJsonGeometry = {
  */
 export type GeoJsonGeometryCollection = {
     /**
-     * Geometries
-     */
-    geometries: Array<GeoJsonGeometry>;
-    /**
      * Type
      */
     type: 'GeometryCollection';
+    /**
+     * Geometries
+     */
+    geometries: Array<GeoJsonGeometry>;
 };
 
 /**
@@ -4438,6 +4438,14 @@ export type HttpValidationError = {
  */
 export type HealthResponse = {
     /**
+     * Status
+     */
+    status: string;
+    /**
+     * Version
+     */
+    version: string;
+    /**
      * Build
      */
     build?: string | null;
@@ -4447,14 +4455,6 @@ export type HealthResponse = {
     providers: {
         [key: string]: ServiceHealth;
     };
-    /**
-     * Status
-     */
-    status: string;
-    /**
-     * Version
-     */
-    version: string;
 };
 
 /**
@@ -4463,30 +4463,6 @@ export type HealthResponse = {
  * Summary of what was applied during an import.
  */
 export type ImportResult = {
-    /**
-     * Oauth Accounts Deleted
-     *
-     * Number of dependent OAuth account links cascade-deleted in overwrite mode.
-     */
-    oauth_accounts_deleted?: number;
-    /**
-     * Oauth Created
-     *
-     * Number of new OAuth providers created.
-     */
-    oauth_created: number;
-    /**
-     * Oauth Deleted
-     *
-     * Number of OAuth providers deleted (overwrite mode only).
-     */
-    oauth_deleted: number;
-    /**
-     * Oauth Updated
-     *
-     * Number of existing OAuth providers updated.
-     */
-    oauth_updated: number;
     /**
      * Settings Applied
      *
@@ -4505,6 +4481,30 @@ export type ImportResult = {
      * Names of restricted setting keys that were skipped by the current runtime.
      */
     settings_skipped_restricted?: Array<string>;
+    /**
+     * Oauth Created
+     *
+     * Number of new OAuth providers created.
+     */
+    oauth_created: number;
+    /**
+     * Oauth Updated
+     *
+     * Number of existing OAuth providers updated.
+     */
+    oauth_updated: number;
+    /**
+     * Oauth Deleted
+     *
+     * Number of OAuth providers deleted (overwrite mode only).
+     */
+    oauth_deleted: number;
+    /**
+     * Oauth Accounts Deleted
+     *
+     * Number of dependent OAuth account links cascade-deleted in overwrite mode.
+     */
+    oauth_accounts_deleted?: number;
 };
 
 /**
@@ -4512,23 +4512,17 @@ export type ImportResult = {
  */
 export type InfrastructureConfig = {
     /**
+     * Storage Provider
+     *
+     * Active storage backend ('local' or 's3').
+     */
+    storage_provider: string;
+    /**
      * Cache Provider
      *
      * Active cache backend ('memory' or 'redis').
      */
     cache_provider: string;
-    /**
-     * Cdn Configured
-     *
-     * Whether a CDN base URL is configured for tile delivery.
-     */
-    cdn_configured: boolean;
-    /**
-     * Database Pooler
-     *
-     * Active connection pooler mode ('sqlalchemy' or 'external').
-     */
-    database_pooler: string;
     /**
      * Database Type
      *
@@ -4536,11 +4530,11 @@ export type InfrastructureConfig = {
      */
     database_type: string;
     /**
-     * Storage Provider
+     * Database Pooler
      *
-     * Active storage backend ('local' or 's3').
+     * Active connection pooler mode ('sqlalchemy' or 'external').
      */
-    storage_provider: string;
+    database_pooler: string;
     /**
      * Tile Cache
      *
@@ -4553,6 +4547,12 @@ export type InfrastructureConfig = {
      * Tile cache TTL in seconds.
      */
     tile_cache_ttl: number;
+    /**
+     * Cdn Configured
+     *
+     * Whether a CDN base URL is configured for tile delivery.
+     */
+    cdn_configured: boolean;
 };
 
 /**
@@ -4586,67 +4586,33 @@ export type InfrastructureResponse = {
  */
 export type JobStatusResponse = {
     /**
-     * Archive Failed
-     */
-    archive_failed?: boolean;
-    /**
-     * Can Retry
-     */
-    can_retry: boolean;
-    /**
-     * Completed At
-     */
-    completed_at: string | null;
-    /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Current Step
-     */
-    current_step?: 'queued' | 'validating' | 'ogr2ogr' | 'finalize' | 'complete' | 'cog_convert' | 'quicklook' | 'analyzing' | 'registering' | null;
-    /**
-     * Dataset Id
-     */
-    dataset_id: string | null;
-    /**
-     * Error Message
-     */
-    error_message: string | null;
-    /**
      * Id
      */
     id: string;
-    /**
-     * Progress
-     */
-    progress?: number | null;
-    /**
-     * Retry Reason
-     */
-    retry_reason: string | null;
-    /**
-     * Rows Processed
-     */
-    rows_processed?: number | null;
-    /**
-     * Source Filename
-     */
-    source_filename: string | null;
-    /**
-     * Started At
-     */
-    started_at: string | null;
     /**
      * Status
      */
     status: 'pending' | 'running' | 'complete' | 'failed' | 'cancelled' | 'fanned_out';
     /**
-     * Temporal Parse Errors
+     * Dataset Id
      */
-    temporal_parse_errors?: {
-        [key: string]: string;
-    };
+    dataset_id: string | null;
+    /**
+     * Source Filename
+     */
+    source_filename: string | null;
+    /**
+     * Error Message
+     */
+    error_message: string | null;
+    /**
+     * Can Retry
+     */
+    can_retry: boolean;
+    /**
+     * Retry Reason
+     */
+    retry_reason: string | null;
     /**
      * Warning Message
      */
@@ -4655,6 +4621,40 @@ export type JobStatusResponse = {
      * Warnings
      */
     warnings?: Array<ReservedRenameWarning | DbfTruncationCollisionWarning | MercatorClipWarning>;
+    /**
+     * Progress
+     */
+    progress?: number | null;
+    /**
+     * Current Step
+     */
+    current_step?: 'queued' | 'validating' | 'ogr2ogr' | 'finalize' | 'complete' | 'cog_convert' | 'quicklook' | 'analyzing' | 'registering' | null;
+    /**
+     * Rows Processed
+     */
+    rows_processed?: number | null;
+    /**
+     * Archive Failed
+     */
+    archive_failed?: boolean;
+    /**
+     * Temporal Parse Errors
+     */
+    temporal_parse_errors?: {
+        [key: string]: string;
+    };
+    /**
+     * Started At
+     */
+    started_at: string | null;
+    /**
+     * Completed At
+     */
+    completed_at: string | null;
+    /**
+     * Created At
+     */
+    created_at: string;
 };
 
 /**
@@ -4666,29 +4666,23 @@ export type KeywordCreate = {
      */
     keyword: string;
     /**
-     * Keyword Type
-     *
-     * ISO MD_KeywordTypeCode, e.g. theme, place, discipline
-     */
-    keyword_type?: string;
-    /**
      * Vocabulary Uri
      *
      * URI of the controlled vocabulary
      */
     vocabulary_uri?: string | null;
+    /**
+     * Keyword Type
+     *
+     * ISO MD_KeywordTypeCode, e.g. theme, place, discipline
+     */
+    keyword_type?: string;
 };
 
 /**
  * KeywordListResponse
  */
 export type KeywordListResponse = {
-    /**
-     * Inherited Audience Gap
-     *
-     * True when at least one keyword is inherited AND this record's audience — at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters, which are honored only for the record's owner and admins — includes someone who cannot open the source dataset (feat #1070).
-     */
-    inherited_audience_gap?: boolean;
     /**
      * Keywords
      */
@@ -4697,6 +4691,12 @@ export type KeywordListResponse = {
      * Total
      */
     total: number;
+    /**
+     * Inherited Audience Gap
+     *
+     * True when at least one keyword is inherited AND this record's audience — at its stored state, or at the counterfactual audience_visibility/audience_record_status query parameters, which are honored only for the record's owner and admins — includes someone who cannot open the source dataset (feat #1070).
+     */
+    inherited_audience_gap?: boolean;
 };
 
 /**
@@ -4708,27 +4708,27 @@ export type KeywordResponse = {
      */
     id: string;
     /**
-     * Inherited
-     *
-     * True when this keyword also exists on the dataset this record was derived from (feat #1070). Derived at read time from derived_from; only ever true for a requester who can access that source dataset, so everyone else sees false — matching the derived_from redaction.
+     * Record Id
      */
-    inherited?: boolean;
+    record_id: string;
     /**
      * Keyword
      */
     keyword: string;
     /**
+     * Vocabulary Uri
+     */
+    vocabulary_uri: string | null;
+    /**
      * Keyword Type
      */
     keyword_type: string;
     /**
-     * Record Id
+     * Inherited
+     *
+     * True when this keyword also exists on the dataset this record was derived from (feat #1070). Derived at read time from derived_from; only ever true for a requester who can access that source dataset, so everyone else sees false — matching the derived_from redaction.
      */
-    record_id: string;
-    /**
-     * Vocabulary Uri
-     */
-    vocabulary_uri: string | null;
+    inherited?: boolean;
 };
 
 /**
@@ -4770,6 +4770,12 @@ export type KeywordSuggestionsResponse = {
  */
 export type LandingPage = {
     /**
+     * Title
+     *
+     * OGC API landing page title.
+     */
+    title: string;
+    /**
      * Description
      *
      * Human-readable API description.
@@ -4781,12 +4787,6 @@ export type LandingPage = {
      * Top-level navigation links to conformance, collections, and API document.
      */
     links: Array<OgcLink>;
-    /**
-     * Title
-     *
-     * OGC API landing page title.
-     */
-    title: string;
 };
 
 /**
@@ -4794,11 +4794,17 @@ export type LandingPage = {
  */
 export type LayerInfo = {
     /**
-     * Feature Count
+     * Name
      *
-     * Total feature count if reported by the service.
+     * Internal layer identifier used by the source service.
      */
-    feature_count?: number | null;
+    name: string;
+    /**
+     * Title
+     *
+     * Human-readable layer title from the service capabilities.
+     */
+    title?: string | null;
     /**
      * Geometry Type
      *
@@ -4806,17 +4812,11 @@ export type LayerInfo = {
      */
     geometry_type?: string | null;
     /**
-     * Kind
+     * Feature Count
      *
-     * Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image*. Everything else (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'.
+     * Total feature count if reported by the service.
      */
-    kind?: 'vector' | 'raster';
-    /**
-     * Layer Id
-     *
-     * Numeric or string layer ID used by ArcGIS services.
-     */
-    layer_id?: number | string | null;
+    feature_count?: number | null;
     /**
      * Layer Type
      *
@@ -4824,11 +4824,11 @@ export type LayerInfo = {
      */
     layer_type?: string;
     /**
-     * Name
+     * Layer Id
      *
-     * Internal layer identifier used by the source service.
+     * Numeric or string layer ID used by ArcGIS services.
      */
-    name: string;
+    layer_id?: number | string | null;
     /**
      * Object Id Field
      *
@@ -4836,17 +4836,21 @@ export type LayerInfo = {
      */
     object_id_field?: string | null;
     /**
-     * Title
+     * Kind
      *
-     * Human-readable layer title from the service capabilities.
+     * Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image*. Everything else (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'.
      */
-    title?: string | null;
+    kind?: 'vector' | 'raster';
 };
 
 /**
  * LayerPreview
  */
 export type LayerPreview = {
+    /**
+     * Name
+     */
+    name: string;
     /**
      * Feature Count
      */
@@ -4855,10 +4859,6 @@ export type LayerPreview = {
      * Field Count
      */
     field_count?: number | null;
-    /**
-     * Name
-     */
-    name: string;
 };
 
 /**
@@ -4880,35 +4880,39 @@ export type LineageDraftResponse = {
  */
 export type ManifestApplyEntryResult = {
     /**
-     * Action
-     */
-    action: 'create' | 'update' | 'skip' | 'error';
-    /**
-     * Dataset Id
-     */
-    dataset_id?: string | null;
-    /**
      * Dataset Key
      */
     dataset_key: string;
     /**
-     * Errors
+     * Action
      */
-    errors?: Array<string>;
+    action: 'create' | 'update' | 'skip' | 'error';
     /**
      * Job Id
      */
     job_id?: string | null;
     /**
+     * Dataset Id
+     */
+    dataset_id?: string | null;
+    /**
      * Message
      */
     message: string;
+    /**
+     * Errors
+     */
+    errors?: Array<string>;
 };
 
 /**
  * ManifestApplyRequest
  */
 export type ManifestApplyRequest = {
+    /**
+     * Manifest Version
+     */
+    manifest_version: '1';
     catalog: ManifestCatalog;
     /**
      * Datasets
@@ -4918,10 +4922,6 @@ export type ManifestApplyRequest = {
      * Dry Run
      */
     dry_run?: boolean;
-    /**
-     * Manifest Version
-     */
-    manifest_version: '1';
 };
 
 /**
@@ -4946,7 +4946,10 @@ export type ManifestApplyResponse = {
  * ManifestCatalog
  */
 export type ManifestCatalog = {
-    contact?: ManifestContact | null;
+    /**
+     * Title
+     */
+    title: string;
     /**
      * Description
      */
@@ -4955,10 +4958,7 @@ export type ManifestCatalog = {
      * Organization
      */
     organization?: string | null;
-    /**
-     * Title
-     */
-    title: string;
+    contact?: ManifestContact | null;
 };
 
 /**
@@ -4966,13 +4966,13 @@ export type ManifestCatalog = {
  */
 export type ManifestContact = {
     /**
-     * Email
-     */
-    email?: string | null;
-    /**
      * Name
      */
     name?: string | null;
+    /**
+     * Email
+     */
+    email?: string | null;
     /**
      * Url
      */
@@ -4984,33 +4984,49 @@ export type ManifestContact = {
  */
 export type ManifestDataset = {
     /**
-     * Description
-     */
-    description?: string | null;
-    /**
      * Key
      *
      * Stable dataset identity key used for idempotent apply operations.
      */
     key: string;
-    metadata?: ManifestMetadata | null;
-    publication: ManifestPublication;
+    /**
+     * Title
+     */
+    title: string;
+    /**
+     * Description
+     */
+    description?: string | null;
     /**
      * Sources
      */
     sources: [
         ManifestSource
     ];
-    /**
-     * Title
-     */
-    title: string;
+    metadata?: ManifestMetadata | null;
+    publication: ManifestPublication;
 };
 
 /**
  * ManifestMetadata
  */
 export type ManifestMetadata = {
+    /**
+     * Tags
+     */
+    tags?: Array<string> | null;
+    /**
+     * Organization
+     */
+    organization?: string | null;
+    /**
+     * Crs
+     */
+    crs?: string | null;
+    /**
+     * License
+     */
+    license?: string | null;
     /**
      * Attribution
      */
@@ -5024,22 +5040,6 @@ export type ManifestMetadata = {
         number,
         number
     ] | null;
-    /**
-     * Crs
-     */
-    crs?: string | null;
-    /**
-     * License
-     */
-    license?: string | null;
-    /**
-     * Organization
-     */
-    organization?: string | null;
-    /**
-     * Tags
-     */
-    tags?: Array<string> | null;
 };
 
 /**
@@ -5059,22 +5059,6 @@ export type ManifestPublication = {
  */
 export type ManifestSource = {
     /**
-     * Description
-     */
-    description?: string | null;
-    /**
-     * Format
-     */
-    format?: string | null;
-    /**
-     * Layer
-     */
-    layer?: string | null;
-    /**
-     * Title
-     */
-    title?: string | null;
-    /**
      * Type
      *
      * Source modality. Vector sources require zip, gpkg, geojson, json, csv, xlsx, or xls; raster_cog sources require tif or tiff.
@@ -5086,6 +5070,22 @@ export type ManifestSource = {
      * Relative path (no `..` traversal), HTTP(S) URL, or storage URI.
      */
     uri: string;
+    /**
+     * Title
+     */
+    title?: string | null;
+    /**
+     * Description
+     */
+    description?: string | null;
+    /**
+     * Format
+     */
+    format?: string | null;
+    /**
+     * Layer
+     */
+    layer?: string | null;
 };
 
 /**
@@ -5093,17 +5093,17 @@ export type ManifestSource = {
  */
 export type MapAccessResponse = {
     /**
-     * Can Edit
-     *
-     * True when the current request may open the map builder
-     */
-    can_edit: boolean;
-    /**
      * Can View
      *
      * True when the current request may read the map
      */
     can_view: boolean;
+    /**
+     * Can Edit
+     *
+     * True when the current request may open the map builder
+     */
+    can_edit: boolean;
 };
 
 /**
@@ -5111,21 +5111,17 @@ export type MapAccessResponse = {
  */
 export type MapCreate = {
     /**
-     * Curated map-level basemap appearance preferences
+     * Name
+     *
+     * Map display name
      */
-    basemap_config?: BasemapConfig | null;
+    name: string;
     /**
      * Description
      *
      * Short description for sharing
      */
     description?: string | null;
-    /**
-     * Name
-     *
-     * Map display name
-     */
-    name: string;
     /**
      * Notes
      *
@@ -5136,6 +5132,10 @@ export type MapCreate = {
      * Map-level terrain source and exaggeration preferences
      */
     terrain_config?: TerrainConfig | null;
+    /**
+     * Curated map-level basemap appearance preferences
+     */
+    basemap_config?: BasemapConfig | null;
 };
 
 /**
@@ -5167,27 +5167,19 @@ export type MapDefaultsResponse = {
  */
 export type MapGenerateRequest = {
     /**
-     * Language
-     */
-    language?: string | null;
-    /**
      * Prompt
      */
     prompt: string;
+    /**
+     * Language
+     */
+    language?: string | null;
 };
 
 /**
  * MapGenerateResponse
  */
 export type MapGenerateResponse = {
-    /**
-     * Datasets Used
-     */
-    datasets_used: Array<string>;
-    /**
-     * Explanation
-     */
-    explanation: string;
     /**
      * Map Id
      */
@@ -5196,34 +5188,20 @@ export type MapGenerateResponse = {
      * Map Name
      */
     map_name: string;
+    /**
+     * Explanation
+     */
+    explanation: string;
+    /**
+     * Datasets Used
+     */
+    datasets_used: Array<string>;
 };
 
 /**
  * MapHistoryEventResponse
  */
 export type MapHistoryEventResponse = {
-    /**
-     * Action
-     */
-    action: string;
-    /**
-     * Actor Id
-     */
-    actor_id?: string | null;
-    /**
-     * Actor Username
-     */
-    actor_username?: string | null;
-    /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Details
-     */
-    details?: {
-        [key: string]: unknown;
-    };
     /**
      * Id
      */
@@ -5233,9 +5211,17 @@ export type MapHistoryEventResponse = {
      */
     map_id: string;
     /**
-     * Summary
+     * Actor Id
      */
-    summary: string;
+    actor_id?: string | null;
+    /**
+     * Actor Username
+     */
+    actor_username?: string | null;
+    /**
+     * Target Type
+     */
+    target_type: string;
     /**
      * Target Id
      */
@@ -5245,9 +5231,23 @@ export type MapHistoryEventResponse = {
      */
     target_name?: string | null;
     /**
-     * Target Type
+     * Action
      */
-    target_type: string;
+    action: string;
+    /**
+     * Summary
+     */
+    summary: string;
+    /**
+     * Details
+     */
+    details?: {
+        [key: string]: unknown;
+    };
+    /**
+     * Created At
+     */
+    created_at: string;
 };
 
 /**
@@ -5259,17 +5259,17 @@ export type MapHistoryListResponse = {
      */
     events: Array<MapHistoryEventResponse>;
     /**
-     * Limit
+     * Total
      */
-    limit: number;
+    total: number;
     /**
      * Skip
      */
     skip: number;
     /**
-     * Total
+     * Limit
      */
-    total: number;
+    limit: number;
 };
 
 /**
@@ -5287,37 +5287,37 @@ export type MapIconListResponse = {
  */
 export type MapIconResponse = {
     /**
-     * Builtin
-     */
-    builtin?: boolean;
-    /**
      * Id
      */
     id: string;
-    /**
-     * Media Type
-     */
-    media_type: string;
     /**
      * Name
      */
     name: string;
     /**
-     * Size Bytes
-     */
-    size_bytes?: number | null;
-    /**
      * Slug
      */
     slug: string;
+    /**
+     * Media Type
+     */
+    media_type: string;
+    /**
+     * Url
+     */
+    url: string;
     /**
      * Sprite Id
      */
     sprite_id: string;
     /**
-     * Url
+     * Size Bytes
      */
-    url: string;
+    size_bytes?: number | null;
+    /**
+     * Builtin
+     */
+    builtin?: boolean;
 };
 
 /**
@@ -5331,11 +5331,13 @@ export type MapLayerDiffRequest = {
      */
     added?: Array<MapLayerInput>;
     /**
-     * Fallback Full Replace
-     *
-     * Client hint only; PATCH never performs full replacement
+     * Updated
      */
-    fallback_full_replace?: boolean;
+    updated?: Array<MapLayerPatch>;
+    /**
+     * Removed
+     */
+    removed?: Array<string>;
     /**
      * Order
      *
@@ -5343,13 +5345,11 @@ export type MapLayerDiffRequest = {
      */
     order?: Array<string> | null;
     /**
-     * Removed
+     * Fallback Full Replace
+     *
+     * Client hint only; PATCH never performs full replacement
      */
-    removed?: Array<string>;
-    /**
-     * Updated
-     */
-    updated?: Array<MapLayerPatch>;
+    fallback_full_replace?: boolean;
 };
 
 /**
@@ -5357,49 +5357,25 @@ export type MapLayerDiffRequest = {
  */
 export type MapLayerInput = {
     /**
-     * Dataset Id
-     */
-    dataset_id: string;
-    /**
-     * Display Name
-     *
-     * Label shown in the layer list
-     */
-    display_name?: string | null;
-    /**
-     * Filter
-     *
-     * MapLibre filter expression
-     */
-    filter?: Array<unknown> | null;
-    /**
      * Id
      *
      * Existing layer id to update in place (full-save reconcile)
      */
     id?: string | null;
     /**
-     * Label Config
-     *
-     * Text label configuration
+     * Dataset Id
      */
-    label_config?: {
-        [key: string]: unknown;
-    } | null;
+    dataset_id: string;
     /**
-     * Layer Type
+     * Sort Order
      *
-     * Auto-detected from record_type if omitted
+     * Draw order (lower draws first)
      */
-    layer_type?: string | null;
+    sort_order?: number;
     /**
-     * Layout
-     *
-     * MapLibre layout properties override
+     * Visible
      */
-    layout?: {
-        [key: string]: unknown;
-    } | null;
+    visible?: boolean;
     /**
      * Opacity
      *
@@ -5415,41 +5391,17 @@ export type MapLayerInput = {
         [key: string]: unknown;
     } | null;
     /**
-     * Popup configuration: {enabled, expression, visible_fields}
-     */
-    popup_config?: PopupConfig | null;
-    /**
-     * Show In Legend
+     * Layout
      *
-     * Whether to include in the map legend
+     * MapLibre layout properties override
      */
-    show_in_legend?: boolean;
-    /**
-     * Sort Order
-     *
-     * Draw order (lower draws first)
-     */
-    sort_order?: number;
-    /**
-     * Style Config
-     *
-     * Data-driven and builder UI style configuration. Builder-only state lives under builder, e.g. fill_disabled, stroke_disabled, outline settings, heatmap metadata, and height_column.
-     */
-    style_config?: {
+    layout?: {
         [key: string]: unknown;
     } | null;
     /**
-     * Visible
-     */
-    visible?: boolean;
-};
-
-/**
- * MapLayerPatch
- */
-export type MapLayerPatch = {
-    /**
      * Display Name
+     *
+     * Label shown in the layer list
      */
     display_name?: string | null;
     /**
@@ -5459,10 +5411,6 @@ export type MapLayerPatch = {
      */
     filter?: Array<unknown> | null;
     /**
-     * Id
-     */
-    id: string;
-    /**
      * Label Config
      *
      * Text label configuration
@@ -5471,17 +5419,47 @@ export type MapLayerPatch = {
         [key: string]: unknown;
     } | null;
     /**
+     * Popup configuration: {enabled, expression, visible_fields}
+     */
+    popup_config?: PopupConfig | null;
+    /**
+     * Style Config
+     *
+     * Data-driven and builder UI style configuration. Builder-only state lives under builder, e.g. fill_disabled, stroke_disabled, outline settings, heatmap metadata, and height_column.
+     */
+    style_config?: {
+        [key: string]: unknown;
+    } | null;
+    /**
      * Layer Type
+     *
+     * Auto-detected from record_type if omitted
      */
     layer_type?: string | null;
     /**
-     * Layout
+     * Show In Legend
      *
-     * MapLibre layout properties override
+     * Whether to include in the map legend
      */
-    layout?: {
-        [key: string]: unknown;
-    } | null;
+    show_in_legend?: boolean;
+};
+
+/**
+ * MapLayerPatch
+ */
+export type MapLayerPatch = {
+    /**
+     * Id
+     */
+    id: string;
+    /**
+     * Sort Order
+     */
+    sort_order?: number | null;
+    /**
+     * Visible
+     */
+    visible?: boolean | null;
     /**
      * Opacity
      */
@@ -5494,15 +5472,33 @@ export type MapLayerPatch = {
     paint?: {
         [key: string]: unknown;
     } | null;
+    /**
+     * Layout
+     *
+     * MapLibre layout properties override
+     */
+    layout?: {
+        [key: string]: unknown;
+    } | null;
+    /**
+     * Display Name
+     */
+    display_name?: string | null;
+    /**
+     * Filter
+     *
+     * MapLibre filter expression
+     */
+    filter?: Array<unknown> | null;
+    /**
+     * Label Config
+     *
+     * Text label configuration
+     */
+    label_config?: {
+        [key: string]: unknown;
+    } | null;
     popup_config?: PopupConfig | null;
-    /**
-     * Show In Legend
-     */
-    show_in_legend?: boolean | null;
-    /**
-     * Sort Order
-     */
-    sort_order?: number | null;
     /**
      * Style Config
      */
@@ -5510,9 +5506,13 @@ export type MapLayerPatch = {
         [key: string]: unknown;
     } | null;
     /**
-     * Visible
+     * Layer Type
      */
-    visible?: boolean | null;
+    layer_type?: string | null;
+    /**
+     * Show In Legend
+     */
+    show_in_legend?: boolean | null;
 };
 
 /**
@@ -5520,27 +5520,9 @@ export type MapLayerPatch = {
  */
 export type MapLayerResponse = {
     /**
-     * Band Count
+     * Id
      */
-    band_count?: number | null;
-    /**
-     * Dataset Column Info
-     */
-    dataset_column_info?: Array<{
-        [key: string]: unknown;
-    }> | null;
-    /**
-     * Dataset Extent Bbox
-     */
-    dataset_extent_bbox: Array<number> | null;
-    /**
-     * Dataset Feature Count
-     */
-    dataset_feature_count?: number | null;
-    /**
-     * Dataset Geometry Type
-     */
-    dataset_geometry_type: string | null;
+    id: string;
     /**
      * Dataset Id
      */
@@ -5550,9 +5532,27 @@ export type MapLayerResponse = {
      */
     dataset_name: string;
     /**
-     * Dataset Record Type
+     * Dataset Geometry Type
      */
-    dataset_record_type?: string | null;
+    dataset_geometry_type: string | null;
+    /**
+     * Dataset Table Name
+     */
+    dataset_table_name: string;
+    /**
+     * Dataset Extent Bbox
+     */
+    dataset_extent_bbox: Array<number> | null;
+    /**
+     * Dataset Column Info
+     */
+    dataset_column_info?: Array<{
+        [key: string]: unknown;
+    }> | null;
+    /**
+     * Dataset Feature Count
+     */
+    dataset_feature_count?: number | null;
     /**
      * Dataset Sample Values
      */
@@ -5560,57 +5560,17 @@ export type MapLayerResponse = {
         [key: string]: unknown;
     } | null;
     /**
-     * Dataset Status
-     */
-    dataset_status?: string | null;
-    /**
-     * Dataset Table Name
-     */
-    dataset_table_name: string;
-    /**
-     * Dataset Visibility
-     */
-    dataset_visibility?: string | null;
-    /**
-     * Dem Vertical Units
-     */
-    dem_vertical_units?: string | null;
-    /**
      * Display Name
      */
     display_name?: string | null;
     /**
-     * Filter
+     * Sort Order
      */
-    filter?: Array<unknown> | null;
+    sort_order: number;
     /**
-     * Id
+     * Visible
      */
-    id: string;
-    /**
-     * Is 3D
-     */
-    is_3d?: boolean | null;
-    /**
-     * Is Dem
-     */
-    is_dem?: boolean | null;
-    /**
-     * Label Config
-     */
-    label_config?: {
-        [key: string]: unknown;
-    } | null;
-    /**
-     * Layer Type
-     */
-    layer_type?: string;
-    /**
-     * Layout
-     */
-    layout: {
-        [key: string]: unknown;
-    };
+    visible: boolean;
     /**
      * Opacity
      */
@@ -5621,15 +5581,31 @@ export type MapLayerResponse = {
     paint: {
         [key: string]: unknown;
     };
+    /**
+     * Layout
+     */
+    layout: {
+        [key: string]: unknown;
+    };
+    /**
+     * Layer Type
+     */
+    layer_type?: string;
+    /**
+     * Dataset Record Type
+     */
+    dataset_record_type?: string | null;
+    /**
+     * Filter
+     */
+    filter?: Array<unknown> | null;
+    /**
+     * Label Config
+     */
+    label_config?: {
+        [key: string]: unknown;
+    } | null;
     popup_config?: PopupConfig | null;
-    /**
-     * Show In Legend
-     */
-    show_in_legend?: boolean;
-    /**
-     * Sort Order
-     */
-    sort_order: number;
     /**
      * Style Config
      */
@@ -5637,13 +5613,37 @@ export type MapLayerResponse = {
         [key: string]: unknown;
     } | null;
     /**
+     * Show In Legend
+     */
+    show_in_legend?: boolean;
+    /**
+     * Is 3D
+     */
+    is_3d?: boolean | null;
+    /**
+     * Is Dem
+     */
+    is_dem?: boolean | null;
+    /**
+     * Dem Vertical Units
+     */
+    dem_vertical_units?: string | null;
+    /**
+     * Band Count
+     */
+    band_count?: number | null;
+    /**
      * Tile Version
      */
     tile_version?: number | null;
     /**
-     * Visible
+     * Dataset Visibility
      */
-    visible: boolean;
+    dataset_visibility?: string | null;
+    /**
+     * Dataset Status
+     */
+    dataset_status?: string | null;
 };
 
 /**
@@ -5664,39 +5664,61 @@ export type MapListResponse = {
  * MapResponse
  */
 export type MapResponse = {
-    basemap_config?: BasemapConfig | null;
     /**
-     * Basemap Style
+     * Id
      */
-    basemap_style: string;
+    id: string;
     /**
-     * Bearing
+     * Name
      */
-    bearing: number;
+    name: string;
     /**
-     * Center Lat
+     * Description
      */
-    center_lat: number | null;
+    description: string | null;
+    /**
+     * Notes
+     */
+    notes?: string | null;
     /**
      * Center Lng
      */
     center_lng: number | null;
     /**
-     * Created At
+     * Center Lat
      */
-    created_at: string;
+    center_lat: number | null;
     /**
-     * Created By
+     * Zoom
      */
-    created_by: string | null;
+    zoom: number | null;
     /**
-     * Created By Username
+     * Bearing
      */
-    created_by_username?: string | null;
+    bearing: number;
     /**
-     * Description
+     * Pitch
      */
-    description: string | null;
+    pitch: number;
+    /**
+     * Basemap Style
+     */
+    basemap_style: string;
+    /**
+     * Show Basemap Labels
+     */
+    show_basemap_labels: boolean;
+    basemap_config?: BasemapConfig | null;
+    terrain_config?: TerrainConfig | null;
+    visibility: MapVisibility;
+    /**
+     * Thumbnail Url
+     */
+    thumbnail_url?: string | null;
+    /**
+     * Og Image Url
+     */
+    og_image_url?: string | null;
     /**
      * Forked From Id
      *
@@ -5708,59 +5730,37 @@ export type MapResponse = {
      */
     forked_from_name?: string | null;
     /**
-     * Id
+     * Created By
      */
-    id: string;
+    created_by: string | null;
     /**
-     * Layer Count
+     * Created By Username
      */
-    layer_count: number;
+    created_by_username?: string | null;
+    /**
+     * Created At
+     */
+    created_at: string;
+    /**
+     * Updated At
+     */
+    updated_at: string;
     /**
      * Layers
      */
     layers: Array<MapLayerResponse>;
     /**
-     * Legend Title
+     * Layer Count
      */
-    legend_title?: string | null;
-    /**
-     * Name
-     */
-    name: string;
-    /**
-     * Notes
-     */
-    notes?: string | null;
-    /**
-     * Og Image Url
-     */
-    og_image_url?: string | null;
-    /**
-     * Pitch
-     */
-    pitch: number;
+    layer_count: number;
     /**
      * Plugins
      */
     plugins?: Array<string> | null;
     /**
-     * Show Basemap Labels
+     * Legend Title
      */
-    show_basemap_labels: boolean;
-    terrain_config?: TerrainConfig | null;
-    /**
-     * Thumbnail Url
-     */
-    thumbnail_url?: string | null;
-    /**
-     * Updated At
-     */
-    updated_at: string;
-    visibility: MapVisibility;
-    /**
-     * Zoom
-     */
-    zoom: number | null;
+    legend_title?: string | null;
 };
 
 /**
@@ -5780,27 +5780,17 @@ export type MapResponse = {
  */
 export type MapStyleImportRequest = {
     /**
-     * Bearing
-     */
-    bearing?: number | null;
-    /**
-     * Center
+     * Version
      *
-     * [longitude, latitude] map center
+     * MapLibre style version (always 8 in current spec)
      */
-    center?: Array<number> | null;
+    version?: number | null;
     /**
-     * Glyphs
-     */
-    glyphs?: string | null;
-    /**
-     * Layers
+     * Name
      *
-     * MapLibre layer specifications
+     * Display name for the imported map
      */
-    layers?: Array<{
-        [key: string]: unknown;
-    }> | null;
+    name?: string | null;
     /**
      * Metadata
      *
@@ -5810,11 +5800,19 @@ export type MapStyleImportRequest = {
         [key: string]: unknown;
     } | null;
     /**
-     * Name
+     * Center
      *
-     * Display name for the imported map
+     * [longitude, latitude] map center
      */
-    name?: string | null;
+    center?: Array<number> | null;
+    /**
+     * Zoom
+     */
+    zoom?: number | null;
+    /**
+     * Bearing
+     */
+    bearing?: number | null;
     /**
      * Pitch
      */
@@ -5832,6 +5830,10 @@ export type MapStyleImportRequest = {
      */
     sprite?: string | null;
     /**
+     * Glyphs
+     */
+    glyphs?: string | null;
+    /**
      * Terrain
      *
      * MapLibre terrain config (source + exaggeration)
@@ -5840,15 +5842,13 @@ export type MapStyleImportRequest = {
         [key: string]: unknown;
     } | null;
     /**
-     * Version
+     * Layers
      *
-     * MapLibre style version (always 8 in current spec)
+     * MapLibre layer specifications
      */
-    version?: number | null;
-    /**
-     * Zoom
-     */
-    zoom?: number | null;
+    layers?: Array<{
+        [key: string]: unknown;
+    }> | null;
     [key: string]: unknown;
 };
 
@@ -5865,14 +5865,6 @@ export type MapStyleImportResponse = {
  */
 export type MapStyleImportSummary = {
     /**
-     * Layers Imported
-     */
-    layers_imported?: number;
-    /**
-     * Layers Skipped
-     */
-    layers_skipped?: number;
-    /**
      * Sources Matched
      */
     sources_matched?: number;
@@ -5880,6 +5872,14 @@ export type MapStyleImportSummary = {
      * Sources Unsupported
      */
     sources_unsupported?: number;
+    /**
+     * Layers Imported
+     */
+    layers_imported?: number;
+    /**
+     * Layers Skipped
+     */
+    layers_skipped?: number;
     /**
      * Warnings
      */
@@ -5895,10 +5895,6 @@ export type MapStyleImportWarning = {
      */
     code: string;
     /**
-     * Layer Id
-     */
-    layer_id?: string | null;
-    /**
      * Message
      */
     message: string;
@@ -5906,6 +5902,10 @@ export type MapStyleImportWarning = {
      * Source Id
      */
     source_id?: string | null;
+    /**
+     * Layer Id
+     */
+    layer_id?: string | null;
 };
 
 /**
@@ -5913,42 +5913,42 @@ export type MapStyleImportWarning = {
  */
 export type MapSummaryResponse = {
     /**
-     * Created At
-     */
-    created_at: string;
-    /**
-     * Created By Username
-     */
-    created_by_username?: string | null;
-    /**
-     * Description
-     */
-    description: string | null;
-    /**
      * Id
      */
     id: string;
-    /**
-     * Layer Count
-     */
-    layer_count: number;
     /**
      * Name
      */
     name: string;
     /**
-     * Thumbnail Updated At
+     * Description
      */
-    thumbnail_updated_at?: string | null;
+    description: string | null;
+    visibility: MapVisibility;
     /**
      * Thumbnail Url
      */
     thumbnail_url?: string | null;
     /**
+     * Thumbnail Updated At
+     */
+    thumbnail_updated_at?: string | null;
+    /**
+     * Layer Count
+     */
+    layer_count: number;
+    /**
+     * Created By Username
+     */
+    created_by_username?: string | null;
+    /**
+     * Created At
+     */
+    created_at: string;
+    /**
      * Updated At
      */
     updated_at: string;
-    visibility: MapVisibility;
 };
 
 /**
@@ -5956,27 +5956,17 @@ export type MapSummaryResponse = {
  */
 export type MapUpdate = {
     /**
-     * Curated map-level basemap appearance preferences
+     * Name
      */
-    basemap_config?: BasemapConfig | null;
+    name?: string | null;
     /**
-     * Basemap Style
-     *
-     * Basemap style ID or URL
+     * Description
      */
-    basemap_style?: string | null;
+    description?: string | null;
     /**
-     * Bearing
-     *
-     * Map rotation in degrees
+     * Notes
      */
-    bearing?: number | null;
-    /**
-     * Center Lat
-     *
-     * Map center latitude
-     */
-    center_lat?: number | null;
+    notes?: string | null;
     /**
      * Center Lng
      *
@@ -5984,29 +5974,23 @@ export type MapUpdate = {
      */
     center_lng?: number | null;
     /**
-     * Description
-     */
-    description?: string | null;
-    /**
-     * Layers
+     * Center Lat
      *
-     * Full replacement layer list (max 200 layers)
+     * Map center latitude
      */
-    layers?: Array<MapLayerInput> | null;
+    center_lat?: number | null;
     /**
-     * Legend Title
+     * Zoom
      *
-     * Custom map-level legend title. Null/empty leaves the legend without a heading override (ENH-06).
+     * Map zoom level
      */
-    legend_title?: string | null;
+    zoom?: number | null;
     /**
-     * Name
+     * Bearing
+     *
+     * Map rotation in degrees
      */
-    name?: string | null;
-    /**
-     * Notes
-     */
-    notes?: string | null;
+    bearing?: number | null;
     /**
      * Pitch
      *
@@ -6014,15 +5998,19 @@ export type MapUpdate = {
      */
     pitch?: number | null;
     /**
-     * Plugins
+     * Basemap Style
      *
-     * Enabled plugin IDs, e.g. ['measurement']
+     * Basemap style ID or URL
      */
-    plugins?: Array<string> | null;
+    basemap_style?: string | null;
     /**
      * Show Basemap Labels
      */
     show_basemap_labels?: boolean | null;
+    /**
+     * Curated map-level basemap appearance preferences
+     */
+    basemap_config?: BasemapConfig | null;
     /**
      * Map-level terrain source and exaggeration preferences
      */
@@ -6032,11 +6020,23 @@ export type MapUpdate = {
      */
     visibility?: MapVisibility | null;
     /**
-     * Zoom
+     * Layers
      *
-     * Map zoom level
+     * Full replacement layer list (max 200 layers)
      */
-    zoom?: number | null;
+    layers?: Array<MapLayerInput> | null;
+    /**
+     * Plugins
+     *
+     * Enabled plugin IDs, e.g. ['measurement']
+     */
+    plugins?: Array<string> | null;
+    /**
+     * Legend Title
+     *
+     * Custom map-level legend title. Null/empty leaves the legend without a heading override (ENH-06).
+     */
+    legend_title?: string | null;
 };
 
 /**
@@ -6060,28 +6060,28 @@ export type MapVisibility = 'private' | 'internal' | 'public';
  */
 export type MercatorClipDetail = {
     /**
-     * Clip Skipped
+     * Dropped Features
      */
-    clip_skipped?: boolean;
+    dropped_features: number;
     /**
      * Clipped Features
      */
     clipped_features: number;
     /**
-     * Dropped Features
+     * Clip Skipped
      */
-    dropped_features: number;
+    clip_skipped?: boolean;
 };
 
 /**
  * MercatorClipWarning
  */
 export type MercatorClipWarning = {
-    details: MercatorClipDetail;
     /**
      * Kind
      */
     kind: 'mercator_clip';
+    details: MercatorClipDetail;
 };
 
 /**
@@ -6144,17 +6144,17 @@ export type NotificationTestChannelResult = {
      */
     channel: string;
     /**
-     * Error
-     *
-     * Safe error string (exception type name + short message) if ok=False, else null. Never contains secrets.
-     */
-    error?: string | null;
-    /**
      * Ok
      *
      * True if the channel delivered the test notification without error.
      */
     ok: boolean;
+    /**
+     * Error
+     *
+     * Safe error string (exception type name + short message) if ok=False, else null. Never contains secrets.
+     */
+    error?: string | null;
 };
 
 /**
@@ -6168,6 +6168,12 @@ export type NotificationTestChannelResult = {
  */
 export type NotificationTestResponse = {
     /**
+     * Sent
+     *
+     * True if at least one channel successfully delivered the test notification.
+     */
+    sent: boolean;
+    /**
      * Channels
      *
      * Per-channel delivery results. Empty when no channel is configured.
@@ -6179,12 +6185,6 @@ export type NotificationTestResponse = {
      * Human-readable summary of the test result.
      */
     message: string;
-    /**
-     * Sent
-     *
-     * True if at least one channel successfully delivered the test notification.
-     */
-    sent: boolean;
 };
 
 /**
@@ -6194,11 +6194,23 @@ export type NotificationTestResponse = {
  */
 export type OAuthProviderCreate = {
     /**
-     * Authorize Url
+     * Slug
      *
-     * Authorization endpoint. Only needed when discovery_url is not set.
+     * URL-safe identifier used in callback URLs (e.g. 'google', 'azure-ad'). Lowercase, digits, and hyphens only.
      */
-    authorize_url?: string | null;
+    slug: string;
+    /**
+     * Display Name
+     *
+     * Human-readable label shown on the login page button.
+     */
+    display_name: string;
+    /**
+     * Provider Type
+     *
+     * OAuth or SAML provider type. 'google' and 'microsoft' auto-populate the discovery URL; 'oidc' is generic OAuth/OIDC; 'github' uses GitHub's fixed OAuth2 endpoints (no discovery URL); 'saml' is available only on SAML-enabled deployments.
+     */
+    provider_type: 'google' | 'microsoft' | 'oidc' | 'saml' | 'github';
     /**
      * Client Id
      *
@@ -6212,29 +6224,65 @@ export type OAuthProviderCreate = {
      */
     client_secret?: string | null;
     /**
-     * Default Role
-     *
-     * Role assigned to new users created via this provider: 'viewer', 'editor', or 'admin'.
-     */
-    default_role?: string;
-    /**
      * Discovery Url
      *
      * OIDC discovery URL ending in `.well-known/openid-configuration`. Auto-populated for Google and Microsoft.
      */
     discovery_url?: string | null;
     /**
-     * Display Name
+     * Authorize Url
      *
-     * Human-readable label shown on the login page button.
+     * Authorization endpoint. Only needed when discovery_url is not set.
      */
-    display_name: string;
+    authorize_url?: string | null;
     /**
-     * Enabled
+     * Token Url
      *
-     * Whether the provider button appears on the login page.
+     * Token endpoint. Only needed when discovery_url is not set.
      */
-    enabled?: boolean;
+    token_url?: string | null;
+    /**
+     * Userinfo Url
+     *
+     * Userinfo endpoint. Only needed when discovery_url is not set.
+     */
+    userinfo_url?: string | null;
+    /**
+     * Idp Entity Id
+     *
+     * SAML IdP entityID. Required for SAML providers.
+     */
+    idp_entity_id?: string | null;
+    /**
+     * Idp Sso Url
+     *
+     * SAML IdP SSO URL (HTTP-Redirect or HTTP-POST binding). Required for SAML providers.
+     */
+    idp_sso_url?: string | null;
+    /**
+     * Idp Certificate
+     *
+     * SAML IdP signing certificate (PEM). Required for SAML providers. Stored Fernet-encrypted at rest; never returned in responses.
+     */
+    idp_certificate?: string | null;
+    /**
+     * Sp Entity Id
+     *
+     * SP entityID for this provider. Required for SAML providers. Default suggestion: {public_api_url}/auth/saml/{slug}.
+     */
+    sp_entity_id?: string | null;
+    /**
+     * Scopes
+     *
+     * Space-separated OAuth scopes.
+     */
+    scopes?: string;
+    /**
+     * Default Role
+     *
+     * Role assigned to new users created via this provider: 'viewer', 'editor', or 'admin'.
+     */
+    default_role?: string;
     /**
      * Group Claim
      *
@@ -6250,59 +6298,11 @@ export type OAuthProviderCreate = {
         [key: string]: unknown;
     } | null;
     /**
-     * Idp Certificate
+     * Enabled
      *
-     * SAML IdP signing certificate (PEM). Required for SAML providers. Stored Fernet-encrypted at rest; never returned in responses.
+     * Whether the provider button appears on the login page.
      */
-    idp_certificate?: string | null;
-    /**
-     * Idp Entity Id
-     *
-     * SAML IdP entityID. Required for SAML providers.
-     */
-    idp_entity_id?: string | null;
-    /**
-     * Idp Sso Url
-     *
-     * SAML IdP SSO URL (HTTP-Redirect or HTTP-POST binding). Required for SAML providers.
-     */
-    idp_sso_url?: string | null;
-    /**
-     * Provider Type
-     *
-     * OAuth or SAML provider type. 'google' and 'microsoft' auto-populate the discovery URL; 'oidc' is generic OAuth/OIDC; 'github' uses GitHub's fixed OAuth2 endpoints (no discovery URL); 'saml' is available only on SAML-enabled deployments.
-     */
-    provider_type: 'google' | 'microsoft' | 'oidc' | 'saml' | 'github';
-    /**
-     * Scopes
-     *
-     * Space-separated OAuth scopes.
-     */
-    scopes?: string;
-    /**
-     * Slug
-     *
-     * URL-safe identifier used in callback URLs (e.g. 'google', 'azure-ad'). Lowercase, digits, and hyphens only.
-     */
-    slug: string;
-    /**
-     * Sp Entity Id
-     *
-     * SP entityID for this provider. Required for SAML providers. Default suggestion: {public_api_url}/auth/saml/{slug}.
-     */
-    sp_entity_id?: string | null;
-    /**
-     * Token Url
-     *
-     * Token endpoint. Only needed when discovery_url is not set.
-     */
-    token_url?: string | null;
-    /**
-     * Userinfo Url
-     *
-     * Userinfo endpoint. Only needed when discovery_url is not set.
-     */
-    userinfo_url?: string | null;
+    enabled?: boolean;
 };
 
 /**
@@ -6311,6 +6311,12 @@ export type OAuthProviderCreate = {
  * Minimal provider info for the login page (no secrets, no config).
  */
 export type OAuthProviderPublic = {
+    /**
+     * Slug
+     *
+     * URL-safe identifier used in the callback URL.
+     */
+    slug: string;
     /**
      * Display Name
      *
@@ -6323,12 +6329,6 @@ export type OAuthProviderPublic = {
      * Provider type, used by the frontend to pick the right icon.
      */
     provider_type: string;
-    /**
-     * Slug
-     *
-     * URL-safe identifier used in the callback URL.
-     */
-    slug: string;
 };
 
 /**
@@ -6354,35 +6354,17 @@ export type OAuthProviderPublic = {
  */
 export type OAuthProviderResponse = {
     /**
-     * Authorize Url
+     * Id
      *
-     * Authorization endpoint.
+     * Unique provider identifier.
      */
-    authorize_url?: string | null;
+    id: string;
     /**
-     * Client Id
+     * Slug
      *
-     * OAuth client ID. Visible to admins; never exposes client_secret. Null for SAML providers.
+     * URL-safe identifier used in the callback URL.
      */
-    client_id?: string | null;
-    /**
-     * Created At
-     *
-     * Timestamp the provider was created.
-     */
-    created_at: string;
-    /**
-     * Default Role
-     *
-     * Default role assigned to new users.
-     */
-    default_role: string;
-    /**
-     * Discovery Url
-     *
-     * OIDC discovery URL.
-     */
-    discovery_url?: string | null;
+    slug: string;
     /**
      * Display Name
      *
@@ -6390,11 +6372,71 @@ export type OAuthProviderResponse = {
      */
     display_name: string;
     /**
-     * Enabled
+     * Provider Type
      *
-     * Whether the provider button appears on the login page.
+     * Provider type: 'google', 'microsoft', 'oidc', or 'saml'.
      */
-    enabled: boolean;
+    provider_type: string;
+    /**
+     * Client Id
+     *
+     * OAuth client ID. Visible to admins; never exposes client_secret. Null for SAML providers.
+     */
+    client_id?: string | null;
+    /**
+     * Discovery Url
+     *
+     * OIDC discovery URL.
+     */
+    discovery_url?: string | null;
+    /**
+     * Authorize Url
+     *
+     * Authorization endpoint.
+     */
+    authorize_url?: string | null;
+    /**
+     * Token Url
+     *
+     * Token endpoint.
+     */
+    token_url?: string | null;
+    /**
+     * Userinfo Url
+     *
+     * Userinfo endpoint.
+     */
+    userinfo_url?: string | null;
+    /**
+     * Idp Entity Id
+     *
+     * SAML IdP entityID (SAML providers only).
+     */
+    idp_entity_id?: string | null;
+    /**
+     * Idp Sso Url
+     *
+     * SAML IdP SSO URL (SAML providers only).
+     */
+    idp_sso_url?: string | null;
+    /**
+     * Sp Entity Id
+     *
+     * SP entityID for this SAML provider (SAML providers only).
+     */
+    sp_entity_id?: string | null;
+    /**
+     * Scopes
+     *
+     * Space-separated OAuth scopes.
+     */
+    scopes: string;
+    /**
+     * Default Role
+     *
+     * Default role assigned to new users.
+     */
+    default_role: string;
     /**
      * Group Claim
      *
@@ -6410,65 +6452,23 @@ export type OAuthProviderResponse = {
         [key: string]: unknown;
     } | null;
     /**
-     * Id
+     * Enabled
      *
-     * Unique provider identifier.
+     * Whether the provider button appears on the login page.
      */
-    id: string;
+    enabled: boolean;
     /**
-     * Idp Entity Id
+     * Created At
      *
-     * SAML IdP entityID (SAML providers only).
+     * Timestamp the provider was created.
      */
-    idp_entity_id?: string | null;
-    /**
-     * Idp Sso Url
-     *
-     * SAML IdP SSO URL (SAML providers only).
-     */
-    idp_sso_url?: string | null;
-    /**
-     * Provider Type
-     *
-     * Provider type: 'google', 'microsoft', 'oidc', or 'saml'.
-     */
-    provider_type: string;
-    /**
-     * Scopes
-     *
-     * Space-separated OAuth scopes.
-     */
-    scopes: string;
-    /**
-     * Slug
-     *
-     * URL-safe identifier used in the callback URL.
-     */
-    slug: string;
-    /**
-     * Sp Entity Id
-     *
-     * SP entityID for this SAML provider (SAML providers only).
-     */
-    sp_entity_id?: string | null;
-    /**
-     * Token Url
-     *
-     * Token endpoint.
-     */
-    token_url?: string | null;
+    created_at: string;
     /**
      * Updated At
      *
      * Timestamp the provider was last updated.
      */
     updated_at: string;
-    /**
-     * Userinfo Url
-     *
-     * Userinfo endpoint.
-     */
-    userinfo_url?: string | null;
 };
 
 /**
@@ -6478,11 +6478,23 @@ export type OAuthProviderResponse = {
  */
 export type OAuthProviderUpdate = {
     /**
-     * Authorize Url
+     * Slug
      *
-     * Updated authorization endpoint.
+     * New slug. Changes the callback URL — coordinate with the IdP before updating.
      */
-    authorize_url?: string | null;
+    slug?: string | null;
+    /**
+     * Display Name
+     *
+     * New display label.
+     */
+    display_name?: string | null;
+    /**
+     * Provider Type
+     *
+     * New provider type. Rarely changed after creation.
+     */
+    provider_type?: 'google' | 'microsoft' | 'oidc' | 'saml' | 'github' | null;
     /**
      * Client Id
      *
@@ -6496,29 +6508,65 @@ export type OAuthProviderUpdate = {
      */
     client_secret?: string | null;
     /**
-     * Default Role
-     *
-     * Updated default role for new users.
-     */
-    default_role?: string | null;
-    /**
      * Discovery Url
      *
      * Updated OIDC discovery URL.
      */
     discovery_url?: string | null;
     /**
-     * Display Name
+     * Authorize Url
      *
-     * New display label.
+     * Updated authorization endpoint.
      */
-    display_name?: string | null;
+    authorize_url?: string | null;
     /**
-     * Enabled
+     * Token Url
      *
-     * Set to false to hide the provider button without deleting the configuration.
+     * Updated token endpoint.
      */
-    enabled?: boolean | null;
+    token_url?: string | null;
+    /**
+     * Userinfo Url
+     *
+     * Updated userinfo endpoint.
+     */
+    userinfo_url?: string | null;
+    /**
+     * Idp Entity Id
+     *
+     * Updated SAML IdP entityID.
+     */
+    idp_entity_id?: string | null;
+    /**
+     * Idp Sso Url
+     *
+     * Updated SAML IdP SSO URL.
+     */
+    idp_sso_url?: string | null;
+    /**
+     * Idp Certificate
+     *
+     * Updated SAML IdP signing certificate (PEM). Setting this rotates the stored cert; omit to leave unchanged.
+     */
+    idp_certificate?: string | null;
+    /**
+     * Sp Entity Id
+     *
+     * Updated SP entityID.
+     */
+    sp_entity_id?: string | null;
+    /**
+     * Scopes
+     *
+     * Updated space-separated scopes.
+     */
+    scopes?: string | null;
+    /**
+     * Default Role
+     *
+     * Updated default role for new users.
+     */
+    default_role?: string | null;
     /**
      * Group Claim
      *
@@ -6534,59 +6582,11 @@ export type OAuthProviderUpdate = {
         [key: string]: unknown;
     } | null;
     /**
-     * Idp Certificate
+     * Enabled
      *
-     * Updated SAML IdP signing certificate (PEM). Setting this rotates the stored cert; omit to leave unchanged.
+     * Set to false to hide the provider button without deleting the configuration.
      */
-    idp_certificate?: string | null;
-    /**
-     * Idp Entity Id
-     *
-     * Updated SAML IdP entityID.
-     */
-    idp_entity_id?: string | null;
-    /**
-     * Idp Sso Url
-     *
-     * Updated SAML IdP SSO URL.
-     */
-    idp_sso_url?: string | null;
-    /**
-     * Provider Type
-     *
-     * New provider type. Rarely changed after creation.
-     */
-    provider_type?: 'google' | 'microsoft' | 'oidc' | 'saml' | 'github' | null;
-    /**
-     * Scopes
-     *
-     * Updated space-separated scopes.
-     */
-    scopes?: string | null;
-    /**
-     * Slug
-     *
-     * New slug. Changes the callback URL — coordinate with the IdP before updating.
-     */
-    slug?: string | null;
-    /**
-     * Sp Entity Id
-     *
-     * Updated SP entityID.
-     */
-    sp_entity_id?: string | null;
-    /**
-     * Token Url
-     *
-     * Updated token endpoint.
-     */
-    token_url?: string | null;
-    /**
-     * Userinfo Url
-     *
-     * Updated userinfo endpoint.
-     */
-    userinfo_url?: string | null;
+    enabled?: boolean | null;
 };
 
 /**
@@ -6600,17 +6600,17 @@ export type OgcAsset = {
      */
     href: string;
     /**
-     * Roles
+     * Type
      */
-    roles?: Array<string> | null;
+    type: string;
     /**
      * Title
      */
     title?: string | null;
     /**
-     * Type
+     * Roles
      */
-    type: string;
+    roles?: Array<string> | null;
 };
 
 /**
@@ -6620,11 +6620,17 @@ export type OgcAsset = {
  */
 export type OgcCollectionMetadata = {
     /**
-     * Crs
+     * Id
      *
-     * Coordinate reference systems supported for items in this collection.
+     * Stable collection identifier (typically the dataset ID).
      */
-    crs?: Array<string>;
+    id: string;
+    /**
+     * Title
+     *
+     * Human-readable collection title.
+     */
+    title: string;
     /**
      * Description
      *
@@ -6640,29 +6646,23 @@ export type OgcCollectionMetadata = {
         [key: string]: unknown;
     } | null;
     /**
-     * Id
-     *
-     * Stable collection identifier (typically the dataset ID).
-     */
-    id: string;
-    /**
      * Itemtype
      *
      * Type of items in the collection: 'feature' for vector feature collections, 'coverage' for raster/VRT collections (which expose tiles instead of feature items).
      */
     itemType?: string;
     /**
+     * Crs
+     *
+     * Coordinate reference systems supported for items in this collection.
+     */
+    crs?: Array<string>;
+    /**
      * Links
      *
      * Collection navigation links (self, items, queryables, etc.).
      */
     links: Array<OgcLink>;
-    /**
-     * Title
-     *
-     * Human-readable collection title.
-     */
-    title: string;
 };
 
 /**
@@ -6672,19 +6672,17 @@ export type OgcCollectionMetadata = {
  */
 export type OgcCollectionMetadataResponse = {
     /**
-     * Description
-     */
-    description: string;
-    /**
-     * Extent
-     */
-    extent?: {
-        [key: string]: unknown;
-    } | null;
-    /**
      * Id
      */
     id: string;
+    /**
+     * Title
+     */
+    title: string;
+    /**
+     * Description
+     */
+    description: string;
     /**
      * Itemtype
      */
@@ -6696,15 +6694,17 @@ export type OgcCollectionMetadataResponse = {
         [key: string]: unknown;
     }>;
     /**
+     * Extent
+     */
+    extent?: {
+        [key: string]: unknown;
+    } | null;
+    /**
      * Summaries
      */
     summaries?: {
         [key: string]: unknown;
     } | null;
-    /**
-     * Title
-     */
-    title: string;
 };
 
 /**
@@ -6732,15 +6732,13 @@ export type OgcCollectionsResponse = {
  */
 export type OgcFeatureCollectionResponse = {
     /**
-     * Features
+     * Type
      */
-    features: Array<OgcRecordResponse>;
+    type?: string;
     /**
-     * Links
-     *
-     * Pagination and self links
+     * Timestamp
      */
-    links?: Array<OgcRecordLink> | null;
+    timeStamp?: string | null;
     /**
      * Numbermatched
      *
@@ -6754,13 +6752,15 @@ export type OgcFeatureCollectionResponse = {
      */
     numberReturned: number;
     /**
-     * Timestamp
+     * Features
      */
-    timeStamp?: string | null;
+    features: Array<OgcRecordResponse>;
     /**
-     * Type
+     * Links
+     *
+     * Pagination and self links
      */
-    type?: string;
+    links?: Array<OgcRecordLink> | null;
 };
 
 /**
@@ -6780,17 +6780,17 @@ export type OgcLink = {
      */
     rel: string;
     /**
-     * Title
-     *
-     * Optional human-readable label for the link.
-     */
-    title?: string | null;
-    /**
      * Type
      *
      * Media type of the linked resource (e.g. 'application/json', 'application/geo+json').
      */
     type: string;
+    /**
+     * Title
+     *
+     * Optional human-readable label for the link.
+     */
+    title?: string | null;
 };
 
 /**
@@ -6800,13 +6800,13 @@ export type OgcLink = {
  */
 export type OgcRecordLink = {
     /**
-     * Href
-     */
-    href: string;
-    /**
      * Rel
      */
     rel: string;
+    /**
+     * Href
+     */
+    href: string;
     /**
      * Type
      */
@@ -6820,9 +6820,63 @@ export type OgcRecordLink = {
  */
 export type OgcRecordProperties = {
     /**
+     * Type
+     */
+    type?: string;
+    /**
+     * Title
+     */
+    title: string;
+    /**
+     * Description
+     */
+    description: string;
+    /**
+     * Keywords
+     */
+    keywords: Array<string>;
+    /**
+     * Created
+     */
+    created?: string | null;
+    /**
+     * Updated
+     */
+    updated?: string | null;
+    /**
+     * Updated By Display
+     */
+    updated_by_display?: string | null;
+    /**
+     * Never Edited
+     */
+    never_edited?: boolean;
+    /**
+     * Crs
+     */
+    crs?: string | null;
+    /**
+     * Record Type
+     */
+    record_type?: string;
+    /**
      * Band Count
      */
     band_count?: number | null;
+    /**
+     * Geometry Type
+     */
+    geometry_type?: string | null;
+    /**
+     * Feature Count
+     */
+    feature_count?: number | null;
+    /**
+     * Row Count
+     *
+     * Row count for tabular records (alias for feature_count when record_type='table').
+     */
+    row_count?: number | null;
     /**
      * Column Count
      *
@@ -6830,91 +6884,19 @@ export type OgcRecordProperties = {
      */
     column_count?: number | null;
     /**
-     * Constraints
-     */
-    constraints?: {
-        [key: string]: unknown;
-    } | null;
-    /**
-     * Contacts
-     */
-    contacts: Array<{
-        [key: string]: unknown;
-    }>;
-    /**
-     * Created
-     */
-    created?: string | null;
-    /**
-     * Crs
-     */
-    crs?: string | null;
-    /**
-     * Crs Is Geographic
-     *
-     * True when the raster CRS is geographic (gsd/res are degrees, not meters); None when the CRS class is unknown.
-     */
-    crs_is_geographic?: boolean | null;
-    /**
-     * Dataset Count
-     */
-    dataset_count?: number | null;
-    /**
-     * Description
-     */
-    description: string;
-    /**
-     * Distributions
-     */
-    distributions?: Array<{
-        [key: string]: unknown;
-    }> | null;
-    /**
-     * Externalids
-     *
-     * Identifiers assigned by the described resource's source system.
-     */
-    externalIds?: Array<string>;
-    /**
-     * Feature Count
-     */
-    feature_count?: number | null;
-    /**
-     * Formats
-     */
-    formats?: Array<string> | null;
-    /**
-     * Geometry Type
-     */
-    geometry_type?: string | null;
-    /**
-     * Gsd
-     */
-    gsd?: number | null;
-    /**
-     * Has Quicklook
-     */
-    has_quicklook?: boolean;
-    /**
-     * Keywords
-     */
-    keywords: Array<string>;
-    /**
-     * Language
-     */
-    language?: string | null;
-    /**
      * License
      */
     license: string;
     /**
-     * Lineage
+     * Source Organization
      */
-    lineage?: string | null;
+    source_organization?: string | null;
     /**
-     * Never Edited
+     * Source Format
+     *
+     * Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac', 'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.
      */
-    never_edited?: boolean;
+    source_format?: string | null;
     /**
      * Quality Detail
      */
@@ -6926,41 +6908,33 @@ export type OgcRecordProperties = {
      */
     quality_statement?: string | null;
     /**
-     * Record Status
+     * Formats
      */
-    record_status?: string | null;
+    formats?: Array<string> | null;
     /**
-     * Record Type
+     * Language
      */
-    record_type?: string;
+    language?: string | null;
+    /**
+     * Externalids
+     *
+     * Identifiers assigned by the described resource's source system.
+     */
+    externalIds?: Array<string>;
+    /**
+     * Themes
+     */
+    themes: Array<{
+        [key: string]: unknown;
+    }>;
     /**
      * Rights
      */
     rights?: string | null;
     /**
-     * Row Count
-     *
-     * Row count for tabular records (alias for feature_count when record_type='table').
+     * Contacts
      */
-    row_count?: number | null;
-    /**
-     * Source Count
-     */
-    source_count?: number | null;
-    /**
-     * Source Format
-     *
-     * Ingest source format ('geojson', 'shapefile', 'geotiff', 'wfs', 'stac', 'created', ...). Null for datasets registered from existing PostGIS tables and for composed VRT datasets.
-     */
-    source_format?: string | null;
-    /**
-     * Source Organization
-     */
-    source_organization?: string | null;
-    /**
-     * Themes
-     */
-    themes: Array<{
+    contacts: Array<{
         [key: string]: unknown;
     }>;
     /**
@@ -6970,29 +6944,55 @@ export type OgcRecordProperties = {
         [key: string]: unknown;
     };
     /**
-     * Title
+     * Lineage
      */
-    title: string;
-    /**
-     * Type
-     */
-    type?: string;
+    lineage?: string | null;
     /**
      * Update Frequency
      */
     update_frequency?: string | null;
     /**
-     * Updated
+     * Constraints
      */
-    updated?: string | null;
+    constraints?: {
+        [key: string]: unknown;
+    } | null;
     /**
-     * Updated By Display
+     * Distributions
      */
-    updated_by_display?: string | null;
+    distributions?: Array<{
+        [key: string]: unknown;
+    }> | null;
+    /**
+     * Record Status
+     */
+    record_status?: string | null;
+    /**
+     * Has Quicklook
+     */
+    has_quicklook?: boolean;
+    /**
+     * Gsd
+     */
+    gsd?: number | null;
+    /**
+     * Crs Is Geographic
+     *
+     * True when the raster CRS is geographic (gsd/res are degrees, not meters); None when the CRS class is unknown.
+     */
+    crs_is_geographic?: boolean | null;
     /**
      * Vrt Type
      */
     vrt_type?: string | null;
+    /**
+     * Source Count
+     */
+    source_count?: number | null;
+    /**
+     * Dataset Count
+     */
+    dataset_count?: number | null;
 };
 
 /**
@@ -7001,6 +7001,35 @@ export type OgcRecordProperties = {
  * Single OGC API Records Feature.
  */
 export type OgcRecordResponse = {
+    /**
+     * Type
+     */
+    type?: string;
+    /**
+     * Id
+     */
+    id: string;
+    /**
+     * Conformsto
+     */
+    conformsTo?: Array<string> | null;
+    /**
+     * Time
+     */
+    time: {
+        [key: string]: unknown;
+    };
+    /**
+     * Geometry
+     */
+    geometry?: {
+        [key: string]: unknown;
+    } | null;
+    properties: OgcRecordProperties;
+    /**
+     * Links
+     */
+    links: Array<OgcRecordLink>;
     /**
      * Assets
      */
@@ -7011,35 +7040,6 @@ export type OgcRecordResponse = {
      * Bbox
      */
     bbox?: Array<number> | null;
-    /**
-     * Conformsto
-     */
-    conformsTo?: Array<string> | null;
-    /**
-     * Geometry
-     */
-    geometry?: {
-        [key: string]: unknown;
-    } | null;
-    /**
-     * Id
-     */
-    id: string;
-    /**
-     * Links
-     */
-    links: Array<OgcRecordLink>;
-    properties: OgcRecordProperties;
-    /**
-     * Time
-     */
-    time: {
-        [key: string]: unknown;
-    };
-    /**
-     * Type
-     */
-    type?: string;
 };
 
 /**
@@ -7138,11 +7138,11 @@ export type PresignedPartInfo = {
  */
 export type PresignedUploadRequest = {
     /**
-     * Content Type
+     * Filename
      *
-     * MIME type to associate with the uploaded object.
+     * Original filename being uploaded. Used to determine the file extension and content disposition.
      */
-    content_type?: string;
+    filename: string;
     /**
      * File Size
      *
@@ -7150,11 +7150,11 @@ export type PresignedUploadRequest = {
      */
     file_size: number;
     /**
-     * Filename
+     * Content Type
      *
-     * Original filename being uploaded. Used to determine the file extension and content disposition.
+     * MIME type to associate with the uploaded object.
      */
-    filename: string;
+    content_type?: string;
 };
 
 /**
@@ -7168,11 +7168,11 @@ export type PresignedUploadResponse = {
      */
     job_id: string;
     /**
-     * Part Size
+     * Urls
      *
-     * Byte size of each part in a multipart upload.
+     * One presigned PUT URL per part. Single-element list for single-part uploads.
      */
-    part_size?: number | null;
+    urls: Array<string>;
     /**
      * S3 Key
      *
@@ -7186,17 +7186,29 @@ export type PresignedUploadResponse = {
      */
     upload_id?: string | null;
     /**
-     * Urls
+     * Part Size
      *
-     * One presigned PUT URL per part. Single-element list for single-part uploads.
+     * Byte size of each part in a multipart upload.
      */
-    urls: Array<string>;
+    part_size?: number | null;
 };
 
 /**
  * PreviewResponse
  */
 export type PreviewResponse = {
+    /**
+     * Job Id
+     *
+     * Identifier of the ingestion job being previewed.
+     */
+    job_id: string;
+    /**
+     * Source Filename
+     *
+     * Original filename of the uploaded file, if known.
+     */
+    source_filename: string | null;
     /**
      * Columns
      *
@@ -7210,13 +7222,11 @@ export type PreviewResponse = {
      */
     crs: number | null;
     /**
-     * Detected Geometry Columns
+     * Geometry Type
      *
-     * Auto-detected lat/lon or geometry columns for CSV/Excel sources. Null for native geospatial formats.
+     * Detected geometry type (Point, LineString, Polygon, MultiPolygon, etc.), or null for non-spatial data.
      */
-    detected_geometry_columns?: {
-        [key: string]: unknown;
-    } | null;
+    geometry_type: string | null;
     /**
      * Feature Count
      *
@@ -7224,17 +7234,13 @@ export type PreviewResponse = {
      */
     feature_count: number | null;
     /**
-     * Geometry Type
+     * Sample Rows
      *
-     * Detected geometry type (Point, LineString, Polygon, MultiPolygon, etc.), or null for non-spatial data.
+     * Up to 5 sample rows from the source file for preview purposes.
      */
-    geometry_type: string | null;
-    /**
-     * Job Id
-     *
-     * Identifier of the ingestion job being previewed.
-     */
-    job_id: string;
+    sample_rows: Array<{
+        [key: string]: unknown;
+    }>;
     /**
      * Layer Name
      *
@@ -7248,19 +7254,13 @@ export type PreviewResponse = {
      */
     layers?: Array<LayerPreview> | null;
     /**
-     * Sample Rows
+     * Detected Geometry Columns
      *
-     * Up to 5 sample rows from the source file for preview purposes.
+     * Auto-detected lat/lon or geometry columns for CSV/Excel sources. Null for native geospatial formats.
      */
-    sample_rows: Array<{
+    detected_geometry_columns?: {
         [key: string]: unknown;
-    }>;
-    /**
-     * Source Filename
-     *
-     * Original filename of the uploaded file, if known.
-     */
-    source_filename: string | null;
+    } | null;
 };
 
 /**
@@ -7268,35 +7268,23 @@ export type PreviewResponse = {
  */
 export type ProbeRequest = {
     /**
-     * Token
-     *
-     * Optional auth token for protected services (passed as query parameter or bearer token depending on service type).
-     */
-    token?: string | null;
-    /**
      * Url
      *
      * Service URL to probe. May be a WFS GetCapabilities URL or an ArcGIS service endpoint.
      */
     url: string;
+    /**
+     * Token
+     *
+     * Optional auth token for protected services (passed as query parameter or bearer token depending on service type).
+     */
+    token?: string | null;
 };
 
 /**
  * ProbeResponse
  */
 export type ProbeResponse = {
-    /**
-     * Layers
-     *
-     * Layers exposed by the probed service.
-     */
-    layers: Array<LayerInfo>;
-    /**
-     * Selected Layer Id
-     *
-     * Auto-selected layer ID when the input URL contained a specific layer number.
-     */
-    selected_layer_id?: number | string | null;
     /**
      * Service Type
      *
@@ -7309,6 +7297,18 @@ export type ProbeResponse = {
      * Normalized service URL after probing.
      */
     url: string;
+    /**
+     * Layers
+     *
+     * Layers exposed by the probed service.
+     */
+    layers: Array<LayerInfo>;
+    /**
+     * Selected Layer Id
+     *
+     * Auto-selected layer ID when the input URL contained a specific layer number.
+     */
+    selected_layer_id?: number | string | null;
 };
 
 /**
@@ -7316,23 +7316,23 @@ export type ProbeResponse = {
  */
 export type ProblemDetail = {
     /**
-     * Detail
+     * Type
      */
-    detail: string | {
-        [key: string]: unknown;
-    } | Array<unknown>;
-    /**
-     * Status
-     */
-    status: number;
+    type?: string;
     /**
      * Title
      */
     title: string;
     /**
-     * Type
+     * Status
      */
-    type?: string;
+    status: number;
+    /**
+     * Detail
+     */
+    detail: string | {
+        [key: string]: unknown;
+    } | Array<unknown>;
 };
 
 /**
@@ -7340,11 +7340,11 @@ export type ProblemDetail = {
  */
 export type ProviderHealth = {
     /**
-     * Error
+     * Status
      *
-     * Error message when status is 'error'.
+     * Provider health status: 'ok' or 'error'.
      */
-    error?: string | null;
+    status: string;
     /**
      * Latency Ms
      *
@@ -7352,11 +7352,11 @@ export type ProviderHealth = {
      */
     latency_ms: number;
     /**
-     * Status
+     * Error
      *
-     * Provider health status: 'ok' or 'error'.
+     * Error message when status is 'error'.
      */
-    status: string;
+    error?: string | null;
 };
 
 /**
@@ -7366,29 +7366,29 @@ export type ProviderHealth = {
  */
 export type QualityDetail = {
     /**
-     * Attribute Completeness
+     * Overall
      */
-    attribute_completeness: number;
-    /**
-     * Computed At
-     */
-    computed_at?: string | null;
-    /**
-     * Crs Defined
-     */
-    crs_defined?: number | null;
-    /**
-     * Geometry Validity
-     */
-    geometry_validity?: number | null;
+    overall: number;
     /**
      * Metadata Completeness
      */
     metadata_completeness: number;
     /**
-     * Overall
+     * Geometry Validity
      */
-    overall: number;
+    geometry_validity?: number | null;
+    /**
+     * Attribute Completeness
+     */
+    attribute_completeness: number;
+    /**
+     * Crs Defined
+     */
+    crs_defined?: number | null;
+    /**
+     * Computed At
+     */
+    computed_at?: string | null;
 };
 
 /**
@@ -7410,11 +7410,11 @@ export type QualityStatementDraftResponse = {
  */
 export type RasterBandInfo = {
     /**
-     * Color Interp
+     * Index
      *
-     * Color interpretation, e.g. Red, Green, Gray
+     * 1-based band index
      */
-    color_interp?: string | null;
+    index: number;
     /**
      * Dtype
      *
@@ -7422,17 +7422,17 @@ export type RasterBandInfo = {
      */
     dtype: string;
     /**
-     * Index
-     *
-     * 1-based band index
-     */
-    index: number;
-    /**
      * Nodata
      *
      * Nodata sentinel value for this band
      */
     nodata?: string | null;
+    /**
+     * Color Interp
+     *
+     * Color interpretation, e.g. Red, Green, Gray
+     */
+    color_interp?: string | null;
 };
 
 /**
@@ -7446,17 +7446,17 @@ export type RasterConnect = {
      */
     download_url?: string | null;
     /**
-     * S3 Uri
-     *
-     * S3 object URI, e.g. s3://bucket/key.tif
-     */
-    s3_uri?: string | null;
-    /**
      * Tile Url
      *
      * Titiler tile endpoint for this raster
      */
     tile_url: string;
+    /**
+     * S3 Uri
+     *
+     * S3 object URI, e.g. s3://bucket/key.tif
+     */
+    s3_uri?: string | null;
 };
 
 /**
@@ -7464,50 +7464,17 @@ export type RasterConnect = {
  */
 export type RasterMetadata = {
     /**
-     * Band Count
-     */
-    band_count?: number | null;
-    /**
-     * Bands
-     */
-    bands?: Array<RasterBandInfo>;
-    /**
-     * Compression
-     *
-     * Internal compression, e.g. DEFLATE, LZW
-     */
-    compression?: string | null;
-    connect?: RasterConnect | null;
-    /**
-     * Crs Is Geographic
-     *
-     * True when the raster CRS is geographic (res_x/res_y are degrees, not meters); None when the CRS class is unknown.
-     */
-    crs_is_geographic?: boolean | null;
-    /**
      * Epsg
      *
      * EPSG code of the raster CRS
      */
     epsg?: number | null;
     /**
-     * Height
+     * Crs Is Geographic
      *
-     * Raster height in pixels
+     * True when the raster CRS is geographic (res_x/res_y are degrees, not meters); None when the CRS class is unknown.
      */
-    height?: number | null;
-    /**
-     * Is Dem
-     *
-     * True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade
-     */
-    is_dem?: boolean | null;
-    /**
-     * Nodata
-     *
-     * Global nodata sentinel value
-     */
-    nodata?: string | null;
+    crs_is_geographic?: boolean | null;
     /**
      * Res X
      *
@@ -7521,11 +7488,39 @@ export type RasterMetadata = {
      */
     res_y?: number | null;
     /**
-     * Resolution Strategy
-     *
-     * VRT resolution strategy, e.g. highest, average
+     * Band Count
      */
-    resolution_strategy?: string | null;
+    band_count?: number | null;
+    /**
+     * Is Dem
+     *
+     * True if this raster is a DEM (single-band float) usable for 3D terrain/hillshade
+     */
+    is_dem?: boolean | null;
+    /**
+     * Nodata
+     *
+     * Global nodata sentinel value
+     */
+    nodata?: string | null;
+    /**
+     * Compression
+     *
+     * Internal compression, e.g. DEFLATE, LZW
+     */
+    compression?: string | null;
+    /**
+     * Width
+     *
+     * Raster width in pixels
+     */
+    width?: number | null;
+    /**
+     * Height
+     *
+     * Raster height in pixels
+     */
+    height?: number | null;
     /**
      * Size Bytes
      *
@@ -7533,11 +7528,16 @@ export type RasterMetadata = {
      */
     size_bytes?: number | null;
     /**
-     * Source Count
+     * Tile Url
      *
-     * Number of source rasters in a VRT mosaic
+     * Titiler XYZ tile endpoint
      */
-    source_count?: number | null;
+    tile_url?: string | null;
+    /**
+     * Bands
+     */
+    bands?: Array<RasterBandInfo>;
+    connect?: RasterConnect | null;
     /**
      * Status
      *
@@ -7545,23 +7545,23 @@ export type RasterMetadata = {
      */
     status?: string | null;
     /**
-     * Tile Url
-     *
-     * Titiler XYZ tile endpoint
-     */
-    tile_url?: string | null;
-    /**
      * Vrt Type
      *
      * VRT variant: mosaic or timeseries
      */
     vrt_type?: string | null;
     /**
-     * Width
+     * Source Count
      *
-     * Raster width in pixels
+     * Number of source rasters in a VRT mosaic
      */
-    width?: number | null;
+    source_count?: number | null;
+    /**
+     * Resolution Strategy
+     *
+     * VRT resolution strategy, e.g. highest, average
+     */
+    resolution_strategy?: string | null;
 };
 
 /**
@@ -7569,23 +7569,17 @@ export type RasterMetadata = {
  */
 export type RasterPreviewResponse = {
     /**
-     * Band Count
+     * Job Id
      *
-     * Number of raster bands.
+     * Identifier of the raster ingestion job being previewed.
      */
-    band_count: number;
+    job_id: string;
     /**
-     * Compliance Reason
+     * Source Filename
      *
-     * Explanation of COG compliance status. Lists missing requirements when not compliant.
+     * Original filename of the uploaded raster file.
      */
-    compliance_reason: string;
-    /**
-     * Compression
-     *
-     * Existing compression method (e.g. 'LZW', 'DEFLATE'), or null for uncompressed.
-     */
-    compression: string | null;
+    source_filename: string | null;
     /**
      * Crs Epsg
      *
@@ -7599,17 +7593,17 @@ export type RasterPreviewResponse = {
      */
     crs_wkt: string | null;
     /**
-     * Dtype
+     * Band Count
      *
-     * Pixel data type (e.g. 'uint8', 'float32').
+     * Number of raster bands.
      */
-    dtype: string;
+    band_count: number;
     /**
-     * File Size Bytes
+     * Width
      *
-     * Source file size in bytes.
+     * Raster width in pixels.
      */
-    file_size_bytes: number | null;
+    width: number;
     /**
      * Height
      *
@@ -7617,17 +7611,11 @@ export type RasterPreviewResponse = {
      */
     height: number;
     /**
-     * Is Cog Compliant
+     * Dtype
      *
-     * Whether the source file is already a Cloud-Optimized GeoTIFF.
+     * Pixel data type (e.g. 'uint8', 'float32').
      */
-    is_cog_compliant: boolean;
-    /**
-     * Job Id
-     *
-     * Identifier of the raster ingestion job being previewed.
-     */
-    job_id: string;
+    dtype: string;
     /**
      * Nodata
      *
@@ -7647,23 +7635,35 @@ export type RasterPreviewResponse = {
      */
     res_y: number;
     /**
-     * Source Filename
+     * Compression
      *
-     * Original filename of the uploaded raster file.
+     * Existing compression method (e.g. 'LZW', 'DEFLATE'), or null for uncompressed.
      */
-    source_filename: string | null;
+    compression: string | null;
+    /**
+     * File Size Bytes
+     *
+     * Source file size in bytes.
+     */
+    file_size_bytes: number | null;
+    /**
+     * Is Cog Compliant
+     *
+     * Whether the source file is already a Cloud-Optimized GeoTIFF.
+     */
+    is_cog_compliant: boolean;
+    /**
+     * Compliance Reason
+     *
+     * Explanation of COG compliance status. Lists missing requirements when not compliant.
+     */
+    compliance_reason: string;
     /**
      * Temporal Start
      *
      * ISO 8601 acquisition timestamp parsed from raster metadata, if present.
      */
     temporal_start?: string | null;
-    /**
-     * Width
-     *
-     * Raster width in pixels.
-     */
-    width: number;
 };
 
 /**
@@ -7685,49 +7685,49 @@ export type RasterPreviewResponse = {
  */
 export type RasterTileToken = {
     /**
-     * Bounds
-     */
-    bounds: Array<number> | null;
-    /**
-     * Exp
-     */
-    exp: number;
-    /**
-     * Expires In
-     */
-    expires_in: number;
-    /**
-     * Format
-     */
-    format: string;
-    /**
      * Kind
      */
     kind: 'raster';
     /**
-     * Maxzoom
+     * Tile Url
      */
-    maxzoom: number;
-    /**
-     * Minzoom
-     */
-    minzoom: number;
-    /**
-     * Scope
-     */
-    scope: string;
+    tile_url: string;
     /**
      * Sig
      */
     sig: string;
     /**
+     * Exp
+     */
+    exp: number;
+    /**
+     * Scope
+     */
+    scope: string;
+    /**
+     * Expires In
+     */
+    expires_in: number;
+    /**
+     * Bounds
+     */
+    bounds: Array<number> | null;
+    /**
+     * Minzoom
+     */
+    minzoom: number;
+    /**
+     * Maxzoom
+     */
+    maxzoom: number;
+    /**
      * Tile Size
      */
     tile_size: number;
     /**
-     * Tile Url
+     * Format
      */
-    tile_url: string;
+    format: string;
 };
 
 /**
@@ -7745,12 +7745,6 @@ export type RefreshRequest = {
  */
 export type RegisterRequest = {
     /**
-     * Summary
-     *
-     * Optional dataset description.
-     */
-    summary?: string | null;
-    /**
      * Table Name
      *
      * PostgreSQL table name in the `data` schema (max 63 chars per PostgreSQL identifier limit).
@@ -7762,6 +7756,12 @@ export type RegisterRequest = {
      * Human-readable dataset title shown in the catalog.
      */
     title: string;
+    /**
+     * Summary
+     *
+     * Optional dataset description.
+     */
+    summary?: string | null;
     /**
      * Visibility
      *
@@ -7791,18 +7791,6 @@ export type RegisterResponse = {
  */
 export type RelatedDatasetItem = {
     /**
-     * Band Count
-     */
-    band_count?: number | null;
-    /**
-     * Feature Count
-     */
-    feature_count?: number | null;
-    /**
-     * Geometry Type
-     */
-    geometry_type: string | null;
-    /**
      * Id
      */
     id: string;
@@ -7811,15 +7799,27 @@ export type RelatedDatasetItem = {
      */
     name: string;
     /**
-     * Record Type
+     * Geometry Type
      */
-    record_type?: string | null;
+    geometry_type: string | null;
     /**
      * Similarity
      *
      * Cosine similarity score (0-1)
      */
     similarity: number;
+    /**
+     * Record Type
+     */
+    record_type?: string | null;
+    /**
+     * Feature Count
+     */
+    feature_count?: number | null;
+    /**
+     * Band Count
+     */
+    band_count?: number | null;
 };
 
 /**
@@ -7879,23 +7879,19 @@ export type ReservedRenameDetail = {
  */
 export type ReservedRenameWarning = {
     /**
-     * Details
-     */
-    details: Array<ReservedRenameDetail>;
-    /**
      * Kind
      */
     kind: 'reserved_rename';
+    /**
+     * Details
+     */
+    details: Array<ReservedRenameDetail>;
 };
 
 /**
  * ReuploadCommitRequest
  */
 export type ReuploadCommitRequest = {
-    /**
-     * Layer Name
-     */
-    layer_name?: string | null;
     /**
      * Srid Override
      */
@@ -7904,6 +7900,10 @@ export type ReuploadCommitRequest = {
      * Token
      */
     token?: string | null;
+    /**
+     * Layer Name
+     */
+    layer_name?: string | null;
 };
 
 /**
@@ -7915,13 +7915,13 @@ export type ReuploadCommitResponse = {
      */
     job_id: string;
     /**
-     * Message
-     */
-    message: string;
-    /**
      * Status
      */
     status: string;
+    /**
+     * Message
+     */
+    message: string;
 };
 
 /**
@@ -7939,11 +7939,13 @@ export type ReuploadPreviewRequest = {
  */
 export type ReuploadPreviewResponse = {
     /**
-     * All Layers
+     * Job Id
      */
-    all_layers?: Array<{
-        [key: string]: unknown;
-    }> | null;
+    job_id: string;
+    /**
+     * Source Filename
+     */
+    source_filename: string | null;
     /**
      * Columns
      */
@@ -7953,36 +7955,34 @@ export type ReuploadPreviewResponse = {
      */
     crs: number | null;
     /**
-     * Feature Count
-     */
-    feature_count: number | null;
-    /**
      * Geometry Type
      */
     geometry_type: string | null;
     /**
-     * Job Id
+     * Feature Count
      */
-    job_id: string;
-    /**
-     * Layer Name
-     */
-    layer_name: string;
-    /**
-     * Previous Source Layer
-     */
-    previous_source_layer?: string | null;
+    feature_count: number | null;
     /**
      * Sample Rows
      */
     sample_rows: Array<{
         [key: string]: unknown;
     }>;
+    /**
+     * Layer Name
+     */
+    layer_name: string;
     schema_diff: SchemaDiff;
     /**
-     * Source Filename
+     * All Layers
      */
-    source_filename: string | null;
+    all_layers?: Array<{
+        [key: string]: unknown;
+    }> | null;
+    /**
+     * Previous Source Layer
+     */
+    previous_source_layer?: string | null;
 };
 
 /**
@@ -7994,13 +7994,13 @@ export type ReuploadResponse = {
      */
     job_id: string;
     /**
-     * Message
-     */
-    message: string;
-    /**
      * Status
      */
     status?: string;
+    /**
+     * Message
+     */
+    message: string;
 };
 
 /**
@@ -8008,9 +8008,13 @@ export type ReuploadResponse = {
  */
 export type ReuploadServicePreviewRequest = {
     /**
-     * Layer Id
+     * Url
      */
-    layer_id?: number | string | null;
+    url: string;
+    /**
+     * Service Type
+     */
+    service_type: string;
     /**
      * Layer Name
      */
@@ -8020,21 +8024,17 @@ export type ReuploadServicePreviewRequest = {
      */
     layer_title?: string | null;
     /**
-     * Object Id Field
+     * Layer Id
      */
-    object_id_field?: string | null;
-    /**
-     * Service Type
-     */
-    service_type: string;
+    layer_id?: number | string | null;
     /**
      * Token
      */
     token?: string | null;
     /**
-     * Url
+     * Object Id Field
      */
-    url: string;
+    object_id_field?: string | null;
 };
 
 /**
@@ -8044,13 +8044,13 @@ export type ReuploadServicePreviewRequest = {
  */
 export type SseActionsEvent = {
     /**
-     * Actions
-     */
-    actions: Array<ChatAction>;
-    /**
      * Type
      */
     type: 'actions';
+    /**
+     * Actions
+     */
+    actions: Array<ChatAction>;
 };
 
 /**
@@ -8060,13 +8060,13 @@ export type SseActionsEvent = {
  */
 export type SseChatDoneEvent = {
     /**
-     * Explanation
-     */
-    explanation: string;
-    /**
      * Type
      */
     type: 'done';
+    /**
+     * Explanation
+     */
+    explanation: string;
 };
 
 /**
@@ -8075,6 +8075,10 @@ export type SseChatDoneEvent = {
  * Error payload carried inside an already-open SSE response.
  */
 export type SseErrorEvent = {
+    /**
+     * Type
+     */
+    type: 'error';
     /**
      * Message
      */
@@ -8087,10 +8091,6 @@ export type SseErrorEvent = {
      * HTTP-equivalent status for router-level failures; provider and model errors raised inside the stream may omit it.
      */
     status?: number | null;
-    /**
-     * Type
-     */
-    type: 'error';
 };
 
 /**
@@ -8100,13 +8100,9 @@ export type SseErrorEvent = {
  */
 export type SseMapDoneEvent = {
     /**
-     * Datasets Used
+     * Type
      */
-    datasets_used: Array<string>;
-    /**
-     * Explanation
-     */
-    explanation: string;
+    type: 'done';
     /**
      * Map Id
      */
@@ -8116,9 +8112,13 @@ export type SseMapDoneEvent = {
      */
     map_name: string;
     /**
-     * Type
+     * Explanation
      */
-    type: 'done';
+    explanation: string;
+    /**
+     * Datasets Used
+     */
+    datasets_used: Array<string>;
 };
 
 /**
@@ -8128,13 +8128,13 @@ export type SseMapDoneEvent = {
  */
 export type SseTokenEvent = {
     /**
-     * Text
-     */
-    text: string;
-    /**
      * Type
      */
     type: 'token';
+    /**
+     * Text
+     */
+    text: string;
 };
 
 /**
@@ -8144,17 +8144,17 @@ export type SseTokenEvent = {
  */
 export type SseToolResultEvent = {
     /**
-     * Success
+     * Type
      */
-    success: boolean;
+    type: 'tool_result';
     /**
      * Tool
      */
     tool: string;
     /**
-     * Type
+     * Success
      */
-    type: 'tool_result';
+    success: boolean;
 };
 
 /**
@@ -8164,17 +8164,17 @@ export type SseToolResultEvent = {
  */
 export type SseToolStartEvent = {
     /**
-     * Label
+     * Type
      */
-    label: string;
+    type: 'tool_start';
     /**
      * Tool
      */
     tool: string;
     /**
-     * Type
+     * Label
      */
-    type: 'tool_start';
+    label: string;
 };
 
 /**
@@ -8220,10 +8220,6 @@ export type SavedSearchListResponse = {
  */
 export type SavedSearchResponse = {
     /**
-     * Created At
-     */
-    created_at: string;
-    /**
      * Id
      */
     id: string;
@@ -8237,6 +8233,10 @@ export type SavedSearchResponse = {
     params: {
         [key: string]: unknown;
     };
+    /**
+     * Created At
+     */
+    created_at: string;
     /**
      * Updated At
      */
@@ -8260,25 +8260,25 @@ export type SchemaDiff = {
      */
     columns_removed: Array<ColumnChange>;
     /**
-     * Row Count Delta
-     *
-     * row_count_new minus row_count_old
-     */
-    row_count_delta: number;
-    /**
-     * Row Count New
-     */
-    row_count_new: number | null;
-    /**
-     * Row Count Old
-     */
-    row_count_old: number | null;
-    /**
      * Type Changes
      *
      * Columns whose data type changed
      */
     type_changes: Array<TypeChange>;
+    /**
+     * Row Count Old
+     */
+    row_count_old: number | null;
+    /**
+     * Row Count New
+     */
+    row_count_new: number | null;
+    /**
+     * Row Count Delta
+     *
+     * row_count_new minus row_count_old
+     */
+    row_count_delta: number;
 };
 
 /**
@@ -8286,17 +8286,17 @@ export type SchemaDiff = {
  */
 export type ServiceHealth = {
     /**
-     * Error
+     * Status
      */
-    error?: string | null;
+    status: string;
     /**
      * Latency Ms
      */
     latency_ms?: number | null;
     /**
-     * Status
+     * Error
      */
-    status: string;
+    error?: string | null;
 };
 
 /**
@@ -8304,11 +8304,17 @@ export type ServiceHealth = {
  */
 export type ServicePreviewRequest = {
     /**
-     * Layer Id
+     * Url
      *
-     * ArcGIS layer ID, when applicable.
+     * Normalized service URL from a previous probe response.
      */
-    layer_id?: number | string | null;
+    url: string;
+    /**
+     * Service Type
+     *
+     * Service type from the probe response, e.g. 'WFS 2.0.0' or 'ArcGIS FeatureServer'.
+     */
+    service_type: string;
     /**
      * Layer Name
      *
@@ -8322,17 +8328,11 @@ export type ServicePreviewRequest = {
      */
     layer_title?: string | null;
     /**
-     * Object Id Field
+     * Layer Id
      *
-     * ArcGIS OID field name used for orderByFields during preview pagination.
+     * ArcGIS layer ID, when applicable.
      */
-    object_id_field?: string | null;
-    /**
-     * Service Type
-     *
-     * Service type from the probe response, e.g. 'WFS 2.0.0' or 'ArcGIS FeatureServer'.
-     */
-    service_type: string;
+    layer_id?: number | string | null;
     /**
      * Token
      *
@@ -8340,17 +8340,29 @@ export type ServicePreviewRequest = {
      */
     token?: string | null;
     /**
-     * Url
+     * Object Id Field
      *
-     * Normalized service URL from a previous probe response.
+     * ArcGIS OID field name used for orderByFields during preview pagination.
      */
-    url: string;
+    object_id_field?: string | null;
 };
 
 /**
  * ServicePreviewResponse
  */
 export type ServicePreviewResponse = {
+    /**
+     * Job Id
+     *
+     * IngestJob ID for the preview. Use this to commit the import.
+     */
+    job_id: string;
+    /**
+     * Source Filename
+     *
+     * Layer name acting as a source filename for downstream ingestion logic.
+     */
+    source_filename: string | null;
     /**
      * Columns
      *
@@ -8366,29 +8378,17 @@ export type ServicePreviewResponse = {
      */
     crs: number | null;
     /**
-     * Feature Count
-     *
-     * Total feature count if reported by the source service.
-     */
-    feature_count: number | null;
-    /**
      * Geometry Type
      *
      * Detected geometry type.
      */
     geometry_type: string | null;
     /**
-     * Job Id
+     * Feature Count
      *
-     * IngestJob ID for the preview. Use this to commit the import.
+     * Total feature count if reported by the source service.
      */
-    job_id: string;
-    /**
-     * Layer Name
-     *
-     * Layer name as it appears in the remote service.
-     */
-    layer_name: string;
+    feature_count: number | null;
     /**
      * Sample Rows
      *
@@ -8398,11 +8398,11 @@ export type ServicePreviewResponse = {
         [key: string]: unknown;
     }>;
     /**
-     * Source Filename
+     * Layer Name
      *
-     * Layer name acting as a source filename for downstream ingestion logic.
+     * Layer name as it appears in the remote service.
      */
-    source_filename: string | null;
+    layer_name: string;
 };
 
 /**
@@ -8411,18 +8411,6 @@ export type ServicePreviewResponse = {
  * Result of a single service connectivity probe.
  */
 export type ServiceProbeResult = {
-    /**
-     * Error
-     *
-     * Error message when status is 'error'.
-     */
-    error?: string | null;
-    /**
-     * Latency Ms
-     *
-     * Round-trip latency in milliseconds.
-     */
-    latency_ms: number;
     /**
      * Name
      *
@@ -8435,6 +8423,18 @@ export type ServiceProbeResult = {
      * Probe outcome.
      */
     status: 'ok' | 'error';
+    /**
+     * Latency Ms
+     *
+     * Round-trip latency in milliseconds.
+     */
+    latency_ms: number;
+    /**
+     * Error
+     *
+     * Error message when status is 'error'.
+     */
+    error?: string | null;
 };
 
 /**
@@ -8450,11 +8450,11 @@ export type SettingItem = {
      */
     key: string;
     /**
-     * Label
+     * Value
      *
-     * Human-readable label for display in the admin UI.
+     * Current value. Type depends on the setting.
      */
-    label: string;
+    value: unknown;
     /**
      * Source
      *
@@ -8462,11 +8462,11 @@ export type SettingItem = {
      */
     source: string;
     /**
-     * Value
+     * Label
      *
-     * Current value. Type depends on the setting.
+     * Human-readable label for display in the admin UI.
      */
-    value: unknown;
+    label: string;
 };
 
 /**
@@ -8544,13 +8544,11 @@ export type ShareTokenRequest = {
  */
 export type ShareTokenResponse = {
     /**
-     * Expires At
+     * Token
+     *
+     * Raw token on create, hint on retrieve
      */
-    expires_at?: string | null;
-    /**
-     * Is Active
-     */
-    is_active?: boolean;
+    token: string;
     /**
      * Share Url
      *
@@ -8558,11 +8556,13 @@ export type ShareTokenResponse = {
      */
     share_url?: string | null;
     /**
-     * Token
-     *
-     * Raw token on create, hint on retrieve
+     * Expires At
      */
-    token: string;
+    expires_at?: string | null;
+    /**
+     * Is Active
+     */
+    is_active?: boolean;
 };
 
 /**
@@ -8570,11 +8570,9 @@ export type ShareTokenResponse = {
  */
 export type SharedLayerResponse = {
     /**
-     * Column Info
+     * Id
      */
-    column_info?: Array<{
-        [key: string]: unknown;
-    }> | null;
+    id: string;
     /**
      * Dataset Id
      */
@@ -8584,57 +8582,31 @@ export type SharedLayerResponse = {
      */
     dataset_name: string;
     /**
-     * Dataset Record Type
-     */
-    dataset_record_type?: string | null;
-    /**
-     * Dem Vertical Units
-     */
-    dem_vertical_units?: string | null;
-    /**
      * Display Name
      */
     display_name?: string | null;
     /**
-     * Feature Count
+     * Table Name
      */
-    feature_count?: number | null;
-    /**
-     * Filter
-     */
-    filter?: Array<unknown> | null;
+    table_name: string;
     /**
      * Geometry Type
      */
     geometry_type: string | null;
     /**
-     * Id
+     * Column Info
      */
-    id: string;
-    /**
-     * Is 3D
-     */
-    is_3d?: boolean | null;
-    /**
-     * Is Dem
-     */
-    is_dem?: boolean | null;
-    /**
-     * Label Config
-     */
-    label_config?: {
+    column_info?: Array<{
         [key: string]: unknown;
-    } | null;
+    }> | null;
     /**
-     * Layer Type
+     * Sort Order
      */
-    layer_type?: string;
+    sort_order: number;
     /**
-     * Layout
+     * Visible
      */
-    layout: {
-        [key: string]: unknown;
-    };
+    visible: boolean;
     /**
      * Opacity
      */
@@ -8645,15 +8617,31 @@ export type SharedLayerResponse = {
     paint: {
         [key: string]: unknown;
     };
+    /**
+     * Layout
+     */
+    layout: {
+        [key: string]: unknown;
+    };
+    /**
+     * Layer Type
+     */
+    layer_type?: string;
+    /**
+     * Dataset Record Type
+     */
+    dataset_record_type?: string | null;
+    /**
+     * Filter
+     */
+    filter?: Array<unknown> | null;
+    /**
+     * Label Config
+     */
+    label_config?: {
+        [key: string]: unknown;
+    } | null;
     popup_config?: PopupConfig | null;
-    /**
-     * Show In Legend
-     */
-    show_in_legend?: boolean;
-    /**
-     * Sort Order
-     */
-    sort_order: number;
     /**
      * Style Config
      */
@@ -8661,77 +8649,89 @@ export type SharedLayerResponse = {
         [key: string]: unknown;
     } | null;
     /**
-     * Table Name
+     * Show In Legend
      */
-    table_name: string;
+    show_in_legend?: boolean;
     /**
      * Tile Url
      */
     tile_url: string;
     /**
+     * Is Dem
+     */
+    is_dem?: boolean | null;
+    /**
+     * Dem Vertical Units
+     */
+    dem_vertical_units?: string | null;
+    /**
+     * Is 3D
+     */
+    is_3d?: boolean | null;
+    /**
+     * Feature Count
+     */
+    feature_count?: number | null;
+    /**
      * Tile Version
      */
     tile_version?: number | null;
-    /**
-     * Visible
-     */
-    visible: boolean;
 };
 
 /**
  * SharedMapResponse
  */
 export type SharedMapResponse = {
-    basemap_config?: BasemapConfig | null;
-    /**
-     * Basemap Style
-     */
-    basemap_style: string;
-    /**
-     * Bearing
-     */
-    bearing: number;
-    /**
-     * Center Lat
-     */
-    center_lat: number;
-    /**
-     * Center Lng
-     */
-    center_lng: number;
-    /**
-     * Description
-     */
-    description: string | null;
-    /**
-     * Has Non Public Layers
-     */
-    has_non_public_layers?: boolean;
-    /**
-     * Layers
-     */
-    layers: Array<SharedLayerResponse>;
-    /**
-     * Legend Title
-     */
-    legend_title?: string | null;
     /**
      * Name
      */
     name: string;
     /**
-     * Pitch
+     * Description
      */
-    pitch: number;
+    description: string | null;
     /**
-     * Show Basemap Labels
+     * Center Lng
      */
-    show_basemap_labels?: boolean;
-    terrain_config?: TerrainConfig | null;
+    center_lng: number;
+    /**
+     * Center Lat
+     */
+    center_lat: number;
     /**
      * Zoom
      */
     zoom: number;
+    /**
+     * Bearing
+     */
+    bearing: number;
+    /**
+     * Pitch
+     */
+    pitch: number;
+    /**
+     * Basemap Style
+     */
+    basemap_style: string;
+    /**
+     * Show Basemap Labels
+     */
+    show_basemap_labels?: boolean;
+    basemap_config?: BasemapConfig | null;
+    terrain_config?: TerrainConfig | null;
+    /**
+     * Has Non Public Layers
+     */
+    has_non_public_layers?: boolean;
+    /**
+     * Legend Title
+     */
+    legend_title?: string | null;
+    /**
+     * Layers
+     */
+    layers: Array<SharedLayerResponse>;
 };
 
 /**
@@ -8739,13 +8739,21 @@ export type SharedMapResponse = {
  */
 export type StacAsset = {
     /**
-     * Description
-     */
-    description?: string | null;
-    /**
      * Href
      */
     href: string;
+    /**
+     * Type
+     */
+    type?: string | null;
+    /**
+     * Title
+     */
+    title?: string | null;
+    /**
+     * Description
+     */
+    description?: string | null;
     /**
      * Roles
      */
@@ -8754,14 +8762,6 @@ export type StacAsset = {
      * Size Bytes
      */
     size_bytes?: number | null;
-    /**
-     * Title
-     */
-    title?: string | null;
-    /**
-     * Type
-     */
-    type?: string | null;
 };
 
 /**
@@ -8771,29 +8771,17 @@ export type StacAsset = {
  */
 export type StacCatalog = {
     /**
-     * Conformsto
+     * Type
      *
-     * List of conformance URIs declaring which STAC and OGC API standards the catalog implements.
+     * STAC object type. Always 'Catalog' for the landing page.
      */
-    conformsTo: Array<string>;
-    /**
-     * Description
-     *
-     * Human-readable catalog description.
-     */
-    description: string;
+    type?: string;
     /**
      * Id
      *
      * Stable identifier for the catalog.
      */
     id: string;
-    /**
-     * Links
-     *
-     * Catalog navigation links (self, root, search, collections, etc.).
-     */
-    links: Array<StacLink>;
     /**
      * Stac Version
      *
@@ -8807,11 +8795,23 @@ export type StacCatalog = {
      */
     title: string;
     /**
-     * Type
+     * Description
      *
-     * STAC object type. Always 'Catalog' for the landing page.
+     * Human-readable catalog description.
      */
-    type?: string;
+    description: string;
+    /**
+     * Conformsto
+     *
+     * List of conformance URIs declaring which STAC and OGC API standards the catalog implements.
+     */
+    conformsTo: Array<string>;
+    /**
+     * Links
+     *
+     * Catalog navigation links (self, root, search, collections, etc.).
+     */
+    links: Array<StacLink>;
 };
 
 /**
@@ -8821,11 +8821,41 @@ export type StacCatalog = {
  */
 export type StacCollection = {
     /**
+     * Type
+     *
+     * STAC object type.
+     */
+    type?: string;
+    /**
+     * Stac Version
+     *
+     * STAC specification version.
+     */
+    stac_version?: string;
+    /**
+     * Id
+     *
+     * Stable collection identifier.
+     */
+    id: string;
+    /**
+     * Title
+     *
+     * Human-readable collection title.
+     */
+    title?: string | null;
+    /**
      * Description
      *
      * Collection description.
      */
     description?: string;
+    /**
+     * License
+     *
+     * SPDX license identifier or 'proprietary'.
+     */
+    license?: string;
     /**
      * Extent
      *
@@ -8835,41 +8865,11 @@ export type StacCollection = {
         [key: string]: unknown;
     };
     /**
-     * Id
-     *
-     * Stable collection identifier.
-     */
-    id: string;
-    /**
-     * License
-     *
-     * SPDX license identifier or 'proprietary'.
-     */
-    license?: string;
-    /**
      * Links
      *
      * Collection navigation links.
      */
     links: Array<StacLink>;
-    /**
-     * Stac Version
-     *
-     * STAC specification version.
-     */
-    stac_version?: string;
-    /**
-     * Title
-     *
-     * Human-readable collection title.
-     */
-    title?: string | null;
-    /**
-     * Type
-     *
-     * STAC object type.
-     */
-    type?: string;
     [key: string]: unknown;
 };
 
@@ -8898,11 +8898,17 @@ export type StacCollectionListResponse = {
  */
 export type StacCollectionSummary = {
     /**
-     * Bbox
+     * Id
      *
-     * Spatial extent as [west, south, east, north].
+     * Collection identifier.
      */
-    bbox?: Array<number> | null;
+    id: string;
+    /**
+     * Title
+     *
+     * Collection title.
+     */
+    title: string;
     /**
      * Description
      *
@@ -8910,17 +8916,11 @@ export type StacCollectionSummary = {
      */
     description: string;
     /**
-     * Id
+     * License
      *
-     * Collection identifier.
+     * SPDX license identifier.
      */
-    id: string;
-    /**
-     * Item Count
-     *
-     * Number of items if reported by the API.
-     */
-    item_count?: number | null;
+    license?: string | null;
     /**
      * Keywords
      *
@@ -8928,17 +8928,11 @@ export type StacCollectionSummary = {
      */
     keywords?: Array<string>;
     /**
-     * License
+     * Bbox
      *
-     * SPDX license identifier.
+     * Spatial extent as [west, south, east, north].
      */
-    license?: string | null;
-    /**
-     * Temporal End
-     *
-     * End of temporal extent (ISO 8601).
-     */
-    temporal_end?: string | null;
+    bbox?: Array<number> | null;
     /**
      * Temporal Start
      *
@@ -8946,11 +8940,17 @@ export type StacCollectionSummary = {
      */
     temporal_start?: string | null;
     /**
-     * Title
+     * Temporal End
      *
-     * Collection title.
+     * End of temporal extent (ISO 8601).
      */
-    title: string;
+    temporal_end?: string | null;
+    /**
+     * Item Count
+     *
+     * Number of items if reported by the API.
+     */
+    item_count?: number | null;
 };
 
 /**
@@ -8958,17 +8958,17 @@ export type StacCollectionSummary = {
  */
 export type StacCollectionsResponse = {
     /**
-     * Collections
-     *
-     * Available collections.
-     */
-    collections: Array<StacCollectionSummary>;
-    /**
      * Url
      *
      * STAC API URL that was queried.
      */
     url: string;
+    /**
+     * Collections
+     *
+     * Available collections.
+     */
+    collections: Array<StacCollectionSummary>;
 };
 
 /**
@@ -9002,11 +9002,23 @@ export type StacConnectRequest = {
  */
 export type StacConnectResponse = {
     /**
+     * Url
+     *
+     * Normalized STAC API URL.
+     */
+    url: string;
+    /**
      * Catalog Id
      *
      * Catalog identifier from the landing page.
      */
     catalog_id: string;
+    /**
+     * Title
+     *
+     * Catalog title.
+     */
+    title: string;
     /**
      * Description
      *
@@ -9019,18 +9031,6 @@ export type StacConnectResponse = {
      * STAC specification version.
      */
     stac_version: string;
-    /**
-     * Title
-     *
-     * Catalog title.
-     */
-    title: string;
-    /**
-     * Url
-     *
-     * Normalized STAC API URL.
-     */
-    url: string;
 };
 
 /**
@@ -9044,13 +9044,13 @@ export type StacContext = {
      */
     limit: number;
     /**
-     * Matched
-     */
-    matched: number;
-    /**
      * Returned
      */
     returned: number;
+    /**
+     * Matched
+     */
+    matched: number;
     [key: string]: unknown;
 };
 
@@ -9059,11 +9059,11 @@ export type StacContext = {
  */
 export type StacImportItem = {
     /**
-     * Bbox
+     * Id
      *
-     * Item bounding box.
+     * STAC item ID.
      */
-    bbox?: Array<number> | null;
+    id: string;
     /**
      * Collection
      *
@@ -9071,23 +9071,23 @@ export type StacImportItem = {
      */
     collection?: string | null;
     /**
+     * Title
+     *
+     * Title to use for the GeoLens dataset.
+     */
+    title: string;
+    /**
      * Data Asset Href
      *
      * URL of the COG asset to reference.
      */
     data_asset_href: string;
     /**
-     * Datetime End
+     * Bbox
      *
-     * Temporal end.
+     * Item bounding box.
      */
-    datetime_end?: string | null;
-    /**
-     * Datetime Start
-     *
-     * Temporal start.
-     */
-    datetime_start?: string | null;
+    bbox?: Array<number> | null;
     /**
      * Epsg
      *
@@ -9095,23 +9095,23 @@ export type StacImportItem = {
      */
     epsg?: number | null;
     /**
-     * Id
+     * Datetime Start
      *
-     * STAC item ID.
+     * Temporal start.
      */
-    id: string;
+    datetime_start?: string | null;
+    /**
+     * Datetime End
+     *
+     * Temporal end.
+     */
+    datetime_end?: string | null;
     /**
      * Keywords
      *
      * Keywords from STAC collection.
      */
     keywords?: Array<string>;
-    /**
-     * Title
-     *
-     * Title to use for the GeoLens dataset.
-     */
-    title: string;
 };
 
 /**
@@ -9119,17 +9119,17 @@ export type StacImportItem = {
  */
 export type StacImportRequest = {
     /**
-     * Items
-     *
-     * Items to import (max 50 per request).
-     */
-    items: Array<StacImportItem>;
-    /**
      * Url
      *
      * STAC API URL for provenance.
      */
     url: string;
+    /**
+     * Items
+     *
+     * Items to import (max 50 per request).
+     */
+    items: Array<StacImportItem>;
     /**
      * Visibility
      *
@@ -9143,29 +9143,29 @@ export type StacImportRequest = {
  */
 export type StacImportResponse = {
     /**
-     * Created
-     *
-     * Number of datasets created.
-     */
-    created: number;
-    /**
-     * Errors
-     *
-     * Number of items that failed.
-     */
-    errors: number;
-    /**
      * Results
      *
      * Per-item import results.
      */
     results: Array<StacImportResult>;
     /**
+     * Created
+     *
+     * Number of datasets created.
+     */
+    created: number;
+    /**
      * Skipped
      *
      * Number of items skipped (duplicates).
      */
     skipped: number;
+    /**
+     * Errors
+     *
+     * Number of items that failed.
+     */
+    errors: number;
 };
 
 /**
@@ -9173,29 +9173,29 @@ export type StacImportResponse = {
  */
 export type StacImportResult = {
     /**
-     * Dataset Id
-     *
-     * Created GeoLens dataset ID.
-     */
-    dataset_id?: string | null;
-    /**
-     * Error
-     *
-     * Error message if failed.
-     */
-    error?: string | null;
-    /**
      * Item Id
      *
      * STAC item ID that was processed.
      */
     item_id: string;
     /**
+     * Dataset Id
+     *
+     * Created GeoLens dataset ID.
+     */
+    dataset_id?: string | null;
+    /**
      * Status
      *
      * Import result status.
      */
     status: 'created' | 'skipped' | 'error';
+    /**
+     * Error
+     *
+     * Error message if failed.
+     */
+    error?: string | null;
 };
 
 /**
@@ -9205,23 +9205,17 @@ export type StacImportResult = {
  */
 export type StacItemAsset = {
     /**
-     * Description
-     *
-     * Human-readable asset description.
-     */
-    description?: string | null;
-    /**
      * Href
      *
      * URL of the asset resource.
      */
     href: string;
     /**
-     * Roles
+     * Type
      *
-     * Semantic roles such as data or visual.
+     * Asset media type.
      */
-    roles?: Array<string> | null;
+    type?: string | null;
     /**
      * Title
      *
@@ -9229,11 +9223,17 @@ export type StacItemAsset = {
      */
     title?: string | null;
     /**
-     * Type
+     * Description
      *
-     * Asset media type.
+     * Human-readable asset description.
      */
-    type?: string | null;
+    description?: string | null;
+    /**
+     * Roles
+     *
+     * Semantic roles such as data or visual.
+     */
+    roles?: Array<string> | null;
     [key: string]: unknown;
 };
 
@@ -9243,7 +9243,10 @@ export type StacItemAsset = {
  * Typed OpenAPI representation of a STAC ItemCollection.
  */
 export type StacItemCollectionResponse = {
-    context: StacContext;
+    /**
+     * Type
+     */
+    type?: 'FeatureCollection';
     /**
      * Features
      */
@@ -9260,10 +9263,7 @@ export type StacItemCollectionResponse = {
      * Numberreturned
      */
     numberReturned: number;
-    /**
-     * Type
-     */
-    type?: 'FeatureCollection';
+    context: StacContext;
     [key: string]: unknown;
 };
 
@@ -9280,11 +9280,11 @@ export type StacItemProperties = {
      */
     datetime: string | null;
     /**
-     * Description
+     * Start Datetime
      *
-     * Human-readable item description.
+     * Start of the item's temporal interval.
      */
-    description?: string | null;
+    start_datetime?: string | null;
     /**
      * End Datetime
      *
@@ -9292,17 +9292,17 @@ export type StacItemProperties = {
      */
     end_datetime?: string | null;
     /**
-     * Start Datetime
-     *
-     * Start of the item's temporal interval.
-     */
-    start_datetime?: string | null;
-    /**
      * Title
      *
      * Human-readable item title.
      */
     title?: string | null;
+    /**
+     * Description
+     *
+     * Human-readable item description.
+     */
+    description?: string | null;
     [key: string]: unknown;
 };
 
@@ -9313,11 +9313,33 @@ export type StacItemProperties = {
  */
 export type StacItemResponse = {
     /**
-     * Assets
+     * Type
      */
-    assets: {
-        [key: string]: StacItemAsset;
-    };
+    type?: 'Feature';
+    /**
+     * Stac Version
+     *
+     * STAC specification version.
+     */
+    stac_version: string;
+    /**
+     * Stac Extensions
+     *
+     * STAC extension schema URIs in use.
+     */
+    stac_extensions?: Array<string>;
+    /**
+     * Id
+     *
+     * Stable item identifier.
+     */
+    id: string;
+    /**
+     * Geometry
+     *
+     * Item footprint as GeoJSON, or null when unavailable.
+     */
+    geometry: GeoJsonGeometryCollection | GeoJsonGeometry | null;
     /**
      * Bbox
      *
@@ -9336,45 +9358,23 @@ export type StacItemResponse = {
         number,
         number
     ] | null;
+    properties: StacItemProperties;
+    /**
+     * Links
+     */
+    links: Array<StacLink>;
+    /**
+     * Assets
+     */
+    assets: {
+        [key: string]: StacItemAsset;
+    };
     /**
      * Collection
      *
      * Identifier of the containing STAC Collection.
      */
     collection?: string | null;
-    /**
-     * Geometry
-     *
-     * Item footprint as GeoJSON, or null when unavailable.
-     */
-    geometry: GeoJsonGeometryCollection | GeoJsonGeometry | null;
-    /**
-     * Id
-     *
-     * Stable item identifier.
-     */
-    id: string;
-    /**
-     * Links
-     */
-    links: Array<StacLink>;
-    properties: StacItemProperties;
-    /**
-     * Stac Extensions
-     *
-     * STAC extension schema URIs in use.
-     */
-    stac_extensions?: Array<string>;
-    /**
-     * Stac Version
-     *
-     * STAC specification version.
-     */
-    stac_version: string;
-    /**
-     * Type
-     */
-    type?: 'Feature';
     [key: string]: unknown;
 };
 
@@ -9383,23 +9383,11 @@ export type StacItemResponse = {
  */
 export type StacItemSummary = {
     /**
-     * Asset Count
+     * Id
      *
-     * Number of assets on this item.
+     * Item identifier.
      */
-    asset_count: number;
-    /**
-     * Bbox
-     *
-     * Item bounding box.
-     */
-    bbox?: Array<number> | null;
-    /**
-     * Cloud Cover
-     *
-     * Cloud cover percentage (eo extension).
-     */
-    cloud_cover?: number | null;
+    id: string;
     /**
      * Collection
      *
@@ -9407,23 +9395,17 @@ export type StacItemSummary = {
      */
     collection?: string | null;
     /**
-     * Data Asset Href
+     * Title
      *
-     * URL of the primary data asset (COG).
+     * Item title (falls back to ID).
      */
-    data_asset_href?: string | null;
+    title: string;
     /**
-     * Data Asset Size Bytes
+     * Bbox
      *
-     * Size of the primary data asset in bytes (from STAC file:size). None when not in manifest.
+     * Item bounding box.
      */
-    data_asset_size_bytes?: number | null;
-    /**
-     * Data Asset Type
-     *
-     * Media type of the data asset.
-     */
-    data_asset_type?: string | null;
+    bbox?: Array<number> | null;
     /**
      * Datetime
      *
@@ -9431,17 +9413,17 @@ export type StacItemSummary = {
      */
     datetime?: string | null;
     /**
-     * Datetime End
-     *
-     * End datetime for ranges.
-     */
-    datetime_end?: string | null;
-    /**
      * Datetime Start
      *
      * Start datetime for ranges.
      */
     datetime_start?: string | null;
+    /**
+     * Datetime End
+     *
+     * End datetime for ranges.
+     */
+    datetime_end?: string | null;
     /**
      * Epsg
      *
@@ -9455,11 +9437,29 @@ export type StacItemSummary = {
      */
     gsd?: number | null;
     /**
-     * Id
+     * Cloud Cover
      *
-     * Item identifier.
+     * Cloud cover percentage (eo extension).
      */
-    id: string;
+    cloud_cover?: number | null;
+    /**
+     * Data Asset Href
+     *
+     * URL of the primary data asset (COG).
+     */
+    data_asset_href?: string | null;
+    /**
+     * Data Asset Type
+     *
+     * Media type of the data asset.
+     */
+    data_asset_type?: string | null;
+    /**
+     * Data Asset Size Bytes
+     *
+     * Size of the primary data asset in bytes (from STAC file:size). None when not in manifest.
+     */
+    data_asset_size_bytes?: number | null;
     /**
      * Thumbnail Href
      *
@@ -9467,11 +9467,11 @@ export type StacItemSummary = {
      */
     thumbnail_href?: string | null;
     /**
-     * Title
+     * Asset Count
      *
-     * Item title (falls back to ID).
+     * Number of assets on this item.
      */
-    title: string;
+    asset_count: number;
 };
 
 /**
@@ -9487,12 +9487,6 @@ export type StacLink = {
      */
     href: string;
     /**
-     * Method
-     *
-     * HTTP method to use (defaults to GET).
-     */
-    method?: string | null;
-    /**
      * Rel
      *
      * Link relation type (e.g. 'self', 'root', 'parent', 'item', 'data').
@@ -9504,6 +9498,12 @@ export type StacLink = {
      * Media type of the linked resource (e.g. 'application/json').
      */
     type?: string | null;
+    /**
+     * Method
+     *
+     * HTTP method to use (defaults to GET).
+     */
+    method?: string | null;
 };
 
 /**
@@ -9517,13 +9517,13 @@ export type StacSearchBody = {
      */
     bbox?: Array<number> | null;
     /**
-     * Collections
-     */
-    collections?: Array<string> | null;
-    /**
      * Datetime
      */
     datetime?: string | null;
+    /**
+     * Collections
+     */
+    collections?: Array<string> | null;
     /**
      * Ids
      */
@@ -9553,6 +9553,18 @@ export type StacSearchBody = {
  */
 export type StacSearchRequest = {
     /**
+     * Url
+     *
+     * STAC API root URL.
+     */
+    url: string;
+    /**
+     * Collections
+     *
+     * Filter by collection IDs.
+     */
+    collections?: Array<string> | null;
+    /**
      * Bbox
      *
      * Bounding box filter as [west, south, east, north].
@@ -9563,12 +9575,6 @@ export type StacSearchRequest = {
         number,
         number
     ] | null;
-    /**
-     * Collections
-     *
-     * Filter by collection IDs.
-     */
-    collections?: Array<string> | null;
     /**
      * Datetime Range
      *
@@ -9581,12 +9587,6 @@ export type StacSearchRequest = {
      * Maximum items to return.
      */
     limit?: number;
-    /**
-     * Url
-     *
-     * STAC API root URL.
-     */
-    url: string;
 };
 
 /**
@@ -9618,10 +9618,6 @@ export type StacSearchResponse = {
  */
 export type StaleCleanupResponse = {
     /**
-     * Local Files Reaped
-     */
-    local_files_reaped: number;
-    /**
      * Pending Failed
      */
     pending_failed: number;
@@ -9629,30 +9625,6 @@ export type StaleCleanupResponse = {
      * Running Failed
      */
     running_failed: number;
-    /**
-     * Staged Cleanup Failures
-     */
-    staged_cleanup_failures: number;
-    /**
-     * Staged Paths Considered
-     */
-    staged_paths_considered: number;
-    /**
-     * Staged Paths Skipped
-     */
-    staged_paths_skipped: number;
-    /**
-     * Storage Objects Reaped
-     */
-    storage_objects_reaped: number;
-    /**
-     * Terminal Jobs Purged
-     */
-    terminal_jobs_purged: number;
-    /**
-     * Total Affected
-     */
-    total_affected: number;
     /**
      * Total Cleaned
      */
@@ -9665,6 +9637,34 @@ export type StaleCleanupResponse = {
      * Vrt Generations Failed
      */
     vrt_generations_failed: number;
+    /**
+     * Terminal Jobs Purged
+     */
+    terminal_jobs_purged: number;
+    /**
+     * Staged Paths Considered
+     */
+    staged_paths_considered: number;
+    /**
+     * Local Files Reaped
+     */
+    local_files_reaped: number;
+    /**
+     * Storage Objects Reaped
+     */
+    storage_objects_reaped: number;
+    /**
+     * Staged Paths Skipped
+     */
+    staged_paths_skipped: number;
+    /**
+     * Staged Cleanup Failures
+     */
+    staged_cleanup_failures: number;
+    /**
+     * Total Affected
+     */
+    total_affected: number;
 };
 
 /**
@@ -9686,15 +9686,15 @@ export type StatusUpdateResponse = {
      */
     id: string;
     /**
+     * Record Status
+     */
+    record_status: string;
+    /**
      * Metadata Warnings
      *
      * Advisory warnings from the status change — the same inherited-keyword disclosure check the metadata PATCH runs (feat #1070, fix #1178 review). The transition has already applied.
      */
     metadata_warnings?: Array<string> | null;
-    /**
-     * Record Status
-     */
-    record_status: string;
 };
 
 /**
@@ -9717,6 +9717,18 @@ export type StatusUpdateResponse = {
  */
 export type SublayerOverride = {
     /**
+     * Stroke Color
+     *
+     * Stroke color in #RRGGBB hex format, or null to use the basemap default.
+     */
+    stroke_color?: string | null;
+    /**
+     * Stroke Width
+     *
+     * Stroke width in pixels (0-20), or null to use the basemap default.
+     */
+    stroke_width?: number | null;
+    /**
      * Casing Color
      *
      * Casing color in #RRGGBB hex format, or null to use the basemap default.
@@ -9729,35 +9741,23 @@ export type SublayerOverride = {
      */
     casing_width?: number | null;
     /**
-     * Max Zoom
-     *
-     * Maximum zoom level at which the sublayer is visible (0-24), or null for default.
-     */
-    max_zoom?: number | null;
-    /**
      * Min Zoom
      *
      * Minimum zoom level at which the sublayer is visible (0-24), or null for default.
      */
     min_zoom?: number | null;
     /**
+     * Max Zoom
+     *
+     * Maximum zoom level at which the sublayer is visible (0-24), or null for default.
+     */
+    max_zoom?: number | null;
+    /**
      * Opacity
      *
      * Per-sublayer opacity (0-1), or null to use the basemap default. Composes on top of BasemapConfig.opacity (the whole-basemap master opacity): the rendered opacity is override.opacity * master_opacity (builder-audit #338 CORR-01). The UI opacity slider in BasemapSublayerEditorScene persists through this field: MapBuilderPage.handleSublayerOpacityChange -> setBasemapSublayerOpacity -> updateBasemapSublayerOverride writes config.sublayer_overrides[key].opacity.
      */
     opacity?: number | null;
-    /**
-     * Stroke Color
-     *
-     * Stroke color in #RRGGBB hex format, or null to use the basemap default.
-     */
-    stroke_color?: string | null;
-    /**
-     * Stroke Width
-     *
-     * Stroke width in pixels (0-20), or null to use the basemap default.
-     */
-    stroke_width?: number | null;
 };
 
 /**
@@ -9785,17 +9785,17 @@ export type TableRegisterResponse = {
      */
     dataset_id: string;
     /**
-     * Table Name
-     *
-     * Source PostgreSQL table that was registered.
-     */
-    table_name: string;
-    /**
      * Title
      *
      * Title of the registered dataset.
      */
     title: string;
+    /**
+     * Table Name
+     *
+     * Source PostgreSQL table that was registered.
+     */
+    table_name: string;
 };
 
 /**
@@ -9807,13 +9807,13 @@ export type TerrainConfig = {
      */
     enabled?: boolean;
     /**
-     * Exaggeration
-     */
-    exaggeration?: number;
-    /**
      * Source Dataset Id
      */
     source_dataset_id?: string | null;
+    /**
+     * Exaggeration
+     */
+    exaggeration?: number;
 };
 
 /**
@@ -9856,11 +9856,11 @@ export type TileConfigResponse = {
      */
     cdn_base_url?: string | null;
     /**
-     * Mvt Source Layer Prefix
+     * Public App Url
      *
-     * Schema prefix emitted inside vector-tile source-layer names. Null when a multi-tenant request has no resolved tenant context.
+     * Browser-facing app URL used for share links and OAuth redirects.
      */
-    mvt_source_layer_prefix?: string | null;
+    public_app_url?: string | null;
     /**
      * Public Api Url
      *
@@ -9868,17 +9868,17 @@ export type TileConfigResponse = {
      */
     public_api_url?: string | null;
     /**
-     * Public App Url
-     *
-     * Browser-facing app URL used for share links and OAuth redirects.
-     */
-    public_app_url?: string | null;
-    /**
      * Public Base Url
      *
      * Deprecated alias for public_api_url. Will be removed in a future release.
      */
     public_base_url?: string | null;
+    /**
+     * Mvt Source Layer Prefix
+     *
+     * Schema prefix emitted inside vector-tile source-layer names. Null when a multi-tenant request has no resolved tenant context.
+     */
+    mvt_source_layer_prefix?: string | null;
 };
 
 /**
@@ -9928,12 +9928,6 @@ export type TokenResponse = {
      */
     access_token: string;
     /**
-     * Expires In
-     *
-     * Seconds until the access token expires
-     */
-    expires_in: number;
-    /**
      * Refresh Token
      *
      * Opaque token used to obtain a new access token
@@ -9943,6 +9937,12 @@ export type TokenResponse = {
      * Token Type
      */
     token_type?: string;
+    /**
+     * Expires In
+     *
+     * Seconds until the access token expires
+     */
+    expires_in: number;
 };
 
 /**
@@ -9950,13 +9950,13 @@ export type TokenResponse = {
  */
 export type TranslationListResponse = {
     /**
-     * Total
-     */
-    total: number;
-    /**
      * Translations
      */
     translations: Array<TranslationResponse>;
+    /**
+     * Total
+     */
+    total: number;
 };
 
 /**
@@ -9964,21 +9964,21 @@ export type TranslationListResponse = {
  */
 export type TranslationResponse = {
     /**
-     * Language
-     */
-    language: string;
-    /**
      * Record Id
      */
     record_id: string;
     /**
-     * Summary
+     * Language
      */
-    summary: string | null;
+    language: string;
     /**
      * Title
      */
     title: string;
+    /**
+     * Summary
+     */
+    summary: string | null;
 };
 
 /**
@@ -9986,13 +9986,13 @@ export type TranslationResponse = {
  */
 export type TranslationUpsert = {
     /**
-     * Summary
-     */
-    summary?: string | null;
-    /**
      * Title
      */
     title: string;
+    /**
+     * Summary
+     */
+    summary?: string | null;
 };
 
 /**
@@ -10004,13 +10004,13 @@ export type TypeChange = {
      */
     name: string;
     /**
-     * New Type
-     */
-    new_type: string;
-    /**
      * Old Type
      */
     old_type: string;
+    /**
+     * New Type
+     */
+    new_type: string;
 };
 
 /**
@@ -10018,17 +10018,11 @@ export type TypeChange = {
  */
 export type UploadConfigResponse = {
     /**
-     * Allowed Extensions
+     * Presigned Uploads
      *
-     * Comma-separated list of allowed file extensions.
+     * Whether presigned S3 uploads are enabled (requires `STORAGE_PROVIDER=s3`).
      */
-    allowed_extensions: string;
-    /**
-     * Max File Size Bytes
-     *
-     * Maximum allowed upload size in bytes.
-     */
-    max_file_size_bytes: number;
+    presigned_uploads: boolean;
     /**
      * Presigned Threshold Bytes
      *
@@ -10036,11 +10030,17 @@ export type UploadConfigResponse = {
      */
     presigned_threshold_bytes: number;
     /**
-     * Presigned Uploads
+     * Max File Size Bytes
      *
-     * Whether presigned S3 uploads are enabled (requires `STORAGE_PROVIDER=s3`).
+     * Maximum allowed upload size in bytes.
      */
-    presigned_uploads: boolean;
+    max_file_size_bytes: number;
+    /**
+     * Allowed Extensions
+     *
+     * Comma-separated list of allowed file extensions.
+     */
+    allowed_extensions: string;
     /**
      * Remaining Dataset Quota
      *
@@ -10060,17 +10060,17 @@ export type UploadResponse = {
      */
     job_id: string;
     /**
-     * Message
-     *
-     * Human-readable message describing the upload result.
-     */
-    message: string;
-    /**
      * Status
      *
      * Initial job status. Always 'pending' on creation.
      */
     status?: string;
+    /**
+     * Message
+     *
+     * Human-readable message describing the upload result.
+     */
+    message: string;
 };
 
 /**
@@ -10078,11 +10078,11 @@ export type UploadResponse = {
  */
 export type UserCreate = {
     /**
-     * Email
+     * Username
      *
-     * Optional email address
+     * Unique login name
      */
-    email?: string | null;
+    username: string;
     /**
      * Password
      *
@@ -10090,11 +10090,11 @@ export type UserCreate = {
      */
     password: string;
     /**
-     * Username
+     * Email
      *
-     * Unique login name
+     * Optional email address
      */
-    username: string;
+    email?: string | null;
 };
 
 /**
@@ -10102,17 +10102,17 @@ export type UserCreate = {
  */
 export type UserListResponse = {
     /**
-     * Total
-     *
-     * Total number of users matching the query (across all pages).
-     */
-    total: number;
-    /**
      * Users
      *
      * Page of users matching the query.
      */
     users: Array<UserResponse>;
+    /**
+     * Total
+     *
+     * Total number of users matching the query (across all pages).
+     */
+    total: number;
 };
 
 /**
@@ -10144,10 +10144,6 @@ export type UserQuotaUsage = {
      */
     bytes_used: number;
     /**
-     * Count Cap
-     */
-    count_cap: number;
-    /**
      * Dataset Count
      */
     dataset_count: number;
@@ -10155,6 +10151,10 @@ export type UserQuotaUsage = {
      * Storage Cap
      */
     storage_cap: number;
+    /**
+     * Count Cap
+     */
+    count_cap: number;
 };
 
 /**
@@ -10162,35 +10162,21 @@ export type UserQuotaUsage = {
  */
 export type UserResponse = {
     /**
-     * Created At
+     * Id
      */
-    created_at: string;
+    id: string;
+    /**
+     * Username
+     */
+    username: string;
     /**
      * Email
      */
     email: string | null;
     /**
-     * Id
-     */
-    id: string;
-    /**
      * Is Active
      */
     is_active: boolean;
-    /**
-     * Last Login At
-     */
-    last_login_at: string | null;
-    /**
-     * Per-user storage quota usage. Populated only on admin list responses; None when the caller did not load usage (e.g. /auth/me, single-user GET).
-     */
-    quota_usage?: UserQuotaUsage | null;
-    /**
-     * Roles
-     *
-     * Assigned role names, e.g. ['admin', 'editor']
-     */
-    roles: Array<string>;
     /**
      * Status
      *
@@ -10198,9 +10184,23 @@ export type UserResponse = {
      */
     status: 'active' | 'pending' | 'suspended' | 'deactivated';
     /**
-     * Username
+     * Last Login At
      */
-    username: string;
+    last_login_at: string | null;
+    /**
+     * Created At
+     */
+    created_at: string;
+    /**
+     * Roles
+     *
+     * Assigned role names, e.g. ['admin', 'editor']
+     */
+    roles: Array<string>;
+    /**
+     * Per-user storage quota usage. Populated only on admin list responses; None when the caller did not load usage (e.g. /auth/me, single-user GET).
+     */
+    quota_usage?: UserQuotaUsage | null;
 };
 
 /**
@@ -10220,33 +10220,23 @@ export type UserUpdate = {
      */
     is_active?: boolean | null;
     /**
-     * Role
-     *
-     * New role: 'admin', 'editor', or 'viewer'. Omit to leave unchanged.
-     */
-    role?: string | null;
-    /**
      * Status
      *
      * Explicit account lifecycle state. Pending registrations must use the approve/reject endpoints.
      */
     status?: 'active' | 'suspended' | 'deactivated' | null;
+    /**
+     * Role
+     *
+     * New role: 'admin', 'editor', or 'viewer'. Omit to leave unchanged.
+     */
+    role?: string | null;
 };
 
 /**
  * ValidationError
  */
 export type ValidationError = {
-    /**
-     * Context
-     */
-    ctx?: {
-        [key: string]: unknown;
-    };
-    /**
-     * Input
-     */
-    input?: unknown;
     /**
      * Location
      */
@@ -10259,6 +10249,16 @@ export type ValidationError = {
      * Error Type
      */
     type: string;
+    /**
+     * Input
+     */
+    input?: unknown;
+    /**
+     * Context
+     */
+    ctx?: {
+        [key: string]: unknown;
+    };
 };
 
 /**
@@ -10284,23 +10284,23 @@ export type ValidationIssue = {
  */
 export type ValidationResultResponse = {
     /**
+     * Is Valid
+     */
+    is_valid: boolean;
+    /**
      * Errors
      */
     errors: Array<ValidationIssue>;
     /**
-     * Is Valid
+     * Warnings
      */
-    is_valid: boolean;
+    warnings: Array<ValidationIssue>;
     /**
      * Quality Score
      */
     quality_score?: {
         [key: string]: unknown;
     } | null;
-    /**
-     * Warnings
-     */
-    warnings: Array<ValidationIssue>;
 };
 
 /**
@@ -10308,25 +10308,25 @@ export type ValidationResultResponse = {
  */
 export type VectorTileToken = {
     /**
-     * Exp
-     */
-    exp: number;
-    /**
-     * Expires In
-     */
-    expires_in: number;
-    /**
      * Kind
      */
     kind: 'vector';
+    /**
+     * Sig
+     */
+    sig: string;
+    /**
+     * Exp
+     */
+    exp: number;
     /**
      * Scope
      */
     scope: string;
     /**
-     * Sig
+     * Expires In
      */
-    sig: string;
+    expires_in: number;
 };
 
 /**
@@ -10346,27 +10346,23 @@ export type VerifyEmailRequest = {
  */
 export type VisibilityCheckResponse = {
     /**
-     * Has Non Public
-     *
-     * True if any layer references a non-public dataset
-     */
-    has_non_public: boolean;
-    /**
      * Non Public Datasets
      *
      * Titles of datasets not publicly visible
      */
     non_public_datasets: Array<string>;
+    /**
+     * Has Non Public
+     *
+     * True if any layer references a non-public dataset
+     */
+    has_non_public: boolean;
 };
 
 /**
  * VrtActiveGeneration
  */
 export type VrtActiveGeneration = {
-    /**
-     * Elapsed Seconds
-     */
-    elapsed_seconds: number;
     /**
      * Generation Id
      */
@@ -10375,6 +10371,10 @@ export type VrtActiveGeneration = {
      * Started At
      */
     started_at: string;
+    /**
+     * Elapsed Seconds
+     */
+    elapsed_seconds: number;
 };
 
 /**
@@ -10394,23 +10394,23 @@ export type VrtAddSourceRequest = {
  */
 export type VrtCreateRequest = {
     /**
-     * Resolution Strategy
-     *
-     * How to resolve mismatched source resolutions: 'finest' uses the highest, 'coarsest' uses the lowest, 'average' computes the mean.
-     */
-    resolution_strategy: 'finest' | 'coarsest' | 'average';
-    /**
      * Source Dataset Ids
      *
      * Source raster dataset IDs to include in the VRT mosaic or band stack (1-500).
      */
     source_dataset_ids: Array<string>;
     /**
-     * Summary
+     * Vrt Type
      *
-     * Optional description for the VRT dataset.
+     * Type of VRT to create. 'mosaic' tiles sources spatially; 'band_stack' aligns same-extent sources as multi-band output.
      */
-    summary?: string | null;
+    vrt_type: 'mosaic' | 'band_stack';
+    /**
+     * Resolution Strategy
+     *
+     * How to resolve mismatched source resolutions: 'finest' uses the highest, 'coarsest' uses the lowest, 'average' computes the mean.
+     */
+    resolution_strategy: 'finest' | 'coarsest' | 'average';
     /**
      * Title
      *
@@ -10418,17 +10418,17 @@ export type VrtCreateRequest = {
      */
     title: string;
     /**
+     * Summary
+     *
+     * Optional description for the VRT dataset.
+     */
+    summary?: string | null;
+    /**
      * Visibility
      *
      * Visibility level for the resulting VRT dataset.
      */
     visibility?: 'private' | 'restricted' | 'internal' | 'public';
-    /**
-     * Vrt Type
-     *
-     * Type of VRT to create. 'mosaic' tiles sources spatially; 'band_stack' aligns same-extent sources as multi-band output.
-     */
-    vrt_type: 'mosaic' | 'band_stack';
 };
 
 /**
@@ -10442,23 +10442,35 @@ export type VrtCreateResponse = {
      */
     job_id: string;
     /**
-     * Message
-     *
-     * Human-readable acceptance message.
-     */
-    message: string;
-    /**
      * Status
      *
      * Initial job status. Always 'accepted' on creation.
      */
     status?: string;
+    /**
+     * Message
+     *
+     * Human-readable acceptance message.
+     */
+    message: string;
 };
 
 /**
  * VrtGenerationItem
  */
 export type VrtGenerationItem = {
+    /**
+     * Id
+     */
+    id: string;
+    /**
+     * Status
+     */
+    status: string;
+    /**
+     * Started At
+     */
+    started_at?: string | null;
     /**
      * Completed At
      */
@@ -10472,21 +10484,9 @@ export type VrtGenerationItem = {
      */
     error_message?: string | null;
     /**
-     * Id
-     */
-    id: string;
-    /**
      * Source Count
      */
     source_count?: number | null;
-    /**
-     * Started At
-     */
-    started_at?: string | null;
-    /**
-     * Status
-     */
-    status: string;
     /**
      * Triggered By
      */
@@ -10518,17 +10518,17 @@ export type VrtMutationResponse = {
      */
     job_id: string;
     /**
-     * Message
-     *
-     * Human-readable acceptance message.
-     */
-    message: string;
-    /**
      * Status
      *
      * Initial job status.
      */
     status?: string;
+    /**
+     * Message
+     *
+     * Human-readable acceptance message.
+     */
+    message: string;
 };
 
 /**
@@ -10540,13 +10540,13 @@ export type VrtSourceHealth = {
      */
     dataset_id: string;
     /**
-     * Status
-     */
-    status: 'healthy' | 'missing' | 'inaccessible';
-    /**
      * Title
      */
     title: string;
+    /**
+     * Status
+     */
+    status: 'healthy' | 'missing' | 'inaccessible';
 };
 
 /**
@@ -10554,25 +10554,21 @@ export type VrtSourceHealth = {
  */
 export type VrtSourceItem = {
     /**
-     * Band Count
-     */
-    band_count?: number | null;
-    /**
-     * Crs Epsg
-     */
-    crs_epsg?: number | null;
-    /**
      * Dataset Id
      */
     dataset_id: string;
     /**
-     * Extent Bbox
+     * Title
      */
-    extent_bbox?: Array<number> | null;
+    title: string;
     /**
      * Position
      */
     position: number;
+    /**
+     * Band Count
+     */
+    band_count?: number | null;
     /**
      * Resolution X
      */
@@ -10582,9 +10578,13 @@ export type VrtSourceItem = {
      */
     resolution_y?: number | null;
     /**
-     * Title
+     * Crs Epsg
      */
-    title: string;
+    crs_epsg?: number | null;
+    /**
+     * Extent Bbox
+     */
+    extent_bbox?: Array<number> | null;
 };
 
 /**
@@ -10601,7 +10601,10 @@ export type VrtSourceListResponse = {
  * VrtStatusResponse
  */
 export type VrtStatusResponse = {
-    active_generation?: VrtActiveGeneration | null;
+    /**
+     * Status
+     */
+    status: 'ready' | 'regenerating' | 'failed';
     /**
      * Last Generation At
      */
@@ -10610,14 +10613,11 @@ export type VrtStatusResponse = {
      * Source Count
      */
     source_count: number;
+    active_generation?: VrtActiveGeneration | null;
     /**
      * Source Health
      */
     source_health: Array<VrtSourceHealth>;
-    /**
-     * Status
-     */
-    status: 'ready' | 'regenerating' | 'failed';
 };
 
 export type LandingPageGetData = {
@@ -15002,6 +15002,30 @@ export type GetCollectionItemsCollectionsDatasetIdItemsGetResponses = {
      */
     200: {
         /**
+         * Type
+         *
+         * GeoJSON object type.
+         */
+        type?: 'FeatureCollection';
+        /**
+         * Timestamp
+         *
+         * ISO 8601 timestamp the response was generated.
+         */
+        timeStamp?: string;
+        /**
+         * Numbermatched
+         *
+         * Total number of features matching the query (across all pages).
+         */
+        numberMatched: number;
+        /**
+         * Numberreturned
+         *
+         * Number of features in this response page.
+         */
+        numberReturned: number;
+        /**
          * Features
          *
          * GeoJSON features returned by the query.
@@ -15028,42 +15052,18 @@ export type GetCollectionItemsCollectionsDatasetIdItemsGetResponses = {
              */
             rel: string;
             /**
-             * Title
-             *
-             * Optional human-readable label for the link.
-             */
-            title?: string | null;
-            /**
              * Type
              *
              * Media type of the linked resource (e.g. 'application/json', 'application/geo+json').
              */
             type: string;
+            /**
+             * Title
+             *
+             * Optional human-readable label for the link.
+             */
+            title?: string | null;
         }>;
-        /**
-         * Numbermatched
-         *
-         * Total number of features matching the query (across all pages).
-         */
-        numberMatched: number;
-        /**
-         * Numberreturned
-         *
-         * Number of features in this response page.
-         */
-        numberReturned: number;
-        /**
-         * Timestamp
-         *
-         * ISO 8601 timestamp the response was generated.
-         */
-        timeStamp?: string;
-        /**
-         * Type
-         *
-         * GeoJSON object type.
-         */
-        type?: 'FeatureCollection';
     };
 };
 
@@ -15123,24 +15123,38 @@ export type GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetRespons
      */
     200: {
         /**
-         * GeoJSON geometry of the feature, or null for geometry-less features.
+         * Type
+         *
+         * GeoJSON object type.
          */
-        geometry: {
-            /**
-             * Coordinates
-             */
-            coordinates: Array<unknown>;
-            /**
-             * Type
-             */
-            type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
-        } | null;
+        type?: 'Feature';
         /**
          * Id
          *
          * Feature identifier within the collection.
          */
         id: number;
+        /**
+         * GeoJSON geometry of the feature, or null for geometry-less features.
+         */
+        geometry: {
+            /**
+             * Type
+             */
+            type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+            /**
+             * Coordinates
+             */
+            coordinates: Array<unknown>;
+        } | null;
+        /**
+         * Properties
+         *
+         * Feature attributes as a JSON object.
+         */
+        properties: {
+            [key: string]: unknown;
+        } | null;
         /**
          * Links
          *
@@ -15160,32 +15174,18 @@ export type GetCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGetRespons
              */
             rel: string;
             /**
-             * Title
-             *
-             * Optional human-readable label for the link.
-             */
-            title?: string | null;
-            /**
              * Type
              *
              * Media type of the linked resource (e.g. 'application/json', 'application/geo+json').
              */
             type: string;
+            /**
+             * Title
+             *
+             * Optional human-readable label for the link.
+             */
+            title?: string | null;
         }>;
-        /**
-         * Properties
-         *
-         * Feature attributes as a JSON object.
-         */
-        properties: {
-            [key: string]: unknown;
-        } | null;
-        /**
-         * Type
-         *
-         * GeoJSON object type.
-         */
-        type?: 'Feature';
     };
 };
 
@@ -17143,72 +17143,9 @@ export type ListFeaturesDatasetsDatasetIdFeaturesGetResponses = {
      */
     200: {
         /**
-         * Features
+         * Type
          */
-        features: Array<{
-            /**
-             * Geometry
-             */
-            geometry?: {
-                /**
-                 * Geometries
-                 */
-                geometries: Array<{
-                    /**
-                     * Coordinates
-                     */
-                    coordinates: Array<unknown>;
-                    /**
-                     * Type
-                     */
-                    type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
-                }>;
-                /**
-                 * Type
-                 */
-                type: 'GeometryCollection';
-            } | {
-                /**
-                 * Coordinates
-                 */
-                coordinates: Array<unknown>;
-                /**
-                 * Type
-                 */
-                type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
-            } | null;
-            /**
-             * Id
-             */
-            id: number;
-            /**
-             * Properties
-             */
-            properties: {
-                [key: string]: unknown;
-            };
-            /**
-             * Type
-             */
-            type?: 'Feature';
-        }>;
-        /**
-         * Links
-         */
-        links: Array<{
-            /**
-             * Href
-             */
-            href: string;
-            /**
-             * Rel
-             */
-            rel: string;
-            /**
-             * Type
-             */
-            type: string;
-        }>;
+        type?: 'FeatureCollection';
         /**
          * Numbermatched
          */
@@ -17218,9 +17155,72 @@ export type ListFeaturesDatasetsDatasetIdFeaturesGetResponses = {
          */
         numberReturned: number;
         /**
-         * Type
+         * Features
          */
-        type?: 'FeatureCollection';
+        features: Array<{
+            /**
+             * Type
+             */
+            type?: 'Feature';
+            /**
+             * Id
+             */
+            id: number;
+            /**
+             * Geometry
+             */
+            geometry?: {
+                /**
+                 * Type
+                 */
+                type: 'GeometryCollection';
+                /**
+                 * Geometries
+                 */
+                geometries: Array<{
+                    /**
+                     * Type
+                     */
+                    type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+                    /**
+                     * Coordinates
+                     */
+                    coordinates: Array<unknown>;
+                }>;
+            } | {
+                /**
+                 * Type
+                 */
+                type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+                /**
+                 * Coordinates
+                 */
+                coordinates: Array<unknown>;
+            } | null;
+            /**
+             * Properties
+             */
+            properties: {
+                [key: string]: unknown;
+            };
+        }>;
+        /**
+         * Links
+         */
+        links: Array<{
+            /**
+             * Rel
+             */
+            rel: string;
+            /**
+             * Href
+             */
+            href: string;
+            /**
+             * Type
+             */
+            type: string;
+        }>;
     };
 };
 
@@ -17287,50 +17287,50 @@ export type CreateFeatureDatasetsDatasetIdFeaturesPostResponses = {
      */
     201: {
         /**
+         * Type
+         */
+        type?: 'Feature';
+        /**
+         * Id
+         */
+        id: number;
+        /**
          * Geometry
          */
         geometry?: {
+            /**
+             * Type
+             */
+            type: 'GeometryCollection';
             /**
              * Geometries
              */
             geometries: Array<{
                 /**
-                 * Coordinates
-                 */
-                coordinates: Array<unknown>;
-                /**
                  * Type
                  */
                 type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+                /**
+                 * Coordinates
+                 */
+                coordinates: Array<unknown>;
             }>;
-            /**
-             * Type
-             */
-            type: 'GeometryCollection';
         } | {
-            /**
-             * Coordinates
-             */
-            coordinates: Array<unknown>;
             /**
              * Type
              */
             type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+            /**
+             * Coordinates
+             */
+            coordinates: Array<unknown>;
         } | null;
-        /**
-         * Id
-         */
-        id: number;
         /**
          * Properties
          */
         properties: {
             [key: string]: unknown;
         };
-        /**
-         * Type
-         */
-        type?: 'Feature';
     };
 };
 
@@ -17463,50 +17463,50 @@ export type GetSingleFeatureDatasetsDatasetIdFeaturesGidGetResponses = {
      */
     200: {
         /**
+         * Type
+         */
+        type?: 'Feature';
+        /**
+         * Id
+         */
+        id: number;
+        /**
          * Geometry
          */
         geometry?: {
+            /**
+             * Type
+             */
+            type: 'GeometryCollection';
             /**
              * Geometries
              */
             geometries: Array<{
                 /**
-                 * Coordinates
-                 */
-                coordinates: Array<unknown>;
-                /**
                  * Type
                  */
                 type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+                /**
+                 * Coordinates
+                 */
+                coordinates: Array<unknown>;
             }>;
-            /**
-             * Type
-             */
-            type: 'GeometryCollection';
         } | {
-            /**
-             * Coordinates
-             */
-            coordinates: Array<unknown>;
             /**
              * Type
              */
             type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+            /**
+             * Coordinates
+             */
+            coordinates: Array<unknown>;
         } | null;
-        /**
-         * Id
-         */
-        id: number;
         /**
          * Properties
          */
         properties: {
             [key: string]: unknown;
         };
-        /**
-         * Type
-         */
-        type?: 'Feature';
     };
 };
 
@@ -17577,50 +17577,50 @@ export type PatchSingleFeatureDatasetsDatasetIdFeaturesGidPatchResponses = {
      */
     200: {
         /**
+         * Type
+         */
+        type?: 'Feature';
+        /**
+         * Id
+         */
+        id: number;
+        /**
          * Geometry
          */
         geometry?: {
+            /**
+             * Type
+             */
+            type: 'GeometryCollection';
             /**
              * Geometries
              */
             geometries: Array<{
                 /**
-                 * Coordinates
-                 */
-                coordinates: Array<unknown>;
-                /**
                  * Type
                  */
                 type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+                /**
+                 * Coordinates
+                 */
+                coordinates: Array<unknown>;
             }>;
-            /**
-             * Type
-             */
-            type: 'GeometryCollection';
         } | {
-            /**
-             * Coordinates
-             */
-            coordinates: Array<unknown>;
             /**
              * Type
              */
             type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+            /**
+             * Coordinates
+             */
+            coordinates: Array<unknown>;
         } | null;
-        /**
-         * Id
-         */
-        id: number;
         /**
          * Properties
          */
         properties: {
             [key: string]: unknown;
         };
-        /**
-         * Type
-         */
-        type?: 'Feature';
     };
 };
 
@@ -17691,50 +17691,50 @@ export type ReplaceSingleFeatureDatasetsDatasetIdFeaturesGidPutResponses = {
      */
     200: {
         /**
+         * Type
+         */
+        type?: 'Feature';
+        /**
+         * Id
+         */
+        id: number;
+        /**
          * Geometry
          */
         geometry?: {
+            /**
+             * Type
+             */
+            type: 'GeometryCollection';
             /**
              * Geometries
              */
             geometries: Array<{
                 /**
-                 * Coordinates
-                 */
-                coordinates: Array<unknown>;
-                /**
                  * Type
                  */
                 type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+                /**
+                 * Coordinates
+                 */
+                coordinates: Array<unknown>;
             }>;
-            /**
-             * Type
-             */
-            type: 'GeometryCollection';
         } | {
-            /**
-             * Coordinates
-             */
-            coordinates: Array<unknown>;
             /**
              * Type
              */
             type: 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+            /**
+             * Coordinates
+             */
+            coordinates: Array<unknown>;
         } | null;
-        /**
-         * Id
-         */
-        id: number;
         /**
          * Properties
          */
         properties: {
             [key: string]: unknown;
         };
-        /**
-         * Type
-         */
-        type?: 'Feature';
     };
 };
 


### PR DESCRIPTION
Closes #1257.

## Problem

`backend/scripts/dump_openapi.py` and `scripts/flatten_openapi_defs.py` both wrote their JSON with `sort_keys=True`, which alphabetizes every schema's `properties` map. `openapi-python-client` derives generated constructor argument order from that map, so adding an optional field whose name sorts early silently reordered positional arguments for every SDK consumer on every release. Concrete instance in v1.10.0: #727's `bbox` field displaced `distance_meters` as `AnalysisPreviewRequest.__init__`'s second positional argument.

## Fix

Both snapshot writers now sort every dict key EXCEPT each schema's `properties` map, which keeps insertion order — and insertion order is Pydantic field declaration order. Diff determinism is preserved for everything else. The flattener's content-identity serializer (`_serialize`, feeding `InlineDef_*` sha1 names) deliberately stays fully sorted so synthetic class names do not churn on a property reorder.

## Impact

- **One-time SDK churn (intentional):** every generated constructor moves from alphabetical to declaration order in this PR. After this, adding a field only appends/inserts where the model declares it. SDK consumers using positional args see one more reorder — the same class of break this PR eliminates going forward; keyword args are unaffected.
- No runtime backend/frontend behavior change; `frontend/src/types/api.generated.ts` reorders declarations only (TypeScript types are structural).
- Timed to land **before** the milestone-5 source-API regeneration wave (#1219/#1222/#1224 PRs), per the 2026-08-07 milestone audit, so those regens are stable.

## Regression coverage

`backend/tests/test_openapi_property_order.py`:
- serializer unit test: `properties` maps (incl. nested) preserved, all sibling keys sorted;
- flattener serializer proven identical to the dump serializer;
- live-app spec assertion: `AnalysisPreviewRequest` property order equals its Pydantic `model_fields` order — this test fails on the exact v1.10.0 instance.

## Verification

- `uv run pytest tests/test_openapi_property_order.py tests/test_api_contract_openapi.py` — 19 passed
- `make openapi && make sdks && npm run types:generate` — regenerated artifacts committed, re-run is clean
- `cd frontend && npm run typecheck` — clean