### PR TITLE
fix(frontend): map the STAC refresh refusal wordings to their taxonomy keys

### DIFF
--- a/frontend/src/lib/__tests__/error-map.test.ts
+++ b/frontend/src/lib/__tests__/error-map.test.ts
@@ -92,6 +92,48 @@ describe('API error localization boundary', () => {
     ).toEqual({ key: 'errors.refreshDatasetBusy' });
   });
 
+  it('maps the STAC door refusal wordings introduced by #1266 (#1332)', () => {
+    expect(
+      classifyApiError(
+        {
+          code: 'refresh_not_applicable',
+          message: 'This dataset was not imported from a STAC item, so there is no item to re-resolve.',
+        },
+        409,
+      ),
+    ).toEqual({ key: 'errors.refreshNotApplicable' });
+    expect(
+      classifyApiError(
+        {
+          code: 'origin_unavailable',
+          message:
+            "This dataset's source binding does not record the STAC item its asset was published in, so GeoLens cannot ask the catalog where that asset is now. Re-import it from the STAC catalog to record one.",
+        },
+        409,
+      ),
+    ).toEqual({ key: 'errors.refreshOriginUnavailable' });
+    expect(
+      classifyApiError(
+        {
+          code: 'origin_unavailable',
+          message:
+            "GeoLens cannot tell this dataset's STAC item from another one its stored URL might serve: the binding predates item-identity tracking and the catalog's item URLs carry no identity of their own. Re-import it from the STAC catalog to record one.",
+        },
+        409,
+      ),
+    ).toEqual({ key: 'errors.refreshOriginUnavailable' });
+    expect(
+      classifyApiError(
+        {
+          code: 'credential_not_applicable',
+          message:
+            'Refreshing a STAC dataset re-reads a public item document and needs no credential. Send the request without a token.',
+        },
+        422,
+      ),
+    ).toEqual({ key: 'errors.refreshCredentialNotApplicable' });
+  });
+
   it('interpolates the dynamic token policy for invalid_service_token without a static key', () => {
     const detail = {
       code: 'invalid_service_token',
@@ -111,6 +153,15 @@ describe('API error localization boundary', () => {
     expect(
       translateApiErrorDetail(
         "This dataset's stored source URL is not reachable: DNS resolved to a private address",
+        400,
+      ),
+    ).toBe(
+      "This dataset's stored source URL failed a safety check and can't be refreshed automatically. Contact an administrator.",
+    );
+    // fix(#1332): the STAC door words the same refusal around its item URL.
+    expect(
+      translateApiErrorDetail(
+        "This dataset's stored STAC item URL is not reachable: DNS resolved to a private address",
         400,
       ),
     ).toBe(

--- a/frontend/src/lib/error-map.ts
+++ b/frontend/src/lib/error-map.ts
@@ -112,6 +112,16 @@ const EXACT_ERROR_KEYS: Record<string, ApiErrorDescriptor['key']> = {
     'errors.refreshOriginChanged',
   'This dataset is backed by a registered table in this instance, which needs no service credential. Send the request without a token.':
     'errors.refreshCredentialNotApplicable',
+  // fix(#1332): the STAC door's wordings of the same taxonomy states,
+  // introduced by #1326 after this table was written.
+  'This dataset was not imported from a STAC item, so there is no item to re-resolve.':
+    'errors.refreshNotApplicable',
+  "This dataset's source binding does not record the STAC item its asset was published in, so GeoLens cannot ask the catalog where that asset is now. Re-import it from the STAC catalog to record one.":
+    'errors.refreshOriginUnavailable',
+  "GeoLens cannot tell this dataset's STAC item from another one its stored URL might serve: the binding predates item-identity tracking and the catalog's item URLs carry no identity of their own. Re-import it from the STAC catalog to record one.":
+    'errors.refreshOriginUnavailable',
+  'Refreshing a STAC dataset re-reads a public item document and needs no credential. Send the request without a token.':
+    'errors.refreshCredentialNotApplicable',
   'Refreshing a protected service needs a shared credential store so the token can reach the worker without being written to disk. Set REDIS_URL and try again.':
     'errors.refreshCredentialStoreUnavailable',
   'Could not stage the service credential for this refresh. Check that the credential store is reachable and try again.':
@@ -214,7 +224,8 @@ function descriptorForMessage(message: string, status: number): ApiErrorDescript
   // exception text after the colon, which is diagnostic detail (resolved IP,
   // blocked range) rather than something a non-admin reader should see.
   // Anchored on the fixed prefix only; the dynamic suffix is dropped.
-  if (/^This dataset's stored source URL is not reachable:/i.test(message)) {
+  // fix(#1332): the STAC door words the same refusal around its item URL.
+  if (/^This dataset's stored (?:source URL|STAC item URL) is not reachable:/i.test(message)) {
     return { key: 'errors.refreshSourceUrlBlocked' };
   }
 


### PR DESCRIPTION
## What

Adds the four STAC refresh-door refusal literals introduced by #1326 to the exact-text table in `frontend/src/lib/error-map.ts`, and widens the SSRF prefix regex to also match the STAC door's "stored STAC item URL is not reachable:" wording.

## Why

The error-map keys refusals by exact backend literal (the #1285 convention). #1326 added new STAC wordings without table entries, so dispatching a refresh on a STAC dataset whose binding predates item-identity tracking rendered the generic "The request conflicts with the resource's current state." instead of the mapped, actionable copy ("Re-import or re-register the source to fix this."). Every STAC dataset imported before this release refuses through exactly that path, so the generic fallback is the first thing an upgrading user sees. Found during Milestone 5 close-out live QA; see #1332 for the enumerated set.

## Impact

Frontend only. No API, schema, or config change. All five target locale keys already exist in en/es/fr/de `common.json` with origin-agnostic copy — no i18n change.

## Verification

- `cd frontend && npx vitest run src/lib/__tests__/error-map.test.ts` — 23 passed (new: one case per STAC literal + the STAC SSRF wording)
- `npm run lint`, `npm run typecheck` — clean

Closes #1332