### PR TITLE
feat(catalog): project source health in search summaries

### DIFF
--- a/backend/app/modules/catalog/search/schemas.py
+++ b/backend/app/modules/catalog/search/schemas.py
@@ -125,6 +125,24 @@ class OGCRecordProperties(BaseModel):
             "score's own freshness."
         ),
     )
+    source_health: str = Field(
+        default="unknown",
+        description=(
+            "healthy, missing, inaccessible, or unknown. 'unknown' means "
+            "never probed, or an origin kind with nothing to probe."
+        ),
+    )
+    last_checked_at: datetime | None = Field(
+        default=None,
+        description=(
+            "Last time GeoLens contacted the origin, whether the attempt "
+            "succeeded or failed."
+        ),
+    )
+    last_refreshed_at: datetime | None = Field(
+        default=None,
+        description="Last committed successful refresh — not the last attempt.",
+    )
     constraints: dict | None = None
     distributions: list[dict] | None = None
     record_status: str | None = None

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -389,8 +389,17 @@ def dataset_to_ogc_record(
             # wire spelling of an unprobed health state aligned with dataset
             # detail responses while preserving nullable timestamps.
             "source_health": project_unknown(dataset.source_health),
-            "last_checked_at": dataset.last_checked_at,
-            "last_refreshed_at": dataset.last_refreshed_at,
+            # ``dataset_to_ogc_record`` also feeds JSONResponse-backed OGC
+            # item and STAC routes, so these must be wire values rather than
+            # raw ORM datetimes (Pydantic does not encode this plain dict).
+            "last_checked_at": (
+                dataset.last_checked_at.isoformat() if dataset.last_checked_at else None
+            ),
+            "last_refreshed_at": (
+                dataset.last_refreshed_at.isoformat()
+                if dataset.last_refreshed_at
+                else None
+            ),
             "constraints": (
                 {"usage": record.usage_constraints, "access": record.access_constraints}
                 if record.usage_constraints or record.access_constraints

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -27,7 +27,7 @@ from app.modules.catalog.search.record_metadata import (
     build_time,
 )
 from app.modules.catalog.sources.provenance import derive_last_edited
-from app.platform.dataset_origin import classify_origin
+from app.platform.dataset_origin import classify_origin, project_unknown
 from app.standards.ogc.utils import build_url
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -384,6 +384,13 @@ def dataset_to_ogc_record(
                 datetime.now(timezone.utc),
                 origin=classify_origin(dataset.source_format, record_type),
             ),
+            # These values are projected only after search_datasets applies
+            # the caller's visibility filter to the Dataset query. Keep the
+            # wire spelling of an unprobed health state aligned with dataset
+            # detail responses while preserving nullable timestamps.
+            "source_health": project_unknown(dataset.source_health),
+            "last_checked_at": dataset.last_checked_at,
+            "last_refreshed_at": dataset.last_refreshed_at,
             "constraints": (
                 {"usage": record.usage_constraints, "access": record.access_constraints}
                 if record.usage_constraints or record.access_constraints

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -12258,6 +12258,38 @@
             "title": "Source Freshness",
             "type": "string"
           },
+          "source_health": {
+            "default": "unknown",
+            "description": "healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an origin kind with nothing to probe.",
+            "title": "Source Health",
+            "type": "string"
+          },
+          "last_checked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last time GeoLens contacted the origin, whether the attempt succeeded or failed.",
+            "title": "Last Checked At"
+          },
+          "last_refreshed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last committed successful refresh \u2014 not the last attempt.",
+            "title": "Last Refreshed At"
+          },
           "constraints": {
             "anyOf": [
               {

--- a/backend/tests/test_dataset_source_freshness.py
+++ b/backend/tests/test_dataset_source_freshness.py
@@ -368,7 +368,10 @@ class TestResponseExposure:
             created_by=admin_id,
             name=f"Freshness {frequency} {age_days}",
         )
-        ds.last_refreshed_at = datetime.now(timezone.utc) - timedelta(days=age_days)
+        refreshed_at = datetime.now(timezone.utc) - timedelta(days=age_days)
+        checked_at = refreshed_at + timedelta(hours=1)
+        ds.last_refreshed_at = refreshed_at
+        ds.last_checked_at = checked_at
         ds.record.update_frequency = frequency
         await test_db_session.commit()
 
@@ -383,6 +386,8 @@ class TestResponseExposure:
         # The two columns it was computed from travel with it on this surface,
         # so a reader can check the arithmetic.
         assert props["update_frequency"] == frequency
+        assert props["last_refreshed_at"] == refreshed_at.isoformat()
+        assert props["last_checked_at"] == checked_at.isoformat()
 
     async def test_never_refreshed_dataset_reports_unknown_on_both(
         self,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1613,7 +1613,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # downloadable asset — a presigned URL on published S3. An allowlist
         # rather than a skip-list so the next internal key is private by
         # default. Cap 500 -> 505, exact.
-        "backend/app/modules/catalog/search/service_records.py": 505,
+        # feat(#1281): +7 — project origin health and freshness timestamps
+        # through the visibility-filtered OGC search representation, including
+        # JSON-safe datetime serialization for the OGC and STAC response paths.
+        # Cap 505 -> 512, exact.
+        "backend/app/modules/catalog/search/service_records.py": 512,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in
         # _run_rrf_merge (perf audit 2026-07-10 §2d). Cap 350 → 390

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -841,6 +841,52 @@ async def test_search_rbac_private_hidden(
     assert str(search_datasets["water"].id) in ids
 
 
+@pytest.mark.anyio
+async def test_anonymous_search_projects_health_without_private_leak(
+    client: AsyncClient,
+    test_db_session,
+    clean_tables,
+):
+    """Anonymous summaries expose health only for visibility-filtered rows."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    token = f"healthprojection{uuid.uuid4().hex}"
+    public = await _create_search_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name=f"Public {token}",
+    )
+    private = await _create_search_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name=f"Private {token}",
+        visibility="private",
+    )
+    public.last_checked_at = datetime(2026, 8, 7, 12, 0, tzinfo=timezone.utc)
+    public.last_refreshed_at = datetime(2026, 8, 6, 11, 0, tzinfo=timezone.utc)
+    public.source_health = "healthy"
+    private.last_checked_at = datetime(2026, 7, 5, 10, 0, tzinfo=timezone.utc)
+    private.last_refreshed_at = datetime(2026, 7, 4, 9, 0, tzinfo=timezone.utc)
+    private.source_health = "inaccessible"
+    await test_db_session.commit()
+
+    resp = await client.get(
+        "/search/datasets/",
+        params={"q": token, "limit": 10},
+    )
+
+    assert resp.status_code == 200, resp.text
+    features = resp.json()["features"]
+    assert [feature["id"] for feature in features] == [str(public.id)]
+    properties = features[0]["properties"]
+    assert properties["source_health"] == "healthy"
+    assert properties["last_checked_at"] == "2026-08-07T12:00:00Z"
+    assert properties["last_refreshed_at"] == "2026-08-06T11:00:00Z"
+    assert str(private.id) not in resp.text
+    assert "2026-07-05T10:00:00Z" not in resp.text
+    assert "2026-07-04T09:00:00Z" not in resp.text
+    assert '"source_health":"inaccessible"' not in resp.text
+
+
 # ---------------------------------------------------------------------------
 # OGC Collections tests
 # ---------------------------------------------------------------------------

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -10367,6 +10367,22 @@ export interface components {
              * @default unknown
              */
             source_freshness: string;
+            /**
+             * Source Health
+             * @description healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an origin kind with nothing to probe.
+             * @default unknown
+             */
+            source_health: string;
+            /**
+             * Last Checked At
+             * @description Last time GeoLens contacted the origin, whether the attempt succeeded or failed.
+             */
+            last_checked_at?: string | null;
+            /**
+             * Last Refreshed At
+             * @description Last committed successful refresh — not the last attempt.
+             */
+            last_refreshed_at?: string | null;
             /** Constraints */
             constraints?: {
                 [key: string]: unknown;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -544,9 +544,12 @@ export interface OGCRecordProperties {
    * carries, so a catalog card and a dataset page cannot disagree about how
    * late a dataset is. Served alongside `update_frequency` below. */
   source_freshness?: SourceFreshness;
-  /** feat(#1226): optional catalog projection of the persisted detail state.
-   * Search responses that do not project it remain valid; cards stay silent. */
+  /** feat(#1281): catalog projection of the persisted detail state. */
   source_health?: SourceHealth;
+  /** Last contact with the origin, whether it succeeded or failed. */
+  last_checked_at?: string | null;
+  /** Last committed successful refresh, not the last attempt. */
+  last_refreshed_at?: string | null;
   update_frequency?: string | null;
   has_quicklook?: boolean;
   band_count?: number | null;

--- a/sdks/python/geolens/models/ogc_record_properties.py
+++ b/sdks/python/geolens/models/ogc_record_properties.py
@@ -71,6 +71,11 @@ class OGCRecordProperties:
         source_freshness (str | Unset): fresh, due, overdue, or unknown — how the dataset's last refresh compares to its
             declared update_frequency. 'unknown' for origins nothing can refresh. Advisory only, and distinct from the
             quality score's own freshness. Default: 'unknown'.
+        source_health (str | Unset): healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an
+            origin kind with nothing to probe. Default: 'unknown'.
+        last_checked_at (datetime.datetime | None | Unset): Last time GeoLens contacted the origin, whether the attempt
+            succeeded or failed.
+        last_refreshed_at (datetime.datetime | None | Unset): Last committed successful refresh — not the last attempt.
         constraints (None | OGCRecordPropertiesConstraintsType0 | Unset):
         distributions (list[OGCRecordPropertiesDistributionsType0Item] | None | Unset):
         record_status (None | str | Unset):
@@ -113,6 +118,9 @@ class OGCRecordProperties:
     lineage: None | str | Unset = UNSET
     update_frequency: None | str | Unset = UNSET
     source_freshness: str | Unset = "unknown"
+    source_health: str | Unset = "unknown"
+    last_checked_at: datetime.datetime | None | Unset = UNSET
+    last_refreshed_at: datetime.datetime | None | Unset = UNSET
     constraints: None | OGCRecordPropertiesConstraintsType0 | Unset = UNSET
     distributions: list[OGCRecordPropertiesDistributionsType0Item] | None | Unset = (
         UNSET
@@ -283,6 +291,24 @@ class OGCRecordProperties:
 
         source_freshness = self.source_freshness
 
+        source_health = self.source_health
+
+        last_checked_at: None | str | Unset
+        if isinstance(self.last_checked_at, Unset):
+            last_checked_at = UNSET
+        elif isinstance(self.last_checked_at, datetime.datetime):
+            last_checked_at = self.last_checked_at.isoformat()
+        else:
+            last_checked_at = self.last_checked_at
+
+        last_refreshed_at: None | str | Unset
+        if isinstance(self.last_refreshed_at, Unset):
+            last_refreshed_at = UNSET
+        elif isinstance(self.last_refreshed_at, datetime.datetime):
+            last_refreshed_at = self.last_refreshed_at.isoformat()
+        else:
+            last_refreshed_at = self.last_refreshed_at
+
         constraints: dict[str, Any] | None | Unset
         if isinstance(self.constraints, Unset):
             constraints = UNSET
@@ -400,6 +426,12 @@ class OGCRecordProperties:
             field_dict["update_frequency"] = update_frequency
         if source_freshness is not UNSET:
             field_dict["source_freshness"] = source_freshness
+        if source_health is not UNSET:
+            field_dict["source_health"] = source_health
+        if last_checked_at is not UNSET:
+            field_dict["last_checked_at"] = last_checked_at
+        if last_refreshed_at is not UNSET:
+            field_dict["last_refreshed_at"] = last_refreshed_at
         if constraints is not UNSET:
             field_dict["constraints"] = constraints
         if distributions is not UNSET:
@@ -679,6 +711,42 @@ class OGCRecordProperties:
 
         source_freshness = d.pop("source_freshness", UNSET)
 
+        source_health = d.pop("source_health", UNSET)
+
+        def _parse_last_checked_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                last_checked_at_type_0 = isoparse(data)
+
+                return last_checked_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        last_checked_at = _parse_last_checked_at(d.pop("last_checked_at", UNSET))
+
+        def _parse_last_refreshed_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                last_refreshed_at_type_0 = isoparse(data)
+
+                return last_refreshed_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        last_refreshed_at = _parse_last_refreshed_at(d.pop("last_refreshed_at", UNSET))
+
         def _parse_constraints(
             data: object,
         ) -> None | OGCRecordPropertiesConstraintsType0 | Unset:
@@ -815,6 +883,9 @@ class OGCRecordProperties:
             lineage=lineage,
             update_frequency=update_frequency,
             source_freshness=source_freshness,
+            source_health=source_health,
+            last_checked_at=last_checked_at,
+            last_refreshed_at=last_refreshed_at,
             constraints=constraints,
             distributions=distributions,
             record_status=record_status,

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -7141,6 +7141,24 @@ export type OgcRecordProperties = {
      */
     source_freshness?: string;
     /**
+     * Source Health
+     *
+     * healthy, missing, inaccessible, or unknown. 'unknown' means never probed, or an origin kind with nothing to probe.
+     */
+    source_health?: string;
+    /**
+     * Last Checked At
+     *
+     * Last time GeoLens contacted the origin, whether the attempt succeeded or failed.
+     */
+    last_checked_at?: string | null;
+    /**
+     * Last Refreshed At
+     *
+     * Last committed successful refresh — not the last attempt.
+     */
+    last_refreshed_at?: string | null;
+    /**
      * Constraints
      */
     constraints?: {


### PR DESCRIPTION
Closes #1281.

Projects source health, last-check, and last-refresh information into visibility-filtered catalog search summaries and the generated API clients. Adds anonymous-private visibility coverage.

This is Wave 3's sole generated-artifact PR: OpenAPI, Python SDK, TypeScript SDK, and frontend API types were freshly regenerated from the rebased source.

Also serializes projected timestamps for the JSONResponse-backed OGC/STAC paths and raises the exact search-records size ratchet with its justification.

Verification:
- `uv run pytest -n 4 -m 'not perf' -q --tb=short` (7,948 passed, 88 skipped)
- `uv run pytest tests/test_dataset_source_freshness.py -q` (59 passed)
- `uv run pytest tests/test_layering.py -q` (40 passed)
- `npm run build && npm run lint && npm run typecheck && npm run test:coverage`
- `make openapi-check && make sdks-check && make sdks-test`
- `uv run --no-project pre-commit run --all-files`