### PR TITLE
feat(catalog): compute dataset source freshness from update_frequency

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -2,6 +2,7 @@
 
 import uuid
 from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,6 +10,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.identity import Identity
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.auth.models import User
+from app.modules.catalog.datasets.domain.source_freshness import (
+    compute_source_freshness,
+)
 from app.modules.catalog.datasets.domain.schemas import (
     DatasetResponse,
     RasterBandInfo,
@@ -164,6 +168,11 @@ def dataset_to_response(
             base_url=base_url,
         )
 
+    # feat(#1218/#1224): resolved once. It is both the `origin` response field
+    # and the gate on source freshness below, and computing it twice is how the
+    # badge and the freshness chip would come to disagree.
+    origin = classify_origin(dataset.source_format, record_type)
+
     return DatasetResponse(
         id=dataset.id,
         record_id=dataset.record_id,
@@ -209,7 +218,7 @@ def dataset_to_response(
         # value could only ever disagree with the two it derives from. Serving
         # it retires the frontend's duplicate rule in OriginBadge.tsx and gives
         # the CLI, MCP server, and SDKs the same answer.
-        origin=classify_origin(dataset.source_format, record_type),
+        origin=origin,
         origin_uri=dataset.origin_uri,
         origin_ref=dataset.origin_ref,
         last_refreshed_at=dataset.last_refreshed_at,
@@ -219,6 +228,18 @@ def dataset_to_response(
         source_health=project_unknown(dataset.source_health),
         source_health_detail=dataset.source_health_detail,
         schema_drift_status=project_unknown(dataset.schema_drift_status),
+        # feat(#1224): the clock read lives here, at the response boundary, so
+        # compute_source_freshness stays a total function of its arguments and
+        # every threshold is testable without freezing time. `origin` gates the
+        # answer — a `created` dataset carries a last_refreshed_at it can never
+        # act on — and it is the same value served as `origin` above, resolved
+        # once so the field and the gate cannot disagree.
+        source_freshness=compute_source_freshness(
+            dataset.last_refreshed_at,
+            record.update_frequency,
+            datetime.now(timezone.utc),
+            origin=origin,
+        ),
         quality_statement=dataset.quality_statement,
         visibility=record.visibility,
         created_by=record.created_by,

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -379,6 +379,21 @@ class DatasetResponse(BaseModel):
             "schema diff; 'unknown' until a refresh has run."
         ),
     )
+    # feat(#1224): computed at read time from last_refreshed_at, the record's
+    # update_frequency, and origin. Not stored — see domain/source_freshness.py.
+    source_freshness: str = Field(
+        default="unknown",
+        description=(
+            "fresh, due, overdue, or unknown, computed from last_refreshed_at "
+            "against the declared update_frequency: due past one declared "
+            "period, overdue past two. 'unknown' when the origin cannot be "
+            "refreshed at all (created), when no cadence is declared "
+            "(asNeeded, irregular, notPlanned, unknown), or when nothing has "
+            "been refreshed yet. Advisory only; never blocks an operation. "
+            "Distinct from the quality score's own freshness, which measures "
+            "quality_detail.computed_at rather than the source."
+        ),
+    )
     quality_statement: str | None = None
     visibility: str = Field(
         description="Access level: private, restricted, internal, public"

--- a/backend/app/modules/catalog/datasets/domain/source_freshness.py
+++ b/backend/app/modules/catalog/datasets/domain/source_freshness.py
@@ -1,0 +1,172 @@
+"""Source freshness: how a dataset's last refresh compares to its cadence.
+
+feat(#1224): ``records.update_frequency`` has carried the ISO 19115
+maintenance-frequency vocabulary since the catalog shipped, and nothing ever
+compared it to anything. ``datasets.last_refreshed_at`` (#1218) supplies the
+other half, so source freshness is a pure read-side computation over stored
+columns.
+
+**"Source freshness", never bare "freshness".** The frontend already owns a
+different concept under that word: ``frontend/src/lib/quality-freshness.ts``
+measures the quality score's ``computed_at`` against the same
+``update_frequency``, with its own thresholds (2 / 14 / 62 / 186 / 550 days,
+plus a 45-day policy for an unknown cadence) and its own state set
+(``fresh`` / ``stale`` / ``missing``). The two share a word, an input, and the
+state name ``fresh`` while answering different questions, so every name here —
+module, function, response field, and copy — carries the ``source_`` qualifier.
+
+ADR-002 Decision 2 is the reason nothing here writes: the state derives from
+live columns, so persisting it would create a value whose only possible
+behaviour is to disagree with the ones it came from. The same argument retires
+``origin_kind`` and ``quality_score_numeric``. Contrast ``schema_drift_status``,
+which IS stored — drift compares a pre-refresh schema that no longer exists, so
+it derives from nothing at read time.
+
+``now`` and ``origin`` are parameters, not lookups, so the mapping is a total
+function of its inputs and every threshold is testable without freezing time.
+
+Source freshness never blocks anything. It is advisory state for the catalog UI
+(#1226), the CLI, and the SDKs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+FRESH = "fresh"
+DUE = "due"
+OVERDUE = "overdue"
+# Spelled the same as dataset_origin.UNKNOWN and unrelated to it: that one is
+# the wire form of a NULL source-state column, this one means "the question
+# cannot be asked of this dataset". Two vocabularies that happen to share a
+# word; do not collapse them.
+UNKNOWN = "unknown"
+
+SOURCE_FRESHNESS_VALUES: tuple[str, ...] = (FRESH, DUE, OVERDUE, UNKNOWN)
+
+# Origins a refresh can actually re-pull from (ADR-002 Decision 5a's per-origin
+# table). An allowlist rather than a denylist on purpose: a future origin kind
+# nobody classified here reads "unknown", which withholds advice, instead of
+# reading "overdue", which names an action that may not exist. The partition
+# below is pinned against dataset_origin.ORIGIN_KINDS in the test suite, so
+# adding a kind fails loudly rather than defaulting either way in silence.
+REFRESHABLE_ORIGINS: frozenset[str] = frozenset(
+    {"upload", "postgis", "service", "stac"}
+)
+
+# `created` is the whole reason origin is a parameter. A dataset drawn in the
+# app came from nowhere, so ADR-002 Decision 5a gives it 409
+# `refresh_not_applicable` — and yet service_create.py stamps every new dataset
+# with `last_refreshed_at` at creation, and migration 0036 backfills a floor for
+# older rows. Without this gate an eighteen-month-old sketch layer carrying
+# `update_frequency='monthly'` would report "overdue" and point the user at an
+# action that does not exist for it.
+NON_REFRESHABLE_ORIGINS: frozenset[str] = frozenset({"created"})
+
+# The full ISO 19115 MD_MaintenanceFrequencyCode set GeoLens accepts, mirroring
+# chk_records_update_frequency on catalog.records. Kept here as well so the two
+# can be compared: tests/test_dataset_source_freshness.py fails if the CHECK
+# gains a value that nothing below assigns a meaning to, which is the loud
+# version of a new vocabulary value silently rendering as "unknown" forever.
+UPDATE_FREQUENCY_VOCABULARY: frozenset[str] = frozenset(
+    {
+        "continual",
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "biannually",
+        "annually",
+        "asNeeded",
+        "irregular",
+        "notPlanned",
+        "unknown",
+    }
+)
+
+# One cycle of each cadence, in days. Calendar-length values are the LONGEST
+# such period (31-day month, 92-day quarter, 366-day year) so a dataset kept on
+# schedule is never reported late by a leap day or a short month; being a day
+# slow to say "due" is the harmless direction.
+#
+# `continual` shares daily's period. ISO defines it as "repeatedly and
+# frequently", with no unit attached, so any number here is invented; one day
+# is the shortest cadence the rest of the table can express and reads the way a
+# continually-updated dataset is meant to behave.
+FREQUENCY_PERIOD_DAYS: dict[str, int] = {
+    "continual": 1,
+    "daily": 1,
+    "weekly": 7,
+    "monthly": 31,
+    "quarterly": 92,
+    "biannually": 183,
+    "annually": 366,
+}
+
+# Vocabulary values that declare no cadence at all, so no age can be late
+# against them. Derived rather than listed, so the two sets cannot disagree.
+UNSCHEDULED_FREQUENCIES: frozenset[str] = UPDATE_FREQUENCY_VOCABULARY - frozenset(
+    FREQUENCY_PERIOD_DAYS
+)
+
+# Past one period a dataset is due; past this multiple of it, overdue.
+OVERDUE_PERIOD_MULTIPLE = 2
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Read a naive datetime as UTC so the subtraction below cannot raise.
+
+    Both inputs are timestamptz in the schema and arrive aware, and the app
+    builds its own clock reads with ``datetime.now(timezone.utc)`` — the only
+    naive datetimes this codebase produces are already UTC. Coercing rather
+    than raising keeps a stray naive value from turning a plain dataset GET
+    into a 500; coercing rather than returning ``UNKNOWN`` keeps it from
+    disappearing into a legitimate-looking state instead.
+    """
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def compute_source_freshness(
+    last_refreshed_at: datetime | None,
+    update_frequency: str | None,
+    now: datetime,
+    *,
+    origin: str | None,
+) -> str:
+    """Map a dataset's refresh age against its declared cadence.
+
+    Returns ``fresh`` within one declared period, ``due`` past one, and
+    ``overdue`` past two. ``unknown`` covers every case where the question
+    cannot be asked: an origin nothing can refresh (``created``), no cadence
+    declared (``asNeeded``, ``irregular``, ``notPlanned``, ``unknown``, or
+    NULL), an unrecognised frequency string, or nothing refreshed yet.
+
+    ``origin`` is the value ``classify_origin`` produces, passed explicitly so
+    this stays a pure function. A NULL origin is a VRT, which is refreshable in
+    the sense that matters here: ADR-002 Decision 5a projects each VRT's latest
+    generation timestamp into ``last_refreshed_at`` precisely so freshness
+    renders uniformly across record types. (A collection also classifies as
+    NULL and never reaches this function — it has no dataset row.)
+
+    Boundaries are strict: an age of exactly one period is still ``fresh``, and
+    exactly two is still ``due``. A refresh timed to the declared cadence lands
+    on the boundary, so the inclusive reading would report an on-time dataset
+    late.
+    """
+    if origin is not None and origin not in REFRESHABLE_ORIGINS:
+        return UNKNOWN
+
+    if last_refreshed_at is None:
+        return UNKNOWN
+
+    period_days = FREQUENCY_PERIOD_DAYS.get(update_frequency or "")
+    if period_days is None:
+        return UNKNOWN
+
+    age = _as_utc(now) - _as_utc(last_refreshed_at)
+    period = timedelta(days=period_days)
+    if age > period * OVERDUE_PERIOD_MULTIPLE:
+        return OVERDUE
+    if age > period:
+        return DUE
+    return FRESH

--- a/backend/app/modules/catalog/search/schemas.py
+++ b/backend/app/modules/catalog/search/schemas.py
@@ -113,6 +113,18 @@ class OGCRecordProperties(BaseModel):
     time: dict
     lineage: str | None = None
     update_frequency: str | None = None
+    # feat(#1224): computed from the dataset's last_refreshed_at against
+    # update_frequency above, gated on origin; never stored. See
+    # datasets/domain/source_freshness.py.
+    source_freshness: str = Field(
+        default="unknown",
+        description=(
+            "fresh, due, overdue, or unknown — how the dataset's last refresh "
+            "compares to its declared update_frequency. 'unknown' for origins "
+            "nothing can refresh. Advisory only, and distinct from the quality "
+            "score's own freshness."
+        ),
+    )
     constraints: dict | None = None
     distributions: list[dict] | None = None
     record_status: str | None = None

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -14,6 +15,9 @@ import structlog
 from app.core.config import settings
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.catalog.datasets.domain.models import Dataset
+from app.modules.catalog.datasets.domain.source_freshness import (
+    compute_source_freshness,
+)
 from app.modules.catalog.records.localization import select_localized_record_text
 from app.modules.catalog.datasets.domain.utils import extract_bbox
 from app.modules.catalog.search.record_metadata import (
@@ -23,6 +27,7 @@ from app.modules.catalog.search.record_metadata import (
     build_time,
 )
 from app.modules.catalog.sources.provenance import derive_last_edited
+from app.platform.dataset_origin import classify_origin
 from app.standards.ogc.utils import build_url
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -359,6 +364,19 @@ def dataset_to_ogc_record(
             # ISO governance fields (API-01)
             "lineage": lineage_summary,
             "update_frequency": record.update_frequency,
+            # feat(#1224): the same read-time computation dataset_to_response
+            # serves, so a catalog card and a dataset detail page cannot
+            # disagree about how late a dataset is. Search responses cache for
+            # SEARCH_CACHE_TTL (30s), which is far below the shortest declared
+            # period (one day), so a cached value can only lag a transition by
+            # that window. Named source_freshness, not freshness: the frontend's
+            # quality-freshness.ts answers a different question under that word.
+            "source_freshness": compute_source_freshness(
+                dataset.last_refreshed_at,
+                record.update_frequency,
+                datetime.now(timezone.utc),
+                origin=classify_origin(dataset.source_format, record_type),
+            ),
             "constraints": (
                 {"usage": record.usage_constraints, "access": record.access_constraints}
                 if record.usage_constraints or record.access_constraints

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5473,6 +5473,12 @@
             "title": "Schema Drift Status",
             "type": "string"
           },
+          "source_freshness": {
+            "default": "unknown",
+            "description": "fresh, due, overdue, or unknown, computed from last_refreshed_at against the declared update_frequency: due past one declared period, overdue past two. 'unknown' when the origin cannot be refreshed at all (created), when no cadence is declared (asNeeded, irregular, notPlanned, unknown), or when nothing has been refreshed yet. Advisory only; never blocks an operation. Distinct from the quality score's own freshness, which measures quality_detail.computed_at rather than the source.",
+            "title": "Source Freshness",
+            "type": "string"
+          },
           "quality_statement": {
             "anyOf": [
               {
@@ -11979,6 +11985,12 @@
               }
             ],
             "title": "Update Frequency"
+          },
+          "source_freshness": {
+            "default": "unknown",
+            "description": "fresh, due, overdue, or unknown \u2014 how the dataset's last refresh compares to its declared update_frequency. 'unknown' for origins nothing can refresh. Advisory only, and distinct from the quality score's own freshness.",
+            "title": "Source Freshness",
+            "type": "string"
           },
           "constraints": {
             "anyOf": [

--- a/backend/tests/test_dataset_source_freshness.py
+++ b/backend/tests/test_dataset_source_freshness.py
@@ -1,0 +1,499 @@
+"""Source freshness from update_frequency, last_refreshed_at, origin (#1224).
+
+Five properties this suite holds:
+
+1. The mapping is total and deterministic. ``now`` and ``origin`` are
+   arguments, so every threshold is pinned without freezing a clock, and every
+   value of the ISO 19115 vocabulary has an asserted answer.
+2. An origin nothing can refresh never reports a deadline. ``created``
+   datasets are stamped with ``last_refreshed_at`` at creation
+   (``service_create.py``) and answer 409 ``refresh_not_applicable``, so
+   without the gate an old sketch layer would read "overdue" and name an
+   action that does not exist for it.
+3. The vocabulary the mapping knows about is the vocabulary the database
+   accepts, and the origins it classifies are the origins that exist. A value
+   added to ``chk_records_update_frequency`` or to ``ORIGIN_KINDS`` with no
+   decision recorded here would otherwise render as ``unknown`` forever, which
+   is a legitimate-looking state and therefore silent.
+4. Source freshness reaches both response surfaces, and they agree. A dataset
+   detail page and a catalog card compute the same thing from the same
+   columns; two independent implementations is the bug ADR-002 Decision 2
+   exists to prevent.
+5. Nothing is written. No column, no PATCHable field. The whole point is that
+   the state derives from live columns, so a stored copy could only go stale.
+
+Boundary cases are asserted in both directions: exactly one period is fresh
+AND one second past it is due. A one-sided assertion cannot notice the
+comparison flipping to inclusive.
+
+Note the name throughout: SOURCE freshness. ``frontend/src/lib/quality-
+freshness.ts`` measures the quality score's ``computed_at`` against the same
+``update_frequency`` with different thresholds and a different state set, and
+the two must never be read as one thing.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.schemas import DatasetMeta
+from app.modules.catalog.datasets.domain.source_freshness import (
+    DUE,
+    FRESH,
+    FREQUENCY_PERIOD_DAYS,
+    NON_REFRESHABLE_ORIGINS,
+    OVERDUE,
+    OVERDUE_PERIOD_MULTIPLE,
+    REFRESHABLE_ORIGINS,
+    SOURCE_FRESHNESS_VALUES,
+    UNKNOWN,
+    UNSCHEDULED_FREQUENCIES,
+    UPDATE_FREQUENCY_VOCABULARY,
+    compute_source_freshness,
+)
+from app.modules.catalog.search.schemas import OGCRecordProperties
+from app.platform.dataset_origin import ORIGIN_KINDS
+from tests.factories import create_dataset as _create_dataset, get_user_id
+
+NOW = datetime(2026, 8, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+# The four vocabulary values that declare no cadence. Listed literally rather
+# than reusing UNSCHEDULED_FREQUENCIES, which is derived from the same table
+# the mapping reads: deriving the expectation from the implementation would
+# make this assertion true by construction.
+_UNSCHEDULED = ("asNeeded", "irregular", "notPlanned", "unknown")
+
+
+def _freshness(
+    last_refreshed_at: datetime | None,
+    update_frequency: str | None,
+    now: datetime,
+    origin: str | None = "upload",
+) -> str:
+    """``compute_source_freshness`` with a refreshable origin by default.
+
+    The threshold tests are not about origin, and repeating ``origin="upload"``
+    across every one of them would bury the argument that IS under test.
+    ``TestOriginApplicabilityGate`` calls the real function directly.
+    """
+    return compute_source_freshness(
+        last_refreshed_at, update_frequency, now, origin=origin
+    )
+
+
+class TestPureMapping:
+    """(last_refreshed_at, update_frequency, now, origin) -> one of four strings."""
+
+    @pytest.mark.parametrize(
+        ("frequency", "period_days"),
+        sorted(FREQUENCY_PERIOD_DAYS.items()),
+    )
+    def test_each_cadence_walks_fresh_due_overdue(
+        self, frequency: str, period_days: int
+    ) -> None:
+        """One period is the fresh/due line, two the due/overdue line.
+
+        Both sides of both lines, for every cadence: a strict comparison that
+        became inclusive would keep passing against the "past the line" case
+        alone, and an on-time refresh lands exactly ON the line.
+        """
+        period = timedelta(days=period_days)
+        second = timedelta(seconds=1)
+
+        cases = (
+            (timedelta(0), FRESH),
+            (period - second, FRESH),
+            (period, FRESH),
+            (period + second, DUE),
+            (period * OVERDUE_PERIOD_MULTIPLE - second, DUE),
+            (period * OVERDUE_PERIOD_MULTIPLE, DUE),
+            (period * OVERDUE_PERIOD_MULTIPLE + second, OVERDUE),
+            (period * 100, OVERDUE),
+        )
+        for age, expected in cases:
+            assert _freshness(NOW - age, frequency, NOW) == expected, (
+                f"{frequency} at age {age} should be {expected}"
+            )
+
+    @pytest.mark.parametrize("frequency", _UNSCHEDULED)
+    def test_unscheduled_frequencies_are_unknown_at_any_age(
+        self, frequency: str
+    ) -> None:
+        """No cadence declared means no age can be late against it."""
+        for age in (timedelta(0), timedelta(days=1), timedelta(days=10_000)):
+            assert _freshness(NOW - age, frequency, NOW) == UNKNOWN
+
+    def test_missing_frequency_is_unknown(self) -> None:
+        assert _freshness(NOW - timedelta(days=999), None, NOW) == UNKNOWN
+
+    def test_missing_last_refreshed_at_is_unknown(self) -> None:
+        assert _freshness(None, "daily", NOW) == UNKNOWN
+        # Both missing at once, the state of a dataset nobody has touched.
+        assert _freshness(None, None, NOW) == UNKNOWN
+
+    def test_unrecognised_frequency_string_is_unknown(self) -> None:
+        """A value the CHECK constraint would reject still cannot raise.
+
+        Pre-CHECK rows and future vocabulary both arrive here as a string
+        nothing maps; a KeyError on a plain dataset GET would be worse than a
+        conservative answer. The drift guard below is what keeps this from
+        being how a real new vocabulary value gets handled.
+        """
+        assert _freshness(NOW - timedelta(days=999), "fortnightly", NOW) == (UNKNOWN)
+        assert _freshness(NOW, "", NOW) == UNKNOWN
+
+    def test_a_future_refresh_timestamp_is_fresh(self) -> None:
+        """Clock skew between the app and the database must not read as late."""
+        assert _freshness(NOW + timedelta(days=5), "daily", NOW) == FRESH
+
+    def test_naive_datetimes_are_read_as_utc(self) -> None:
+        """The only naive datetimes this codebase makes are already UTC.
+
+        Coercing keeps a stray naive value from turning a read path into a
+        500, and the answer it produces is the same one the aware pair gives.
+        """
+        naive_now = NOW.replace(tzinfo=None)
+        naive_old = (NOW - timedelta(days=3)).replace(tzinfo=None)
+        assert _freshness(naive_old, "daily", naive_now) == OVERDUE
+        # Mixed awareness, the shape that actually raises without the coercion.
+        assert _freshness(naive_old, "daily", NOW) == OVERDUE
+        assert _freshness(NOW - timedelta(days=3), "daily", naive_now) == (OVERDUE)
+
+    def test_the_mapping_only_ever_returns_a_declared_value(self) -> None:
+        for frequency in sorted(UPDATE_FREQUENCY_VOCABULARY) + [None, "nonsense"]:
+            for age_days in (0, 1, 8, 40, 200, 400, 5000):
+                result = _freshness(NOW - timedelta(days=age_days), frequency, NOW)
+                assert result in SOURCE_FRESHNESS_VALUES
+
+
+class TestOriginApplicabilityGate:
+    """An origin nothing can refresh never reports a deadline."""
+
+    @pytest.mark.parametrize("frequency", sorted(FREQUENCY_PERIOD_DAYS))
+    @pytest.mark.parametrize("age_days", [0, 400, 5000])
+    def test_created_origin_is_unknown_at_every_age_and_cadence(
+        self, frequency: str, age_days: int
+    ) -> None:
+        """The whole reason origin is a parameter.
+
+        ``service_create.py`` stamps every new dataset with
+        ``last_refreshed_at``, and migration 0036 backfills a floor for older
+        rows, so a sketch layer always has a timestamp. ADR-002 Decision 5a
+        gives ``created`` a 409 ``refresh_not_applicable``, so any answer other
+        than ``unknown`` here points the user at an action that does not exist.
+        """
+        assert (
+            compute_source_freshness(
+                NOW - timedelta(days=age_days), frequency, NOW, origin="created"
+            )
+            == UNKNOWN
+        )
+
+    @pytest.mark.parametrize("origin", sorted(REFRESHABLE_ORIGINS))
+    def test_every_refreshable_origin_still_reports_a_deadline(
+        self, origin: str
+    ) -> None:
+        """The admission half.
+
+        A gate that starts refusing everything passes the refusal test above
+        while silently reporting ``unknown`` for the whole catalog, and nothing
+        in a refusal assertion notices that.
+        """
+        assert (
+            compute_source_freshness(
+                NOW - timedelta(days=800), "annually", NOW, origin=origin
+            )
+            == OVERDUE
+        )
+
+    def test_a_null_origin_still_reports_a_deadline(self) -> None:
+        """NULL is a VRT, and ADR-002 Decision 5a projects its generation
+        timestamp into last_refreshed_at precisely so freshness renders
+        uniformly across record types. Gating it out would defeat that.
+        """
+        assert (
+            compute_source_freshness(
+                NOW - timedelta(days=800), "annually", NOW, origin=None
+            )
+            == OVERDUE
+        )
+
+    def test_an_unclassified_origin_withholds_advice_rather_than_inventing_it(
+        self,
+    ) -> None:
+        """The allowlist's direction, pinned.
+
+        A kind added to ORIGIN_KINDS and forgotten here reads ``unknown``. The
+        partition test below is what makes that a loud failure rather than the
+        permanent state, but the safe default matters on its own: the opposite
+        default would announce a deadline for something that may not be
+        refreshable at all.
+        """
+        assert (
+            compute_source_freshness(
+                NOW - timedelta(days=800), "annually", NOW, origin="warehouse"
+            )
+            == UNKNOWN
+        )
+
+    def test_the_origin_partition_covers_every_kind_that_exists(self) -> None:
+        assert REFRESHABLE_ORIGINS | NON_REFRESHABLE_ORIGINS == set(ORIGIN_KINDS), (
+            "REFRESHABLE_ORIGINS and NON_REFRESHABLE_ORIGINS no longer partition "
+            "dataset_origin.ORIGIN_KINDS. A new origin kind needs a decision "
+            "recorded in one of the two sets — leaving it out means it silently "
+            "reports 'unknown' forever."
+        )
+        assert not REFRESHABLE_ORIGINS & NON_REFRESHABLE_ORIGINS
+
+
+class TestVocabularyStaysInStepWithTheSchema:
+    """The loud half: a new CHECK value must not default to ``unknown``."""
+
+    def test_vocabulary_matches_the_records_check_constraint(self) -> None:
+        constraint = next(
+            c
+            for c in Record.__table__.constraints
+            if c.name == "chk_records_update_frequency"
+        )
+        stored = set(re.findall(r"'([^']+)'", str(constraint.sqltext)))
+        assert stored, "failed to parse the CHECK constraint; fix this test first"
+        assert stored == set(UPDATE_FREQUENCY_VOCABULARY), (
+            "chk_records_update_frequency and UPDATE_FREQUENCY_VOCABULARY have "
+            "drifted. Every accepted frequency needs either a period in "
+            "FREQUENCY_PERIOD_DAYS or a deliberate place among the "
+            "unscheduled values."
+        )
+
+    def test_every_vocabulary_value_is_either_timed_or_unscheduled(self) -> None:
+        timed = set(FREQUENCY_PERIOD_DAYS)
+        assert timed | UNSCHEDULED_FREQUENCIES == set(UPDATE_FREQUENCY_VOCABULARY)
+        assert not timed & UNSCHEDULED_FREQUENCIES
+        assert UNSCHEDULED_FREQUENCIES == set(_UNSCHEDULED)
+
+    def test_periods_are_ordered_by_cadence(self) -> None:
+        """A transposed pair in the table would otherwise be invisible."""
+        by_cadence = [
+            "continual",
+            "daily",
+            "weekly",
+            "monthly",
+            "quarterly",
+            "biannually",
+            "annually",
+        ]
+        periods = [FREQUENCY_PERIOD_DAYS[name] for name in by_cadence]
+        assert periods == sorted(periods)
+        assert set(by_cadence) == set(FREQUENCY_PERIOD_DAYS)
+
+
+class TestNothingIsPersisted:
+    """ADR-002 Decision 2: derived state gets no column and no write path."""
+
+    def test_freshness_is_not_a_column_on_either_table(self) -> None:
+        assert "source_freshness" not in Dataset.__table__.columns
+        assert "source_freshness" not in Record.__table__.columns
+
+    def test_freshness_is_not_accepted_by_the_metadata_patch(self) -> None:
+        assert "source_freshness" not in DatasetMeta.model_fields
+
+    async def test_patch_cannot_set_freshness_but_moves_what_it_derives_from(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        """Refusal and admission in one request.
+
+        ``update_frequency`` IS in the PATCH allowlist and freshness is
+        computed from it, so this pins the whole shape at once: the body's
+        ``freshness`` is ignored, and the value that comes back is the one the
+        newly-PATCHed cadence implies rather than either the body's or the
+        pre-PATCH answer.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session, created_by=admin_id, name="Patch Freshness"
+        )
+        ds.last_refreshed_at = datetime.now(timezone.utc) - timedelta(days=400)
+        ds.record.update_frequency = "asNeeded"
+        await test_db_session.commit()
+
+        before = await client.get(f"/datasets/{ds.id}", headers=admin_auth_header)
+        assert before.json()["source_freshness"] == UNKNOWN
+
+        resp = await client.patch(
+            f"/datasets/{ds.id}",
+            json={"source_freshness": FRESH, "update_frequency": "annually"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["update_frequency"] == "annually"
+        assert resp.json()["source_freshness"] == DUE
+
+        after = await client.get(f"/datasets/{ds.id}", headers=admin_auth_header)
+        assert after.status_code == 200
+        assert after.json()["source_freshness"] == DUE
+
+
+class TestResponseExposure:
+    """Both surfaces serve it, and they serve the same answer."""
+
+    @pytest.mark.parametrize(
+        ("age_days", "frequency", "expected"),
+        [
+            (2, "annually", FRESH),
+            (400, "annually", DUE),
+            (800, "annually", OVERDUE),
+            (800, "asNeeded", UNKNOWN),
+        ],
+    )
+    async def test_dataset_and_ogc_record_agree(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        age_days: int,
+        frequency: str,
+        expected: str,
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name=f"Freshness {frequency} {age_days}",
+        )
+        ds.last_refreshed_at = datetime.now(timezone.utc) - timedelta(days=age_days)
+        ds.record.update_frequency = frequency
+        await test_db_session.commit()
+
+        detail = await client.get(f"/datasets/{ds.id}", headers=admin_auth_header)
+        assert detail.status_code == 200
+        assert detail.json()["source_freshness"] == expected
+
+        record = await client.get(f"/collections/datasets/items/{ds.id}")
+        assert record.status_code == 200
+        props = record.json()["properties"]
+        assert props["source_freshness"] == expected
+        # The two columns it was computed from travel with it on this surface,
+        # so a reader can check the arithmetic.
+        assert props["update_frequency"] == frequency
+
+    async def test_never_refreshed_dataset_reports_unknown_on_both(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session, created_by=admin_id, name="Never Refreshed"
+        )
+        ds.last_refreshed_at = None
+        ds.record.update_frequency = "daily"
+        await test_db_session.commit()
+
+        detail = await client.get(f"/datasets/{ds.id}", headers=admin_auth_header)
+        assert detail.json()["source_freshness"] == UNKNOWN
+        assert detail.json()["last_refreshed_at"] is None
+
+        record = await client.get(f"/collections/datasets/items/{ds.id}")
+        assert record.json()["properties"]["source_freshness"] == UNKNOWN
+
+    async def test_a_created_dataset_reports_unknown_on_both_surfaces(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        """The origin gate, end to end, on the case that motivated it.
+
+        Identical inputs to the ``overdue`` row above apart from
+        ``source_format``, so this pins the gate rather than some other reason
+        the answer might be ``unknown``. The ``origin`` assertion is what makes
+        that claim honest: without it, a fixture that failed to produce a
+        ``created`` dataset would pass this test for the wrong reason.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Sketch Layer",
+            source_format="created",
+        )
+        ds.last_refreshed_at = datetime.now(timezone.utc) - timedelta(days=800)
+        ds.record.update_frequency = "annually"
+        await test_db_session.commit()
+
+        detail = await client.get(f"/datasets/{ds.id}", headers=admin_auth_header)
+        assert detail.status_code == 200
+        body = detail.json()
+        assert body["origin"] == "created", "fixture did not produce a created origin"
+        assert body["source_freshness"] == UNKNOWN
+        # The timestamp is still served; only the verdict is withheld.
+        assert body["last_refreshed_at"] is not None
+
+        record = await client.get(f"/collections/datasets/items/{ds.id}")
+        assert record.status_code == 200
+        assert record.json()["properties"]["source_freshness"] == UNKNOWN
+
+    async def test_the_search_listing_carries_it_through_its_response_model(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        """The listing is the surface the catalog cards read, and it filters.
+
+        ``/collections/datasets/items/{id}`` returns a raw ``JSONResponse``, so
+        a key arriving there says nothing about ``/search/datasets/``, which
+        serializes through ``OGCFeatureCollectionResponse`` and drops any
+        property ``OGCRecordProperties`` does not declare.
+
+        Filtered to a unique ``source_organization`` rather than reading the
+        first row: the per-worker database accumulates datasets from every
+        earlier test, so an unfiltered listing is a claim about the whole
+        worker.
+        """
+        org = f"Freshness Listing Org {uuid.uuid4().hex[:8]}"
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Freshness In Listing",
+            visibility="public",
+        )
+        ds.last_refreshed_at = datetime.now(timezone.utc) - timedelta(days=800)
+        ds.record.update_frequency = "annually"
+        ds.record.source_organization = org
+        await test_db_session.commit()
+
+        resp = await client.get(
+            "/search/datasets/",
+            params={"source_organization": org},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        features = resp.json()["features"]
+        assert len(features) == 1, (
+            f"expected exactly the seeded dataset, got {features}"
+        )
+        assert features[0]["id"] == str(ds.id)
+        assert features[0]["properties"]["source_freshness"] == OVERDUE
+
+    def test_both_response_schemas_declare_the_field(self) -> None:
+        """Held separately from the wire assertions above.
+
+        A dict key that no model declares would still serialize on the OGC
+        surface, so the schema is what makes the field appear in OpenAPI and
+        therefore in the SDKs.
+        """
+        from app.modules.catalog.datasets.domain.schemas import DatasetResponse
+
+        assert "source_freshness" in DatasetResponse.model_fields
+        assert "source_freshness" in OGCRecordProperties.model_fields

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2300,7 +2300,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reader will go looking for the column. source_health and
     # schema_drift_status carry the NULL -> "unknown" projection, which is
     # only discoverable from the description. Cap 1215 -> 1271, exact.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1271,
+    # feat(#1224): +15 — the computed `source_freshness` field. The description
+    # spends its lines on the three things a reader cannot see from the type:
+    # that the value is derived from last_refreshed_at, update_frequency, and
+    # origin rather than stored (so nobody goes looking for a column); that a
+    # non-refreshable origin reads "unknown"; and that it is a different thing
+    # from the quality score's own freshness, which the frontend already
+    # computes under that word. Cap 1271 -> 1286, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1286,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7374,6 +7374,12 @@ export interface components {
              * @default unknown
              */
             schema_drift_status: string;
+            /**
+             * Source Freshness
+             * @description fresh, due, overdue, or unknown, computed from last_refreshed_at against the declared update_frequency: due past one declared period, overdue past two. 'unknown' when the origin cannot be refreshed at all (created), when no cadence is declared (asNeeded, irregular, notPlanned, unknown), or when nothing has been refreshed yet. Advisory only; never blocks an operation. Distinct from the quality score's own freshness, which measures quality_detail.computed_at rather than the source.
+             * @default unknown
+             */
+            source_freshness: string;
             /** Quality Statement */
             quality_statement?: string | null;
             /**
@@ -10124,6 +10130,12 @@ export interface components {
             lineage?: string | null;
             /** Update Frequency */
             update_frequency?: string | null;
+            /**
+             * Source Freshness
+             * @description fresh, due, overdue, or unknown — how the dataset's last refresh compares to its declared update_frequency. 'unknown' for origins nothing can refresh. Advisory only, and distinct from the quality score's own freshness.
+             * @default unknown
+             */
+            source_freshness: string;
             /** Constraints */
             constraints?: {
                 [key: string]: unknown;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -191,6 +191,20 @@ export type DatasetOrigin = 'upload' | 'postgis' | 'service' | 'stac' | 'created
  *  literal, so there is exactly one way to spell "never determined". */
 export type SourceHealth = 'healthy' | 'missing' | 'inaccessible' | 'unknown';
 export type SchemaDriftStatus = 'none' | 'drifted' | 'unknown';
+/** feat(#1224): how a dataset's last refresh of its SOURCE compares to the
+ *  cadence it declares in `update_frequency` — due past one declared period,
+ *  overdue past two. Computed server-side on every read, never stored, so there
+ *  is no client-side copy of the rule to drift. 'unknown' when the origin
+ *  cannot be refreshed at all (`created`), when no cadence is declared
+ *  (asNeeded, irregular, notPlanned, unknown), or when nothing has been
+ *  refreshed yet. Advisory: it never gates an action.
+ *
+ *  NOT the same thing as `QualityFreshnessState` in lib/quality-freshness.ts,
+ *  which measures the quality score's `computed_at` against the same
+ *  `update_frequency` with its own thresholds and its own states
+ *  ('fresh' | 'stale' | 'missing'). Both words say freshness; only one is about
+ *  the source. Keep the `source` qualifier on every name and label. */
+export type SourceFreshness = 'fresh' | 'due' | 'overdue' | 'unknown';
 
 /** Response returned by dataset publication-status mutation endpoints. */
 export type StatusUpdateResponse = components['schemas']['StatusUpdateResponse'];
@@ -279,6 +293,10 @@ export interface DatasetResponse {
   source_health_detail?: string | null;
   /** 'unknown' until a refresh has run. */
   schema_drift_status?: SchemaDriftStatus;
+  /** feat(#1224): computed from `last_refreshed_at` against the
+   * `update_frequency` below, gated on `origin`. Read-only, like the block
+   * above. */
+  source_freshness?: SourceFreshness;
   quality_statement: string | null;
   collections: Array<{ id: string; name: string }> | null;
   quality_detail?: {
@@ -522,6 +540,11 @@ export interface OGCRecordProperties {
   } | null;
   record_status?: string | null;
   record_type?: RecordType;
+  /** feat(#1224): the same computed value `DatasetResponse.source_freshness`
+   * carries, so a catalog card and a dataset page cannot disagree about how
+   * late a dataset is. Served alongside `update_frequency` below. */
+  source_freshness?: SourceFreshness;
+  update_frequency?: string | null;
   has_quicklook?: boolean;
   band_count?: number | null;
   epsg?: number | null;

--- a/sdks/python/geolens/models/dataset_response.py
+++ b/sdks/python/geolens/models/dataset_response.py
@@ -85,6 +85,11 @@ class DatasetResponse:
         source_health_detail (None | str | Unset): Short redacted reason for a non-healthy state
         schema_drift_status (str | Unset): none, drifted, or unknown. Set at refresh commit from the schema diff;
             'unknown' until a refresh has run. Default: 'unknown'.
+        source_freshness (str | Unset): fresh, due, overdue, or unknown, computed from last_refreshed_at against the
+            declared update_frequency: due past one declared period, overdue past two. 'unknown' when the origin cannot be
+            refreshed at all (created), when no cadence is declared (asNeeded, irregular, notPlanned, unknown), or when
+            nothing has been refreshed yet. Advisory only; never blocks an operation. Distinct from the quality score's own
+            freshness, which measures quality_detail.computed_at rather than the source. Default: 'unknown'.
         quality_statement (None | str | Unset):
         last_edited_by_display (None | str | Unset):
         last_edited_at (datetime.datetime | None | Unset):
@@ -155,6 +160,7 @@ class DatasetResponse:
     source_health: str | Unset = "unknown"
     source_health_detail: None | str | Unset = UNSET
     schema_drift_status: str | Unset = "unknown"
+    source_freshness: str | Unset = "unknown"
     quality_statement: None | str | Unset = UNSET
     last_edited_by_display: None | str | Unset = UNSET
     last_edited_at: datetime.datetime | None | Unset = UNSET
@@ -390,6 +396,8 @@ class DatasetResponse:
 
         schema_drift_status = self.schema_drift_status
 
+        source_freshness = self.source_freshness
+
         quality_statement: None | str | Unset
         if isinstance(self.quality_statement, Unset):
             quality_statement = UNSET
@@ -607,6 +615,8 @@ class DatasetResponse:
             field_dict["source_health_detail"] = source_health_detail
         if schema_drift_status is not UNSET:
             field_dict["schema_drift_status"] = schema_drift_status
+        if source_freshness is not UNSET:
+            field_dict["source_freshness"] = source_freshness
         if quality_statement is not UNSET:
             field_dict["quality_statement"] = quality_statement
         if last_edited_by_display is not UNSET:
@@ -1021,6 +1031,8 @@ class DatasetResponse:
 
         schema_drift_status = d.pop("schema_drift_status", UNSET)
 
+        source_freshness = d.pop("source_freshness", UNSET)
+
         def _parse_quality_statement(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -1331,6 +1343,7 @@ class DatasetResponse:
             source_health=source_health,
             source_health_detail=source_health_detail,
             schema_drift_status=schema_drift_status,
+            source_freshness=source_freshness,
             quality_statement=quality_statement,
             last_edited_by_display=last_edited_by_display,
             last_edited_at=last_edited_at,

--- a/sdks/python/geolens/models/ogc_record_properties.py
+++ b/sdks/python/geolens/models/ogc_record_properties.py
@@ -68,6 +68,9 @@ class OGCRecordProperties:
         rights (None | str | Unset):
         lineage (None | str | Unset):
         update_frequency (None | str | Unset):
+        source_freshness (str | Unset): fresh, due, overdue, or unknown — how the dataset's last refresh compares to its
+            declared update_frequency. 'unknown' for origins nothing can refresh. Advisory only, and distinct from the
+            quality score's own freshness. Default: 'unknown'.
         constraints (None | OGCRecordPropertiesConstraintsType0 | Unset):
         distributions (list[OGCRecordPropertiesDistributionsType0Item] | None | Unset):
         record_status (None | str | Unset):
@@ -109,6 +112,7 @@ class OGCRecordProperties:
     rights: None | str | Unset = UNSET
     lineage: None | str | Unset = UNSET
     update_frequency: None | str | Unset = UNSET
+    source_freshness: str | Unset = "unknown"
     constraints: None | OGCRecordPropertiesConstraintsType0 | Unset = UNSET
     distributions: list[OGCRecordPropertiesDistributionsType0Item] | None | Unset = (
         UNSET
@@ -277,6 +281,8 @@ class OGCRecordProperties:
         else:
             update_frequency = self.update_frequency
 
+        source_freshness = self.source_freshness
+
         constraints: dict[str, Any] | None | Unset
         if isinstance(self.constraints, Unset):
             constraints = UNSET
@@ -392,6 +398,8 @@ class OGCRecordProperties:
             field_dict["lineage"] = lineage
         if update_frequency is not UNSET:
             field_dict["update_frequency"] = update_frequency
+        if source_freshness is not UNSET:
+            field_dict["source_freshness"] = source_freshness
         if constraints is not UNSET:
             field_dict["constraints"] = constraints
         if distributions is not UNSET:
@@ -669,6 +677,8 @@ class OGCRecordProperties:
 
         update_frequency = _parse_update_frequency(d.pop("update_frequency", UNSET))
 
+        source_freshness = d.pop("source_freshness", UNSET)
+
         def _parse_constraints(
             data: object,
         ) -> None | OGCRecordPropertiesConstraintsType0 | Unset:
@@ -804,6 +814,7 @@ class OGCRecordProperties:
             rights=rights,
             lineage=lineage,
             update_frequency=update_frequency,
+            source_freshness=source_freshness,
             constraints=constraints,
             distributions=distributions,
             record_status=record_status,

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3224,6 +3224,12 @@ export type DatasetResponse = {
      */
     schema_drift_status?: string;
     /**
+     * Source Freshness
+     *
+     * fresh, due, overdue, or unknown, computed from last_refreshed_at against the declared update_frequency: due past one declared period, overdue past two. 'unknown' when the origin cannot be refreshed at all (created), when no cadence is declared (asNeeded, irregular, notPlanned, unknown), or when nothing has been refreshed yet. Advisory only; never blocks an operation. Distinct from the quality score's own freshness, which measures quality_detail.computed_at rather than the source.
+     */
+    source_freshness?: string;
+    /**
      * Quality Statement
      */
     quality_statement?: string | null;
@@ -6951,6 +6957,12 @@ export type OgcRecordProperties = {
      * Update Frequency
      */
     update_frequency?: string | null;
+    /**
+     * Source Freshness
+     *
+     * fresh, due, overdue, or unknown — how the dataset's last refresh compares to its declared update_frequency. 'unknown' for origins nothing can refresh. Advisory only, and distinct from the quality score's own freshness.
+     */
+    source_freshness?: string;
     /**
      * Constraints
      */


### PR DESCRIPTION
Closes #1224. Implements ADR-002 Amendment A6.

## What

`records.update_frequency` has carried the ISO 19115 maintenance-frequency vocabulary since the catalog shipped, and nothing ever compared it to anything. With `datasets.last_refreshed_at` in place (#1218), source freshness becomes a pure read-side computation over stored columns — no new writes, no persistence, computed at response time.

`domain/source_freshness.py` maps `(last_refreshed_at, update_frequency, now, origin)` to `fresh` / `due` / `overdue` / `unknown`: due past one declared period, overdue past two (periods: continual/daily 1 day, weekly 7, monthly 31, quarterly 92, biannually 183, annually 366). `asNeeded`, `irregular`, `notPlanned`, missing frequency, or missing refresh timestamp yield `unknown`.

## Origin gates the answer (Amendment A6)

`created` datasets are stamped with `last_refreshed_at` at creation but answer 409 `refresh_not_applicable` — without the gate, an eighteen-month-old sketch layer declaring monthly cadence would report "overdue" and name an action that does not exist for it. Refreshable origins are an **allowlist pinned against `ORIGIN_KINDS`**, so adding a future origin kind fails loudly instead of silently inheriting a deadline. NULL-origin (VRT) datasets keep their deadline because Decision 5a projects VRT generation timestamps into `last_refreshed_at`.

Named **source freshness** everywhere — deliberately distinct from the existing quality-freshness concept in `frontend/src/lib/quality-freshness.ts`, which has different states and thresholds.

## Surface

- `source_freshness` on `DatasetResponse` and search record responses; `now` read at the response boundary only.
- Zero writes, zero migrations.
- Regen trio committed (post-#1263 declaration-order scripts).
- `test_layering.py`: `schemas.py` cap 1271 → 1286 for the field + description.

## Verification

- Whole-tree backend at the rebased sha: **7507 passed, 89 skipped**; ruff check + format clean.
- `backend/tests/test_dataset_source_freshness.py`: 499 lines — every threshold boundary with explicit `now`, the created-origin gate, the allowlist-pinning test.
- Frontend: typecheck, lint, **4669 vitest passed**.