### PR TITLE
feat(mcp): expose dataset source trust metadata

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -51,8 +51,8 @@ Cursor / Codex / any client that reads an `mcpServers` block:
 
 | Tool | What it does |
 |---|---|
-| `search_datasets` | Catalog search by free text (semantic ranking where the instance enables it). Returns dataset records as GeoJSON features. |
-| `get_dataset_schema` | A dataset's columns, geometry type, CRS/SRID, feature count, and extent. |
+| `search_datasets` | Catalog search by free text (semantic ranking where the instance enables it). Returns dataset records as GeoJSON features with safe origin and freshness state; health/check/refresh keys are null when unavailable in the search summary. |
+| `get_dataset_schema` | A dataset's columns, geometry type, CRS/SRID, feature count, extent, and source trust metadata. |
 | `get_features` | Bounded GeoJSON features for a dataset (OGC API — Features), with optional bbox. |
 | `list_maps` | Saved maps (id, name, visibility, layer count). |
 | `get_map` | One saved map's full metadata, including layers and view state. |

--- a/mcp/geolens_mcp/client.py
+++ b/mcp/geolens_mcp/client.py
@@ -28,6 +28,21 @@ import httpx
 
 DEFAULT_TIMEOUT = 30.0
 
+# Kept local because catalog search currently exposes ``source_format`` but not
+# the backend's computed ``origin`` field. These values mirror the public source
+# formats accepted by GeoLens; the MCP response exposes only the coarse origin
+# kind, never the provider pointer used to refresh it.
+_SERVICE_SOURCE_FORMATS = frozenset({"wfs", "arcgis_featureserver", "ogcapi_features"})
+_ORIGINLESS_RECORD_TYPES = frozenset({"collection", "vrt_dataset"})
+_RAW_SOURCE_POINTER_FIELDS = frozenset({"source_url", "origin_uri", "origin_ref"})
+_SOURCE_STATE_FIELDS = (
+    "source_freshness",
+    "source_health",
+    "source_health_detail",
+    "last_checked_at",
+    "last_refreshed_at",
+)
+
 
 class ConfigError(RuntimeError):
     """Raised when required MCP configuration (e.g. GEOLENS_INSTANCE) is absent."""
@@ -121,6 +136,72 @@ def _datasets_only(fc: Any) -> Any:
     return out
 
 
+def _source_origin(properties: dict[str, Any]) -> str | None:
+    """Return the safe, coarse origin kind for a dataset response."""
+    if "origin" in properties:
+        origin = properties["origin"]
+        return origin if isinstance(origin, str) else None
+
+    record_type = properties.get("record_type") or "vector_dataset"
+    if record_type in _ORIGINLESS_RECORD_TYPES:
+        return None
+    source_format = properties.get("source_format")
+    if not source_format:
+        return "postgis"
+    if source_format in ("created", "stac"):
+        return source_format
+    if source_format in _SERVICE_SOURCE_FORMATS:
+        return "service"
+    return "upload"
+
+
+def _with_search_source_state(fc: Any) -> Any:
+    """Add a stable, provider-safe source-state shape to search features.
+
+    Catalog search currently supplies source origin inputs and freshness, but
+    not health/check/refresh state. Null placeholders distinguish "not present
+    in this summary" from a detail response's explicit ``unknown`` health and
+    let callers consume one stable set of keys without per-row detail requests.
+    """
+    if not isinstance(fc, dict) or not isinstance(fc.get("features"), list):
+        return fc
+
+    features: list[Any] = []
+    for feature in fc["features"]:
+        if not isinstance(feature, dict):
+            features.append(feature)
+            continue
+        properties = feature.get("properties")
+        if not isinstance(properties, dict):
+            features.append(feature)
+            continue
+        safe_properties = {
+            key: value
+            for key, value in properties.items()
+            if key not in _RAW_SOURCE_POINTER_FIELDS
+        }
+        safe_properties["source_origin"] = _source_origin(properties)
+        for field in _SOURCE_STATE_FIELDS:
+            safe_properties.setdefault(field, None)
+        features.append({**feature, "properties": safe_properties})
+    return {**fc, "features": features}
+
+
+def _with_detail_source_state(detail: Any) -> Any:
+    """Add agent-facing source state and remove raw provider pointers."""
+    if not isinstance(detail, dict):
+        return detail
+    safe = {
+        key: value
+        for key, value in detail.items()
+        if key not in _RAW_SOURCE_POINTER_FIELDS
+    }
+    safe["source_origin"] = _source_origin(detail)
+    for field in _SOURCE_STATE_FIELDS:
+        safe.setdefault(field, None)
+    return safe
+
+
 def _id_segment(value: str) -> str:
     """Validate a path-parameter id as a UUID and return its canonical string.
 
@@ -172,13 +253,20 @@ class GeoLensReadOnlyAPI:
     def search_datasets(self, query: str, limit: int = 10, offset: int = 0) -> Any:
         # /search/datasets augments page 0 with up to 5 collection records; drop
         # them so every returned id is usable by the dataset tools.
-        return _datasets_only(
-            self._get("/search/datasets", _params(q=query, limit=limit, offset=offset))
+        return _with_search_source_state(
+            _datasets_only(
+                self._get(
+                    "/search/datasets",
+                    _params(q=query, limit=limit, offset=offset),
+                )
+            )
         )
 
     def get_dataset_schema(self, dataset_id: str) -> Any:
         # No trailing-slash sibling on this route — must omit it.
-        return self._get(f"/datasets/{_id_segment(dataset_id)}")
+        return _with_detail_source_state(
+            self._get(f"/datasets/{_id_segment(dataset_id)}")
+        )
 
     def get_features(
         self,

--- a/mcp/geolens_mcp/server.py
+++ b/mcp/geolens_mcp/server.py
@@ -35,7 +35,17 @@ def search_datasets(query: str, limit: int = 10, offset: int = 0) -> Any:
     Matches title, description, and keywords (semantic ranking is used
     automatically when the instance has it enabled). Returns a GeoJSON
     FeatureCollection where each feature is a dataset record; use the feature
-    `id` as the dataset_id for the other tools.
+    `id` as the dataset_id for the other tools. Each feature's properties include
+    `source_origin` (upload, postgis, service, stac, created, or null) and
+    `source_freshness` (fresh, due, overdue, or unknown). Freshness is advisory:
+    `due` means one declared update interval has elapsed, while `overdue` means
+    two have elapsed; neither proves that the content is wrong.
+
+    Search does not make a detail request per result. When the catalog summary
+    has no health/check/refresh value, `source_health`, `source_health_detail`,
+    `last_checked_at`, and `last_refreshed_at` are null. Call
+    `get_dataset_schema` for populated trust metadata. Raw provider URLs and
+    credentials are never included in these source-state fields.
 
     Args:
         query: Search text.
@@ -47,9 +57,19 @@ def search_datasets(query: str, limit: int = 10, offset: int = 0) -> Any:
 
 @mcp.tool()
 def get_dataset_schema(dataset_id: str) -> Any:
-    """Get a dataset's schema: columns (name/type/role), geometry type, CRS/SRID,
-    feature count, and spatial extent. Call this before writing spatial questions
-    so you know the available columns and geometry.
+    """Get a dataset's schema and source trust metadata.
+
+    Returns columns (name/type/role), geometry type, CRS/SRID, feature count,
+    spatial extent, and the safe `source_origin`. `source_health` is healthy,
+    missing, inaccessible, or unknown: inaccessible means GeoLens could not
+    determine whether the source still exists, while unknown means it was never
+    probed or cannot be probed. `source_health_detail` is a fixed GeoLens reason
+    code, not provider text. `last_checked_at` records the latest probe attempt;
+    `last_refreshed_at` records only the latest successful committed refresh.
+    `source_freshness` is advisory; overdue means two declared update intervals
+    elapsed without a successful refresh. Raw provider URLs, origin pointers,
+    and credentials are excluded. Call this before writing spatial questions so
+    you know both the available columns and whether the source may be stale.
 
     Args:
         dataset_id: Dataset id (e.g. from search_datasets).

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -105,10 +105,115 @@ def test_search_datasets_drops_collection_features():
     assert out["numberReturned"] == 2  # count kept consistent
 
 
+@pytest.mark.parametrize(
+    ("source_format", "record_type", "expected_origin"),
+    [
+        ("gpkg", "vector_dataset", "upload"),
+        (None, "vector_dataset", "postgis"),
+        ("wfs", "vector_dataset", "service"),
+        ("stac", "raster_dataset", "stac"),
+        ("created", "vector_dataset", "created"),
+        ("geotiff", "vrt_dataset", None),
+    ],
+)
+def test_search_datasets_adds_stable_source_state_summary(
+    source_format, record_type, expected_origin
+):
+    payload = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "id": "d1",
+                "properties": {
+                    "record_type": record_type,
+                    "source_format": source_format,
+                    "source_freshness": "overdue",
+                },
+            }
+        ],
+    }
+    api, seen = _api(_ok(payload))
+
+    properties = api.search_datasets("roads")["features"][0]["properties"]
+
+    assert len(seen) == 1  # never fan out into one detail request per result
+    assert properties["source_origin"] == expected_origin
+    assert properties["source_freshness"] == "overdue"
+    assert properties["source_health"] is None
+    assert properties["source_health_detail"] is None
+    assert properties["last_checked_at"] is None
+    assert properties["last_refreshed_at"] is None
+
+
+def test_search_datasets_prefers_future_summary_state_and_drops_raw_pointers():
+    payload = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "id": "d1",
+                "properties": {
+                    "origin": "service",
+                    "source_format": "wfs",
+                    "source_health": "inaccessible",
+                    "source_health_detail": "unauthorized",
+                    "last_checked_at": "2026-08-08T12:00:00Z",
+                    "last_refreshed_at": "2026-08-01T12:00:00Z",
+                    "origin_uri": "https://provider.example/private-layer",
+                    "origin_ref": {
+                        "kind": "service",
+                        "url": "https://provider.example/wfs?token=secret",
+                    },
+                    "source_url": "https://provider.example/?token=secret",
+                },
+            }
+        ],
+    }
+    api, _ = _api(_ok(payload))
+
+    properties = api.search_datasets("roads")["features"][0]["properties"]
+
+    assert properties["source_origin"] == "service"
+    assert properties["source_health"] == "inaccessible"
+    assert properties["source_health_detail"] == "unauthorized"
+    assert properties["last_checked_at"] == "2026-08-08T12:00:00Z"
+    assert properties["last_refreshed_at"] == "2026-08-01T12:00:00Z"
+    assert not {"origin_uri", "origin_ref", "source_url"} & properties.keys()
+
+
 def test_get_dataset_schema_has_no_trailing_slash():
     api, seen = _api(_ok({"id": DS, "column_info": []}))
     api.get_dataset_schema(DS)
     assert seen[-1].url.path == f"/api/datasets/{DS}"  # detail route: NO trailing slash
+
+
+def test_get_dataset_schema_surfaces_real_source_state_without_provider_pointers():
+    payload = {
+        "id": DS,
+        "source_format": "wfs",
+        "origin": "service",
+        "origin_uri": "https://provider.example/private-layer",
+        "origin_ref": {
+            "kind": "service",
+            "url": "https://provider.example/wfs?token=secret",
+        },
+        "source_url": "https://provider.example/?token=secret",
+        "source_freshness": "overdue",
+        "source_health": "inaccessible",
+        "source_health_detail": "unauthorized",
+        "last_checked_at": "2026-08-08T12:00:00Z",
+        "last_refreshed_at": "2026-08-01T12:00:00Z",
+    }
+    api, _ = _api(_ok(payload))
+
+    detail = api.get_dataset_schema(DS)
+
+    assert detail["source_origin"] == "service"
+    assert detail["source_freshness"] == "overdue"
+    assert detail["source_health"] == "inaccessible"
+    assert detail["source_health_detail"] == "unauthorized"
+    assert detail["last_checked_at"] == "2026-08-08T12:00:00Z"
+    assert detail["last_refreshed_at"] == "2026-08-01T12:00:00Z"
+    assert not {"origin_uri", "origin_ref", "source_url"} & detail.keys()
 
 
 def test_get_features_uses_ogc_items_and_bbox():

--- a/mcp/tests/test_live_contract.py
+++ b/mcp/tests/test_live_contract.py
@@ -290,9 +290,22 @@ def test_search_datasets_contract(live):
         # The wrapper strips catalog collections (their ids 404 in the other
         # tools) — none may leak through.
         assert props.get("record_type") != "collection"
+        # Search emits one stable source-state shape without making a detail
+        # request per row. Health/check/refresh values are null until the
+        # backend summary API grows them; detail below carries real values.
+        for key in (
+            "source_origin",
+            "source_freshness",
+            "source_health",
+            "source_health_detail",
+            "last_checked_at",
+            "last_refreshed_at",
+        ):
+            assert key in props, key
         by_id[str(feature["id"])] = props
     assert live.dataset_id in by_id, "seeded dataset is findable by its marker"
     assert by_id[live.dataset_id].get("title") == live.dataset_title
+    assert by_id[live.dataset_id]["source_origin"] == "created"
 
 
 def test_get_dataset_schema_contract(live):
@@ -303,6 +316,18 @@ def test_get_dataset_schema_contract(live):
     # type, CRS/SRID, feature count, and spatial extent.
     for key in ("column_info", "geometry_type", "srid", "feature_count", "extent_bbox"):
         assert key in schema, key
+    for key in (
+        "source_origin",
+        "source_freshness",
+        "source_health",
+        "source_health_detail",
+        "last_checked_at",
+        "last_refreshed_at",
+    ):
+        assert key in schema, key
+    assert schema["source_origin"] == "created"
+    assert schema["source_health"] == "unknown"
+    assert not {"origin_uri", "origin_ref", "source_url"} & schema.keys()
     columns = {c["name"]: c for c in schema["column_info"] or []}
     assert "name" in columns, "seeded user column is reported"
     assert columns["name"].get("type"), "columns carry a type"

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -48,6 +48,22 @@ def test_every_tool_has_a_description():
         assert tool.description and tool.description.strip(), tool.name
 
 
+def test_dataset_tool_descriptions_explain_source_trust_contract():
+    descriptions = {tool.name: tool.description for tool in _tools()}
+
+    search = descriptions["search_datasets"]
+    assert "source_origin" in search
+    assert "overdue" in search
+    assert "null" in search
+    assert "get_dataset_schema" in search
+
+    detail = descriptions["get_dataset_schema"]
+    assert "inaccessible" in detail
+    assert "last_checked_at" in detail
+    assert "last_refreshed_at" in detail
+    assert "Raw provider URLs" in detail
+
+
 def test_tool_functions_stay_plain_callables():
     # The live tier (and any direct import) calls these as normal functions; an
     # MCP SDK upgrade whose decorator returns a wrapper would break that quietly.


### PR DESCRIPTION
## Summary

- add stable agent-facing `source_origin`, freshness, health, checked, and refreshed fields to MCP dataset search and detail reads
- derive a coarse provider-safe origin from search summary fields without an authenticated detail request per row
- return explicit nulls when search summaries do not carry health or timestamps, while dataset detail returns the populated backend state
- document freshness and health semantics in MCP tool docstrings so agents can judge dataset trust correctly
- strip raw source URLs and origin pointers from the shaped MCP results

## API and SDK impact

- MCP-only change; no backend API or schema changes
- generated Python SDK detail models already contain the source-state fields
- current catalog search summaries expose source format and computed freshness but not health/check/refresh values, so those search keys are stable nulls until the summary contract grows
- no OpenAPI regeneration, generated SDK edits, or hand-maintained SDK wrapper changes

## Verification

- `make mcp-test` — 27 passed, 6 live-only skipped
- `make mcp-live-test` — 6 passed against the running API
- `make mcp-build` — wheel and sdist built successfully
- Ruff check and format check over `mcp/geolens_mcp` and `mcp/tests`
- pre-commit hooks on all changed files

Closes #1228