### PR TITLE
fix(dev): raise API memory cap for coverage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,10 +255,10 @@ services:
     init: true
     stop_grace_period: 30s
     restart: unless-stopped
-    # GAP-001: 2 GB covers the Python process + Uvicorn workers + ORM caches.
-    # Raise if ingesting very large files with many concurrent workers.
+    # GAP-001: 4 GB also accommodates pytest -n 4 with coverage instrumentation.
+    # Lower via API_MEM_LIMIT on constrained hosts when not running the full suite.
     # fix(#448): env-overridable — mirrors docker-compose.prod.yml.
-    mem_limit: "${API_MEM_LIMIT:-2g}"
+    mem_limit: "${API_MEM_LIMIT:-4g}"
     # Hardening (security_opt + cap_drop + cap_add + read_only): see
     # x-hardened-base anchor at top of file. no-new-privileges:true blocks
     # setuid escalation but NOT setpriv (which de-escalates), so the


### PR DESCRIPTION
## Summary

- raise the development API container's default memory limit from 2 GiB to 4 GiB
- preserve `API_MEM_LIMIT` as the operator override for constrained hosts
- leave the production Compose default and every non-API service unchanged

## Root cause

The current 2 GiB development limit does not reliably fit four pytest-xdist workers plus coverage instrumentation. The kernel can OOM-kill a worker, which both invalidates the coverage result and makes the in-container verification path unreliable.

## Effective Compose impact

Only the development `api` service's rendered `mem_limit` changes, from `2147483648` to `4294967296` bytes. After removing that field, the complete rendered development configuration matches `main`. The complete rendered production configuration matches `main` without exclusions, including all production profiles and resource limits.

## Scope note

This issue is intentionally limited to the development API resource-limit stanza. The shared `.env.example` remains unchanged: its commented `API_MEM_LIMIT=2g` line does not set the development default and remains a valid constrained-host override and the unchanged production default. Distinguishing the two Compose defaults in shared operator documentation is a release-sync follow-up.

## Verification

- `docker compose --env-file .env.example -f docker-compose.yml config --quiet`
- `docker compose --env-file .env.example -f docker-compose.prod.yml config --quiet`
- normalized rendered-config comparison against `origin/main` for both Compose files
- `pre-commit run --files docker-compose.yml`
- focused Compose regression suite: 65 passed

Closes #1255