### PR TITLE
sec(titiler): add scoped object-store credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -535,6 +535,21 @@ FRONTEND_PORT=8080
 # Type: string | No default
 # S3_SECRET_ACCESS_KEY=
 
+# [RECOMMENDED] Dedicated TiTiler access key ID. Grant this principal read-only
+# access to rasters/* and tenants/*/rasters/* in S3_BUCKET; see the deployment
+# guide for the policy:
+# https://github.com/geolens-io/geolens-deployments#titiler-read-only-s3-credentials
+# When unset, Compose falls back to S3_ACCESS_KEY_ID so existing installs
+# continue to render tiles while the dedicated credential is provisioned.
+# Type: string | Compatibility fallback: S3_ACCESS_KEY_ID
+# TITILER_S3_ACCESS_KEY_ID=<read-only-key-id>
+
+# [RECOMMENDED] Secret for the dedicated TiTiler read-only principal. Keep it
+# paired with TITILER_S3_ACCESS_KEY_ID. Never grant this principal object write,
+# delete, or bucket-administration actions.
+# Type: string | Compatibility fallback: S3_SECRET_ACCESS_KEY
+# TITILER_S3_SECRET_ACCESS_KEY=<read-only-secret>
+
 # [OPTIONAL] S3 region
 # Type: string | Default: us-east-1
 # S3_REGION=us-east-1
@@ -584,6 +599,8 @@ FRONTEND_PORT=8080
 # S3_BUCKET=geolens
 # S3_ACCESS_KEY_ID=<same value as MINIO_ROOT_USER>
 # S3_SECRET_ACCESS_KEY=<same value as MINIO_ROOT_PASSWORD>
+# TITILER_S3_ACCESS_KEY_ID=<read-only MinIO user from the deployment guide>
+# TITILER_S3_SECRET_ACCESS_KEY=<that user's generated secret>
 # S3_ALLOW_HTTP=true
 
 # --- Azure Blob Storage (cloud-dev or production) ---

--- a/backend/tests/test_titiler_credentials.py
+++ b/backend/tests/test_titiler_credentials.py
@@ -1,0 +1,81 @@
+"""Security contract for TiTiler object-store credentials (#1191).
+
+TiTiler only reads managed rasters. Its container must prefer a distinct,
+prefix-scoped credential without also carrying the API/worker credential in a
+second environment variable. A shared-credential fallback keeps upgrades
+compatible until operators provision the dedicated principal.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+import yaml
+
+from tests.repo_paths import repo_root
+
+_REPO_ROOT = repo_root(__file__)
+_COMPOSE_FILES = ("docker-compose.yml", "docker-compose.prod.yml")
+_EXPECTED_MAPPINGS = {
+    "AWS_ACCESS_KEY_ID": ("${TITILER_S3_ACCESS_KEY_ID:-${S3_ACCESS_KEY_ID:-}}"),
+    "AWS_SECRET_ACCESS_KEY": (
+        "${TITILER_S3_SECRET_ACCESS_KEY:-${S3_SECRET_ACCESS_KEY:-}}"
+    ),
+}
+_EXPECTED_PRESENCE_FLAGS = {
+    "TITILER_S3_ACCESS_KEY_ID_SET": "${TITILER_S3_ACCESS_KEY_ID:+1}",
+    "TITILER_S3_SECRET_ACCESS_KEY_SET": "${TITILER_S3_SECRET_ACCESS_KEY:+1}",
+}
+
+
+@pytest.mark.parametrize("filename", _COMPOSE_FILES)
+def test_titiler_prefers_dedicated_s3_credentials(filename: str) -> None:
+    body = yaml.safe_load((_REPO_ROOT / filename).read_text(encoding="utf-8"))
+    env = body["services"]["titiler"]["environment"]
+
+    for aws_key, expected in _EXPECTED_MAPPINGS.items():
+        assert env.get(aws_key) == expected, (
+            f"{filename}: {aws_key} must prefer the dedicated TITILER_S3_* "
+            "input and retain only the shared-credential upgrade fallback"
+        )
+
+    assert "S3_ACCESS_KEY_ID" not in env
+    assert "S3_SECRET_ACCESS_KEY" not in env
+    assert "TITILER_S3_ACCESS_KEY_ID" not in env
+    assert "TITILER_S3_SECRET_ACCESS_KEY" not in env
+
+
+@pytest.mark.parametrize("filename", _COMPOSE_FILES)
+def test_titiler_rejects_a_partial_dedicated_credential_pair(filename: str) -> None:
+    body = yaml.safe_load((_REPO_ROOT / filename).read_text(encoding="utf-8"))
+    titiler = body["services"]["titiler"]
+    env = titiler["environment"]
+
+    for flag, expected in _EXPECTED_PRESENCE_FLAGS.items():
+        assert env.get(flag) == expected
+
+    # Compose reduces $$ to $ before the command reaches /bin/sh. Simulate that
+    # boundary and prove a partial rollout exits before the final uvicorn exec.
+    command = titiler["command"][2].replace("$$", "$")
+    result = subprocess.run(
+        ["/bin/sh", "-ec", command],
+        env={
+            "PATH": os.environ["PATH"],
+            "TITILER_S3_ACCESS_KEY_ID_SET": "1",
+            "TITILER_S3_SECRET_ACCESS_KEY_SET": "",
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "dedicated S3 access key and secret must be set together" in result.stderr
+
+
+def test_env_example_documents_the_dedicated_pair() -> None:
+    text = (_REPO_ROOT / ".env.example").read_text(encoding="utf-8")
+    assert "# TITILER_S3_ACCESS_KEY_ID=<read-only-key-id>" in text
+    assert "# TITILER_S3_SECRET_ACCESS_KEY=<read-only-secret>" in text

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -394,15 +394,22 @@ services:
     read_only: true
     tmpfs:
       - /tmp:size=128m,mode=1777
-    # fix(#579): derive GDAL's AWS_* trio from the app's S3_* settings before
-    # exec'ing uvicorn — /vsis3/ reads against a custom endpoint (MinIO, R2)
-    # otherwise target the default AWS endpoint and fail. Mirrors the wrapper
+    # fix(#579): derive GDAL's AWS endpoint settings from the app's S3 endpoint
+    # settings before exec'ing uvicorn — /vsis3/ reads against a custom endpoint
+    # (MinIO, R2) otherwise target the default AWS endpoint and fail. Mirrors the wrapper
     # in docker-compose.yml ($$ escapes compose interpolation; explicitly set
     # AWS_* env always wins).
     command:
       - /bin/sh
       - -ec
       - |
+        # fix(#1191): the flags carry no credential material. They let the
+        # sidecar reject a partial dedicated-pair rollout before Uvicorn starts
+        # without also exposing the unused shared writer credential.
+        if [ "$${TITILER_S3_ACCESS_KEY_ID_SET:-}" != "$${TITILER_S3_SECRET_ACCESS_KEY_SET:-}" ]; then
+          echo "TiTiler dedicated S3 access key and secret must be set together" >&2
+          exit 1
+        fi
         if [ -z "$${AWS_S3_ENDPOINT:-}" ]; then
           ep="$${S3_ENDPOINT:-}"
           allow_http=$$(printf '%s' "$${S3_ALLOW_HTTP:-}" | tr '[:upper:]' '[:lower:]')
@@ -419,7 +426,7 @@ services:
         [ "$${S3_ADDRESSING_STYLE:-auto}" = "path" ] && export AWS_VIRTUAL_HOSTING="$${AWS_VIRTUAL_HOSTING:-FALSE}"
         exec uvicorn titiler.application.main:app --host 0.0.0.0 --port 8000 --workers $${TITILER_WORKERS:-1}
     environment:
-      # fix(#579): inputs for the AWS_* derivation in the command wrapper above.
+      # fix(#579): inputs for the AWS endpoint derivation in the command wrapper above.
       S3_ENDPOINT: "${S3_ENDPOINT:-}"
       S3_ALLOW_HTTP: "${S3_ALLOW_HTTP:-}"
       S3_ADDRESSING_STYLE: "${S3_ADDRESSING_STYLE:-auto}"
@@ -454,8 +461,16 @@ services:
       CPL_VSIL_CURL_CACHE_SIZE: "16777216"
       GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: "YES"
       # fix(#937): do not re-add GDAL_HTTP_FOLLOWLOCATION — not a GDAL option, no effect.
-      AWS_ACCESS_KEY_ID: "${S3_ACCESS_KEY_ID:-}"
-      AWS_SECRET_ACCESS_KEY: "${S3_SECRET_ACCESS_KEY:-}"
+      # fix(#1191): prefer TiTiler's read-only, rasters-prefix credential. The
+      # nested fallback preserves existing installs until operators provision
+      # the dedicated principal, while only the selected credential enters the
+      # sidecar environment (the shared write credential is not also exposed).
+      AWS_ACCESS_KEY_ID: "${TITILER_S3_ACCESS_KEY_ID:-${S3_ACCESS_KEY_ID:-}}"
+      AWS_SECRET_ACCESS_KEY: "${TITILER_S3_SECRET_ACCESS_KEY:-${S3_SECRET_ACCESS_KEY:-}}"
+      # Presence flags contain no secrets and make a partial dedicated pair
+      # fail closed in the command wrapper before the mixed AWS_* pair is used.
+      TITILER_S3_ACCESS_KEY_ID_SET: "${TITILER_S3_ACCESS_KEY_ID:+1}"
+      TITILER_S3_SECRET_ACCESS_KEY_SET: "${TITILER_S3_SECRET_ACCESS_KEY:+1}"
       AWS_DEFAULT_REGION: "${S3_REGION:-us-east-1}"
       AZURE_STORAGE_CONNECTION_STRING: "${AZURE_STORAGE_CONNECTION_STRING:-}"
       AZURE_STORAGE_ACCOUNT: "${AZURE_STORAGE_ACCOUNT:-}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -488,15 +488,22 @@ services:
     read_only: true
     tmpfs:
       - /tmp:size=128m,mode=1777
-    # fix(#579): derive GDAL's AWS_* trio from the app's S3_* settings before
-    # exec'ing uvicorn — /vsis3/ reads against a custom endpoint (MinIO, R2)
-    # otherwise target the default AWS endpoint and fail. Compose has no
-    # string functions, so a sh wrapper does the scheme/host split ($$ escapes
+    # fix(#579): derive GDAL's AWS endpoint settings from the app's S3 endpoint
+    # settings before exec'ing uvicorn — /vsis3/ reads against a custom endpoint
+    # (MinIO, R2) otherwise target the default AWS endpoint and fail. Compose has
+    # no string functions, so a sh wrapper does the scheme/host split ($$ escapes
     # compose interpolation; the vars come from this container's environment).
     command:
       - /bin/sh
       - -ec
       - |
+        # fix(#1191): the flags carry no credential material. They let the
+        # sidecar reject a partial dedicated-pair rollout before Uvicorn starts
+        # without also exposing the unused shared writer credential.
+        if [ "$${TITILER_S3_ACCESS_KEY_ID_SET:-}" != "$${TITILER_S3_SECRET_ACCESS_KEY_SET:-}" ]; then
+          echo "TiTiler dedicated S3 access key and secret must be set together" >&2
+          exit 1
+        fi
         if [ -z "$${AWS_S3_ENDPOINT:-}" ]; then
           ep="$${S3_ENDPOINT:-}"
           allow_http=$$(printf '%s' "$${S3_ALLOW_HTTP:-}" | tr '[:upper:]' '[:lower:]')
@@ -513,7 +520,7 @@ services:
         [ "$${S3_ADDRESSING_STYLE:-auto}" = "path" ] && export AWS_VIRTUAL_HOSTING="$${AWS_VIRTUAL_HOSTING:-FALSE}"
         exec uvicorn titiler.application.main:app --host 0.0.0.0 --port 8000 --workers $${TITILER_WORKERS:-1}
     environment:
-      # fix(#579): inputs for the AWS_* derivation in the command wrapper above.
+      # fix(#579): inputs for the AWS endpoint derivation in the command wrapper above.
       S3_ENDPOINT: "${S3_ENDPOINT:-}"
       S3_ALLOW_HTTP: "${S3_ALLOW_HTTP:-}"
       S3_ADDRESSING_STYLE: "${S3_ADDRESSING_STYLE:-auto}"
@@ -595,8 +602,16 @@ services:
       # No GDAL option disables redirect-following. TiTiler's real constraints are
       # the CPL_VSIL_CURL_ALLOWED_EXTENSIONS allow-list above and API-layer URL
       # validation; redirect exposure beyond those needs network-layer egress rules.
-      AWS_ACCESS_KEY_ID: "${S3_ACCESS_KEY_ID:-}"
-      AWS_SECRET_ACCESS_KEY: "${S3_SECRET_ACCESS_KEY:-}"
+      # fix(#1191): prefer TiTiler's read-only, rasters-prefix credential. The
+      # nested fallback preserves existing installs until operators provision
+      # the dedicated principal, while only the selected credential enters the
+      # sidecar environment (the shared write credential is not also exposed).
+      AWS_ACCESS_KEY_ID: "${TITILER_S3_ACCESS_KEY_ID:-${S3_ACCESS_KEY_ID:-}}"
+      AWS_SECRET_ACCESS_KEY: "${TITILER_S3_SECRET_ACCESS_KEY:-${S3_SECRET_ACCESS_KEY:-}}"
+      # Presence flags contain no secrets and make a partial dedicated pair
+      # fail closed in the command wrapper before the mixed AWS_* pair is used.
+      TITILER_S3_ACCESS_KEY_ID_SET: "${TITILER_S3_ACCESS_KEY_ID:+1}"
+      TITILER_S3_SECRET_ACCESS_KEY_SET: "${TITILER_S3_SECRET_ACCESS_KEY:+1}"
       AWS_DEFAULT_REGION: "${S3_REGION:-us-east-1}"
       # Azure Blob / Azurite (STOR-03, Phase 1210) — GDAL /vsiaz/ credentials.
       # For Azurite: set AZURE_STORAGE_CONNECTION_STRING to the well-known dev string.

--- a/scripts/check_env_doc_drift.py
+++ b/scripts/check_env_doc_drift.py
@@ -288,6 +288,10 @@ def compose_contract_errors(compose_files: tuple[Path, ...]) -> list[str]:
     }
     errors: list[str] = []
     canonical_key_mapping = 'AZURE_STORAGE_ACCESS_KEY: "${AZURE_STORAGE_ACCOUNT_KEY:-}"'
+    titiler_s3_mappings = (
+        'AWS_ACCESS_KEY_ID: "${TITILER_S3_ACCESS_KEY_ID:-${S3_ACCESS_KEY_ID:-}}"',
+        'AWS_SECRET_ACCESS_KEY: "${TITILER_S3_SECRET_ACCESS_KEY:-${S3_SECRET_ACCESS_KEY:-}}"',
+    )
 
     for path in compose_files:
         text = path.read_text()
@@ -301,6 +305,12 @@ def compose_contract_errors(compose_files: tuple[Path, ...]) -> list[str]:
                 f"{path.name}: Titiler must map AZURE_STORAGE_ACCOUNT_KEY "
                 "to AZURE_STORAGE_ACCESS_KEY"
             )
+        for mapping in titiler_s3_mappings:
+            if mapping not in text:
+                errors.append(
+                    f"{path.name}: Titiler must prefer its dedicated S3 credential "
+                    f"with the shared-credential compatibility fallback: {mapping}"
+                )
     return errors
 
 


### PR DESCRIPTION
## Summary

- let TiTiler use a dedicated operator-supplied S3 access key and secret
- preserve the shared `S3_*` credential as an upgrade-compatibility fallback
- ensure only the selected credential enters the sidecar as `AWS_*`
- fail closed before Uvicorn when only half of the dedicated pair is configured
- point operators to the companion deployment guide for the prefix-scoped policy
- add fail-closed Compose and environment-documentation contracts

## Security impact

TiTiler only reads managed raster objects. Operators can now give it a distinct principal with `GetObject` access to the managed raster prefixes instead of exposing the API/worker writer credential. No real or known-public credential is included; every value remains operator supplied.

Existing installations continue to render tiles when the dedicated pair is unset. Once both `TITILER_S3_ACCESS_KEY_ID` and `TITILER_S3_SECRET_ACCESS_KEY` are set, the shared writer credential is not also present in the TiTiler environment. Two non-secret presence flags make a partial rollout fail before Uvicorn starts, preventing mixed-principal AWS signing. The existing Azure mapping is unchanged.

## Compose impact

Both development and production Compose files parse with every profile against a verbatim `.env.example`. Default and shared-fallback AWS credential values remain compatible; the only default rendered additions are two empty, non-secret presence flags on TiTiler. Supplying the dedicated pair changes only the TiTiler service. The MinIO entrypoint guard, parse-safe `${VAR:-}` forms, and every non-TiTiler service remain unchanged.

## Helm companion

A backward-compatible `titiler.s3Credentials` Secret selector and the prefix-scoped MinIO policy are committed in `geolens-deployments` and will land immediately after this core PR. This PR links #1191 without completing the issue.

## Verification

- development and production Compose config with all profiles against verbatim `.env.example`
- normalized default, dedicated-pair, shared-fallback, and partial-pair rendered-config comparisons
- failing-first partial-pair startup regression; corrected suite: 32 passed, 4 skipped
- `make env-doc-check`
- `make public-surface-check`
- full backend Ruff and format checks
- pre-commit hooks on all changed files
- `git diff --check`

Refs #1191