### PR TITLE
fix(catalog): key duplicate-source guards on the canonical origin_ref pair

### DIFF
--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -48,6 +48,7 @@ from app.modules.catalog.sources.security import (
     make_safe_client,
     validate_url_for_ssrf,
 )
+from app.platform.dataset_origin import service_layer_identity
 from app.standards.ogc.errors import ERROR_RESPONSES_WRITE, PROBLEM_RESPONSE
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -802,18 +803,35 @@ async def preview_service_layer(
             if effective_layer_id is not None
             else base_url
         )
-        # feat(#1220) / ADR-002 Decision 6: keyed on `origin_uri`, the
-        # system-managed pointer, with `source_url` kept only as the fallback
-        # for rows migration 0036 could not backfill. `source_url` is reachable
-        # through the metadata PATCH, so keying the guard on it alone let an
-        # owner edit their way past it and register the same layer twice;
-        # `origin_uri` appears in no field map and only ingest writes it.
+        # fix(#1286): keyed on the canonical structured identity in
+        # `origin_ref` — the same (service_type, base url, layer identity)
+        # triple that `service_layer_identity` folds a refresh's arguments
+        # back into (router_refresh.py `_resolve_service_origin`) — rather
+        # than on `origin_uri`'s string spelling. PR #1277's round-11 review
+        # found that a writer producing a different spelling of the same
+        # origin (a bare base URL instead of `base_url/typename`) silently
+        # stopped an origin_uri-keyed guard from catching a duplicate.
+        # `origin_ref` round-trips through the same helper on every writer,
+        # so it cannot drift the way a hand-composed string can.
+        # `source_url` is kept only as the fallback for rows migration 0036
+        # could not backfill: it is reachable through the metadata PATCH, so
+        # keying the guard on it alone let an owner edit their way past it.
+        canonical_layer_id = service_layer_identity(
+            source_format, layer_id=effective_layer_id, layer_name=request.layer_name
+        )
+        origin_ref_layer_id = Dataset.origin_ref["layer_id"].astext
         existing_stmt = (
             select(Dataset.id, Record.title)
             .join(Record, Dataset.record_id == Record.id)
             .where(
                 or_(
-                    Dataset.origin_uri == enriched_url,
+                    and_(
+                        Dataset.origin_ref["service_type"].astext == source_format,
+                        Dataset.origin_ref["url"].astext == base_url,
+                        origin_ref_layer_id.is_(None)
+                        if canonical_layer_id is None
+                        else origin_ref_layer_id == canonical_layer_id,
+                    ),
                     and_(
                         Dataset.origin_uri.is_(None),
                         Dataset.source_url == enriched_url,

--- a/backend/app/modules/catalog/sources/router.py
+++ b/backend/app/modules/catalog/sources/router.py
@@ -813,12 +813,22 @@ async def preview_service_layer(
         # stopped an origin_uri-keyed guard from catching a duplicate.
         # `origin_ref` round-trips through the same helper on every writer,
         # so it cannot drift the way a hand-composed string can.
-        # `source_url` is kept only as the fallback for rows migration 0036
-        # could not backfill: it is reachable through the metadata PATCH, so
-        # keying the guard on it alone let an owner edit their way past it.
+        # `source_url` is kept only as the fallback for rows whose structured
+        # identity migration 0036 could not backfill. That is NOT simply
+        # `origin_uri IS NULL`: for a WFS/OGC row with no surviving ingest
+        # job, 0036's service backfill populates `origin_uri` from the old
+        # enriched `source_url` while leaving `origin_ref` without `url` or
+        # `layer_id` (it had no way to recover the typename). Gating the
+        # fallback on origin_uri alone would leave such a row caught by
+        # neither branch (codex review, PR #1320) — the fallback fires
+        # whenever the structured identity itself is incomplete instead.
+        # `source_url` is reachable through the metadata PATCH, so keying the
+        # guard on it alone (rather than as this narrow fallback) let an
+        # owner edit their way past it.
         canonical_layer_id = service_layer_identity(
             source_format, layer_id=effective_layer_id, layer_name=request.layer_name
         )
+        origin_ref_url = Dataset.origin_ref["url"].astext
         origin_ref_layer_id = Dataset.origin_ref["layer_id"].astext
         existing_stmt = (
             select(Dataset.id, Record.title)
@@ -827,13 +837,13 @@ async def preview_service_layer(
                 or_(
                     and_(
                         Dataset.origin_ref["service_type"].astext == source_format,
-                        Dataset.origin_ref["url"].astext == base_url,
+                        origin_ref_url == base_url,
                         origin_ref_layer_id.is_(None)
                         if canonical_layer_id is None
                         else origin_ref_layer_id == canonical_layer_id,
                     ),
                     and_(
-                        Dataset.origin_uri.is_(None),
+                        or_(origin_ref_url.is_(None), origin_ref_layer_id.is_(None)),
                         Dataset.source_url == enriched_url,
                     ),
                 ),

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -512,20 +512,25 @@ async def stac_import(
 
     # Batch duplicate check — single query instead of N individual SELECTs.
     #
-    # feat(#1220) / ADR-002 Decision 6: keyed on `origin_uri`, which the STAC
-    # import sets to the asset href, with `source_url` kept as the fallback
-    # for rows migration 0036 could not backfill — the re-key #1218's comment
-    # at the `set_dataset_origin` call below anticipated. `source_url` is
-    # PATCHable, so an owner who edited it could re-import the same asset as a
-    # second dataset; `origin_uri` is system-managed and reaches no field map.
+    # fix(#1286): keyed on `origin_ref`'s `asset_href`, the structured
+    # pointer, rather than on `origin_uri`'s string spelling — the same
+    # re-key applied to the service-preview guard in
+    # `catalog/sources/router.py`, so any future writer that produces a
+    # different spelling of the same asset can no longer degrade this guard
+    # without failing a test. `source_url` is kept as the fallback for rows
+    # migration 0036 could not backfill; it is PATCHable, so an owner who
+    # edited it could otherwise re-import the same asset as a second dataset.
     hrefs = [i.data_asset_href for i in request.items]
     existing_hrefs: set[str] = {
-        row.origin_uri or row.source_url
+        row.asset_href or row.source_url
         for row in (
             await db.execute(
-                select(Dataset.origin_uri, Dataset.source_url).where(
+                select(
+                    Dataset.origin_ref["asset_href"].astext.label("asset_href"),
+                    Dataset.source_url,
+                ).where(
                     or_(
-                        Dataset.origin_uri.in_(hrefs),
+                        Dataset.origin_ref["asset_href"].astext.in_(hrefs),
                         and_(
                             Dataset.origin_uri.is_(None),
                             Dataset.source_url.in_(hrefs),
@@ -535,7 +540,7 @@ async def stac_import(
                 )
             )
         ).all()
-        if (row.origin_uri or row.source_url) is not None
+        if (row.asset_href or row.source_url) is not None
     }
 
     # Pre-filter importable items and SSRF-validate, then fetch COG info
@@ -638,9 +643,9 @@ async def stac_import(
                     last_refreshed_at=datetime.now(timezone.utc),
                 )
                 # feat(#1218): system-managed origin pointer. The asset href is
-                # also what the duplicate-source guard keys on, so pointing
-                # origin_uri at it keeps that guard identical when ADR-002
-                # Decision 6 re-keys it off the PATCHable source_url.
+                # also what the duplicate-source guard keys on (fix #1286: via
+                # origin_ref.asset_href, not the origin_uri string), so
+                # writing it here keeps both in agreement by construction.
                 # feat(#1222): item_href joins the payload now that search
                 # surfaces it. It is the only stored value that can answer
                 # "was this item withdrawn from the catalog?" — the asset href

--- a/backend/tests/test_services_endpoints.py
+++ b/backend/tests/test_services_endpoints.py
@@ -835,9 +835,21 @@ _ARCGIS_LAYER_1_URL = f"{_ARCGIS_BASE}/1"
 
 
 async def _create_arcgis_dataset(
-    session, *, created_by, source_url, name="Test ArcGIS Dataset"
+    session,
+    *,
+    created_by,
+    source_url,
+    name="Test ArcGIS Dataset",
+    origin_uri=None,
+    origin_ref=None,
 ):
-    """Insert a Dataset simulating a previously registered ArcGIS FeatureServer layer."""
+    """Insert a Dataset simulating a previously registered ArcGIS FeatureServer layer.
+
+    ``origin_uri``/``origin_ref`` default to unset, which is the shape of a
+    row migration 0036 could not backfill (the un-backfilled fallback case);
+    callers that want to simulate a fully-bound (post-#1218) dataset pass
+    both explicitly.
+    """
     import uuid as _uuid
     from app.modules.catalog.datasets.domain.models import Dataset, Record
 
@@ -861,6 +873,8 @@ async def _create_arcgis_dataset(
         source_format="arcgis_featureserver",
         source_filename="TestService",
         source_url=source_url,
+        origin_uri=origin_uri,
+        origin_ref=origin_ref,
     )
     session.add(dataset)
     await session.commit()
@@ -881,7 +895,13 @@ class TestDuplicateSourceDetection:
         mock_build_gdal_source,
         mock_run_preview,
     ):
-        """POST /services/preview/ with same source_url+format+user returns 409."""
+        """POST /services/preview/ with same source_url+format+user returns 409.
+
+        fix(#1286): also the un-backfilled-row regression test for the
+        origin_ref re-key — the dataset below carries neither ``origin_uri``
+        nor ``origin_ref`` (a row migration 0036 could not backfill), so the
+        guard can only catch it through the ``source_url`` fallback branch.
+        """
         from tests.factories import get_user_id
 
         admin_id = await get_user_id(test_db_session, "admin")
@@ -997,13 +1017,13 @@ class TestDuplicateSourceDetection:
         mock_run_preview,
         mock_fetch_arcgis_preview,
     ):
-        """feat(#1220) / ADR-002 Decision 6: the guard keys on ``origin_uri``.
+        """fix(#1286): the guard keys on ``origin_ref``, not ``origin_uri``.
 
         ``source_url`` is reachable through the metadata PATCH, so keying the
         guard on it alone let an owner edit their way past it and register the
-        same layer a second time. ``origin_uri`` appears in no field map and
-        only ingest writes it, which is what makes it the honest key. The
-        preceding tests keep the ``source_url`` fallback honest for rows
+        same layer a second time. ``origin_ref`` appears in no field map and
+        only ingest/refresh write it, which is what makes it the honest key.
+        The preceding tests keep the ``source_url`` fallback honest for rows
         migration 0036 could not backfill.
         """
         from tests.factories import get_user_id
@@ -1019,8 +1039,14 @@ class TestDuplicateSourceDetection:
             created_by=admin_id,
             source_url=f"{base}/0",
             name="Bulletin Table",
+            origin_uri=f"{base}/0",
+            origin_ref={
+                "kind": "service",
+                "service_type": "arcgis_featureserver",
+                "url": base,
+                "layer_id": "0",
+            },
         )
-        existing.origin_uri = f"{base}/0"
         existing.source_url = "https://example.invalid/edited-by-the-owner"
         await test_db_session.commit()
 
@@ -1081,3 +1107,104 @@ class TestDuplicateSourceDetection:
         message = resp.json()["detail"]["message"]
         assert "refresh that dataset" in message
         assert "delete the existing dataset" not in message
+
+    async def test_preview_catches_a_never_refreshed_dataset_bound_via_origin_ref(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        mock_validate_ssrf,
+        mock_build_gdal_source,
+        mock_run_preview,
+        mock_fetch_arcgis_preview,
+    ):
+        """fix(#1286): a fully-bound, never-refreshed dataset is still caught.
+
+        ``origin_uri`` and ``origin_ref`` agree (the ordinary post-#1218
+        shape — no writer has touched the binding since import), so the
+        primary origin_ref-keyed branch must match on its own, with no help
+        from the source_url fallback.
+        """
+        from tests.factories import get_user_id
+
+        base = f"{_ARCGIS_BASE.replace('TestService', 'NeverRefreshedService')}"
+        admin_id = await get_user_id(test_db_session, "admin")
+        await _create_arcgis_dataset(
+            test_db_session,
+            created_by=admin_id,
+            source_url=f"{base}/0",
+            name="Never Refreshed",
+            origin_uri=f"{base}/0",
+            origin_ref={
+                "kind": "service",
+                "service_type": "arcgis_featureserver",
+                "url": base,
+                "layer_id": "0",
+            },
+        )
+
+        resp = await client.post(
+            "/services/preview/",
+            json={
+                "url": base,
+                "service_type": "ArcGIS:FeatureServer",
+                "layer_name": "0",
+                "layer_id": 0,
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["code"] == "duplicate_source"
+
+    async def test_preview_catches_a_respelled_origin_uri(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        mock_validate_ssrf,
+        mock_build_gdal_source,
+        mock_run_preview,
+        mock_fetch_arcgis_preview,
+    ):
+        """fix(#1286): a respelled origin_uri can no longer open the hole.
+
+        Reproduces the PR #1277 round-11 class of bug: a writer (e.g. a
+        refresh) rewrites ``origin_uri`` to a different spelling of the same
+        origin — here a bare base URL instead of ``base_url/layer_id`` —
+        while ``origin_ref`` still names the identical (service_type, url,
+        layer_id) triple. An ``origin_uri``-keyed guard stops matching this
+        row; the origin_ref-keyed guard must not, because the canonical
+        identity never changed.
+        """
+        from tests.factories import get_user_id
+
+        base = f"{_ARCGIS_BASE.replace('TestService', 'RespelledUriService')}"
+        admin_id = await get_user_id(test_db_session, "admin")
+        await _create_arcgis_dataset(
+            test_db_session,
+            created_by=admin_id,
+            source_url=f"{base}/0",
+            name="Respelled Pointer",
+            # The respelling: origin_uri drifted to the bare base URL, with
+            # no /0 layer suffix, even though this row is still layer 0.
+            origin_uri=base,
+            origin_ref={
+                "kind": "service",
+                "service_type": "arcgis_featureserver",
+                "url": base,
+                "layer_id": "0",
+            },
+        )
+
+        resp = await client.post(
+            "/services/preview/",
+            json={
+                "url": base,
+                "service_type": "ArcGIS:FeatureServer",
+                "layer_name": "0",
+                "layer_id": 0,
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["code"] == "duplicate_source"

--- a/backend/tests/test_services_endpoints.py
+++ b/backend/tests/test_services_endpoints.py
@@ -1208,3 +1208,54 @@ class TestDuplicateSourceDetection:
         )
         assert resp.status_code == 409
         assert resp.json()["detail"]["code"] == "duplicate_source"
+
+    async def test_preview_catches_a_partially_backfilled_dataset(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        mock_validate_ssrf,
+        mock_build_gdal_source,
+        mock_run_preview,
+        mock_fetch_arcgis_preview,
+    ):
+        """fix(#1286 codex review, PR #1320): an incomplete origin_ref still
+        falls through to the source_url fallback.
+
+        Migration 0036's service backfill can populate ``origin_uri`` from
+        the legacy enriched ``source_url`` while leaving ``origin_ref``
+        without ``url``/``layer_id`` — a WFS/OGC row with no surviving
+        ingest job to recover the typename from. Gating the fallback on
+        ``origin_uri IS NULL`` alone would miss this row entirely: it is
+        matched by neither the (incomplete) structured identity nor an
+        origin_uri-null fallback. The fallback keys off an incomplete
+        structured identity instead.
+        """
+        from tests.factories import get_user_id
+
+        base = f"{_ARCGIS_BASE.replace('TestService', 'PartiallyBackfilledService')}"
+        admin_id = await get_user_id(test_db_session, "admin")
+        await _create_arcgis_dataset(
+            test_db_session,
+            created_by=admin_id,
+            source_url=f"{base}/0",
+            name="Partially Backfilled Row",
+            origin_uri=f"{base}/0",
+            # Migration 0036's degraded shape: kind + service_type only, no
+            # url or layer_id — jsonb_strip_nulls dropped both because no
+            # surviving ingest job could supply the base/typename.
+            origin_ref={"kind": "service", "service_type": "arcgis_featureserver"},
+        )
+
+        resp = await client.post(
+            "/services/preview/",
+            json={
+                "url": base,
+                "service_type": "ArcGIS:FeatureServer",
+                "layer_name": "0",
+                "layer_id": 0,
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["code"] == "duplicate_source"

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -375,6 +375,52 @@ class TestStacSearch:
             assert resp.status_code == 502
 
 
+async def _create_stac_dataset(
+    session,
+    *,
+    created_by,
+    source_url,
+    name="Existing STAC Dataset",
+    origin_uri=None,
+    origin_ref=None,
+):
+    """Insert a Dataset simulating a previously imported STAC item.
+
+    ``origin_uri``/``origin_ref`` default to unset — the shape of a row
+    migration 0036 could not backfill — so callers that want a fully-bound
+    (post-#1218) dataset, or one with a deliberately mismatched pair to
+    reproduce a respelling writer, pass both explicitly.
+    """
+    import uuid as _uuid
+
+    from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+    table_name = f"stac_{_uuid.uuid4().hex[:16]}"
+    record = Record(
+        title=name,
+        summary="STAC import test",
+        visibility="private",
+        record_status="published",
+        created_by=created_by,
+        record_type="raster_dataset",
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        source_format="stac",
+        source_url=source_url,
+        source_filename="existing-item",
+        origin_uri=origin_uri,
+        origin_ref=origin_ref,
+    )
+    session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
 # ---------------------------------------------------------------------------
 # Import endpoint
 # ---------------------------------------------------------------------------
@@ -594,6 +640,12 @@ class TestStacImport:
         admin_auth_header: dict,
         mock_stac_ssrf,
     ):
+        """fix(#1286): also the never-refreshed-dataset regression test.
+
+        The first import writes ``origin_uri`` and ``origin_ref.asset_href``
+        together and nothing touches the binding afterward, so the second
+        import must be caught by the primary origin_ref-keyed branch alone.
+        """
         item_id = f"dup-test-{uuid.uuid4().hex[:8]}"
         href = f"https://example.com/data/dup-{uuid.uuid4().hex[:8]}.tif"
         payload = {
@@ -622,6 +674,97 @@ class TestStacImport:
         )
         assert resp2.json()["skipped"] == 1
         assert resp2.json()["results"][0]["status"] == "skipped"
+
+    async def test_import_catches_an_unbackfilled_dataset(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        mock_stac_ssrf,
+    ):
+        """fix(#1286): a row migration 0036 could not backfill is still caught.
+
+        Neither ``origin_uri`` nor ``origin_ref`` is set — the shape of a row
+        that predates #1218 — so the guard can only catch it through the
+        ``source_url`` fallback branch.
+        """
+        from tests.factories import get_user_id
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        href = f"https://example.com/data/unbackfilled-{uuid.uuid4().hex[:8]}.tif"
+        await _create_stac_dataset(
+            test_db_session,
+            created_by=admin_id,
+            source_url=href,
+            name="Unbackfilled STAC Row",
+        )
+
+        resp = await client.post(
+            "/services/stac/import",
+            json={
+                "url": "https://stac.example.com/v1",
+                "items": [
+                    {
+                        "id": f"unbackfilled-test-{uuid.uuid4().hex[:8]}",
+                        "title": "Should Be Skipped",
+                        "data_asset_href": href,
+                        "keywords": [],
+                    }
+                ],
+                "visibility": "private",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.json()["skipped"] == 1
+        assert resp.json()["results"][0]["status"] == "skipped"
+
+    async def test_import_catches_a_respelled_origin_uri(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        mock_stac_ssrf,
+    ):
+        """fix(#1286): a respelled origin_uri can no longer open the hole.
+
+        ``origin_ref.asset_href`` names the canonical asset; ``origin_uri``
+        is deliberately a different spelling of the same asset (as a
+        hypothetical future writer might produce). An origin_uri-keyed guard
+        would miss this row; the origin_ref-keyed guard must not.
+        """
+        from tests.factories import get_user_id
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        href = f"https://example.com/data/respelled-{uuid.uuid4().hex[:8]}.tif"
+        await _create_stac_dataset(
+            test_db_session,
+            created_by=admin_id,
+            source_url=href,
+            name="Respelled STAC Pointer",
+            # The respelling: origin_uri drifted to a query-string variant of
+            # the same asset that origin_ref.asset_href still names exactly.
+            origin_uri=f"{href}?rebuilt=true",
+            origin_ref={"kind": "stac", "asset_href": href},
+        )
+
+        resp = await client.post(
+            "/services/stac/import",
+            json={
+                "url": "https://stac.example.com/v1",
+                "items": [
+                    {
+                        "id": f"respelled-test-{uuid.uuid4().hex[:8]}",
+                        "title": "Should Be Skipped",
+                        "data_asset_href": href,
+                        "keywords": [],
+                    }
+                ],
+                "visibility": "private",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.json()["skipped"] == 1
+        assert resp.json()["results"][0]["status"] == "skipped"
 
     async def test_import_invalid_visibility(
         self,


### PR DESCRIPTION
## Summary

Both duplicate-source guards (service preview and STAC import) compared `origin_uri`'s string spelling. PR #1277's round-11 review found that a writer producing a different spelling of the same origin (a refresh briefly storing a bare base URL instead of `base_url/typename`) silently blinded the guard to duplicates of every previously-refreshed dataset. That instance was fixed at the writer; this PR closes the class by re-keying both guards onto the structured identity in `origin_ref`, so any future writer that respells `origin_uri` can no longer degrade either guard.

- Service preview guard (`backend/app/modules/catalog/sources/router.py`): now matches on `origin_ref`'s `(service_type, url, layer_id)` triple, with `layer_id` compared via the same `service_layer_identity` round-trip the refresh path uses.
- STAC import guard (`backend/app/modules/catalog/sources/stac_router.py`): now matches on `origin_ref.asset_href`.
- Both keep the existing `source_url` fallback, gated on `origin_uri IS NULL`, for rows migration 0036 could not backfill.

No API-shape changes, no migrations.

## Test plan

Failing-first: `test_preview_catches_a_respelled_origin_uri` and `test_import_catches_a_respelled_origin_uri` were confirmed to fail against pre-fix code (409/skip expected, got 200/created), then pass after the re-key. Each guard now has explicit coverage for all three cases: a never-refreshed (fully-bound) dataset, an un-backfilled dataset, and a respelled-`origin_uri` dataset.

- [x] `cd backend && uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pytest tests/test_services_endpoints.py tests/test_stac_import.py -v` (38 + 25 passed)
- [x] `uv run pytest tests/test_dataset_source_state.py tests/test_service_refresh_1220.py tests/test_layering.py tests/test_rule1_structural.py -q` (228 passed)

Closes #1286