### PR TITLE
fix(datasets): stop returning raw exception text from single delete

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -518,16 +518,24 @@ async def delete_dataset_endpoint(
                 "dependent_vrts": exc.dependents,
             },
         )
-    except ValueError as exc:
-        msg = str(exc)
-        if "not found" in msg.lower():
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=msg,
-            )
+    except DatasetTitleMismatchError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=msg,
+            detail=str(exc),
+        )
+    except ValueError as exc:
+        if str(exc) == "Dataset not found":
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Dataset not found",
+            )
+        logger.exception(
+            "Unexpected error during dataset delete",
+            dataset_id=str(dataset_id),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Dataset deletion failed unexpectedly",
         )
 
     await audit_emit(

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -2011,3 +2011,48 @@ class TestBulkDeleteDatasets:
             and record.get("dataset_id") == str(ds.id)
             for record in captured
         ), f"expected the exception to be logged server-side; got: {captured}"
+
+
+class TestSingleDeleteDataset:
+    """Tests for DELETE /datasets/{dataset_id}."""
+
+    async def test_unexpected_value_error_hides_detail(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        monkeypatch,
+    ):
+        """fix(#1317): unexpected delete errors do not reach the client."""
+        import structlog
+
+        from app.modules.catalog.datasets.api import router as datasets_router
+
+        user_id = await _get_user_id(test_db_session, "admin")
+        ds = await _create_dataset(
+            test_db_session, created_by=user_id, name="Single Delete Leak Check"
+        )
+
+        sentinel = "Invalid table name: secret_table_xyz"
+
+        async def _boom(db, dataset_id, confirm_title):
+            raise ValueError(sentinel)
+
+        monkeypatch.setattr(datasets_router, "delete_dataset", _boom)
+
+        with structlog.testing.capture_logs() as captured:
+            resp = await client.request(
+                "DELETE",
+                f"/datasets/{ds.id}",
+                json={"confirm_title": "Single Delete Leak Check"},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 500
+        assert sentinel not in resp.text
+        assert resp.json()["detail"] == "Dataset deletion failed unexpectedly"
+        assert any(
+            record.get("event") == "Unexpected error during dataset delete"
+            and record.get("dataset_id") == str(ds.id)
+            for record in captured
+        ), f"expected the exception to be logged server-side; got: {captured}"


### PR DESCRIPTION
## Summary

The single-dataset delete endpoint returned `str(exc)` for every `ValueError`
and identified not-found errors by searching the exception message. This could
expose internal details and report unexpected server failures as client errors.

- Catch `DatasetTitleMismatchError` explicitly and preserve its intended public
  400 response.
- Return the fixed `"Dataset not found"` detail for the deletion race as a 404.
- Log any other `ValueError` server-side and return a generic 500 response.
- Add regression coverage proving internal table information does not reach the
  HTTP response and the complete failure is still logged.

This mirrors the bulk-delete error handling introduced in #1309.

No schema or configuration changes.

Closes #1317

## Testing

- `uv run pytest tests/test_datasets.py::TestSingleDeleteDataset::test_unexpected_value_error_hides_detail -vv` — 1 passed
- `uv run pytest tests/test_layering.py -q` — 40 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed (940 files already formatted)