### PR TITLE
fix(ingest): stamp file_hash on first-ingest raster origin

### DIFF
--- a/backend/app/processing/ingest/tasks_raster_common.py
+++ b/backend/app/processing/ingest/tasks_raster_common.py
@@ -165,7 +165,13 @@ async def create_raster_dataset(
     # feat(#1218): a raster dataset IS the COG; the pre-conversion upload is a
     # transient input, so the origin is the uploaded file and there is no
     # remote URI to point at (ADR-002 Decision 7).
-    set_dataset_origin(dataset, "upload", filename=source_filename)
+    # fix(#1294): file_hash was missing here, unlike the replace tail's
+    # equivalent call in tasks_raster_swap.py — both go through this same
+    # set_dataset_origin authority, so passing the sha256 the caller already
+    # computed for `source_sha256` is the whole fix.
+    set_dataset_origin(
+        dataset, "upload", filename=source_filename, file_hash=source_sha256
+    )
     session.add(dataset)
     await session.flush()
 

--- a/backend/tests/test_raster_ingest.py
+++ b/backend/tests/test_raster_ingest.py
@@ -590,3 +590,73 @@ class TestRasterDistributionAndQuicklook:
         assert f"{dataset_id}" in asset.quicklook_256_uri
         assert "quicklook_256.png" in asset.quicklook_256_uri
         assert "quicklook_512.png" in asset.quicklook_512_uri
+
+
+# ---------------------------------------------------------------------------
+# #1294: first-ingest origin must carry file_hash, like the replace tail's
+# ---------------------------------------------------------------------------
+
+
+class TestFirstIngestOriginFileHash:
+    @pytest.mark.anyio
+    async def test_create_raster_dataset_stamps_origin_file_hash(
+        self, test_db_session
+    ) -> None:
+        """create_raster_dataset must record source_sha256 on origin_ref.
+
+        ADR-002 Decision 7 leans on this provenance hash to justify deleting
+        the pre-conversion source after a sample-preserving conversion. The
+        replace tail's equivalent call (_write_swapped_fields in
+        tasks_raster_swap.py) already passes file_hash=source_sha256 to the
+        same set_dataset_origin authority; first-ingest silently omitted it,
+        even though source_sha256 was already a required argument here.
+        """
+        from sqlalchemy import delete, select
+
+        from app.modules.auth.models import User
+        from app.modules.catalog.datasets.domain.models import Dataset, Record
+        from app.processing.ingest.tasks_raster import create_raster_dataset
+
+        admin_id = (
+            await test_db_session.execute(
+                select(User.id).where(User.username == "admin")
+            )
+        ).scalar_one()
+        source_sha256 = "a" * 64
+
+        record, dataset, raster_asset = await create_raster_dataset(
+            test_db_session,
+            meta={
+                "driver": "GTiff",
+                "epsg": 4326,
+                "band_count": 1,
+                "dtype": "uint8",
+                "width": 64,
+                "height": 64,
+            },
+            source_sha256=source_sha256,
+            asset_sha256="b" * 64,
+            cog_status="verified",
+            cog_size=2048,
+            source_filename="first-ingest-1294.tif",
+            created_by=admin_id,
+            title="First Ingest File Hash 1294",
+            summary=None,
+            visibility="private",
+            record_status="published",
+        )
+        await test_db_session.commit()
+
+        try:
+            await test_db_session.refresh(dataset)
+            # Unaffected by #1294 — the RasterAsset column already carried
+            # this. What was missing is the origin_ref pointer.
+            assert raster_asset.source_sha256 == source_sha256
+            assert (dataset.origin_ref or {}).get("kind") == "upload"
+            assert (dataset.origin_ref or {}).get("file_hash") == source_sha256
+        finally:
+            await test_db_session.execute(
+                delete(Dataset).where(Dataset.id == dataset.id)
+            )
+            await test_db_session.execute(delete(Record).where(Record.id == record.id))
+            await test_db_session.commit()


### PR DESCRIPTION
## What / why

`create_raster_dataset` already computed `source_sha256` (it hashes the raster's own `RasterAsset.source_sha256` column) but never forwarded it to `set_dataset_origin`, so a raster dataset's `origin_ref.file_hash` was absent until its first replace. The replace tail (`_write_swapped_fields` in `tasks_raster_swap.py`) already passes `file_hash=source_sha256` through the same `set_dataset_origin` authority — first-ingest now does the same.

ADR-002 Decision 7 leans on this provenance hash as part of the justification for deleting the pre-conversion source after a sample-preserving conversion, so first-ingest rasters were missing that provenance.

The fix is one line: forwarding a value `create_raster_dataset` already receives as a parameter into the `set_dataset_origin` call it already makes. Both tails now derive/stamp the hash through the same shared helper (`app/platform/dataset_origin.set_dataset_origin`), so they cannot drift by construction — no new hashing pass or new helper needed.

## Schema / API / config impact

None. `origin_ref` is a JSONB column and `file_hash` is already an allowed key for the `upload` origin kind (used by the replace path since #1218/#1290). No migration required.

## Verification

- `cd backend && uv run ruff check .` — pass
- `cd backend && uv run ruff format --check .` — pass
- Failing-first test added: `tests/test_raster_ingest.py::TestFirstIngestOriginFileHash::test_create_raster_dataset_stamps_origin_file_hash` — confirmed failing against pre-fix code (stashed the fix and re-ran), passing after the fix.
- `uv run pytest tests/test_raster_ingest.py -v` — 21 passed
- `uv run pytest tests/test_raster_replace_1221.py tests/test_manifest_apply_roundtrip.py tests/test_manifest_apply_service.py -q` — 148 passed
- `uv run pytest tests/test_layering.py -q` — 40 passed

Closes #1294