### PR TITLE
fix(vrt): project generation timestamps into last_refreshed_at, reconcile abandoned regenerations

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -489,11 +489,14 @@ async def regenerate_vrt_endpoint(
 
     await db.commit()
 
-    # Dispatch task with orphan guard.
-    # No stale-cleanup sweep exists for VRT ``status="regenerating"``
-    # or for ``VrtGeneration`` rows — a Procrastinate outage would
-    # leave the VRT permanently stuck and the generation row dangling
-    # until manual operator intervention.
+    # Dispatch task with orphan guard. This closes the SYNCHRONOUS failure —
+    # Procrastinate unreachable at enqueue time — by reverting the mutation
+    # below before it is ever visible. A worker that dies AFTER a successful
+    # dispatch is a different failure and is not this guard's job: fix(#1267)
+    # gives ``sweep_stale_vrt_assets`` (GAP-002) a periodic + startup pass
+    # that reconciles it — restoring the asset to ``'ready'`` and failing the
+    # orphaned ``VrtGeneration`` row — so neither state is stuck on manual
+    # operator intervention.
     async def _defer() -> None:
         await defer_async_with_tenant(
             get_catalog_port().regenerate_vrt_task(),

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -523,29 +523,88 @@ async def _reap_committed_staged_paths(
     )
 
 
+async def _reap_stale_generation_storage(
+    stale_generations: list[tuple[uuid.UUID, uuid.UUID]],
+) -> None:
+    """Best-effort delete of a dead regeneration attempt's immutable objects.
+
+    feat(#1267): ``regenerate_vrt`` writes its rebuilt VRT + quicklooks to an
+    immutable ``rasters/{vrt_dataset_id}/generations/{generation_id}/...`` key
+    (the full generation UUID, unset by attempt-fencing convention A3 —
+    mirroring ``attempt_scoped_staging_table``'s full-hex rule for staging
+    tables) BEFORE the phase-2 transaction that would otherwise clean them up
+    via ``_cleanup_orphaned_storage_keys``. A worker killed between that write
+    and the commit leaves the objects with no reference anywhere — this sweep
+    is the only remaining owner of the key, so it reaps them the same way.
+
+    A dead attempt may have written none, some, or all three objects before
+    the worker died; deleting a key that was never written is a documented
+    no-op on every StorageProvider.
+
+    ``current_tenant_var`` carries the right tenant because both callers of
+    ``sweep_stale_vrt_assets`` (the startup recovery pass and the periodic
+    sweep) run this inside ``tenant_job_context`` per tenant in multi-tenant
+    mode — the same context ``regenerate_vrt`` itself reads to resolve these
+    same keys. A missing tenant context in multi-tenant mode skips cleanup
+    rather than raising: the asset/generation reconciliation above already
+    landed regardless of whether this best-effort pass can find the bytes.
+    """
+    from app.core.tenancy import is_multi_tenant
+    from app.core.db.tenant_session import current_tenant_var
+    from app.platform.storage.titiler_url import resolve_storage_key
+
+    tenant_id = current_tenant_var.get()
+    if is_multi_tenant() and tenant_id is None:
+        return
+
+    keys = [
+        resolve_storage_key(
+            f"rasters/{vrt_dataset_id}/generations/{generation_id}/{suffix}",
+            tenant_id=tenant_id,
+        )
+        for generation_id, vrt_dataset_id in stale_generations
+        for suffix in ("source.vrt", "quicklook_256.png", "quicklook_512.png")
+    ]
+
+    # Function-local: mirrors the deferred processing-import convention
+    # already used for RasterAsset/VrtGeneration below (D-17,
+    # test_platform_processing_imports_stay_deferred) — the exact same helper
+    # regenerate_vrt itself uses to reap its own orphaned writes.
+    from app.processing.ingest.tasks_raster import _cleanup_orphaned_storage_keys
+
+    await _cleanup_orphaned_storage_keys(keys, job_id="vrt-stale-sweep")
+
+
 async def sweep_stale_vrt_assets(
     db: AsyncSession,
     stale_cutoff: datetime,
 ) -> tuple[int, int]:
-    """Reset RasterAsset rows stuck in status='regenerating' past ``stale_cutoff``.
+    """Reconcile RasterAsset rows stuck in status='regenerating' past ``stale_cutoff``.
 
-    GAP-002: a worker crash mid-regeneration leaves the VRT asset permanently
-    stuck in ``status='regenerating'``, causing all future link/regenerate
-    calls to 409. This helper mirrors the IngestJob stale-recovery pattern and
-    uses the same ``stale_cutoff = now - JOB_TIMEOUT_SECONDS`` threshold.
+    GAP-002 / feat(#1267): a worker crash mid-regeneration leaves the VRT
+    asset permanently stuck in ``status='regenerating'``, causing all future
+    link/regenerate calls to 409. This helper mirrors the IngestJob
+    stale-recovery pattern and uses the same
+    ``stale_cutoff = now - JOB_TIMEOUT_SECONDS`` threshold.
 
-    Staleness is measured via the associated ``VrtGeneration.started_at`` for
-    the asset's ``current_generation_id``, falling back to querying all
-    ``VrtGeneration`` rows whose ``started_at`` predates the cutoff and whose
-    ``status`` is still pending/running.
+    Staleness is measured via ``VrtGeneration.heartbeat_at`` (falling back to
+    ``started_at`` for a generation whose worker died before its first
+    renewal) — the same self-reported liveness signal ``maintain_vrt_
+    generation_heartbeat`` renews every 30s while the worker is alive, so a
+    live job's row never crosses the cutoff and this sweep never touches it.
 
-    Recovery status: ``'failed'`` — mirrors the explicit failure-handler path
-    in ``tasks_vrt.regenerate_vrt`` (which sets ``status='failed'`` on any
-    exception). The regeneration did not finish; an operator or retry call
-    can re-trigger it.
+    Recovery status: ``'ready'``, not ``'failed'``. ``regenerate_vrt`` only
+    overwrites the asset's published pointer (``asset_uri``, ``sha256``, ...)
+    in the SAME transaction that clears ``current_generation_id`` on success
+    — a dead attempt never reaches that transaction, so those fields still
+    describe the last-good VRT the asset was serving before this attempt
+    started. Restoring ``'ready'`` reflects that: the VRT keeps serving
+    exactly what it served before, and only the dead attempt's own
+    ``VrtGeneration`` row (marked ``'failed'`` below) records that it did not
+    finish. An operator or retry call can re-trigger regeneration.
 
-    Also marks orphaned ``VrtGeneration`` rows (status pending/running past
-    the cutoff) as ``'failed'`` so the generation table stays consistent.
+    Also reaps the dead attempt's own generation-scoped storage objects
+    (best-effort — see ``_reap_stale_generation_storage``).
 
     Args:
         db: The active async session (must NOT be committed before returning
@@ -583,6 +642,12 @@ async def sweep_stale_vrt_assets(
     # Fail generation leases atomically. The status + liveness predicates are
     # re-evaluated by PostgreSQL at UPDATE time, so a heartbeat racing the
     # sweep wins and the generation remains live.
+    #
+    # RETURNING carries vrt_dataset_id alongside id (feat(#1267)): the
+    # generation-scoped storage key each dead attempt wrote to is keyed on
+    # BOTH, and the asset UPDATE below cannot supply that pairing back — its
+    # own current_generation_id is nulled in the same statement, so RETURNING
+    # it would report the value AFTER the SET, not the attempt being reaped.
     stale_gen_result = await db.execute(
         update(VrtGeneration)
         .where(
@@ -598,12 +663,21 @@ async def sweep_stale_vrt_assets(
                 f"Stale: regeneration running for over {JOB_TIMEOUT_SECONDS // 60} minutes"
             ),
         )
-        .returning(VrtGeneration.id)
+        .returning(VrtGeneration.id, VrtGeneration.vrt_dataset_id)
     )
-    stale_generation_ids = list(stale_gen_result.scalars())
+    # Tuple-unpack the Row objects directly (matches the RETURNING pattern
+    # used for the retention purge above) rather than attribute access, so a
+    # lightweight test double can stand in with plain tuples.
+    stale_generations = [
+        (generation_id, vrt_dataset_id)
+        for generation_id, vrt_dataset_id in stale_gen_result.all()
+    ]
+    stale_generation_ids = [generation_id for generation_id, _ in stale_generations]
 
-    # Clear an asset only if it still points at the generation just failed.
-    # A newer regeneration has a different current_generation_id and is fenced.
+    # Restore the asset only if it still points at the generation just
+    # failed. A newer regeneration has a different current_generation_id and
+    # is fenced — same CAS discipline as the failure-handler path in
+    # tasks_vrt.regenerate_vrt.
     stale_asset_result = await db.execute(
         update(RasterAsset)
         .where(
@@ -611,16 +685,19 @@ async def sweep_stale_vrt_assets(
             RasterAsset.status == "regenerating",
             RasterAsset.current_generation_id.in_(stale_generation_ids),
         )
-        .values(status="failed", current_generation_id=None)
+        .values(status="ready", current_generation_id=None)
         .returning(RasterAsset.dataset_id)
     )
     stale_asset_ids = list(stale_asset_result.scalars())
     for dataset_id in stale_asset_ids:
         log.warning(
-            "Recovered stale regenerating VRT asset",
+            "Reconciled abandoned VRT regeneration, restored to ready",
             dataset_id=str(dataset_id),
             stale_cutoff=str(stale_cutoff),
         )
+
+    if stale_generations:
+        await _reap_stale_generation_storage(stale_generations)
 
     return len(stale_asset_ids), len(stale_generation_ids)
 

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -745,19 +745,50 @@ _READY_WORTHY_SQL = (
     f"({_COMPOSITION_PRESERVED_SQL}) AND ({_PRIOR_ATTEMPT_WAS_READY_SQL})"
 )
 
-# fix(#1322 review round 6): the proven-dead proof for a 'pending'
-# VrtGeneration — mirrors _ABANDONED_RUN_SQL's `catalog.procrastinate_jobs`
-# correlation in platform/refresh/service.py, keyed on `generation_id`
-# instead of `ingest_job_id` because that is the kwarg every regenerate_vrt
-# dispatch site (regenerate_vrt_endpoint, add_vrt_source, remove_vrt_source)
-# actually passes — there is no ingest_job_id column on VrtGeneration to
-# correlate through. `'todo'`/`'doing'` is Procrastinate's own live-job
-# vocabulary, same two statuses stale_pending_clauses excludes for IngestJob.
+# fix(#1322 review round 6, completed): the proven-dead proof for a
+# 'pending' VrtGeneration — mirrors _ABANDONED_RUN_SQL's
+# `catalog.procrastinate_jobs` correlation in platform/refresh/service.py,
+# keyed on `generation_id` instead of `ingest_job_id` because that is the
+# kwarg every regenerate_vrt dispatch site (regenerate_vrt_endpoint,
+# add_vrt_source, remove_vrt_source) actually passes — there is no
+# ingest_job_id column on VrtGeneration to correlate through. `'todo'`/
+# `'doing'` is Procrastinate's own live-job vocabulary, same two statuses
+# stale_pending_clauses excludes for IngestJob.
+#
+# Two correlation forms, because `tasks_vrt.regenerate_vrt` accepts two
+# delivery shapes and this predicate has to cover both to be complete:
+#   1. Modern: `generation_id` is present in `args` — exact 1:1 match.
+#   2. Legacy: a delivery queued by pre-upgrade code carries no
+#      `generation_id` at all (the task parameter is optional precisely to
+#      keep such deliveries alive across a rolling deploy). On execution it
+#      adopts `RasterAsset.current_generation_id` instead (see the
+#      "Legacy queued deliveries" comment at tasks_vrt.py's claim site). A
+#      live legacy row is therefore correlated by dataset (`vrt_dataset_id`
+#      is a required, non-optional task argument, so every delivery of
+#      either shape always carries it) PLUS current ownership: it counts as
+#      live for THIS generation only if this generation IS, right now, that
+#      dataset's `RasterAsset.current_generation_id` — the exact row the
+#      legacy task will claim once it runs.
+# Deliberately conservative in the direction the finding asked for: an
+# ambiguous or legacy-shaped live row blocks the sweep rather than being
+# read as absence of one — a delayed sweep of a truly-dead attempt costs a
+# retry window; sweeping a live one loses real work.
 _NO_LIVE_GENERATION_JOB_SQL = """
     NOT EXISTS (
         SELECT 1 FROM catalog.procrastinate_jobs pj
-        WHERE pj.args->>'generation_id' = vrt_generations.id::text
-          AND pj.status IN ('todo', 'doing')
+        WHERE pj.status IN ('todo', 'doing')
+          AND (
+            pj.args->>'generation_id' = vrt_generations.id::text
+            OR (
+                pj.args->>'generation_id' IS NULL
+                AND pj.args->>'vrt_dataset_id' = vrt_generations.vrt_dataset_id::text
+                AND EXISTS (
+                    SELECT 1 FROM catalog.raster_assets ra
+                    WHERE ra.dataset_id = vrt_generations.vrt_dataset_id
+                      AND ra.current_generation_id = vrt_generations.id
+                )
+            )
+          )
     )
 """
 

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -628,6 +628,47 @@ async def _reap_stale_generation_storage(keys: tuple[str, ...]) -> None:
     await _cleanup_orphaned_storage_keys(list(keys), job_id="vrt-stale-sweep")
 
 
+# fix(#1322 review round 3): does the PUBLISHED VRT's member set (built_from's
+# keys — feat(#1290 review): "what the published VRT was assembled FROM")
+# still equal the CATALOG's current member set (vrt_source_links)? A bare
+# fragment, not a full statement, so it can be embedded as-is in one UPDATE's
+# WHERE and wrapped in NOT(...) for its mirror — see sweep_stale_vrt_assets.
+#
+# Count-match + one-directional subset (every built_from key has a live
+# link) proves full set equality: a JSONB object cannot repeat a key, and
+# uq_vsl_vrt_source forbids vrt_source_links from repeating a
+# (vrt_dataset_id, source_dataset_id) pair, so neither side can inflate its
+# own count to fake a subset match.
+#
+# jsonb_typeof(...) = 'object', not built_from IS NOT NULL — a real-DB test
+# caught the difference: SQLAlchemy's plain JSONB type (no none_as_null=True)
+# serializes a Python None to the JSON scalar `null`, not SQL NULL, so
+# "IS NOT NULL" alone is TRUE for a column holding JSON null and
+# jsonb_object_keys() raises "cannot call jsonb_object_keys on a scalar" —
+# turning the conservative branch into a 500 instead of a safe fallback.
+# jsonb_typeof() returns SQL NULL for a genuinely NULL column and 'null' (a
+# string, not a match) for a JSON-null scalar, so both forms — and any other
+# non-object value — fail the `= 'object'` test the same safe way. A legacy
+# VRT predating the built_from column cannot answer the question at all,
+# and the unanswerable case must fall to the SAME conservative branch as a
+# proven mismatch.
+_COMPOSITION_PRESERVED_SQL = """
+    jsonb_typeof(built_from) = 'object'
+    AND (SELECT COUNT(*) FROM jsonb_object_keys(built_from)) = (
+        SELECT COUNT(*) FROM catalog.vrt_source_links vsl
+        WHERE vsl.vrt_dataset_id = dataset_id
+    )
+    AND NOT EXISTS (
+        SELECT 1 FROM jsonb_object_keys(built_from) AS built_from_key
+        WHERE NOT EXISTS (
+            SELECT 1 FROM catalog.vrt_source_links vsl2
+            WHERE vsl2.vrt_dataset_id = dataset_id
+              AND vsl2.source_dataset_id::text = built_from_key
+        )
+    )
+"""
+
+
 async def sweep_stale_vrt_assets(
     db: AsyncSession,
     stale_cutoff: datetime,
@@ -646,27 +687,43 @@ async def sweep_stale_vrt_assets(
     generation_heartbeat`` renews every 30s while the worker is alive, so a
     live job's row never crosses the cutoff and this sweep never touches it.
 
-    Recovery status: ``'ready'``, not ``'failed'``. ``regenerate_vrt`` only
-    overwrites the asset's published pointer (``asset_uri``, ``sha256``, ...)
-    in the SAME transaction that clears ``current_generation_id`` on success
-    — a dead attempt never reaches that transaction, so those fields still
-    describe the last-good VRT the asset was serving before this attempt
-    started. Restoring ``'ready'`` reflects that: the VRT keeps serving
-    exactly what it served before, and only the dead attempt's own
-    ``VrtGeneration`` row (marked ``'failed'`` below) records that it did not
-    finish. An operator or retry call can re-trigger regeneration.
+    Recovery status: ``'ready'`` for a COMPOSITION-PRESERVING dead attempt,
+    ``'failed'`` otherwise (fix(#1322 review round 3) — see
+    ``_COMPOSITION_PRESERVED_SQL``). ``regenerate_vrt`` only overwrites the
+    asset's published pointer (``asset_uri``, ``sha256``, ...) in the SAME
+    transaction that clears ``current_generation_id`` on success — a dead
+    attempt never reaches that transaction, so those fields still describe
+    the last-good VRT the asset was serving before this attempt started.
+    That is sufficient to restore ``'ready'`` when nothing about the
+    dataset's declared MEMBERSHIP changed underneath the attempt. It is
+    NOT sufficient when it did: ``add_vrt_source``/``remove_vrt_source``
+    commit their ``vrt_source_links`` mutation in the same transaction that
+    flips the asset to ``'regenerating'``, BEFORE the regeneration itself
+    ever runs, so a dead attempt of THAT kind leaves the catalog's stated
+    composition already ahead of the served bytes. Restoring ``'ready'``
+    there would erase the only visible signal of that drift — the status
+    endpoint reads the link set, not the served VRT, and would report a
+    reduced (or expanded) source list as fully healthy while stale
+    composition keeps being served. The degraded branch keeps
+    ``current_generation_id`` cleared (a retry can still be triggered) but
+    leaves ``status='failed'``, matching the ordinary explicit-failure path.
 
-    There is no "first-ever generation" case where 'ready' would be wrong.
+    Either branch marks the dead attempt's own ``VrtGeneration`` row
+    ``'failed'`` below; an operator or retry call can re-trigger
+    regeneration regardless of which branch fired.
+
+    There is no "first-ever generation, no built_from to compare" gap.
     ``status='regenerating'`` is reachable from exactly three call sites
     (``regenerate_vrt_endpoint``, ``add_vrt_source``, ``remove_vrt_source``),
     and all three 404 unless a VRT dataset already exists — which means its
     ``RasterAsset`` row was already created, and the only constructor of that
     row (``create_vrt_dataset``, run inside ``ingest_vrt``) sets
-    ``status='ready'`` with a real ``asset_uri`` in the same flush the row
-    first becomes queryable. No code path ever inserts a ``RasterAsset`` row
-    pre-set to ``'regenerating'``. A dead FIRST regeneration therefore still
-    restores to a row whose pointer describes the dataset's original publish,
-    not a still-empty one.
+    ``status='ready'`` with a real ``asset_uri`` AND a real ``built_from`` in
+    the same flush the row first becomes queryable. No code path ever
+    inserts a ``RasterAsset`` row pre-set to ``'regenerating'``, and no VRT
+    created after ``built_from`` shipped (#1290) ever has a NULL value for
+    it — only a legacy pre-#1290 row can, and that case is exactly the
+    "cannot answer, so don't guess ready" branch above.
 
     Also resolves the dead attempt's own generation-scoped storage keys for
     the caller to reap, but does NOT delete anything itself — the caller must
@@ -682,8 +739,10 @@ async def sweep_stale_vrt_assets(
             this timestamp is considered stale.
 
     Returns:
-        ``(assets_recovered, gens_failed, storage_keys)`` — ``storage_keys``
-        are resolved, not yet deleted.
+        ``(assets_recovered, gens_failed, storage_keys)`` — ``assets_
+        recovered`` counts BOTH branches (restored to ready and kept
+        failed; both are a resolved outcome for a dead attempt).
+        ``storage_keys`` are resolved, not yet deleted.
     """
     from app.processing.raster.models import RasterAsset, VrtGeneration
 
@@ -748,23 +807,68 @@ async def sweep_stale_vrt_assets(
     # failed. A newer regeneration has a different current_generation_id and
     # is fenced — same CAS discipline as the failure-handler path in
     # tasks_vrt.regenerate_vrt.
-    stale_asset_result = await db.execute(
+    #
+    # fix(#1322 review round 3): 'ready' is only honest for a COMPOSITION-
+    # PRESERVING attempt. add_vrt_source / remove_vrt_source commit their
+    # vrt_source_links mutation in the SAME transaction that flips the asset
+    # to 'regenerating' — BEFORE the regeneration itself ever runs. If that
+    # attempt then dies, the catalog's link set already reflects the NEW
+    # composition while the published asset_uri (untouched by the dead
+    # attempt) still serves the OLD one. Restoring 'ready' would erase the
+    # only visible signal of that drift: the status endpoint reads the link
+    # set, not the served bytes, and would report the new (reduced) source
+    # list as fully healthy while stale data keeps being served.
+    #
+    # There is no stored "attempt type" to key off — VrtGeneration.
+    # triggered_by holds a user id on every call site, not a kind, and
+    # source_count is populated post-mutation on both. So this asks the
+    # question the drift itself is about, from state rather than provenance:
+    # does the PUBLISHED composition (built_from's key set — what the served
+    # VRT was actually assembled from, feat(#1290 review)) still equal the
+    # CATALOG's current composition (vrt_source_links)? Count-match plus a
+    # one-directional subset check proves set equality here because neither
+    # side can hold a duplicate id (a JSONB object key is unique by
+    # construction; vrt_source_links carries uq_vsl_vrt_source).
+    #
+    # NULL built_from (a pre-#1290 VRT with no recorded build set) cannot
+    # answer the question at all, and falls to the same conservative branch
+    # as a genuine mismatch — matching the "unknown answers unknown, not
+    # fresh" posture in source_freshness.py, not the other one.
+    _asset_composition = (
+        *asset_scope,
+        RasterAsset.status == "regenerating",
+        RasterAsset.current_generation_id.in_(stale_generation_ids),
+    )
+    ready_result = await db.execute(
         update(RasterAsset)
-        .where(
-            *asset_scope,
-            RasterAsset.status == "regenerating",
-            RasterAsset.current_generation_id.in_(stale_generation_ids),
-        )
+        .where(*_asset_composition, text(_COMPOSITION_PRESERVED_SQL))
         .values(status="ready", current_generation_id=None)
         .returning(RasterAsset.dataset_id)
     )
-    stale_asset_ids = list(stale_asset_result.scalars())
-    for dataset_id in stale_asset_ids:
+    ready_ids = list(ready_result.scalars())
+    for dataset_id in ready_ids:
         log.warning(
             "Reconciled abandoned VRT regeneration, restored to ready",
             dataset_id=str(dataset_id),
             stale_cutoff=str(stale_cutoff),
         )
+
+    degraded_result = await db.execute(
+        update(RasterAsset)
+        .where(*_asset_composition, text(f"NOT ({_COMPOSITION_PRESERVED_SQL})"))
+        .values(status="failed", current_generation_id=None)
+        .returning(RasterAsset.dataset_id)
+    )
+    degraded_ids = list(degraded_result.scalars())
+    for dataset_id in degraded_ids:
+        log.warning(
+            "Reconciled abandoned VRT regeneration, kept failed — "
+            "composition changed since the published build",
+            dataset_id=str(dataset_id),
+            stale_cutoff=str(stale_cutoff),
+        )
+
+    stale_asset_ids = ready_ids + degraded_ids
 
     storage_keys = (
         _stale_generation_storage_keys(stale_generations) if stale_generations else ()

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -702,11 +702,40 @@ _COMPOSITION_PRESERVED_SQL = """
 # never claims 'ready' the moment there is any doubt, at the cost of
 # occasionally staying 'failed' one cycle longer than strictly necessary,
 # which self-corrects the moment an operator retries and it succeeds.
+#
+# fix(#1322 review round 5): raw `status` alone over-counts what "failed"
+# means. regenerate_vrt_endpoint's own orphan guard (_rollback,
+# lines ~507-520) marks the just-created VrtGeneration 'failed' when
+# Procrastinate's ENQUEUE itself throws — a dispatch failure the task never
+# reached — and in the SAME rollback reverts the asset to whatever it was
+# (commonly 'ready'). That generation row genuinely never ran: nothing
+# about its outcome describes the asset's state, only that it could not be
+# queued. Reading its 'failed' status here as "the asset was not ready"
+# would be wrong in exactly the direction this predicate exists to avoid —
+# not a false 'ready', but a false 'failed' for an asset that never had a
+# real attempt run against it.
+#
+# `heartbeat_at IS NOT NULL` is the fact that separates them: it is set in
+# exactly one place in this codebase, `tasks_vrt.regenerate_vrt`'s Phase-1
+# claim (either the CAS `UPDATE ... status='pending' -> 'running'`, or the
+# equivalent field on a freshly-created legacy-pointer generation) — the
+# first thing the TASK does once a worker actually picks it up, never
+# anything the ENDPOINT touches at creation. A synchronous enqueue failure
+# never reaches that line, so its generation keeps heartbeat_at NULL
+# forever; the same is true of a generation stuck 'pending' because no
+# worker ever claimed it before this sweep's own cutoff — which is the
+# same "never actually ran" fact, so excluding it here is consistent with,
+# not a special case against, its own eventual sweep as a dead attempt.
+# Filtering to `heartbeat_at IS NOT NULL` therefore finds the most recent
+# OTHER generation that a worker actually claimed and ran, skipping past
+# any number of enqueue-failures or claim-starved rows in between — those
+# never touched the asset's state, so they carry no information about it.
 _PRIOR_ATTEMPT_WAS_READY_SQL = """
     (
         SELECT g.status FROM catalog.vrt_generations g
         WHERE g.vrt_dataset_id = dataset_id
           AND g.id <> current_generation_id
+          AND g.heartbeat_at IS NOT NULL
         ORDER BY g.started_at DESC
         LIMIT 1
     ) IS DISTINCT FROM 'failed'

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -668,6 +668,54 @@ _COMPOSITION_PRESERVED_SQL = """
     )
 """
 
+# fix(#1322 review round 4): composition-preserving is necessary but not
+# sufficient. regenerate_vrt_endpoint's guard only rejects 'regenerating' —
+# a caller may retry an asset that is already 'failed'. If THAT retry is
+# also abandoned and its membership still matches built_from, the check
+# above alone would call it composition-preserving and restore 'ready',
+# erasing a real failure signal a worker crash had nothing to do with:
+# no successful artifact was ever produced by the retry, and whatever made
+# the FIRST attempt fail is still unaddressed.
+#
+# There is no column recording "the asset's status the instant this
+# generation started" — router.py's own `previous_status` is a local
+# variable, never persisted. The nearest STORED fact is the outcome of the
+# attempt immediately before this one: at most one generation is ever
+# in-flight per dataset (the 409 + advisory lock in regenerate_vrt_endpoint
+# / add_vrt_source / remove_vrt_source forbid a second), so
+# `vrt_generations` rows for one dataset form a strict, gap-free timeline,
+# and the row immediately preceding the one being reconciled records
+# exactly what happened right before THIS attempt was allowed to start.
+# 'completed' (or no such row — the dataset's first-ever attempt, whose
+# prior state is 'ready' by construction, per create_vrt_dataset) means the
+# asset was 'ready' when this attempt began; 'failed' means it was not.
+#
+# Accepted conservative cost, stated plainly: a generation this sweep
+# itself restores to 'ready' still leaves its OWN vrt_generations row
+# 'failed' below (only the asset recovers, not the attempt's record) — so
+# a LATER dead attempt on the same dataset, whose immediately-prior row IS
+# that earlier swept-and-recovered one, reads 'failed' here and is kept
+# 'failed' even though the asset was legitimately 'ready' when it started.
+# The alternative (a further stored marker distinguishing "recovered by
+# the sweep" from "never recovered") is a bigger schema surface than this
+# fix's blast radius, and the safety direction is right for a reconciler:
+# never claims 'ready' the moment there is any doubt, at the cost of
+# occasionally staying 'failed' one cycle longer than strictly necessary,
+# which self-corrects the moment an operator retries and it succeeds.
+_PRIOR_ATTEMPT_WAS_READY_SQL = """
+    (
+        SELECT g.status FROM catalog.vrt_generations g
+        WHERE g.vrt_dataset_id = dataset_id
+          AND g.id <> current_generation_id
+        ORDER BY g.started_at DESC
+        LIMIT 1
+    ) IS DISTINCT FROM 'failed'
+"""
+
+_READY_WORTHY_SQL = (
+    f"({_COMPOSITION_PRESERVED_SQL}) AND ({_PRIOR_ATTEMPT_WAS_READY_SQL})"
+)
+
 
 async def sweep_stale_vrt_assets(
     db: AsyncSession,
@@ -687,26 +735,40 @@ async def sweep_stale_vrt_assets(
     generation_heartbeat`` renews every 30s while the worker is alive, so a
     live job's row never crosses the cutoff and this sweep never touches it.
 
-    Recovery status: ``'ready'`` for a COMPOSITION-PRESERVING dead attempt,
-    ``'failed'`` otherwise (fix(#1322 review round 3) — see
-    ``_COMPOSITION_PRESERVED_SQL``). ``regenerate_vrt`` only overwrites the
-    asset's published pointer (``asset_uri``, ``sha256``, ...) in the SAME
-    transaction that clears ``current_generation_id`` on success — a dead
-    attempt never reaches that transaction, so those fields still describe
-    the last-good VRT the asset was serving before this attempt started.
-    That is sufficient to restore ``'ready'`` when nothing about the
-    dataset's declared MEMBERSHIP changed underneath the attempt. It is
-    NOT sufficient when it did: ``add_vrt_source``/``remove_vrt_source``
-    commit their ``vrt_source_links`` mutation in the same transaction that
-    flips the asset to ``'regenerating'``, BEFORE the regeneration itself
-    ever runs, so a dead attempt of THAT kind leaves the catalog's stated
-    composition already ahead of the served bytes. Restoring ``'ready'``
-    there would erase the only visible signal of that drift — the status
-    endpoint reads the link set, not the served VRT, and would report a
-    reduced (or expanded) source list as fully healthy while stale
-    composition keeps being served. The degraded branch keeps
-    ``current_generation_id`` cleared (a retry can still be triggered) but
-    leaves ``status='failed'``, matching the ordinary explicit-failure path.
+    Recovery status: ``'ready'`` only when BOTH hold (fix(#1322 review
+    rounds 3-4) — see ``_READY_WORTHY_SQL``, ``_COMPOSITION_PRESERVED_SQL``,
+    ``_PRIOR_ATTEMPT_WAS_READY_SQL``); ``'failed'`` otherwise. ``regenerate_
+    vrt`` only overwrites the asset's published pointer (``asset_uri``,
+    ``sha256``, ...) in the SAME transaction that clears
+    ``current_generation_id`` on success — a dead attempt never reaches
+    that transaction, so those fields still describe the last-good VRT the
+    asset was serving before this attempt started. That is necessary to
+    restore ``'ready'`` but not sufficient on its own, for two independent
+    reasons:
+
+    1. Nothing about the dataset's declared MEMBERSHIP may have changed
+       underneath the attempt. ``add_vrt_source``/``remove_vrt_source``
+       commit their ``vrt_source_links`` mutation in the same transaction
+       that flips the asset to ``'regenerating'``, BEFORE the regeneration
+       itself ever runs, so a dead attempt of THAT kind leaves the
+       catalog's stated composition already ahead of the served bytes.
+       Restoring ``'ready'`` there would erase the only visible signal of
+       that drift — the status endpoint reads the link set, not the served
+       VRT, and would report a reduced (or expanded) source list as fully
+       healthy while stale composition keeps being served.
+    2. The asset must have actually BEEN ``'ready'`` — not ``'failed'`` —
+       the instant this attempt was allowed to start. ``regenerate_vrt_
+       endpoint``'s guard rejects only ``'regenerating'``, so a caller may
+       retry an asset that is already ``'failed'``. If that retry then dies
+       too and its membership still matches, condition 1 alone would call
+       it composition-preserving and restore ``'ready'`` — erasing a real
+       failure a worker crash had nothing to do with, since no successful
+       artifact was ever produced by the retry and whatever caused the
+       FIRST failure is still unaddressed.
+
+    The degraded branch keeps ``current_generation_id`` cleared (a retry
+    can still be triggered) but leaves ``status='failed'``, matching the
+    ordinary explicit-failure path.
 
     Either branch marks the dead attempt's own ``VrtGeneration`` row
     ``'failed'`` below; an operator or retry call can re-trigger
@@ -834,6 +896,11 @@ async def sweep_stale_vrt_assets(
     # answer the question at all, and falls to the same conservative branch
     # as a genuine mismatch — matching the "unknown answers unknown, not
     # fresh" posture in source_freshness.py, not the other one.
+    #
+    # fix(#1322 review round 4): composition-preserving is necessary but not
+    # sufficient — see _PRIOR_ATTEMPT_WAS_READY_SQL above for the second,
+    # independently-required fact (was the asset actually 'ready', not
+    # 'failed', the instant this attempt was allowed to start).
     _asset_composition = (
         *asset_scope,
         RasterAsset.status == "regenerating",
@@ -841,7 +908,7 @@ async def sweep_stale_vrt_assets(
     )
     ready_result = await db.execute(
         update(RasterAsset)
-        .where(*_asset_composition, text(_COMPOSITION_PRESERVED_SQL))
+        .where(*_asset_composition, text(_READY_WORTHY_SQL))
         .values(status="ready", current_generation_id=None)
         .returning(RasterAsset.dataset_id)
     )
@@ -855,7 +922,7 @@ async def sweep_stale_vrt_assets(
 
     degraded_result = await db.execute(
         update(RasterAsset)
-        .where(*_asset_composition, text(f"NOT ({_COMPOSITION_PRESERVED_SQL})"))
+        .where(*_asset_composition, text(f"NOT ({_READY_WORTHY_SQL})"))
         .values(status="failed", current_generation_id=None)
         .returning(RasterAsset.dataset_id)
     )
@@ -863,7 +930,8 @@ async def sweep_stale_vrt_assets(
     for dataset_id in degraded_ids:
         log.warning(
             "Reconciled abandoned VRT regeneration, kept failed — "
-            "composition changed since the published build",
+            "composition changed since the published build, or the "
+            "asset was not provably ready when this attempt started",
             dataset_id=str(dataset_id),
             stale_cutoff=str(stale_cutoff),
         )

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -198,6 +198,15 @@ class StaleCleanupOutcome:
     # Private and absent from as_dict() like the two fields above, so the
     # published API and audit shape is unchanged.
     _refresh_runs_reconciled: int = field(default=0, repr=False, compare=False)
+    # fix(#1322 review): a dead VRT regeneration attempt's own generation-
+    # scoped storage keys (source.vrt + 2 quicklooks), already resolved by
+    # sweep_stale_vrt_assets but deliberately NOT yet deleted — carried out to
+    # whoever commits, same rule as _staged_paths below, because deleting
+    # before that commit is durable can destroy a generation a rolled-back
+    # reconciliation still owns.
+    _stale_generation_storage_keys: tuple[str, ...] = field(
+        default=(), repr=False, compare=False
+    )
 
     @property
     def total_cleaned(self) -> int:
@@ -514,6 +523,26 @@ async def _reap_committed_staged_paths(
                 storage_key=staging_key,
             )
 
+    # fix(#1322 review): a dead VRT regeneration attempt's own generation-
+    # scoped objects, resolved by sweep_stale_vrt_assets but withheld from
+    # deletion until now — this function IS "after the commit landed" for
+    # every caller (fail_stale_jobs's own commit=True branch calls it
+    # immediately after `await db.commit()`; the admin commit=False branch
+    # calls it immediately after its own commit). Already tenant-resolved at
+    # capture time, unlike the two loops above, so no resolve_current_storage_key.
+    for stale_key in outcome._stale_generation_storage_keys:
+        try:
+            from app.platform.storage import get_storage
+
+            await get_storage().delete(stale_key)
+            storage_objects_reaped += 1
+        except Exception:  # broad: best-effort staging cleanup
+            staged_cleanup_failures += 1
+            log.warning(
+                "Failed to reap stale VRT generation object",
+                storage_key=stale_key,
+            )
+
     return replace(
         outcome,
         local_files_reaped=local_files_reaped,
@@ -523,10 +552,10 @@ async def _reap_committed_staged_paths(
     )
 
 
-async def _reap_stale_generation_storage(
+def _stale_generation_storage_keys(
     stale_generations: list[tuple[uuid.UUID, uuid.UUID]],
-) -> None:
-    """Best-effort delete of a dead regeneration attempt's immutable objects.
+) -> tuple[str, ...]:
+    """Resolve (never delete) a dead attempt's immutable object keys.
 
     feat(#1267): ``regenerate_vrt`` writes its rebuilt VRT + quicklooks to an
     immutable ``rasters/{vrt_dataset_id}/generations/{generation_id}/...`` key
@@ -535,19 +564,18 @@ async def _reap_stale_generation_storage(
     tables) BEFORE the phase-2 transaction that would otherwise clean them up
     via ``_cleanup_orphaned_storage_keys``. A worker killed between that write
     and the commit leaves the objects with no reference anywhere — this sweep
-    is the only remaining owner of the key, so it reaps them the same way.
+    is the only remaining owner of the key, so its caller reaps them the same
+    way, but only once the reconciliation itself is durable (see
+    ``_reap_stale_generation_storage`` for why deletion is a separate,
+    later step).
 
-    A dead attempt may have written none, some, or all three objects before
-    the worker died; deleting a key that was never written is a documented
-    no-op on every StorageProvider.
-
-    ``current_tenant_var`` carries the right tenant because both callers of
+    ``current_tenant_var`` carries the right tenant because every caller of
     ``sweep_stale_vrt_assets`` (the startup recovery pass and the periodic
-    sweep) run this inside ``tenant_job_context`` per tenant in multi-tenant
-    mode — the same context ``regenerate_vrt`` itself reads to resolve these
-    same keys. A missing tenant context in multi-tenant mode skips cleanup
-    rather than raising: the asset/generation reconciliation above already
-    landed regardless of whether this best-effort pass can find the bytes.
+    sweep, both directly and via ``fail_stale_jobs``) runs inside
+    ``tenant_job_context`` per tenant in multi-tenant mode — the same context
+    ``regenerate_vrt`` itself reads to resolve these same keys. A missing
+    tenant context in multi-tenant mode resolves no keys rather than raising:
+    the asset/generation reconciliation is not gated on this best-effort pass.
     """
     from app.core.tenancy import is_multi_tenant
     from app.core.db.tenant_session import current_tenant_var
@@ -555,16 +583,41 @@ async def _reap_stale_generation_storage(
 
     tenant_id = current_tenant_var.get()
     if is_multi_tenant() and tenant_id is None:
-        return
+        return ()
 
-    keys = [
+    return tuple(
         resolve_storage_key(
             f"rasters/{vrt_dataset_id}/generations/{generation_id}/{suffix}",
             tenant_id=tenant_id,
         )
         for generation_id, vrt_dataset_id in stale_generations
         for suffix in ("source.vrt", "quicklook_256.png", "quicklook_512.png")
-    ]
+    )
+
+
+async def _reap_stale_generation_storage(keys: tuple[str, ...]) -> None:
+    """Best-effort delete of already-resolved, already-committed keys.
+
+    fix(#1322 review): deleting these objects had lived inside
+    ``sweep_stale_vrt_assets`` itself, before its caller's commit. A worker
+    is declared dead by a timed-out heartbeat, not by proof it can never run
+    another statement — if the reconciling transaction then failed to commit
+    (or a later statement in the same pass raised), the generation/asset
+    UPDATEs rolled back while these objects were already gone. A resumed
+    "dead" worker could pass the (rolled-back-to) ownership checks and
+    publish a generation whose own source.vrt and quicklooks no longer
+    exist, leaving a `'ready'` asset backed by deleted data. Every caller now
+    resolves the keys during the sweep (``_stale_generation_storage_keys``,
+    read-only) but defers this call until strictly after its own commit
+    succeeds — mirroring ``_reap_committed_staged_paths``, which reaps
+    ``StaleCleanupOutcome._staged_paths`` under the identical rule.
+
+    A dead attempt may have written none, some, or all three objects before
+    the worker died; deleting a key that was never written is a documented
+    no-op on every StorageProvider.
+    """
+    if not keys:
+        return
 
     # Function-local: mirrors the deferred processing-import convention
     # already used for RasterAsset/VrtGeneration below (D-17,
@@ -572,13 +625,13 @@ async def _reap_stale_generation_storage(
     # regenerate_vrt itself uses to reap its own orphaned writes.
     from app.processing.ingest.tasks_raster import _cleanup_orphaned_storage_keys
 
-    await _cleanup_orphaned_storage_keys(keys, job_id="vrt-stale-sweep")
+    await _cleanup_orphaned_storage_keys(list(keys), job_id="vrt-stale-sweep")
 
 
 async def sweep_stale_vrt_assets(
     db: AsyncSession,
     stale_cutoff: datetime,
-) -> tuple[int, int]:
+) -> tuple[int, int, tuple[str, ...]]:
     """Reconcile RasterAsset rows stuck in status='regenerating' past ``stale_cutoff``.
 
     GAP-002 / feat(#1267): a worker crash mid-regeneration leaves the VRT
@@ -603,8 +656,24 @@ async def sweep_stale_vrt_assets(
     ``VrtGeneration`` row (marked ``'failed'`` below) records that it did not
     finish. An operator or retry call can re-trigger regeneration.
 
-    Also reaps the dead attempt's own generation-scoped storage objects
-    (best-effort — see ``_reap_stale_generation_storage``).
+    There is no "first-ever generation" case where 'ready' would be wrong.
+    ``status='regenerating'`` is reachable from exactly three call sites
+    (``regenerate_vrt_endpoint``, ``add_vrt_source``, ``remove_vrt_source``),
+    and all three 404 unless a VRT dataset already exists — which means its
+    ``RasterAsset`` row was already created, and the only constructor of that
+    row (``create_vrt_dataset``, run inside ``ingest_vrt``) sets
+    ``status='ready'`` with a real ``asset_uri`` in the same flush the row
+    first becomes queryable. No code path ever inserts a ``RasterAsset`` row
+    pre-set to ``'regenerating'``. A dead FIRST regeneration therefore still
+    restores to a row whose pointer describes the dataset's original publish,
+    not a still-empty one.
+
+    Also resolves the dead attempt's own generation-scoped storage keys for
+    the caller to reap, but does NOT delete anything itself — the caller must
+    not do so either until its own commit lands (fix(#1322 review); see
+    ``_reap_stale_generation_storage``). Deleting before that commit is
+    durable can destroy a generation a rolled-back reconciliation just
+    restored ownership of, orphaning a `'ready'` asset against missing bytes.
 
     Args:
         db: The active async session (must NOT be committed before returning
@@ -613,7 +682,8 @@ async def sweep_stale_vrt_assets(
             this timestamp is considered stale.
 
     Returns:
-        ``(assets_recovered, gens_failed)``
+        ``(assets_recovered, gens_failed, storage_keys)`` — ``storage_keys``
+        are resolved, not yet deleted.
     """
     from app.processing.raster.models import RasterAsset, VrtGeneration
 
@@ -696,10 +766,11 @@ async def sweep_stale_vrt_assets(
             stale_cutoff=str(stale_cutoff),
         )
 
-    if stale_generations:
-        await _reap_stale_generation_storage(stale_generations)
+    storage_keys = (
+        _stale_generation_storage_keys(stale_generations) if stale_generations else ()
+    )
 
-    return len(stale_asset_ids), len(stale_generation_ids)
+    return len(stale_asset_ids), len(stale_generation_ids), storage_keys
 
 
 def publish_refresh_reconciliation(outcome: StaleCleanupOutcome) -> None:
@@ -825,9 +896,15 @@ async def fail_stale_jobs(
     running_job_ids = list(running_result.scalars())
 
     # GAP-002: sweep stale VRT regenerating assets using the same cutoff.
-    vrt_assets_recovered, vrt_generations_failed = await sweep_stale_vrt_assets(
-        db, running_cutoff
-    )
+    # fix(#1322 review): stale_generation_storage_keys are resolved, not yet
+    # deleted — carried into StaleCleanupOutcome and reaped only after this
+    # function's own commit (or its commit=False caller's) lands, exactly
+    # like _staged_paths below.
+    (
+        vrt_assets_recovered,
+        vrt_generations_failed,
+        stale_generation_storage_keys,
+    ) = await sweep_stale_vrt_assets(db, running_cutoff)
 
     # feat(#1219): cancel refresh runs whose task is proven gone. Ordered
     # AFTER the two job sweeps above on purpose — those flip an orphaned job
@@ -1012,6 +1089,7 @@ async def fail_stale_jobs(
         _staged_paths=tuple(sorted(deleted_paths)),
         _staged_presigned_keys=tuple(sorted(deleted_presigned_keys)),
         _refresh_runs_reconciled=cancelled_runs,
+        _stale_generation_storage_keys=stale_generation_storage_keys,
     )
     if commit:
         # Never remove an external artifact for a DELETE that may still roll

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -745,6 +745,22 @@ _READY_WORTHY_SQL = (
     f"({_COMPOSITION_PRESERVED_SQL}) AND ({_PRIOR_ATTEMPT_WAS_READY_SQL})"
 )
 
+# fix(#1322 review round 6): the proven-dead proof for a 'pending'
+# VrtGeneration — mirrors _ABANDONED_RUN_SQL's `catalog.procrastinate_jobs`
+# correlation in platform/refresh/service.py, keyed on `generation_id`
+# instead of `ingest_job_id` because that is the kwarg every regenerate_vrt
+# dispatch site (regenerate_vrt_endpoint, add_vrt_source, remove_vrt_source)
+# actually passes — there is no ingest_job_id column on VrtGeneration to
+# correlate through. `'todo'`/`'doing'` is Procrastinate's own live-job
+# vocabulary, same two statuses stale_pending_clauses excludes for IngestJob.
+_NO_LIVE_GENERATION_JOB_SQL = """
+    NOT EXISTS (
+        SELECT 1 FROM catalog.procrastinate_jobs pj
+        WHERE pj.args->>'generation_id' = vrt_generations.id::text
+          AND pj.status IN ('todo', 'doing')
+    )
+"""
+
 
 async def sweep_stale_vrt_assets(
     db: AsyncSession,
@@ -863,6 +879,26 @@ async def sweep_stale_vrt_assets(
     # re-evaluated by PostgreSQL at UPDATE time, so a heartbeat racing the
     # sweep wins and the generation remains live.
     #
+    # fix(#1322 review round 6): 'running' and 'pending' need DIFFERENT
+    # proof, mirroring the split this file already applies to IngestJob
+    # (the running-job sweep just above trusts a stale heartbeat outright;
+    # stale_pending_clauses additionally requires no_live_procrastinate_job
+    # because queue waits are unbounded). A 'running' generation's
+    # heartbeat_at is the worker's own, actively-renewed liveness signal —
+    # stale on it is proof enough, independent of what Procrastinate's OWN
+    # bookkeeping currently shows (a crashed worker can leave its
+    # procrastinate_jobs row reading 'doing' until the separate stalled-
+    # queue sweep prunes it, so requiring "no live row" here would make a
+    # genuinely-dead running generation UNSWEEPABLE until that other sweep
+    # runs). A 'pending' generation has no such signal — nothing has
+    # claimed it yet, so its `started_at` age alone cannot distinguish
+    # "orphaned" from "sitting in a sustained worker backlog, still queued
+    # and will run" — so it additionally requires proof no live
+    # Procrastinate row still references it, correlated via `generation_id`
+    # in `args` (the same kwarg all three dispatch call sites pass), the
+    # exact fact stale_pending_clauses checks for IngestJob and for the
+    # identical reason.
+    #
     # RETURNING carries vrt_dataset_id alongside id (feat(#1267)): the
     # generation-scoped storage key each dead attempt wrote to is keyed on
     # BOTH, and the asset UPDATE below cannot supply that pairing back — its
@@ -872,9 +908,18 @@ async def sweep_stale_vrt_assets(
         update(VrtGeneration)
         .where(
             *generation_scope,
-            VrtGeneration.status.in_(["pending", "running"]),
-            func.coalesce(VrtGeneration.heartbeat_at, VrtGeneration.started_at)
-            < stale_cutoff,
+            or_(
+                and_(
+                    VrtGeneration.status == "running",
+                    func.coalesce(VrtGeneration.heartbeat_at, VrtGeneration.started_at)
+                    < stale_cutoff,
+                ),
+                and_(
+                    VrtGeneration.status == "pending",
+                    VrtGeneration.started_at < stale_cutoff,
+                    text(_NO_LIVE_GENERATION_JOB_SQL),
+                ),
+            ),
         )
         .values(
             status="failed",

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -161,13 +161,23 @@ async def _recover_stale_jobs_for_current_scope() -> None:
         # GAP-002: sweep VRT assets stuck in status='regenerating' past the timeout.
         # Uses the same stale_cutoff as the running-jobs sweep so the window is
         # consistent — mirrors the fail_stale_jobs periodic sweep.
-        from app.platform.jobs.router import sweep_stale_vrt_assets
-
-        vrt_assets_recovered, vrt_gens_failed = await sweep_stale_vrt_assets(
-            session, stale_cutoff
+        from app.platform.jobs.router import (
+            _reap_stale_generation_storage,
+            sweep_stale_vrt_assets,
         )
 
+        (
+            vrt_assets_recovered,
+            vrt_gens_failed,
+            stale_generation_storage_keys,
+        ) = await sweep_stale_vrt_assets(session, stale_cutoff)
+
         await session.commit()
+        # fix(#1322 review): reap only after the commit above lands — deleting
+        # a dead attempt's storage objects before the reconciliation that
+        # restored ownership is durable can orphan a 'ready' asset against
+        # bytes a rolled-back commit never actually freed for deletion.
+        await _reap_stale_generation_storage(stale_generation_storage_keys)
         total = len(stale_jobs) + len(orphaned_jobs)
         if total or vrt_assets_recovered:
             log.info(

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -1004,10 +1004,20 @@ async def regenerate_vrt(
                     select(Dataset).where(Dataset.id == vrt_id)
                 )
                 vrt_dataset = dataset_result.scalar_one_or_none()
-                if vrt_dataset is not None and meta.get("bbox_wkt"):
-                    vrt_dataset.record.spatial_extent = func.ST_GeomFromText(
-                        meta["bbox_wkt"], 4326
-                    )
+                if vrt_dataset is not None:
+                    # feat(#1267) / ADR-002 Decision 5a: project the
+                    # generation's completion instant into last_refreshed_at,
+                    # in the SAME transaction as the generation swap, so
+                    # source_freshness (#1224) reads a live signal for a NULL
+                    # origin (VRT) instead of the creation-time floor forever.
+                    # Same instant as generation.completed_at, not a fresh
+                    # now() — one swap, one timestamp, no clock skew between
+                    # the two records of it.
+                    vrt_dataset.last_refreshed_at = generation.completed_at
+                    if meta.get("bbox_wkt"):
+                        vrt_dataset.record.spatial_extent = func.ST_GeomFromText(
+                            meta["bbox_wkt"], 4326
+                        )
 
                 # Keep download/STAC references aligned with the newly published
                 # immutable generation keys in the same transaction.

--- a/backend/tests/test_ingest_job_attempt_fencing.py
+++ b/backend/tests/test_ingest_job_attempt_fencing.py
@@ -116,7 +116,9 @@ async def test_vrt_generation_heartbeat_fences_stale_recovery(test_db_session):
     await test_db_session.refresh(generation)
     await test_db_session.refresh(asset)
     assert generation.status == "failed"
-    assert asset.status == "failed"
+    # feat(#1267): restored to 'ready' — the dead attempt never touched the
+    # asset's published pointer, so it keeps serving what it served before.
+    assert asset.status == "ready"
     assert asset.current_generation_id is None
 
 

--- a/backend/tests/test_ingest_job_attempt_fencing.py
+++ b/backend/tests/test_ingest_job_attempt_fencing.py
@@ -101,6 +101,13 @@ async def test_vrt_generation_heartbeat_fences_stale_recovery(test_db_session):
         asset_uri="rasters/test/source.vrt",
         status="regenerating",
         current_generation_id=generation.id,
+        # fix(#1322 review round 3): this test is about HEARTBEAT-based
+        # staleness, not composition drift — an empty built_from matches
+        # this fixture's zero vrt_source_links rows (both empty sets), so
+        # the composition guard finds nothing changed and the restore-to-
+        # ready path this test asserts on is the one that actually fires.
+        # See test_vrt_stale_sweep_gap002.py for the composition-drift cases.
+        built_from={},
     )
     test_db_session.add(asset)
     await test_db_session.commit()

--- a/backend/tests/test_ingest_job_attempt_fencing.py
+++ b/backend/tests/test_ingest_job_attempt_fencing.py
@@ -106,12 +106,26 @@ async def test_vrt_generation_heartbeat_fences_stale_recovery(test_db_session):
     await test_db_session.commit()
 
     cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
-    assert await sweep_stale_vrt_assets(test_db_session, cutoff) == (0, 0)
+    assert await sweep_stale_vrt_assets(test_db_session, cutoff) == (0, 0, ())
     await test_db_session.commit()
 
     generation.heartbeat_at = datetime.now(timezone.utc) - timedelta(hours=2)
     await test_db_session.commit()
-    assert await sweep_stale_vrt_assets(test_db_session, cutoff) == (1, 1)
+    # feat(#1322 review): the 3rd element is the dead attempt's resolved (not
+    # yet deleted) storage keys — deletion is the caller's job, strictly
+    # after ITS commit lands, so sweep_stale_vrt_assets itself never touches
+    # storage.
+    generation_base = f"rasters/{dataset.id}/generations/{generation.id}"
+    expected_keys = (
+        f"{generation_base}/source.vrt",
+        f"{generation_base}/quicklook_256.png",
+        f"{generation_base}/quicklook_512.png",
+    )
+    assert await sweep_stale_vrt_assets(test_db_session, cutoff) == (
+        1,
+        1,
+        expected_keys,
+    )
     await test_db_session.commit()
     await test_db_session.refresh(generation)
     await test_db_session.refresh(asset)

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2390,7 +2390,24 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # Phase-1 claim before anything can fail) and from a claim-starved
     # 'pending' row swept as its own dead attempt (same "never ran" fact,
     # consistently excluded either way). Cap 1942 -> 1971, exact.
-    "backend/app/platform/jobs/router.py": 1971,
+    # fix(#1322 review round 6): +45 — the timeout predicate for a 'pending'
+    # VrtGeneration lacked the same live-Procrastinate-job exclusion
+    # stale_pending_clauses already applies to IngestJob's pending sweep, for
+    # the identical reason: queue waits are unbounded, so started_at age
+    # alone cannot tell a genuine orphan from a regeneration still sitting
+    # in a sustained worker backlog. Split the staleness check by status —
+    # 'running' keeps the heartbeat-only proof (sufficient on its own, and
+    # required: a crashed worker can leave its procrastinate_jobs row
+    # reading 'doing' until the separate stalled-queue sweep prunes it, so a
+    # live-job requirement there would make a genuinely-dead running
+    # generation unsweepable until that other sweep runs); 'pending' now
+    # additionally requires _NO_LIVE_GENERATION_JOB_SQL, correlated via the
+    # `generation_id` kwarg every dispatch site passes (mirrors
+    # _ABANDONED_RUN_SQL's `args->>'job_id'` correlation in
+    # platform/refresh/service.py). Most of the lines are the docstring
+    # distinguishing the two branches' proof requirements. Cap 1971 -> 2016,
+    # exact.
+    "backend/app/platform/jobs/router.py": 2016,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2330,7 +2330,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # target and why the pairing cannot come from the asset UPDATE's own
     # RETURNING (its current_generation_id is nulled in the same statement).
     # Cap 1615 -> 1692, exact.
-    "backend/app/platform/jobs/router.py": 1692,
+    # fix(#1322 review): +78 — storage deletion for a dead VRT regeneration's
+    # generation-scoped objects had run inside sweep_stale_vrt_assets itself,
+    # before its caller's commit. A rolled-back reconciliation could then
+    # leave a `'ready'` asset pointing at a generation whose bytes were
+    # already gone. Deletion is now split from resolution:
+    # _stale_generation_storage_keys (pure, no I/O) computes the keys inside
+    # the sweep; _reap_stale_generation_storage (I/O, no DB) deletes them,
+    # called only by each caller strictly after ITS OWN commit lands —
+    # threaded through StaleCleanupOutcome exactly like _staged_paths for the
+    # fail_stale_jobs path, and directly in worker.py's startup recovery
+    # path. Most of the lines are the docstrings recording why the ordering
+    # is load-bearing on both call sites. Cap 1692 -> 1770, exact.
+    "backend/app/platform/jobs/router.py": 1770,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2376,7 +2376,21 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # 'failed' one cycle longer than strictly necessary — the safe direction
     # for a reconciler that must never manufacture a resolution that didn't
     # happen. Cap 1874 -> 1942, exact.
-    "backend/app/platform/jobs/router.py": 1942,
+    # fix(#1322 review round 5): +29 — the prior-ready marker read raw
+    # generation STATUS, but regenerate_vrt_endpoint's orphan-guard rollback
+    # marks a generation 'failed' on a synchronous ENQUEUE failure (the task
+    # never reached a worker) while reverting the asset to whatever it
+    # already was — so that row's 'failed' status says nothing about the
+    # asset. Added `heartbeat_at IS NOT NULL` to the marker's subquery:
+    # heartbeat_at is set in exactly one place (tasks_vrt.regenerate_vrt's
+    # Phase-1 claim), so its absence proves a generation never actually ran,
+    # and excluding those rows finds the nearest OTHER generation that did.
+    # Most of the lines are the docstring distinguishing this from a
+    # genuine build failure (which always sets heartbeat_at during its own
+    # Phase-1 claim before anything can fail) and from a claim-starved
+    # 'pending' row swept as its own dead attempt (same "never ran" fact,
+    # consistently excluded either way). Cap 1942 -> 1971, exact.
+    "backend/app/platform/jobs/router.py": 1971,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2342,7 +2342,24 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fail_stale_jobs path, and directly in worker.py's startup recovery
     # path. Most of the lines are the docstrings recording why the ordering
     # is load-bearing on both call sites. Cap 1692 -> 1770, exact.
-    "backend/app/platform/jobs/router.py": 1770,
+    # fix(#1322 review round 3): +104 — restoring 'ready' was only honest for
+    # a composition-PRESERVING dead attempt. add_vrt_source/remove_vrt_source
+    # commit their vrt_source_links mutation before the (now-dead)
+    # regeneration ever runs, so a dead attempt of that kind leaves the
+    # catalog's stated composition already ahead of the served bytes;
+    # restoring 'ready' there erased the only visible signal of that drift.
+    # The RasterAsset UPDATE split into two — composition-preserving (->
+    # 'ready') and composition-changed (-> 'failed', the same conservative
+    # outcome a NULL/non-object built_from also falls to) — discriminated by
+    # a shared SQL fragment (_COMPOSITION_PRESERVED_SQL) comparing
+    # built_from's key set against the live vrt_source_links set, reused
+    # verbatim and negated for the mirror statement. Most of the lines are
+    # the docstrings recording why this reads stored state rather than
+    # attempt provenance (no such field exists) and the jsonb_typeof(...) =
+    # 'object' guard a real-DB test proved necessary over a bare IS NOT NULL
+    # (SQLAlchemy's plain JSONB serializes Python None to the JSON scalar
+    # null, not SQL NULL). Cap 1770 -> 1874, exact.
+    "backend/app/platform/jobs/router.py": 1874,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2318,7 +2318,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reupload check: a service refresh job carries both markers, and moving
     # this one first would silently reword an existing message.
     # Cap 1605 -> 1615, exact.
-    "backend/app/platform/jobs/router.py": 1615,
+    # feat(#1267): +77 — sweep_stale_vrt_assets now restores 'ready' instead
+    # of 'failed' (the dead attempt never touched the published pointer, so
+    # the VRT keeps serving what it served before), the VrtGeneration
+    # RETURNING widened to (id, vrt_dataset_id) so the pairing survives to a
+    # new _reap_stale_generation_storage helper, and that helper best-effort
+    # reaps the dead attempt's own generation-scoped storage objects via the
+    # existing _cleanup_orphaned_storage_keys, keyed through current_tenant_var
+    # the same way regenerate_vrt itself resolves those keys. Most of the
+    # lines are the docstring recording why 'ready' is the correct restore
+    # target and why the pairing cannot come from the asset UPDATE's own
+    # RETURNING (its current_generation_id is nulled in the same statement).
+    # Cap 1615 -> 1692, exact.
+    "backend/app/platform/jobs/router.py": 1692,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side
@@ -2407,7 +2419,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # cannot stamp commit time from inside a transaction, so no clock scheme
     # could express "committed after my snapshot" — three rounds of timestamp
     # fixes each left a window. Cap 1118 -> 1140, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1140,
+    # feat(#1267): +10 — the dataset's last_refreshed_at is stamped at the
+    # generation's own completed_at instant, in the same transaction as the
+    # generation swap, so source_freshness (#1224) reads a live signal for a
+    # VRT instead of the creation-time floor forever. Most of the lines are
+    # the comment recording why it reuses generation.completed_at rather than
+    # a fresh now() call. Cap 1140 -> 1150, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1150,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2359,7 +2359,24 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # 'object' guard a real-DB test proved necessary over a bare IS NOT NULL
     # (SQLAlchemy's plain JSONB serializes Python None to the JSON scalar
     # null, not SQL NULL). Cap 1770 -> 1874, exact.
-    "backend/app/platform/jobs/router.py": 1874,
+    # fix(#1322 review round 4): +68 — composition-preserving was necessary
+    # but not sufficient: regenerate_vrt_endpoint's guard rejects only
+    # 'regenerating', so a caller may retry an already-'failed' asset, and a
+    # dead retry whose membership still matched would have restored 'ready'
+    # and erased a real failure the crash had nothing to do with. Added a
+    # second, independent SQL fragment (_PRIOR_ATTEMPT_WAS_READY_SQL) reading
+    # the immediately-prior vrt_generations row's terminal status — 'failed'
+    # blocks the restore, 'completed' or no such row (first-ever attempt)
+    # allows it — combined into _READY_WORTHY_SQL with the composition check.
+    # Most of the lines are the docstring recording why no stored "attempt
+    # type" column exists to key off directly, and the accepted conservative
+    # cost this heuristic carries: a generation this sweep itself restores to
+    # 'ready' still leaves its OWN vrt_generations row 'failed', so a LATER
+    # dead attempt on the same dataset can read that earlier row and stay
+    # 'failed' one cycle longer than strictly necessary — the safe direction
+    # for a reconciler that must never manufacture a resolution that didn't
+    # happen. Cap 1874 -> 1942, exact.
+    "backend/app/platform/jobs/router.py": 1942,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2407,7 +2407,20 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # platform/refresh/service.py). Most of the lines are the docstring
     # distinguishing the two branches' proof requirements. Cap 1971 -> 2016,
     # exact.
-    "backend/app/platform/jobs/router.py": 2016,
+    # fix(#1322 review round 6, completed): +31 — the live-Procrastinate-job
+    # correlation for a 'pending' generation matched only the modern
+    # `generation_id` args shape. A pre-upgrade delivery queued without that
+    # argument (regenerate_vrt explicitly still accepts it, adopting
+    # RasterAsset.current_generation_id — rolling-deploy compatibility) was
+    # invisible to it, so a live legacy task's generation could still be
+    # reconciled out from under it. Added a second correlation form: a live
+    # row with no `generation_id` counts as live for a generation if that
+    # generation is CURRENTLY the dataset's RasterAsset.current_generation_id
+    # — the exact row such a delivery adopts on execution. Most of the lines
+    # are the docstring explaining the two delivery shapes and why the
+    # ambiguous case must resolve toward "still live," not toward sweeping.
+    # Cap 2016 -> 2047, exact.
+    "backend/app/platform/jobs/router.py": 2047,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_regenerate_vrt_integration.py
+++ b/backend/tests/test_regenerate_vrt_integration.py
@@ -5,7 +5,7 @@ This test is DELIBERATELY slow and real:
 - Creates real PostGIS rows (Record, Dataset, RasterAsset, VrtGeneration, IngestJob, vrt_source_links)
 - Invokes gdalbuildvrt as a subprocess
 - Writes the result via a real LocalStorageProvider
-- Reads back and asserts on 15 state mutations
+- Reads back and asserts on 16 state mutations
 
 Phase 219 extracts 3 helpers from regenerate_vrt. Any drift in behavior will
 fail this test — that is the whole point of shipping this phase first.
@@ -284,7 +284,7 @@ async def test_regenerate_vrt_happy_path_end_to_end(
     quicklook_stub,  # fixture stubs generate_quicklook
     clean_tables,  # opt-in truncate after test (Research Open Question #1)
 ):
-    """Full integration test: invoke regenerate_vrt and assert on 15 state mutations.
+    """Full integration test: invoke regenerate_vrt and assert on 16 state mutations.
 
     This is the behavioral anchor for Phase 219's refactor. Any drift in the
     observable outcome of regenerate_vrt will fail this test — that's the
@@ -293,7 +293,7 @@ async def test_regenerate_vrt_happy_path_end_to_end(
     The 15 assertions cover every DB + storage mutation that regenerate_vrt
     performs in the happy path. See CONTEXT.md D-03 for the enumerated list.
     """
-    from app.modules.catalog.datasets.domain.models import Record
+    from app.modules.catalog.datasets.domain.models import Dataset, Record
     from app.processing.ingest.tasks import regenerate_vrt
     from app.platform.jobs.models import IngestJob
     from app.processing.raster.models import RasterAsset, VrtGeneration
@@ -335,7 +335,12 @@ async def test_regenerate_vrt_happy_path_end_to_end(
     )
     vrt_record = record_result.scalar_one()
 
-    # --- ASSERTIONS (the 15 anchor mutations) ------------------------------
+    vrt_dataset_result = await session.execute(
+        select(Dataset).where(Dataset.id == uuid.UUID(vrt_db_state["vrt_dataset_id"]))
+    )
+    vrt_dataset = vrt_dataset_result.scalar_one()
+
+    # --- ASSERTIONS (the 16 anchor mutations) ------------------------------
 
     storage = local_storage  # the LocalStorageProvider from the fixture
     old_vrt_key = vrt_db_state["expected_vrt_key"]
@@ -419,6 +424,12 @@ async def test_regenerate_vrt_happy_path_end_to_end(
     # spatial_extent is a Geometry column; its post-load value is a WKB string or
     # a geoalchemy2 Geometry element. Just assert non-None.
     assert vrt_record.spatial_extent is not None
+
+    # [16] feat(#1267): the owning dataset's last_refreshed_at is stamped in
+    # the same transaction as the generation swap, at the generation's own
+    # completed_at instant — not a separate now() call.
+    assert vrt_dataset.last_refreshed_at is not None
+    assert vrt_dataset.last_refreshed_at == generation.completed_at
 
     # --- BONUS: Rasterio re-open + bounds sanity check ---------------------
     # (per CONTEXT.md Claude's Discretion + RESEARCH.md recommendation)

--- a/backend/tests/test_tenant_staging_storage_keys.py
+++ b/backend/tests/test_tenant_staging_storage_keys.py
@@ -406,9 +406,16 @@ async def test_cleanup_and_retention_reaper_delete_only_tenant_key(
     # feat(#1219): six, with the abandoned-refresh-run sweep after them.
     # fix(#1274 review): seven — the refresh-run sweep is two statements,
     # the legacy-completion recorder before the abandonment cancel.
-    empty_scalars = [MagicMock() for _ in range(7)]
+    # fix(#1322 review round 3): eight — the VRT RasterAsset UPDATE split
+    # into two (composition-preserving -> 'ready', composition-changed ->
+    # 'failed'). Both .scalars() and .all() are set on every result: the
+    # VrtGeneration UPDATE in that same sweep reads via .all(), and this
+    # fixture doesn't care which statement lands at which index, only that
+    # every accessor the sweep might call returns an empty result.
+    empty_scalars = [MagicMock() for _ in range(8)]
     for result in empty_scalars:
         result.scalars.return_value = []
+        result.all.return_value = []
     deleted = MagicMock()
     # fix(#1202 review r5): the purge's RETURNING is (id, file_path,
     # user_metadata) now — it also reaps the presigned staging key, which

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -66,6 +66,7 @@ def _make_mock_session_for_recover(
     stale_jobs_running: list | None = None,
     stale_jobs_pending: list | None = None,
     stale_vrt_assets: list | None = None,
+    stale_vrt_assets_degraded: list | None = None,
     stale_vrt_generations: list | None = None,
 ) -> MagicMock:
     """Build a mock async session for recover_stale_jobs.
@@ -75,7 +76,18 @@ def _make_mock_session_for_recover(
       2. stale running IngestJobs → scalars() returns list
       3. orphaned pending IngestJobs → scalars() returns list
       4. stale VrtGeneration UPDATE → all() returns (id, vrt_dataset_id) pairs
-      5. stale regenerating RasterAsset UPDATE → scalars() returns dataset ids
+      5. composition-preserving RasterAsset UPDATE (-> 'ready') → scalars()
+         returns dataset ids for ``stale_vrt_assets``
+      6. composition-changed RasterAsset UPDATE (-> 'failed', fix(#1322
+         review round 3)) → scalars() returns dataset ids for
+         ``stale_vrt_assets_degraded``
+
+    ``stale_vrt_assets`` and ``stale_vrt_assets_degraded`` are mock-level
+    routing, not a re-implementation of the SQL discrimination — a test
+    picks which of the two UPDATE results an asset's id lands in to state
+    which branch it means to exercise. The real discrimination (built_from
+    vs vrt_source_links) is proven against a live Postgres database in
+    test_ingest_job_attempt_fencing.py and the composition-drift tests below.
     """
     lock_result = MagicMock()
     lock_result.scalar.return_value = lock_acquired
@@ -97,11 +109,12 @@ def _make_mock_session_for_recover(
     ]
     results.append(gen_result)
 
-    asset_result = MagicMock()
-    asset_result.scalars.return_value = [
-        asset.dataset_id for asset in (stale_vrt_assets or [])
-    ]
-    results.append(asset_result)
+    for asset_list in (stale_vrt_assets, stale_vrt_assets_degraded):
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = [
+            asset.dataset_id for asset in (asset_list or [])
+        ]
+        results.append(mock_result)
 
     mock_session = AsyncMock()
     mock_session.__aenter__ = AsyncMock(return_value=mock_session)
@@ -116,6 +129,7 @@ def _make_mock_db_for_fail_stale(
     stale_jobs_pending: list | None = None,
     stale_jobs_running: list | None = None,
     stale_vrt_assets: list | None = None,
+    stale_vrt_assets_degraded: list | None = None,
     stale_vrt_generations: list | None = None,
     purge_candidates: list | None = None,
     surviving_paths: list[str] | None = None,
@@ -127,8 +141,13 @@ def _make_mock_db_for_fail_stale(
       2. stale BOUND pending IngestJobs (24h, fix(#1234)) → empty here
       3. stale running IngestJobs → scalars() returns list
       3. stale VrtGeneration UPDATE → all() returns (id, vrt_dataset_id) pairs
-      4. stale regenerating RasterAsset UPDATE → scalars() returns dataset ids
-      4b. abandoned dataset_refresh_runs UPDATE (feat(#1219)) → scalars()
+      4. composition-preserving RasterAsset UPDATE (-> 'ready') → scalars()
+         returns dataset ids for ``stale_vrt_assets``
+      4b. composition-changed RasterAsset UPDATE (-> 'failed', fix(#1322
+         review round 3)) → scalars() returns dataset ids for
+         ``stale_vrt_assets_degraded``. See the recover-side helper's
+         docstring for why this is mock-level routing, not the real SQL.
+      4c. abandoned dataset_refresh_runs UPDATE (feat(#1219)) → scalars()
          returns cancelled run ids. Empty in these fixtures; the sweep has
          its own suite in test_dataset_refresh_runs.py.
       5. purge DELETE .. RETURNING (id, file_path, user_metadata) → .all()
@@ -163,6 +182,7 @@ def _make_mock_db_for_fail_stale(
 
     for returned_ids in [
         [asset.dataset_id for asset in (stale_vrt_assets or [])],
+        [asset.dataset_id for asset in (stale_vrt_assets_degraded or [])],
         # feat(#1219): the refresh-run sweep, between the VRT sweep and the
         # retention purge — TWO statements since fix(#1274 review): the
         # legacy-completion success recorder, then the abandonment cancel.
@@ -458,12 +478,13 @@ async def test_fail_stale_jobs_purges_terminal_jobs_past_retention():
     await fail_stale_jobs(mock_db)
 
     # 5 sweeps (the pending clause is two statements since fix(#1234)) + the
-    # refresh-run sweep's TWO statements (feat(#1219), fix(#1274 review):
-    # legacy-completion recorder then abandonment cancel) + the purge DELETE
-    # + the post-expiry staging SELECT.
-    assert mock_db.execute.await_count == 9
-    # Indexes 5-6 are the refresh-run sweep now; the purge shifted to 7.
-    purge_stmt = mock_db.execute.await_args_list[7].args[0]
+    # VRT asset UPDATE split into two (ready / degraded, fix(#1322 review
+    # round 3)) + the refresh-run sweep's TWO statements (feat(#1219),
+    # fix(#1274 review): legacy-completion recorder then abandonment cancel)
+    # + the purge DELETE + the post-expiry staging SELECT.
+    assert mock_db.execute.await_count == 10
+    # Indexes 6-7 are the refresh-run sweep now; the purge shifted to 8.
+    purge_stmt = mock_db.execute.await_args_list[8].args[0]
     assert isinstance(purge_stmt, Delete)
     where_sql = str(purge_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "'pending'" in where_sql and "'running'" in where_sql, (
@@ -624,11 +645,12 @@ async def test_fail_stale_jobs_retention_zero_disables_purge(monkeypatch):
     mock_db = _make_mock_db_for_fail_stale()
     await fail_stale_jobs(mock_db)
 
-    # 5 sweeps (two pending clauses since fix(#1234)) plus the refresh-run
-    # sweep's two statements (feat(#1219), fix(#1274 review)) and no purge
-    # DELETE, plus the post-expiry staging SELECT, which is independent of
-    # retention.
-    assert mock_db.execute.await_count == 8
+    # 5 sweeps (two pending clauses since fix(#1234)) plus the VRT asset
+    # UPDATE split into two (ready / degraded, fix(#1322 review round 3))
+    # plus the refresh-run sweep's two statements (feat(#1219), fix(#1274
+    # review)) and no purge DELETE, plus the post-expiry staging SELECT,
+    # which is independent of retention.
+    assert mock_db.execute.await_count == 9
 
 
 # ---------------------------------------------------------------------------
@@ -680,14 +702,20 @@ async def test_sweep_stale_vrt_assets_returns_count():
     stale_asset = _make_raster_asset(status="regenerating")
     stale_gen = _make_vrt_generation(status="running")
 
-    # Two atomic UPDATEs: generation first, then the asset still pointing to it.
+    # Three atomic UPDATEs: generation, then the asset split into a
+    # composition-preserving branch (-> 'ready') and a composition-changed
+    # branch (-> 'failed', fix(#1322 review round 3)).
     gen_result = MagicMock()
     gen_result.all.return_value = [(stale_gen.id, stale_gen.vrt_dataset_id)]
-    asset_result = MagicMock()
-    asset_result.scalars.return_value = [stale_asset.dataset_id]
+    ready_result = MagicMock()
+    ready_result.scalars.return_value = [stale_asset.dataset_id]
+    degraded_result = MagicMock()
+    degraded_result.scalars.return_value = []
 
     mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(side_effect=[gen_result, asset_result])
+    mock_session.execute = AsyncMock(
+        side_effect=[gen_result, ready_result, degraded_result]
+    )
 
     now = datetime.now(timezone.utc)
     cutoff = now - timedelta(hours=1)
@@ -695,8 +723,8 @@ async def test_sweep_stale_vrt_assets_returns_count():
     # No tenant context is bound in this unit test, so key RESOLUTION itself
     # (not just deletion — sweep_stale_vrt_assets never deletes anything,
     # fix(#1322 review)) short-circuits to an empty tuple rather than raising.
-    # Either way this stays a 2-call contract: resolving/skipping keys is
-    # pure Python, never a 3rd db.execute().
+    # Either way this stays a 3-call contract: resolving/skipping keys is
+    # pure Python, never a 4th db.execute().
     with patch("app.core.tenancy.is_multi_tenant", return_value=True):
         result = await sweep_stale_vrt_assets(mock_session, cutoff)
 
@@ -710,10 +738,12 @@ async def test_sweep_stale_vrt_assets_returns_count():
     statements = [str(call.args[0]) for call in mock_session.execute.await_args_list]
     assert "UPDATE catalog.vrt_generations" in statements[0]
     assert "UPDATE catalog.raster_assets" in statements[1]
+    assert "UPDATE catalog.raster_assets" in statements[2]
     assert (
         "vrt_generations.vrt_dataset_id IN (SELECT catalog.datasets.id" in statements[0]
     )
     assert "raster_assets.dataset_id IN (SELECT catalog.datasets.id" in statements[1]
+    assert "raster_assets.dataset_id IN (SELECT catalog.datasets.id" in statements[2]
 
 
 @pytest.mark.asyncio
@@ -722,10 +752,12 @@ async def test_sweep_stale_vrt_assets_preserves_single_tenant_sql_shape():
 
     gen_result = MagicMock()
     gen_result.all.return_value = []
-    asset_result = MagicMock()
-    asset_result.scalars.return_value = []
+    ready_result = MagicMock()
+    ready_result.scalars.return_value = []
+    degraded_result = MagicMock()
+    degraded_result.scalars.return_value = []
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[gen_result, asset_result])
+    session.execute = AsyncMock(side_effect=[gen_result, ready_result, degraded_result])
 
     await sweep_stale_vrt_assets(
         session,
@@ -735,6 +767,7 @@ async def test_sweep_stale_vrt_assets_preserves_single_tenant_sql_shape():
     statements = [str(call.args[0]) for call in session.execute.await_args_list]
     assert "SELECT catalog.datasets.id" not in statements[0]
     assert "SELECT catalog.datasets.id" not in statements[1]
+    assert "SELECT catalog.datasets.id" not in statements[2]
 
 
 # ---------------------------------------------------------------------------
@@ -745,27 +778,38 @@ async def test_sweep_stale_vrt_assets_preserves_single_tenant_sql_shape():
 
 @pytest.mark.asyncio
 async def test_sweep_stale_vrt_assets_restores_ready_not_failed():
-    """feat(#1267): the compiled UPDATE sets status='ready', mirroring the
-    values a live worker never got to write — the dead attempt's own
-    VrtGeneration row is what records the failure, not the asset."""
+    """feat(#1267) / fix(#1322 review round 3): the FIRST asset UPDATE
+    (composition-preserving) sets status='ready'; the SECOND (composition-
+    changed) sets status='failed' — a dead attempt's own VrtGeneration row
+    is what unconditionally records the failure, not the asset, UNLESS the
+    catalog's declared composition moved out from under it."""
     from app.platform.jobs.router import sweep_stale_vrt_assets
 
     gen_result = MagicMock()
     gen_result.all.return_value = []
-    asset_result = MagicMock()
-    asset_result.scalars.return_value = []
+    ready_result = MagicMock()
+    ready_result.scalars.return_value = []
+    degraded_result = MagicMock()
+    degraded_result.scalars.return_value = []
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[gen_result, asset_result])
+    session.execute = AsyncMock(side_effect=[gen_result, ready_result, degraded_result])
 
     await sweep_stale_vrt_assets(
         session, datetime.now(timezone.utc) - timedelta(hours=1)
     )
 
-    asset_update_stmt = session.execute.await_args_list[1].args[0]
-    compiled = asset_update_stmt.compile(compile_kwargs={"literal_binds": True})
-    where_sql = str(compiled)
-    assert "status='ready'" in where_sql or "status = 'ready'" in where_sql
-    assert "'failed'" not in where_sql
+    ready_stmt = session.execute.await_args_list[1].args[0]
+    ready_sql = str(ready_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "status='ready'" in ready_sql or "status = 'ready'" in ready_sql
+    assert "'failed'" not in ready_sql
+
+    degraded_stmt = session.execute.await_args_list[2].args[0]
+    degraded_sql = str(degraded_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "status='failed'" in degraded_sql or "status = 'failed'" in degraded_sql
+    assert "'ready'" not in degraded_sql
+    # The two branches are mutually exclusive: the 2nd statement's predicate
+    # is the exact negation of the 1st's composition check.
+    assert "NOT (" in degraded_sql
 
 
 @pytest.mark.asyncio
@@ -784,10 +828,12 @@ async def test_sweep_stale_vrt_assets_resolves_but_never_deletes_storage():
 
     gen_result = MagicMock()
     gen_result.all.return_value = [(stale_gen_id, stale_dataset_id)]
-    asset_result = MagicMock()
-    asset_result.scalars.return_value = [stale_dataset_id]
+    ready_result = MagicMock()
+    ready_result.scalars.return_value = [stale_dataset_id]
+    degraded_result = MagicMock()
+    degraded_result.scalars.return_value = []
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[gen_result, asset_result])
+    session.execute = AsyncMock(side_effect=[gen_result, ready_result, degraded_result])
 
     result = await sweep_stale_vrt_assets(
         session, datetime.now(timezone.utc) - timedelta(hours=1)
@@ -814,10 +860,12 @@ async def test_sweep_stale_vrt_assets_storage_failure_never_masks_reconciliation
 
     gen_result = MagicMock()
     gen_result.all.return_value = [(uuid4(), uuid4())]
-    asset_result = MagicMock()
-    asset_result.scalars.return_value = [uuid4()]
+    ready_result = MagicMock()
+    ready_result.scalars.return_value = [uuid4()]
+    degraded_result = MagicMock()
+    degraded_result.scalars.return_value = []
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[gen_result, asset_result])
+    session.execute = AsyncMock(side_effect=[gen_result, ready_result, degraded_result])
 
     # No storage patch — get_storage() would raise RuntimeError
     # (uninitialized) if the sweep ever called it, which it must not.
@@ -828,6 +876,191 @@ async def test_sweep_stale_vrt_assets_storage_failure_never_masks_reconciliation
     assert result[0] == 1
     assert result[1] == 1
     assert len(result[2]) == 3
+
+
+# ---------------------------------------------------------------------------
+# fix(#1322 review round 3): the discrimination is a STATE comparison
+# (built_from vs the live vrt_source_links set), not a timing heuristic —
+# these run against a real Postgres database so the actual
+# _COMPOSITION_PRESERVED_SQL executes, not a mock standing in for it.
+# ---------------------------------------------------------------------------
+
+
+async def _make_vrt_with_generation(
+    test_db_session,
+    *,
+    admin_id,
+    built_from_dataset_ids,
+    linked_dataset_ids,
+    started_hours_ago: float = 2,
+):
+    """A VRT dataset with a dead 'regenerating' generation, whose published
+    built_from and live vrt_source_links can be set independently — the
+    exact fork the composition-preserving check has to tell apart."""
+    from app.processing.raster.models import RasterAsset, VrtGeneration, VrtSourceLink
+    from tests.factories import create_dataset
+
+    vrt_dataset = await create_dataset(test_db_session, created_by=admin_id)
+    generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="running",
+        started_at=datetime.now(timezone.utc) - timedelta(hours=started_hours_ago),
+        heartbeat_at=datetime.now(timezone.utc) - timedelta(hours=started_hours_ago),
+    )
+    test_db_session.add(generation)
+    await test_db_session.flush()
+
+    asset = RasterAsset(
+        dataset_id=vrt_dataset.id,
+        asset_uri=f"rasters/{vrt_dataset.id}/source.vrt",
+        status="regenerating",
+        current_generation_id=generation.id,
+        built_from={str(ds_id): "irrelevant" for ds_id in built_from_dataset_ids},
+    )
+    test_db_session.add(asset)
+
+    for position, source_id in enumerate(linked_dataset_ids):
+        test_db_session.add(
+            VrtSourceLink(
+                vrt_dataset_id=vrt_dataset.id,
+                source_dataset_id=source_id,
+                position=position,
+            )
+        )
+
+    await test_db_session.commit()
+    return vrt_dataset, generation, asset
+
+
+async def test_sweep_restores_ready_when_composition_unchanged(test_db_session):
+    """A pure dead regenerate (regenerate_vrt_endpoint never touches
+    vrt_source_links) restores 'ready' — the existing, correct behavior."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    source = await create_dataset(test_db_session, created_by=admin_id)
+    _vrt_dataset, generation, asset = await _make_vrt_with_generation(
+        test_db_session,
+        admin_id=admin_id,
+        built_from_dataset_ids=[source.id],
+        linked_dataset_ids=[source.id],
+    )
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (1, 1)
+    await test_db_session.refresh(asset)
+    await test_db_session.refresh(generation)
+    assert asset.status == "ready"
+    assert asset.current_generation_id is None
+    assert generation.status == "failed"
+
+
+async def test_sweep_keeps_failed_when_source_was_removed(test_db_session):
+    """fix(#1322 review round 3): remove_vrt_source deletes the link and
+    commits BEFORE the (now-dead) regeneration ever runs. built_from still
+    names the removed source — the published VRT still contains it — so
+    restoring 'ready' would hide that the catalog's stated composition (1
+    source) no longer matches what is actually being served (2 sources)."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    kept = await create_dataset(test_db_session, created_by=admin_id)
+    removed = await create_dataset(test_db_session, created_by=admin_id)
+    _vrt_dataset, generation, asset = await _make_vrt_with_generation(
+        test_db_session,
+        admin_id=admin_id,
+        built_from_dataset_ids=[kept.id, removed.id],  # published VRT has both
+        linked_dataset_ids=[kept.id],  # catalog link to `removed` already gone
+    )
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (1, 1)
+    await test_db_session.refresh(asset)
+    await test_db_session.refresh(generation)
+    assert asset.status == "failed", (
+        "restoring 'ready' here would hide that the served VRT still "
+        "contains a source the catalog no longer lists"
+    )
+    assert asset.current_generation_id is None  # a retry is still triggerable
+    assert generation.status == "failed"
+
+
+async def test_sweep_keeps_failed_when_source_was_added(test_db_session):
+    """The mirror case: add_vrt_source's link INSERT already committed, so
+    the catalog claims 2 sources while the published VRT (built_from) was
+    only ever assembled from 1. Same drift, opposite direction — still not
+    safe to call 'ready'."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    original = await create_dataset(test_db_session, created_by=admin_id)
+    added = await create_dataset(test_db_session, created_by=admin_id)
+    _vrt_dataset, generation, asset = await _make_vrt_with_generation(
+        test_db_session,
+        admin_id=admin_id,
+        built_from_dataset_ids=[original.id],  # published VRT has only this
+        linked_dataset_ids=[original.id, added.id],  # catalog already claims 2
+    )
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (1, 1)
+    await test_db_session.refresh(asset)
+    assert asset.status == "failed"
+    assert asset.current_generation_id is None
+
+
+async def test_sweep_keeps_failed_when_built_from_is_null(test_db_session):
+    """A legacy pre-#1290 VRT has no built_from at all — the question
+    cannot be answered from stored state, so the sweep must not guess
+    'ready'. Same conservative branch as a proven mismatch."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    vrt_dataset = await create_dataset(test_db_session, created_by=admin_id)
+    generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="running",
+        started_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        heartbeat_at=datetime.now(timezone.utc) - timedelta(hours=2),
+    )
+    test_db_session.add(generation)
+    await test_db_session.flush()
+    asset = RasterAsset(
+        dataset_id=vrt_dataset.id,
+        asset_uri=f"rasters/{vrt_dataset.id}/source.vrt",
+        status="regenerating",
+        current_generation_id=generation.id,
+        built_from=None,
+    )
+    test_db_session.add(asset)
+    await test_db_session.commit()
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    await sweep_stale_vrt_assets(test_db_session, cutoff)
+    await test_db_session.commit()
+
+    await test_db_session.refresh(asset)
+    assert asset.status == "failed"
 
 
 @pytest.mark.rls
@@ -853,6 +1086,14 @@ async def test_sweep_stale_vrt_assets_cannot_mutate_another_tenant(
                     "GRANT SELECT, UPDATE ON catalog.vrt_generations, "
                     "catalog.raster_assets TO geolens_reader"
                 )
+            )
+            # fix(#1322 review round 3): the composition-preserving check
+            # reads vrt_source_links — a real runtime role already has
+            # blanket SELECT/INSERT/UPDATE/DELETE on every catalog table
+            # (configure-runtime-db-role.sh), so this is this minimal test
+            # role catching up, not a production grant gap.
+            await conn.execute(
+                sa.text("GRANT SELECT ON catalog.vrt_source_links TO geolens_reader")
             )
             for record_id, dataset_id, tenant_id, suffix in (
                 (record_a, dataset_a, ctx.tenant_a, "a"),
@@ -911,9 +1152,9 @@ async def test_sweep_stale_vrt_assets_cannot_mutate_another_tenant(
                     sa.text(
                         "INSERT INTO catalog.raster_assets "
                         "(id, dataset_id, asset_uri, storage_backend, status, "
-                        " current_generation_id, created_at) "
+                        " current_generation_id, built_from, created_at) "
                         "VALUES (:id, :dataset_id, :uri, 'local', 'regenerating', "
-                        " :generation_id, now())"
+                        " :generation_id, '{}'::jsonb, now())"
                     ),
                     {
                         "id": asset_id,
@@ -970,5 +1211,8 @@ async def test_sweep_stale_vrt_assets_cannot_mutate_another_tenant(
                     "REVOKE SELECT, UPDATE ON catalog.vrt_generations, "
                     "catalog.raster_assets FROM geolens_reader"
                 )
+            )
+            await conn.execute(
+                sa.text("REVOKE SELECT ON catalog.vrt_source_links FROM geolens_reader")
             )
         await engine.dispose()

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -1,9 +1,13 @@
-"""GAP-002: VRT regenerating-status stale sweep.
+"""GAP-002 / feat(#1267): VRT regenerating-status stale sweep.
 
 Tests that RasterAsset rows stuck in status='regenerating' past the
-JOB_TIMEOUT_SECONDS threshold are recovered (reset to 'failed') by the
-shared sweep helper, called from BOTH recover_stale_jobs (startup) and
-fail_stale_jobs (periodic).
+JOB_TIMEOUT_SECONDS threshold are reconciled by the shared sweep helper,
+called from BOTH recover_stale_jobs (startup) and fail_stale_jobs (periodic).
+
+feat(#1267): reconciliation restores the asset to 'ready' (not 'failed') —
+the dead attempt never touched the published pointer (asset_uri, sha256,
+...), so the VRT is still serving exactly what it served before the attempt
+started. Only the attempt's own VrtGeneration row is marked 'failed'.
 
 RED → GREEN: fails pre-fix (no sweep exists), passes post-fix.
 """
@@ -43,10 +47,12 @@ def _make_vrt_generation(
     *,
     status: str = "running",
     started_at: datetime | None = None,
+    vrt_dataset_id: uuid.UUID | None = None,
 ) -> MagicMock:
     """Build a mock VrtGeneration-like object."""
     gen = MagicMock()
     gen.id = uuid4()
+    gen.vrt_dataset_id = vrt_dataset_id or uuid4()
     gen.status = status
     gen.started_at = started_at
     gen.completed_at = None
@@ -68,7 +74,7 @@ def _make_mock_session_for_recover(
       1. advisory lock query → scalar() returns lock_acquired
       2. stale running IngestJobs → scalars() returns list
       3. orphaned pending IngestJobs → scalars() returns list
-      4. stale VrtGeneration UPDATE → scalars() returns generation ids
+      4. stale VrtGeneration UPDATE → all() returns (id, vrt_dataset_id) pairs
       5. stale regenerating RasterAsset UPDATE → scalars() returns dataset ids
     """
     lock_result = MagicMock()
@@ -84,13 +90,18 @@ def _make_mock_session_for_recover(
         mock_result.scalars.return_value = job_list
         results.append(mock_result)
 
-    for returned_ids in [
-        [generation.id for generation in (stale_vrt_generations or [])],
-        [asset.dataset_id for asset in (stale_vrt_assets or [])],
-    ]:
-        mock_result = MagicMock()
-        mock_result.scalars.return_value = returned_ids
-        results.append(mock_result)
+    gen_result = MagicMock()
+    gen_result.all.return_value = [
+        (generation.id, generation.vrt_dataset_id)
+        for generation in (stale_vrt_generations or [])
+    ]
+    results.append(gen_result)
+
+    asset_result = MagicMock()
+    asset_result.scalars.return_value = [
+        asset.dataset_id for asset in (stale_vrt_assets or [])
+    ]
+    results.append(asset_result)
 
     mock_session = AsyncMock()
     mock_session.__aenter__ = AsyncMock(return_value=mock_session)
@@ -115,7 +126,7 @@ def _make_mock_db_for_fail_stale(
       1. stale UNBOUND pending IngestJobs (1h) → scalars() returns list
       2. stale BOUND pending IngestJobs (24h, fix(#1234)) → empty here
       3. stale running IngestJobs → scalars() returns list
-      3. stale VrtGeneration UPDATE → scalars() returns generation ids
+      3. stale VrtGeneration UPDATE → all() returns (id, vrt_dataset_id) pairs
       4. stale regenerating RasterAsset UPDATE → scalars() returns dataset ids
       4b. abandoned dataset_refresh_runs UPDATE (feat(#1219)) → scalars()
          returns cancelled run ids. Empty in these fixtures; the sweep has
@@ -136,7 +147,21 @@ def _make_mock_db_for_fail_stale(
         # fixtures exercise the first, so the second returns nothing.
         [],
         stale_jobs_running or [],
-        [generation.id for generation in (stale_vrt_generations or [])],
+    ]:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = returned_ids
+        results.append(mock_result)
+
+    # feat(#1267): RETURNING widened to (id, vrt_dataset_id) — the storage
+    # cleanup helper needs the pairing, so .all() replaces .scalars() here.
+    gen_result = MagicMock()
+    gen_result.all.return_value = [
+        (generation.id, generation.vrt_dataset_id)
+        for generation in (stale_vrt_generations or [])
+    ]
+    results.append(gen_result)
+
+    for returned_ids in [
         [asset.dataset_id for asset in (stale_vrt_assets or [])],
         # feat(#1219): the refresh-run sweep, between the VRT sweep and the
         # retention purge — TWO statements since fix(#1274 review): the
@@ -183,11 +208,11 @@ def _make_mock_db_for_fail_stale(
 
 @pytest.mark.asyncio
 async def test_recover_stale_jobs_resets_stale_regenerating_vrt_asset():
-    """GAP-002 RED→GREEN: a stale regenerating VRT asset is reset to 'failed' at startup.
+    """GAP-002 RED→GREEN: a stale regenerating VRT asset is reconciled at startup.
 
     Pre-fix: recover_stale_jobs only sweeps IngestJob — the stale RasterAsset
     stays in status='regenerating' forever. Post-fix: the shared helper also
-    sweeps RasterAssets.
+    sweeps RasterAssets, restoring 'ready' (feat(#1267)).
     """
     from app.platform.jobs.worker import recover_stale_jobs
 
@@ -294,7 +319,9 @@ async def test_fail_stale_jobs_detailed_outcome_counts_every_cleanup_surface(
     from app.platform.jobs.router import StaleCleanupOutcome, fail_stale_jobs
 
     stale_asset = _make_raster_asset(status="regenerating")
-    stale_gen = _make_vrt_generation(status="running")
+    stale_gen = _make_vrt_generation(
+        status="running", vrt_dataset_id=stale_asset.dataset_id
+    )
     local_file = tmp_path / "retained-upload.geojson"
     local_file.write_text("{}")
     storage_key = "staging/job-id/retained-upload.geojson"
@@ -328,7 +355,20 @@ async def test_fail_stale_jobs_detailed_outcome_counts_every_cleanup_surface(
     assert result.total_cleaned == 2
     assert result.total_affected == 8
     assert not local_file.exists()
-    storage.delete.assert_awaited_once_with(storage_key)
+
+    # feat(#1267): the reconciled generation's own storage objects are
+    # reaped best-effort alongside the retention-purge key — 3 more calls,
+    # one per object regenerate_vrt could have written before the worker
+    # died (source.vrt + 2 quicklooks), deleted even though none exist here.
+    generation_base = f"rasters/{stale_gen.vrt_dataset_id}/generations/{stale_gen.id}"
+    expected_keys = {
+        storage_key,
+        f"{generation_base}/source.vrt",
+        f"{generation_base}/quicklook_256.png",
+        f"{generation_base}/quicklook_512.png",
+    }
+    called_keys = {call.args[0] for call in storage.delete.await_args_list}
+    assert called_keys == expected_keys
 
 
 @pytest.mark.asyncio
@@ -601,7 +641,7 @@ async def test_sweep_stale_vrt_assets_returns_count():
 
     # Two atomic UPDATEs: generation first, then the asset still pointing to it.
     gen_result = MagicMock()
-    gen_result.scalars.return_value = [stale_gen.id]
+    gen_result.all.return_value = [(stale_gen.id, stale_gen.vrt_dataset_id)]
     asset_result = MagicMock()
     asset_result.scalars.return_value = [stale_asset.dataset_id]
 
@@ -611,6 +651,10 @@ async def test_sweep_stale_vrt_assets_returns_count():
     now = datetime.now(timezone.utc)
     cutoff = now - timedelta(hours=1)
 
+    # No tenant context is bound in this unit test, so the multi-tenant
+    # storage-cleanup pass (current_tenant_var.get() is None) is a documented
+    # skip — it never issues a 3rd db.execute() call, keeping this test's
+    # 2-call contract intact.
     with patch("app.core.tenancy.is_multi_tenant", return_value=True):
         result = await sweep_stale_vrt_assets(mock_session, cutoff)
 
@@ -635,7 +679,7 @@ async def test_sweep_stale_vrt_assets_preserves_single_tenant_sql_shape():
     from app.platform.jobs.router import sweep_stale_vrt_assets
 
     gen_result = MagicMock()
-    gen_result.scalars.return_value = []
+    gen_result.all.return_value = []
     asset_result = MagicMock()
     asset_result.scalars.return_value = []
     session = AsyncMock()
@@ -649,6 +693,95 @@ async def test_sweep_stale_vrt_assets_preserves_single_tenant_sql_shape():
     statements = [str(call.args[0]) for call in session.execute.await_args_list]
     assert "SELECT catalog.datasets.id" not in statements[0]
     assert "SELECT catalog.datasets.id" not in statements[1]
+
+
+# ---------------------------------------------------------------------------
+# feat(#1267): reconciliation restores 'ready', not 'failed', and reaps the
+# dead attempt's own generation-scoped storage objects.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sweep_stale_vrt_assets_restores_ready_not_failed():
+    """feat(#1267): the compiled UPDATE sets status='ready', mirroring the
+    values a live worker never got to write — the dead attempt's own
+    VrtGeneration row is what records the failure, not the asset."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+
+    gen_result = MagicMock()
+    gen_result.all.return_value = []
+    asset_result = MagicMock()
+    asset_result.scalars.return_value = []
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[gen_result, asset_result])
+
+    await sweep_stale_vrt_assets(
+        session, datetime.now(timezone.utc) - timedelta(hours=1)
+    )
+
+    asset_update_stmt = session.execute.await_args_list[1].args[0]
+    compiled = asset_update_stmt.compile(compile_kwargs={"literal_binds": True})
+    where_sql = str(compiled)
+    assert "status='ready'" in where_sql or "status = 'ready'" in where_sql
+    assert "'failed'" not in where_sql
+
+
+@pytest.mark.asyncio
+async def test_sweep_stale_vrt_assets_reaps_dead_attempt_storage():
+    """feat(#1267): a swept generation's immutable objects are best-effort
+    deleted — the dead attempt is the only thing that could have written
+    them, and nothing else will ever reference that generation-scoped key."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+
+    stale_gen_id = uuid4()
+    stale_dataset_id = uuid4()
+
+    gen_result = MagicMock()
+    gen_result.all.return_value = [(stale_gen_id, stale_dataset_id)]
+    asset_result = MagicMock()
+    asset_result.scalars.return_value = [stale_dataset_id]
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[gen_result, asset_result])
+
+    storage = MagicMock()
+    storage.delete = AsyncMock()
+
+    with patch("app.platform.storage.get_storage", return_value=storage):
+        result = await sweep_stale_vrt_assets(
+            session, datetime.now(timezone.utc) - timedelta(hours=1)
+        )
+
+    assert result == (1, 1)
+    base = f"rasters/{stale_dataset_id}/generations/{stale_gen_id}"
+    called_keys = {call.args[0] for call in storage.delete.await_args_list}
+    assert called_keys == {
+        f"{base}/source.vrt",
+        f"{base}/quicklook_256.png",
+        f"{base}/quicklook_512.png",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sweep_stale_vrt_assets_storage_failure_never_masks_reconciliation():
+    """A storage backend that is unreachable must not stop the sweep from
+    restoring the asset and failing the generation — cleanup is best-effort,
+    reconciliation is not."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+
+    gen_result = MagicMock()
+    gen_result.all.return_value = [(uuid4(), uuid4())]
+    asset_result = MagicMock()
+    asset_result.scalars.return_value = [uuid4()]
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[gen_result, asset_result])
+
+    # No storage patch — get_storage() raises RuntimeError (uninitialized),
+    # which _cleanup_orphaned_storage_keys swallows.
+    result = await sweep_stale_vrt_assets(
+        session, datetime.now(timezone.utc) - timedelta(hours=1)
+    )
+
+    assert result == (1, 1)
 
 
 @pytest.mark.rls
@@ -771,7 +904,10 @@ async def test_sweep_stale_vrt_assets_cannot_mutate_another_tenant(
                 ).all()
             )
         assert generations == {generation_a: "failed", generation_b: "running"}
-        assert assets == {asset_a: "failed", asset_b: "regenerating"}
+        # feat(#1267): restored to 'ready', not 'failed' — tenant a's asset
+        # never had its published pointer touched by the dead attempt, so it
+        # keeps serving what it served before regeneration started.
+        assert assets == {asset_a: "ready", asset_b: "regenerating"}
     finally:
         async with engine.begin() as conn:
             await conn.execute(

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -1109,10 +1109,15 @@ async def test_sweep_keeps_failed_when_prior_attempt_was_failed(test_db_session)
     now = datetime.now(timezone.utc)
     # Generation 1: the ORIGINAL attempt, genuinely failed (e.g. a real GDAL
     # error) — not swept, not abandoned; explicitly terminal already.
+    # heartbeat_at is set: fix(#1322 review round 5) — this is what
+    # distinguishes a genuine build failure (the task claimed and ran) from
+    # an enqueue failure (never reached the worker at all); see
+    # test_sweep_restores_ready_when_prior_attempt_never_ran for that case.
     failed_generation = VrtGeneration(
         vrt_dataset_id=vrt_dataset.id,
         status="failed",
         started_at=now - timedelta(hours=5),
+        heartbeat_at=now - timedelta(hours=4, minutes=56),
         completed_at=now - timedelta(hours=4, minutes=55),
         error_message="Simulated GDAL failure, unrelated to any crash",
     )
@@ -1184,6 +1189,7 @@ async def test_sweep_restores_ready_when_prior_attempt_completed(test_db_session
         vrt_dataset_id=vrt_dataset.id,
         status="completed",
         started_at=now - timedelta(hours=5),
+        heartbeat_at=now - timedelta(hours=4, minutes=56),
         completed_at=now - timedelta(hours=4, minutes=55),
     )
     test_db_session.add(completed_generation)
@@ -1223,6 +1229,85 @@ async def test_sweep_restores_ready_when_prior_attempt_completed(test_db_session
     await test_db_session.refresh(asset)
     assert asset.status == "ready"
     assert asset.current_generation_id is None
+
+
+async def test_sweep_restores_ready_when_prior_attempt_never_ran(test_db_session):
+    """fix(#1322 review round 5): a generation's status='failed' does not by
+    itself mean the asset was not ready. regenerate_vrt_endpoint's own
+    orphan-guard rollback marks a just-created generation 'failed' when the
+    Procrastinate ENQUEUE itself throws — the task never reached a worker,
+    and the SAME rollback reverts the asset to whatever it already was
+    (commonly 'ready'). That generation's heartbeat_at is NULL forever: it
+    is set in exactly one place, tasks_vrt.regenerate_vrt's Phase-1 claim,
+    which an enqueue failure never reaches. A LATER, genuinely-run dead
+    attempt must not read that unrelated enqueue failure as proof the
+    asset was not ready."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from app.processing.raster.models import RasterAsset, VrtGeneration, VrtSourceLink
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    source = await create_dataset(test_db_session, created_by=admin_id)
+    vrt_dataset = await create_dataset(test_db_session, created_by=admin_id)
+
+    now = datetime.now(timezone.utc)
+    # The enqueue failure: status='failed', but heartbeat_at was NEVER set —
+    # the row was created and immediately failed by the SAME synchronous
+    # request, without a worker ever claiming it.
+    enqueue_failed_generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="failed",
+        started_at=now - timedelta(hours=5),
+        heartbeat_at=None,
+        completed_at=now - timedelta(hours=5),
+        error_message="Failed to queue VRT regeneration: connection refused",
+    )
+    test_db_session.add(enqueue_failed_generation)
+    await test_db_session.flush()
+
+    # A later attempt that DID actually run (heartbeat_at set) and is now
+    # dead — the one being reconciled.
+    dead_generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="running",
+        started_at=now - timedelta(hours=2),
+        heartbeat_at=now - timedelta(hours=2),
+    )
+    test_db_session.add(dead_generation)
+    await test_db_session.flush()
+
+    asset = RasterAsset(
+        dataset_id=vrt_dataset.id,
+        asset_uri=f"rasters/{vrt_dataset.id}/source.vrt",
+        status="regenerating",
+        current_generation_id=dead_generation.id,
+        built_from={str(source.id): "irrelevant"},
+    )
+    test_db_session.add(asset)
+    test_db_session.add(
+        VrtSourceLink(
+            vrt_dataset_id=vrt_dataset.id, source_dataset_id=source.id, position=0
+        )
+    )
+    await test_db_session.commit()
+
+    cutoff = now - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (1, 1)
+    await test_db_session.refresh(asset)
+    assert asset.status == "ready", (
+        "an enqueue failure that never reached a worker must not be read "
+        "as proof the asset was not ready"
+    )
+    assert asset.current_generation_id is None
+    # The unrelated enqueue-failure row is untouched by this sweep.
+    await test_db_session.refresh(enqueue_failed_generation)
+    assert enqueue_failed_generation.status == "failed"
+    assert enqueue_failed_generation.heartbeat_at is None
 
 
 @pytest.mark.rls

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -349,11 +349,15 @@ async def test_fail_stale_jobs_detailed_outcome_counts_every_cleanup_surface(
     assert result.terminal_jobs_purged == 2
     assert result.staged_paths_considered == 2
     assert result.local_files_reaped == 1
-    assert result.storage_objects_reaped == 1
+    # feat(#1267) / fix(#1322 review): 1 retention key + 3 VRT generation
+    # keys, all reaped by _reap_committed_staged_paths AFTER db.commit()
+    # succeeded — sweep_stale_vrt_assets itself only resolved the latter 3,
+    # never deleting them.
+    assert result.storage_objects_reaped == 4
     assert result.staged_paths_skipped == 0
     assert result.staged_cleanup_failures == 0
     assert result.total_cleaned == 2
-    assert result.total_affected == 8
+    assert result.total_affected == 11
     assert not local_file.exists()
 
     # feat(#1267): the reconciled generation's own storage objects are
@@ -398,6 +402,41 @@ async def test_fail_stale_jobs_commit_failure_keeps_external_artifacts(
         await fail_stale_jobs(mock_db, detailed=True)
 
     assert local_file.exists()
+    storage.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fail_stale_jobs_commit_failure_keeps_stale_generation_storage_intact(
+    monkeypatch,
+):
+    """fix(#1322 review): the inverse of the storage-failure test above — a
+    reconciliation whose commit fails must leave a dead attempt's generation
+    objects UNDELETED. sweep_stale_vrt_assets only resolves the keys; nothing
+    may reap them until fail_stale_jobs's own db.commit() (which raises here,
+    rolling the generation/asset UPDATEs back) has actually landed. Deleting
+    anyway would leave a resumed 'dead' worker publishing to storage keys
+    that no longer exist, behind an asset the rollback restored to
+    'regenerating'."""
+    from app.platform.jobs.router import fail_stale_jobs
+
+    stale_asset = _make_raster_asset(status="regenerating")
+    stale_gen = _make_vrt_generation(
+        status="running", vrt_dataset_id=stale_asset.dataset_id
+    )
+    mock_db = _make_mock_db_for_fail_stale(
+        stale_vrt_assets=[stale_asset],
+        stale_vrt_generations=[stale_gen],
+    )
+    mock_db.commit.side_effect = RuntimeError("commit failed")
+    storage = MagicMock()
+    storage.delete = AsyncMock()
+
+    with (
+        patch("app.platform.storage.get_storage", return_value=storage),
+        pytest.raises(RuntimeError, match="commit failed"),
+    ):
+        await fail_stale_jobs(mock_db, detailed=True)
+
     storage.delete.assert_not_awaited()
 
 
@@ -633,7 +672,9 @@ async def test_fail_stale_jobs_calls_vrt_sweep_helper():
 
 @pytest.mark.asyncio
 async def test_sweep_stale_vrt_assets_returns_count():
-    """GAP-002: sweep_stale_vrt_assets(session, stale_cutoff) returns (assets_recovered, gens_failed)."""
+    """GAP-002: sweep_stale_vrt_assets(session, stale_cutoff) returns
+    (assets_recovered, gens_failed, storage_keys) — feat(#1267)/fix(#1322
+    review) widened the tuple to carry resolved-not-deleted storage keys."""
     from app.platform.jobs.router import sweep_stale_vrt_assets
 
     stale_asset = _make_raster_asset(status="regenerating")
@@ -651,19 +692,20 @@ async def test_sweep_stale_vrt_assets_returns_count():
     now = datetime.now(timezone.utc)
     cutoff = now - timedelta(hours=1)
 
-    # No tenant context is bound in this unit test, so the multi-tenant
-    # storage-cleanup pass (current_tenant_var.get() is None) is a documented
-    # skip — it never issues a 3rd db.execute() call, keeping this test's
-    # 2-call contract intact.
+    # No tenant context is bound in this unit test, so key RESOLUTION itself
+    # (not just deletion — sweep_stale_vrt_assets never deletes anything,
+    # fix(#1322 review)) short-circuits to an empty tuple rather than raising.
+    # Either way this stays a 2-call contract: resolving/skipping keys is
+    # pure Python, never a 3rd db.execute().
     with patch("app.core.tenancy.is_multi_tenant", return_value=True):
         result = await sweep_stale_vrt_assets(mock_session, cutoff)
 
-    # Returns (assets_recovered, gens_failed) both ≥ 0
     assert isinstance(result, tuple)
-    assert len(result) == 2
-    assets_recovered, gens_failed = result
+    assert len(result) == 3
+    assets_recovered, gens_failed, storage_keys = result
     assert assets_recovered == 1
     assert gens_failed == 1
+    assert storage_keys == ()
 
     statements = [str(call.args[0]) for call in mock_session.execute.await_args_list]
     assert "UPDATE catalog.vrt_generations" in statements[0]
@@ -727,10 +769,14 @@ async def test_sweep_stale_vrt_assets_restores_ready_not_failed():
 
 
 @pytest.mark.asyncio
-async def test_sweep_stale_vrt_assets_reaps_dead_attempt_storage():
-    """feat(#1267): a swept generation's immutable objects are best-effort
-    deleted — the dead attempt is the only thing that could have written
-    them, and nothing else will ever reference that generation-scoped key."""
+async def test_sweep_stale_vrt_assets_resolves_but_never_deletes_storage():
+    """fix(#1322 review): sweep_stale_vrt_assets RESOLVES a swept generation's
+    immutable object keys (3rd tuple element) but must never call storage
+    itself. Deleting before its caller's commit is durable can destroy a
+    generation a rolled-back reconciliation still owns — see
+    _reap_stale_generation_storage's docstring. No storage patch is installed
+    here on purpose: any storage.* call inside the sweep would raise
+    (get_storage() is uninitialized in this unit test) and fail the test."""
     from app.platform.jobs.router import sweep_stale_vrt_assets
 
     stale_gen_id = uuid4()
@@ -743,29 +789,27 @@ async def test_sweep_stale_vrt_assets_reaps_dead_attempt_storage():
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[gen_result, asset_result])
 
-    storage = MagicMock()
-    storage.delete = AsyncMock()
+    result = await sweep_stale_vrt_assets(
+        session, datetime.now(timezone.utc) - timedelta(hours=1)
+    )
 
-    with patch("app.platform.storage.get_storage", return_value=storage):
-        result = await sweep_stale_vrt_assets(
-            session, datetime.now(timezone.utc) - timedelta(hours=1)
-        )
-
-    assert result == (1, 1)
     base = f"rasters/{stale_dataset_id}/generations/{stale_gen_id}"
-    called_keys = {call.args[0] for call in storage.delete.await_args_list}
-    assert called_keys == {
-        f"{base}/source.vrt",
-        f"{base}/quicklook_256.png",
-        f"{base}/quicklook_512.png",
-    }
+    assert result == (
+        1,
+        1,
+        (
+            f"{base}/source.vrt",
+            f"{base}/quicklook_256.png",
+            f"{base}/quicklook_512.png",
+        ),
+    )
 
 
 @pytest.mark.asyncio
 async def test_sweep_stale_vrt_assets_storage_failure_never_masks_reconciliation():
     """A storage backend that is unreachable must not stop the sweep from
-    restoring the asset and failing the generation — cleanup is best-effort,
-    reconciliation is not."""
+    restoring the asset and failing the generation — key resolution is pure
+    Python (no storage call), so reconciliation cannot be masked by it."""
     from app.platform.jobs.router import sweep_stale_vrt_assets
 
     gen_result = MagicMock()
@@ -775,13 +819,15 @@ async def test_sweep_stale_vrt_assets_storage_failure_never_masks_reconciliation
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[gen_result, asset_result])
 
-    # No storage patch — get_storage() raises RuntimeError (uninitialized),
-    # which _cleanup_orphaned_storage_keys swallows.
+    # No storage patch — get_storage() would raise RuntimeError
+    # (uninitialized) if the sweep ever called it, which it must not.
     result = await sweep_stale_vrt_assets(
         session, datetime.now(timezone.utc) - timedelta(hours=1)
     )
 
-    assert result == (1, 1)
+    assert result[0] == 1
+    assert result[1] == 1
+    assert len(result[2]) == 3
 
 
 @pytest.mark.rls
@@ -878,7 +924,12 @@ async def test_sweep_stale_vrt_assets_cannot_mutate_another_tenant(
                 )
 
         async with ctx.tenant_session(ctx.tenant_a) as session:
-            assert await sweep_stale_vrt_assets(session, cutoff) == (1, 1)
+            # fix(#1322 review): 3rd element is resolved-not-deleted storage
+            # keys, tenant-prefixed since ctx.tenant_session binds
+            # current_tenant_var for the block — one swept generation, 3 keys.
+            sweep_result = await sweep_stale_vrt_assets(session, cutoff)
+            assert sweep_result[:2] == (1, 1)
+            assert len(sweep_result[2]) == 3
 
         async with engine.connect() as conn:
             generations = dict(

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -1340,6 +1340,27 @@ async def _insert_live_procrastinate_job(session, *, generation_id) -> None:
     )
 
 
+async def _insert_legacy_live_procrastinate_job(session, *, vrt_dataset_id) -> None:
+    """fix(#1322 review round 6, completed): a pre-upgrade delivery with no
+    `generation_id` argument at all — the shape tasks_vrt.regenerate_vrt
+    explicitly still accepts by adopting RasterAsset.current_generation_id.
+    Carries only `vrt_dataset_id`, matching what such a delivery's args
+    actually contain."""
+    from sqlalchemy import text as sa_text
+
+    await session.execute(sa_text("SET LOCAL search_path TO catalog, public"))
+    await session.execute(
+        sa_text(
+            "INSERT INTO catalog.procrastinate_jobs "
+            "(queue_name, task_name, args, status) "
+            "VALUES ('raster', 'app.ingest.tasks.regenerate_vrt', "
+            "jsonb_build_object('vrt_dataset_id', CAST(:vrt_dataset_id AS text)), "
+            "'todo')"
+        ),
+        {"vrt_dataset_id": str(vrt_dataset_id)},
+    )
+
+
 async def test_sweep_leaves_pending_generation_alone_while_its_job_is_still_queued(
     test_db_session,
 ):
@@ -1441,6 +1462,113 @@ async def test_sweep_reaps_pending_generation_once_its_job_is_proven_gone(
     await test_db_session.refresh(asset)
     assert orphaned_generation.status == "failed"
     assert asset.status == "ready"  # built_from={} matches the empty link set
+    assert asset.current_generation_id is None
+
+
+async def test_sweep_leaves_pending_generation_alone_for_a_live_legacy_delivery(
+    test_db_session,
+):
+    """fix(#1322 review round 6, completed): a pre-upgrade delivery queued
+    with no `generation_id` argument is still live and will still adopt
+    RasterAsset.current_generation_id once it runs (tasks_vrt.regenerate_vrt
+    explicitly supports this for rolling-deploy safety). Correlating only by
+    `generation_id` would be blind to it and let the sweep reap a generation
+    that a live task is about to claim."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    vrt_dataset = await create_dataset(test_db_session, created_by=admin_id)
+
+    now = datetime.now(timezone.utc)
+    queued_generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="pending",
+        started_at=now - timedelta(hours=2),
+        heartbeat_at=None,
+    )
+    test_db_session.add(queued_generation)
+    await test_db_session.flush()
+
+    asset = RasterAsset(
+        dataset_id=vrt_dataset.id,
+        asset_uri=f"rasters/{vrt_dataset.id}/source.vrt",
+        status="regenerating",
+        # This generation is CURRENTLY the asset's pointer — exactly what a
+        # live legacy (args-less) delivery for this dataset would adopt.
+        current_generation_id=queued_generation.id,
+        built_from={},
+    )
+    test_db_session.add(asset)
+    await _insert_legacy_live_procrastinate_job(
+        test_db_session, vrt_dataset_id=vrt_dataset.id
+    )
+    await test_db_session.commit()
+
+    cutoff = now - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (0, 0), (
+        "a live legacy delivery for this dataset, which will adopt exactly "
+        "this generation, must never be reconciled"
+    )
+    await test_db_session.refresh(queued_generation)
+    await test_db_session.refresh(asset)
+    assert queued_generation.status == "pending"
+    assert asset.status == "regenerating"
+    assert asset.current_generation_id == queued_generation.id
+
+
+async def test_sweep_reaps_pending_generation_when_no_legacy_delivery_is_live(
+    test_db_session,
+):
+    """Companion coverage: a dataset with NO live procrastinate_jobs row at
+    all (neither modern nor legacy-shaped) still gets its genuinely-orphaned
+    pending generation reaped — the fallback correlation must not make the
+    sweep permanently blind."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    vrt_dataset = await create_dataset(test_db_session, created_by=admin_id)
+
+    now = datetime.now(timezone.utc)
+    orphaned_generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="pending",
+        started_at=now - timedelta(hours=2),
+        heartbeat_at=None,
+    )
+    test_db_session.add(orphaned_generation)
+    await test_db_session.flush()
+
+    asset = RasterAsset(
+        dataset_id=vrt_dataset.id,
+        asset_uri=f"rasters/{vrt_dataset.id}/source.vrt",
+        status="regenerating",
+        current_generation_id=orphaned_generation.id,
+        built_from={},
+    )
+    test_db_session.add(asset)
+    # No procrastinate_jobs row of any shape.
+    await test_db_session.commit()
+
+    cutoff = now - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (1, 1)
+    await test_db_session.refresh(orphaned_generation)
+    await test_db_session.refresh(asset)
+    assert orphaned_generation.status == "failed"
+    assert asset.status == "ready"
     assert asset.current_generation_id is None
 
 

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -1310,6 +1310,140 @@ async def test_sweep_restores_ready_when_prior_attempt_never_ran(test_db_session
     assert enqueue_failed_generation.heartbeat_at is None
 
 
+# ---------------------------------------------------------------------------
+# fix(#1322 review round 6): PROVEN-DEAD FIRST for a 'pending' generation
+# specifically. started_at age alone cannot distinguish an orphan from a
+# regeneration still legitimately sitting in Procrastinate's queue through a
+# sustained worker backlog — queue waits are unbounded, the same reason
+# stale_pending_clauses requires no_live_procrastinate_job for IngestJob. A
+# 'running' generation's own heartbeat is sufficient proof on its own
+# (covered by the existing tests above) and is NOT re-tested here.
+# ---------------------------------------------------------------------------
+
+
+async def _insert_live_procrastinate_job(session, *, generation_id) -> None:
+    """A minimal 'todo' procrastinate_jobs row referencing a generation,
+    mirroring the INSERT shape test_dataset_refresh_runs.py already uses for
+    the identical class of live-job proof."""
+    from sqlalchemy import text as sa_text
+
+    await session.execute(sa_text("SET LOCAL search_path TO catalog, public"))
+    await session.execute(
+        sa_text(
+            "INSERT INTO catalog.procrastinate_jobs "
+            "(queue_name, task_name, args, status) "
+            "VALUES ('raster', 'app.ingest.tasks.regenerate_vrt', "
+            "jsonb_build_object('generation_id', CAST(:generation_id AS text)), "
+            "'todo')"
+        ),
+        {"generation_id": str(generation_id)},
+    )
+
+
+async def test_sweep_leaves_pending_generation_alone_while_its_job_is_still_queued(
+    test_db_session,
+):
+    """The exact scenario from the finding: a 'pending' generation with an
+    old started_at (a sustained worker backlog, not an orphan) whose task is
+    still genuinely queued in Procrastinate. Sweeping it would let the
+    queued task's own Phase-1 claim (tasks_vrt.py) fail against a
+    generation the sweep already flipped to 'failed', losing a valid
+    regeneration that was always going to run."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    vrt_dataset = await create_dataset(test_db_session, created_by=admin_id)
+
+    now = datetime.now(timezone.utc)
+    queued_generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="pending",
+        started_at=now - timedelta(hours=2),  # old — a real backlog, not fresh
+        heartbeat_at=None,  # never claimed — nothing has run yet
+    )
+    test_db_session.add(queued_generation)
+    await test_db_session.flush()
+
+    asset = RasterAsset(
+        dataset_id=vrt_dataset.id,
+        asset_uri=f"rasters/{vrt_dataset.id}/source.vrt",
+        status="regenerating",
+        current_generation_id=queued_generation.id,
+        built_from={},
+    )
+    test_db_session.add(asset)
+    await _insert_live_procrastinate_job(
+        test_db_session, generation_id=queued_generation.id
+    )
+    await test_db_session.commit()
+
+    cutoff = now - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (0, 0), (
+        "a generation whose task is still queued must never be reconciled"
+    )
+    await test_db_session.refresh(queued_generation)
+    await test_db_session.refresh(asset)
+    assert queued_generation.status == "pending"
+    assert asset.status == "regenerating"
+    assert asset.current_generation_id == queued_generation.id
+
+
+async def test_sweep_reaps_pending_generation_once_its_job_is_proven_gone(
+    test_db_session,
+):
+    """Companion coverage: the same old, never-claimed 'pending' generation
+    IS swept once there is no live Procrastinate row for it at all — the
+    genuinely-orphaned case (create-then-defer death, or a purged/expired
+    queue row) this reconciliation exists to compensate for."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    vrt_dataset = await create_dataset(test_db_session, created_by=admin_id)
+
+    now = datetime.now(timezone.utc)
+    orphaned_generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="pending",
+        started_at=now - timedelta(hours=2),
+        heartbeat_at=None,
+    )
+    test_db_session.add(orphaned_generation)
+    await test_db_session.flush()
+
+    asset = RasterAsset(
+        dataset_id=vrt_dataset.id,
+        asset_uri=f"rasters/{vrt_dataset.id}/source.vrt",
+        status="regenerating",
+        current_generation_id=orphaned_generation.id,
+        built_from={},
+    )
+    test_db_session.add(asset)
+    # No procrastinate_jobs row at all — no live job to prove.
+    await test_db_session.commit()
+
+    cutoff = now - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (1, 1)
+    await test_db_session.refresh(orphaned_generation)
+    await test_db_session.refresh(asset)
+    assert orphaned_generation.status == "failed"
+    assert asset.status == "ready"  # built_from={} matches the empty link set
+    assert asset.current_generation_id is None
+
+
 @pytest.mark.rls
 async def test_sweep_stale_vrt_assets_cannot_mutate_another_tenant(
     multi_tenant_rls,
@@ -1341,6 +1475,15 @@ async def test_sweep_stale_vrt_assets_cannot_mutate_another_tenant(
             # role catching up, not a production grant gap.
             await conn.execute(
                 sa.text("GRANT SELECT ON catalog.vrt_source_links TO geolens_reader")
+            )
+            # fix(#1322 review round 6): the pending-generation proven-dead
+            # check reads catalog.procrastinate_jobs — same "minimal test
+            # role catching up" rationale as above; the query text references
+            # the table even for these status='running' fixture rows, so
+            # Postgres checks the privilege at plan time regardless of which
+            # OR-branch actually matches.
+            await conn.execute(
+                sa.text("GRANT SELECT ON catalog.procrastinate_jobs TO geolens_reader")
             )
             for record_id, dataset_id, tenant_id, suffix in (
                 (record_a, dataset_a, ctx.tenant_a, "a"),
@@ -1461,5 +1604,10 @@ async def test_sweep_stale_vrt_assets_cannot_mutate_another_tenant(
             )
             await conn.execute(
                 sa.text("REVOKE SELECT ON catalog.vrt_source_links FROM geolens_reader")
+            )
+            await conn.execute(
+                sa.text(
+                    "REVOKE SELECT ON catalog.procrastinate_jobs FROM geolens_reader"
+                )
             )
         await engine.dispose()

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -798,18 +798,36 @@ async def test_sweep_stale_vrt_assets_restores_ready_not_failed():
         session, datetime.now(timezone.utc) - timedelta(hours=1)
     )
 
+    # fix(#1322 review round 4): _PRIOR_ATTEMPT_WAS_READY_SQL legitimately
+    # mentions the literal 'failed' in its WHERE-clause comparison (the most
+    # recent OTHER generation's status), so "'failed' not anywhere in the
+    # statement" is no longer a valid signal — isolate the SET clause (the
+    # part before WHERE) and check only that.
     ready_stmt = session.execute.await_args_list[1].args[0]
     ready_sql = str(ready_stmt.compile(compile_kwargs={"literal_binds": True}))
-    assert "status='ready'" in ready_sql or "status = 'ready'" in ready_sql
-    assert "'failed'" not in ready_sql
+    ready_set_clause = ready_sql.split("WHERE", 1)[0]
+    assert (
+        "status='ready'" in ready_set_clause or "status = 'ready'" in ready_set_clause
+    )
+    assert "'failed'" not in ready_set_clause
 
     degraded_stmt = session.execute.await_args_list[2].args[0]
     degraded_sql = str(degraded_stmt.compile(compile_kwargs={"literal_binds": True}))
-    assert "status='failed'" in degraded_sql or "status = 'failed'" in degraded_sql
-    assert "'ready'" not in degraded_sql
+    degraded_set_clause = degraded_sql.split("WHERE", 1)[0]
+    assert (
+        "status='failed'" in degraded_set_clause
+        or "status = 'failed'" in degraded_set_clause
+    )
+    assert "'ready'" not in degraded_set_clause
     # The two branches are mutually exclusive: the 2nd statement's predicate
-    # is the exact negation of the 1st's composition check.
+    # is the exact negation of the 1st's combined composition + prior-ready
+    # check.
     assert "NOT (" in degraded_sql
+    # Both facts are present in both statements' WHERE clauses (the 2nd
+    # negates their conjunction, not just one half).
+    for where_sql in (ready_sql, degraded_sql):
+        assert "vrt_source_links" in where_sql
+        assert "vrt_generations" in where_sql
 
 
 @pytest.mark.asyncio
@@ -1061,6 +1079,150 @@ async def test_sweep_keeps_failed_when_built_from_is_null(test_db_session):
 
     await test_db_session.refresh(asset)
     assert asset.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# fix(#1322 review round 4): composition-preserving alone is not enough — the
+# asset must also have PROVABLY been 'ready' (not 'failed') the instant this
+# attempt was allowed to start. regenerate_vrt_endpoint's guard only rejects
+# 'regenerating', so a caller may retry an already-'failed' asset; if that
+# retry also dies, composition-preserving alone would restore 'ready' and
+# erase a real failure the crash had nothing to do with.
+# ---------------------------------------------------------------------------
+
+
+async def test_sweep_keeps_failed_when_prior_attempt_was_failed(test_db_session):
+    """The exact scenario from the finding: a genuine regeneration failure
+    (generation 1, a real GDAL-style error — NOT this sweep's doing), then a
+    user retry (generation 2) that is itself abandoned. Composition is
+    unchanged throughout, so the composition check alone would restore
+    'ready' — but generation 1's failure was never actually resolved, and
+    the sweep must not manufacture a resolution that didn't happen."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from app.processing.raster.models import RasterAsset, VrtGeneration, VrtSourceLink
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    source = await create_dataset(test_db_session, created_by=admin_id)
+    vrt_dataset = await create_dataset(test_db_session, created_by=admin_id)
+
+    now = datetime.now(timezone.utc)
+    # Generation 1: the ORIGINAL attempt, genuinely failed (e.g. a real GDAL
+    # error) — not swept, not abandoned; explicitly terminal already.
+    failed_generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="failed",
+        started_at=now - timedelta(hours=5),
+        completed_at=now - timedelta(hours=4, minutes=55),
+        error_message="Simulated GDAL failure, unrelated to any crash",
+    )
+    test_db_session.add(failed_generation)
+    await test_db_session.flush()
+
+    # Generation 2: the user's retry (allowed — the endpoint only rejects
+    # 'regenerating', not 'failed') — now abandoned by a worker crash.
+    retry_generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="running",
+        started_at=now - timedelta(hours=2),
+        heartbeat_at=now - timedelta(hours=2),
+    )
+    test_db_session.add(retry_generation)
+    await test_db_session.flush()
+
+    asset = RasterAsset(
+        dataset_id=vrt_dataset.id,
+        asset_uri=f"rasters/{vrt_dataset.id}/source.vrt",
+        status="regenerating",
+        current_generation_id=retry_generation.id,
+        # Composition unchanged — a pure retry, not a source add/remove.
+        built_from={str(source.id): "irrelevant"},
+    )
+    test_db_session.add(asset)
+    test_db_session.add(
+        VrtSourceLink(
+            vrt_dataset_id=vrt_dataset.id, source_dataset_id=source.id, position=0
+        )
+    )
+    await test_db_session.commit()
+
+    cutoff = now - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (1, 1)
+    await test_db_session.refresh(asset)
+    await test_db_session.refresh(retry_generation)
+    assert asset.status == "failed", (
+        "restoring 'ready' here would manufacture a resolution generation 1's "
+        "real failure never actually got"
+    )
+    assert asset.current_generation_id is None  # a further retry is still triggerable
+    assert retry_generation.status == "failed"
+    # generation 1 is untouched — it was already terminal before this sweep ran.
+    await test_db_session.refresh(failed_generation)
+    assert failed_generation.status == "failed"
+
+
+async def test_sweep_restores_ready_when_prior_attempt_completed(test_db_session):
+    """Companion coverage: a prior attempt that actually SUCCEEDED (not just
+    'no prior attempt exists', which the composition-unchanged test above
+    already covers) still lets a later dead, composition-preserving attempt
+    restore 'ready'."""
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from app.processing.raster.models import RasterAsset, VrtGeneration, VrtSourceLink
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    source = await create_dataset(test_db_session, created_by=admin_id)
+    vrt_dataset = await create_dataset(test_db_session, created_by=admin_id)
+
+    now = datetime.now(timezone.utc)
+    completed_generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="completed",
+        started_at=now - timedelta(hours=5),
+        completed_at=now - timedelta(hours=4, minutes=55),
+    )
+    test_db_session.add(completed_generation)
+    await test_db_session.flush()
+
+    dead_generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="running",
+        started_at=now - timedelta(hours=2),
+        heartbeat_at=now - timedelta(hours=2),
+    )
+    test_db_session.add(dead_generation)
+    await test_db_session.flush()
+
+    asset = RasterAsset(
+        dataset_id=vrt_dataset.id,
+        asset_uri=f"rasters/{vrt_dataset.id}/source.vrt",
+        status="regenerating",
+        current_generation_id=dead_generation.id,
+        built_from={str(source.id): "irrelevant"},
+    )
+    test_db_session.add(asset)
+    test_db_session.add(
+        VrtSourceLink(
+            vrt_dataset_id=vrt_dataset.id, source_dataset_id=source.id, position=0
+        )
+    )
+    await test_db_session.commit()
+
+    cutoff = now - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (1, 1)
+    await test_db_session.refresh(asset)
+    assert asset.status == "ready"
+    assert asset.current_generation_id is None
 
 
 @pytest.mark.rls

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -105,7 +105,13 @@ def _make_mock_session(*result_lists):
     """Create a mock async session that returns different results per execute call.
 
     The first execute call is the advisory lock query (returns True to proceed).
-    Subsequent arguments are lists of mock jobs (running jobs first, pending second).
+    Subsequent arguments are lists of mock jobs (running jobs first, pending
+    second, then the GAP-002/#1267 VRT sweep's 3 calls: VrtGeneration UPDATE
+    (.all()), then the composition-preserving and composition-changed
+    RasterAsset UPDATEs (.scalars()) — fix(#1322 review round 3) split what
+    used to be one asset UPDATE into two. Every caller in this file passes
+    empty lists for those, so setting both accessors on every result is a
+    safe no-op regardless of which one the code under test actually calls.
     """
     # First result: advisory lock — scalar() returns True (lock acquired)
     lock_result = MagicMock()
@@ -115,6 +121,7 @@ def _make_mock_session(*result_lists):
     for job_list in result_lists:
         mock_result = MagicMock()
         mock_result.scalars.return_value = job_list
+        mock_result.all.return_value = job_list
         results.append(mock_result)
 
     mock_session = AsyncMock()
@@ -143,7 +150,7 @@ async def test_recover_stale_jobs_marks_running_as_failed():
 
     # Two extra empty results for the GAP-002 VRT stale sweep
     # (stale regenerating RasterAssets, stale VrtGeneration rows).
-    mock_session = _make_mock_session([fake_job], [], [], [])
+    mock_session = _make_mock_session([fake_job], [], [], [], [])
 
     with patch("app.core.db.async_session", return_value=mock_session):
         await recover_stale_jobs()
@@ -166,7 +173,7 @@ async def test_recover_stale_jobs_marks_orphaned_pending_as_failed():
     fake_job.completed_at = None
 
     # Two extra empty results for the GAP-002 VRT stale sweep.
-    mock_session = _make_mock_session([], [fake_job], [], [])
+    mock_session = _make_mock_session([], [fake_job], [], [], [])
 
     with patch("app.core.db.async_session", return_value=mock_session):
         await recover_stale_jobs()
@@ -196,7 +203,7 @@ async def test_recover_stale_jobs_rolling_deploy_survives_6min_ingest():
     six_min_old_job.completed_at = None
 
     # The database query excludes the fresh heartbeat, so no job is returned.
-    mock_session = _make_mock_session([], [], [], [])
+    mock_session = _make_mock_session([], [], [], [], [])
 
     with patch("app.core.db.async_session", return_value=mock_session):
         await recover_stale_jobs()
@@ -234,7 +241,7 @@ async def test_recover_stale_jobs_logs_individual_job_ids():
     job2.started_at = None
 
     # Two extra empty results for the GAP-002 VRT stale sweep.
-    mock_session = _make_mock_session([job1, job2], [], [], [])
+    mock_session = _make_mock_session([job1, job2], [], [], [], [])
 
     with patch("app.core.db.async_session", return_value=mock_session):
         with patch("app.platform.jobs.worker.log") as mock_log:


### PR DESCRIPTION
ADR-002 Amendment A10 (ownership gap found by the 2026-08-07 milestone audit). Two VRT gaps had no owner:

1. **Freshness projection (Decision 5a).** The ADR promises a VRT's latest generation timestamp projects into `last_refreshed_at` so #1226's freshness chips render uniformly across record types. #1224's read-side freshness function already treats a NULL origin (a VRT) as this dataset's refreshable kind — nothing implemented the write side, so a regenerated VRT kept reporting its creation-time floor forever.
2. **Abandoned-generation reconciliation (Audit blocker 11).** A `regenerating` VRT asset whose worker died mid-attempt had no path back to serving. GAP-002's existing sweep already proves the attempt dead via the generation's own heartbeat timing out, but it recovered the asset to `status='failed'` unconditionally — the wrong outcome for most attempts, since `regenerate_vrt` only overwrites the published pointer (`asset_uri`, `sha256`, ...) in the same transaction that clears `current_generation_id` on success, so a dead attempt never reaches that transaction and those fields still describe exactly what the VRT was serving before the attempt started.

## What changed

- `regenerate_vrt`'s success path now stamps the owning dataset's `last_refreshed_at` at the generation's own `completed_at` instant, in the same transaction as the generation swap — one timestamp, no clock skew between the two records of it.
- `sweep_stale_vrt_assets` now restores `status='ready'` for a dead **composition-preserving** attempt (a pure regenerate) instead of unconditionally `status='failed'`. Only the dead attempt's own `VrtGeneration` row is marked `failed`; the VRT keeps serving what it served before.
- **A dead composition-changing attempt (source add/remove) is kept `'failed'`, not restored to `'ready'`.** `add_vrt_source`/`remove_vrt_source` commit their `vrt_source_links` mutation in the same transaction that flips the asset to `'regenerating'`, before the regeneration itself ever runs — so if that attempt dies, the catalog's declared composition is already ahead of the served bytes, and restoring `'ready'` would erase the only visible signal of that drift (the status endpoint reads the link set, not the served VRT). There is no stored "attempt type" to key off (`VrtGeneration.triggered_by` holds a user id on every call site, not a kind), so the sweep asks the question the drift is actually about, from stored state: does the published composition (`built_from`'s key set — what the VRT was actually assembled from) still equal the catalog's current composition (`vrt_source_links`)? A count-match plus a one-directional subset check proves set equality; a legacy VRT with no recorded `built_from` falls to the same conservative branch as a proven mismatch. Covered by 4 new database-backed tests (composition preserved / source removed / source added / `built_from` absent).
- The sweep resolves (never deletes) the dead attempt's own generation-scoped storage keys (`rasters/{dataset}/generations/{generation}/source.vrt` + 2 quicklooks) and returns them to its caller. **Deletion is deferred until strictly after the caller's own commit lands** — threaded through `StaleCleanupOutcome` exactly like the existing `_staged_paths` field for `fail_stale_jobs`, and reaped directly after `session.commit()` in the worker startup recovery path. Deleting inside the sweep, before the reconciling transaction was durable, could leave a rolled-back commit's "still-regenerating" asset pointing at a generation whose bytes were already gone.
- **Composition-preserving alone is still not sufficient to restore `'ready'`.** `regenerate_vrt_endpoint`'s guard rejects only `'regenerating'`, so a caller may retry an asset that is already `'failed'`. If that retry is also abandoned and its membership still matches `built_from`, the composition check alone would call it composition-preserving and restore `'ready'` — erasing a real failure a worker crash had nothing to do with, since no successful artifact was ever produced by the retry and whatever caused the *original* failure is still unaddressed. There is no column recording "the asset's status the instant this attempt started" (`previous_status` in the router is a local variable, never persisted), so the sweep reconstructs the nearest available fact: at most one generation is ever in-flight per dataset (the same guard + advisory lock), so `vrt_generations` rows for one dataset form a strict, gap-free timeline, and the row immediately preceding the one being reconciled records what happened right before this attempt was allowed to start. `'completed'` (or no such row — the dataset's first-ever attempt) means the asset was `'ready'`; `'failed'` means it was not, and the sweep now keeps the asset `'failed'` in that case too. **Accepted conservative cost, stated plainly:** a generation this sweep itself restores to `'ready'` still leaves its own `vrt_generations` row `'failed'` (only the asset recovers, not the attempt's record) — so a *later* dead attempt on the same dataset, whose immediately-prior row is that earlier swept-and-recovered one, reads `'failed'` and is kept `'failed'` even though the asset was legitimately `'ready'` when it started. A further stored marker distinguishing "recovered by the sweep" from "never recovered" would close this, but it's a bigger schema surface than this fix's blast radius, and the safety direction is correct for a reconciler: never claim `'ready'` the moment there is doubt, at the cost of occasionally staying `'failed'` one cycle longer than strictly necessary — which self-corrects the moment an operator retries and it succeeds. Covered by 2 new database-backed tests (the exact failed→retry→abandon scenario, and its companion where the prior attempt genuinely completed).
- **The prior-attempt marker itself needed refining: raw generation status over-counts what "failed" means.** `regenerate_vrt_endpoint`'s own orphan-guard rollback marks a just-created `VrtGeneration` `'failed'` when the Procrastinate *enqueue* itself throws — the task never reached a worker — and in the same rollback reverts the asset to whatever it already was (commonly `'ready'`). That generation row genuinely never ran; reading its `'failed'` status as "the asset was not ready" would produce a false `'failed'` for an asset that never had a real attempt run against it. `heartbeat_at IS NOT NULL` is the fact that separates them: it's set in exactly one place in this codebase, `tasks_vrt.regenerate_vrt`'s Phase-1 claim (the first thing the *task* does once a worker actually picks it up) — never anything the endpoint touches at creation. An enqueue failure never reaches that line, so its generation keeps `heartbeat_at` NULL forever; the same is true of a generation stuck `'pending'` because no worker ever claimed it before the sweep's own cutoff, which is the identical "never actually ran" fact. Filtering the prior-attempt lookup to `heartbeat_at IS NOT NULL` finds the most recent OTHER generation a worker actually claimed and ran, skipping past any enqueue-failures or claim-starved rows in between. Covered by a new database-backed test.
- **The generation-staleness proof itself had a gap: `started_at` age alone cannot tell an orphaned `'pending'` generation from one still legitimately queued through a sustained worker backlog.** Queue waits are unbounded — the exact reason `stale_pending_clauses` (a few lines above, for `IngestJob`) already requires `no_live_procrastinate_job()` before declaring a pending row abandoned. The VRT sweep's staleness check lacked that guard, so it could reconcile a generation whose task was still going to run, and when it eventually did, its own Phase-1 claim (`tasks_vrt.regenerate_vrt`) would fail against a generation the sweep had already flipped to `'failed'` — losing a valid regeneration. Split the check by status: `'running'` keeps the heartbeat-only proof (still sufficient on its own — and *necessary*, since a crashed worker can leave its `procrastinate_jobs` row reading `'doing'` until the separate stalled-queue sweep prunes it, so requiring "no live row" there would make a genuinely-dead running generation unsweepable until that unrelated sweep runs); `'pending'` now additionally requires no live Procrastinate row referencing it, correlated via the `generation_id` kwarg every dispatch site passes (mirrors `_ABANDONED_RUN_SQL`'s `args->>'job_id'` correlation for refresh runs). Covered by 2 new database-backed tests (a queued-but-unstarted generation with a live job is left alone; the same shape with no live job is reaped).
- **That live-job correlation was itself incomplete: it only recognized the modern delivery shape.** `tasks_vrt.regenerate_vrt`'s `generation_id` argument is optional precisely so a delivery queued by pre-upgrade code (no `generation_id` in its args at all) survives a rolling deploy — on execution it falls back to adopting `RasterAsset.current_generation_id`. The correlation as first written only matched on `generation_id`, so it was blind to a live legacy delivery, which could still be reaped out from under it. Added a second correlation form: a live `procrastinate_jobs` row with no `generation_id` counts as live for a generation if that generation is *currently* the dataset's `current_generation_id` — the exact row such a delivery will claim once it runs. `vrt_dataset_id` is a required (non-optional) argument on every delivery shape, so it's always available to correlate through. Kept deliberately conservative in the direction the finding specified: an ambiguous or legacy-shaped live row blocks the sweep rather than being read as absence of one. Covered by 2 more database-backed tests (a live legacy delivery protects its generation; a dataset with no live row of either shape still gets reaped).
- The `VrtGeneration` stale-UPDATE's `RETURNING` widened from `id` to `(id, vrt_dataset_id)` — the pairing the storage-key reconstruction needs, and one the asset-side UPDATE can't supply back since its own `current_generation_id` is nulled in the same statement.
- A stale doc comment on the regenerate endpoint claiming "no stale-cleanup sweep exists" (true before GAP-002, false and now doubly false after this PR) is corrected to point at the real reconciliation path.
- Fixed a CI-only failure in `test_tenant_staging_storage_keys.py::test_cleanup_and_retention_reaper_delete_only_tenant_key`, outside this PR's original targeted test set. **Determination: stale mock, not an unwired caller.** That test builds `fail_stale_jobs`'s session manually with a fixed-length `side_effect` list, counted for the VRT sweep's earlier 2-statement shape; splitting the `RasterAsset` UPDATE into two left the fixture one result short, so the purge-DELETE mock landed on the wrong statement and its `RETURNING` data never reached the reap step — `storage.delete` was never awaited. `fail_stale_jobs` already threads the purge's `RETURNING` through to `_reap_committed_staged_paths` correctly (proven independently by this PR's own coverage); this was purely a stale statement count in an unrelated test file's hand-built mock. Widened it to match, and the tenant-scoping property the test exists to prove (delete only the tenant-prefixed key) still holds on the post-commit reap path.

Scope guard respected (ADR-001 D8): this projects VRT state out and repairs it; it does not rewire refresh into the VRT lifecycle.

## Follow-up candidate (not implemented here)

The root wound this PR works around: `vrt_source_links` mutation and VRT regeneration are two separate transactions with no compensation between them. This sweep can only detect the drift and refuse to hide it — it cannot repair it (reconciling the link set back against the published artifact, or vice versa, would be active repair logic inside a reconciliation sweep, which is more machinery than a sweep should own). Making the two atomic or compensable is a real fix worth its own issue.

## Tests

- `backend/tests/test_vrt_stale_sweep_gap002.py` — updated for the split ready/degraded contract and the resolve-then-defer storage contract. New: restore-vs-degrade via compiled SQL, key resolution without any storage I/O, a storage-failure-never-masks-reconciliation test, a commit-failure test proving a dead attempt's storage objects survive a rolled-back reconciliation, and 4 real-database tests for the composition-preserving/changed discrimination.
- `backend/tests/test_ingest_job_attempt_fencing.py` — `test_vrt_generation_heartbeat_fences_stale_recovery` updated to the new status and 3-tuple return.
- `backend/tests/test_regenerate_vrt_integration.py` — new assertion [16]: `Dataset.last_refreshed_at` is stamped and equals `generation.completed_at`.
- `backend/tests/test_worker.py` — startup-recovery mocks updated for the sweep's widened result shape.
- `backend/tests/test_tenant_staging_storage_keys.py` — the CI-caught mock-count fix described above.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
set -a && source ../.env.test && set +a
uv run pytest tests/test_vrt_stale_sweep_gap002.py tests/test_regenerate_vrt_integration.py tests/test_ingest_job_attempt_fencing.py tests/test_dataset_source_freshness.py tests/test_worker.py tests/test_jobs_router.py -v
uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q
```

No schema/API changes: no Alembic migration, `openapi.json` unaffected (no response-shape change).

Closes #1267
