### PR TITLE
feat(frontend): expose raster replace in the reupload dialog

### DIFF
--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -87,6 +87,11 @@ interface ReuploadDialogProps {
   dataset: DatasetResponse;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** fix(#1362 codex r1): called once a raster replacement job completes, so
+   * the caller can force its hero map to remount and pick up the new tiles —
+   * the raster tile URL is a fixed per-dataset route, so nothing else in the
+   * app tells MapLibre's already-added raster source to reload. */
+  onReplaceComplete?: () => void;
 }
 
 function humanizeLayerName(layer: LayerInfo): string {
@@ -119,6 +124,7 @@ export function ReuploadDialog({
   dataset,
   open,
   onOpenChange,
+  onReplaceComplete,
 }: ReuploadDialogProps) {
   const { t } = useTranslation('dataset');
   // #1289: raster datasets now reach this dialog (DatasetPage relaxes its
@@ -189,6 +195,16 @@ export function ReuploadDialog({
       });
       queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
+      // fix(#1362 codex r1): a raster's tile URL is a fixed per-dataset route,
+      // not versioned by content — invalidating the dataset query alone
+      // doesn't touch the hero map's already-added MapLibre raster source,
+      // so it keeps serving the old tiles until something remounts it. The
+      // vector path doesn't need this: its tiles are cache-busted through
+      // `tileVersion` (dataset.updated_at), which this same invalidation
+      // already refreshes.
+      if (isRaster) {
+        onReplaceComplete?.();
+      }
       setStep('complete');
       toast.success(t('reupload.toastSuccess'));
     } else if (jobData.status === 'failed') {
@@ -200,7 +216,7 @@ export function ReuploadDialog({
       );
       setStep('error');
     }
-  }, [step, jobData, dataset.id, queryClient, sourceType, appendRetryGuidance, t]);
+  }, [step, jobData, dataset.id, queryClient, sourceType, isRaster, onReplaceComplete, appendRetryGuidance, t]);
 
   const handleSelectSource = useCallback((nextSource: ReuploadSourceType) => {
     setSourceType(nextSource);
@@ -561,11 +577,19 @@ export function ReuploadDialog({
         {step === 'source-select' && (
           <div className="space-y-4" data-testid="reupload-source-selector">
             <p className="text-sm text-muted-foreground">
-              {t('reupload.sourceSelector.helpText', {
-                defaultValue: 'Select whether to re-upload from a local file or a service URL.',
-              })}
+              {/* fix(#1362 codex r1): raster has no service path — nothing
+                  fetches a GeoTIFF from a feature service, and the backend
+                  refuses a raster service-preview outright — so raster
+                  never sees the Service URL option below. */}
+              {isRaster
+                ? t('reupload.raster.sourceSelectHelpText', {
+                  defaultValue: 'Select a replacement raster file.',
+                })
+                : t('reupload.sourceSelector.helpText', {
+                  defaultValue: 'Select whether to re-upload from a local file or a service URL.',
+                })}
             </p>
-            <div className="grid gap-2 sm:grid-cols-2">
+            <div className={cn('grid gap-2', !isRaster && 'sm:grid-cols-2')}>
               <Button
                 type="button"
                 variant="outline"
@@ -574,14 +598,16 @@ export function ReuploadDialog({
                 <Upload className="me-2 h-4 w-4" />
                 {t('reupload.sourceSelector.file', { defaultValue: 'File' })}
               </Button>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => handleSelectSource('service_url')}
-              >
-                <Globe className="me-2 h-4 w-4" />
-                {t('reupload.sourceSelector.service', { defaultValue: 'Service URL' })}
-              </Button>
+              {!isRaster && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleSelectSource('service_url')}
+                >
+                  <Globe className="me-2 h-4 w-4" />
+                  {t('reupload.sourceSelector.service', { defaultValue: 'Service URL' })}
+                </Button>
+              )}
             </div>
           </div>
         )}
@@ -945,9 +971,12 @@ export function ReuploadDialog({
                 : t('reupload.processingMessage')}
             </p>
             <p className="text-xs text-muted-foreground">
+              {/* fix(#1362 codex r1): job tracking (useJobStatus polling)
+                  stops once the dialog closes and steps away from
+                  'tracking', so this must not promise closing is safe. */}
               {isRaster
                 ? t('reupload.raster.trackingBackground', {
-                  defaultValue: 'This can take a few minutes. You can close this dialog — the map updates automatically once the conversion finishes.',
+                  defaultValue: 'This can take a few minutes. Keep this dialog open until the conversion finishes.',
                 })
                 : t('reupload.trackingBackground')}
             </p>

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -189,24 +189,35 @@ export function ReuploadDialog({
     if (step !== 'tracking' || !jobData) return;
 
     if (jobData.status === 'complete') {
-      queryClient.invalidateQueries({ queryKey: queryKeys.datasets.detail(dataset.id) });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.datasets.versionsPrefix(dataset.id),
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.search.all });
-      // fix(#1362 codex r1): a raster's tile URL is a fixed per-dataset route,
-      // not versioned by content — invalidating the dataset query alone
-      // doesn't touch the hero map's already-added MapLibre raster source,
-      // so it keeps serving the old tiles until something remounts it. The
-      // vector path doesn't need this: its tiles are cache-busted through
-      // `tileVersion` (dataset.updated_at), which this same invalidation
-      // already refreshes.
-      if (isRaster) {
-        onReplaceComplete?.();
-      }
-      setStep('complete');
-      toast.success(t('reupload.toastSuccess'));
+      // fix(#1362 codex r2): invalidateQueries only SCHEDULES a refetch —
+      // firing onReplaceComplete without waiting for it raced the remount
+      // against the still-in-flight dataset-detail refetch, so a replacement
+      // with a different extent could remount using the OLD bbox (DatasetMap
+      // only fits the new one on an explicit zoom-to-extent, never on prop
+      // change). Await the detail refetch first so the remount reads fresh
+      // bbox/tile_url/updated_at off the query cache.
+      void (async () => {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: queryKeys.datasets.detail(dataset.id) }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.datasets.versionsPrefix(dataset.id),
+          }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.search.all }),
+        ]);
+        // fix(#1362 codex r1): a raster's tile URL is a fixed per-dataset
+        // route, not versioned by content — invalidating the dataset query
+        // alone doesn't touch the hero map's already-added MapLibre raster
+        // source, so it keeps serving the old tiles until something remounts
+        // it. The vector path doesn't need this: its tiles are cache-busted
+        // through `tileVersion` (dataset.updated_at), which this same
+        // invalidation already refreshes.
+        if (isRaster) {
+          onReplaceComplete?.();
+        }
+        setStep('complete');
+        toast.success(t('reupload.toastSuccess'));
+      })();
     } else if (jobData.status === 'failed') {
       const message = jobData.error_message ?? t('reupload.jobFailed');
       setError(

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -189,6 +189,15 @@ export function ReuploadDialog({
     if (step !== 'tracking' || !jobData) return;
 
     if (jobData.status === 'complete') {
+      // fix(#1362 codex r3): the await below leaves this continuation
+      // in flight across a render where `step`/`jobId` can change under it —
+      // closing the dialog (resetState) or starting a second reupload before
+      // the first's invalidation settles must not let this stale run apply
+      // its 'complete' transition on top of whatever is current. `cancelled`
+      // is flipped by the effect cleanup, which fires on any dependency
+      // change (step leaving 'tracking' included) before this branch's next
+      // invocation runs.
+      let cancelled = false;
       // fix(#1362 codex r2): invalidateQueries only SCHEDULES a refetch —
       // firing onReplaceComplete without waiting for it raced the remount
       // against the still-in-flight dataset-detail refetch, so a replacement
@@ -205,6 +214,7 @@ export function ReuploadDialog({
           queryClient.invalidateQueries({ queryKey: queryKeys.datasets.all }),
           queryClient.invalidateQueries({ queryKey: queryKeys.search.all }),
         ]);
+        if (cancelled) return;
         // fix(#1362 codex r1): a raster's tile URL is a fixed per-dataset
         // route, not versioned by content — invalidating the dataset query
         // alone doesn't touch the hero map's already-added MapLibre raster
@@ -218,6 +228,9 @@ export function ReuploadDialog({
         setStep('complete');
         toast.success(t('reupload.toastSuccess'));
       })();
+      return () => {
+        cancelled = true;
+      };
     } else if (jobData.status === 'failed') {
       const message = jobData.error_message ?? t('reupload.jobFailed');
       setError(

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -74,7 +74,14 @@ const AUTH_ERROR_HINTS = [
   'auth',
 ];
 
-const UNSUPPORTED_REUPLOAD_EXTENSIONS = new Set(['.tif', '.tiff', '.vrt']);
+// VRT datasets never reach this dialog (DatasetPage keeps them on the
+// regenerate flow) and no reupload source produces a .vrt, so it stays
+// excluded from every reupload context as a defensive floor.
+const VRT_EXTENSION = '.vrt';
+// #1289: raster reupload accepts only raster source formats; vector/table
+// reupload accepts everything the backend allows except raster/VRT formats
+// (rasters go through the branch below, VRTs through the regenerate flow).
+const RASTER_REUPLOAD_EXTENSIONS = new Set(['.tif', '.tiff']);
 
 interface ReuploadDialogProps {
   dataset: DatasetResponse;
@@ -114,6 +121,10 @@ export function ReuploadDialog({
   onOpenChange,
 }: ReuploadDialogProps) {
   const { t } = useTranslation('dataset');
+  // #1289: raster datasets now reach this dialog (DatasetPage relaxes its
+  // gate to canEdit && !isVrt); this flag drives the upload -> commit
+  // shortcut below and the raster-specific copy in the preview/tracking steps.
+  const isRaster = dataset.record_type === 'raster_dataset';
   const [step, setStep] = useState<ReuploadStep>('source-select');
   const [sourceType, setSourceType] = useState<ReuploadSourceType | null>(null);
   const [jobId, setJobId] = useState<string | null>(null);
@@ -223,6 +234,15 @@ export function ReuploadDialog({
           });
         }
         setJobId(uploadResult.job_id);
+
+        // #1289: raster has no schema-preview step — the preview endpoint
+        // returns 400 for raster by design (nothing for ogrinfo to diff a
+        // COG against). Skip straight to the confirm gate.
+        if (isRaster) {
+          setStep('preview');
+          return;
+        }
+
         const previewResult = await previewMutation.mutateAsync({
           datasetId: dataset.id,
           jobId: uploadResult.job_id,
@@ -257,7 +277,7 @@ export function ReuploadDialog({
         setStep('error');
       }
     },
-    [dataset.id, uploadMutation, previewMutation, uploadConfig?.presigned_uploads, t],
+    [dataset.id, isRaster, uploadMutation, previewMutation, uploadConfig?.presigned_uploads, t],
   );
 
   const handleServiceConnect = useCallback(
@@ -429,12 +449,16 @@ export function ReuploadDialog({
     () => uploadConfig?.allowed_extensions
       ?.split(',')
       .map((extension) => extension.trim())
-      .filter(
-        (extension) =>
-          Boolean(extension) &&
-          !UNSUPPORTED_REUPLOAD_EXTENSIONS.has(extension.toLowerCase()),
-      ),
-    [uploadConfig?.allowed_extensions],
+      .filter((extension) => {
+        if (!extension) return false;
+        const normalized = extension.toLowerCase();
+        if (normalized === VRT_EXTENSION) return false;
+        // #1289: raster reupload offers only raster formats; every other
+        // reupload (vector/table) offers everything except raster/VRT.
+        const isRasterExtension = RASTER_REUPLOAD_EXTENSIONS.has(normalized);
+        return isRaster ? isRasterExtension : !isRasterExtension;
+      }),
+    [uploadConfig?.allowed_extensions, isRaster],
   );
   const reuploadAccept = useMemo(
     () => reuploadExtensions ? buildAcceptMap(reuploadExtensions) : undefined,
@@ -491,9 +515,19 @@ export function ReuploadDialog({
     previewing: t('reupload.service.previewing', {
       defaultValue: 'Preparing re-upload preview...',
     }),
-    preview: t('reupload.descriptions.preview'),
+    // #1289: raster has no schema diff to review, so the preview/tracking
+    // copy swaps to describe the COG conversion instead.
+    preview: isRaster
+      ? t('reupload.raster.previewDescription', {
+        defaultValue: 'Confirm to replace the raster.',
+      })
+      : t('reupload.descriptions.preview'),
     committing: t('reupload.descriptions.committing'),
-    tracking: t('reupload.descriptions.tracking'),
+    tracking: isRaster
+      ? t('reupload.raster.trackingDescription', {
+        defaultValue: 'Converting to Cloud Optimized GeoTIFF. This can take several minutes.',
+      })
+      : t('reupload.descriptions.tracking'),
     complete: t('reupload.descriptions.complete'),
     error: t('reupload.descriptions.error'),
   };
@@ -821,7 +855,10 @@ export function ReuploadDialog({
           </div>
         )}
 
-        {step === 'preview' && preview && (
+        {/* #1289: raster has no preview payload to render (schema-preview is
+            skipped in handleUpload above), so this step renders on isRaster
+            alone rather than waiting for `preview`. */}
+        {step === 'preview' && (preview || isRaster) && (
           <div className="space-y-4">
             {/* GPKG-02 Phase 1058: file-path multi-layer shows File + Layer lines; single-layer or service shows one line */}
             {sourceType === 'file' && selectedFileLayer !== null ? (
@@ -841,23 +878,36 @@ export function ReuploadDialog({
                 <span className="font-medium">{previewSourceValue}</span>
               </p>
             )}
-            {/* GPKG-02 Phase 1058: schema-change advisory banner (informational, distinct from hasWarning) */}
-            {hasSchemaChange && (
-              <div
-                className="rounded-md border border-warning/30 bg-warning/10 p-3 text-sm"
-                data-testid="schema-change-advisory"
+            {isRaster ? (
+              <p
+                className="rounded-md border border-muted-foreground/20 bg-muted/40 p-3 text-sm text-muted-foreground"
+                data-testid="raster-preview-note"
               >
-                {t('reupload.schemaChangeAdvisory', {
-                  added: preview.schema_diff.columns_added.length,
-                  removed: preview.schema_diff.columns_removed.length,
+                {t('reupload.raster.previewNote', {
+                  defaultValue: 'Raster re-uploads skip schema comparison. Confirming starts a Cloud Optimized GeoTIFF conversion, which can take several minutes.',
                 })}
-              </div>
-            )}
-            <SchemaDiffView schemaDiff={preview.schema_diff} />
-            {hasWarning && (
-              <p className="text-sm text-warning">
-                {t('reupload.warningSchemaChanges')}
               </p>
+            ) : preview && (
+              <>
+                {/* GPKG-02 Phase 1058: schema-change advisory banner (informational, distinct from hasWarning) */}
+                {hasSchemaChange && (
+                  <div
+                    className="rounded-md border border-warning/30 bg-warning/10 p-3 text-sm"
+                    data-testid="schema-change-advisory"
+                  >
+                    {t('reupload.schemaChangeAdvisory', {
+                      added: preview.schema_diff.columns_added.length,
+                      removed: preview.schema_diff.columns_removed.length,
+                    })}
+                  </div>
+                )}
+                <SchemaDiffView schemaDiff={preview.schema_diff} />
+                {hasWarning && (
+                  <p className="text-sm text-warning">
+                    {t('reupload.warningSchemaChanges')}
+                  </p>
+                )}
+              </>
             )}
             <DialogFooter>
               <Button
@@ -886,10 +936,20 @@ export function ReuploadDialog({
           <div className="flex flex-col items-center justify-center gap-3 py-8">
             <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
             <p className="text-sm text-muted-foreground">
-              {t('reupload.processingMessage')}
+              {/* #1289: COG conversion runs on the raster queue and takes
+                  minutes, not the seconds a vector reupload takes. */}
+              {isRaster
+                ? t('reupload.raster.processingMessage', {
+                  defaultValue: 'Converting to Cloud Optimized GeoTIFF...',
+                })
+                : t('reupload.processingMessage')}
             </p>
             <p className="text-xs text-muted-foreground">
-              {t('reupload.trackingBackground')}
+              {isRaster
+                ? t('reupload.raster.trackingBackground', {
+                  defaultValue: 'This can take a few minutes. You can close this dialog — the map updates automatically once the conversion finishes.',
+                })
+                : t('reupload.trackingBackground')}
             </p>
           </div>
         )}

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -857,6 +857,16 @@ describe('ReuploadDialog raster reupload', () => {
     } as unknown as ReturnType<typeof useJobStatus>);
   });
 
+  // codex(#1362 r1): raster has no service path — the backend refuses a
+  // raster service-preview outright, so the source selector must not offer it.
+  it('shows only the File source option for raster datasets', () => {
+    renderRasterDialog();
+
+    expect(screen.getByTestId('reupload-source-selector')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'File' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Service URL' })).not.toBeInTheDocument();
+  });
+
   it('advertises only raster formats for raster reupload', async () => {
     const user = userEvent.setup();
     renderRasterDialog();
@@ -926,5 +936,60 @@ describe('ReuploadDialog raster reupload', () => {
     expect(
       screen.getByText(/This can take a few minutes/),
     ).toBeInTheDocument();
+  });
+
+  // codex(#1362 r1): the raster hero map's MapLibre source is added once and
+  // never re-added on prop change (the tile URL is a fixed per-dataset route,
+  // not content-versioned), so the caller needs an explicit signal to remount
+  // it once the replacement job completes.
+  it('calls onReplaceComplete once the replacement job completes', async () => {
+    const user = userEvent.setup();
+    const onReplaceComplete = vi.fn();
+    mockUseJobStatus.mockReturnValue({
+      data: { status: 'complete' },
+    } as unknown as ReturnType<typeof useJobStatus>);
+
+    render(
+      <ReuploadDialog
+        dataset={makeRasterDataset()}
+        open
+        onOpenChange={vi.fn()}
+        onReplaceComplete={onReplaceComplete}
+      />,
+    );
+
+    await openFileSource(user);
+    await dropFile('ortho.tif');
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await waitFor(() => {
+      expect(onReplaceComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not call onReplaceComplete while the job is still pending', async () => {
+    const user = userEvent.setup();
+    const onReplaceComplete = vi.fn();
+    mockUseJobStatus.mockReturnValue({
+      data: { status: 'pending' },
+    } as unknown as ReturnType<typeof useJobStatus>);
+
+    render(
+      <ReuploadDialog
+        dataset={makeRasterDataset()}
+        open
+        onOpenChange={vi.fn()}
+        onReplaceComplete={onReplaceComplete}
+      />,
+    );
+
+    await openFileSource(user);
+    await dropFile('ortho.tif');
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await screen.findByText('Converting to Cloud Optimized GeoTIFF...');
+    expect(onReplaceComplete).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -1,5 +1,6 @@
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, render as rtlRender, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@/test/test-utils';
 import {
   useReuploadDataset,
@@ -991,5 +992,61 @@ describe('ReuploadDialog raster reupload', () => {
 
     await screen.findByText('Converting to Cloud Optimized GeoTIFF...');
     expect(onReplaceComplete).not.toHaveBeenCalled();
+  });
+
+  // codex(#1362 r2): invalidateQueries only SCHEDULES a refetch — firing
+  // onReplaceComplete without waiting for it raced the remount against the
+  // still-in-flight dataset-detail refetch, so a replacement with a
+  // different extent could remount using the OLD bbox. Uses a real
+  // QueryClient (spied, not mocked away) so the fix's actual await matters.
+  it('waits for the dataset invalidation to settle before firing onReplaceComplete', async () => {
+    const user = userEvent.setup();
+    const onReplaceComplete = vi.fn();
+    mockUseJobStatus.mockReturnValue({
+      data: { status: 'complete' },
+    } as unknown as ReturnType<typeof useJobStatus>);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const pendingResolvers: Array<() => void> = [];
+    vi.spyOn(queryClient, 'invalidateQueries').mockImplementation(
+      () => new Promise<void>((resolve) => { pendingResolvers.push(resolve); }),
+    );
+
+    rtlRender(
+      <QueryClientProvider client={queryClient}>
+        <ReuploadDialog
+          dataset={makeRasterDataset()}
+          open
+          onOpenChange={vi.fn()}
+          onReplaceComplete={onReplaceComplete}
+        />
+      </QueryClientProvider>,
+    );
+
+    await openFileSource(user);
+    await dropFile('ortho.tif');
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    // The invalidations were kicked off but left deliberately unresolved —
+    // onReplaceComplete (and the 'complete' step transition) must not have
+    // fired yet.
+    await waitFor(() => {
+      expect(pendingResolvers.length).toBeGreaterThan(0);
+    });
+    expect(onReplaceComplete).not.toHaveBeenCalled();
+    expect(screen.queryByText('Re-upload complete!')).not.toBeInTheDocument();
+
+    // Now let the invalidations settle.
+    await act(async () => {
+      pendingResolvers.forEach((resolve) => resolve());
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(onReplaceComplete).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -114,6 +114,22 @@ function makeDataset(): DatasetResponse {
   };
 }
 
+// #1289: raster reupload fixture — upload -> commit, no schema preview.
+function makeRasterDataset(): DatasetResponse {
+  return {
+    ...makeDataset(),
+    id: 'dataset-raster-1',
+    table_name: 'ortho',
+    title: 'Orthophoto',
+    source_format: 'GeoTIFF',
+    source_filename: 'ortho.tif',
+    record_type: 'raster_dataset',
+    raster: {
+      tile_url: '/raster-tiles/dataset-raster-1/{z}/{x}/{y}.png',
+    } as DatasetResponse['raster'],
+  };
+}
+
 function makeProbeResponse(): ProbeResponse {
   return {
     service_type: 'WFS',
@@ -175,6 +191,16 @@ function renderDialog() {
   render(
     <ReuploadDialog
       dataset={makeDataset()}
+      open
+      onOpenChange={vi.fn()}
+    />,
+  );
+}
+
+function renderRasterDialog() {
+  render(
+    <ReuploadDialog
+      dataset={makeRasterDataset()}
       open
       onOpenChange={vi.fn()}
     />,
@@ -789,5 +815,116 @@ describe('ReuploadDialog file path multi-layer', () => {
 
     // Advisory banner should NOT be rendered
     expect(screen.queryByTestId('schema-change-advisory')).not.toBeInTheDocument();
+  });
+});
+
+// #1289: raster reupload — upload -> commit, skipping the vector
+// schema-preview step (the preview endpoint 400s for raster by design).
+describe('ReuploadDialog raster reupload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dropHandler = null;
+
+    uploadMutateAsync.mockResolvedValue({ job_id: 'raster-job' });
+    commitMutateAsync.mockResolvedValue({
+      job_id: 'commit-job',
+      status: 'pending',
+      message: 'queued',
+    });
+
+    mockUseReuploadDataset.mockReturnValue({
+      mutateAsync: uploadMutateAsync,
+    } as unknown as ReturnType<typeof useReuploadDataset>);
+    mockUseReuploadPreview.mockReturnValue({
+      mutateAsync: previewMutateAsync,
+    } as unknown as ReturnType<typeof useReuploadPreview>);
+    mockUseReuploadServicePreview.mockReturnValue({
+      mutateAsync: servicePreviewMutateAsync,
+    } as unknown as ReturnType<typeof useReuploadServicePreview>);
+    mockUseReuploadCommit.mockReturnValue({
+      mutateAsync: commitMutateAsync,
+    } as unknown as ReturnType<typeof useReuploadCommit>);
+    mockUseUploadConfig.mockReturnValue({
+      data: {
+        presigned_uploads: false,
+        presigned_threshold_bytes: 10485760,
+        max_file_size_bytes: 524288000,
+        allowed_extensions: '.zip,.gpkg,.geojson,.json,.csv,.tif,.tiff,.xlsx,.xls',
+      },
+    } as unknown as ReturnType<typeof useUploadConfig>);
+    mockUseJobStatus.mockReturnValue({
+      data: null,
+    } as unknown as ReturnType<typeof useJobStatus>);
+  });
+
+  it('advertises only raster formats for raster reupload', async () => {
+    const user = userEvent.setup();
+    renderRasterDialog();
+
+    await openFileSource(user);
+
+    // deriveFormatBadges collapses the .tif/.tiff alias pair into one badge.
+    expect(screen.getByText('.tif')).toBeInTheDocument();
+    expect(screen.queryByText('.tiff')).not.toBeInTheDocument();
+    expect(screen.queryByText('.geojson')).not.toBeInTheDocument();
+    expect(screen.queryByText('.gpkg')).not.toBeInTheDocument();
+    expect(screen.queryByText('.vrt')).not.toBeInTheDocument();
+  });
+
+  it('skips the schema-preview call and lands on the confirm gate', async () => {
+    const user = userEvent.setup();
+    renderRasterDialog();
+
+    await openFileSource(user);
+    await dropFile('ortho.tif');
+
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+
+    // The preview endpoint 400s for raster by design — the raster branch
+    // must never call it.
+    expect(previewMutateAsync).not.toHaveBeenCalled();
+    expect(servicePreviewMutateAsync).not.toHaveBeenCalled();
+    // No schema diff to show for raster.
+    expect(screen.queryByTestId('schema-change-advisory')).not.toBeInTheDocument();
+    expect(screen.getByTestId('raster-preview-note')).toBeInTheDocument();
+    expect(screen.getByText(/ortho\.tif/)).toBeInTheDocument();
+  });
+
+  it('commits using the uploaded job id when confirmed', async () => {
+    const user = userEvent.setup();
+    renderRasterDialog();
+
+    await openFileSource(user);
+    await dropFile('ortho.tif');
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await waitFor(() => {
+      expect(commitMutateAsync).toHaveBeenCalled();
+    });
+    const payload = commitMutateAsync.mock.calls[0][0];
+    expect(payload.datasetId).toBe('dataset-raster-1');
+    expect(payload.jobId).toBe('raster-job');
+    expect(payload.token).toBeUndefined();
+    expect(payload.layerName).toBeUndefined();
+  });
+
+  it('shows COG-conversion progress copy while tracking the background job', async () => {
+    const user = userEvent.setup();
+    mockUseJobStatus.mockReturnValue({
+      data: { status: 'pending' },
+    } as unknown as ReturnType<typeof useJobStatus>);
+    renderRasterDialog();
+
+    await openFileSource(user);
+    await dropFile('ortho.tif');
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await screen.findByText('Converting to Cloud Optimized GeoTIFF...');
+    expect(
+      screen.getByText(/This can take a few minutes/),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -1049,4 +1049,60 @@ describe('ReuploadDialog raster reupload', () => {
       expect(onReplaceComplete).toHaveBeenCalledTimes(1);
     });
   });
+
+  // codex(#1362 r3): the await above leaves the completion continuation in
+  // flight across renders — closing the dialog before it settles must not
+  // let it apply setStep('complete')/onReplaceComplete on top of the reset
+  // state (or, worse, on top of a second reupload started in the meantime).
+  it('ignores a stale completion once the dialog resets mid-invalidation', async () => {
+    const user = userEvent.setup();
+    const onReplaceComplete = vi.fn();
+    mockUseJobStatus.mockReturnValue({
+      data: { status: 'complete' },
+    } as unknown as ReturnType<typeof useJobStatus>);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const pendingResolvers: Array<() => void> = [];
+    vi.spyOn(queryClient, 'invalidateQueries').mockImplementation(
+      () => new Promise<void>((resolve) => { pendingResolvers.push(resolve); }),
+    );
+
+    rtlRender(
+      <QueryClientProvider client={queryClient}>
+        <ReuploadDialog
+          dataset={makeRasterDataset()}
+          open
+          onOpenChange={vi.fn()}
+          onReplaceComplete={onReplaceComplete}
+        />
+      </QueryClientProvider>,
+    );
+
+    await openFileSource(user);
+    await dropFile('ortho.tif');
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    await waitFor(() => {
+      expect(pendingResolvers.length).toBeGreaterThan(0);
+    });
+
+    // User closes the dialog (its own X button) while the invalidation is
+    // still in flight — this resets `step` out from under the pending run.
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await screen.findByTestId('reupload-source-selector');
+
+    // Let the stale invalidation settle now.
+    await act(async () => {
+      pendingResolvers.forEach((resolve) => resolve());
+      await Promise.resolve();
+    });
+
+    expect(onReplaceComplete).not.toHaveBeenCalled();
+    expect(screen.queryByText('Re-upload complete!')).not.toBeInTheDocument();
+    // Reset really did win: still on the reset source-selector screen.
+    expect(screen.getByTestId('reupload-source-selector')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/dataset/hooks/__tests__/use-hero-state.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-hero-state.test.ts
@@ -114,6 +114,47 @@ describe('useHeroState', () => {
     expect(result.current.mapKey).toBe(1);
   });
 
+  // #1362 codex r4: a completed replacement is not a failed-tile retry —
+  // routing it through handleRetry would spend the 3-attempt manual-retry
+  // budget on a SUCCESS, leaving a later genuine tile failure unretryable.
+  it('handleReplaceComplete resets to loading, bumps mapKey, and does NOT spend the retry budget', () => {
+    const { result } = renderHook(() =>
+      useHeroState({ datasetId: 'd1', recordType: 'raster_dataset', hasTileUrl: true }),
+    );
+
+    act(() => {
+      result.current.handleReplaceComplete();
+    });
+
+    expect(result.current.heroState).toBe('loading');
+    expect(result.current.mapKey).toBe(1);
+    expect(result.current.retryCount).toBe(0);
+  });
+
+  it('handleReplaceComplete resets an already-spent retry budget instead of adding to it', () => {
+    const { result } = renderHook(() =>
+      useHeroState({ datasetId: 'd1', recordType: 'raster_dataset', hasTileUrl: true }),
+    );
+
+    // Exhaust the manual-retry budget first.
+    act(() => { result.current.onTileError(); });
+    act(() => { result.current.handleRetry(); });
+    act(() => { result.current.onTileError(); });
+    act(() => { result.current.handleRetry(); });
+    act(() => { result.current.onTileError(); });
+    act(() => { result.current.handleRetry(); });
+    expect(result.current.retryCount).toBe(3);
+
+    act(() => {
+      result.current.handleReplaceComplete();
+    });
+
+    // A successful replace hands back a fresh budget rather than pushing
+    // retryCount even further past the Retry-button cutoff.
+    expect(result.current.retryCount).toBe(0);
+    expect(result.current.heroState).toBe('loading');
+  });
+
   it('skips to loaded for raster with no tile URL', () => {
     const { result } = renderHook(() =>
       useHeroState({ datasetId: 'd1', recordType: 'raster_dataset', hasTileUrl: false }),

--- a/frontend/src/components/dataset/hooks/use-hero-state.ts
+++ b/frontend/src/components/dataset/hooks/use-hero-state.ts
@@ -33,6 +33,19 @@ export function useHeroState({ datasetId, recordType, hasTileUrl }: UseHeroState
     setMapKey(prev => prev + 1);
   }, []);
 
+  // fix(#1362 codex r4): a completed replacement remounts the hero the same
+  // way a manual retry does (fresh heroState + mapKey), but it is NOT a
+  // failed-tile retry — routing it through handleRetry spent the 3-attempt
+  // manual-retry budget on a SUCCESS, so a later genuine tile failure could
+  // land with the Retry button already exhausted. Reset retryCount instead
+  // of incrementing it: a successful replace is a natural point to hand the
+  // user a fresh budget, not consume theirs.
+  const handleReplaceComplete = useCallback(() => {
+    setRetryCount(0);
+    setHeroState('loading');
+    setMapKey(prev => prev + 1);
+  }, []);
+
   // Reset hero state when the dataset CHANGES — skip the initial mount, where
   // state is already fresh and a map that reports ready in the same commit
   // (cached lazy chunk) would be clobbered back to 'loading'.
@@ -59,6 +72,7 @@ export function useHeroState({ datasetId, recordType, hasTileUrl }: UseHeroState
     retryCount,
     mapKey,
     handleRetry,
+    handleReplaceComplete,
     onMapReady: useCallback(() => setHeroState('loaded'), []),
     onTileError: useCallback(() => setHeroState('error'), []),
   };

--- a/frontend/src/components/maps/hooks/__tests__/use-map-layers.test.ts
+++ b/frontend/src/components/maps/hooks/__tests__/use-map-layers.test.ts
@@ -106,3 +106,48 @@ describe('useMapLayers generic-geometry rendering (fix #430 codex r21)', () => {
     expect(addedLayers(map)[0]?.['source-layer']).toBe('tenant_acme.roads');
   });
 });
+
+// #1362 codex r2: the raster tile route is a fixed per-dataset path, and a
+// public dataset's tile response carries `Cache-Control: public,
+// max-age=3600` — so the browser's own HTTP cache can keep serving
+// pre-replace bytes for an identical URL. tileVersion busts that the same
+// way the vector source already does via buildSignedTileUrl.
+describe('useMapLayers raster tile source cache-busting', () => {
+  function runRasterHook(rasterTileUrl: string | null, tileVersion?: string | null) {
+    const mapRef = { current: null };
+    const { result } = renderHook(() =>
+      useMapLayers({
+        tableName: null,
+        geometryType: null,
+        rasterTileUrl,
+        tileVersion,
+        tileToken: null,
+        mapRef,
+      }),
+    );
+    const map = fakeMap();
+    result.current.addRasterLayers(map);
+    return map;
+  }
+
+  function addedSourceConfig(map: MaplibreMap) {
+    const call = (map.addSource as ReturnType<typeof vi.fn>).mock.calls[0];
+    return call?.[1] as { tiles: string[] } | undefined;
+  }
+
+  it('appends tileVersion as a cache-busting query param when present', () => {
+    const map = runRasterHook(
+      '/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png',
+      '2026-08-10T00:00:00Z',
+    );
+    const source = addedSourceConfig(map);
+    expect(source?.tiles[0]).toContain('/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png?v=');
+    expect(source?.tiles[0]).toContain(encodeURIComponent('2026-08-10T00:00:00Z'));
+  });
+
+  it('omits the query param when tileVersion is absent', () => {
+    const map = runRasterHook('/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png', null);
+    const source = addedSourceConfig(map);
+    expect(source?.tiles[0]).not.toContain('?v=');
+  });
+});

--- a/frontend/src/components/maps/hooks/use-map-layers.ts
+++ b/frontend/src/components/maps/hooks/use-map-layers.ts
@@ -218,9 +218,24 @@ export function useMapLayers({
       if (!rasterTileUrl || rasterLayersAdded.current) return;
       if (map.getSource('raster-tile-source')) return;
       try {
+        // #1362 codex r2: the raster tile route is a fixed per-dataset path
+        // (never re-added, see the guard above), and the api response for a
+        // public dataset carries `Cache-Control: public, max-age=3600` — so
+        // the browser's OWN cache can keep serving pre-replace tile bytes
+        // for an identical URL for up to an hour even after this source is
+        // freshly re-added on remount. Bust that with tileVersion (the
+        // dataset's updated_at) the same way the vector source already does
+        // via buildSignedTileUrl. This does NOT reach the shared nginx
+        // raster_cache — its proxy_cache_key whitelists only the Titiler
+        // render params (colormap_name/stretch/pmin/pmax/sigma), so an
+        // unlisted query param has no effect there (see #1362 follow-up
+        // filed for that separate, infra-scoped gap).
+        const versionedTileUrl = tileVersion
+          ? `${window.location.origin}${rasterTileUrl}?v=${encodeURIComponent(tileVersion)}`
+          : `${window.location.origin}${rasterTileUrl}`;
         map.addSource('raster-tile-source', {
           type: 'raster',
-          tiles: [`${window.location.origin}${rasterTileUrl}`],
+          tiles: [versionedTileUrl],
           tileSize: 256,
           minzoom: 0,
           maxzoom: 22,
@@ -236,7 +251,7 @@ export function useMapLayers({
         if (import.meta.env.DEV) console.warn('addRasterLayers: failed', e);
       }
     },
-    [rasterTileUrl],
+    [rasterTileUrl, tileVersion],
   );
 
   const addOverlaySource = useCallback((map: MaplibreMap) => {

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -344,11 +344,12 @@
       "tableLabel": "Datei-Layer"
     },
     "raster": {
+      "sourceSelectHelpText": "Wählen Sie eine Ersatz-Rasterdatei aus.",
       "previewDescription": "Bestätigen, um den Raster zu ersetzen.",
       "previewNote": "Raster-Re-Uploads überspringen den Schemavergleich. Die Bestätigung startet eine Cloud Optimized GeoTIFF-Konvertierung, die mehrere Minuten dauern kann.",
       "trackingDescription": "Konvertierung zu Cloud Optimized GeoTIFF. Dies kann mehrere Minuten dauern.",
       "processingMessage": "Konvertierung zu Cloud Optimized GeoTIFF...",
-      "trackingBackground": "Dies kann einige Minuten dauern. Sie können diesen Dialog schließen — die Karte wird automatisch aktualisiert, sobald die Konvertierung abgeschlossen ist."
+      "trackingBackground": "Dies kann einige Minuten dauern. Lassen Sie diesen Dialog geöffnet, bis die Konvertierung abgeschlossen ist."
     },
     "dropzone": "Datei hierher ziehen oder klicken zum Durchsuchen",
     "uploadingMessage": "Datei wird hochgeladen und analysiert...",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -343,6 +343,13 @@
       "previewLayer": "Layer prüfen",
       "tableLabel": "Datei-Layer"
     },
+    "raster": {
+      "previewDescription": "Bestätigen, um den Raster zu ersetzen.",
+      "previewNote": "Raster-Re-Uploads überspringen den Schemavergleich. Die Bestätigung startet eine Cloud Optimized GeoTIFF-Konvertierung, die mehrere Minuten dauern kann.",
+      "trackingDescription": "Konvertierung zu Cloud Optimized GeoTIFF. Dies kann mehrere Minuten dauern.",
+      "processingMessage": "Konvertierung zu Cloud Optimized GeoTIFF...",
+      "trackingBackground": "Dies kann einige Minuten dauern. Sie können diesen Dialog schließen — die Karte wird automatisch aktualisiert, sobald die Konvertierung abgeschlossen ist."
+    },
     "dropzone": "Datei hierher ziehen oder klicken zum Durchsuchen",
     "uploadingMessage": "Datei wird hochgeladen und analysiert...",
     "file": "Datei:",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -294,6 +294,13 @@
       "previewLayer": "Preview Layer",
       "tableLabel": "File layers"
     },
+    "raster": {
+      "previewDescription": "Confirm to replace the raster.",
+      "previewNote": "Raster re-uploads skip schema comparison. Confirming starts a Cloud Optimized GeoTIFF conversion, which can take several minutes.",
+      "trackingDescription": "Converting to Cloud Optimized GeoTIFF. This can take several minutes.",
+      "processingMessage": "Converting to Cloud Optimized GeoTIFF...",
+      "trackingBackground": "This can take a few minutes. You can close this dialog — the map updates automatically once the conversion finishes."
+    },
     "dropzone": "Drag and drop a file here, or click to browse",
     "uploadingMessage": "Uploading and analyzing file...",
     "file": "File:",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -295,11 +295,12 @@
       "tableLabel": "File layers"
     },
     "raster": {
+      "sourceSelectHelpText": "Select a replacement raster file.",
       "previewDescription": "Confirm to replace the raster.",
       "previewNote": "Raster re-uploads skip schema comparison. Confirming starts a Cloud Optimized GeoTIFF conversion, which can take several minutes.",
       "trackingDescription": "Converting to Cloud Optimized GeoTIFF. This can take several minutes.",
       "processingMessage": "Converting to Cloud Optimized GeoTIFF...",
-      "trackingBackground": "This can take a few minutes. You can close this dialog — the map updates automatically once the conversion finishes."
+      "trackingBackground": "This can take a few minutes. Keep this dialog open until the conversion finishes."
     },
     "dropzone": "Drag and drop a file here, or click to browse",
     "uploadingMessage": "Uploading and analyzing file...",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -344,11 +344,12 @@
       "tableLabel": "Capas del archivo"
     },
     "raster": {
+      "sourceSelectHelpText": "Seleccione un archivo ráster de reemplazo.",
       "previewDescription": "Confirme para reemplazar el ráster.",
       "previewNote": "Las re-cargas de ráster omiten la comparación de esquema. Confirmar inicia una conversión a GeoTIFF optimizado en la nube, que puede tardar varios minutos.",
       "trackingDescription": "Convirtiendo a GeoTIFF optimizado en la nube. Esto puede tardar varios minutos.",
       "processingMessage": "Convirtiendo a GeoTIFF optimizado en la nube...",
-      "trackingBackground": "Esto puede tardar unos minutos. Puede cerrar este cuadro de diálogo — el mapa se actualizará automáticamente cuando la conversión finalice."
+      "trackingBackground": "Esto puede tardar unos minutos. Mantenga este cuadro de diálogo abierto hasta que finalice la conversión."
     },
     "dropzone": "Arrastre y suelte un archivo aquí, o haga clic para explorar",
     "uploadingMessage": "Subiendo y analizando archivo...",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -343,6 +343,13 @@
       "previewLayer": "Vista previa de la capa",
       "tableLabel": "Capas del archivo"
     },
+    "raster": {
+      "previewDescription": "Confirme para reemplazar el ráster.",
+      "previewNote": "Las re-cargas de ráster omiten la comparación de esquema. Confirmar inicia una conversión a GeoTIFF optimizado en la nube, que puede tardar varios minutos.",
+      "trackingDescription": "Convirtiendo a GeoTIFF optimizado en la nube. Esto puede tardar varios minutos.",
+      "processingMessage": "Convirtiendo a GeoTIFF optimizado en la nube...",
+      "trackingBackground": "Esto puede tardar unos minutos. Puede cerrar este cuadro de diálogo — el mapa se actualizará automáticamente cuando la conversión finalice."
+    },
     "dropzone": "Arrastre y suelte un archivo aquí, o haga clic para explorar",
     "uploadingMessage": "Subiendo y analizando archivo...",
     "file": "Archivo:",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -344,11 +344,12 @@
       "tableLabel": "Couches du fichier"
     },
     "raster": {
+      "sourceSelectHelpText": "Sélectionnez un fichier raster de remplacement.",
       "previewDescription": "Confirmez pour remplacer le raster.",
       "previewNote": "Les re-téléversements raster n'affichent pas de comparaison de schéma. Confirmer démarre une conversion en GeoTIFF optimisé pour le cloud, ce qui peut prendre plusieurs minutes.",
       "trackingDescription": "Conversion en GeoTIFF optimisé pour le cloud. Cela peut prendre plusieurs minutes.",
       "processingMessage": "Conversion en GeoTIFF optimisé pour le cloud...",
-      "trackingBackground": "Cela peut prendre quelques minutes. Vous pouvez fermer cette boîte de dialogue — la carte se mettra à jour automatiquement une fois la conversion terminée."
+      "trackingBackground": "Cela peut prendre quelques minutes. Gardez cette boîte de dialogue ouverte jusqu'à la fin de la conversion."
     },
     "dropzone": "Glissez-déposez un fichier ici, ou cliquez pour parcourir",
     "uploadingMessage": "Téléchargement et analyse du fichier...",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -343,6 +343,13 @@
       "previewLayer": "Prévisualiser la couche",
       "tableLabel": "Couches du fichier"
     },
+    "raster": {
+      "previewDescription": "Confirmez pour remplacer le raster.",
+      "previewNote": "Les re-téléversements raster n'affichent pas de comparaison de schéma. Confirmer démarre une conversion en GeoTIFF optimisé pour le cloud, ce qui peut prendre plusieurs minutes.",
+      "trackingDescription": "Conversion en GeoTIFF optimisé pour le cloud. Cela peut prendre plusieurs minutes.",
+      "processingMessage": "Conversion en GeoTIFF optimisé pour le cloud...",
+      "trackingBackground": "Cela peut prendre quelques minutes. Vous pouvez fermer cette boîte de dialogue — la carte se mettra à jour automatiquement une fois la conversion terminée."
+    },
     "dropzone": "Glissez-déposez un fichier ici, ou cliquez pour parcourir",
     "uploadingMessage": "Téléchargement et analyse du fichier...",
     "file": "Fichier :",

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -233,6 +233,7 @@ export function DatasetPage() {
     retryCount,
     mapKey,
     handleRetry,
+    handleReplaceComplete,
     onMapReady,
     onTileError,
   } = useHeroState({
@@ -674,9 +675,12 @@ export function DatasetPage() {
             // route (not content-versioned), and the hero map's raster
             // source is added once and never re-added on prop change — so a
             // completed replacement needs an explicit remount to show the
-            // new tiles. Reuse the existing hero-error retry mechanism,
-            // which already does exactly that (reset heroState, bump mapKey).
-            onReplaceComplete={handleRetry}
+            // new tiles.
+            // fix(#1362 codex r4): use the dedicated handleReplaceComplete,
+            // not handleRetry — a success isn't a failed-tile retry, and
+            // routing it through handleRetry spent the 3-attempt manual-retry
+            // budget on every successful replace.
+            onReplaceComplete={handleReplaceComplete}
           />
         </Suspense>
       )}

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -670,6 +670,13 @@ export function DatasetPage() {
             dataset={dataset}
             open={activeDialog === 'reupload'}
             onOpenChange={(open) => setActiveDialog(open ? 'reupload' : null)}
+            // fix(#1362 codex r1): a raster's tile URL is a fixed per-dataset
+            // route (not content-versioned), and the hero map's raster
+            // source is added once and never re-added on prop change — so a
+            // completed replacement needs an explicit remount to show the
+            // new tiles. Reuse the existing hero-error retry mechanism,
+            // which already does exactly that (reset heroState, bump mapKey).
+            onReplaceComplete={handleRetry}
           />
         </Suspense>
       )}

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -465,7 +465,10 @@ export function DatasetPage() {
       icon: Upload,
       onSelect: () => setActiveDialog('reupload'),
       priority: 10,
-      visible: canEdit && !isRaster && !isVrt,
+      // #1289: raster now has a reupload flow too (upload -> commit,
+      // skipping the vector schema-preview step); VRT stays excluded — VRT
+      // datasets keep the regenerate action instead.
+      visible: canEdit && !isVrt,
       variant: 'outline',
     },
     {
@@ -661,7 +664,7 @@ export function DatasetPage() {
         />
       )}
 
-      {canEdit && !isRaster && !isVrt && (
+      {canEdit && !isVrt && (
         <Suspense fallback={null}>
           <ReuploadDialog
             dataset={dataset}

--- a/frontend/src/pages/__tests__/DatasetPage.edit-affordances.test.tsx
+++ b/frontend/src/pages/__tests__/DatasetPage.edit-affordances.test.tsx
@@ -366,7 +366,10 @@ describe('DatasetPage editable affordance integration', () => {
     expect(screen.queryByTestId('pending-edits-bar')).not.toBeInTheDocument();
   });
 
-  it('does not offer reupload for raster datasets', async () => {
+  // #1289: raster reupload (upload -> commit, skipping the schema-preview
+  // step) is now reachable from the app — raster offers both Create VRT and
+  // Re-Upload.
+  it('offers both reupload and create-vrt for raster datasets', async () => {
     setUser(EDITOR_USER);
     mockUseDataset.mockReturnValue({
       data: {
@@ -387,6 +390,37 @@ describe('DatasetPage editable affordance integration', () => {
     expect(
       await screen.findByRole('menuitem', { name: 'Create VRT' }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Re-Upload' }),
+    ).toBeInTheDocument();
+  });
+
+  // VRT stays on the regenerate flow — it never gets a reupload action,
+  // and Create VRT is raster-only so it's absent here too.
+  it('does not offer reupload or create-vrt for VRT datasets', async () => {
+    setUser(EDITOR_USER);
+    mockUseDataset.mockReturnValue({
+      data: {
+        ...makeDataset(),
+        record_type: 'vrt_dataset',
+        raster: {
+          tile_url: '/raster-tiles/test/{z}/{x}/{y}.png',
+        } as DatasetResponse['raster'],
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useDataset>);
+    const user = userEvent.setup();
+
+    render(<DatasetPage />, { route: '/datasets/dataset-1' });
+    await user.click(screen.getByRole('button', { name: 'More actions' }));
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'Delete' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: 'Create VRT' }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('menuitem', { name: 'Re-Upload' }),
     ).not.toBeInTheDocument();

--- a/frontend/src/pages/__tests__/DatasetPage.hero.test.tsx
+++ b/frontend/src/pages/__tests__/DatasetPage.hero.test.tsx
@@ -91,7 +91,18 @@ vi.mock('@/components/dataset/DatasetDeleteDialog', () => ({
 }));
 
 vi.mock('@/components/dataset/ReuploadDialog', () => ({
-  ReuploadDialog: () => null,
+  // codex(#1362 r1): exposes onReplaceComplete as a clickable stub so tests
+  // can simulate "a raster reupload job just completed" without driving the
+  // full dialog flow (that flow is covered in ReuploadDialog.test.tsx).
+  ReuploadDialog: (props: { onReplaceComplete?: () => void }) => (
+    <button
+      type="button"
+      data-testid="reupload-dialog-stub"
+      onClick={() => props.onReplaceComplete?.()}
+    >
+      reupload dialog stub
+    </button>
+  ),
 }));
 
 vi.mock('@/components/dataset/DatasetDetailSkeleton', () => ({
@@ -345,6 +356,30 @@ describe('DatasetPage hero state machine', () => {
     }
 
     // After 3rd retry, trigger timeout again
+    act(() => { vi.advanceTimersByTime(10_000); });
+
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+    expect(screen.getByText('Tiles may still be processing')).toBeInTheDocument();
+  });
+
+  // codex(#1362 r1): a raster's tile URL is a fixed per-dataset route (not
+  // content-versioned), and the hero map's MapLibre raster source is added
+  // once and never re-added on prop change — so ReuploadDialog's
+  // onReplaceComplete is wired to handleRetry (the same remount mechanism
+  // the manual Retry button uses) to pick up a completed replacement.
+  it('wires ReuploadDialog onReplaceComplete to the same retry mechanism as the manual Retry button', () => {
+    setup({ record_type: 'raster_dataset', raster: { tile_url: '/raster-tiles/test/{z}/{x}/{y}.png' } as DatasetResponse['raster'] });
+    render(<DatasetPage />, { route: '/datasets/dataset-1' });
+
+    const replaceStub = screen.getByTestId('reupload-dialog-stub');
+
+    // Mirrors the "hides retry button after 3 retries" test above, but
+    // drives retryCount via onReplaceComplete instead of clicking Retry —
+    // proving it increments the same counter through the same handler.
+    for (let i = 0; i < 3; i++) {
+      act(() => { vi.advanceTimersByTime(10_000); });
+      act(() => { replaceStub.click(); });
+    }
     act(() => { vi.advanceTimersByTime(10_000); });
 
     expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();

--- a/frontend/src/pages/__tests__/DatasetPage.hero.test.tsx
+++ b/frontend/src/pages/__tests__/DatasetPage.hero.test.tsx
@@ -367,23 +367,34 @@ describe('DatasetPage hero state machine', () => {
   // once and never re-added on prop change — so ReuploadDialog's
   // onReplaceComplete is wired to handleRetry (the same remount mechanism
   // the manual Retry button uses) to pick up a completed replacement.
-  it('wires ReuploadDialog onReplaceComplete to the same retry mechanism as the manual Retry button', () => {
+  // codex(#1362 r4): onReplaceComplete must remount the hero map WITHOUT
+  // spending the manual-retry budget — a successful replace is not a failed
+  // retry, and routing it through handleRetry would leave a later genuine
+  // tile failure unretryable once 3 replaces (or a mix of retries/replaces)
+  // had accumulated.
+  it('wires ReuploadDialog onReplaceComplete to a remount that resets the manual-retry budget', () => {
     setup({ record_type: 'raster_dataset', raster: { tile_url: '/raster-tiles/test/{z}/{x}/{y}.png' } as DatasetResponse['raster'] });
     render(<DatasetPage />, { route: '/datasets/dataset-1' });
 
-    const replaceStub = screen.getByTestId('reupload-dialog-stub');
-
-    // Mirrors the "hides retry button after 3 retries" test above, but
-    // drives retryCount via onReplaceComplete instead of clicking Retry —
-    // proving it increments the same counter through the same handler.
+    // Exhaust the manual-retry budget via the error overlay first.
     for (let i = 0; i < 3; i++) {
       act(() => { vi.advanceTimersByTime(10_000); });
-      act(() => { replaceStub.click(); });
+      const retryBtn = screen.getByRole('button', { name: 'Retry' });
+      act(() => { retryBtn.click(); });
     }
     act(() => { vi.advanceTimersByTime(10_000); });
-
     expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
     expect(screen.getByText('Tiles may still be processing')).toBeInTheDocument();
+
+    // A raster replacement completes — must hand back a fresh budget rather
+    // than push retryCount even further past the cutoff.
+    const replaceStub = screen.getByTestId('reupload-dialog-stub');
+    act(() => { replaceStub.click(); });
+
+    // A genuine tile failure on the freshly remounted hero must be
+    // retryable again, proving the budget was reset, not spent.
+    act(() => { vi.advanceTimersByTime(10_000); });
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 
   it('vector datasets pass onMapReady/onTileError to DatasetMap', () => {


### PR DESCRIPTION
## What

Relaxes the two gates that previously hid the Re-Upload action for raster datasets:

- `DatasetPage.tsx` header action + dialog mount: `canEdit && !isRaster && !isVrt` -> `canEdit && !isVrt`. VRT stays excluded (VRT datasets keep the regenerate flow).
- `ReuploadDialog.tsx` adds a raster branch: upload -> commit, skipping the schema-preview step entirely, since the preview endpoint returns 400 for raster by design (nothing for ogrinfo to diff a COG against). The 'preview' step now renders on `isRaster` alone (no preview payload needed) and shows a note explaining there's no schema comparison, instead of the schema-diff view.
- Format filtering (`reuploadExtensions`) is dataset-type aware rather than a blanket unsupported-list edit: raster reupload offers only `.tif`/`.tiff`; vector/table reupload is unchanged (still excludes raster + `.vrt`). A literal "just remove tif/tiff from the unsupported set" would have also opened raster formats to vector/table reuploads and vector formats to raster reuploads, so the filter branches on `isRaster` instead.
- Preview and background-tracking copy swaps to raster-specific text noting the longer COG conversion time (the job runs on the `raster` queue, taking minutes rather than the seconds a vector reupload takes).
- Hides the Service URL source option for raster (the backend refuses a raster service-preview outright — that branch was always a dead end).

## Why

The API has supported replacing a raster dataset's COG through the reupload door since #1221, but the frontend hid the action entirely, so the feature was unreachable from the app.

## Schema/API/config impact

None — frontend only. No backend, migration, or OpenAPI changes.

## Post-replace tile handling

Two distinct concerns here, both addressed:

**Brief post-replace tile-error flash (the backend's ~60s self-healing window):** already tolerated before this PR and unchanged — `DatasetMap.tsx`'s `fireErrorOnce()` guards with `if (errorFiredRef.current || readyConfirmedRef.current) return;`, so once the initial load is confirmed, sporadic post-replace tile errors from that window never surface the retry/error overlay.

**The hero map never showing the new tiles at all (found in review, fixed):** the raster tile URL is a fixed per-dataset route, and the hero map's MapLibre raster source was added once and never re-added on prop change, so a completed replacement left the *old* tiles showing indefinitely in the same browser session — no error, just stale data. Fixed with:
- `onReplaceComplete` callback on `ReuploadDialog`, fired once a raster job completes, wired to a new `handleReplaceComplete` in `useHeroState` that remounts the hero (fresh `heroState`, bumped `mapKey`) *without* spending the manual-retry budget that gates the error overlay's Retry button (a success is not a failed retry).
- The completion handler now awaits the dataset-detail invalidation before firing that callback, so the remount reads the refreshed bbox/tile_url instead of racing the still-in-flight refetch — fenced against a stale continuation applying itself after the dialog is reset or a second reupload is started in the meantime.
- The raster tile URL is cache-busted with `dataset.updated_at` so the browser's own HTTP cache (the tile route responds `Cache-Control: public, max-age=3600` for public datasets) doesn't keep serving pre-replace bytes.

**Residual gap, filed as #1372 (out of frontend-PR scope):** that cache-buster doesn't reach the *shared* nginx tile cache — `frontend/nginx.conf`'s `proxy_cache_key` for the raster-tiles location whitelists only the Titiler render params, so an unlisted query param has no effect there. A public raster's tiles can still be served stale from nginx's `raster_cache` zone (`proxy_cache_valid 200 1h`) for up to an hour after a replace, for any client — this is a pre-existing backend/infra characteristic of the #1221 replace API that #1289 just makes far easier to hit, and needs a backend-emitted cache-key version and/or an active purge to fix properly.

## Verification

Run from the worktree (`cd frontend`):
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run test:i18n` — pass (new `reupload.raster.*` keys added to all four locales: en/es/fr/de)
- `npx vitest run` (whole frontend suite) — 385 files / 4767 tests pass, re-run clean after every review round including after a rebase onto a new main commit

**Not run from this worktree** (per the worktree caveat in AGENTS.md — the dev stack's bind mount serves `main`, so a worktree Playwright run would validate the wrong code): the live acceptance check from #1289 — upload a GeoTIFF, put it on a map, replace it with a different GeoTIFF, confirm the map tile changes without re-adding the layer. That's a post-merge live-QA step.

Closes #1289