### PR TITLE
docs(contributing): make the documented backend test commands runnable

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -149,4 +149,4 @@ v5, Tailwind, and shadcn/ui primitives in `components/ui/`.
 - **Don't import split service internals across domains** — go through the domain facade (enforced by `test_layering.py`).
 - **Locale parity is a CI gate** — a new `t()` key needs all 4 locale files, not just a `defaultValue`.
 - **The worker is Postgres-backed** (procrastinate) — no Redis/RabbitMQ broker to run.
-- **Tests run in the container:** `docker compose exec api pytest` / `docker compose exec frontend npm test`. E2E (Playwright) is local-only by policy.
+- **Tests run in the container:** `make test` for the backend (a bare `docker compose exec api pytest` fails against the container's read-only uv cache — CONTRIBUTING.md has the filtered-run recipe) / `docker compose exec frontend npm test`. E2E (Playwright) is local-only by policy.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -63,9 +63,15 @@ A non-zero exit there (a failed migration, schema drift) is what blocks the rest
 **Backend:**
 
 ```bash
-docker compose exec api pytest                              # Full test suite
-docker compose exec api pytest -v -k "<pattern>"            # Filter by test name pattern
-docker compose exec api pytest backend/tests/test_auth.py   # Run a single test file
+make test   # Full test suite (wraps the writable uv environment below)
+
+# Filtered runs need the same writable uv environment the Makefile uses — a bare
+# `pytest` fails against the container's read-only default uv cache. Tests are
+# mounted at /app/tests inside the container, so paths are tests/..., not backend/tests/...
+docker compose exec api env UV_CACHE_DIR=/app/staging/uv-cache UV_PROJECT_ENVIRONMENT=/app/staging/geolens-api-test-venv \
+  uv run pytest -o cache_dir=/app/staging/.pytest_cache -v -k "<pattern>"    # Filter by test name pattern
+docker compose exec api env UV_CACHE_DIR=/app/staging/uv-cache UV_PROJECT_ENVIRONMENT=/app/staging/geolens-api-test-venv \
+  uv run pytest -o cache_dir=/app/staging/.pytest_cache tests/test_auth.py   # Run a single test file
 ```
 
 Backend tests live under `backend/tests/` as a flat directory of `test_*.py` files (no `unit/` or `api/` subdirectories). Coverage thresholds are configured in `backend/pyproject.toml`.
@@ -214,7 +220,7 @@ geolens/
 │       │   ├── import/         # File/service import workflow
 │       │   ├── layout/         # Navbar, page chrome
 │       │   ├── map/            # Shared map components (popups, basemap)
-│       │   ├── map-widgets/    # Map toolbar widgets (measure, etc.)
+│       │   ├── map-plugins/    # Map plugins (measure, etc.)
 │       │   ├── maps/           # Map list & create dialog
 │       │   ├── search/         # Search bar, filters, result cards
 │       │   ├── settings/       # User settings panels


### PR DESCRIPTION
Fixes the three contributor-doc drifts from the 2026-08-07 doc audit (DOC-SETUP-01):

- `.github/CONTRIBUTING.md` prescribed a bare `docker compose exec api pytest`, which fails against the container's read-only default uv cache. The full-suite line now points at `make test`, and the filtered/single-file examples use the writable staging uv environment the Makefile uses.
- The single-file example used the host path `backend/tests/test_auth.py`; tests are mounted at `/app/tests` in the container, so the in-container path is `tests/test_auth.py`.
- The component tree named the removed `map-widgets/` directory; it is `map-plugins/` (`frontend/src/components/map-plugins/` exists, `map-widgets/` does not).
- `.github/ARCHITECTURE.md`'s testing bullet repeated the broken bare-pytest command; it now points at `make test` and cross-references the CONTRIBUTING recipe.

Docs-only; no code or config changes.

Verification: the corrected in-container recipe is the same one documented in AGENTS.md ("Running a single test") and used by `make test` (Makefile:78-85); `ls frontend/src/components` confirms `map-plugins/`.