### PR TITLE
fix(cli): make the refresh_not_applicable copy origin-kind-agnostic

### DIFF
--- a/cli/geolens_cli/refresh.py
+++ b/cli/geolens_cli/refresh.py
@@ -54,8 +54,9 @@ class RefreshPollResult:
 
 _REFUSAL_MESSAGES: dict[str, str] = {
     "refresh_not_applicable": (
-        "This dataset has no refreshable service origin. Replace its data "
-        "through re-upload instead."
+        "This dataset's origin does not support refresh. Replace its data "
+        "through re-upload, or re-run 'geolens apply' with an updated "
+        "manifest."
     ),
     "origin_unavailable": (
         "This dataset's stored service binding is incomplete. Re-import the "

--- a/cli/tests/test_refresh.py
+++ b/cli/tests/test_refresh.py
@@ -212,7 +212,7 @@ class TestRefreshRequest:
 @pytest.mark.parametrize(
     "code,expected",
     [
-        ("refresh_not_applicable", "no refreshable service origin"),
+        ("refresh_not_applicable", "origin does not support refresh"),
         ("origin_unavailable", "stored service binding is incomplete"),
         ("dataset_busy", "already running"),
         ("origin_changed", "source changed"),


### PR DESCRIPTION
One-string copy fix per #1318: the `refresh_not_applicable` refusal said "no refreshable service origin", stale since #1313 made registered-PostGIS origins refreshable. The new copy avoids enumerating origin kinds (they will drift again) and points at both replacement paths.

Test updated to match the new copy substring.

Verification: `cd cli && uv run --extra dev python -m pytest tests/ -q` — 308 passed.

Closes #1318