### PR TITLE
test(e2e): match admin jobs navigation pathname

### DIFF
--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -285,7 +285,7 @@ test.describe('Admin Panel', () => {
     ).toBeVisible();
 
     await page.getByRole('link', { name: 'Jobs' }).click();
-    await page.waitForURL('/admin/jobs');
+    await page.waitForURL((url) => url.pathname === '/admin/jobs');
     await expect(
       page.getByRole('heading', { level: 1, name: 'Jobs' }),
     ).toBeVisible();


### PR DESCRIPTION
## Summary

- match admin jobs navigation by pathname instead of the full URL
- accept both the badge-zero /admin/jobs target and the badge-nonzero /admin/jobs?status=failed target
- preserve the existing conditional sidebar link behavior, which already has unit coverage for both hrefs

## Verification

- cd frontend && npm run typecheck
- cd frontend && npm run lint
- cd frontend && npx vitest run (380 files, 4,669 tests passed)
- npx playwright test e2e/admin.spec.ts --project=chromium (15 passed)

Closes #1252