### PR TITLE
feat(cli): add dataset refresh and source status

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -39,8 +39,9 @@ source whose data changed independently.
 `geolens refresh <dataset-id>` is the explicit data-refresh path. It re-pulls
 the dataset from the origin binding stored by GeoLens, without accepting a URL,
 layer, or client-selected trigger. Add `--wait` to poll the refresh job to a
-terminal state. This is the supported command for scheduled cron or CI refresh
-jobs; use `apply` when the declared source configuration itself changes.
+terminal state without an implicit deadline; pass `--timeout` when automation
+needs a finite bound. This is the supported command for scheduled cron or CI
+refresh jobs; use `apply` when the declared source configuration itself changes.
 
 Protected services can receive a transient credential with `--token`. Use bare
 `--token` to open a hidden-input prompt, which keeps the value out of terminal

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,7 +2,7 @@
 
 Apache-2.0 command-line interface for the [GeoLens](https://github.com/geolens-io/geolens) API.
 
-Login, scan local directories of spatial data, apply manifest-driven catalogs, publish vector or raster files, run PostGIS analysis operations, and export STAC metadata against any GeoLens instance.
+Login, scan local directories of spatial data, apply manifest-driven catalogs, publish vector or raster files, refresh remote service datasets, inspect source status, run PostGIS analysis operations, and export STAC metadata against any GeoLens instance.
 
 See [docs.getgeolens.com](https://docs.getgeolens.com/) for the full command reference.
 
@@ -18,6 +18,8 @@ geolens schema --output geolens-manifest-v1.schema.json
 geolens apply --dry-run geolens.yaml
 geolens apply geolens.yaml
 geolens publish ./data/cities.geojson
+geolens status <dataset-id>
+geolens refresh <dataset-id> --wait
 geolens analysis preview <dataset-id> --operation buffer --distance 500 > ring.geojson
 geolens analysis materialize <dataset-id> --operation buffer --distance 500 --title "500 m ring"  # waits for the job; --timeout to bound it
 geolens export stac <dataset-id> -o cities.stac.json
@@ -26,6 +28,30 @@ geolens export stac <dataset-id> -o cities.stac.json
 For a one-command quickstart, run `geolens publish examples/manifests/first-catalog/city-parks.geojson` against a running stack. See the full walkthrough at [docs.getgeolens.com](https://docs.getgeolens.com/).
 
 The CLI consumes the [`geolens`](https://pypi.org/project/geolens/) Python SDK package. Manifest apply posts to the generated `POST /ingest/manifest/apply` contract through the SDK-owned client transport rather than a hand-rolled HTTP client.
+
+## Apply versus refresh
+
+`geolens apply` reconciles declared catalog configuration. It re-imports a
+manifest entry only when that entry's fingerprint changes; applying an
+unchanged manifest returns `skip_complete` and does not re-fetch a remote
+source whose data changed independently.
+
+`geolens refresh <dataset-id>` is the explicit data-refresh path. It re-pulls
+the dataset from the origin binding stored by GeoLens, without accepting a URL,
+layer, or client-selected trigger. Add `--wait` to poll the refresh job to a
+terminal state. This is the supported command for scheduled cron or CI refresh
+jobs; use `apply` when the declared source configuration itself changes.
+
+Protected services can receive a transient credential with `--token`. Use bare
+`--token` to open a hidden-input prompt, which keeps the value out of terminal
+output and shell history. Supplying a token value directly is supported for
+automation but can expose it through process arguments or shell history, so
+inject it only through an appropriately protected runner. GeoLens never stores
+the credential in the dataset binding.
+
+`geolens status <dataset-id>` reports the catalog status together with source
+origin, freshness, health, and the last successful refresh time. Use `--json`
+before the command for a machine-readable status payload.
 
 ## Manifest schema distribution
 

--- a/cli/geolens_cli/_sdk_helpers.py
+++ b/cli/geolens_cli/_sdk_helpers.py
@@ -29,6 +29,10 @@ EXIT_NETWORK = 4
 EXIT_SERVER = 5
 
 
+class DeadlineTimeout(Exception):
+    """An SDK request consumed the caller's operation deadline."""
+
+
 def unwrap(resp: Any, *, expected: int = 200) -> Any:
     """Translate an SDK Response into either parsed model or typer.Exit.
 
@@ -64,13 +68,20 @@ def unwrap(resp: Any, *, expected: int = 200) -> Any:
     raise typer.Exit(EXIT_GENERIC)
 
 
-def call_sdk(fn: Callable[..., Any], **kwargs: Any) -> Any:
+def call_sdk(
+    fn: Callable[..., Any],
+    *,
+    deadline_expired: Callable[[], bool] | None = None,
+    **kwargs: Any,
+) -> Any:
     """Run a sync_detailed call, mapping httpx exceptions to exit codes."""
     import httpx  # lazy — only for exception types
 
     try:
         return fn(**kwargs)
     except httpx.TimeoutException:
+        if deadline_expired is not None and deadline_expired():
+            raise DeadlineTimeout from None
         typer.secho("Request timed out", fg="red", err=True)
         raise typer.Exit(EXIT_NETWORK)
     except httpx.NetworkError as exc:

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -26,6 +26,7 @@ from . import export_stac as _export_stac
 from . import manifest_apply as _manifest_apply
 from . import output as _output
 from . import publish as _publish
+from . import refresh as _refresh
 from . import scan as _scan
 from ._sdk_helpers import EXIT_AUTH, EXIT_GENERIC, EXIT_USAGE, call_sdk, unwrap
 
@@ -498,6 +499,33 @@ def whoami(ctx: typer.Context) -> None:
         state.output.success(f"{email} @ {instance}")
 
 
+@app.command()
+def status(
+    ctx: typer.Context,
+    dataset_id: Annotated[
+        str,
+        typer.Argument(help="Dataset UUID"),
+    ],
+) -> None:
+    """Show a dataset's catalog and source status."""
+    state: AppState = ctx.obj
+    try:
+        from uuid import UUID
+
+        dataset_uuid = UUID(dataset_id)
+    except ValueError as exc:
+        raise typer.BadParameter(
+            "Dataset id must be a UUID", param_hint="dataset_id"
+        ) from exc
+
+    dataset = _refresh.fetch_dataset_status(state.sdk().client, dataset_uuid)
+    payload = _refresh.dataset_status_payload(dataset)
+    if state.json_mode:
+        state.output.json(payload)
+    else:
+        _refresh.render_dataset_status(state.output.console_stdout, payload)
+
+
 # Stub subcommands so `geolens --help` lists them and exit-code tests can run
 # before Plans 03-05 fill them in. Each raises Exit(2) (EXIT_USAGE) with
 # "not yet implemented" — replaced atomically when its plan lands.
@@ -736,6 +764,96 @@ def publish(
         for failure in extras_failures:
             state.output.warn(f"Dataset created, but: {failure}")
     if extras_failures:
+        raise typer.Exit(EXIT_GENERIC)
+
+
+@app.command()
+def refresh(
+    ctx: typer.Context,
+    dataset_id: Annotated[str, typer.Argument(help="Dataset UUID")],
+    token: Annotated[
+        Optional[str],
+        typer.Option(
+            "--token",
+            prompt="Service token",
+            prompt_required=False,
+            hide_input=True,
+            help=(
+                "Transient protected-service token. Pass --token with no value "
+                "for a hidden prompt; an explicit value may be visible in shell history."
+            ),
+        ),
+    ] = None,
+    wait: Annotated[
+        bool,
+        typer.Option("--wait/--no-wait", help="Wait for the refresh job to finish"),
+    ] = False,
+    timeout: Annotated[
+        float,
+        typer.Option(
+            "--timeout",
+            min=0.1,
+            help="Maximum seconds to wait (only with --wait)",
+        ),
+    ] = _refresh.DEFAULT_POLL_TIMEOUT_SECONDS,
+) -> None:
+    """Re-pull a dataset from its server-stored source binding."""
+    state: AppState = ctx.obj
+    try:
+        from uuid import UUID
+
+        dataset_uuid = UUID(dataset_id)
+    except ValueError as exc:
+        raise typer.BadParameter(
+            "Dataset id must be a UUID", param_hint="dataset_id"
+        ) from exc
+    if not math.isfinite(timeout):
+        state.output.error("--timeout must be finite")
+        raise typer.Exit(EXIT_USAGE)
+    if not wait and timeout != _refresh.DEFAULT_POLL_TIMEOUT_SECONDS:
+        state.output.error("--timeout requires --wait")
+        raise typer.Exit(EXIT_USAGE)
+    if token == "":
+        state.output.error("Service token must not be empty")
+        raise typer.Exit(EXIT_USAGE)
+
+    sdk = state.sdk()
+    try:
+        accepted = _refresh.start_refresh(sdk.client, dataset_uuid, token)
+    except _refresh.RefreshRequestError as exc:
+        state.output.error(exc.message)
+        raise typer.Exit(exc.exit_code)
+
+    poll = None
+    if wait:
+        poll = _refresh.wait_for_refresh(
+            sdk.client,
+            accepted.job_id,
+            token=token,
+            timeout=timeout,
+        )
+
+    payload = _refresh.refresh_payload(accepted, poll)
+    if state.json_mode:
+        state.output.json(payload)
+    elif poll is None:
+        state.output.success(
+            f"Refresh queued for dataset {payload['dataset_id']} "
+            f"(job {payload['job_id']}, run {payload['run_id']}; "
+            f"origin={payload['origin_kind']}, trigger={payload['trigger']}, "
+            f"status={payload['status']})"
+        )
+        state.output.info(str(payload["message"]))
+    elif poll.succeeded:
+        state.output.success(
+            f"Refresh complete for dataset {payload['dataset_id']} "
+            f"(job {payload['job_id']}, run {payload['run_id']})"
+        )
+    else:
+        message = poll.error_message or f"Refresh job ended with status {poll.status}."
+        state.output.error(message)
+
+    if poll is not None and not poll.succeeded:
         raise typer.Exit(EXIT_GENERIC)
 
 

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -832,11 +832,8 @@ def refresh(
 
     poll = None
     if wait:
-        poll_client = (
-            sdk.client if timeout is None else sdk.client.with_timeout(timeout)
-        )
         poll = _refresh.wait_for_refresh(
-            poll_client,
+            sdk.client,
             accepted.job_id,
             token=token,
             timeout=timeout,

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -789,15 +789,21 @@ def refresh(
         typer.Option("--wait/--no-wait", help="Wait for the refresh job to finish"),
     ] = False,
     timeout: Annotated[
-        float,
+        Optional[float],
         typer.Option(
             "--timeout",
-            min=0.1,
-            help="Maximum seconds to wait (only with --wait)",
+            help=(
+                "Seconds to wait before giving up (only with --wait; default: "
+                "until the job finishes)"
+            ),
         ),
-    ] = _refresh.DEFAULT_POLL_TIMEOUT_SECONDS,
+    ] = None,
 ) -> None:
-    """Re-pull a dataset from its server-stored source binding."""
+    """Re-pull a dataset from its server-stored source binding.
+
+    Queue time has no upper bound, so ``--wait`` follows the job to a terminal
+    state by default. Pass ``--timeout`` when automation needs a finite bound.
+    """
     state: AppState = ctx.obj
     try:
         from uuid import UUID
@@ -807,10 +813,10 @@ def refresh(
         raise typer.BadParameter(
             "Dataset id must be a UUID", param_hint="dataset_id"
         ) from exc
-    if not math.isfinite(timeout):
-        state.output.error("--timeout must be finite")
+    if timeout is not None and (timeout <= 0 or not math.isfinite(timeout)):
+        state.output.error("--timeout must be a finite number greater than 0")
         raise typer.Exit(EXIT_USAGE)
-    if not wait and timeout != _refresh.DEFAULT_POLL_TIMEOUT_SECONDS:
+    if not wait and timeout is not None:
         state.output.error("--timeout requires --wait")
         raise typer.Exit(EXIT_USAGE)
     if token == "":
@@ -826,8 +832,11 @@ def refresh(
 
     poll = None
     if wait:
+        poll_client = (
+            sdk.client if timeout is None else sdk.client.with_timeout(timeout)
+        )
         poll = _refresh.wait_for_refresh(
-            sdk.client,
+            poll_client,
             accepted.job_id,
             token=token,
             timeout=timeout,

--- a/cli/geolens_cli/main.py
+++ b/cli/geolens_cli/main.py
@@ -522,7 +522,7 @@ def status(
     payload = _refresh.dataset_status_payload(dataset)
     if state.json_mode:
         state.output.json(payload)
-    else:
+    elif not state.quiet:
         _refresh.render_dataset_status(state.output.console_stdout, payload)
 
 

--- a/cli/geolens_cli/refresh.py
+++ b/cli/geolens_cli/refresh.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dataset refresh and source-status helpers.
+
+Hand-maintained — NOT regenerated.  The request path deliberately stays on
+the generated SDK surface: the only client-supplied refresh field is the
+transient service ``token``.  Origin, layer, and trigger remain server-owned.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+from urllib.parse import quote
+from uuid import UUID
+
+from rich.table import Table
+
+from ._sdk_helpers import (
+    EXIT_AUTH,
+    EXIT_GENERIC,
+    EXIT_SERVER,
+    call_sdk,
+    unwrap,
+)
+
+REFRESH_ACCEPTED_STATUS = 202
+DATASET_STATUS_OK = 200
+JOB_STATUS_OK = 200
+DEFAULT_POLL_INTERVAL_SECONDS = 1.0
+DEFAULT_POLL_TIMEOUT_SECONDS = 120.0
+
+
+@dataclass(frozen=True)
+class RefreshRequestError(Exception):
+    """A refresh refusal translated into a stable CLI message and exit code."""
+
+    message: str
+    exit_code: int = EXIT_GENERIC
+    code: str | None = None
+
+
+@dataclass(frozen=True)
+class RefreshPollResult:
+    """Terminal (or timed-out) state observed through ``GET /jobs/{id}``."""
+
+    status: str
+    error_message: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status == "complete"
+
+
+_REFUSAL_MESSAGES: dict[str, str] = {
+    "refresh_not_applicable": (
+        "This dataset has no refreshable service origin. Replace its data "
+        "through re-upload instead."
+    ),
+    "origin_unavailable": (
+        "This dataset's stored service binding is incomplete. Re-import the "
+        "layer through the service import flow before refreshing it."
+    ),
+    "dataset_busy": (
+        "A refresh or re-upload is already running for this dataset. Wait for "
+        "it to finish, then try again."
+    ),
+    "origin_changed": (
+        "The dataset's source changed while the refresh was being queued. "
+        "Check its current status, then try again."
+    ),
+    "credential_store_unavailable": (
+        "GeoLens cannot securely hand the service credential to a worker. "
+        "Ask an operator to check the shared credential store, then try again."
+    ),
+    "invalid_service_token": (
+        "GeoLens rejected the service token. Supply a token that meets the "
+        "service's credential policy and try again."
+    ),
+}
+
+
+def start_refresh(client: Any, dataset_id: UUID, token: str | None = None) -> Any:
+    """Dispatch a refresh through the generated SDK.
+
+    With no credential, the optional request body is omitted.  With a
+    credential, ``DatasetRefreshRequest`` guarantees that the serialized body
+    contains only ``token``; notably, there is no client-supplied trigger or
+    source pointer.
+    """
+    from geolens.api.datasets_refresh import (
+        refresh_dataset_datasets_dataset_id_refresh_post as refresh_endpoint,
+    )
+
+    kwargs: dict[str, Any] = {"dataset_id": dataset_id, "client": client}
+    if token is not None:
+        from geolens.models.dataset_refresh_request import DatasetRefreshRequest
+
+        kwargs["body"] = DatasetRefreshRequest(token=token)
+
+    response = call_sdk(refresh_endpoint.sync_detailed, **kwargs)
+    if int(response.status_code) != REFRESH_ACCEPTED_STATUS:
+        raise _refresh_request_error(response, token=token)
+    return unwrap(response, expected=REFRESH_ACCEPTED_STATUS)
+
+
+def _refresh_request_error(
+    response: Any, *, token: str | None = None
+) -> RefreshRequestError:
+    status_code = int(response.status_code)
+    code, server_message = _problem_detail(response.parsed)
+
+    if status_code in {401, 403}:
+        return RefreshRequestError(
+            "Authentication or edit permission is required to refresh this dataset.",
+            exit_code=EXIT_AUTH,
+            code=code,
+        )
+    if status_code == 400:
+        # Stored URLs are revalidated for SSRF at dispatch time.  Do not repeat
+        # the rejected URL (or provider text) into terminal history.
+        return RefreshRequestError(
+            "GeoLens refused the stored source URL because it failed network-safety "
+            "checks. Review or re-import the dataset's source before retrying.",
+            code=code,
+        )
+    if code in _REFUSAL_MESSAGES:
+        return RefreshRequestError(
+            _REFUSAL_MESSAGES[code],
+            exit_code=EXIT_SERVER if status_code >= 500 else EXIT_GENERIC,
+            code=code,
+        )
+    if status_code >= 500:
+        return RefreshRequestError(
+            _redact_secret(server_message, token)
+            if server_message
+            else f"GeoLens could not queue the refresh ({status_code}).",
+            exit_code=EXIT_SERVER,
+            code=code,
+        )
+    return RefreshRequestError(
+        _redact_secret(server_message, token)
+        if server_message
+        else f"Refresh request failed ({status_code}).",
+        code=code,
+    )
+
+
+def _problem_detail(parsed: Any) -> tuple[str | None, str | None]:
+    """Return a ProblemDetail's structured ``(code, message)`` defensively."""
+    from geolens.models.problem_detail import ProblemDetail
+
+    if not isinstance(parsed, ProblemDetail):
+        return None, None
+    detail = parsed.detail
+    if isinstance(detail, str):
+        return None, detail
+    if isinstance(detail, Mapping):
+        payload = detail
+    else:
+        to_dict = getattr(detail, "to_dict", None)
+        payload = to_dict() if callable(to_dict) else {}
+    code = payload.get("code")
+    message = payload.get("message")
+    return (
+        str(code) if code is not None else None,
+        str(message) if message is not None else None,
+    )
+
+
+def wait_for_refresh(
+    client: Any,
+    job_id: str | UUID,
+    *,
+    token: str | None = None,
+    interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    timeout: float = DEFAULT_POLL_TIMEOUT_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> RefreshPollResult:
+    """Poll a refresh job until it completes, fails, is cancelled, or times out."""
+    from geolens.api.admin import get_job_status_jobs_job_id_get
+
+    uuid_arg = job_id if isinstance(job_id, UUID) else UUID(str(job_id))
+    deadline = monotonic() + timeout
+    while True:
+        response = call_sdk(
+            get_job_status_jobs_job_id_get.sync_detailed,
+            job_id=uuid_arg,
+            client=client,
+        )
+        if int(response.status_code) != JOB_STATUS_OK:
+            # ``unwrap`` preserves the CLI's standard auth/server exit mapping.
+            unwrap(response, expected=JOB_STATUS_OK)
+        job = unwrap(response, expected=JOB_STATUS_OK)
+        status = str(getattr(job, "status", "unknown"))
+        if status == "complete":
+            return RefreshPollResult(status=status)
+        if status in {"failed", "cancelled"}:
+            error = getattr(job, "error_message", None)
+            return RefreshPollResult(
+                status=status,
+                error_message=_redact_secret(str(error), token) if error else None,
+            )
+        if monotonic() >= deadline:
+            return RefreshPollResult(
+                status="timed_out",
+                error_message=(
+                    f"Refresh job {job_id} is still {status}; check its status later."
+                ),
+            )
+        sleep(interval)
+
+
+def _redact_secret(message: str, secret: str | None) -> str:
+    """Keep a supplied token out of an upstream failure message."""
+    if not secret:
+        return message
+    redacted = message.replace(secret, "[REDACTED]")
+    encoded = quote(secret, safe="")
+    if encoded != secret:
+        redacted = redacted.replace(encoded, "[REDACTED]")
+    return redacted
+
+
+def refresh_payload(response: Any, poll: RefreshPollResult | None = None) -> dict:
+    """Serialize the 202 response, optionally replacing status with job status."""
+    to_dict = getattr(response, "to_dict", None)
+    payload = (
+        to_dict()
+        if callable(to_dict)
+        else {
+            key: getattr(response, key, None)
+            for key in (
+                "run_id",
+                "job_id",
+                "dataset_id",
+                "origin_kind",
+                "trigger",
+                "status",
+                "message",
+            )
+        }
+    )
+    if poll is not None:
+        payload["status"] = poll.status
+        if poll.error_message:
+            payload["error_message"] = poll.error_message
+    return payload
+
+
+def fetch_dataset_status(client: Any, dataset_id: UUID) -> Any:
+    """Read the generated dataset detail model used by ``geolens status``."""
+    from geolens.api.datasets import get_single_dataset_datasets_dataset_id_get
+
+    response = call_sdk(
+        get_single_dataset_datasets_dataset_id_get.sync_detailed,
+        dataset_id=dataset_id,
+        client=client,
+    )
+    return unwrap(response, expected=DATASET_STATUS_OK)
+
+
+def dataset_status_payload(dataset: Any) -> dict[str, Any]:
+    """Select stable source-status fields from ``DatasetResponse``."""
+    return {
+        "dataset_id": str(dataset.id),
+        "title": dataset.title,
+        "status": _value(getattr(dataset, "record_status", None)),
+        "origin": _value(getattr(dataset, "origin", None)),
+        "source_freshness": _value(getattr(dataset, "source_freshness", None)),
+        "source_health": _value(getattr(dataset, "source_health", None)),
+        "source_health_detail": _value(getattr(dataset, "source_health_detail", None)),
+        "last_refreshed_at": _value(getattr(dataset, "last_refreshed_at", None)),
+        "last_checked_at": _value(getattr(dataset, "last_checked_at", None)),
+        "update_frequency": _value(getattr(dataset, "update_frequency", None)),
+    }
+
+
+def _value(value: Any) -> Any:
+    from geolens.types import Unset
+
+    return None if isinstance(value, Unset) else value
+
+
+def render_dataset_status(console: Any, payload: Mapping[str, Any]) -> None:
+    """Render one dataset as a terminal-width-safe source-status table."""
+    table = Table(title="Dataset status", show_header=False)
+    table.add_column("FIELD", style="bold")
+    table.add_column("VALUE", overflow="fold")
+
+    health = _display(payload.get("source_health"))
+    if payload.get("source_health_detail"):
+        health = f"{health} ({payload['source_health_detail']})"
+    rows = (
+        (
+            "Dataset",
+            f"{payload.get('title') or '(untitled)'} ({payload['dataset_id']})",
+        ),
+        ("Status", _display(payload.get("status"))),
+        ("Origin", _display(payload.get("origin"))),
+        ("Freshness", _display(payload.get("source_freshness"))),
+        ("Health", health),
+        ("Last refreshed", _display(payload.get("last_refreshed_at"))),
+        ("Last checked", _display(payload.get("last_checked_at"))),
+        ("Update frequency", _display(payload.get("update_frequency"))),
+    )
+    for label, value in rows:
+        table.add_row(label, value)
+    console.print(table)
+
+
+def _display(value: Any) -> str:
+    if value is None or value == "":
+        return "—"
+    isoformat = getattr(value, "isoformat", None)
+    return isoformat() if callable(isoformat) else str(value)

--- a/cli/geolens_cli/refresh.py
+++ b/cli/geolens_cli/refresh.py
@@ -17,6 +17,7 @@ from uuid import UUID
 from rich.table import Table
 
 from ._sdk_helpers import (
+    DeadlineTimeout,
     EXIT_AUTH,
     EXIT_GENERIC,
     EXIT_SERVER,
@@ -198,11 +199,23 @@ def wait_for_refresh(
                         ),
                     )
                 transport.timeout = remaining
-            response = call_sdk(
-                get_job_status_jobs_job_id_get.sync_detailed,
-                job_id=uuid_arg,
-                client=client,
-            )
+            try:
+                response = call_sdk(
+                    get_job_status_jobs_job_id_get.sync_detailed,
+                    deadline_expired=lambda: (
+                        deadline is not None and monotonic() >= deadline
+                    ),
+                    job_id=uuid_arg,
+                    client=client,
+                )
+            except DeadlineTimeout:
+                return RefreshPollResult(
+                    status="timed_out",
+                    error_message=(
+                        f"Refresh job {job_id} is still {status}; "
+                        "check its status later."
+                    ),
+                )
             if int(response.status_code) != JOB_STATUS_OK:
                 # ``unwrap`` preserves the CLI's standard auth/server exit mapping.
                 unwrap(response, expected=JOB_STATUS_OK)

--- a/cli/geolens_cli/refresh.py
+++ b/cli/geolens_cli/refresh.py
@@ -182,11 +182,25 @@ def wait_for_refresh(
 
     uuid_arg = job_id if isinstance(job_id, UUID) else UUID(str(job_id))
     deadline = monotonic() + timeout if timeout is not None else None
+    status = "pending"
     while True:
+        if deadline is None:
+            request_client = client
+        else:
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                return RefreshPollResult(
+                    status="timed_out",
+                    error_message=(
+                        f"Refresh job {job_id} is still {status}; "
+                        "check its status later."
+                    ),
+                )
+            request_client = client.with_timeout(remaining)
         response = call_sdk(
             get_job_status_jobs_job_id_get.sync_detailed,
             job_id=uuid_arg,
-            client=client,
+            client=request_client,
         )
         if int(response.status_code) != JOB_STATUS_OK:
             # ``unwrap`` preserves the CLI's standard auth/server exit mapping.
@@ -201,14 +215,18 @@ def wait_for_refresh(
                 status=status,
                 error_message=_redact_secret(str(error), token) if error else None,
             )
-        if deadline is not None and monotonic() >= deadline:
+        if deadline is None:
+            sleep(interval)
+            continue
+        remaining = deadline - monotonic()
+        if remaining <= 0:
             return RefreshPollResult(
                 status="timed_out",
                 error_message=(
                     f"Refresh job {job_id} is still {status}; check its status later."
                 ),
             )
-        sleep(interval)
+        sleep(min(interval, remaining))
 
 
 def _redact_secret(message: str, secret: str | None) -> str:

--- a/cli/geolens_cli/refresh.py
+++ b/cli/geolens_cli/refresh.py
@@ -182,11 +182,43 @@ def wait_for_refresh(
 
     uuid_arg = job_id if isinstance(job_id, UUID) else UUID(str(job_id))
     deadline = monotonic() + timeout if timeout is not None else None
+    transport = client.get_httpx_client() if deadline is not None else None
+    original_timeout = transport.timeout if transport is not None else None
     status = "pending"
-    while True:
-        if deadline is None:
-            request_client = client
-        else:
+    try:
+        while True:
+            if deadline is not None:
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    return RefreshPollResult(
+                        status="timed_out",
+                        error_message=(
+                            f"Refresh job {job_id} is still {status}; "
+                            "check its status later."
+                        ),
+                    )
+                transport.timeout = remaining
+            response = call_sdk(
+                get_job_status_jobs_job_id_get.sync_detailed,
+                job_id=uuid_arg,
+                client=client,
+            )
+            if int(response.status_code) != JOB_STATUS_OK:
+                # ``unwrap`` preserves the CLI's standard auth/server exit mapping.
+                unwrap(response, expected=JOB_STATUS_OK)
+            job = unwrap(response, expected=JOB_STATUS_OK)
+            status = str(getattr(job, "status", "unknown"))
+            if status == "complete":
+                return RefreshPollResult(status=status)
+            if status in {"failed", "cancelled"}:
+                error = getattr(job, "error_message", None)
+                return RefreshPollResult(
+                    status=status,
+                    error_message=_redact_secret(str(error), token) if error else None,
+                )
+            if deadline is None:
+                sleep(interval)
+                continue
             remaining = deadline - monotonic()
             if remaining <= 0:
                 return RefreshPollResult(
@@ -196,37 +228,10 @@ def wait_for_refresh(
                         "check its status later."
                     ),
                 )
-            request_client = client.with_timeout(remaining)
-        response = call_sdk(
-            get_job_status_jobs_job_id_get.sync_detailed,
-            job_id=uuid_arg,
-            client=request_client,
-        )
-        if int(response.status_code) != JOB_STATUS_OK:
-            # ``unwrap`` preserves the CLI's standard auth/server exit mapping.
-            unwrap(response, expected=JOB_STATUS_OK)
-        job = unwrap(response, expected=JOB_STATUS_OK)
-        status = str(getattr(job, "status", "unknown"))
-        if status == "complete":
-            return RefreshPollResult(status=status)
-        if status in {"failed", "cancelled"}:
-            error = getattr(job, "error_message", None)
-            return RefreshPollResult(
-                status=status,
-                error_message=_redact_secret(str(error), token) if error else None,
-            )
-        if deadline is None:
-            sleep(interval)
-            continue
-        remaining = deadline - monotonic()
-        if remaining <= 0:
-            return RefreshPollResult(
-                status="timed_out",
-                error_message=(
-                    f"Refresh job {job_id} is still {status}; check its status later."
-                ),
-            )
-        sleep(min(interval, remaining))
+            sleep(min(interval, remaining))
+    finally:
+        if transport is not None:
+            transport.timeout = original_timeout
 
 
 def _redact_secret(message: str, secret: str | None) -> str:

--- a/cli/geolens_cli/refresh.py
+++ b/cli/geolens_cli/refresh.py
@@ -28,7 +28,6 @@ REFRESH_ACCEPTED_STATUS = 202
 DATASET_STATUS_OK = 200
 JOB_STATUS_OK = 200
 DEFAULT_POLL_INTERVAL_SECONDS = 1.0
-DEFAULT_POLL_TIMEOUT_SECONDS = 120.0
 
 
 @dataclass(frozen=True)
@@ -174,15 +173,15 @@ def wait_for_refresh(
     *,
     token: str | None = None,
     interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
-    timeout: float = DEFAULT_POLL_TIMEOUT_SECONDS,
+    timeout: float | None = None,
     sleep: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
 ) -> RefreshPollResult:
-    """Poll a refresh job until it completes, fails, is cancelled, or times out."""
+    """Poll until terminal, or until an explicitly supplied timeout expires."""
     from geolens.api.admin import get_job_status_jobs_job_id_get
 
     uuid_arg = job_id if isinstance(job_id, UUID) else UUID(str(job_id))
-    deadline = monotonic() + timeout
+    deadline = monotonic() + timeout if timeout is not None else None
     while True:
         response = call_sdk(
             get_job_status_jobs_job_id_get.sync_detailed,
@@ -202,7 +201,7 @@ def wait_for_refresh(
                 status=status,
                 error_message=_redact_secret(str(error), token) if error else None,
             )
-        if monotonic() >= deadline:
+        if deadline is not None and monotonic() >= deadline:
             return RefreshPollResult(
                 status="timed_out",
                 error_message=(

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -41,7 +41,9 @@ dependencies = [
   # define join_dataset_id/join_fields; the builders pass those keywords
   # unconditionally, so a 1.5/1.6 SDK raises TypeError on every analysis
   # command, not just spatial_join.
-  "geolens>=1.7.0,<2.0.0",
+  # feat(#1227): 1.10.0 adds the generated one-request dataset refresh method
+  # and the source freshness/health/origin fields consumed by CLI status.
+  "geolens>=1.10.0,<2.0.0",
   # PYSEC-2026-215 (idna.encode DoS, fixed 3.15): keep this floor in step with
   # backend's; without it a re-lock resolves idna back to a vulnerable 3.13.
   "idna>=3.18",

--- a/cli/tests/test_refresh.py
+++ b/cli/tests/test_refresh.py
@@ -278,6 +278,18 @@ def test_ssrf_refusal_does_not_repeat_the_stored_url(
 
 
 class TestRefreshWait:
+    @staticmethod
+    def _timeout_tracking_client():
+        class Client:
+            def __init__(self) -> None:
+                self.timeouts: list[float] = []
+
+            def with_timeout(self, timeout: float):
+                self.timeouts.append(timeout)
+                return self
+
+        return Client()
+
     def test_default_wait_survives_queue_time_beyond_120_seconds(
         self, monkeypatch
     ) -> None:
@@ -318,6 +330,7 @@ class TestRefreshWait:
         from geolens_cli.refresh import wait_for_refresh
 
         elapsed = [0.0]
+        client = self._timeout_tracking_client()
         statuses = iter(("pending", "running", "complete"))
 
         def next_status(**_kwargs):
@@ -333,7 +346,7 @@ class TestRefreshWait:
         )
 
         result = wait_for_refresh(
-            SimpleNamespace(),
+            client,
             JOB_ID,
             interval=0,
             timeout=120.0,
@@ -343,6 +356,84 @@ class TestRefreshWait:
 
         assert elapsed[0] == 122.0
         assert result.status == "timed_out"
+
+    def test_timeout_stops_before_sleeping_past_deadline_or_next_get(
+        self, monkeypatch
+    ) -> None:
+        from geolens_cli.refresh import wait_for_refresh
+
+        elapsed = [0.0]
+        requests = [0]
+        sleeps: list[float] = []
+        client = self._timeout_tracking_client()
+
+        def next_status(**_kwargs):
+            requests[0] += 1
+            if requests[0] == 1:
+                elapsed[0] += 9.75
+                status = "pending"
+            else:
+                status = "complete"
+            return SimpleNamespace(
+                status_code=HTTPStatus.OK,
+                parsed=SimpleNamespace(status=status, error_message=None),
+            )
+
+        def advance_clock(seconds: float) -> None:
+            sleeps.append(seconds)
+            elapsed[0] += seconds
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            next_status,
+        )
+
+        result = wait_for_refresh(
+            client,
+            JOB_ID,
+            interval=1.0,
+            timeout=10.0,
+            sleep=advance_clock,
+            monotonic=lambda: elapsed[0],
+        )
+
+        assert result.status == "timed_out"
+        assert requests[0] == 1
+        assert sleeps == pytest.approx([0.25])
+        assert client.timeouts == pytest.approx([10.0])
+
+    def test_each_get_uses_only_the_remaining_timeout_budget(self, monkeypatch) -> None:
+        from geolens_cli.refresh import wait_for_refresh
+
+        elapsed = [0.0]
+        client = self._timeout_tracking_client()
+        statuses = iter(("pending", "complete"))
+
+        def next_status(**_kwargs):
+            status = next(statuses)
+            if status == "pending":
+                elapsed[0] += 4.0
+            return SimpleNamespace(
+                status_code=HTTPStatus.OK,
+                parsed=SimpleNamespace(status=status, error_message=None),
+            )
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            next_status,
+        )
+
+        result = wait_for_refresh(
+            client,
+            JOB_ID,
+            interval=1.0,
+            timeout=10.0,
+            sleep=lambda seconds: elapsed.__setitem__(0, elapsed[0] + seconds),
+            monotonic=lambda: elapsed[0],
+        )
+
+        assert result.status == "complete"
+        assert client.timeouts == pytest.approx([10.0, 5.0])
 
     def test_cli_default_wait_passes_no_deadline_to_the_poller(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch

--- a/cli/tests/test_refresh.py
+++ b/cli/tests/test_refresh.py
@@ -457,6 +457,76 @@ class TestRefreshWait:
         assert client.timeouts == []
         assert client.transport.timeout is None
 
+    def test_request_timeout_at_deadline_returns_timed_out_json(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        import httpx
+
+        from geolens_cli.main import app
+        from geolens_cli.refresh import wait_for_refresh
+
+        _seed_login(mock_keyring)
+        _patch_refresh_endpoint(monkeypatch, _accepted())
+        elapsed = [0.0]
+
+        def exhaust_request_budget(**_kwargs):
+            elapsed[0] = 10.0
+            raise httpx.ReadTimeout("request consumed the deadline budget")
+
+        def wait_with_clock(client, job_id, **kwargs):
+            return wait_for_refresh(
+                client,
+                job_id,
+                **kwargs,
+                sleep=lambda seconds: elapsed.__setitem__(0, elapsed[0] + seconds),
+                monotonic=lambda: elapsed[0],
+            )
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            exhaust_request_budget,
+        )
+        monkeypatch.setattr("geolens_cli.refresh.wait_for_refresh", wait_with_clock)
+
+        result = runner.invoke(
+            app,
+            ["--json", "refresh", str(DATASET_ID), "--wait", "--timeout", "10"],
+        )
+
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "timed_out"
+        assert "check its status later" in payload["error_message"]
+
+    def test_request_timeout_before_deadline_remains_a_network_error(
+        self, monkeypatch
+    ) -> None:
+        import httpx
+        import typer
+
+        from geolens_cli._sdk_helpers import EXIT_NETWORK
+        from geolens_cli.refresh import wait_for_refresh
+
+        client = self._timeout_tracking_client()
+
+        def timeout_before_deadline(**_kwargs):
+            raise httpx.ReadTimeout("upstream stalled before the CLI deadline")
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            timeout_before_deadline,
+        )
+
+        with pytest.raises(typer.Exit) as exc_info:
+            wait_for_refresh(
+                client,
+                JOB_ID,
+                timeout=10.0,
+                monotonic=lambda: 0.0,
+            )
+
+        assert exc_info.value.exit_code == EXIT_NETWORK
+
     def test_cli_default_wait_passes_no_deadline_to_the_poller(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:

--- a/cli/tests/test_refresh.py
+++ b/cli/tests/test_refresh.py
@@ -206,7 +206,7 @@ class TestRefreshRequest:
         )
 
         assert result.exit_code == 2
-        assert "--timeout must be finite" in result.output
+        assert "--timeout must be a finite number greater than 0" in result.output
 
 
 @pytest.mark.parametrize(
@@ -278,6 +278,117 @@ def test_ssrf_refusal_does_not_repeat_the_stored_url(
 
 
 class TestRefreshWait:
+    def test_default_wait_survives_queue_time_beyond_120_seconds(
+        self, monkeypatch
+    ) -> None:
+        """Without an explicit bound, --wait follows the job to completion.
+
+        Queue time is unbounded, so a healthy job can still be pending or
+        running after the old 120-second default without having failed.
+        """
+        from geolens_cli.refresh import wait_for_refresh
+
+        elapsed = [0.0]
+        statuses = iter(("pending", "running", "complete"))
+
+        def next_status(**_kwargs):
+            elapsed[0] += 61.0
+            return SimpleNamespace(
+                status_code=HTTPStatus.OK,
+                parsed=SimpleNamespace(status=next(statuses), error_message=None),
+            )
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            next_status,
+        )
+
+        result = wait_for_refresh(
+            SimpleNamespace(),
+            JOB_ID,
+            interval=0,
+            sleep=lambda _seconds: None,
+            monotonic=lambda: elapsed[0],
+        )
+
+        assert elapsed[0] == 183.0
+        assert result.status == "complete"
+
+    def test_explicit_timeout_still_bounds_the_poll(self, monkeypatch) -> None:
+        from geolens_cli.refresh import wait_for_refresh
+
+        elapsed = [0.0]
+        statuses = iter(("pending", "running", "complete"))
+
+        def next_status(**_kwargs):
+            elapsed[0] += 61.0
+            return SimpleNamespace(
+                status_code=HTTPStatus.OK,
+                parsed=SimpleNamespace(status=next(statuses), error_message=None),
+            )
+
+        monkeypatch.setattr(
+            "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+            next_status,
+        )
+
+        result = wait_for_refresh(
+            SimpleNamespace(),
+            JOB_ID,
+            interval=0,
+            timeout=120.0,
+            sleep=lambda _seconds: None,
+            monotonic=lambda: elapsed[0],
+        )
+
+        assert elapsed[0] == 122.0
+        assert result.status == "timed_out"
+
+    def test_cli_default_wait_passes_no_deadline_to_the_poller(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+        from geolens_cli.refresh import RefreshPollResult
+
+        _seed_login(mock_keyring)
+        _patch_refresh_endpoint(monkeypatch, _accepted())
+        seen: dict = {}
+
+        def capture_wait(_client, _job_id, **kwargs):
+            seen.update(kwargs)
+            return RefreshPollResult(status="complete")
+
+        monkeypatch.setattr("geolens_cli.refresh.wait_for_refresh", capture_wait)
+
+        result = runner.invoke(app, ["refresh", str(DATASET_ID), "--wait"])
+
+        assert result.exit_code == 0, result.output
+        assert seen["timeout"] is None
+
+    def test_cli_explicit_timeout_reaches_the_poller(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+        from geolens_cli.refresh import RefreshPollResult
+
+        _seed_login(mock_keyring)
+        _patch_refresh_endpoint(monkeypatch, _accepted())
+        seen: dict = {}
+
+        def capture_wait(_client, _job_id, **kwargs):
+            seen.update(kwargs)
+            return RefreshPollResult(status="complete")
+
+        monkeypatch.setattr("geolens_cli.refresh.wait_for_refresh", capture_wait)
+
+        result = runner.invoke(
+            app,
+            ["refresh", str(DATASET_ID), "--wait", "--timeout", "30"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert seen["timeout"] == 30.0
+
     def test_wait_reports_terminal_success(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:

--- a/cli/tests/test_refresh.py
+++ b/cli/tests/test_refresh.py
@@ -281,12 +281,18 @@ class TestRefreshWait:
     @staticmethod
     def _timeout_tracking_client():
         class Client:
-            def __init__(self) -> None:
-                self.timeouts: list[float] = []
+            def __init__(self, timeouts: list[float] | None = None) -> None:
+                self.timeouts = timeouts if timeouts is not None else []
+                self.transport = SimpleNamespace(timeout=None)
 
             def with_timeout(self, timeout: float):
                 self.timeouts.append(timeout)
-                return self
+                clone = Client(self.timeouts)
+                clone.transport.timeout = timeout
+                return clone
+
+            def get_httpx_client(self):
+                return self.transport
 
         return Client()
 
@@ -364,11 +370,13 @@ class TestRefreshWait:
 
         elapsed = [0.0]
         requests = [0]
+        request_timeouts: list[float] = []
         sleeps: list[float] = []
         client = self._timeout_tracking_client()
 
-        def next_status(**_kwargs):
+        def next_status(**kwargs):
             requests[0] += 1
+            request_timeouts.append(kwargs["client"].get_httpx_client().timeout)
             if requests[0] == 1:
                 elapsed[0] += 9.75
                 status = "pending"
@@ -400,16 +408,26 @@ class TestRefreshWait:
         assert result.status == "timed_out"
         assert requests[0] == 1
         assert sleeps == pytest.approx([0.25])
-        assert client.timeouts == pytest.approx([10.0])
+        assert request_timeouts == pytest.approx([10.0])
 
-    def test_each_get_uses_only_the_remaining_timeout_budget(self, monkeypatch) -> None:
+    def test_each_get_reuses_transport_with_remaining_timeout_budget(
+        self, monkeypatch
+    ) -> None:
         from geolens_cli.refresh import wait_for_refresh
 
         elapsed = [0.0]
         client = self._timeout_tracking_client()
         statuses = iter(("pending", "complete"))
+        request_clients = []
+        request_transports = []
+        request_timeouts: list[float] = []
 
-        def next_status(**_kwargs):
+        def next_status(**kwargs):
+            request_client = kwargs["client"]
+            transport = request_client.get_httpx_client()
+            request_clients.append(request_client)
+            request_transports.append(transport)
+            request_timeouts.append(transport.timeout)
             status = next(statuses)
             if status == "pending":
                 elapsed[0] += 4.0
@@ -433,7 +451,11 @@ class TestRefreshWait:
         )
 
         assert result.status == "complete"
-        assert client.timeouts == pytest.approx([10.0, 5.0])
+        assert request_clients == [client, client]
+        assert request_transports[0] is request_transports[1]
+        assert request_timeouts == pytest.approx([10.0, 5.0])
+        assert client.timeouts == []
+        assert client.transport.timeout is None
 
     def test_cli_default_wait_passes_no_deadline_to_the_poller(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
@@ -561,6 +583,19 @@ class TestDatasetStatus:
         for value in ("service", "overdue", "inaccessible", "unauthorized"):
             assert value in result.output
 
+    def test_quiet_status_suppresses_the_human_table(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        self._patch_status(monkeypatch)
+
+        result = runner.invoke(app, ["--quiet", "status", str(DATASET_ID)])
+
+        assert result.exit_code == 0, result.output
+        assert result.output == ""
+
     def test_json_status_uses_the_shipped_dataset_fields(
         self, runner, tmp_xdg_home, mock_keyring, monkeypatch
     ) -> None:
@@ -569,7 +604,10 @@ class TestDatasetStatus:
         _seed_login(mock_keyring)
         self._patch_status(monkeypatch)
 
-        result = runner.invoke(app, ["--json", "status", str(DATASET_ID)])
+        result = runner.invoke(
+            app,
+            ["--quiet", "--json", "status", str(DATASET_ID)],
+        )
 
         assert result.exit_code == 0, result.output
         payload = json.loads(result.output)

--- a/cli/tests/test_refresh.py
+++ b/cli/tests/test_refresh.py
@@ -1,0 +1,377 @@
+"""CLI coverage for dataset refresh dispatch, polling, and source status."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from http import HTTPStatus
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+DATASET_ID = UUID("00000000-0000-0000-0000-000000000122")
+RUN_ID = UUID("00000000-0000-0000-0000-000000000123")
+JOB_ID = UUID("00000000-0000-0000-0000-000000000124")
+INSTANCE = "https://x.example.com/api"
+
+
+def _seed_login(mock_keyring: dict) -> None:
+    from geolens_cli import config
+
+    mock_keyring[("geolens", INSTANCE)] = "cli-auth-token"
+    config.write_default_instance(INSTANCE, username="alice")
+
+
+def _accepted(trigger: str = "api"):
+    from geolens.models.dataset_refresh_response import DatasetRefreshResponse
+
+    return SimpleNamespace(
+        status_code=HTTPStatus.ACCEPTED,
+        parsed=DatasetRefreshResponse(
+            run_id=RUN_ID,
+            job_id=JOB_ID,
+            dataset_id=DATASET_ID,
+            origin_kind="service",
+            trigger=trigger,
+            status="pending",
+            message="Refresh queued from the stored source",
+        ),
+    )
+
+
+def _problem(status: int, detail: str | dict):
+    from geolens.models.problem_detail import ProblemDetail
+    from geolens.models.problem_detail_detail_type_1 import ProblemDetailDetailType1
+
+    parsed_detail = (
+        ProblemDetailDetailType1.from_dict(detail)
+        if isinstance(detail, dict)
+        else detail
+    )
+    return SimpleNamespace(
+        status_code=HTTPStatus(status),
+        parsed=ProblemDetail(
+            title="Refresh refused",
+            status=status,
+            detail=parsed_detail,
+        ),
+    )
+
+
+def _patch_refresh_endpoint(monkeypatch, response, captured: dict | None = None):
+    def fake_sync_detailed(**kwargs):
+        if captured is not None:
+            captured.update(kwargs)
+        return response
+
+    monkeypatch.setattr(
+        "geolens.api.datasets_refresh."
+        "refresh_dataset_datasets_dataset_id_refresh_post.sync_detailed",
+        fake_sync_detailed,
+    )
+
+
+def _patch_job(monkeypatch, *, status: str, error_message: str | None = None):
+    monkeypatch.setattr(
+        "geolens.api.admin.get_job_status_jobs_job_id_get.sync_detailed",
+        lambda **_kwargs: SimpleNamespace(
+            status_code=HTTPStatus.OK,
+            parsed=SimpleNamespace(status=status, error_message=error_message),
+        ),
+    )
+
+
+class TestRefreshRequest:
+    def test_no_token_omits_the_optional_body_and_preserves_202_payload(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        captured: dict = {}
+        _patch_refresh_endpoint(monkeypatch, _accepted(), captured)
+
+        result = runner.invoke(app, ["--json", "refresh", str(DATASET_ID)])
+
+        assert result.exit_code == 0, result.output
+        assert "body" not in captured
+        assert set(json.loads(result.output)) == {
+            "run_id",
+            "job_id",
+            "dataset_id",
+            "origin_kind",
+            "trigger",
+            "status",
+            "message",
+        }
+
+    def test_explicit_token_body_contains_only_token_and_is_never_printed(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        captured: dict = {}
+        secret = "protected-source-token-42"
+        _patch_refresh_endpoint(monkeypatch, _accepted(trigger="cli"), captured)
+
+        result = runner.invoke(
+            app,
+            ["--json", "refresh", str(DATASET_ID), "--token", secret],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["body"].to_dict() == {"token": secret}
+        assert secret not in result.output
+        assert json.loads(result.output)["trigger"] == "cli"
+
+    def test_bare_token_option_uses_a_hidden_prompt(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        captured: dict = {}
+        secret = "prompt-only-secret-84"
+        _patch_refresh_endpoint(monkeypatch, _accepted(), captured)
+
+        result = runner.invoke(
+            app,
+            ["refresh", str(DATASET_ID), "--token"],
+            input=f"{secret}\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Service token:" in result.output
+        assert captured["body"].to_dict() == {"token": secret}
+        assert secret not in result.output
+
+    def test_bare_token_can_prompt_before_wait_flag(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        captured: dict = {}
+        secret = "prompt-then-wait-secret"
+        _patch_refresh_endpoint(monkeypatch, _accepted(), captured)
+        _patch_job(monkeypatch, status="complete")
+
+        result = runner.invoke(
+            app,
+            ["refresh", str(DATASET_ID), "--token", "--wait"],
+            input=f"{secret}\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["body"].to_dict() == {"token": secret}
+        assert secret not in result.output
+
+    def test_timeout_without_wait_is_rejected_before_dispatch(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        called = False
+
+        def should_not_run(**_kwargs):
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(
+            "geolens.api.datasets_refresh."
+            "refresh_dataset_datasets_dataset_id_refresh_post.sync_detailed",
+            should_not_run,
+        )
+        result = runner.invoke(
+            app,
+            ["refresh", str(DATASET_ID), "--timeout", "10"],
+        )
+
+        assert result.exit_code == 2
+        assert "--timeout requires --wait" in result.output
+        assert called is False
+
+    def test_non_finite_wait_timeout_is_a_usage_error(
+        self, runner, tmp_xdg_home, mock_keyring
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        result = runner.invoke(
+            app,
+            ["refresh", str(DATASET_ID), "--wait", "--timeout", "nan"],
+        )
+
+        assert result.exit_code == 2
+        assert "--timeout must be finite" in result.output
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("refresh_not_applicable", "no refreshable service origin"),
+        ("origin_unavailable", "stored service binding is incomplete"),
+        ("dataset_busy", "already running"),
+        ("origin_changed", "source changed"),
+    ],
+)
+def test_409_refusals_are_actionable(
+    code, expected, runner, tmp_xdg_home, mock_keyring, monkeypatch
+) -> None:
+    from geolens_cli.main import app
+
+    _seed_login(mock_keyring)
+    _patch_refresh_endpoint(
+        monkeypatch,
+        _problem(409, {"code": code, "message": "backend detail"}),
+    )
+
+    result = runner.invoke(app, ["refresh", str(DATASET_ID)])
+
+    assert result.exit_code == 1
+    assert expected in result.output
+
+
+def test_credential_store_unavailable_is_a_server_error(
+    runner, tmp_xdg_home, mock_keyring, monkeypatch
+) -> None:
+    from geolens_cli.main import app
+
+    _seed_login(mock_keyring)
+    _patch_refresh_endpoint(
+        monkeypatch,
+        _problem(
+            503,
+            {
+                "code": "credential_store_unavailable",
+                "message": "store unavailable",
+            },
+        ),
+    )
+
+    result = runner.invoke(app, ["refresh", str(DATASET_ID)])
+
+    assert result.exit_code == 5
+    assert "shared credential store" in result.output
+
+
+def test_ssrf_refusal_does_not_repeat_the_stored_url(
+    runner, tmp_xdg_home, mock_keyring, monkeypatch
+) -> None:
+    from geolens_cli.main import app
+
+    _seed_login(mock_keyring)
+    rejected_url = "http://127.0.0.1/private-source"
+    _patch_refresh_endpoint(
+        monkeypatch,
+        _problem(400, f"Stored source URL is not reachable: {rejected_url}"),
+    )
+
+    result = runner.invoke(app, ["refresh", str(DATASET_ID)])
+
+    assert result.exit_code == 1
+    assert "network-safety checks" in result.output
+    assert rejected_url not in result.output
+
+
+class TestRefreshWait:
+    def test_wait_reports_terminal_success(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        _patch_refresh_endpoint(monkeypatch, _accepted())
+        _patch_job(monkeypatch, status="complete")
+
+        result = runner.invoke(
+            app,
+            ["--json", "refresh", str(DATASET_ID), "--wait"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["status"] == "complete"
+
+    def test_failed_job_is_nonzero_and_redacts_the_submitted_token(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        secret = "never-print-this-service-token"
+        _patch_refresh_endpoint(monkeypatch, _accepted())
+        _patch_job(
+            monkeypatch,
+            status="failed",
+            error_message=f"Upstream rejected credential {secret}",
+        )
+
+        result = runner.invoke(
+            app,
+            ["refresh", str(DATASET_ID), "--token", secret, "--wait"],
+        )
+
+        assert result.exit_code == 1
+        assert secret not in result.output
+        assert "[REDACTED]" in result.output
+
+
+class TestDatasetStatus:
+    @staticmethod
+    def _dataset():
+        return SimpleNamespace(
+            id=DATASET_ID,
+            title="Parcels",
+            record_status="published",
+            origin="service",
+            source_freshness="overdue",
+            source_health="inaccessible",
+            source_health_detail="unauthorized",
+            last_refreshed_at=datetime(2026, 8, 1, 12, 0, tzinfo=UTC),
+            last_checked_at=datetime(2026, 8, 8, 12, 0, tzinfo=UTC),
+            update_frequency="daily",
+        )
+
+    def _patch_status(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "geolens.api.datasets."
+            "get_single_dataset_datasets_dataset_id_get.sync_detailed",
+            lambda **_kwargs: SimpleNamespace(
+                status_code=HTTPStatus.OK,
+                parsed=self._dataset(),
+            ),
+        )
+
+    def test_human_status_shows_origin_freshness_and_health(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        self._patch_status(monkeypatch)
+
+        result = runner.invoke(app, ["status", str(DATASET_ID)])
+
+        assert result.exit_code == 0, result.output
+        for value in ("service", "overdue", "inaccessible", "unauthorized"):
+            assert value in result.output
+
+    def test_json_status_uses_the_shipped_dataset_fields(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+
+        _seed_login(mock_keyring)
+        self._patch_status(monkeypatch)
+
+        result = runner.invoke(app, ["--json", "status", str(DATASET_ID)])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["origin"] == "service"
+        assert payload["source_freshness"] == "overdue"
+        assert payload["source_health"] == "inaccessible"
+        assert payload["source_health_detail"] == "unauthorized"


### PR DESCRIPTION
Closes #1227.

Adds `geolens refresh <dataset-id>` with optional waiting, safe prompt/flag token handling, and actionable server errors. Adds `geolens status <dataset-id>` source origin, freshness, health, and timestamp output; documents `apply` versus `refresh`.

No generated SDK files changed. Live refresh against a mutable seeded service dataset remains a follow-up because that fixture is not available locally.

Follow-up: refresh provenance is server-owned. This wave deliberately leaves the reserved refresh router unchanged and the CLI sends no client-supplied trigger field; server-side differentiation of CLI versus generic API dispatch requires a separately scoped backend change.

Verification:
- `make cli-test` (303 passed; round trip 8 passed, 2 skipped)
- `make cli-build`
- `make version-check`
- `uv run --no-project pre-commit run --all-files`