### PR TITLE
i18n(frontend): externalize remaining hardcoded UI strings

### DIFF
--- a/frontend/src/components/admin/AuditLogViewer.tsx
+++ b/frontend/src/components/admin/AuditLogViewer.tsx
@@ -302,7 +302,7 @@ export function AuditLogViewer() {
           <DataTableSearch
             value={searchQuery}
             onChange={(v) => { setSearchQuery(v); setPage(0); }}
-            placeholder={t('audit.table.user') + ' / ' + t('audit.table.action')}
+            placeholder={t('audit.searchPlaceholder')}
           />
         </CardAction>
       </CardHeader>

--- a/frontend/src/components/admin/UserList.tsx
+++ b/frontend/src/components/admin/UserList.tsx
@@ -234,7 +234,7 @@ export function UserList() {
             <DataTableSearch
               value={searchQuery}
               onChange={(v) => { setSearchQuery(v); setPage(0); }}
-              placeholder={t('users.table.username') + ' / ' + t('users.table.email')}
+              placeholder={t('users.searchPlaceholder')}
             />
             <FilterSelect
               label=""

--- a/frontend/src/components/admin/saml/SamlProvidersSection.tsx
+++ b/frontend/src/components/admin/saml/SamlProvidersSection.tsx
@@ -463,7 +463,7 @@ export function SamlProvidersSection() {
                 }
                 placeholder={
                   editingProvider
-                    ? '(leave blank to keep existing certificate)'
+                    ? `(${t('saml.idpCertificateKeep')})`
                     : '-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----'
                 }
               />

--- a/frontend/src/components/admin/settings/SettingsAITab.tsx
+++ b/frontend/src/components/admin/settings/SettingsAITab.tsx
@@ -178,7 +178,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, sa
         <div className="flex items-center justify-between max-w-md">
           <div className="space-y-0.5">
             <div className="flex items-center gap-2">
-              <Label htmlFor="ai-toggle">{findSetting(settings, 'ai_enabled')?.label ?? t('ai.labels.aiEnabled')}</Label>
+              <Label htmlFor="ai-toggle">{t('ai.labels.aiEnabled')}</Label>
               <SettingSourceBadge source={findSetting(settings, 'ai_enabled')?.source ?? 'default'} settingKey="ai_enabled" onReset={onReset} />
             </div>
             <p className="text-sm text-muted-foreground">{t('settings.general.aiFeaturesDescription')}</p>
@@ -194,7 +194,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, sa
         <div className="flex items-center justify-between max-w-md">
           <div className="space-y-0.5">
             <div className="flex items-center gap-2">
-              <Label htmlFor="sample-values-toggle">{findSetting(settings, 'ai_send_sample_values')?.label ?? t('ai.labels.sendSampleValues')}</Label>
+              <Label htmlFor="sample-values-toggle">{t('ai.labels.sendSampleValues')}</Label>
               <SettingSourceBadge source={findSetting(settings, 'ai_send_sample_values')?.source ?? 'default'} settingKey="ai_send_sample_values" onReset={onReset} />
             </div>
             <p className="text-sm text-muted-foreground">{t('ai.sendSampleValuesDescription')}</p>
@@ -210,8 +210,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, sa
         <div className="space-y-2 max-w-md">
           <div className="flex items-center gap-2">
             <Label htmlFor="max-ai-tokens-per-day">
-              {findSetting(settings, 'max_ai_tokens_per_user_per_day')?.label ??
-                'Max AI Tokens per User per Day (0=unlimited)'}
+              {t('ai.labels.maxAiTokensPerDay')}
             </Label>
             <SettingSourceBadge
               source={findSetting(settings, 'max_ai_tokens_per_user_per_day')?.source ?? 'default'}
@@ -233,7 +232,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, sa
 
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <Label htmlFor="llm-provider">{findSetting(settings, 'llm_provider')?.label ?? t('ai.labels.llmProvider')}</Label>
+          <Label htmlFor="llm-provider">{t('ai.labels.llmProvider')}</Label>
           <SettingSourceBadge source={findSetting(settings, 'llm_provider')?.source ?? 'default'} settingKey="llm_provider" onReset={onReset} />
         </div>
         <Select value={llmProvider} onValueChange={setters.llm_provider} disabled={envOnly}>
@@ -250,7 +249,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, sa
 
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <Label htmlFor="llm-model">{findSetting(settings, 'llm_model')?.label ?? t('ai.labels.model')}</Label>
+          <Label htmlFor="llm-model">{t('ai.labels.model')}</Label>
           <SettingSourceBadge source={findSetting(settings, 'llm_model')?.source ?? 'default'} settingKey="llm_model" onReset={onReset} />
         </div>
         <Input
@@ -268,7 +267,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, sa
       {llmProvider === 'openai_compatible' && (
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <Label htmlFor="openai-base-url">{findSetting(settings, 'openai_base_url')?.label ?? t('ai.labels.openaiBaseUrl')}</Label>
+            <Label htmlFor="openai-base-url">{t('ai.labels.openaiBaseUrl')}</Label>
             <SettingSourceBadge source={findSetting(settings, 'openai_base_url')?.source ?? 'default'} settingKey="openai_base_url" onReset={onReset} />
           </div>
           <Input
@@ -310,7 +309,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, sa
           {/* Embedding model config */}
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <Label htmlFor="embedding-model">{findSetting(settings, 'embedding_model')?.label ?? t('ai.labels.embeddingModel')}</Label>
+              <Label htmlFor="embedding-model">{t('ai.labels.embeddingModel')}</Label>
               <SettingSourceBadge source={findSetting(settings, 'embedding_model')?.source ?? 'default'} settingKey="embedding_model" onReset={onReset} />
             </div>
             <Input
@@ -328,7 +327,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, sa
           {/* Embedding base URL */}
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <Label htmlFor="embedding-base-url">{findSetting(settings, 'embedding_base_url')?.label ?? t('ai.labels.embeddingBaseUrl')}</Label>
+              <Label htmlFor="embedding-base-url">{t('ai.labels.embeddingBaseUrl')}</Label>
               <SettingSourceBadge source={findSetting(settings, 'embedding_base_url')?.source ?? 'default'} settingKey="embedding_base_url" onReset={onReset} />
             </div>
             <Input
@@ -345,7 +344,7 @@ export function SettingsAITab({ settings, envOnly, onSave, onReset, isSaving, sa
 
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <Label htmlFor="embedding-dims">{findSetting(settings, 'embedding_dims')?.label ?? t('ai.labels.embeddingDims')}</Label>
+              <Label htmlFor="embedding-dims">{t('ai.labels.embeddingDims')}</Label>
               <SettingSourceBadge source={findSetting(settings, 'embedding_dims')?.source ?? 'default'} settingKey="embedding_dims" onReset={onReset} />
             </div>
             <div className="flex items-center gap-3">

--- a/frontend/src/components/admin/settings/SettingsNetworkTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsNetworkTab.tsx
@@ -79,7 +79,7 @@ export function SettingsNetworkTab({ settings, envOnly, onSave, onReset, isSavin
     <div className="space-y-6">
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <Label htmlFor="cors-origins">{findSetting(settings, 'cors_allowed_origins')?.label ?? t('settings.network.corsAllowedOrigins')}</Label>
+          <Label htmlFor="cors-origins">{t('settings.network.corsAllowedOrigins')}</Label>
           <SettingSourceBadge source={findSetting(settings, 'cors_allowed_origins')?.source ?? 'default'} settingKey="cors_allowed_origins" onReset={onReset} />
         </div>
         <p className="text-sm text-muted-foreground">{t('settings.network.corsAllowedOriginsDescription')}</p>
@@ -96,7 +96,7 @@ export function SettingsNetworkTab({ settings, envOnly, onSave, onReset, isSavin
 
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <Label htmlFor="global-rate-limit">{findSetting(settings, 'global_rate_limit')?.label ?? t('settings.network.globalRateLimit')}</Label>
+          <Label htmlFor="global-rate-limit">{t('settings.network.globalRateLimit')}</Label>
           <SettingSourceBadge source={findSetting(settings, 'global_rate_limit')?.source ?? 'default'} settingKey="global_rate_limit" onReset={onReset} />
         </div>
         <p className="text-sm text-muted-foreground">{t('settings.network.globalRateLimitDescription')}</p>
@@ -114,7 +114,7 @@ export function SettingsNetworkTab({ settings, envOnly, onSave, onReset, isSavin
 
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <Label htmlFor="ogc-items-max-page-size">{findSetting(settings, 'ogc_items_max_page_size')?.label ?? t('settings.network.ogcItemsMaxPageSize')}</Label>
+          <Label htmlFor="ogc-items-max-page-size">{t('settings.network.ogcItemsMaxPageSize')}</Label>
           <SettingSourceBadge source={findSetting(settings, 'ogc_items_max_page_size')?.source ?? 'default'} settingKey="ogc_items_max_page_size" onReset={onReset} />
         </div>
         <p className="text-sm text-muted-foreground">{t('settings.network.ogcItemsMaxPageSizeDescription')}</p>

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -34,7 +34,7 @@ import {
 } from '@/components/map/cluster-interactions';
 import { substitutePopupTemplate } from '@/lib/popup-template';
 import { MapCoordReadout } from '@/components/map/MapCoordReadout';
-import { clusterFallbackMessage, getClusterSourceEligibility, getClusterSourceKey, getClusterSourceStrategy, isClusterRenderMode, shouldFetchClusterGeoJson } from './cluster-source';
+import { getClusterSourceEligibility, getClusterSourceKey, getClusterSourceStrategy, isClusterRenderMode, shouldFetchClusterGeoJson, type ClusterSourceStatus } from './cluster-source';
 import type { VectorTileSource } from 'maplibre-gl';
 import {
   toSyncInput,
@@ -166,6 +166,21 @@ function visibleLayerBoundsKey(bounds: VisibleLayerBounds | null): string {
   return bounds
     ? `${bounds[0][0]},${bounds[0][1]},${bounds[1][0]},${bounds[1][1]}`
     : '';
+}
+
+// The five statuses that leave a cluster layer rendering as points, mapped to
+// their builderMap.clusterReason.* translation key. 'not-cluster' and
+// 'eligible' never reach getClusterFallbackReasonKey's caller below.
+const CLUSTER_FALLBACK_REASON_KEYS: Partial<Record<ClusterSourceStatus, string>> = {
+  'missing-count': 'builderMap.clusterReason.missingCount',
+  'too-many-features': 'builderMap.clusterReason.tooManyFeatures',
+  'not-point': 'builderMap.clusterReason.notPoint',
+  'not-vector': 'builderMap.clusterReason.notVector',
+  'unsupported-record-type': 'builderMap.clusterReason.unsupportedRecordType',
+};
+
+function getClusterFallbackReasonKey(status: ClusterSourceStatus): string | null {
+  return CLUSTER_FALLBACK_REASON_KEYS[status] ?? null;
 }
 
 /**
@@ -422,14 +437,14 @@ export const BuilderMap = memo(function BuilderMap({
           return;
         }
         if (!shouldFetchClusterGeoJson(layer)) {
-          const message = clusterFallbackMessage(eligibility.status);
+          const reasonKey = getClusterFallbackReasonKey(eligibility.status);
           const key = `${layer.id}:${eligibility.status}:${eligibility.featureCount ?? 'unknown'}`;
-          if (message && !clusterFallbackNotifiedRef.current.has(key)) {
+          if (reasonKey && !clusterFallbackNotifiedRef.current.has(key)) {
             clusterFallbackNotifiedRef.current.add(key);
             toast.warning(t('builderMap.clusterFallback', {
               defaultValue: '{{name}} is rendering as points: {{reason}}',
               name: layerName,
-              reason: message,
+              reason: t(reasonKey),
             }));
           }
           return;

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -1352,7 +1352,7 @@ export function ChatPanel({
                       variant="default"
                       className="h-7 text-xs"
                       onClick={() => void staging.acceptOne(idx)}
-                      aria-label={`${t('chat.staging.accept')} ${fullText}`}
+                      aria-label={t('chat.staging.acceptAction', { action: fullText })}
                     >
                       {t('chat.staging.accept')}
                     </Button>
@@ -1361,7 +1361,7 @@ export function ChatPanel({
                       variant="outline"
                       className="h-7 text-xs border-destructive/50 text-destructive hover:bg-destructive/10"
                       onClick={() => staging.rejectOne(idx)}
-                      aria-label={`${t('chat.staging.reject')} ${fullText}`}
+                      aria-label={t('chat.staging.rejectAction', { action: fullText })}
                     >
                       {t('chat.staging.reject')}
                     </Button>

--- a/frontend/src/components/builder/DatasetSearchPanel.tsx
+++ b/frontend/src/components/builder/DatasetSearchPanel.tsx
@@ -399,8 +399,8 @@ export function DatasetSearchPanel({
         // "Add to map <name>" buttons in one result row.
         aria-label={
           compact
-            ? `${t('search.addToMapDetails', { defaultValue: 'Add to map (details panel)' })} ${record.properties.title}`
-            : `${t('search.addToMap', { defaultValue: 'Add to map' })} ${record.properties.title}`
+            ? t('search.addToMapDetailsNamed', { name: record.properties.title, defaultValue: 'Add to map (details panel): {{name}}' })
+            : t('search.addToMapNamed', { name: record.properties.title, defaultValue: 'Add to map: {{name}}' })
         }
       >
         {addingDatasetId === record.id ? (

--- a/frontend/src/components/builder/LayerStyleEditor/ClusterEditor.tsx
+++ b/frontend/src/components/builder/LayerStyleEditor/ClusterEditor.tsx
@@ -130,12 +130,12 @@ export function ClusterEditor({
                   value={stop.count}
                   onChange={(e) => updateStop(index, { count: Number(e.target.value) })}
                   className="h-7 w-20"
-                  aria-label={`${t('style.cluster.atCount')} ${index}`}
+                  aria-label={t('style.cluster.atCountIndexed', { index })}
                 />
                 <SwatchColorPopover
                   color={stop.color}
                   onChange={(hex) => updateStop(index, { color: hex })}
-                  label={`${t('style.cluster.colorByCount')} ${index}`}
+                  label={t('style.cluster.colorByCountIndexed', { index })}
                 />
                 <Button
                   type="button"

--- a/frontend/src/components/builder/MapTitleBar.tsx
+++ b/frontend/src/components/builder/MapTitleBar.tsx
@@ -89,9 +89,13 @@ export function MapTitleBar({
   // computation, so an sr-only status span inside the button was never
   // conveyed. Fold the status into the label itself; the role="status" region
   // below announces status CHANGES without the button needing focus.
-  const saveButtonAriaLabel = `${saveStatus === 'failed'
-    ? t('titleBar.retrySave', { defaultValue: 'Retry save' })
-    : t('tooltips.save', { shortcut: SAVE_SHORTCUT, defaultValue: `Save (${SAVE_SHORTCUT})` })}, ${saveStatusLabel}`;
+  const saveButtonAriaLabel = t('titleBar.saveButtonAriaLabel', {
+    action: saveStatus === 'failed'
+      ? t('titleBar.retrySave', { defaultValue: 'Retry save' })
+      : t('tooltips.save', { shortcut: SAVE_SHORTCUT, defaultValue: `Save (${SAVE_SHORTCUT})` }),
+    status: saveStatusLabel,
+    defaultValue: '{{action}}, {{status}}',
+  });
 
   return (
     <div className="h-10 border-b bg-background flex items-center gap-3 px-3 shrink-0">

--- a/frontend/src/components/builder/__tests__/DatasetSearchPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/DatasetSearchPanel.test.tsx
@@ -219,7 +219,7 @@ describe('DatasetSearchPanel', () => {
     fireEvent.click(within(roadsRow as HTMLElement).getByRole('button', { name: 'another rendering' }));
     expect(onDuplicateRendering).toHaveBeenCalledWith('roads-layer');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add to map Population' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add to map: Population' }));
     expect(onAddDataset).toHaveBeenCalledWith('population');
   });
 
@@ -231,7 +231,7 @@ describe('DatasetSearchPanel', () => {
 
     expect(screen.getByText('Population description')).toBeInTheDocument();
     expect(screen.getByText('Count')).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Add to map Population' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: 'Add to map: Population' }).length).toBeGreaterThan(0);
     expect(screen.getByRole('link', { name: 'Import data...' })).toHaveAttribute('href', '/import');
   });
 

--- a/frontend/src/components/builder/__tests__/MapTitleBar.test.tsx
+++ b/frontend/src/components/builder/__tests__/MapTitleBar.test.tsx
@@ -3,11 +3,17 @@ import userEvent from '@testing-library/user-event';
 import { MapTitleBar, type OverflowActions } from '../MapTitleBar';
 
 // i18n mock — same defaultValue-passthrough pattern used in
-// MapToolbar.test.tsx and LayerPanel.test.tsx in this dir.
+// MapToolbar.test.tsx and LayerPanel.test.tsx in this dir, extended to
+// interpolate {{var}} placeholders (matching real i18next) since
+// saveButtonAriaLabel composes translated fragments via {{action}}/{{status}}.
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, options?: { defaultValue?: string } & Record<string, unknown>) =>
-      options?.defaultValue ?? key,
+    t: (key: string, options?: { defaultValue?: string } & Record<string, unknown>) => {
+      const template = options?.defaultValue ?? key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+        options?.[name] != null ? String(options[name]) : '',
+      );
+    },
   }),
 }));
 

--- a/frontend/src/components/builder/cluster-source.ts
+++ b/frontend/src/components/builder/cluster-source.ts
@@ -134,22 +134,3 @@ export function getClusterSourceKey(
     .map((layer) => `${layer.id ?? ''}|${layer.dataset_id ?? ''}|${getClusterSourceStrategy(layer).kind}`)
     .join(',');
 }
-
-export function clusterFallbackMessage(status: ClusterSourceStatus) {
-  switch (status) {
-    case 'missing-count':
-      return 'Feature count is unavailable for bounded clustering.';
-    case 'too-many-features':
-      return 'Dataset is too large for bounded client-side clustering.';
-    case 'not-point':
-      return 'Only point datasets can be clustered.';
-    case 'not-vector':
-      return 'Only vector datasets can be clustered.';
-    case 'unsupported-record-type':
-      return 'Dataset type does not support clustering.';
-    case 'not-cluster':
-    case 'eligible':
-    default:
-      return null;
-  }
-}

--- a/frontend/src/components/builder/ephemeral-preview.ts
+++ b/frontend/src/components/builder/ephemeral-preview.ts
@@ -81,7 +81,11 @@ export function ephemeralCountLabel(
  * announce the same thing.
  */
 export function ephemeralStatusLabel(t: BuilderTranslator, input: EphemeralCountInput): string {
-  return `${t('ephemeralBadge.queryResult')} · ${ephemeralCountLabel(t, input)}`;
+  return t('ephemeralBadge.statusLabel', {
+    result: t('ephemeralBadge.queryResult'),
+    summary: ephemeralCountLabel(t, input),
+    defaultValue: '{{result}} · {{summary}}',
+  });
 }
 
 /**

--- a/frontend/src/components/builder/hooks/builder-layer-mutations.ts
+++ b/frontend/src/components/builder/hooks/builder-layer-mutations.ts
@@ -105,12 +105,26 @@ export function removePerLayerCompanions(
   }
 }
 
+export interface DuplicateRenderingLabels {
+  layerFallback: string;
+  duplicateName: (baseName: string) => string;
+}
+
+// Kept pure (no t() call) — matches the current English copy so existing
+// callers that omit `labels` see unchanged behavior. Real call sites pass
+// translated labels; see useBuilderLayers' handleDuplicateRendering.
+const DEFAULT_DUPLICATE_RENDERING_LABELS: DuplicateRenderingLabels = {
+  layerFallback: 'Layer',
+  duplicateName: (baseName) => `${baseName} rendering`,
+};
+
 export function buildDuplicateRenderingInput(
   layer: MapLayerResponse,
   // fix(#392): no longer used for the sort_order hint (kept
   // for call-site/type stability); the duplicate now anchors on the source
   // layer's own sort_order instead of scanning the full stack for its max. (audit B-004b/LM-02)
   _currentLayers: MapLayerResponse[],
+  labels: DuplicateRenderingLabels = DEFAULT_DUPLICATE_RENDERING_LABELS,
 ): MapLayerInput {
   // Place the duplicate adjacent to its source (source.sort_order + 1) instead
   // of at the stack bottom (max(sort_order)+1) — a grouped source's copy must
@@ -119,7 +133,7 @@ export function buildDuplicateRenderingInput(
   // by final local array index at splice time, and prepareLayersForPersistence
   // renumbers again by array index at save time.
   const nextSortOrder = layer.sort_order + 1;
-  const baseName = layer.display_name || layer.dataset_name || layer.dataset_table_name || 'Layer';
+  const baseName = layer.display_name || layer.dataset_name || layer.dataset_table_name || labels.layerFallback;
   return {
     dataset_id: layer.dataset_id,
     sort_order: nextSortOrder,
@@ -129,7 +143,7 @@ export function buildDuplicateRenderingInput(
     opacity: layer.opacity,
     paint: { ...(layer.paint ?? {}) },
     layout: { ...(layer.layout ?? {}) },
-    display_name: `${baseName} rendering`,
+    display_name: labels.duplicateName(baseName),
     filter: layer.filter ?? null,
     label_config: layer.label_config ?? null,
     popup_config: layer.popup_config ?? null,

--- a/frontend/src/components/builder/hooks/use-builder-editor-scene.ts
+++ b/frontend/src/components/builder/hooks/use-builder-editor-scene.ts
@@ -10,6 +10,23 @@ export interface BuilderEditorBasemapGroup {
   sublayers: Array<{ id: string; name: string }>;
 }
 
+export interface BuilderEditorSyntheticLabels {
+  settingsName: string;
+  sublayerFallback: string;
+  untitledFallback: string;
+  basemapGroupName: (presetName: string) => string;
+}
+
+// Kept pure (no t() call) — matches the current English copy so callers that
+// omit `labels` see unchanged behavior. Real call sites (MapBuilderPage) pass
+// translated labels.
+const DEFAULT_SYNTHETIC_LABELS: BuilderEditorSyntheticLabels = {
+  settingsName: 'Settings',
+  sublayerFallback: 'Sublayer',
+  untitledFallback: 'Untitled',
+  basemapGroupName: (presetName) => `Basemap · ${presetName}`,
+};
+
 export function deriveBuilderEditorScene(
   expandedLayerId: string | null,
   editingLayer: Pick<MapLayerResponse, 'is_dem' | 'layer_type'> | null,
@@ -66,21 +83,23 @@ export function createSyntheticEditorLayer({
   editorScene,
   expandedLayerId,
   basemapGroup,
+  labels = DEFAULT_SYNTHETIC_LABELS,
 }: {
   editorScene: BuilderEditorScene;
   expandedLayerId: string | null;
   basemapGroup: BuilderEditorBasemapGroup | null;
+  labels?: BuilderEditorSyntheticLabels;
 }): MapLayerResponse | null {
   if (editorScene === 'settings') {
     return syntheticLayerBase({
       id: 'settings',
-      name: 'Settings',
+      name: labels.settingsName,
       tableName: 'settings',
     });
   }
 
   if (editorScene === 'basemap-sublayer') {
-    const sublayerName = basemapGroup?.sublayers.find((s) => s.id === expandedLayerId)?.name ?? 'Sublayer';
+    const sublayerName = basemapGroup?.sublayers.find((s) => s.id === expandedLayerId)?.name ?? labels.sublayerFallback;
     return syntheticLayerBase({
       id: expandedLayerId ?? 'basemap-group',
       name: sublayerName,
@@ -91,7 +110,7 @@ export function createSyntheticEditorLayer({
   if (editorScene === 'basemap-group') {
     return syntheticLayerBase({
       id: expandedLayerId ?? basemapGroup?.id ?? 'basemap-group',
-      name: `Basemap · ${basemapGroup?.presetName ?? 'Untitled'}`,
+      name: labels.basemapGroupName(basemapGroup?.presetName ?? labels.untitledFallback),
       tableName: 'basemap',
     });
   }
@@ -104,11 +123,13 @@ export function useBuilderEditorScene({
   localLayers,
   savedLayerBaseline,
   basemapGroup,
+  labels,
 }: {
   expandedLayerId: string | null;
   localLayers: MapLayerResponse[];
   savedLayerBaseline: MapLayerResponse[];
   basemapGroup: BuilderEditorBasemapGroup | null;
+  labels?: BuilderEditorSyntheticLabels;
 }) {
   const matchedLayer = useMemo(
     () => expandedLayerId ? localLayers.find((layer) => layer.id === expandedLayerId) ?? null : null,
@@ -133,8 +154,8 @@ export function useBuilderEditorScene({
   );
 
   const syntheticEditorLayer = useMemo(
-    () => createSyntheticEditorLayer({ editorScene, expandedLayerId, basemapGroup }),
-    [basemapGroup, editorScene, expandedLayerId],
+    () => createSyntheticEditorLayer({ editorScene, expandedLayerId, basemapGroup, labels }),
+    [basemapGroup, editorScene, expandedLayerId, labels],
   );
 
   const editorLayer = editorScene === 'group' ? null : (editingLayer ?? syntheticEditorLayer);

--- a/frontend/src/components/builder/hooks/use-builder-layers.ts
+++ b/frontend/src/components/builder/hooks/use-builder-layers.ts
@@ -799,7 +799,10 @@ export function useBuilderLayers(
     // terrain_config pointer, so duplicates can no longer accumulate terrain.
 
     const currentLayers = layersRef.current;
-    const data = buildDuplicateRenderingInput(layer, currentLayers);
+    const data = buildDuplicateRenderingInput(layer, currentLayers, {
+      layerFallback: t('layerMutations.layerFallback', { defaultValue: 'Layer' }),
+      duplicateName: (baseName) => t('layerMutations.duplicateName', { name: baseName, defaultValue: '{{name}} rendering' }),
+    });
     // fix(#392): carry the source's frontend-only
     // parent_group_id so a duplicate of a grouped layer stays in the group
     // instead of escaping to the stack bottom. MapLayerInput/the API cannot

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -480,7 +480,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
                   <TableHead key={`filter-${header.id}`} className="py-1">
                     {!NON_FILTERABLE_COLUMNS.has(header.column.id) ? (
                       <Input
-                        aria-label={`${t('attributes.filter')} ${header.column.id}`}
+                        aria-label={t('attributes.filterColumn', { column: header.column.id })}
                         value={columnFilters[header.column.id] ?? ''}
                         onChange={(e) => handleFilterChange(header.column.id, e.target.value)}
                         placeholder={t('attributes.filter')}

--- a/frontend/src/components/dataset/ChangeHistory.tsx
+++ b/frontend/src/components/dataset/ChangeHistory.tsx
@@ -28,7 +28,7 @@ export function ChangeHistory({ datasetId }: ChangeHistoryProps) {
   function formatDetails(log: AuditLogResponse): string | null {
     if (!log.details || Object.keys(log.details).length === 0) return null;
     if (log.action === 'metadata.edit') {
-      return `${t('changeHistory.changed')} ${Object.keys(log.details).join(', ')}`;
+      return t('changeHistory.changedFields', { fields: Object.keys(log.details).join(', ') });
     }
     return Object.keys(log.details).join(', ');
   }

--- a/frontend/src/components/dataset/SpatialExtentCard.tsx
+++ b/frontend/src/components/dataset/SpatialExtentCard.tsx
@@ -15,7 +15,10 @@ function formatSrid(
 ): string {
   const current = srid ? `EPSG:${srid}` : unknownLabel;
   if (originalSrid && originalSrid !== srid) {
-    return `${current} (${t('metadata.original', { srid: originalSrid })})`;
+    return t('metadata.sridWithOriginal', {
+      current,
+      original: t('metadata.original', { srid: originalSrid }),
+    });
   }
   return current;
 }

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -373,7 +373,11 @@ export function FilterPanel({
     if (datetime) {
       return (
         <FilterChip
-          label={`${t('filters.temporalExtent', { defaultValue: 'Temporal Extent' })}: ${temporalStart || '..'} - ${temporalEnd || '..'}`}
+          label={t('filters.temporalExtentRange', {
+            start: temporalStart || '..',
+            end: temporalEnd || '..',
+            defaultValue: 'Temporal Extent: {{start}} - {{end}}',
+          })}
           onRemove={() => useSearchStore.getState().setFilter('datetime', '')}
         />
       );

--- a/frontend/src/components/search/FilterSheet.tsx
+++ b/frontend/src/components/search/FilterSheet.tsx
@@ -277,7 +277,11 @@ export function FilterSheet({ totalResults }: FilterSheetProps) {
             )}
             {datetime && (
               <FilterChip
-                label={`${t('filters.temporalExtent', { defaultValue: 'Temporal Extent' })}: ${temporalStart || '..'} - ${temporalEnd || '..'}`}
+                label={t('filters.temporalExtentRange', {
+                  start: temporalStart || '..',
+                  end: temporalEnd || '..',
+                  defaultValue: 'Temporal Extent: {{start}} - {{end}}',
+                })}
                 onRemove={() => useSearchStore.getState().setFilter('datetime', '')}
               />
             )}

--- a/frontend/src/components/search/SearchResultCard.tsx
+++ b/frontend/src/components/search/SearchResultCard.tsx
@@ -352,8 +352,12 @@ export const SearchResultCard = memo(function SearchResultCard({ feature }: { fe
                           data-testid="table-thumbnail-icon"
                         />
                         <span className="text-xs font-medium font-mono tabular-nums tracking-wide">
-                          {t('card.tableRows', { count: properties.feature_count ?? 0 })}
-                          {properties.column_count ? ` · ${t('card.tableCols', { count: properties.column_count })}` : ''}
+                          {properties.column_count
+                            ? t('card.tableRowsColsJoined', {
+                                rows: t('card.tableRows', { count: properties.feature_count ?? 0 }),
+                                cols: t('card.tableCols', { count: properties.column_count }),
+                              })
+                            : t('card.tableRows', { count: properties.feature_count ?? 0 })}
                         </span>
                       </div>
                     ) : quicklookBlobUrl ? (

--- a/frontend/src/components/search/SpatialFilterPanel.tsx
+++ b/frontend/src/components/search/SpatialFilterPanel.tsx
@@ -355,7 +355,7 @@ export function SpatialFilterPanel({
               <p className="mt-2 text-xs text-muted-foreground">
                 {drawMode === 'rectangle'
                   ? `Bbox: ${pendingBbox.split(',').map((n) => Number(n).toFixed(2)).join(', ')}`
-                  : '1 polygon selected'}
+                  : t('spatial.polygonSelected', { count: 1 })}
               </p>
             ) : (
               <p className="mt-2 text-xs text-muted-foreground">

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -39,6 +39,7 @@
     "exportEmailsCsv": "E-Mails exportieren (CSV)",
     "loading": "Benutzer werden geladen...",
     "errorLoading": "Benutzer konnten nicht geladen werden: {{message}}",
+    "searchPlaceholder": "Benutzername / E-Mail",
     "filters": {
       "allUsers": "Alle Benutzer",
       "pending": "Ausstehend",
@@ -199,6 +200,7 @@
     "title": "Protokoll",
     "loading": "Protokolleinträge werden geladen...",
     "errorLoading": "Protokolleinträge konnten nicht geladen werden: {{message}}",
+    "searchPlaceholder": "Benutzer / Aktion",
     "filters": {
       "allActions": "Alle Aktionen",
       "datasetView": "Datensatz angesehen",
@@ -290,6 +292,7 @@
     "labels": {
       "aiEnabled": "KI-Chat aktiviert",
       "sendSampleValues": "Beispielwerte an LLM senden",
+      "maxAiTokensPerDay": "Max. KI-Tokens pro Nutzer und Tag (0=unbegrenzt)",
       "llmProvider": "LLM-Anbieter",
       "model": "Modell",
       "openaiBaseUrl": "OpenAI-kompatible Basis-URL",
@@ -745,7 +748,7 @@
     "spEntityId": "SP Entity ID",
     "spEntityIdWarning": "Dies muss exakt mit der bei Ihrem IdP registrierten SP entityID übereinstimmen. Nach der Konfiguration nicht mehr ändern.",
     "defaultRole": "Standardrolle",
-    "groupClaim": "Group Claim",
+    "groupClaim": "Gruppen-Claim",
     "groupClaimHint": "SAML-Attributname mit Gruppenmitgliedschaften der Benutzer für automatisches Rollenmapping (z. B. \"groups\", \"http://schemas.xmlsoap.org/claims/Group\").",
     "groupRoleMapping": "Group-Rollen-Mapping (JSON)",
     "groupRoleMappingHint": "Ordnet IdP-Gruppennamen GeoLens-Rollen zu. JSON-Objektformat.",

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -339,6 +339,8 @@
       "colorByCount": "Nach Clustergröße einfärben",
       "baseColor": "Grundfarbe",
       "atCount": "Ab Anzahl",
+      "atCountIndexed": "Ab Anzahl, Stufe {{index}}",
+      "colorByCountIndexed": "Nach Clustergröße einfärben, Stufe {{index}}",
       "addStop": "Farbstufe hinzufügen",
       "removeStop": "Farbstufe entfernen"
     },
@@ -581,6 +583,8 @@
     "added": "Hinzugefügt",
     "addToMap": "Zur Karte hinzufügen",
     "addToMapDetails": "Zur Karte hinzufügen (Detailbereich)",
+    "addToMapNamed": "Zur Karte hinzufügen: {{name}}",
+    "addToMapDetailsNamed": "Zur Karte hinzufügen (Detailbereich): {{name}}",
     "dragHandle": "In die Karte ziehen",
     "catalogEmpty": "Ihr Katalog ist leer. Laden Sie einen Datensatz hoch, um zu beginnen.",
     "uploadCta": "Datei hochladen →",
@@ -761,6 +765,8 @@
       "rejectAll": "Alle verwerfen",
       "accept": "Übernehmen",
       "reject": "Verwerfen",
+      "acceptAction": "{{action}} übernehmen",
+      "rejectAction": "{{action}} verwerfen",
       "chipAdd": "\"{{name}}\" hinzufügen",
       "chipAddBelow": "\"{{name}}\" unter \"{{ref}}\" hinzufügen",
       "chipRemove": "\"{{name}}\" entfernen",
@@ -833,6 +839,7 @@
     "saved": "Gespeichert",
     "retry": "Erneut versuchen",
     "retrySave": "Speichern erneut versuchen",
+    "saveButtonAriaLabel": "{{action}}, {{status}}",
     "saveStatus": {
       "saved": "Gespeichert",
       "unsaved": "Ungespeicherte Änderungen",
@@ -936,7 +943,18 @@
     "clusterFallback": "{{name}} wird als Punkte dargestellt: {{reason}}",
     "clusterTruncated": "die Cluster-Quelle hat das begrenzte GeoJSON-Limit überschritten",
     "clusterLoadError": "{{name}} wird als Punkte dargestellt, weil die Cluster-Daten nicht geladen werden konnten.",
-    "tokenError": "Kachel-Tokens konnten nicht geladen werden — einige Ebenen werden eventuell nicht angezeigt."
+    "tokenError": "Kachel-Tokens konnten nicht geladen werden — einige Ebenen werden eventuell nicht angezeigt.",
+    "clusterReason": {
+      "missingCount": "Für begrenztes Clustering ist keine Objektanzahl verfügbar.",
+      "tooManyFeatures": "Der Datensatz ist für begrenztes clientseitiges Clustering zu groß.",
+      "notPoint": "Nur Punktdatensätze können gruppiert werden.",
+      "notVector": "Nur Vektordatensätze können gruppiert werden.",
+      "unsupportedRecordType": "Dieser Datensatztyp unterstützt kein Clustering."
+    }
+  },
+  "layerMutations": {
+    "layerFallback": "Layer",
+    "duplicateName": "Rendering von {{name}}"
   },
   "mapCreate": {
     "title": "Karte erstellen",
@@ -1060,6 +1078,7 @@
   },
   "ephemeralBadge": {
     "queryResult": "Ergebnis",
+    "statusLabel": "{{result}} · {{summary}}",
     "featureCount_one": "{{count, number}} Feature",
     "featureCount_other": "{{count, number}} Features",
     "dismiss": "Ergebnis verwerfen",
@@ -1346,6 +1365,7 @@
     "breadcrumbLabel": "Zurück zur Basiskarten-Gruppe",
     "breadcrumb": "Basiskarte · {{name}} ›",
     "breadcrumbUntitled": "Ohne Titel",
+    "sublayerFallback": "Subebene",
     "casingColor": "Umrandungsfarbe",
     "casingLabel": "UMRANDUNG",
     "casingWidth": "Breite",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -144,6 +144,7 @@
     "copyToClipboard": "In Zwischenablage kopieren",
     "unknown": "Unbekannt",
     "original": "Original: EPSG:{{srid}}",
+    "sridWithOriginal": "{{current}} ({{original}})",
     "present": "heute",
     "recordStatus": "Datensatzstatus",
     "createdBy": "Erstellt von",
@@ -203,6 +204,7 @@
     "editFailed": "Zelle konnte nicht aktualisiert werden",
     "editInvalidValue": "Kein gültiger {{type}}-Wert",
     "filter": "Filtern...",
+    "filterColumn": "{{column}} filtern",
     "noResults": "Keine passenden Zeilen gefunden.",
     "showingExact": "{{start}}-{{end}} von {{total}} Zeilen",
     "rowsPerPage": "Zeilen pro Seite",
@@ -217,6 +219,7 @@
     "noChanges": "Noch keine Änderungen erfasst.",
     "system": "System",
     "changed": "Geändert:",
+    "changedFields": "Geändert: {{fields}}",
     "actions": {
       "metadataEdit": "Metadaten aktualisiert",
       "datasetDelete": "Datensatz gelöscht",

--- a/frontend/src/i18n/locales/de/search.json
+++ b/frontend/src/i18n/locales/de/search.json
@@ -57,6 +57,7 @@
     "collection": "Sammlung",
     "collections": "Sammlungen",
     "temporalExtent": "Zeitliche Ausdehnung",
+    "temporalExtentRange": "Zeitliche Ausdehnung: {{start}} - {{end}}",
     "keywords": "Schlagworte",
     "keywordSearch": "Schlagworte suchen...",
     "noKeywords": "Keine Schlagworte verfügbar",
@@ -118,6 +119,7 @@
     "tableRows_other": "{{count}} Zeilen",
     "tableCols_one": "{{count}} Spalte",
     "tableCols_other": "{{count}} Spalten",
+    "tableRowsColsJoined": "{{rows}} · {{cols}}",
     "testData": "Testdaten",
     "noUpdateMetadata": "Keine Aktualisierungsmetadaten",
     "status": {
@@ -197,6 +199,8 @@
     "intersects": "Schneidet",
     "within": "Innerhalb",
     "useExtent": "Aktuellen Kartenausschnitt verwenden",
-    "clearArea": "Bereich löschen"
+    "clearArea": "Bereich löschen",
+    "polygonSelected_one": "{{count}} Polygon ausgewählt",
+    "polygonSelected_other": "{{count}} Polygone ausgewählt"
   }
 }

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -39,6 +39,7 @@
     "exportEmailsCsv": "Export emails (CSV)",
     "loading": "Loading users...",
     "errorLoading": "Failed to load users: {{message}}",
+    "searchPlaceholder": "Username / Email",
     "filters": {
       "allUsers": "All Users",
       "pending": "Pending",
@@ -199,6 +200,7 @@
     "title": "Audit Logs",
     "loading": "Loading audit logs...",
     "errorLoading": "Failed to load audit logs: {{message}}",
+    "searchPlaceholder": "User / Action",
     "filters": {
       "allActions": "All Actions",
       "datasetView": "Dataset View",
@@ -320,6 +322,7 @@
     "labels": {
       "aiEnabled": "AI Chat Enabled",
       "sendSampleValues": "Send Sample Values to LLM",
+      "maxAiTokensPerDay": "Max AI Tokens per User per Day (0=unlimited)",
       "llmProvider": "LLM Provider",
       "model": "Model",
       "openaiBaseUrl": "OpenAI-Compatible Base URL",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -339,6 +339,8 @@
       "colorByCount": "Color by cluster size",
       "baseColor": "Base color",
       "atCount": "From count",
+      "atCountIndexed": "From count, stop {{index}}",
+      "colorByCountIndexed": "Color by cluster size, stop {{index}}",
       "addStop": "Add color stop",
       "removeStop": "Remove color stop"
     },
@@ -581,6 +583,8 @@
     "added": "Added",
     "addToMap": "Add to map",
     "addToMapDetails": "Add to map (details panel)",
+    "addToMapNamed": "Add to map: {{name}}",
+    "addToMapDetailsNamed": "Add to map (details panel): {{name}}",
     "dragHandle": "Drag into map",
     "catalogEmpty": "Your catalog is empty. Upload a dataset to get started.",
     "uploadCta": "Upload a file →",
@@ -762,6 +766,8 @@
       "rejectAll": "Reject all",
       "accept": "Accept",
       "reject": "Reject",
+      "acceptAction": "Accept {{action}}",
+      "rejectAction": "Reject {{action}}",
       "chipAdd": "Add \"{{name}}\"",
       "chipAddBelow": "Add \"{{name}}\" below \"{{ref}}\"",
       "chipRemove": "Remove \"{{name}}\"",
@@ -833,6 +839,7 @@
     "saved": "Saved",
     "retry": "Retry",
     "retrySave": "Retry save",
+    "saveButtonAriaLabel": "{{action}}, {{status}}",
     "description": "Description",
     "unsavedDot": "Unsaved changes",
     "untitled": "Untitled Map",
@@ -936,7 +943,18 @@
     "clusterFallback": "{{name}} is rendering as points: {{reason}}",
     "clusterTruncated": "cluster source exceeded the bounded GeoJSON limit",
     "clusterLoadError": "{{name}} is rendering as points because cluster data could not load.",
-    "tokenError": "Failed to load tile tokens — some layers may not display."
+    "tokenError": "Failed to load tile tokens — some layers may not display.",
+    "clusterReason": {
+      "missingCount": "Feature count is unavailable for bounded clustering.",
+      "tooManyFeatures": "Dataset is too large for bounded client-side clustering.",
+      "notPoint": "Only point datasets can be clustered.",
+      "notVector": "Only vector datasets can be clustered.",
+      "unsupportedRecordType": "Dataset type does not support clustering."
+    }
+  },
+  "layerMutations": {
+    "layerFallback": "Layer",
+    "duplicateName": "{{name}} rendering"
   },
   "mapCreate": {
     "title": "Create Map",
@@ -1060,6 +1078,7 @@
   },
   "ephemeralBadge": {
     "queryResult": "Result",
+    "statusLabel": "{{result}} · {{summary}}",
     "featureCount_one": "{{count, number}} feature",
     "featureCount_other": "{{count, number}} features",
     "featureCountTruncated_one": "{{count, number}} of {{total, number}} features",
@@ -1350,6 +1369,7 @@
     "breadcrumbLabel": "Back to basemap group",
     "breadcrumb": "Basemap · {{name}} ›",
     "breadcrumbUntitled": "Untitled",
+    "sublayerFallback": "Sublayer",
     "resetAction": "Reset to default",
     "casingColor": "Casing color",
     "casingLabel": "CASING",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -144,6 +144,7 @@
     "copyToClipboard": "Copy to clipboard",
     "unknown": "Unknown",
     "original": "original: EPSG:{{srid}}",
+    "sridWithOriginal": "{{current}} ({{original}})",
     "present": "present",
     "temporalExtent": "Temporal Extent",
     "noTemporalExtent": "Not set",
@@ -200,6 +201,7 @@
     "showing": "Showing {{start}}-{{end}} of ~{{total}} rows",
     "previous": "Previous",
     "filter": "Filter...",
+    "filterColumn": "Filter {{column}}",
     "editSaved": "Cell updated",
     "editFailed": "Failed to update cell",
     "editInvalidValue": "Not a valid {{type}} value",
@@ -217,6 +219,7 @@
     "noChanges": "No changes recorded yet.",
     "system": "System",
     "changed": "Changed:",
+    "changedFields": "Changed: {{fields}}",
     "actions": {
       "metadataEdit": "Metadata updated",
       "datasetDelete": "Dataset deleted",

--- a/frontend/src/i18n/locales/en/search.json
+++ b/frontend/src/i18n/locales/en/search.json
@@ -65,6 +65,7 @@
     "collection": "Collection",
     "collections": "Collections",
     "temporalExtent": "Temporal Extent",
+    "temporalExtentRange": "Temporal Extent: {{start}} - {{end}}",
     "keywords": "Keywords",
     "keywordSearch": "Search keywords...",
     "noKeywords": "No keywords available",
@@ -118,6 +119,7 @@
     "tableRows_other": "{{count}} rows",
     "tableCols_one": "{{count}} col",
     "tableCols_other": "{{count}} cols",
+    "tableRowsColsJoined": "{{rows}} · {{cols}}",
     "testData": "Test Data",
     "noUpdateMetadata": "No update metadata",
     "status": {
@@ -152,7 +154,9 @@
     "intersects": "Intersects",
     "within": "Within",
     "useExtent": "Use current map extent",
-    "clearArea": "Clear area"
+    "clearArea": "Clear area",
+    "polygonSelected_one": "{{count}} polygon selected",
+    "polygonSelected_other": "{{count}} polygons selected"
   },
   "bbox": {
     "mapAriaLabel": "Bounding box map",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -39,6 +39,7 @@
     "exportEmailsCsv": "Exportar correos (CSV)",
     "loading": "Cargando usuarios...",
     "errorLoading": "Error al cargar usuarios: {{message}}",
+    "searchPlaceholder": "Nombre de usuario / Correo electrónico",
     "filters": {
       "allUsers": "Todos los usuarios",
       "pending": "Pendientes",
@@ -199,6 +200,7 @@
     "title": "Registros de auditoría",
     "loading": "Cargando registros de auditoría...",
     "errorLoading": "Error al cargar registros de auditoría: {{message}}",
+    "searchPlaceholder": "Usuario / Acción",
     "filters": {
       "allActions": "Todas las acciones",
       "datasetView": "Vista de conjunto de datos",
@@ -290,6 +292,7 @@
     "labels": {
       "aiEnabled": "Chat IA habilitado",
       "sendSampleValues": "Enviar valores de ejemplo al LLM",
+      "maxAiTokensPerDay": "Máximo de tokens de IA por usuario al día (0=ilimitado)",
       "llmProvider": "Proveedor LLM",
       "model": "Modelo",
       "openaiBaseUrl": "URL base compatible con OpenAI",
@@ -745,7 +748,7 @@
     "spEntityId": "Entity ID del SP",
     "spEntityIdWarning": "Esto debe coincidir exactamente con el entityID del SP registrado con su IdP. Una vez configurado, no lo cambie.",
     "defaultRole": "Rol predeterminado",
-    "groupClaim": "Group Claim",
+    "groupClaim": "Claim de grupo",
     "groupClaimHint": "Nombre del atributo SAML que contiene las pertenencias a grupos del usuario para el mapeo automático de roles (p. ej., \"groups\", \"http://schemas.xmlsoap.org/claims/Group\").",
     "groupRoleMapping": "Mapeo de Grupos a Roles (JSON)",
     "groupRoleMappingHint": "Asigna nombres de grupos del IdP a roles de GeoLens. Formato de objeto JSON.",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -339,6 +339,8 @@
       "colorByCount": "Colorear por tamaño de clúster",
       "baseColor": "Color base",
       "atCount": "Desde recuento",
+      "atCountIndexed": "Desde recuento, parada {{index}}",
+      "colorByCountIndexed": "Colorear por tamaño de clúster, parada {{index}}",
       "addStop": "Añadir parada de color",
       "removeStop": "Quitar parada de color"
     },
@@ -581,6 +583,8 @@
     "added": "Agregado",
     "addToMap": "Agregar al mapa",
     "addToMapDetails": "Agregar al mapa (panel de detalles)",
+    "addToMapNamed": "Agregar al mapa: {{name}}",
+    "addToMapDetailsNamed": "Agregar al mapa (panel de detalles): {{name}}",
     "dragHandle": "Arrastrar hacia el mapa",
     "catalogEmpty": "Su catálogo está vacío. Cargue un conjunto de datos para comenzar.",
     "uploadCta": "Subir un archivo →",
@@ -761,6 +765,8 @@
       "rejectAll": "Rechazar todo",
       "accept": "Aceptar",
       "reject": "Rechazar",
+      "acceptAction": "Aceptar {{action}}",
+      "rejectAction": "Rechazar {{action}}",
       "chipAdd": "Agregar \"{{name}}\"",
       "chipAddBelow": "Agregar \"{{name}}\" debajo de \"{{ref}}\"",
       "chipRemove": "Quitar \"{{name}}\"",
@@ -833,6 +839,7 @@
     "saved": "Guardado",
     "retry": "Reintentar",
     "retrySave": "Reintentar guardado",
+    "saveButtonAriaLabel": "{{action}}, {{status}}",
     "saveStatus": {
       "saved": "Guardado",
       "unsaved": "Cambios sin guardar",
@@ -936,7 +943,18 @@
     "clusterFallback": "{{name}} se renderiza como puntos: {{reason}}",
     "clusterTruncated": "la fuente agrupada superó el límite de GeoJSON acotado",
     "clusterLoadError": "{{name}} se renderiza como puntos porque no se pudieron cargar los datos agrupados.",
-    "tokenError": "No se pudieron cargar los tokens de mosaico — es posible que algunas capas no se muestren."
+    "tokenError": "No se pudieron cargar los tokens de mosaico — es posible que algunas capas no se muestren.",
+    "clusterReason": {
+      "missingCount": "El recuento de entidades no está disponible para la agrupación acotada.",
+      "tooManyFeatures": "El conjunto de datos es demasiado grande para la agrupación acotada del lado del cliente.",
+      "notPoint": "Solo los conjuntos de datos de puntos se pueden agrupar.",
+      "notVector": "Solo los conjuntos de datos vectoriales se pueden agrupar.",
+      "unsupportedRecordType": "El tipo de conjunto de datos no admite agrupación."
+    }
+  },
+  "layerMutations": {
+    "layerFallback": "Capa",
+    "duplicateName": "Renderizado de {{name}}"
   },
   "mapCreate": {
     "title": "Crear mapa",
@@ -1060,6 +1078,7 @@
   },
   "ephemeralBadge": {
     "queryResult": "Resultado",
+    "statusLabel": "{{result}} · {{summary}}",
     "featureCount_one": "{{count, number}} entidad",
     "featureCount_other": "{{count, number}} entidades",
     "dismiss": "Descartar resultado",
@@ -1346,6 +1365,7 @@
     "breadcrumbLabel": "Volver al grupo de mapa base",
     "breadcrumb": "Mapa base · {{name}} ›",
     "breadcrumbUntitled": "Sin título",
+    "sublayerFallback": "Subcapa",
     "casingColor": "Color del contorno",
     "casingLabel": "CONTORNO",
     "casingWidth": "Ancho",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -144,6 +144,7 @@
     "copyToClipboard": "Copiar al portapapeles",
     "unknown": "Desconocido",
     "original": "original: EPSG:{{srid}}",
+    "sridWithOriginal": "{{current}} ({{original}})",
     "present": "presente",
     "recordStatus": "Estado del registro",
     "createdBy": "Creado por",
@@ -203,6 +204,7 @@
     "editFailed": "Error al actualizar celda",
     "editInvalidValue": "No es un valor {{type}} válido",
     "filter": "Filtrar...",
+    "filterColumn": "Filtrar {{column}}",
     "noResults": "No se encontraron filas coincidentes.",
     "showingExact": "Mostrando {{start}}-{{end}} de {{total}} filas",
     "rowsPerPage": "Filas por página",
@@ -217,6 +219,7 @@
     "noChanges": "Aún no se han registrado cambios.",
     "system": "Sistema",
     "changed": "Cambiado:",
+    "changedFields": "Cambiado: {{fields}}",
     "actions": {
       "metadataEdit": "Metadatos actualizados",
       "datasetDelete": "Conjunto de datos eliminado",

--- a/frontend/src/i18n/locales/es/search.json
+++ b/frontend/src/i18n/locales/es/search.json
@@ -57,6 +57,7 @@
     "collection": "Colección",
     "collections": "Colecciones",
     "temporalExtent": "Extensión temporal",
+    "temporalExtentRange": "Extensión temporal: {{start}} - {{end}}",
     "keywords": "Palabras clave",
     "keywordSearch": "Buscar palabras clave...",
     "noKeywords": "No hay palabras clave disponibles",
@@ -118,6 +119,7 @@
     "tableRows_other": "{{count}} filas",
     "tableCols_one": "{{count}} col.",
     "tableCols_other": "{{count}} col.",
+    "tableRowsColsJoined": "{{rows}} · {{cols}}",
     "testData": "Datos de prueba",
     "noUpdateMetadata": "Sin metadatos de actualización",
     "status": {
@@ -197,6 +199,8 @@
     "intersects": "Interseca",
     "within": "Dentro",
     "useExtent": "Usar extensión actual del mapa",
-    "clearArea": "Borrar área"
+    "clearArea": "Borrar área",
+    "polygonSelected_one": "{{count}} polígono seleccionado",
+    "polygonSelected_other": "{{count}} polígonos seleccionados"
   }
 }

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -39,6 +39,7 @@
     "exportEmailsCsv": "Exporter les e-mails (CSV)",
     "loading": "Chargement des utilisateurs...",
     "errorLoading": "Échec du chargement des utilisateurs : {{message}}",
+    "searchPlaceholder": "Nom d'utilisateur / E-mail",
     "filters": {
       "allUsers": "Tous les utilisateurs",
       "pending": "En attente",
@@ -199,6 +200,7 @@
     "title": "Journal d'audit",
     "loading": "Chargement du journal d'audit...",
     "errorLoading": "Échec du chargement du journal d'audit : {{message}}",
+    "searchPlaceholder": "Utilisateur / Action",
     "filters": {
       "allActions": "Toutes les actions",
       "datasetView": "Consultation de jeu de données",
@@ -290,6 +292,7 @@
     "labels": {
       "aiEnabled": "Chat IA activé",
       "sendSampleValues": "Envoyer des valeurs d'exemple au LLM",
+      "maxAiTokensPerDay": "Jetons IA max par utilisateur et par jour (0=illimité)",
       "llmProvider": "Fournisseur LLM",
       "model": "Modèle",
       "openaiBaseUrl": "URL de base compatible OpenAI",
@@ -745,7 +748,7 @@
     "spEntityId": "Entity ID du SP",
     "spEntityIdWarning": "Doit correspondre exactement à l'entityID SP enregistré auprès de votre IdP. Une fois configuré, ne pas modifier.",
     "defaultRole": "Rôle par défaut",
-    "groupClaim": "Group Claim",
+    "groupClaim": "Claim de groupe",
     "groupClaimHint": "Nom de l'attribut SAML contenant les appartenances aux groupes de l'utilisateur pour le mapping automatique des rôles (p. ex. \"groups\", \"http://schemas.xmlsoap.org/claims/Group\").",
     "groupRoleMapping": "Mapping Groupes → Rôles (JSON)",
     "groupRoleMappingHint": "Associe les noms de groupes IdP aux rôles GeoLens. Format objet JSON.",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -339,6 +339,8 @@
       "colorByCount": "Colorer par taille de cluster",
       "baseColor": "Couleur de base",
       "atCount": "À partir du nombre",
+      "atCountIndexed": "À partir du nombre, palier {{index}}",
+      "colorByCountIndexed": "Colorer par taille de cluster, palier {{index}}",
       "addStop": "Ajouter un palier de couleur",
       "removeStop": "Supprimer le palier de couleur"
     },
@@ -581,6 +583,8 @@
     "added": "Ajouté",
     "addToMap": "Ajouter à la carte",
     "addToMapDetails": "Ajouter à la carte (panneau de détails)",
+    "addToMapNamed": "Ajouter à la carte : {{name}}",
+    "addToMapDetailsNamed": "Ajouter à la carte (panneau de détails) : {{name}}",
     "dragHandle": "Glisser dans la carte",
     "catalogEmpty": "Votre catalogue est vide. Importez un jeu de données pour commencer.",
     "uploadCta": "Téléverser un fichier →",
@@ -761,6 +765,8 @@
       "rejectAll": "Tout rejeter",
       "accept": "Accepter",
       "reject": "Rejeter",
+      "acceptAction": "Accepter {{action}}",
+      "rejectAction": "Rejeter {{action}}",
       "chipAdd": "Ajouter \"{{name}}\"",
       "chipAddBelow": "Ajouter \"{{name}}\" sous \"{{ref}}\"",
       "chipRemove": "Supprimer \"{{name}}\"",
@@ -833,6 +839,7 @@
     "saved": "Enregistré",
     "retry": "Réessayer",
     "retrySave": "Réessayer l'enregistrement",
+    "saveButtonAriaLabel": "{{action}}, {{status}}",
     "saveStatus": {
       "saved": "Enregistré",
       "unsaved": "Modifications non enregistrées",
@@ -936,7 +943,18 @@
     "clusterFallback": "{{name}} s'affiche sous forme de points : {{reason}}",
     "clusterTruncated": "la source d'agrégats dépasse la limite GeoJSON bornée",
     "clusterLoadError": "{{name}} s'affiche sous forme de points, car les données d'agrégats n'ont pas pu être chargées.",
-    "tokenError": "Impossible de charger les jetons de tuiles — certaines couches peuvent ne pas s'afficher."
+    "tokenError": "Impossible de charger les jetons de tuiles — certaines couches peuvent ne pas s'afficher.",
+    "clusterReason": {
+      "missingCount": "Le nombre d'entités est indisponible pour le clustering borné.",
+      "tooManyFeatures": "Le jeu de données est trop volumineux pour un clustering borné côté client.",
+      "notPoint": "Seuls les jeux de données ponctuels peuvent être regroupés.",
+      "notVector": "Seuls les jeux de données vectoriels peuvent être regroupés.",
+      "unsupportedRecordType": "Ce type de jeu de données ne prend pas en charge le regroupement."
+    }
+  },
+  "layerMutations": {
+    "layerFallback": "Couche",
+    "duplicateName": "Rendu de {{name}}"
   },
   "mapCreate": {
     "title": "Créer une carte",
@@ -1060,6 +1078,7 @@
   },
   "ephemeralBadge": {
     "queryResult": "Résultat",
+    "statusLabel": "{{result}} · {{summary}}",
     "featureCount_one": "{{count, number}} entité",
     "featureCount_other": "{{count, number}} entités",
     "dismiss": "Fermer le résultat",
@@ -1346,6 +1365,7 @@
     "breadcrumbLabel": "Retour au groupe de fond de carte",
     "breadcrumb": "Fond de carte · {{name}} ›",
     "breadcrumbUntitled": "Sans titre",
+    "sublayerFallback": "Sous-couche",
     "casingColor": "Couleur du contour",
     "casingLabel": "CONTOUR",
     "casingWidth": "Largeur",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -144,6 +144,7 @@
     "copyToClipboard": "Copier dans le presse-papiers",
     "unknown": "Inconnu",
     "original": "original : EPSG:{{srid}}",
+    "sridWithOriginal": "{{current}} ({{original}})",
     "present": "présent",
     "recordStatus": "Statut de l'enregistrement",
     "createdBy": "Créé par",
@@ -203,6 +204,7 @@
     "editFailed": "Échec de la mise à jour de la cellule",
     "editInvalidValue": "Valeur {{type}} non valide",
     "filter": "Filtrer...",
+    "filterColumn": "Filtrer {{column}}",
     "noResults": "Aucune ligne correspondante trouvée.",
     "showingExact": "Affichage {{start}}-{{end}} sur {{total}} lignes",
     "rowsPerPage": "Lignes par page",
@@ -217,6 +219,7 @@
     "noChanges": "Aucune modification enregistrée.",
     "system": "Système",
     "changed": "Modifié :",
+    "changedFields": "Modifié : {{fields}}",
     "actions": {
       "metadataEdit": "Métadonnées mises à jour",
       "datasetDelete": "Jeu de données supprimé",

--- a/frontend/src/i18n/locales/fr/search.json
+++ b/frontend/src/i18n/locales/fr/search.json
@@ -57,6 +57,7 @@
     "collection": "Collection",
     "collections": "Collections",
     "temporalExtent": "Etendue temporelle",
+    "temporalExtentRange": "Étendue temporelle : {{start}} - {{end}}",
     "keywords": "Mots-clés",
     "keywordSearch": "Rechercher des mots-clés...",
     "noKeywords": "Aucun mot-clé disponible",
@@ -118,6 +119,7 @@
     "tableRows_other": "{{count}} lignes",
     "tableCols_one": "{{count}} col.",
     "tableCols_other": "{{count}} col.",
+    "tableRowsColsJoined": "{{rows}} · {{cols}}",
     "testData": "Données de test",
     "noUpdateMetadata": "Pas de métadonnées de mise à jour",
     "status": {
@@ -197,6 +199,8 @@
     "intersects": "Intersecte",
     "within": "Dans",
     "useExtent": "Utiliser l'étendue de la carte actuelle",
-    "clearArea": "Effacer la zone"
+    "clearArea": "Effacer la zone",
+    "polygonSelected_one": "{{count}} polygone sélectionné",
+    "polygonSelected_other": "{{count}} polygones sélectionnés"
   }
 }

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -603,7 +603,7 @@ export function MapBuilderPage() {
     const presetName = presetId
       .replace(/^(openfreemap-|carto-|mapbox-|maptiler-|esri-|stamen-|stadia-)/, '')
       .replace(/-/g, ' ')
-      .replace(/\b\w/g, (c) => c.toUpperCase()) || 'Basemap';
+      .replace(/\b\w/g, (c) => c.toUpperCase()) || t('search.basemap', { defaultValue: 'Basemap' });
 
     return {
       id: 'basemap-group',
@@ -631,6 +631,12 @@ export function MapBuilderPage() {
     localLayers: layers.localLayers,
     savedLayerBaseline: layers.savedLayerBaseline,
     basemapGroup,
+    labels: {
+      settingsName: t('unifiedStack.settings', { defaultValue: 'Settings' }),
+      sublayerFallback: t('basemapSublayer.sublayerFallback', { defaultValue: 'Sublayer' }),
+      untitledFallback: t('basemapSublayer.breadcrumbUntitled', { defaultValue: 'Untitled' }),
+      basemapGroupName: (presetName) => t('basemapGroup.rowName', { name: presetName, defaultValue: 'Basemap · {{name}}' }),
+    },
   });
 
   // fix(#392): 'group' means the editor is closed (LayerEditorPanel never


### PR DESCRIPTION
## Summary

Closes the four string clusters surfaced by the 2026-08-07 internal i18n audit (44 remaining English strings vs. 3,883 externalized keys per locale):

- **Workstream A** — `SettingsAITab.tsx` / `SettingsNetworkTab.tsx` dropped the dead `findSetting(...)?.label` half at all 12 sites so the `t(...)` fallback actually renders (backend `SettingItem.label` is English-only and `label` stays for CLI/script consumers).
- **Workstream B** — `clusterFallbackMessage` in `cluster-source.ts` now returns the `ClusterSourceStatus` code instead of an English sentence; `BuilderMap.tsx` translates at the call site via new `builderMap.clusterReason.*` keys. The helper itself stays pure (no `t()`).
- **Workstream C** — `use-builder-editor-scene.ts` and `builder-layer-mutations.ts` accept translated label objects (defaulting to the current English copy, so existing pure-function tests pass unmodified) instead of hardcoding `'Settings'`/`'Sublayer'`/`'Untitled'`/`'Layer'`/`'rendering'`. `MapBuilderPage.tsx`'s basemap-ID fallback and `SamlProvidersSection.tsx`'s certificate placeholder now reuse existing translated keys. `SpatialFilterPanel.tsx`'s `1 polygon selected` moved to a proper `_one`/`_other` plural key. `admin:saml.groupClaim` is now translated in es/fr/de (it matched the OAuth `groupClaim` sibling key, which was already translated).
- **Workstream D** — replaced string concatenation with full interpolation keys across `DatasetSearchPanel`, `ChatPanel`, `ClusterEditor`, `AttributeTable`, `MapTitleBar`, `FilterPanel`/`FilterSheet`, `UserList`/`AuditLogViewer`, `ChangeHistory`, `ephemeral-preview.ts`, and `SearchResultCard`/`SpatialExtentCard`, so translators control word order instead of JS-level string glue.

Every new/changed key ships with real translations in all four locales (en/es/fr/de) — no `defaultValue`-only keys.

## Test plan

- [x] `cd frontend && npm ci`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:i18n`
- [x] `npm run check:i18n:changed`
- [x] `npm run check:i18n:toast-strings`
- [x] `npm run check:i18n:api-errors`
- [x] `npm run test:coverage` (full suite: 383 files / 4693 tests passed)
- [x] Targeted `npx vitest run` for every touched component/hook

Closes #1301