### PR TITLE
test(e2e): zoom analysis preview to seeded layer

### DIFF
--- a/e2e/analysis.spec.ts
+++ b/e2e/analysis.spec.ts
@@ -67,6 +67,12 @@ test.describe('builder analysis tools', () => {
     await page.getByRole('button', { name: 'Analysis', exact: true }).click();
     await expect(page.getByTestId('analysis-panel')).toBeVisible();
 
+    // fix(#1253): preview is clipped to the current viewport, so fit the map
+    // to the seeded New York layer after the panel opens and finalizes layout.
+    await page.getByRole('button', { name: `Layer options for ${seed.title}` }).click();
+    await page.getByTestId('kebab-zoom-to-layer').click();
+    await page.waitForTimeout(1500); // the fly-to animation
+
     // Default operation is buffer @ 500 m; the only dataset layer auto-selects.
     await page.getByRole('button', { name: 'Preview', exact: true }).click();
     await expect(page.getByRole('button', { name: 'Clear preview' })).toBeVisible({


### PR DESCRIPTION
## Summary

- zoom the map to the seeded New York layer before requesting an analysis preview
- preserve the viewport-bounded preview behavior while restoring a trustworthy E2E signal

## Smoke-suite policy

This PR deliberately leaves analysis.spec.ts out of the e2e:smoke scripts. The full stateful spec performs ingest, materialization, polling, and cleanup, so adding it would materially change the PR smoke policy. Until a dedicated analysis gate or lightweight preview-only smoke is approved, changes affecting analysis or viewport-bbox behavior should run the focused analysis spec explicitly; the nightly catch-all remains the backstop.

## Verification

- npx playwright test e2e/analysis.spec.ts --project=chromium (5 passed)

Closes #1253