### PR TITLE
sec(catalog): apply owner-or-admin provenance projection to dataset reads and versions

### DIFF
--- a/backend/app/modules/catalog/authorization.py
+++ b/backend/app/modules/catalog/authorization.py
@@ -456,6 +456,27 @@ async def visible_lineage_summary(
     return (await visible_lineage_summaries(db, [record], user, user_roles))[record.id]
 
 
+def can_view_dataset_provenance(
+    record: Any, user: Identity | None, user_roles: set[str]
+) -> bool:
+    """Owner-or-admin predicate for the provenance projection (#1316).
+
+    Decided 2026-08-09 (ADR-002 amendment): the refresh-runs redaction model
+    (Decision 4e) is the single provenance projection for every surface that
+    carries it — dataset reads (single, list, collection), ``/versions/``,
+    and refresh-runs itself. The dataset's owner and any admin see raw
+    provenance in full (``origin_uri``, ``origin_ref``, ``uploaded_by``,
+    ``file_hash``); every other reader of an accessible dataset, named or
+    anonymous, gets those fields nulled and keeps only the capability summary
+    (origin kind, ``source_freshness``, ``source_health``,
+    ``last_refreshed_at``, ``last_checked_at``).
+
+    Extracted from the inline check refresh-runs used before this decision so
+    every surface applies the same rule rather than a hand-copied one.
+    """
+    return bool(user and (record.created_by == user.id or "admin" in user_roles))
+
+
 async def check_dataset_write_access(
     db: AsyncSession,
     dataset: Any,

--- a/backend/app/modules/catalog/collections/router.py
+++ b/backend/app/modules/catalog/collections/router.py
@@ -15,6 +15,7 @@ from app.core.identity import Identity
 from app.modules.auth.dependencies import get_optional_user, require_permission
 from app.modules.auth.models import User
 from app.modules.catalog.authorization import (
+    can_view_dataset_provenance,
     check_datasets_access_bulk,
     get_user_roles,
     visible_lineage_summaries,
@@ -443,7 +444,13 @@ async def get_collection_datasets_endpoint(
     return DatasetListResponse(
         datasets=[
             dataset_to_response(
-                d, actors_by_id=actor_map, lineage_summary=lineage[d.record_id]
+                d,
+                actors_by_id=actor_map,
+                lineage_summary=lineage[d.record_id],
+                # feat(#1316): per-row, same reasoning as the plain dataset list.
+                can_view_provenance=can_view_dataset_provenance(
+                    d.record, user, user_roles
+                ),
             )
             for d in datasets
         ],

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -24,6 +24,7 @@ from app.modules.auth.dependencies import (
     require_permission,
 )
 from app.modules.catalog.authorization import (
+    can_view_dataset_provenance,
     check_dataset_access_or_anonymous,
     check_dataset_write_access,
     get_user_roles,
@@ -156,6 +157,8 @@ async def create_empty_dataset_endpoint(
         lineage_summary=await visible_lineage_summary(
             db, dataset.record, user, await get_user_roles(db, user)
         ),
+        # feat(#1316): the caller is the dataset's own creator — always owner.
+        can_view_provenance=True,
     )
 
 
@@ -389,6 +392,9 @@ async def update_dataset_metadata(
         lineage_summary=await visible_lineage_summary(
             db, dataset.record, user, user_roles
         ),
+        # feat(#1316): reached only after check_dataset_write_access, which is
+        # the owner-or-admin gate itself.
+        can_view_provenance=True,
     )
     if metadata_warnings:
         response.metadata_warnings = metadata_warnings
@@ -616,6 +622,11 @@ async def list_dataset_refresh_runs(
     strings. The redaction is tested against a NAMED signed-in third party as
     well as an anonymous reader; a requester-scoped check that only exercises
     the anonymous case reads as complete and is not.
+
+    The owner-or-admin predicate (`can_view_dataset_provenance`) was extracted
+    to `authorization.py` under #1316, which applies the same rule to dataset
+    reads and `/versions/` — this endpoint's redaction is no longer the odd
+    one out among the three.
     """
     dataset = await get_dataset(db, dataset_id)
     if dataset is None:
@@ -625,9 +636,7 @@ async def list_dataset_refresh_runs(
         )
 
     user_roles = await check_dataset_access_or_anonymous(db, dataset, dataset_id, user)
-    can_view_detail = bool(
-        user and (dataset.record.created_by == user.id or "admin" in user_roles)
-    )
+    can_view_detail = can_view_dataset_provenance(dataset.record, user, user_roles)
 
     runs, total = await list_runs_for_dataset(db, dataset_id, skip=skip, limit=limit)
     actors = (

--- a/backend/app/modules/catalog/datasets/api/router_metadata.py
+++ b/backend/app/modules/catalog/datasets/api/router_metadata.py
@@ -23,6 +23,7 @@ from app.modules.auth.dependencies import (
     require_permission,
 )
 from app.modules.catalog.authorization import (
+    can_view_dataset_provenance,
     check_dataset_access,
     check_dataset_access_or_anonymous,
     check_dataset_write_access,
@@ -68,7 +69,15 @@ async def get_dataset_versions_endpoint(
     user: Identity | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
 ) -> DatasetVersionListResponse:
-    """Get paginated version history for a dataset."""
+    """Get paginated version history for a dataset.
+
+    Access follows Rule 1 on the read path. feat(#1316): field redaction on
+    top follows the same owner-or-admin predicate as refresh-runs and dataset
+    reads — a caller who is neither the owner nor an admin gets the version
+    timeline (filenames, formats, feature counts) but not ``file_hash`` or
+    ``uploaded_by``. Unredacted, a PUBLIC dataset's version history enumerates
+    its editors, the exact leak ADR-002 Decision 4e closed for refresh-runs.
+    """
     dataset = await get_dataset(db, dataset_id)
     if dataset is None:
         raise HTTPException(
@@ -76,13 +85,29 @@ async def get_dataset_versions_endpoint(
             detail="Dataset not found",
         )
 
-    # Visibility check
-    await check_dataset_access_or_anonymous(db, dataset, dataset_id, user)
+    # Visibility check — returns resolved user_roles to avoid duplicate DB query
+    user_roles = await check_dataset_access_or_anonymous(db, dataset, dataset_id, user)
+    can_view_provenance = can_view_dataset_provenance(dataset.record, user, user_roles)
 
     versions, total = await get_dataset_versions(db, dataset_id, skip=skip, limit=limit)
 
     return DatasetVersionListResponse(
-        versions=[DatasetVersionResponse.model_validate(v) for v in versions],
+        versions=[
+            DatasetVersionResponse(
+                id=v.id,
+                dataset_id=v.dataset_id,
+                version_number=v.version_number,
+                source_filename=v.source_filename,
+                source_format=v.source_format,
+                feature_count=v.feature_count,
+                srid=v.srid,
+                geometry_type=v.geometry_type,
+                file_hash=v.file_hash if can_view_provenance else None,
+                uploaded_by=v.uploaded_by if can_view_provenance else None,
+                uploaded_at=v.uploaded_at,
+            )
+            for v in versions
+        ],
         total=total,
     )
 

--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -136,8 +136,19 @@ def dataset_to_response(
     stac_assets=None,
     derived_from: dict | None = None,
     lineage_summary: str | None = None,
+    can_view_provenance: bool = False,
 ) -> DatasetResponse:
-    """Convert a Dataset ORM object to a DatasetResponse schema."""
+    """Convert a Dataset ORM object to a DatasetResponse schema.
+
+    ``can_view_provenance`` gates ``origin_uri``/``origin_ref`` per #1316: the
+    dataset owner and admins see the raw pointer, every other accessible-dataset
+    reader (named or anonymous) sees it nulled and keeps only the capability
+    summary fields (``origin``, ``source_freshness``, ``source_health``,
+    ``last_refreshed_at``, ``last_checked_at``), which are never gated. Callers
+    resolve the predicate via ``can_view_dataset_provenance`` in
+    ``authorization.py`` and pass the result in; it defaults to False so a
+    call site that forgets to decide redacts rather than leaks.
+    """
     record = dataset.record
     actor_map = actors_by_id or {}
 
@@ -219,8 +230,10 @@ def dataset_to_response(
         # it retires the frontend's duplicate rule in OriginBadge.tsx and gives
         # the CLI, MCP server, and SDKs the same answer.
         origin=origin,
-        origin_uri=dataset.origin_uri,
-        origin_ref=dataset.origin_ref,
+        # feat(#1316): raw pointers are owner-or-admin only; every other
+        # reader keeps `origin` (above) and the freshness/health fields below.
+        origin_uri=dataset.origin_uri if can_view_provenance else None,
+        origin_ref=dataset.origin_ref if can_view_provenance else None,
         last_refreshed_at=dataset.last_refreshed_at,
         last_checked_at=dataset.last_checked_at,
         # NULL is the stored spelling of "never determined"; "unknown" is the

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -354,7 +354,11 @@ class DatasetResponse(BaseModel):
         description=(
             "Machine-readable pointer back to the origin, written only by "
             "ingest and refresh. Distinct from source_url, which is editable "
-            "descriptive metadata. Null for uploads and created datasets."
+            "descriptive metadata. Null for uploads and created datasets. "
+            "feat(#1316): also null for any reader who is neither the "
+            "dataset's owner nor an admin — origin (above) and the "
+            "freshness/health fields below are not gated and still describe "
+            "the dataset's capabilities."
         ),
     )
     origin_ref: dict[str, Any] | None = Field(
@@ -362,7 +366,8 @@ class DatasetResponse(BaseModel):
         description=(
             "Typed per-origin payload with a `kind` discriminator, e.g. "
             '{"kind": "service", "service_type": "wfs", "url": "...", '
-            '"layer_id": "0"}. Never contains credentials.'
+            '"layer_id": "0"}. Never contains credentials. feat(#1316): '
+            "owner-or-admin only, same redaction as origin_uri."
         ),
     )
     last_refreshed_at: datetime | None = Field(
@@ -807,6 +812,15 @@ class DatasetRefreshResponse(BaseModel):
 
 
 class DatasetVersionResponse(BaseModel):
+    """One version in a dataset's history.
+
+    feat(#1316): ``file_hash`` and ``uploaded_by`` are null for any caller who
+    is neither the dataset's owner nor an admin — the same predicate that
+    gates ``origin_uri``/``origin_ref`` on the dataset itself and
+    ``triggered_by`` on refresh-runs (ADR-002 Decision 4e). Unredacted, a
+    public dataset's version history enumerates its editors.
+    """
+
     id: uuid.UUID
     dataset_id: uuid.UUID
     version_number: int

--- a/backend/app/modules/catalog/datasets/domain/service_query.py
+++ b/backend/app/modules/catalog/datasets/domain/service_query.py
@@ -19,7 +19,10 @@ from sqlalchemy.orm import joinedload
 from app.core.db.sqlstate import TABLE_ABSENT, sqlstate
 from app.core.identity import Identity
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
-from app.modules.catalog.authorization import apply_visibility_filter
+from app.modules.catalog.authorization import (
+    apply_visibility_filter,
+    can_view_dataset_provenance,
+)
 from app.modules.catalog.datasets.domain._sql_safety import SAFE_TABLE_NAME_RE
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
@@ -165,6 +168,10 @@ async def get_datasets_list(
             source_count=source_counts.get(str(d.id)),
             base_url=base_url,
             lineage_summary=lineage[d.record_id],
+            # feat(#1316): per-row — the page can mix the caller's own
+            # datasets with peers' public ones, so one page-level flag would
+            # either over- or under-redact.
+            can_view_provenance=can_view_dataset_provenance(d.record, user, user_roles),
         )
         for d in datasets
     ]
@@ -292,6 +299,11 @@ async def get_dataset_detail(
         # fix(#1103): the prose names the same datasets the reference points at.
         lineage_summary=await visible_lineage_summary(
             db, dataset.record, user, user_roles
+        ),
+        # feat(#1316): owner-or-admin only; every other accessible-dataset
+        # reader (named or anonymous) gets origin_uri/origin_ref nulled.
+        can_view_provenance=can_view_dataset_provenance(
+            dataset.record, user, user_roles
         ),
     )
     # fix(#430 codex r18): genericity probe (helpers.py) keeps all draw modes.

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5673,7 +5673,7 @@
                 "type": "null"
               }
             ],
-            "description": "Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.",
+            "description": "Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets. feat(#1316): also null for any reader who is neither the dataset's owner nor an admin \u2014 origin (above) and the freshness/health fields below are not gated and still describe the dataset's capabilities.",
             "title": "Origin Uri"
           },
           "origin_ref": {
@@ -5686,7 +5686,7 @@
                 "type": "null"
               }
             ],
-            "description": "Typed per-origin payload with a `kind` discriminator, e.g. {\"kind\": \"service\", \"service_type\": \"wfs\", \"url\": \"...\", \"layer_id\": \"0\"}. Never contains credentials.",
+            "description": "Typed per-origin payload with a `kind` discriminator, e.g. {\"kind\": \"service\", \"service_type\": \"wfs\", \"url\": \"...\", \"layer_id\": \"0\"}. Never contains credentials. feat(#1316): owner-or-admin only, same redaction as origin_uri.",
             "title": "Origin Ref"
           },
           "last_refreshed_at": {
@@ -6106,6 +6106,7 @@
         "type": "object"
       },
       "DatasetVersionResponse": {
+        "description": "One version in a dataset's history.\n\nfeat(#1316): ``file_hash`` and ``uploaded_by`` are null for any caller who\nis neither the dataset's owner nor an admin \u2014 the same predicate that\ngates ``origin_uri``/``origin_ref`` on the dataset itself and\n``triggered_by`` on refresh-runs (ADR-002 Decision 4e). Unredacted, a\npublic dataset's version history enumerates its editors.",
         "properties": {
           "id": {
             "format": "uuid",
@@ -36353,7 +36354,7 @@
     },
     "/datasets/{dataset_id}/refresh-runs": {
       "get": {
-        "description": "Refresh history for a dataset: every attempt, including the failures.\n\nDurable across the `ingest_jobs` retention purge \u2014 that purge is why this\ntable exists rather than the jobs table serving as the record (#1219).\n\nAccess follows Rule 1 on the read path, and ADR-002 Decision 4e adds field\nredaction on top: a caller who is neither the dataset owner nor an admin\nsees the timeline and outcomes but not who triggered each run, nor the\nfailure text, nor the schema diff. Without that, a PUBLIC dataset's\nhistory enumerates its editors and leaks origin detail through error\nstrings. The redaction is tested against a NAMED signed-in third party as\nwell as an anonymous reader; a requester-scoped check that only exercises\nthe anonymous case reads as complete and is not.",
+        "description": "Refresh history for a dataset: every attempt, including the failures.\n\nDurable across the `ingest_jobs` retention purge \u2014 that purge is why this\ntable exists rather than the jobs table serving as the record (#1219).\n\nAccess follows Rule 1 on the read path, and ADR-002 Decision 4e adds field\nredaction on top: a caller who is neither the dataset owner nor an admin\nsees the timeline and outcomes but not who triggered each run, nor the\nfailure text, nor the schema diff. Without that, a PUBLIC dataset's\nhistory enumerates its editors and leaks origin detail through error\nstrings. The redaction is tested against a NAMED signed-in third party as\nwell as an anonymous reader; a requester-scoped check that only exercises\nthe anonymous case reads as complete and is not.\n\nThe owner-or-admin predicate (`can_view_dataset_provenance`) was extracted\nto `authorization.py` under #1316, which applies the same rule to dataset\nreads and `/versions/` \u2014 this endpoint's redaction is no longer the odd\none out among the three.",
         "operationId": "list_dataset_refresh_runs_datasets__dataset_id__refresh_runs_get",
         "parameters": [
           {
@@ -38788,7 +38789,7 @@
     },
     "/datasets/{dataset_id}/versions/": {
       "get": {
-        "description": "Get paginated version history for a dataset.",
+        "description": "Get paginated version history for a dataset.\n\nAccess follows Rule 1 on the read path. feat(#1316): field redaction on\ntop follows the same owner-or-admin predicate as refresh-runs and dataset\nreads \u2014 a caller who is neither the owner nor an admin gets the version\ntimeline (filenames, formats, feature counts) but not ``file_hash`` or\n``uploaded_by``. Unredacted, a PUBLIC dataset's version history enumerates\nits editors, the exact leak ADR-002 Decision 4e closed for refresh-runs.",
         "operationId": "get_dataset_versions_endpoint_datasets__dataset_id__versions__get",
         "parameters": [
           {

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1700,7 +1700,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # payload structure; `GET /datasets/{id}` had been building its assets
         # straight off the ORM rows and leaked the archived original's href and
         # filename to every viewer. Cap 419 -> 426, exact.
-        "backend/app/modules/catalog/datasets/domain/service_query.py": 426,
+        # feat(#1316): +12 — the list and detail builders each now resolve
+        # can_view_dataset_provenance(record, user, user_roles) and pass it
+        # into dataset_to_response, so origin_uri/origin_ref are nulled for
+        # every reader but the owner or an admin. Cap 426 -> 438, exact.
+        "backend/app/modules/catalog/datasets/domain/service_query.py": 438,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.
@@ -2557,7 +2561,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # comment is the value: the member probes healthy and it is the PARENT
     # that needs regenerating, which is the opposite of where `inaccessible`
     # sends the reader. Cap 1435 -> 1440, exact.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1440,
+    # feat(#1316): +14 — origin_uri/origin_ref descriptions now state the
+    # owner-or-admin redaction inline (the same fact the field-level
+    # description already carries for every other gated field in this
+    # module), and DatasetVersionResponse gained a docstring for the same
+    # reason on file_hash/uploaded_by. Cap 1440 -> 1454, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1454,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/backend/tests/test_provenance_projection_1316.py
+++ b/backend/tests/test_provenance_projection_1316.py
@@ -1,0 +1,320 @@
+"""Single provenance projection across dataset reads, /versions/, and
+collection dataset listings (#1316, ADR-002 amendment).
+
+Decided 2026-08-09: the refresh-runs redaction model (ADR-002 Decision 4e) is
+the single provenance projection everywhere it applies. The dataset owner and
+any admin see raw provenance in full; every other reader of an accessible
+dataset — a named signed-in third party or an anonymous reader — gets
+`origin_uri`/`origin_ref` nulled on dataset reads and `uploaded_by`/
+`file_hash` nulled on `/versions/`. The capability summary
+(`origin`, `source_health`, `last_refreshed_at`, `last_checked_at`) is never
+gated — it survives redaction for everyone. See `can_view_dataset_provenance`
+in `app/modules/catalog/authorization.py`, the single predicate every one of
+these surfaces now shares.
+
+Every redaction case below is checked against BOTH a named signed-in third
+party (a real account with a real token and no grant on the dataset) and an
+anonymous reader — a requester-scoped check that only exercises the
+anonymous case is a different code path from `user is None` and reads as
+complete when it is not (the same lesson the refresh-runs suite pins).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+
+from app.modules.catalog.collections.models import DatasetVersion
+from tests.factories import create_collection_via_api, create_dataset, get_user_id
+
+pytestmark = pytest.mark.anyio
+
+_ORIGIN_URI = "https://origin.test/services/Parcels/FeatureServer/0"
+_ORIGIN_REF = {"kind": "service", "service_type": "wfs", "url": "https://o.test"}
+_LAST_REFRESHED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+_LAST_CHECKED_AT = datetime(2026, 1, 2, 3, 4, 6, tzinfo=timezone.utc)
+
+
+async def _own_user_id(client: AsyncClient, headers: dict) -> uuid.UUID:
+    """Resolve the caller's own user id.
+
+    `viewer_auth_header`/`editor_auth_header` mint a fresh `<role>_<hex>`
+    account per test, so the username is not knowable up front.
+    """
+    resp = await client.get("/auth/me/", headers=headers)
+    assert resp.status_code == 200
+    return uuid.UUID(resp.json()["id"])
+
+
+async def _create_dataset_with_origin(session, *, created_by: uuid.UUID, name: str):
+    """A public, probed service dataset — enough state to exercise both the
+    raw pointer fields (`origin_uri`/`origin_ref`) and the capability summary
+    that must survive redaction alongside them.
+    """
+    dataset = await create_dataset(
+        session,
+        created_by=created_by,
+        name=name,
+        visibility="public",
+        source_format="arcgis_featureserver",
+    )
+    dataset.origin_uri = _ORIGIN_URI
+    dataset.origin_ref = _ORIGIN_REF
+    dataset.last_refreshed_at = _LAST_REFRESHED_AT
+    dataset.last_checked_at = _LAST_CHECKED_AT
+    dataset.source_health = "healthy"
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+def _assert_summary_survives(body: dict) -> None:
+    assert body["origin"] == "service"
+    assert body["source_health"] == "healthy"
+    assert body["last_refreshed_at"] is not None
+    assert body["last_checked_at"] is not None
+
+
+class TestDatasetReadProjection:
+    """GET /datasets/{id}: origin_uri/origin_ref are owner-or-admin only."""
+
+    async def test_owner_sees_full_provenance(
+        self, client: AsyncClient, viewer_auth_header: dict, test_db_session
+    ) -> None:
+        viewer_id = await _own_user_id(client, viewer_auth_header)
+        ds = await _create_dataset_with_origin(
+            test_db_session, created_by=viewer_id, name="Owner Full DS"
+        )
+
+        resp = await client.get(f"/datasets/{ds.id}", headers=viewer_auth_header)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["origin_uri"] == _ORIGIN_URI
+        assert body["origin_ref"] == _ORIGIN_REF
+
+    async def test_admin_non_owner_sees_full_provenance(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        """An admin is not the owner here — the predicate must still admit them."""
+        viewer_id = await _own_user_id(client, viewer_auth_header)
+        ds = await _create_dataset_with_origin(
+            test_db_session, created_by=viewer_id, name="Admin Non-Owner DS"
+        )
+
+        resp = await client.get(f"/datasets/{ds.id}", headers=admin_auth_header)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["origin_uri"] == _ORIGIN_URI
+        assert body["origin_ref"] == _ORIGIN_REF
+
+    @pytest.mark.parametrize("reader", ["viewer", "editor"])
+    async def test_a_named_third_party_gets_the_summary_without_the_pointers(
+        self,
+        client: AsyncClient,
+        viewer_auth_header: dict,
+        editor_auth_header: dict,
+        test_db_session,
+        reader: str,
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset_with_origin(
+            test_db_session, created_by=admin_id, name=f"Third Party DS {reader}"
+        )
+        headers = {"viewer": viewer_auth_header, "editor": editor_auth_header}[reader]
+
+        resp = await client.get(f"/datasets/{ds.id}", headers=headers)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["origin_uri"] is None, f"origin_uri leaked to a {reader}"
+        assert body["origin_ref"] is None, f"origin_ref leaked to a {reader}"
+        _assert_summary_survives(body)
+
+    async def test_anonymous_reader_is_redacted_too(
+        self, client: AsyncClient, test_db_session
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset_with_origin(
+            test_db_session, created_by=admin_id, name="Anon Read DS"
+        )
+
+        resp = await client.get(f"/datasets/{ds.id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["origin_uri"] is None
+        assert body["origin_ref"] is None
+        _assert_summary_survives(body)
+
+
+class TestCollectionDatasetListProjection:
+    """GET /catalog/collections/{id}/datasets/: redaction is PER ROW.
+
+    A single collection page mixes the caller's own dataset with a peer's —
+    a page-level admin/owner flag would either leak the peer's pointers or
+    strip the caller's own, so this pins that the decision is made once per
+    row rather than once per page.
+    """
+
+    async def test_own_row_full_peer_row_redacted(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        viewer_id = await _own_user_id(client, viewer_auth_header)
+        admin_id = await get_user_id(test_db_session, "admin")
+        admin_ds = await _create_dataset_with_origin(
+            test_db_session, created_by=admin_id, name="Collection Admin DS"
+        )
+        viewer_ds = await _create_dataset_with_origin(
+            test_db_session, created_by=viewer_id, name="Collection Viewer DS"
+        )
+
+        collection = await create_collection_via_api(client, admin_auth_header)
+        resp = await client.post(
+            f"/catalog/collections/{collection['id']}/datasets/",
+            json={"dataset_ids": [str(admin_ds.id), str(viewer_ds.id)]},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+
+        resp = await client.get(
+            f"/catalog/collections/{collection['id']}/datasets/",
+            headers=viewer_auth_header,
+        )
+        assert resp.status_code == 200
+        by_id = {d["id"]: d for d in resp.json()["datasets"]}
+
+        # The viewer's own row: full projection.
+        assert by_id[str(viewer_ds.id)]["origin_uri"] == _ORIGIN_URI
+        assert by_id[str(viewer_ds.id)]["origin_ref"] == _ORIGIN_REF
+
+        # The admin-owned peer row, same page: redacted, summary intact.
+        peer_row = by_id[str(admin_ds.id)]
+        assert peer_row["origin_uri"] is None
+        assert peer_row["origin_ref"] is None
+        _assert_summary_survives(peer_row)
+
+
+class TestVersionsProjection:
+    """GET /datasets/{id}/versions/: file_hash/uploaded_by are owner-or-admin only.
+
+    Unredacted, a PUBLIC dataset's version history enumerates its editors —
+    the exact leak ADR-002 Decision 4e closed for refresh-runs.
+    """
+
+    @staticmethod
+    async def _seed_version(session, dataset_id: uuid.UUID, uploader_id: uuid.UUID):
+        version = DatasetVersion(
+            dataset_id=dataset_id,
+            version_number=1,
+            source_filename="original.geojson",
+            source_format="geojson",
+            feature_count=100,
+            srid=4326,
+            geometry_type="MultiPolygon",
+            file_hash="sha256:deadbeef",
+            uploaded_by=uploader_id,
+        )
+        session.add(version)
+        await session.commit()
+        return version
+
+    async def test_owner_sees_file_hash_and_uploaded_by(
+        self, client: AsyncClient, viewer_auth_header: dict, test_db_session
+    ) -> None:
+        viewer_id = await _own_user_id(client, viewer_auth_header)
+        ds = await create_dataset(
+            test_db_session,
+            created_by=viewer_id,
+            name="Owner Versions DS",
+            visibility="public",
+        )
+        await self._seed_version(test_db_session, ds.id, viewer_id)
+
+        resp = await client.get(
+            f"/datasets/{ds.id}/versions/", headers=viewer_auth_header
+        )
+        assert resp.status_code == 200
+        row = resp.json()["versions"][0]
+        assert row["file_hash"] == "sha256:deadbeef"
+        assert row["uploaded_by"] == str(viewer_id)
+
+    async def test_admin_non_owner_sees_full_versions(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        viewer_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        viewer_id = await _own_user_id(client, viewer_auth_header)
+        ds = await create_dataset(
+            test_db_session,
+            created_by=viewer_id,
+            name="Admin Non-Owner Versions DS",
+            visibility="public",
+        )
+        await self._seed_version(test_db_session, ds.id, viewer_id)
+
+        resp = await client.get(
+            f"/datasets/{ds.id}/versions/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200
+        row = resp.json()["versions"][0]
+        assert row["file_hash"] == "sha256:deadbeef"
+        assert row["uploaded_by"] == str(viewer_id)
+
+    @pytest.mark.parametrize("reader", ["viewer", "editor"])
+    async def test_a_named_third_party_gets_the_timeline_without_the_hash(
+        self,
+        client: AsyncClient,
+        viewer_auth_header: dict,
+        editor_auth_header: dict,
+        test_db_session,
+        reader: str,
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name=f"Third Party Versions DS {reader}",
+            visibility="public",
+        )
+        await self._seed_version(test_db_session, ds.id, admin_id)
+        headers = {"viewer": viewer_auth_header, "editor": editor_auth_header}[reader]
+
+        resp = await client.get(f"/datasets/{ds.id}/versions/", headers=headers)
+        assert resp.status_code == 200, resp.text
+        row = resp.json()["versions"][0]
+        assert row["file_hash"] is None, f"file_hash leaked to a {reader}"
+        assert row["uploaded_by"] is None, f"uploaded_by leaked to a {reader}"
+        # The timeline itself survives redaction.
+        assert row["source_filename"] == "original.geojson"
+        assert row["feature_count"] == 100
+        assert row["version_number"] == 1
+
+    async def test_anonymous_reader_is_redacted_too(
+        self, client: AsyncClient, test_db_session
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="Anon Versions DS",
+            visibility="public",
+        )
+        await self._seed_version(test_db_session, ds.id, admin_id)
+
+        resp = await client.get(f"/datasets/{ds.id}/versions/")
+        assert resp.status_code == 200
+        row = resp.json()["versions"][0]
+        assert row["file_hash"] is None
+        assert row["uploaded_by"] is None
+        assert row["source_filename"] == "original.geojson"

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2340,6 +2340,11 @@ export interface paths {
          *     strings. The redaction is tested against a NAMED signed-in third party as
          *     well as an anonymous reader; a requester-scoped check that only exercises
          *     the anonymous case reads as complete and is not.
+         *
+         *     The owner-or-admin predicate (`can_view_dataset_provenance`) was extracted
+         *     to `authorization.py` under #1316, which applies the same rule to dataset
+         *     reads and `/versions/` — this endpoint's redaction is no longer the odd
+         *     one out among the three.
          */
         get: operations["list_dataset_refresh_runs_datasets__dataset_id__refresh_runs_get"];
         put?: never;
@@ -2657,6 +2662,13 @@ export interface paths {
         /**
          * Get Dataset Versions Endpoint
          * @description Get paginated version history for a dataset.
+         *
+         *     Access follows Rule 1 on the read path. feat(#1316): field redaction on
+         *     top follows the same owner-or-admin predicate as refresh-runs and dataset
+         *     reads — a caller who is neither the owner nor an admin gets the version
+         *     timeline (filenames, formats, feature counts) but not ``file_hash`` or
+         *     ``uploaded_by``. Unredacted, a PUBLIC dataset's version history enumerates
+         *     its editors, the exact leak ADR-002 Decision 4e closed for refresh-runs.
          */
         get: operations["get_dataset_versions_endpoint_datasets__dataset_id__versions__get"];
         put?: never;
@@ -7575,12 +7587,12 @@ export interface components {
             origin?: string | null;
             /**
              * Origin Uri
-             * @description Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.
+             * @description Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets. feat(#1316): also null for any reader who is neither the dataset's owner nor an admin — origin (above) and the freshness/health fields below are not gated and still describe the dataset's capabilities.
              */
             origin_uri?: string | null;
             /**
              * Origin Ref
-             * @description Typed per-origin payload with a `kind` discriminator, e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials.
+             * @description Typed per-origin payload with a `kind` discriminator, e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials. feat(#1316): owner-or-admin only, same redaction as origin_uri.
              */
             origin_ref?: {
                 [key: string]: unknown;
@@ -7740,7 +7752,16 @@ export interface components {
             /** Total */
             total: number;
         };
-        /** DatasetVersionResponse */
+        /**
+         * DatasetVersionResponse
+         * @description One version in a dataset's history.
+         *
+         *     feat(#1316): ``file_hash`` and ``uploaded_by`` are null for any caller who
+         *     is neither the dataset's owner nor an admin — the same predicate that
+         *     gates ``origin_uri``/``origin_ref`` on the dataset itself and
+         *     ``triggered_by`` on refresh-runs (ADR-002 Decision 4e). Unredacted, a
+         *     public dataset's version history enumerates its editors.
+         */
         DatasetVersionResponse: {
             /**
              * Id

--- a/sdks/python/geolens/api/datasets/list_dataset_refresh_runs_datasets_dataset_id_refresh_runs_get.py
+++ b/sdks/python/geolens/api/datasets/list_dataset_refresh_runs_datasets_dataset_id_refresh_runs_get.py
@@ -133,6 +133,11 @@ def sync_detailed(
     well as an anonymous reader; a requester-scoped check that only exercises
     the anonymous case reads as complete and is not.
 
+    The owner-or-admin predicate (`can_view_dataset_provenance`) was extracted
+    to `authorization.py` under #1316, which applies the same rule to dataset
+    reads and `/versions/` — this endpoint's redaction is no longer the odd
+    one out among the three.
+
     Args:
         dataset_id (UUID):
         skip (int | Unset):  Default: 0.
@@ -182,6 +187,11 @@ def sync(
     well as an anonymous reader; a requester-scoped check that only exercises
     the anonymous case reads as complete and is not.
 
+    The owner-or-admin predicate (`can_view_dataset_provenance`) was extracted
+    to `authorization.py` under #1316, which applies the same rule to dataset
+    reads and `/versions/` — this endpoint's redaction is no longer the odd
+    one out among the three.
+
     Args:
         dataset_id (UUID):
         skip (int | Unset):  Default: 0.
@@ -225,6 +235,11 @@ async def asyncio_detailed(
     strings. The redaction is tested against a NAMED signed-in third party as
     well as an anonymous reader; a requester-scoped check that only exercises
     the anonymous case reads as complete and is not.
+
+    The owner-or-admin predicate (`can_view_dataset_provenance`) was extracted
+    to `authorization.py` under #1316, which applies the same rule to dataset
+    reads and `/versions/` — this endpoint's redaction is no longer the odd
+    one out among the three.
 
     Args:
         dataset_id (UUID):
@@ -272,6 +287,11 @@ async def asyncio(
     strings. The redaction is tested against a NAMED signed-in third party as
     well as an anonymous reader; a requester-scoped check that only exercises
     the anonymous case reads as complete and is not.
+
+    The owner-or-admin predicate (`can_view_dataset_provenance`) was extracted
+    to `authorization.py` under #1316, which applies the same rule to dataset
+    reads and `/versions/` — this endpoint's redaction is no longer the odd
+    one out among the three.
 
     Args:
         dataset_id (UUID):

--- a/sdks/python/geolens/api/datasets_metadata/get_dataset_versions_endpoint_datasets_dataset_id_versions_get.py
+++ b/sdks/python/geolens/api/datasets_metadata/get_dataset_versions_endpoint_datasets_dataset_id_versions_get.py
@@ -121,6 +121,13 @@ def sync_detailed(
 
      Get paginated version history for a dataset.
 
+    Access follows Rule 1 on the read path. feat(#1316): field redaction on
+    top follows the same owner-or-admin predicate as refresh-runs and dataset
+    reads — a caller who is neither the owner nor an admin gets the version
+    timeline (filenames, formats, feature counts) but not ``file_hash`` or
+    ``uploaded_by``. Unredacted, a PUBLIC dataset's version history enumerates
+    its editors, the exact leak ADR-002 Decision 4e closed for refresh-runs.
+
     Args:
         dataset_id (UUID):
         skip (int | Unset):  Default: 0.
@@ -158,6 +165,13 @@ def sync(
 
      Get paginated version history for a dataset.
 
+    Access follows Rule 1 on the read path. feat(#1316): field redaction on
+    top follows the same owner-or-admin predicate as refresh-runs and dataset
+    reads — a caller who is neither the owner nor an admin gets the version
+    timeline (filenames, formats, feature counts) but not ``file_hash`` or
+    ``uploaded_by``. Unredacted, a PUBLIC dataset's version history enumerates
+    its editors, the exact leak ADR-002 Decision 4e closed for refresh-runs.
+
     Args:
         dataset_id (UUID):
         skip (int | Unset):  Default: 0.
@@ -189,6 +203,13 @@ async def asyncio_detailed(
     """Get Dataset Versions Endpoint
 
      Get paginated version history for a dataset.
+
+    Access follows Rule 1 on the read path. feat(#1316): field redaction on
+    top follows the same owner-or-admin predicate as refresh-runs and dataset
+    reads — a caller who is neither the owner nor an admin gets the version
+    timeline (filenames, formats, feature counts) but not ``file_hash`` or
+    ``uploaded_by``. Unredacted, a PUBLIC dataset's version history enumerates
+    its editors, the exact leak ADR-002 Decision 4e closed for refresh-runs.
 
     Args:
         dataset_id (UUID):
@@ -224,6 +245,13 @@ async def asyncio(
     """Get Dataset Versions Endpoint
 
      Get paginated version history for a dataset.
+
+    Access follows Rule 1 on the read path. feat(#1316): field redaction on
+    top follows the same owner-or-admin predicate as refresh-runs and dataset
+    reads — a caller who is neither the owner nor an admin gets the version
+    timeline (filenames, formats, feature counts) but not ``file_hash`` or
+    ``uploaded_by``. Unredacted, a PUBLIC dataset's version history enumerates
+    its editors, the exact leak ADR-002 Decision 4e closed for refresh-runs.
 
     Args:
         dataset_id (UUID):

--- a/sdks/python/geolens/models/dataset_response.py
+++ b/sdks/python/geolens/models/dataset_response.py
@@ -74,9 +74,11 @@ class DatasetResponse:
             their own.
         origin_uri (None | str | Unset): Machine-readable pointer back to the origin, written only by ingest and
             refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created
-            datasets.
+            datasets. feat(#1316): also null for any reader who is neither the dataset's owner nor an admin — origin (above)
+            and the freshness/health fields below are not gated and still describe the dataset's capabilities.
         origin_ref (DatasetResponseOriginRefType0 | None | Unset): Typed per-origin payload with a `kind` discriminator,
             e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials.
+            feat(#1316): owner-or-admin only, same redaction as origin_uri.
         last_refreshed_at (datetime.datetime | None | Unset): Last committed successful refresh — not the last attempt
         last_checked_at (datetime.datetime | None | Unset): Last time GeoLens contacted the origin at all, whether the
             attempt succeeded or failed

--- a/sdks/python/geolens/models/dataset_version_response.py
+++ b/sdks/python/geolens/models/dataset_version_response.py
@@ -18,19 +18,26 @@ T = TypeVar("T", bound="DatasetVersionResponse")
 
 @_attrs_define
 class DatasetVersionResponse:
-    """
-    Attributes:
-        id (UUID):
-        dataset_id (UUID):
-        version_number (int):
-        source_filename (None | str):
-        source_format (None | str):
-        feature_count (int | None):
-        srid (int | None):
-        geometry_type (None | str):
-        file_hash (None | str):
-        uploaded_by (None | UUID):
-        uploaded_at (datetime.datetime):
+    """One version in a dataset's history.
+
+    feat(#1316): ``file_hash`` and ``uploaded_by`` are null for any caller who
+    is neither the dataset's owner nor an admin — the same predicate that
+    gates ``origin_uri``/``origin_ref`` on the dataset itself and
+    ``triggered_by`` on refresh-runs (ADR-002 Decision 4e). Unredacted, a
+    public dataset's version history enumerates its editors.
+
+        Attributes:
+            id (UUID):
+            dataset_id (UUID):
+            version_number (int):
+            source_filename (None | str):
+            source_format (None | str):
+            feature_count (int | None):
+            srid (int | None):
+            geometry_type (None | str):
+            file_hash (None | str):
+            uploaded_by (None | UUID):
+            uploaded_at (datetime.datetime):
     """
 
     id: UUID

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -2509,6 +2509,11 @@ export const refreshDatasetDatasetsDatasetIdRefreshPost = <ThrowOnError extends 
  * strings. The redaction is tested against a NAMED signed-in third party as
  * well as an anonymous reader; a requester-scoped check that only exercises
  * the anonymous case reads as complete and is not.
+ *
+ * The owner-or-admin predicate (`can_view_dataset_provenance`) was extracted
+ * to `authorization.py` under #1316, which applies the same rule to dataset
+ * reads and `/versions/` — this endpoint's redaction is no longer the odd
+ * one out among the three.
  */
 export const listDatasetRefreshRunsDatasetsDatasetIdRefreshRunsGet = <ThrowOnError extends boolean = false>(options: Options<ListDatasetRefreshRunsDatasetsDatasetIdRefreshRunsGetData, ThrowOnError>): RequestResult<ListDatasetRefreshRunsDatasetsDatasetIdRefreshRunsGetResponses, ListDatasetRefreshRunsDatasetsDatasetIdRefreshRunsGetErrors, ThrowOnError> => (options.client ?? client).get<ListDatasetRefreshRunsDatasetsDatasetIdRefreshRunsGetResponses, ListDatasetRefreshRunsDatasetsDatasetIdRefreshRunsGetErrors, ThrowOnError>({
     security: [
@@ -2864,6 +2869,13 @@ export const validateDatasetDatasetsDatasetIdValidateGet = <ThrowOnError extends
  * Get Dataset Versions Endpoint
  *
  * Get paginated version history for a dataset.
+ *
+ * Access follows Rule 1 on the read path. feat(#1316): field redaction on
+ * top follows the same owner-or-admin predicate as refresh-runs and dataset
+ * reads — a caller who is neither the owner nor an admin gets the version
+ * timeline (filenames, formats, feature counts) but not ``file_hash`` or
+ * ``uploaded_by``. Unredacted, a PUBLIC dataset's version history enumerates
+ * its editors, the exact leak ADR-002 Decision 4e closed for refresh-runs.
  */
 export const getDatasetVersionsEndpointDatasetsDatasetIdVersionsGet = <ThrowOnError extends boolean = false>(options: Options<GetDatasetVersionsEndpointDatasetsDatasetIdVersionsGetData, ThrowOnError>): RequestResult<GetDatasetVersionsEndpointDatasetsDatasetIdVersionsGetResponses, GetDatasetVersionsEndpointDatasetsDatasetIdVersionsGetErrors, ThrowOnError> => (options.client ?? client).get<GetDatasetVersionsEndpointDatasetsDatasetIdVersionsGetResponses, GetDatasetVersionsEndpointDatasetsDatasetIdVersionsGetErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3359,13 +3359,13 @@ export type DatasetResponse = {
     /**
      * Origin Uri
      *
-     * Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets.
+     * Machine-readable pointer back to the origin, written only by ingest and refresh. Distinct from source_url, which is editable descriptive metadata. Null for uploads and created datasets. feat(#1316): also null for any reader who is neither the dataset's owner nor an admin — origin (above) and the freshness/health fields below are not gated and still describe the dataset's capabilities.
      */
     origin_uri?: string | null;
     /**
      * Origin Ref
      *
-     * Typed per-origin payload with a `kind` discriminator, e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials.
+     * Typed per-origin payload with a `kind` discriminator, e.g. {"kind": "service", "service_type": "wfs", "url": "...", "layer_id": "0"}. Never contains credentials. feat(#1316): owner-or-admin only, same redaction as origin_uri.
      */
     origin_ref?: {
         [key: string]: unknown;
@@ -3580,6 +3580,14 @@ export type DatasetVersionListResponse = {
 
 /**
  * DatasetVersionResponse
+ *
+ * One version in a dataset's history.
+ *
+ * feat(#1316): ``file_hash`` and ``uploaded_by`` are null for any caller who
+ * is neither the dataset's owner nor an admin — the same predicate that
+ * gates ``origin_uri``/``origin_ref`` on the dataset itself and
+ * ``triggered_by`` on refresh-runs (ADR-002 Decision 4e). Unredacted, a
+ * public dataset's version history enumerates its editors.
  */
 export type DatasetVersionResponse = {
     /**


### PR DESCRIPTION
## Summary

Adopts the refresh-runs redaction model (ADR-002 Decision 4e) as the single provenance projection across dataset reads and `/versions/`, per the decision recorded on #1316 (2026-08-09).

Before this change, three surfaces disagreed:
- `GET /datasets/{id}` and list reads served `origin_uri`/`origin_ref` to any accessible-dataset reader, including anonymous readers of public datasets.
- `GET /datasets/{id}/versions/` served `file_hash`/`uploaded_by` unredacted to the same audience — a public dataset's version history enumerated its editors.
- `GET /datasets/{id}/refresh-runs` redacted a strict superset of that information for the same audience (owner-or-admin only).

An anonymous browser request could read fields the MCP server refuses to show the dataset's own owner.

## Changes

- Extracts the owner-or-admin predicate refresh-runs already used into `can_view_dataset_provenance()` in `backend/app/modules/catalog/authorization.py`, and points the refresh-runs endpoint at it instead of its own inline copy.
- Applies the predicate at every `DatasetResponse` construction site: single dataset read, dataset list, and collection dataset listing (`dataset_to_response()` gains a `can_view_provenance` parameter, defaulting to `False` so a call site that forgets to decide redacts rather than leaks).
- Applies the same predicate to `GET /datasets/{id}/versions/`, nulling `file_hash`/`uploaded_by` for non-owner/non-admin readers.
- The capability summary (`origin`, `source_health`, `source_freshness`, `last_refreshed_at`, `last_checked_at`) is never gated — it survives redaction for everyone, matching the decision.
- MCP's unconditional strip is untouched, per the decision (re-evaluating it is a follow-up).
- `origin_uri`/`origin_ref`/`DatasetVersionResponse` field descriptions now state the redaction inline, which is the only reason `openapi.json` and the generated SDKs shifted — no shape change, every affected field was already `X | None`.

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .`
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_provenance_projection_1316.py tests/test_datasets.py tests/test_search.py tests/test_dataset_refresh_runs.py tests/test_reupload.py tests/test_collections.py tests/test_provenance_responses.py tests/test_dataset_source_state.py tests/test_vrt_catalog_175.py tests/test_antimeridian_extent.py -q` — 460 passed
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py tests/test_rule1_structural.py -q` — 57 passed
- `make openapi-check` and `make sdks-check` (both pass once this branch's regen artifacts are committed; TypeScript SDK `npm run build && npm test` also verified separately)

New test coverage (`tests/test_provenance_projection_1316.py`) asserts redaction against both a named signed-in third party and an anonymous reader for dataset reads and `/versions/`, confirms the owner and a non-owner admin still see full fields, confirms the capability summary survives redaction, and confirms per-row (not per-page) redaction on collection dataset listings.

Closes #1316