### PR TITLE
fix(frontend): render stroke-only polygon swatches in legend and layer panel

### DIFF
--- a/frontend/src/components/builder/LayerStyleEditor/utils.ts
+++ b/frontend/src/components/builder/LayerStyleEditor/utils.ts
@@ -124,7 +124,10 @@ export function stylePreviewStyle(layer: MapLayerResponse) {
   const gt = (layer.dataset_geometry_type ?? '').toUpperCase();
   if (gt.includes('POLYGON')) {
     return {
-      outlineColor: typeof paint['_outline-color'] === 'string' ? paint['_outline-color'] as string : undefined,
+      // fix(#1288): builder.outlineColor wins over the flat paint mirror, which
+      // can go stale — the map itself renders from style_config.builder.
+      outlineColor: layer.style_config?.builder?.outlineColor
+        ?? (typeof paint['_outline-color'] === 'string' ? paint['_outline-color'] as string : undefined),
       strokeDisabled: Boolean(layer.style_config?.builder?.strokeDisabled ?? paint['_stroke-disabled']),
       opacity: layer.opacity,
       fillOpacity: typeof paint['fill-opacity'] === 'number' ? paint['fill-opacity'] as number : undefined,

--- a/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
+++ b/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
@@ -30,12 +30,16 @@ function getSwatchStyleFromPaint(
   geometryType: string | null | undefined,
   masterOpacity: number,
   // fix(#914): the builder block carries the fill-pattern tint stash.
-  builder?: { fillColorSaved?: string },
+  // fix(#1288): also carries outlineColor — the map renders from builder state,
+  // so the legend must prefer it over the paint mirror below, which can go stale.
+  builder?: { fillColorSaved?: string; outlineColor?: string },
 ): SwatchStyle {
   const gt = (inferGeometryType(paint, geometryType) ?? '').toUpperCase();
   const strokeDisabled = !!paint?.['_stroke-disabled'];
 
-  const rawOutline = gt.includes('POINT') ? paint?.['circle-stroke-color'] : paint?.['_outline-color'];
+  const rawOutline = gt.includes('POINT')
+    ? paint?.['circle-stroke-color']
+    : (builder?.outlineColor ?? paint?.['_outline-color']);
   const outlineColor = typeof rawOutline === 'string' ? rawOutline : undefined;
 
   const rawStrokeW = gt.includes('POINT') ? paint?.['circle-stroke-width'] : paint?.['_outline-width'];

--- a/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
+++ b/frontend/src/components/map-plugins/builtin/LegendPlugin.tsx
@@ -25,27 +25,35 @@ import { resolveTerrainSourceLayer } from '@/components/builder/map-stack';
 import type { PluginContext } from '../types';
 
 /** Extract swatch style properties from layer paint based on geometry type. */
-function getSwatchStyleFromPaint(
+export function getSwatchStyleFromPaint(
   paint: Record<string, unknown> | undefined,
   geometryType: string | null | undefined,
   masterOpacity: number,
   // fix(#914): the builder block carries the fill-pattern tint stash.
-  // fix(#1288): also carries outlineColor — the map renders from builder state,
-  // so the legend must prefer it over the paint mirror below, which can go stale.
-  builder?: { fillColorSaved?: string; outlineColor?: string },
+  // fix(#1288): also carries outlineColor/strokeDisabled/outlineWidth — the map
+  // renders from builder state, so the legend must prefer it over the paint
+  // mirror below, which can go stale (toggling a stroke off leaves paint's
+  // _stroke-disabled/_outline-width unchanged).
+  builder?: { fillColorSaved?: string; outlineColor?: string; strokeDisabled?: boolean; outlineWidth?: number },
 ): SwatchStyle {
   const gt = (inferGeometryType(paint, geometryType) ?? '').toUpperCase();
-  const strokeDisabled = !!paint?.['_stroke-disabled'];
+  const isPoint = gt.includes('POINT');
 
-  const rawOutline = gt.includes('POINT')
+  const rawStrokeW = isPoint ? paint?.['circle-stroke-width'] : (builder?.outlineWidth ?? paint?.['_outline-width']);
+  const strokeWidth = typeof rawStrokeW === 'number' ? rawStrokeW : undefined;
+
+  // fix(#1288 codex): an explicit zero-width outline draws nothing on the map,
+  // same "treat explicit zero as disabled" precedence as extractStyleHints.
+  const strokeDisabled = isPoint
+    ? !!paint?.['_stroke-disabled']
+    : Boolean(builder?.strokeDisabled ?? paint?.['_stroke-disabled']) || strokeWidth === 0;
+
+  const rawOutline = isPoint
     ? paint?.['circle-stroke-color']
     : (builder?.outlineColor ?? paint?.['_outline-color']);
   const outlineColor = typeof rawOutline === 'string' ? rawOutline : undefined;
 
-  const rawStrokeW = gt.includes('POINT') ? paint?.['circle-stroke-width'] : paint?.['_outline-width'];
-  const strokeWidth = typeof rawStrokeW === 'number' ? rawStrokeW : undefined;
-
-  const rawFillOp = gt.includes('POINT')
+  const rawFillOp = isPoint
     ? paint?.['circle-opacity']
     : gt.includes('LINE')
       ? paint?.['line-opacity']

--- a/frontend/src/components/map-plugins/builtin/__tests__/LegendPlugin.test.ts
+++ b/frontend/src/components/map-plugins/builtin/__tests__/LegendPlugin.test.ts
@@ -1,4 +1,4 @@
-import { expressionColumn, displayColumn } from '../LegendPlugin';
+import { expressionColumn, displayColumn, getSwatchStyleFromPaint } from '../LegendPlugin';
 
 // Pure-logic coverage for the legend plugin's expression/column helpers. The
 // full legend render needs MapLibre paint objects; these helpers are the parts
@@ -39,5 +39,45 @@ describe('displayColumn', () => {
 
   it('expands the mhi token to income', () => {
     expect(displayColumn('_median_mhi')).toBe('median income');
+  });
+});
+
+// fix(#1288 codex): a stroke the user turned off through the builder can leave
+// paint's _stroke-disabled/_outline-width unchanged (toggling a polygon stroke
+// off writes both builder.strokeDisabled and builder.outlineWidth: 0, not the
+// paint mirror) — the categorical/graduated legend swatch must prefer builder
+// state, same as extractStyleHints on the layer-icon path.
+describe('getSwatchStyleFromPaint — builder stroke precedence (fix #1288)', () => {
+  it('prefers builder.strokeDisabled over a stale paint mirror', () => {
+    const style = getSwatchStyleFromPaint(
+      { 'fill-opacity': 0, '_outline-color': '#ec4b7f' },
+      'POLYGON',
+      1,
+      { strokeDisabled: true, outlineColor: '#ec4b7f' },
+    );
+    expect(style.strokeDisabled).toBe(true);
+  });
+
+  it('treats an explicit builder.outlineWidth of 0 as a disabled stroke', () => {
+    const style = getSwatchStyleFromPaint(
+      { 'fill-opacity': 0, '_outline-color': '#ec4b7f', '_outline-width': 2 },
+      'POLYGON',
+      1,
+      { outlineWidth: 0, outlineColor: '#ec4b7f' },
+    );
+    expect(style.strokeDisabled).toBe(true);
+    expect(style.strokeWidth).toBe(0);
+  });
+
+  it('leaves a normal visible outline unchanged', () => {
+    const style = getSwatchStyleFromPaint(
+      { 'fill-opacity': 0.5, '_outline-color': '#ec4b7f', '_outline-width': 2 },
+      'POLYGON',
+      1,
+      undefined,
+    );
+    expect(style.strokeDisabled).toBe(false);
+    expect(style.outlineColor).toBe('#ec4b7f');
+    expect(style.strokeWidth).toBe(2);
   });
 });

--- a/frontend/src/components/map/LegendEntries.tsx
+++ b/frontend/src/components/map/LegendEntries.tsx
@@ -24,10 +24,26 @@ export interface SwatchStyle {
   fillPatternColor?: string;
 }
 
-/** Compute compound opacity style from swatch style. */
+/**
+ * Compute element-level opacity style from swatch style — LAYER opacity only.
+ * fix(#1288): fillOpacity used to be folded in here and applied to the whole
+ * swatch, so a stroke-only style (fill-opacity: 0) hid its own outline along
+ * with the fill. fillOpacity is now applied per-element (SVG fill-opacity /
+ * stroke-opacity, or an alpha-blended background) by each renderer below.
+ */
 function swatchOpacityStyle(s?: SwatchStyle): React.CSSProperties | undefined {
-  const compoundOpacity = (s?.opacity ?? 1) * (s?.fillOpacity ?? 1);
-  return compoundOpacity < 1 ? { opacity: compoundOpacity } : undefined;
+  const opacity = s?.opacity ?? 1;
+  return opacity < 1 ? { opacity } : undefined;
+}
+
+/** Blend fillOpacity into a hex color for a CSS background, so a transparent
+ * fill can sit inside a fully opaque border. Non-hex colors pass through. */
+function withFillOpacity(color: string, fillOpacity?: number): string {
+  if (fillOpacity === undefined) return color;
+  const m = color.match(/^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i);
+  if (!m) return color;
+  const [r, g, b] = [m[1], m[2], m[3]].map((h) => parseInt(h, 16));
+  return `rgba(${r}, ${g}, ${b}, ${fillOpacity})`;
 }
 
 /* ── Geometry-aware swatch ─────────────────────────── */
@@ -49,6 +65,7 @@ export function GeometrySwatch({ geometryType, color, style: s }: GeometrySwatch
         <circle
           cx="7" cy="7" r="5"
           fill={color}
+          fillOpacity={s?.fillOpacity}
           stroke={s?.outlineColor ?? MAP_COLORS.legendOutline}
           strokeWidth={s?.strokeDisabled ? 0 : (s?.strokeWidth ?? 1)}
         />
@@ -63,6 +80,7 @@ export function GeometrySwatch({ geometryType, color, style: s }: GeometrySwatch
         <line
           x1="1" y1="7" x2="13" y2="7"
           stroke={color}
+          strokeOpacity={s?.fillOpacity}
           strokeWidth={2.5}
           strokeLinecap="round"
         />
@@ -81,7 +99,10 @@ export function GeometrySwatch({ geometryType, color, style: s }: GeometrySwatch
           backgroundColor: 'transparent',
           ...patternPreviewStyle(s.fillPattern),
         }
-      : { backgroundColor: color }),
+      // fix(#1288): alpha-blend fillOpacity into the fill itself — a stroke-only
+      // style (fillOpacity: 0) then renders a transparent fill inside a fully
+      // opaque border, instead of an invisible swatch.
+      : { backgroundColor: withFillOpacity(color, s?.fillOpacity) }),
     ...(borderColor ? { borderColor } : {}),
     ...(s?.strokeWidth ? { borderWidth: s.strokeWidth } : {}),
     ...opacityStyle,
@@ -160,6 +181,7 @@ export const GraduatedRadiusLegend = memo(function GraduatedRadiusLegend({ sizes
               cx="12" cy="12"
               r={Math.min(size, 12)}
               fill={safeColors?.[Math.min(i, safeColors.length - 1)] ?? circleColor}
+              fillOpacity={s?.fillOpacity}
               stroke={s?.outlineColor ?? MAP_COLORS.legendOutline}
               strokeWidth={s?.strokeDisabled ? 0 : (s?.strokeWidth ?? 1)}
             />
@@ -187,7 +209,7 @@ export const GraduatedWidthLegend = memo(function GraduatedWidthLegend({ sizes, 
       {sizes.map((size, i) => (
         <li key={i} className="flex items-center gap-1.5">
           <svg width="24" height="16" className="shrink-0" style={opacityStyle}>
-            <line x1="0" y1="8" x2="24" y2="8" stroke={lineColor} strokeWidth={Math.min(size, 8)} strokeLinecap="round" />
+            <line x1="0" y1="8" x2="24" y2="8" stroke={lineColor} strokeOpacity={s?.fillOpacity} strokeWidth={Math.min(size, 8)} strokeLinecap="round" />
           </svg>
           <span className="text-muted-foreground truncate">{breakLabel(i, breaks)}</span>
         </li>

--- a/frontend/src/components/map/LegendEntries.tsx
+++ b/frontend/src/components/map/LegendEntries.tsx
@@ -102,7 +102,10 @@ export function GeometrySwatch({ geometryType, color, style: s }: GeometrySwatch
       className={cn('relative w-3.5 h-3.5 rounded-sm shrink-0 overflow-hidden', !s?.strokeDisabled && 'border')}
       style={{
         ...(borderColor ? { borderColor } : {}),
-        ...(s?.strokeWidth ? { borderWidth: s.strokeWidth } : {}),
+        // fix(#1288 codex): a truthy check drops an EXPLICIT strokeWidth of 0,
+        // falling back to the default 1px border — the map draws no outline at
+        // width 0, so the swatch must not either.
+        ...(s?.strokeWidth !== undefined ? { borderWidth: s.strokeWidth } : {}),
         ...opacityStyle,
       }}
       aria-hidden="true"

--- a/frontend/src/components/map/LegendEntries.tsx
+++ b/frontend/src/components/map/LegendEntries.tsx
@@ -36,16 +36,6 @@ function swatchOpacityStyle(s?: SwatchStyle): React.CSSProperties | undefined {
   return opacity < 1 ? { opacity } : undefined;
 }
 
-/** Blend fillOpacity into a hex color for a CSS background, so a transparent
- * fill can sit inside a fully opaque border. Non-hex colors pass through. */
-function withFillOpacity(color: string, fillOpacity?: number): string {
-  if (fillOpacity === undefined) return color;
-  const m = color.match(/^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i);
-  if (!m) return color;
-  const [r, g, b] = [m[1], m[2], m[3]].map((h) => parseInt(h, 16));
-  return `rgba(${r}, ${g}, ${b}, ${fillOpacity})`;
-}
-
 /* ── Geometry-aware swatch ─────────────────────────── */
 
 interface GeometrySwatchProps {
@@ -92,27 +82,33 @@ export function GeometrySwatch({ geometryType, color, style: s }: GeometrySwatch
   // carries a fill-pattern, since MapLibre draws the pattern INSTEAD of the fill
   // (fix(#951): the chip used to show a solid block that appeared nowhere on the map).
   const borderColor = !s?.strokeDisabled ? (s?.outlineColor ?? MAP_COLORS.legendOutline) : undefined;
-  const style: React.CSSProperties = {
-    ...(s?.fillPattern
-      ? {
-          color: s.fillPatternColor ?? color,
-          backgroundColor: 'transparent',
-          ...patternPreviewStyle(s.fillPattern),
-        }
-      // fix(#1288): alpha-blend fillOpacity into the fill itself — a stroke-only
-      // style (fillOpacity: 0) then renders a transparent fill inside a fully
-      // opaque border, instead of an invisible swatch.
-      : { backgroundColor: withFillOpacity(color, s?.fillOpacity) }),
-    ...(borderColor ? { borderColor } : {}),
-    ...(s?.strokeWidth ? { borderWidth: s.strokeWidth } : {}),
-    ...opacityStyle,
-  };
+  const fillStyle: React.CSSProperties = s?.fillPattern
+    ? {
+        color: s.fillPatternColor ?? color,
+        backgroundColor: 'transparent',
+        ...patternPreviewStyle(s.fillPattern),
+      }
+    : { backgroundColor: color };
+  // fix(#1288 codex): fillOpacity dims the fill LAYER only, rendered as a
+  // nested element behind the border. Plain CSS opacity works for every CSS
+  // color format (hex3/4/6/8, rgb()/hsl(), named colors) with no parsing, and
+  // never touches the border, which must stay fully opaque for a stroke-only
+  // style (fillOpacity 0) to remain visible.
+  if (s?.fillOpacity !== undefined && s.fillOpacity < 1) {
+    fillStyle.opacity = s.fillOpacity;
+  }
   return (
     <div
-      className={cn('w-3.5 h-3.5 rounded-sm shrink-0', !s?.strokeDisabled && 'border')}
-      style={style}
+      className={cn('relative w-3.5 h-3.5 rounded-sm shrink-0 overflow-hidden', !s?.strokeDisabled && 'border')}
+      style={{
+        ...(borderColor ? { borderColor } : {}),
+        ...(s?.strokeWidth ? { borderWidth: s.strokeWidth } : {}),
+        ...opacityStyle,
+      }}
       aria-hidden="true"
-    />
+    >
+      <div className="absolute inset-0" style={fillStyle} />
+    </div>
   );
 }
 

--- a/frontend/src/components/map/__tests__/LegendEntries.test.tsx
+++ b/frontend/src/components/map/__tests__/LegendEntries.test.tsx
@@ -150,4 +150,19 @@ describe('GeometrySwatch — stroke-only polygons (fix #1288)', () => {
     const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
     expect(swatch.style.opacity).toBe('0.5');
   });
+
+  // fix(#1288 codex): a truthy check on strokeWidth dropped an EXPLICIT 0,
+  // falling back to the default 1px border even though the map draws no
+  // outline at width 0.
+  it('honors an explicit zero-width outline as no border', () => {
+    const { container } = render(
+      <CategoricalLegend
+        geometryType="Polygon"
+        categories={[{ value: 'a', label: 'A', color: '#3b82f6' }]}
+        style={{ strokeWidth: 0, outlineColor: '#ec4b7f' }}
+      />,
+    );
+    const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(swatch.style.borderWidth).toBe('0px');
+  });
 });

--- a/frontend/src/components/map/__tests__/LegendEntries.test.tsx
+++ b/frontend/src/components/map/__tests__/LegendEntries.test.tsx
@@ -23,6 +23,9 @@ describe('CategoricalLegend', () => {
 
 // fix(#951): MapLibre draws a fill-pattern INSTEAD of the fill, so a solid chip
 // described a colour that appeared nowhere on the map.
+// fix(#1288 codex): the fill/pattern now lives on a nested div, split from the
+// border, so fillOpacity can dim one without the other — assertions below read
+// the inner div for fill/pattern styling and the outer for border/opacity.
 describe('GeometrySwatch — patterned polygons', () => {
   it('draws the pattern preview, in the class colour, instead of a solid block', () => {
     const { container } = render(
@@ -33,9 +36,10 @@ describe('GeometrySwatch — patterned polygons', () => {
       />,
     );
     const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
-    expect(swatch.style.backgroundImage).toContain('repeating-linear-gradient');
-    expect(swatch.style.backgroundColor).toBe('transparent');
-    expect(swatch.style.color).toBe('rgb(255, 90, 95)');
+    const fill = swatch.firstElementChild as HTMLElement;
+    expect(fill.style.backgroundImage).toContain('repeating-linear-gradient');
+    expect(fill.style.backgroundColor).toBe('transparent');
+    expect(fill.style.color).toBe('rgb(255, 90, 95)');
   });
 
   // fix(#914): the map tints the pattern with the layer's fill colour, which for a
@@ -50,7 +54,8 @@ describe('GeometrySwatch — patterned polygons', () => {
       />,
     );
     const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
-    expect(swatch.style.color).toBe('rgb(29, 78, 216)');
+    const fill = swatch.firstElementChild as HTMLElement;
+    expect(fill.style.color).toBe('rgb(29, 78, 216)');
   });
 
   it('leaves unpatterned polygons on the solid chip', () => {
@@ -61,8 +66,27 @@ describe('GeometrySwatch — patterned polygons', () => {
       />,
     );
     const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
-    expect(swatch.style.backgroundImage).toBe('');
-    expect(swatch.style.backgroundColor).toBe('rgb(255, 90, 95)');
+    const fill = swatch.firstElementChild as HTMLElement;
+    expect(fill.style.backgroundImage).toBe('');
+    expect(fill.style.backgroundColor).toBe('rgb(255, 90, 95)');
+  });
+
+  // fix(#1288 codex): a partially-transparent pattern must dim independently of
+  // the border, and for ANY color format — not just 6-digit hex — since opacity
+  // is applied via plain CSS opacity on the fill layer, not string parsing.
+  it('applies fillOpacity to the pattern layer only, not the border', () => {
+    const { container } = render(
+      <CategoricalLegend
+        geometryType="Polygon"
+        categories={[{ value: 'a', label: 'A', color: 'rgb(255, 90, 95)' }]}
+        style={{ fillPattern: 'geolens-fill-hatch', fillOpacity: 0, outlineColor: '#ec4b7f' }}
+      />,
+    );
+    const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    const fill = swatch.firstElementChild as HTMLElement;
+    expect(swatch.style.opacity).toBe('');
+    expect(swatch.style.borderColor).toBe('rgb(236, 75, 127)');
+    expect(fill.style.opacity).toBe('0');
   });
 });
 
@@ -78,9 +102,28 @@ describe('GeometrySwatch — stroke-only polygons (fix #1288)', () => {
       />,
     );
     const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    const fill = swatch.firstElementChild as HTMLElement;
     expect(swatch.style.opacity).toBe('');
-    expect(swatch.style.backgroundColor).toBe('rgba(59, 130, 246, 0)');
     expect(swatch.style.borderColor).toBe('rgb(236, 75, 127)');
+    expect(fill.style.backgroundColor).toBe('rgb(59, 130, 246)');
+    expect(fill.style.opacity).toBe('0');
+  });
+
+  // fix(#1288 codex): #f00 (3-digit hex) is a valid CSS color the alpha-blend
+  // helper used to silently ignore — plain opacity on the fill layer handles it
+  // (and every other CSS color syntax) with no format-specific parsing.
+  it('dims a fill given in a non-6-digit-hex color format', () => {
+    const { container } = render(
+      <CategoricalLegend
+        geometryType="Polygon"
+        categories={[{ value: 'a', label: 'A', color: '#f00' }]}
+        style={{ fillOpacity: 0.3 }}
+      />,
+    );
+    const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    const fill = swatch.firstElementChild as HTMLElement;
+    expect(fill.style.backgroundColor).toBe('rgb(255, 0, 0)');
+    expect(fill.style.opacity).toBe('0.3');
   });
 
   it('leaves a normal fill unchanged', () => {
@@ -91,7 +134,9 @@ describe('GeometrySwatch — stroke-only polygons (fix #1288)', () => {
       />,
     );
     const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
-    expect(swatch.style.backgroundColor).toBe('rgb(59, 130, 246)');
+    const fill = swatch.firstElementChild as HTMLElement;
+    expect(fill.style.backgroundColor).toBe('rgb(59, 130, 246)');
+    expect(fill.style.opacity).toBe('');
   });
 
   it('still applies layer-level opacity to the whole swatch', () => {

--- a/frontend/src/components/map/__tests__/LegendEntries.test.tsx
+++ b/frontend/src/components/map/__tests__/LegendEntries.test.tsx
@@ -65,3 +65,44 @@ describe('GeometrySwatch — patterned polygons', () => {
     expect(swatch.style.backgroundColor).toBe('rgb(255, 90, 95)');
   });
 });
+
+// fix(#1288): a stroke-only polygon (fillOpacity: 0) used to render at
+// container-level opacity 0 — invisible, even though it has a visible outline.
+describe('GeometrySwatch — stroke-only polygons (fix #1288)', () => {
+  it('renders a transparent fill inside a fully opaque border', () => {
+    const { container } = render(
+      <CategoricalLegend
+        geometryType="Polygon"
+        categories={[{ value: 'a', label: 'A', color: '#3b82f6' }]}
+        style={{ fillOpacity: 0, outlineColor: '#ec4b7f' }}
+      />,
+    );
+    const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(swatch.style.opacity).toBe('');
+    expect(swatch.style.backgroundColor).toBe('rgba(59, 130, 246, 0)');
+    expect(swatch.style.borderColor).toBe('rgb(236, 75, 127)');
+  });
+
+  it('leaves a normal fill unchanged', () => {
+    const { container } = render(
+      <CategoricalLegend
+        geometryType="Polygon"
+        categories={[{ value: 'a', label: 'A', color: '#3b82f6' }]}
+      />,
+    );
+    const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(swatch.style.backgroundColor).toBe('rgb(59, 130, 246)');
+  });
+
+  it('still applies layer-level opacity to the whole swatch', () => {
+    const { container } = render(
+      <CategoricalLegend
+        geometryType="Polygon"
+        categories={[{ value: 'a', label: 'A', color: '#3b82f6' }]}
+        style={{ opacity: 0.5 }}
+      />,
+    );
+    const swatch = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(swatch.style.opacity).toBe('0.5');
+  });
+});

--- a/frontend/src/components/map/__tests__/layer-icons.test.tsx
+++ b/frontend/src/components/map/__tests__/layer-icons.test.tsx
@@ -179,7 +179,9 @@ describe('patterned polygon swatch (fix #951)', () => {
       />,
     );
     expect(container.querySelector('.lucide-pentagon')).toBeNull();
-    const chip = container.firstElementChild as HTMLElement;
+    // fix(#1288 codex): the pattern now lives on a nested span so its opacity
+    // can be dimmed independently of the border — assert on that inner span.
+    const chip = container.firstElementChild!.firstElementChild as HTMLElement;
     expect(chip.style.backgroundImage).toContain('radial-gradient');
     expect(chip.style.color).toBe('rgb(255, 90, 95)');
   });
@@ -194,7 +196,26 @@ describe('patterned polygon swatch (fix #951)', () => {
         styleHints={{ fillPattern: 'geolens-fill-dots', fillPatternColor: '#1d4ed8' }}
       />,
     );
-    expect((container.firstElementChild as HTMLElement).style.color).toBe('rgb(29, 78, 216)');
+    const chip = container.firstElementChild!.firstElementChild as HTMLElement;
+    expect(chip.style.color).toBe('rgb(29, 78, 216)');
+  });
+
+  // fix(#1288 codex): a partially-transparent patterned fill (fillOpacity < 1)
+  // must dim the pattern pixels without touching the border.
+  it('applies fillOpacity to the pattern layer only, not the border', () => {
+    const { container } = render(
+      <ColorizedGeometryIcon
+        geometryType="POLYGON"
+        colors={['#ff5a5f']}
+        layerId="x"
+        styleHints={{ fillPattern: 'geolens-fill-dots', fillOpacity: 0, strokeColor: '#ec4b7f' }}
+      />,
+    );
+    const outer = container.firstElementChild as HTMLElement;
+    const inner = outer.firstElementChild as HTMLElement;
+    expect(outer.style.opacity).toBe('');
+    expect(outer.style.borderColor).toBe('rgb(236, 75, 127)');
+    expect(inner.style.opacity).toBe('0');
   });
 
   it('extractStyleHints resolves the tint from the fillColorSaved stash', () => {

--- a/frontend/src/components/map/__tests__/layer-icons.test.tsx
+++ b/frontend/src/components/map/__tests__/layer-icons.test.tsx
@@ -340,4 +340,19 @@ describe('stroke-only polygon swatch (fix #1288)', () => {
     expect(hints.strokeColor).toBe('#ec4b7f');
     expect(hints.fillOpacity).toBe(0);
   });
+
+  // fix(#1288 codex): with fill-opacity now revealing the outline instead of
+  // hiding the whole swatch, a stroke the user turned off via the builder (which
+  // can leave a stale/absent paint['_stroke-disabled']) must not draw as visible.
+  it('extractStyleHints prefers builder.strokeDisabled over a stale paint mirror', () => {
+    const hints = extractStyleHints(
+      { 'fill-opacity': 0, '_outline-color': '#ec4b7f' },
+      {},
+      'POLYGON',
+      1,
+      { builder: { strokeDisabled: true, outlineColor: '#ec4b7f' } },
+    );
+    expect(hints.strokeDisabled).toBe(true);
+    expect(hints.strokeColor).toBeUndefined();
+  });
 });

--- a/frontend/src/components/map/__tests__/layer-icons.test.tsx
+++ b/frontend/src/components/map/__tests__/layer-icons.test.tsx
@@ -261,3 +261,62 @@ describe('patterned polygon swatch (fix #951)', () => {
     expect(container.querySelector('.lucide-pentagon')).not.toBeNull();
   });
 });
+
+// fix(#1288): a stroke-only polygon (fill-opacity: 0, visible outline) used to
+// render an invisible swatch — element-level opacity hid the outline along with
+// the fill it was meant to suppress. fillOpacity now lands on the SVG fill only.
+describe('stroke-only polygon swatch (fix #1288)', () => {
+  it('renders a visible outline when fill-opacity is 0', () => {
+    const { container } = render(
+      <ColorizedGeometryIcon
+        geometryType="POLYGON"
+        colors={['#3b82f6']}
+        layerId="x"
+        styleHints={{ fillOpacity: 0, strokeColor: '#ec4b7f' }}
+      />,
+    );
+    const span = container.firstElementChild as HTMLElement;
+    expect(span.style.opacity).toBe('');
+    const icon = container.querySelector('.lucide-pentagon') as SVGElement;
+    expect(icon.getAttribute('fill-opacity')).toBe('0');
+    expect(icon.getAttribute('stroke')).toBe('#ec4b7f');
+  });
+
+  it('leaves a normal filled polygon unchanged', () => {
+    const { container } = render(
+      <ColorizedGeometryIcon geometryType="POLYGON" colors={['#3b82f6']} layerId="x" />,
+    );
+    const span = container.firstElementChild as HTMLElement;
+    expect(span.style.opacity).toBe('');
+    const icon = container.querySelector('.lucide-pentagon') as SVGElement;
+    expect(icon.getAttribute('fill')).toBe('#3b82f6');
+    expect(icon.getAttribute('fill-opacity')).toBeNull();
+  });
+
+  it('still applies layer-level opacity to the whole swatch', () => {
+    const { container } = render(
+      <ColorizedGeometryIcon
+        geometryType="POLYGON"
+        colors={['#3b82f6']}
+        layerId="x"
+        styleHints={{ opacity: 0.4 }}
+      />,
+    );
+    const span = container.firstElementChild as HTMLElement;
+    expect(span.style.opacity).toBe('0.4');
+  });
+
+  it('extractStyleHints prefers builder.outlineColor over a stale paint mirror', () => {
+    // The renderer draws from style_config.builder, so a swatch reading only the
+    // flat paint mirror can show a color the map no longer draws.
+    const hints = extractStyleHints(
+      { 'fill-opacity': 0, '_outline-color': '#0058ac' },
+      {},
+      'POLYGON',
+      1,
+      { builder: { outlineColor: '#ec4b7f' } },
+    );
+    expect(hints.strokeColor).toBe('#ec4b7f');
+    expect(hints.fillOpacity).toBe(0);
+  });
+});

--- a/frontend/src/components/map/__tests__/layer-icons.test.tsx
+++ b/frontend/src/components/map/__tests__/layer-icons.test.tsx
@@ -393,4 +393,21 @@ describe('stroke-only polygon swatch (fix #1288)', () => {
     expect(hints.strokeDisabled).toBe(true);
     expect(hints.strokeColor).toBeUndefined();
   });
+
+  // fix(#1288 codex): circle-adapter.ts (the real point renderer) applies
+  // circle paint properties directly and never reads style_config.builder — a
+  // stale builder.strokeDisabled left over from before an Advanced JSON/API
+  // edit restored a real circle-stroke-width must not suppress a stroke the
+  // map still draws. Builder precedence is polygon-only.
+  it('extractStyleHints ignores builder.strokeDisabled for points with a real stroke width', () => {
+    const hints = extractStyleHints(
+      { 'circle-opacity': 1, 'circle-stroke-color': '#ec4b7f', 'circle-stroke-width': 3 },
+      {},
+      'POINT',
+      1,
+      { builder: { strokeDisabled: true } },
+    );
+    expect(hints.strokeDisabled).toBeUndefined();
+    expect(hints.strokeColor).toBe('#ec4b7f');
+  });
 });

--- a/frontend/src/components/map/__tests__/layer-icons.test.tsx
+++ b/frontend/src/components/map/__tests__/layer-icons.test.tsx
@@ -380,4 +380,17 @@ describe('stroke-only polygon swatch (fix #1288)', () => {
     expect(hints.strokeDisabled).toBe(true);
     expect(hints.strokeColor).toBeUndefined();
   });
+
+  // fix(#1288 codex): a retained circle-stroke-color with an explicit
+  // circle-stroke-width of 0 draws nothing on the map — the point swatch must
+  // not draw ShapeIcon's fixed-width stroke for it regardless.
+  it('extractStyleHints treats an explicit zero circle stroke width as a disabled stroke', () => {
+    const hints = extractStyleHints(
+      { 'circle-opacity': 0, 'circle-stroke-color': '#ec4b7f', 'circle-stroke-width': 0 },
+      {},
+      'POINT',
+    );
+    expect(hints.strokeDisabled).toBe(true);
+    expect(hints.strokeColor).toBeUndefined();
+  });
 });

--- a/frontend/src/components/map/__tests__/layer-icons.test.tsx
+++ b/frontend/src/components/map/__tests__/layer-icons.test.tsx
@@ -355,4 +355,29 @@ describe('stroke-only polygon swatch (fix #1288)', () => {
     expect(hints.strokeDisabled).toBe(true);
     expect(hints.strokeColor).toBeUndefined();
   });
+
+  // fix(#1288 codex): an explicit outline width of 0 draws nothing on the map
+  // (distinct from strokeDisabled, which is a separate private flag) — the
+  // swatch must not draw ShapeIcon's fixed-width outline for it regardless.
+  it('extractStyleHints treats an explicit zero outline width as a disabled stroke', () => {
+    const hints = extractStyleHints(
+      { 'fill-opacity': 0, '_outline-color': '#ec4b7f', '_outline-width': 0 },
+      {},
+      'POLYGON',
+    );
+    expect(hints.strokeDisabled).toBe(true);
+    expect(hints.strokeColor).toBeUndefined();
+  });
+
+  it('extractStyleHints prefers builder.outlineWidth over a stale paint mirror', () => {
+    const hints = extractStyleHints(
+      { 'fill-opacity': 0, '_outline-color': '#ec4b7f', '_outline-width': 2 },
+      {},
+      'POLYGON',
+      1,
+      { builder: { outlineWidth: 0, outlineColor: '#ec4b7f' } },
+    );
+    expect(hints.strokeDisabled).toBe(true);
+    expect(hints.strokeColor).toBeUndefined();
+  });
 });

--- a/frontend/src/components/map/layer-icons.tsx
+++ b/frontend/src/components/map/layer-icons.tsx
@@ -43,7 +43,7 @@ export function extractStyleHints(
   // before its last edit).
   styleConfig?: {
     render_mode?: string;
-    builder?: { fillColorSaved?: string; outlineColor?: string; strokeDisabled?: boolean };
+    builder?: { fillColorSaved?: string; outlineColor?: string; strokeDisabled?: boolean; outlineWidth?: number };
   } | null,
 ): StyleHints {
   const gt = (geometryType ?? '').toUpperCase();
@@ -75,7 +75,16 @@ export function extractStyleHints(
     const lo = paint['line-opacity'];
     if (typeof lo === 'number' && lo < 1) hints.fillOpacity = lo;
   } else if (gt.includes('POLYGON')) {
-    if (!strokeDisabled) {
+    // fix(#1288 codex): an explicit zero-width outline draws nothing on the
+    // map — builder.outlineWidth wins over the paint mirror, same precedence
+    // as outlineColor/strokeDisabled — so treat it as a disabled stroke
+    // instead of drawing ShapeIcon's fixed-width outline for a layer that
+    // renders none.
+    const ow = styleConfig?.builder?.outlineWidth ?? paint['_outline-width'];
+    const outlineDisabled = strokeDisabled || (typeof ow === 'number' && ow === 0);
+    if (outlineDisabled) {
+      hints.strokeDisabled = true;
+    } else {
       // fix(#1288): builder.outlineColor wins over the flat paint mirror.
       const oc = styleConfig?.builder?.outlineColor ?? paint['_outline-color'];
       if (typeof oc === 'string') hints.strokeColor = oc;

--- a/frontend/src/components/map/layer-icons.tsx
+++ b/frontend/src/components/map/layer-icons.tsx
@@ -37,7 +37,10 @@ export function extractStyleHints(
   geometryType: string | null,
   opacity?: number,
   // fix(#914): `builder` is read for the fill-pattern tint stash.
-  styleConfig?: { render_mode?: string; builder?: { fillColorSaved?: string } } | null,
+  // fix(#1288): also read for outlineColor — the renderer draws from builder
+  // state, so the swatch must prefer it over the paint mirror below, which can
+  // go stale (paint keeps the color a layer had before its last outline edit).
+  styleConfig?: { render_mode?: string; builder?: { fillColorSaved?: string; outlineColor?: string } } | null,
 ): StyleHints {
   const gt = (geometryType ?? '').toUpperCase();
   const hints: StyleHints = {};
@@ -65,7 +68,8 @@ export function extractStyleHints(
     if (typeof lo === 'number' && lo < 1) hints.fillOpacity = lo;
   } else if (gt.includes('POLYGON')) {
     if (!paint['_stroke-disabled']) {
-      const oc = paint['_outline-color'];
+      // fix(#1288): builder.outlineColor wins over the flat paint mirror.
+      const oc = styleConfig?.builder?.outlineColor ?? paint['_outline-color'];
       if (typeof oc === 'string') hints.strokeColor = oc;
     }
     const fo = paint['fill-opacity'];
@@ -175,7 +179,7 @@ function LineIcon({ colors, layerId, opacityStyle, styleHints, discrete }: IconS
             </linearGradient>
           </defs>
         )}
-        <line x1="1" y1="7" x2="13" y2="7" stroke={strokeColor} strokeWidth={svgStrokeWidth} strokeLinecap="round" strokeDasharray={dashArray} />
+        <line x1="1" y1="7" x2="13" y2="7" stroke={strokeColor} strokeOpacity={styleHints?.fillOpacity} strokeWidth={svgStrokeWidth} strokeLinecap="round" strokeDasharray={dashArray} />
       </svg>
     </span>
   );
@@ -218,7 +222,9 @@ function ShapeIcon({ colors, layerId, opacityStyle, styleHints, isPoint, discret
         : { strokeWidth: 0 };
     return (
       <span style={opacityStyle} className="inline-flex">
-        <Icon className={sizeClass} fill={color} {...stroke} />
+        {/* fix(#1288): fillOpacity on the SVG fill, not the span — a stroke-only
+            style (fill-opacity: 0) must leave the outline (stroke above) visible. */}
+        <Icon className={sizeClass} fill={color} fillOpacity={styleHints?.fillOpacity} {...stroke} />
       </span>
     );
   }
@@ -240,7 +246,7 @@ function ShapeIcon({ colors, layerId, opacityStyle, styleHints, isPoint, discret
             </linearGradient>
           </defs>
         </svg>
-        <Icon className={sizeClass} fill={`url(#${gradientId})`} {...stroke} />
+        <Icon className={sizeClass} fill={`url(#${gradientId})`} fillOpacity={styleHints?.fillOpacity} {...stroke} />
       </span>
     </span>
   );
@@ -266,8 +272,12 @@ export function ColorizedGeometryIcon({
   if (layerType === 'raster') return <Grid3x3 className="h-3.5 w-3.5 text-muted-foreground" />;
 
   const gt = (geometryType ?? '').toUpperCase();
-  const compoundOpacity = (styleHints?.opacity ?? 1) * (styleHints?.fillOpacity ?? 1);
-  const opacityStyle: React.CSSProperties | undefined = compoundOpacity < 1 ? { opacity: compoundOpacity } : undefined;
+  // fix(#1288): element-level opacity is for the LAYER opacity only. fillOpacity
+  // (paint's fill-/circle-/line-opacity) is a per-element hint the sub-icons
+  // apply to the specific SVG attribute (fill-opacity or stroke-opacity) so a
+  // stroke-only style (fill-opacity: 0) doesn't hide the outline it's drawn with.
+  const layerOpacity = styleHints?.opacity ?? 1;
+  const opacityStyle: React.CSSProperties | undefined = layerOpacity < 1 ? { opacity: layerOpacity } : undefined;
   const sub: IconSubProps = { colors, layerId, opacityStyle, styleHints, discrete };
 
   if (styleHints?.isHeatmap && colors.length > 1) return <HeatmapIcon {...sub} />;

--- a/frontend/src/components/map/layer-icons.tsx
+++ b/frontend/src/components/map/layer-icons.tsx
@@ -102,7 +102,15 @@ export function extractStyleHints(
   hints.fillPatternColor = fillPatternTint(paint, styleConfig?.builder);
 
   if (gt.includes('POINT')) {
-    if (!strokeDisabled) {
+    // fix(#1288 codex): an explicit circle-stroke-width of 0 draws nothing on
+    // the map (no builder mirror exists for it, unlike the polygon outline
+    // width, so this reads paint directly) — treat it as a disabled stroke,
+    // same as the polygon outline-width fix above.
+    const csw = paint['circle-stroke-width'];
+    const pointStrokeDisabled = strokeDisabled || (typeof csw === 'number' && csw === 0);
+    if (pointStrokeDisabled) {
+      hints.strokeDisabled = true;
+    } else {
       const sc = paint['circle-stroke-color'];
       if (typeof sc === 'string') hints.strokeColor = sc;
     }

--- a/frontend/src/components/map/layer-icons.tsx
+++ b/frontend/src/components/map/layer-icons.tsx
@@ -57,10 +57,17 @@ export function extractStyleHints(
     hints.opacity = opacity;
   }
 
-  // fix(#1288 codex): builder.strokeDisabled wins over the paint mirror, the
-  // same precedence the map adapters and the builder's own style preview use
-  // (stylePreviewStyle). Computed once so every branch below agrees on it.
-  const strokeDisabled = Boolean(styleConfig?.builder?.strokeDisabled ?? paint['_stroke-disabled']);
+  // fix(#1288 codex): builder.strokeDisabled wins over the paint mirror ONLY
+  // where the real map renderer also consults builder state — fill-adapter.ts
+  // (polygons and the mixed GEOMETRY adapter's fill sublayer). circle-adapter.ts
+  // (points) applies circle paint properties directly and never reads
+  // style_config.builder, so a point must resolve purely from paint below —
+  // otherwise a stale builder.strokeDisabled (e.g. after an Advanced JSON/API
+  // edit restored a real stroke) would hide a stroke the map still draws.
+  const isPoint = gt.includes('POINT');
+  const strokeDisabled = isPoint
+    ? !!paint['_stroke-disabled']
+    : Boolean(styleConfig?.builder?.strokeDisabled ?? paint['_stroke-disabled']);
   if (strokeDisabled) {
     hints.strokeDisabled = true;
   }
@@ -101,7 +108,7 @@ export function extractStyleHints(
   // default while the map tints from the stash — resolve the map's colour here.
   hints.fillPatternColor = fillPatternTint(paint, styleConfig?.builder);
 
-  if (gt.includes('POINT')) {
+  if (isPoint) {
     // fix(#1288 codex): an explicit circle-stroke-width of 0 draws nothing on
     // the map (no builder mirror exists for it, unlike the polygon outline
     // width, so this reads paint directly) — treat it as a disabled stroke,

--- a/frontend/src/components/map/layer-icons.tsx
+++ b/frontend/src/components/map/layer-icons.tsx
@@ -199,17 +199,28 @@ function ShapeIcon({ colors, layerId, opacityStyle, styleHints, isPoint, discret
   // the pentagon glyph has no fill we can pattern without duplicating all five
   // patterns as SVG defs.
   if (!isPoint && styleHints?.fillPattern) {
+    // fix(#1288 codex): fillOpacity dims the PATTERN only, as a nested layer —
+    // plain CSS opacity, so it works for `color` in any format the pattern's
+    // `currentColor` resolves to — and never the border, which must stay fully
+    // opaque for a stroke-only style (fillOpacity 0) to remain visible.
+    const patternFillStyle: React.CSSProperties = {
+      color: styleHints.fillPatternColor ?? colors[0] ?? MAP_COLORS.icon.fallback,
+      ...patternPreviewStyle(styleHints.fillPattern),
+    };
+    if (styleHints.fillOpacity !== undefined && styleHints.fillOpacity < 1) {
+      patternFillStyle.opacity = styleHints.fillOpacity;
+    }
     return (
       <span
-        className="inline-block h-3.5 w-3.5 shrink-0 rounded-sm border"
+        className="relative inline-block h-3.5 w-3.5 shrink-0 overflow-hidden rounded-sm border"
         style={{
-          color: styleHints.fillPatternColor ?? colors[0] ?? MAP_COLORS.icon.fallback,
           borderColor: showOutline ? (styleHints.strokeColor ?? MAP_COLORS.icon.outline) : 'transparent',
-          ...patternPreviewStyle(styleHints.fillPattern),
           ...opacityStyle,
         }}
         aria-hidden="true"
-      />
+      >
+        <span className="absolute inset-0" style={patternFillStyle} />
+      </span>
     );
   }
 

--- a/frontend/src/components/map/layer-icons.tsx
+++ b/frontend/src/components/map/layer-icons.tsx
@@ -37,10 +37,14 @@ export function extractStyleHints(
   geometryType: string | null,
   opacity?: number,
   // fix(#914): `builder` is read for the fill-pattern tint stash.
-  // fix(#1288): also read for outlineColor — the renderer draws from builder
-  // state, so the swatch must prefer it over the paint mirror below, which can
-  // go stale (paint keeps the color a layer had before its last outline edit).
-  styleConfig?: { render_mode?: string; builder?: { fillColorSaved?: string; outlineColor?: string } } | null,
+  // fix(#1288): also read for outlineColor and strokeDisabled — the renderer
+  // draws from builder state, so the swatch must prefer it over the paint
+  // mirror below, which can go stale (paint keeps the color/flag a layer had
+  // before its last edit).
+  styleConfig?: {
+    render_mode?: string;
+    builder?: { fillColorSaved?: string; outlineColor?: string; strokeDisabled?: boolean };
+  } | null,
 ): StyleHints {
   const gt = (geometryType ?? '').toUpperCase();
   const hints: StyleHints = {};
@@ -53,7 +57,11 @@ export function extractStyleHints(
     hints.opacity = opacity;
   }
 
-  if (paint['_stroke-disabled']) {
+  // fix(#1288 codex): builder.strokeDisabled wins over the paint mirror, the
+  // same precedence the map adapters and the builder's own style preview use
+  // (stylePreviewStyle). Computed once so every branch below agrees on it.
+  const strokeDisabled = Boolean(styleConfig?.builder?.strokeDisabled ?? paint['_stroke-disabled']);
+  if (strokeDisabled) {
     hints.strokeDisabled = true;
   }
 
@@ -67,7 +75,7 @@ export function extractStyleHints(
     const lo = paint['line-opacity'];
     if (typeof lo === 'number' && lo < 1) hints.fillOpacity = lo;
   } else if (gt.includes('POLYGON')) {
-    if (!paint['_stroke-disabled']) {
+    if (!strokeDisabled) {
       // fix(#1288): builder.outlineColor wins over the flat paint mirror.
       const oc = styleConfig?.builder?.outlineColor ?? paint['_outline-color'];
       if (typeof oc === 'string') hints.strokeColor = oc;
@@ -85,7 +93,7 @@ export function extractStyleHints(
   hints.fillPatternColor = fillPatternTint(paint, styleConfig?.builder);
 
   if (gt.includes('POINT')) {
-    if (!paint['_stroke-disabled']) {
+    if (!strokeDisabled) {
       const sc = paint['circle-stroke-color'];
       if (typeof sc === 'string') hints.strokeColor = sc;
     }

--- a/frontend/src/components/viewer/LayerLegend.tsx
+++ b/frontend/src/components/viewer/LayerLegend.tsx
@@ -52,7 +52,9 @@ function viewerLegendEntryName(layer: SharedLayerResponse): string {
 
 /** Build SwatchStyle from viewer layer paint for consistent legend rendering. */
 function viewerSwatchStyle(layer: SharedLayerResponse): SwatchStyle {
-  const rawOutline = layer.paint?.['_outline-color'];
+  // fix(#1288): builder.outlineColor wins over the flat paint mirror, which can
+  // go stale — the map itself renders from style_config.builder.
+  const rawOutline = layer.style_config?.builder?.outlineColor ?? layer.paint?.['_outline-color'];
   const outlineColor = typeof rawOutline === 'string' ? rawOutline : undefined;
   const rawStrokeW = layer.paint?.['circle-stroke-width'] ?? layer.paint?.['_outline-width'];
   const strokeWidth = typeof rawStrokeW === 'number' ? rawStrokeW : undefined;

--- a/frontend/src/components/viewer/LayerLegend.tsx
+++ b/frontend/src/components/viewer/LayerLegend.tsx
@@ -51,20 +51,39 @@ function viewerLegendEntryName(layer: SharedLayerResponse): string {
 }
 
 /** Build SwatchStyle from viewer layer paint for consistent legend rendering. */
-function viewerSwatchStyle(layer: SharedLayerResponse): SwatchStyle {
+export function viewerSwatchStyle(layer: SharedLayerResponse): SwatchStyle {
+  const gt = (layer.geometry_type ?? '').toUpperCase();
+  const isPoint = gt.includes('POINT');
+  const builder = layer.style_config?.builder;
+
+  const rawStrokeW = isPoint
+    ? layer.paint?.['circle-stroke-width']
+    : (builder?.outlineWidth ?? layer.paint?.['_outline-width']);
+  const strokeWidth = typeof rawStrokeW === 'number' ? rawStrokeW : undefined;
+
+  // fix(#1288 codex): builder.strokeDisabled/outlineWidth win over the paint
+  // mirror, matching extractStyleHints/getSwatchStyleFromPaint — a stroke the
+  // user turned off through the builder can leave paint's
+  // _stroke-disabled/_outline-width unchanged, and a zero-width outline draws
+  // nothing on the map either way.
+  const strokeDisabled = isPoint
+    ? !!layer.paint?.['_stroke-disabled']
+    : Boolean(builder?.strokeDisabled ?? layer.paint?.['_stroke-disabled']) || strokeWidth === 0;
+
   // fix(#1288): builder.outlineColor wins over the flat paint mirror, which can
   // go stale — the map itself renders from style_config.builder.
-  const rawOutline = layer.style_config?.builder?.outlineColor ?? layer.paint?.['_outline-color'];
+  const rawOutline = isPoint
+    ? layer.paint?.['circle-stroke-color']
+    : (builder?.outlineColor ?? layer.paint?.['_outline-color']);
   const outlineColor = typeof rawOutline === 'string' ? rawOutline : undefined;
-  const rawStrokeW = layer.paint?.['circle-stroke-width'] ?? layer.paint?.['_outline-width'];
-  const strokeWidth = typeof rawStrokeW === 'number' ? rawStrokeW : undefined;
-  const gt = (layer.geometry_type ?? '').toUpperCase();
-  const rawFillOp = gt.includes('POINT')
+
+  const rawFillOp = isPoint
     ? layer.paint?.['circle-opacity']
     : gt.includes('LINE') ? layer.paint?.['line-opacity'] : layer.paint?.['fill-opacity'];
   const fillOpacity = typeof rawFillOp === 'number' ? rawFillOp : undefined;
   return {
     outlineColor,
+    strokeDisabled,
     opacity: layer.opacity ?? 1,
     fillOpacity,
     strokeWidth,

--- a/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
+++ b/frontend/src/components/viewer/__tests__/LayerLegend.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { LayerLegend } from '../LayerLegend';
+import { LayerLegend, viewerSwatchStyle } from '../LayerLegend';
 import type { MapTerrainConfig, SharedLayerResponse } from '@/types/api';
 
 function layer(overrides: Partial<SharedLayerResponse> = {}): SharedLayerResponse {
@@ -439,5 +439,40 @@ describe('LayerLegend terrain consistency (Fix 1)', () => {
     const synthetic = screen.getByTestId('legend-terrain-synthetic');
     expect(within(synthetic).getByText('◬')).toBeInTheDocument();
     expect(screen.getByText('⛰')).toBeInTheDocument();
+  });
+});
+
+// fix(#1288 codex): a stroke the user turned off through the builder can leave
+// paint's _stroke-disabled/_outline-width unchanged — the viewer legend swatch
+// must prefer builder state, same as extractStyleHints/getSwatchStyleFromPaint.
+describe('viewerSwatchStyle — builder stroke precedence (fix #1288)', () => {
+  it('prefers builder.strokeDisabled over a stale paint mirror', () => {
+    const style = viewerSwatchStyle(layer({
+      geometry_type: 'POLYGON',
+      paint: { 'fill-opacity': 0, '_outline-color': '#ec4b7f' },
+      style_config: { mode: 'categorical', builder: { strokeDisabled: true, outlineColor: '#ec4b7f' } } as SharedLayerResponse['style_config'],
+    }));
+    expect(style.strokeDisabled).toBe(true);
+  });
+
+  it('treats an explicit builder.outlineWidth of 0 as a disabled stroke', () => {
+    const style = viewerSwatchStyle(layer({
+      geometry_type: 'POLYGON',
+      paint: { 'fill-opacity': 0, '_outline-color': '#ec4b7f', '_outline-width': 2 },
+      style_config: { mode: 'categorical', builder: { outlineWidth: 0, outlineColor: '#ec4b7f' } } as SharedLayerResponse['style_config'],
+    }));
+    expect(style.strokeDisabled).toBe(true);
+    expect(style.strokeWidth).toBe(0);
+  });
+
+  it('leaves a normal visible outline unchanged', () => {
+    const style = viewerSwatchStyle(layer({
+      geometry_type: 'POLYGON',
+      paint: { 'fill-opacity': 0.5, '_outline-color': '#ec4b7f', '_outline-width': 2 },
+      style_config: { mode: 'categorical' } as SharedLayerResponse['style_config'],
+    }));
+    expect(style.strokeDisabled).toBe(false);
+    expect(style.outlineColor).toBe('#ec4b7f');
+    expect(style.strokeWidth).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

A polygon layer styled stroke-only (fill disabled, colored outline) draws correctly on the map, but its swatch was invisible in the legend widget and the Layers panel row.

Root cause: `paint['fill-opacity']` was extracted as a `fillOpacity` hint and multiplied into a single CSS `opacity` applied to the whole swatch element. For a stroke-only polygon, `fill-opacity` is 0 by design, so the entire swatch — including the outline it's actually drawn with — disappeared.

## Fix

- `fillOpacity` now lands on the specific SVG attribute (`fill-opacity` for shape fills, `stroke-opacity` for line-only elements), or is alpha-blended into the CSS background for the div-based polygon chip. Element-level `opacity` is reserved for layer-level opacity only.
- Applied consistently across every consumer of the shared swatch helpers: `layer-icons.tsx` (`ColorizedGeometryIcon` / `LayerTypeIcon`, used by the Layers panel, `LegendPlugin`, and the viewer `LayerLegend`) and `LegendEntries.tsx` (`GeometrySwatch`, `GraduatedRadiusLegend`, `GraduatedWidthLegend`, used by categorical/graduated legend rows).
- While in there: swatch outline color now prefers `style_config.builder.outlineColor` over the flat `paint['_outline-color']` mirror, matching how the map itself renders outlines (the mirror can go stale relative to builder state — same pattern the fill adapter already uses).

## Verification

- `cd frontend && npm run lint`
- `cd frontend && npm run typecheck`
- `cd frontend && npx vitest run src/components/map/__tests__/layer-icons.test.tsx src/components/map/__tests__/LegendEntries.test.tsx src/components/viewer/__tests__/LayerLegend.test.tsx src/components/builder/__tests__/LayerStyleEditor.test.tsx src/components/map-plugins/builtin/__tests__/LegendPlugin.test.ts src/components/map-plugins/builtin/__tests__/LegendPlugin.terrain.test.tsx src/components/builder/__tests__/SidebarRail.test.tsx src/components/builder/__tests__/StackRow.test.tsx src/components/builder/__tests__/LayerEditorPanel.test.tsx`
- `cd frontend && npm run test:coverage` (full suite, 383 files / 4700 tests passing)

Closes #1288