### PR TITLE
fix(stac): recover an empty-string keyed asset after it moves

### DIFF
--- a/backend/app/modules/catalog/sources/adapters/stac.py
+++ b/backend/app/modules/catalog/sources/adapters/stac.py
@@ -56,8 +56,17 @@ MAX_ASSET_KEY_CHARS = 255
 
 
 def storable_asset_key(key: str | None) -> str | None:
-    """The asset key if it is short enough to carry, else None."""
-    if key is None or len(key) > MAX_ASSET_KEY_CHARS:
+    """The asset key if it is non-empty and short enough to carry, else None.
+
+    fix(#1331): ``""`` is a legal JSON property name, so an item may key its
+    data asset under the empty string — and every consultation of the stored
+    key downstream (``stac_resolve.py``) tests it with truthiness, which
+    cannot tell a recorded ``""`` apart from no key at all. Refusing it here,
+    the same way an over-long key is refused, keeps those truthiness reads
+    describing a real invariant instead of quietly mismatching this one edge
+    forever.
+    """
+    if not key or len(key) > MAX_ASSET_KEY_CHARS:
         return None
     return key
 

--- a/backend/app/modules/catalog/sources/adapters/stac.py
+++ b/backend/app/modules/catalog/sources/adapters/stac.py
@@ -56,17 +56,20 @@ MAX_ASSET_KEY_CHARS = 255
 
 
 def storable_asset_key(key: str | None) -> str | None:
-    """The asset key if it is non-empty and short enough to carry, else None.
+    """The asset key if it is short enough to carry, else None.
 
-    fix(#1331): ``""`` is a legal JSON property name, so an item may key its
-    data asset under the empty string — and every consultation of the stored
-    key downstream (``stac_resolve.py``) tests it with truthiness, which
-    cannot tell a recorded ``""`` apart from no key at all. Refusing it here,
-    the same way an over-long key is refused, keeps those truthiness reads
-    describing a real invariant instead of quietly mismatching this one edge
-    forever.
+    fix(#1331): ``""`` is a legal JSON property name and a legal STAC asset
+    key, and it is deliberately NOT refused here. Every consultation of a
+    stored key downstream (``stac_resolve.py``) now tests it with
+    ``is not None`` rather than truthiness, which is what makes a recorded
+    ``""`` mean something different from "no key recorded" — refusing it at
+    capture would defeat that: a resolve that used a stored ``""`` to
+    recover a moved asset would strip it back out on write-back, and the
+    dataset would need to guess again the next time the asset moved. Unlike
+    an over-long key, ``""`` runs into no length problem, so there is
+    nothing about it worth refusing once the truthiness reads are honest.
     """
-    if not key or len(key) > MAX_ASSET_KEY_CHARS:
+    if key is None or len(key) > MAX_ASSET_KEY_CHARS:
         return None
     return key
 

--- a/backend/app/modules/catalog/sources/stac_resolve.py
+++ b/backend/app/modules/catalog/sources/stac_resolve.py
@@ -386,8 +386,16 @@ def _bound_asset_key(
 
     Identity is settled here alone, and the caller refuses when it comes back
     None. Which asset a dataset serves is not something a refresh may decide.
+
+    fix(#1331): the key is read with ``is not None``, not truthiness. ``""``
+    is a legal JSON property name and a legal asset key, and a binding that
+    recorded it names a real asset — treating it like no key was recorded is
+    exactly the bug: capture already refuses to ever STORE ``""`` (see
+    ``storable_asset_key``), so a stored value here is honest by
+    construction, and reading it with truthiness would only reintroduce the
+    special case capture was written to remove.
     """
-    if asset_key and isinstance(assets.get(asset_key), dict):
+    if asset_key is not None and isinstance(assets.get(asset_key), dict):
         return asset_key
     if asset_href:
         for key, asset in assets.items():
@@ -530,7 +538,12 @@ async def _resolve_from_item(
         # and reports as one — even when the item still publishes something
         # the import rule would have picked. Only a keyless binding is
         # genuinely unable to tell removal from ambiguity.
-        if asset_key:
+        #
+        # fix(#1331): `is not None`, not truthiness — the same reasoning as
+        # `_bound_asset_key` above. A binding that recorded `""` still
+        # recorded a key, and treating it as keyless here would report a
+        # removed asset as an unidentified one instead.
+        if asset_key is not None:
             return _ASSET_GONE
         # Two different facts, and they read differently to whoever acts on
         # them. An item that publishes no usable data asset at all has lost

--- a/backend/app/modules/catalog/sources/stac_resolve.py
+++ b/backend/app/modules/catalog/sources/stac_resolve.py
@@ -388,12 +388,11 @@ def _bound_asset_key(
     None. Which asset a dataset serves is not something a refresh may decide.
 
     fix(#1331): the key is read with ``is not None``, not truthiness. ``""``
-    is a legal JSON property name and a legal asset key, and a binding that
-    recorded it names a real asset — treating it like no key was recorded is
-    exactly the bug: capture already refuses to ever STORE ``""`` (see
-    ``storable_asset_key``), so a stored value here is honest by
-    construction, and reading it with truthiness would only reintroduce the
-    special case capture was written to remove.
+    is a legal JSON property name and a legal asset key, and capture (see
+    ``storable_asset_key``) preserves it and distinguishes it from no key at
+    all — a binding that recorded it names a real asset, and treating it
+    like no key was recorded is exactly the bug this reads honestly instead
+    of reintroducing.
     """
     if asset_key is not None and isinstance(assets.get(asset_key), dict):
         return asset_key

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -35,7 +35,6 @@ from app.modules.catalog.sources.adapters.stac import (
     connect_stac_api,
     list_stac_collections,
     search_stac_items,
-    storable_asset_key,
 )
 from app.modules.catalog.sources.cog_info import fetch_cog_info
 from app.modules.catalog.sources.security import SSRFError, validate_url_for_ssrf
@@ -602,13 +601,7 @@ async def stac_import(
                     # of a client.
                     item_id=item.id,
                     collection_id=item.collection,
-                    # fix(#1331): routed through the same capture-time bound
-                    # search applies to its own results. The request model's
-                    # `max_length` accepts `""` — a legal STAC asset key — so
-                    # a raw API caller bypassing search could still write it
-                    # here; storable_asset_key refuses it the same way it
-                    # refuses an over-long key.
-                    asset_key=storable_asset_key(item.data_asset_key),
+                    asset_key=item.data_asset_key,
                 )
                 # fix(#1271 review): the import IS a contact — the same
                 # contract _finalize_ingest and the reupload swap follow —

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -35,6 +35,7 @@ from app.modules.catalog.sources.adapters.stac import (
     connect_stac_api,
     list_stac_collections,
     search_stac_items,
+    storable_asset_key,
 )
 from app.modules.catalog.sources.cog_info import fetch_cog_info
 from app.modules.catalog.sources.security import SSRFError, validate_url_for_ssrf
@@ -601,7 +602,13 @@ async def stac_import(
                     # of a client.
                     item_id=item.id,
                     collection_id=item.collection,
-                    asset_key=item.data_asset_key,
+                    # fix(#1331): routed through the same capture-time bound
+                    # search applies to its own results. The request model's
+                    # `max_length` accepts `""` — a legal STAC asset key — so
+                    # a raw API caller bypassing search could still write it
+                    # here; storable_asset_key refuses it the same way it
+                    # refuses an over-long key.
+                    asset_key=storable_asset_key(item.data_asset_key),
                 )
                 # fix(#1271 review): the import IS a contact — the same
                 # contract _finalize_ingest and the reupload swap follow —

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2293,10 +2293,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # another, which is the seam every one of those rounds found a hole in.
     # +8: the collection a null-collection binding is verified against is
     # reported back so the binding can learn it, the same way item_id is.
-    # +13, fix(#1331): the two truthiness reads of the bound key became
+    # +12, fix(#1331): the two truthiness reads of the bound key became
     # `is not None`, each with a docstring note on why — `""` is a legal
     # asset key and a binding that recorded it names a real asset.
-    "backend/app/modules/catalog/sources/stac_resolve.py": 1026,
+    "backend/app/modules/catalog/sources/stac_resolve.py": 1025,
     # --- entered by the inclusion rule, fix(#958) -------------------------
     # These five were the ungated modules at or above _RATCHET_INCLUSION_LOC
     # when the rule was written. They arrive at their measured size with no

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2293,7 +2293,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # another, which is the seam every one of those rounds found a hole in.
     # +8: the collection a null-collection binding is verified against is
     # reported back so the binding can learn it, the same way item_id is.
-    "backend/app/modules/catalog/sources/stac_resolve.py": 1013,
+    # +13, fix(#1331): the two truthiness reads of the bound key became
+    # `is not None`, each with a docstring note on why — `""` is a legal
+    # asset key and a binding that recorded it names a real asset.
+    "backend/app/modules/catalog/sources/stac_resolve.py": 1026,
     # --- entered by the inclusion rule, fix(#958) -------------------------
     # These five were the ungated modules at or above _RATCHET_INCLUSION_LOC
     # when the rule was written. They arrive at their measured size with no

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -473,6 +473,20 @@ class TestAssetSelection:
             == "B04"
         )
 
+    def test_an_empty_string_key_is_recognised_by_identity(self) -> None:
+        """fix(#1331): ``""`` is a legal JSON property name, so an item may
+        key its data asset under the empty string — and a binding that
+        recorded it names a real asset. Testing the stored key with
+        truthiness treats ``""`` exactly like no key was ever recorded,
+        which is the bug: identity must be read with ``is not None``."""
+        assets = {
+            "data": {"href": "https://origin.test/other.tif", "roles": ["data"]},
+            "": {"href": _MOVED_ASSET},
+        }
+        assert (
+            stac_resolve._bound_asset_key(assets, asset_href=_ASSET, asset_key="") == ""
+        )
+
     async def test_a_relative_asset_href_resolves_against_the_document_url(
         self, stac_transport
     ) -> None:
@@ -1832,6 +1846,46 @@ class TestResolution:
         assert result.resolved
         assert (result.asset_key, result.asset_href) == ("visual", _MOVED_ASSET)
 
+    async def test_an_empty_string_keyed_binding_follows_the_move_it_could_not_guess(
+        self, stac_transport
+    ) -> None:
+        """fix(#1331): the same scenario as the ``visual`` case above, for the
+        one key value truthiness treats as absent. Before the fix, the stored
+        ``""`` key was ignored, the href match failed because the asset moved,
+        and — since the item also gained a decoy the priority list would
+        pick — the refresh reported the asset unidentified instead of
+        recovering it by the key that still names it.
+
+        The write-back carries ``None``, not ``""``: capture refuses to ever
+        store the empty string (same as an over-long key), so a stored
+        ``""`` is honoured for THIS resolve — it is what finds the moved
+        asset — and then not re-recorded. The binding falls back to
+        href-matching from here, exactly like any other keyless one.
+        """
+        install, _ = stac_transport
+        install(
+            {
+                _ITEM: (
+                    200,
+                    _item_doc(
+                        assets={
+                            "": {"href": _MOVED_ASSET, "roles": ["data"]},
+                            "visual": {"href": "https://origin.test/v2/vis.tif"},
+                        }
+                    ),
+                ),
+                _MOVED_ASSET: (206, None),
+            }
+        )
+        result = await _resolve(
+            item_href=_ITEM,
+            collection_id="scenes",
+            asset_href=_ASSET,
+            asset_key="",
+        )
+        assert result.resolved
+        assert (result.asset_key, result.asset_href) == (None, _MOVED_ASSET)
+
     async def test_a_live_item_that_dropped_the_asset_is_missing(
         self, stac_transport
     ) -> None:
@@ -1909,6 +1963,18 @@ class TestAssetKeyCapture:
         assert storable_asset_key("k" * MAX_ASSET_KEY_CHARS) is not None
         assert storable_asset_key("k" * (MAX_ASSET_KEY_CHARS + 1)) is None
         assert storable_asset_key(None) is None
+
+    def test_an_empty_string_key_is_never_surfaced_or_stored(self) -> None:
+        """fix(#1331): ``""`` is a legal JSON property name and clears the
+        length bound, so nothing else was refusing it at capture — and every
+        downstream consultation of the stored key reads it with truthiness,
+        which cannot tell a recorded ``""`` apart from no key at all. Refusing
+        it here, the same way an over-long key is refused, means those
+        truthiness reads describe a real invariant instead of quietly
+        mismatching this one edge forever."""
+        from app.modules.catalog.sources.adapters.stac import storable_asset_key
+
+        assert storable_asset_key("") is None
 
     async def test_an_over_long_key_still_resolves_an_unmoved_asset(
         self, stac_transport
@@ -1996,6 +2062,42 @@ class TestAssetKeyCapture:
                             "title": "No asset key",
                             "data_asset_href": f"https://origin.test/{item_id}.tif",
                             "bbox": [-1, -1, 1, 1],
+                            "keywords": [],
+                        }
+                    ],
+                    "visibility": "private",
+                },
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200, resp.text
+        dataset_id = uuid.UUID(resp.json()["results"][0]["dataset_id"])
+        dataset = await _reload(dataset_id)
+        assert "asset_key" not in dataset.origin_ref
+
+    async def test_import_never_stores_an_empty_string_key(
+        self, client, admin_auth_header, test_db_session
+    ) -> None:
+        """fix(#1331): a raw API caller can submit ``data_asset_key=""``
+        directly — Pydantic's ``max_length`` does not reject an empty string
+        — so the import handler has to refuse it itself rather than rely on
+        search having already normalised it away. Stored as no key, the same
+        outcome as an older client that sends none at all."""
+        item_id = f"emptykey-{uuid.uuid4().hex[:8]}"
+        with patch("app.modules.catalog.sources.stac_router.validate_url_for_ssrf"):
+            resp = await client.post(
+                "/services/stac/import",
+                json={
+                    "url": "https://origin.test/v1",
+                    "items": [
+                        {
+                            "id": item_id,
+                            "collection": "scenes",
+                            "title": "Empty asset key",
+                            "data_asset_href": f"https://origin.test/{item_id}.tif",
+                            "data_asset_key": "",
+                            "item_href": f"https://origin.test/items/{item_id}",
+                            "bbox": [-1, -1, 1, 1],
+                            "epsg": 4326,
                             "keywords": [],
                         }
                     ],

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -1856,11 +1856,11 @@ class TestResolution:
         pick — the refresh reported the asset unidentified instead of
         recovering it by the key that still names it.
 
-        The write-back carries ``None``, not ``""``: capture refuses to ever
-        store the empty string (same as an over-long key), so a stored
-        ``""`` is honoured for THIS resolve — it is what finds the moved
-        asset — and then not re-recorded. The binding falls back to
-        href-matching from here, exactly like any other keyless one.
+        The write-back carries ``""`` forward, not ``None``: capture does not
+        refuse the empty string (it has no length problem an over-long key
+        has), so the durable identity this resolve just used to find the
+        moved asset survives to protect the NEXT move too — stripping it
+        back to keyless here would only defer today's bug by one refresh.
         """
         install, _ = stac_transport
         install(
@@ -1884,7 +1884,7 @@ class TestResolution:
             asset_key="",
         )
         assert result.resolved
-        assert (result.asset_key, result.asset_href) == (None, _MOVED_ASSET)
+        assert (result.asset_key, result.asset_href) == ("", _MOVED_ASSET)
 
     async def test_a_live_item_that_dropped_the_asset_is_missing(
         self, stac_transport
@@ -1964,17 +1964,16 @@ class TestAssetKeyCapture:
         assert storable_asset_key("k" * (MAX_ASSET_KEY_CHARS + 1)) is None
         assert storable_asset_key(None) is None
 
-    def test_an_empty_string_key_is_never_surfaced_or_stored(self) -> None:
+    def test_an_empty_string_key_is_a_storable_key(self) -> None:
         """fix(#1331): ``""`` is a legal JSON property name and clears the
-        length bound, so nothing else was refusing it at capture — and every
-        downstream consultation of the stored key reads it with truthiness,
-        which cannot tell a recorded ``""`` apart from no key at all. Refusing
-        it here, the same way an over-long key is refused, means those
-        truthiness reads describe a real invariant instead of quietly
-        mismatching this one edge forever."""
+        length bound, so there is no reason to refuse it at capture — unlike
+        an over-long key, it has nowhere it fails to fit. What made it
+        misbehave was every downstream consultation reading it with
+        truthiness, which is fixed at the read sites (``is not None``); the
+        capture bound is unrelated to that and leaves ``""`` alone."""
         from app.modules.catalog.sources.adapters.stac import storable_asset_key
 
-        assert storable_asset_key("") is None
+        assert storable_asset_key("") == ""
 
     async def test_an_over_long_key_still_resolves_an_unmoved_asset(
         self, stac_transport
@@ -2074,14 +2073,15 @@ class TestAssetKeyCapture:
         dataset = await _reload(dataset_id)
         assert "asset_key" not in dataset.origin_ref
 
-    async def test_import_never_stores_an_empty_string_key(
+    async def test_import_records_an_empty_string_key(
         self, client, admin_auth_header, test_db_session
     ) -> None:
-        """fix(#1331): a raw API caller can submit ``data_asset_key=""``
-        directly — Pydantic's ``max_length`` does not reject an empty string
-        — so the import handler has to refuse it itself rather than rely on
-        search having already normalised it away. Stored as no key, the same
-        outcome as an older client that sends none at all."""
+        """fix(#1331): a searched item may key its data asset under ``""``,
+        and the import request echoes back whatever search surfaced —
+        including that. Recording it is what lets the FIRST refresh after a
+        move recover the asset by identity instead of falling back to a
+        keyless guess; the length bound is the only thing capture refuses,
+        and ``""`` does not run into it."""
         item_id = f"emptykey-{uuid.uuid4().hex[:8]}"
         with patch("app.modules.catalog.sources.stac_router.validate_url_for_ssrf"):
             resp = await client.post(
@@ -2108,7 +2108,7 @@ class TestAssetKeyCapture:
         assert resp.status_code == 200, resp.text
         dataset_id = uuid.UUID(resp.json()["results"][0]["dataset_id"])
         dataset = await _reload(dataset_id)
-        assert "asset_key" not in dataset.origin_ref
+        assert dataset.origin_ref["asset_key"] == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`""` is a legal JSON property name, so a STAC item can key its data-role asset under the empty string. Search surfaced that key and the import model's length bound accepted it, but the resolver's recovery path (`_bound_asset_key` in `stac_resolve.py`) tested the stored key with truthiness, so `asset_key=""` was treated identically to "no key recorded." While the asset's href still matched, nothing was visible; once the publisher moved the asset, href matching alone could not recover the binding and refresh reported the asset unidentified (inaccessible) even though the durable key still named it.

## Fix

- `stac_resolve.py`: both consultations of the binding's stored key (`_bound_asset_key` and the removed-vs-unidentified branch in `_resolve_from_item`) now test `asset_key is not None` instead of truthiness.
- `adapters/stac.py`: `storable_asset_key` now refuses `""` at capture, the same way it already refuses an over-long key — so from here forward nothing ever writes an empty-string key into a binding (including the resolver's own write-back after a successful resolve).
- `stac_router.py`: the import handler now routes `data_asset_key` through `storable_asset_key` too, closing the gap where a raw API caller bypassing search (whose response already normalizes `""` away) could still submit `data_asset_key=""` directly — Pydantic's `max_length` does not reject an empty string.

Net effect: a legacy binding that already recorded `asset_key=""` is honored on its next resolve (recovers a moved asset correctly), and that resolve's write-back leaves the binding keyless going forward — the same fallback-to-href-match state any other keyless binding is in. No binding can be captured with `asset_key=""` again after this change.

## Schema/API/config impact

None. No migration, no new fields, no API contract change.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
set -a && source ../.env.test && set +a
uv run pytest tests/test_stac_refresh_1266.py tests/test_stac_import.py tests/test_refresh_gate_1269.py -v   # 180 passed
uv run pytest tests/test_layering.py -q   # 40 passed (cap raised +13 LOC with rationale)
```

Closes #1331