### PR TITLE
chore(extensions): re-anchor the audit-seam removal promise to #1303

### DIFF
--- a/backend/app/platform/extensions/__init__.py
+++ b/backend/app/platform/extensions/__init__.py
@@ -331,10 +331,10 @@ def get_audit_extension() -> AuditExtension:
     """DEPRECATED — scheduled for removal at the next EXTENSION_API_VERSION bump.
 
     fix(#873 review r1+r3): the whole seam is deprecated (no core caller
-    consumes it and no known overlay registers the ``audit`` slot), but while
-    EXTENSION_API_VERSION == 2 the v2 surface must keep BEHAVING, not merely
-    importing — so the registry dispatch stays until the bump removes the seam
-    wholesale. An overlay registered under ``audit`` is returned; otherwise the
+    consumes it and no known overlay registers the ``audit`` slot), but until
+    the next EXTENSION_API_VERSION bump (removal tracked in #1303) the
+    deprecated surface must keep BEHAVING, not merely importing — so the
+    registry dispatch stays until that bump removes the seam wholesale. An overlay registered under ``audit`` is returned; otherwise the
     no-op community default.
     """
     ext = _extensions.get("audit")

--- a/backend/app/platform/extensions/protocols.py
+++ b/backend/app/platform/extensions/protocols.py
@@ -47,11 +47,12 @@ class AuditExtension(Protocol):
 
     fix(#873 review r1+r3): the seam has no consumer (core never calls
     ``get_export_formats`` and no overlay registers the ``audit`` slot), but
-    removing any part of it while EXTENSION_API_VERSION stays 2 breaks the v2
-    contract: a deleted symbol ImportErrors an overlay into a silent
-    ``load_extensions()`` skip, and a dispatch-less accessor silently no-ops a
-    registered overlay. Protocol, default, accessor, and dispatch therefore all
-    stay until the next version bump removes the seam wholesale.
+    removing any part of it before the coordinated EXTENSION_API_VERSION bump
+    (removal tracked in #1303) breaks the compatibility contract: a deleted
+    symbol ImportErrors an overlay into a silent ``load_extensions()`` skip,
+    and a dispatch-less accessor silently no-ops a registered overlay.
+    Protocol, default, accessor, and dispatch therefore all stay until that
+    bump removes the seam wholesale.
     """
 
     def get_export_formats(self) -> list[str]: ...

--- a/backend/tests/test_extensions.py
+++ b/backend/tests/test_extensions.py
@@ -214,10 +214,11 @@ class TestProtocolDefaults:
         """fix(#836 / #873 review r1): the AuditExtension seam is deprecated.
 
         Its registry dispatch is gone, but the three public names must stay
-        importable while EXTENSION_API_VERSION == 2 — an overlay built against
-        v2 that imports them would otherwise ImportError into a silent
-        load_extensions() skip. Delete this test with the aliases at the next
-        version bump.
+        importable until the next EXTENSION_API_VERSION bump (removal tracked
+        in #1303) — an overlay built against v2 or any later version that
+        imports them would otherwise ImportError into a silent
+        load_extensions() skip. Delete this test with the aliases at that
+        bump.
         """
         # fix(#873 review r2): import the protocol exactly the way an overlay
         # would — from the package root, at runtime. A TYPE_CHECKING-only


### PR DESCRIPTION
The deprecated AuditExtension seam (#836/#873) promised removal "at the next EXTENSION_API_VERSION bump" while the version was 2. The version is now 4, so the docstrings in the protocol, the accessor, and the compatibility test promise a removal point that already passed — twice — which reads as self-contradictory to anyone auditing the seam.

This re-anchors those three docstrings to the coordinated removal tracked in #1303 instead of a hardcoded version number. Docstring/comment-only: no behavior, no API surface, no test semantics change. The seam itself stays intact per the compatibility contract (removing it mid-version would ImportError overlays into a silent `load_extensions()` skip).

Refs #1303 (stays open — it tracks the actual removal at the bump).

Verification:
- `uv run ruff check` / `ruff format --check` on the touched files: clean
- `uv run pytest tests/test_extensions.py -q`: 27 passed
- `uv run pytest tests/test_layering.py -q`: 40 passed