### PR TITLE
fix(datasets): stop returning raw exception text from bulk delete

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -52,6 +52,7 @@ from app.platform.cache.provider import get_tile_cache
 from app.platform.cache.tiles import invalidate_catalog_cache
 from app.modules.catalog.collections.service import get_dataset_collections
 from app.modules.catalog.datasets.domain.service import (
+    DatasetTitleMismatchError,
     DependentVrtError,
     create_empty_dataset,
     delete_dataset,
@@ -459,7 +460,7 @@ async def bulk_delete_datasets_endpoint(
             deleted += 1
         except Exception as exc:  # broad: per-item bulk-delete is isolated — any failure is recorded per-item without aborting the batch
             await db.rollback()
-            if isinstance(exc, (DependentVrtError, ValueError)):
+            if isinstance(exc, (DependentVrtError, DatasetTitleMismatchError)):
                 detail = str(exc)
             else:
                 logger.exception(

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -459,16 +459,19 @@ async def bulk_delete_datasets_endpoint(
             deleted += 1
         except Exception as exc:  # broad: per-item bulk-delete is isolated — any failure is recorded per-item without aborting the batch
             await db.rollback()
-            if not isinstance(exc, (DependentVrtError, ValueError)):
+            if isinstance(exc, (DependentVrtError, ValueError)):
+                detail = str(exc)
+            else:
                 logger.exception(
                     "Unexpected error during bulk delete",
                     dataset_id=str(item.dataset_id),
                 )
+                detail = "Dataset deletion failed unexpectedly"
             results.append(
                 BulkDeleteResultItem(
                     dataset_id=item.dataset_id,
                     status="error",
-                    detail=str(exc),
+                    detail=detail,
                 )
             )
 

--- a/backend/app/modules/catalog/datasets/domain/service.py
+++ b/backend/app/modules/catalog/datasets/domain/service.py
@@ -41,6 +41,7 @@ from app.modules.catalog.datasets.domain.service_create import (
     create_empty_dataset,
 )
 from app.modules.catalog.datasets.domain.service_lifecycle import (
+    DatasetTitleMismatchError,
     DependentVrtError,
     delete_dataset,
     get_dataset_versions,
@@ -72,6 +73,7 @@ from app.modules.catalog.datasets.domain.service_relationships import (
 )
 
 __all__ = [
+    "DatasetTitleMismatchError",
     "DependentVrtError",
     "auto_detect_relationships",
     "build_preview_sql",

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -24,10 +24,21 @@ logger = structlog.stdlib.get_logger(__name__)
 
 
 __all__ = [
+    "DatasetTitleMismatchError",
     "DependentVrtError",
     "delete_dataset",
     "get_dataset_versions",
 ]
+
+
+class DatasetTitleMismatchError(ValueError):
+    """Raised when confirm_title does not match the dataset's stored title.
+
+    A ValueError subclass so existing broad `except ValueError` callers are
+    unaffected; a distinct type so callers that need to tell this expected,
+    public-safe case apart from other ValueErrors (e.g. a malformed
+    persisted table name) can do so by type rather than by message content.
+    """
 
 
 class DependentVrtError(Exception):
@@ -64,7 +75,7 @@ async def delete_dataset(
         raise ValueError("Dataset not found")
 
     if dataset.record.title != confirm_title:
-        raise ValueError("Dataset title does not match confirmation")
+        raise DatasetTitleMismatchError("Dataset title does not match confirmation")
 
     table_name = dataset.table_name
     if not SAFE_TABLE_NAME_RE.match(table_name):

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -1951,3 +1951,63 @@ class TestBulkDeleteDatasets:
         assert data["deleted"] == 0
         assert data["errors"] == 1
         assert "does not match" in data["results"][0]["detail"]
+
+    async def test_bulk_delete_unexpected_exception_hides_detail(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        monkeypatch,
+    ):
+        """fix(#1297): an unexpected exception's message must never reach the client.
+
+        `DependentVrtError`/`ValueError` messages stay public (asserted by the
+        two tests above); anything else — an asyncpg error, a storage SDK
+        error — must collapse to a fixed string while the full exception still
+        goes to the server log.
+        """
+        import structlog
+
+        from app.modules.catalog.datasets.api import router as datasets_router
+
+        user_id = await _get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session, created_by=user_id, name="Bulk Leak Check"
+        )
+
+        sentinel = (
+            "relation catalog.secret_table failed; "
+            "path=/var/lib/geolens/staging/leak.tif; password=fake-sentinel"
+        )
+
+        async def _boom(db, dataset_id, confirm_title):
+            raise RuntimeError(sentinel)
+
+        monkeypatch.setattr(datasets_router, "delete_dataset", _boom)
+
+        with structlog.testing.capture_logs() as captured:
+            resp = await client.post(
+                "/datasets/bulk-delete/",
+                json={
+                    "datasets": [
+                        {"dataset_id": str(ds.id), "confirm_title": "Bulk Leak Check"},
+                    ]
+                },
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 200
+        assert "secret_table" not in resp.text
+        assert "leak.tif" not in resp.text
+        assert "fake-sentinel" not in resp.text
+
+        data = resp.json()
+        assert data["deleted"] == 0
+        assert data["errors"] == 1
+        assert data["results"][0]["detail"] == "Dataset deletion failed unexpectedly"
+
+        assert any(
+            record.get("event") == "Unexpected error during bulk delete"
+            and record.get("dataset_id") == str(ds.id)
+            for record in captured
+        ), f"expected the exception to be logged server-side; got: {captured}"


### PR DESCRIPTION
## Summary

The bulk-delete endpoint's per-item exception handler in `router.py` already branched on exception type to decide whether to log server-side, but always serialized `str(exc)` into the response `detail` regardless of that branch — so an unexpected exception (asyncpg/SQLAlchemy error, storage SDK error, audit-sink failure) shipped its raw message, including relation names, paths, and potentially credential fragments, to any caller with bulk-delete access. Since the response is a 200 envelope, the central exception sanitizer never sees it.

Fix: branch the `detail` value the same way the logging branch already does. `DependentVrtError` and title-mismatch `ValueError` keep their public messages unchanged; every other exception now returns a fixed `"Dataset deletion failed unexpectedly"` string while the full exception still reaches the server log via the existing `logger.exception(...)` call.

Checked sibling `except Exception` blocks in the same file (quicklook storage fallback) and in `router_export.py` / `router_reupload.py` / `router_vrt.py` — those already use fixed detail strings with server-side logging, so this was the only instance of the leak.

## Test plan

- [x] New regression test `test_bulk_delete_unexpected_exception_hides_detail` in `TestBulkDeleteDatasets`: monkeypatches `delete_dataset` to raise a `RuntimeError` containing a sentinel relation name, object path, and fake credential marker; asserts none of the three appear anywhere in the response body, the item detail equals the fixed string, and the full exception still reaches the server log via `structlog.testing.capture_logs()`.
- [x] Existing `TestBulkDeleteDatasets` tests pass unmodified (`DependentVrtError`/`ValueError` messages unchanged).

```
cd backend && uv run ruff check app tests && uv run ruff format --check app tests
cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_datasets.py -k BulkDelete -v
cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_datasets.py -q
cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q
```

Closes #1297