### PR TITLE
chore(release): v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-08-10
+
+### Added
+
+- **Datasets can now be refreshed from their source.** A dataset imported
+  from a remote origin (an OGC/ArcGIS service, a STAC catalog, or a
+  registered PostGIS table) can be re-pulled in place from the Source panel,
+  the CLI (`geolens dataset refresh`), or `POST /datasets/{id}/refresh`.
+  Refresh runs are durable rows with admission control: one run per dataset
+  at a time, every attempt recorded with before/after counts and schema
+  drift, and the dataset keeps serving its current data until the new data
+  is ready (#1274, #1277, #1313, #1323, #1305).
+- **STAC refreshes re-resolve moved items and assets.** A refresh re-reads
+  the stored item document, follows the catalog to the asset's current
+  location, and falls back to a collection-scoped search when the item URL
+  itself is gone. Nothing is adopted unverified: the item must affirm the
+  identity the import recorded, and a binding that predates identity
+  tracking is refused with advice to re-import rather than guessed at.
+  Imports now capture the item pointer, collection, and asset key so
+  every future refresh has something to verify against (#1326).
+- **Source health and freshness are visible everywhere datasets are.**
+  STAC and service origins are probed for availability; dataset pages,
+  search summaries, and the MCP server now surface health, freshness
+  derived from the declared update frequency, and drift state, and the
+  read-only Source panel shows the origin, storage mode, safe source
+  pointer, and full refresh history (#1261, #1264, #1271, #1279, #1304,
+  #1278, #1280).
+- **A raster dataset's COG can be replaced in place** through the reupload
+  door, preserving the dataset's identity, maps, and shares while swapping
+  the underlying imagery (#1290).
+- **Opt-in least-privilege database runtime role.** Setting
+  `GEOLENS_RUNTIME_DB_ROLE` makes the API and worker connect under a role
+  that owns no DDL, as defense in depth for self-hosted deployments
+  (#1287).
+
+### Fixed
+
+- **VRT regeneration is visible and recoverable.** Generation timestamps
+  now project into `last_refreshed_at`, and a recovery sweep reconciles
+  regenerations whose worker died mid-flight instead of leaving them
+  stranded (#1322).
+- **STAC refresh refusals now explain themselves in the UI.** The refusal
+  wordings introduced by the STAC door were missing from the frontend's
+  error map, so a dataset imported before identity tracking showed a
+  generic conflict message instead of the re-import instruction (#1333).
+- **Duplicate-source detection keys on the canonical origin pair**, so a
+  different spelling of the same asset URL can no longer slip past the
+  guard or falsely block a distinct source (#1320).
+- **Bulk delete no longer returns raw exception text** to the client
+  (#1309).
+- **Local object-storage listings are contained to their prefix** (#1307).
+- **Stroke-only polygon styles render honest swatches** in the legend and
+  layer panel instead of filled squares (#1310).
+- **Generated SDK constructors keep a stable argument order.** The OpenAPI
+  snapshot now serializes schema properties in declaration order, so
+  regenerating an SDK cannot silently shift positional constructor
+  arguments again (#1263).
+
+### Security
+
+- **Dataset provenance is projected owner-or-admin.** Anonymous and
+  non-owner readers of a public dataset see the safe source pointer but
+  not the structured origin binding, and refresh-run history hides who
+  triggered each run (#1321).
+- **Titiler now uses scoped object-store credentials** instead of the
+  instance-wide MinIO/S3 identity (#1284).
+
+### Operations
+
+- **Protected service refreshes need a shared credential store.** Passing
+  a service token to a refresh requires `REDIS_URL` (Valkey/Redis) so the
+  credential can reach the worker without touching disk; deployments that
+  only refresh public sources need no change.
+
 ## [1.10.0] - 2026-08-07
 
 ### Security

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -630,7 +630,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.10.0"
+_FALLBACK_APP_VERSION = "1.11.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18360,7 +18360,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.10.0"
+    "version": "1.11.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.10.0"
+version = "1.11.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.10.0"
+version = "1.11.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.10.0"
+version = "1.11.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.10.0"
+version = "1.11.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.10.0
+package_version_override: 1.11.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.10.0"
+version = "1.11.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
## What

Version bump to 1.11.0 across all 19 version sites (`make bump`), plus the v1.11.0 CHANGELOG section for Milestone 5 (Sources & Refresh v1).

## Verification

- `make version-check`: all 19 sites agree on 1.11.0
- Pre-tag smoke pass on the base commit d2c43a20c: full ci.yml dispatch green (E2E, Accessibility, STAC conformance genuinely ran; the single AI-evals red was a live-provider flake, green on re-run), local `openapi-check`/`sdks-check`/`alembic-check` clean, live adversarial refresh-lifecycle pass on the dev stack.

Tag v1.11.0 will be cut on the merge commit after this lands.