### PR TITLE
perf(catalog): index the origin_ref keys the duplicate-source guards query

### DIFF
--- a/backend/alembic/versions/0040_dataset_origin_ref_indexes.py
+++ b/backend/alembic/versions/0040_dataset_origin_ref_indexes.py
@@ -1,0 +1,142 @@
+"""Index the origin_ref keys the duplicate-source guards query.
+
+perf(#1324). Follow-up to #1286 / PR #1320, which re-keyed the
+service-preview and STAC-import duplicate-source guards from the
+`origin_uri` string onto the structured `origin_ref` identity —
+`origin_ref->>'url'` / `origin_ref->>'layer_id'` for services
+(``catalog/sources/router.py``) and `origin_ref->>'asset_href'` for STAC
+(``catalog/sources/stac_router.py``). Migration 0036 indexed only
+`origin_uri`, so both re-keyed guards fell back to a sequential scan with
+per-row JSONB extraction.
+
+All three indexes below are `USING hash`, scoped with `IS NOT NULL` on the
+indexed expression itself rather than on `source_format`, mirroring
+`ix_datasets_origin_uri` (0036) rather than the
+`_SERVICE_FORMATS`/`SERVICE_SOURCE_FORMATS` value list. The guards send
+`source_format` as a bound parameter, and proving a partial index predicate
+implied by a parameterized equality (`source_format = $1` implies
+`source_format IN (...)`) only holds for a custom plan built from the
+literal value; once postgres's plan cache promotes a query to a generic
+plan (``plan_cache_mode = auto``, the default, after enough executions on
+one prepared statement), the parameter is opaque and the implication is no
+longer provable, silently discarding the index. `origin_ref->>'url' = $1`
+implying `origin_ref->>'url' IS NOT NULL` is a strict-operator implication
+postgres proves independent of the parameter's value, so it holds under
+both custom and generic plans regardless of access method. It is also
+self-maintaining: a new service kind that starts writing `url` is covered
+without a migration, where a `source_format` list would need one.
+
+Why hash, not btree, for EVERY one of these three (closing the class, not
+patching per-column — round 2 caught it on `source_url`, round 4 caught the
+same hazard on the two `origin_ref` columns): all three call sites compare
+with pure equality only — `origin_ref->>'url' == base_url` /
+`origin_ref->>'asset_href'` `.in_(hrefs)` / `source_url == enriched_url` /
+`source_url.in_(hrefs)` (postgres decomposes an `IN` list into an OR of `=`
+conditions at plan time, so a hash index serves it exactly like a btree
+would, confirmed by EXPLAIN) — never a range, prefix, or LIKE comparison,
+so hash loses nothing a btree would have offered here. It gains something a
+btree cannot: a btree index stores the value itself and has a ~2704-byte
+tuple limit on standard 8kB pages, while `source_url` is `VARCHAR(2000)`
+(caps CHARACTER count, not bytes) and WFS/OGC API `layer_name` — which
+migration 0036's backfill and every subsequent write flow into
+`origin_ref->>'layer_id'` for those service types — is a separate
+`max_length=500` field with no charset restriction, so a multibyte-heavy
+`url` (astral-plane/CJK-dense, reproduced: 2000 random astral-plane
+characters is 8000 bytes) combined with a multibyte `layer_id` can exceed
+the btree ceiling in the COMPOSITE key even when neither column alone
+would, and a scratch btree `CREATE INDEX` on such a row fails outright with
+"index row size exceeds btree ... maximum". A hash index stores a
+fixed-size hash of the value, never the value itself, so it has no such
+ceiling regardless of how long or how multibyte-heavy the source string is.
+
+Postgres hash indexes are single-column only, so `layer_id` is NOT part of
+`ix_datasets_origin_ref_url` (it was a second btree column in an earlier
+revision of this migration). The service-preview guard's `layer_id`
+equality/`IS NULL` check becomes a residual Filter on whatever rows the
+`url` hash index narrows to, rather than an Index Cond — confirmed
+acceptable by EXPLAIN: `url` alone is the selective key for this guard
+(it is unique per remote service+base-path combination in practice), the
+endpoint is interactive and low-frequency, and every row the hash index
+does NOT filter out still gets the exact right answer from the Filter, so
+correctness is identical to the composite-btree shape; only the width of
+the candidate set before the Filter changes.
+
+Plain, transactional `CREATE INDEX` -- not `CONCURRENTLY` -- for all three,
+which is a deliberate reversal from an earlier revision of this migration.
+`catalog.datasets` is the core catalog table, but is small in any realistic
+install (thousands of rows, not millions): the Clean-DB CI job's own log
+shows the WHOLE migration chain up to and including this one completing in
+about 1.5 seconds, so a brief SHARE lock during the build is cheap in every
+environment this actually runs in. `CREATE INDEX CONCURRENTLY` trades that
+brief lock for a much sharper failure mode under this test suite's own
+bootstrap: pytest-xdist migrates each worker's database with
+`alembic.command.upgrade` running several workers against one Postgres
+instance in parallel, and a CIC interrupted mid-build (lock contention from
+a sibling worker's migration, a killed process) leaves an INVALID index
+behind; `IF NOT EXISTS` then treats that husk as "already there" and never
+retries or errors. An invalid index is invisible to SQLAlchemy's reflection
+(autogenerate reports it as missing -> `alembic check` drift) and is never
+chosen by the planner (the guard queries silently stop using it) --
+reproduced exactly in CI: `test_email_verification_migration.py`'s
+drift check and this migration's own EXPLAIN tests both failed against a
+worker database that turned out to hold invalid copies of all three
+indexes. The post-squash migration chain (0001 onward) has no other
+`CONCURRENTLY` migration, so this bootstrap path had no prior green run to
+catch the pattern. A plain `CREATE INDEX` participates in the migration's
+ambient transaction: it either fully commits or the whole migration rolls
+back, so there is no invalid-index state to leave behind, no
+`_index_state()` resumability check needed, and no `autocommit_block()`
+needed either. `IF NOT EXISTS` is kept only for idempotency on a retried
+migration, not because a partial build is possible under plain DDL.
+Index-only, additive: no column added, no existing index touched, no table
+rewrite.
+
+Revision ID: 0040_dataset_origin_ref_indexes
+Revises: 0039_raster_assets_built_from
+Create Date: 2026-08-10
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0040_dataset_origin_ref_indexes"
+down_revision: Union[str, None] = "0039_raster_assets_built_from"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (index_name, index_expression_sql, partial_where_sql). All USING hash,
+# hence all single-column expressions -- see the module docstring's
+# `layer_id` paragraph for why the service-url index dropped its second
+# column rather than staying a composite.
+_ORIGIN_REF_INDEXES: tuple[tuple[str, str, str], ...] = (
+    (
+        "ix_datasets_origin_ref_url",
+        "(origin_ref ->> 'url')",
+        "(origin_ref ->> 'url') IS NOT NULL",
+    ),
+    (
+        "ix_datasets_origin_ref_asset_href",
+        "(origin_ref ->> 'asset_href')",
+        "(origin_ref ->> 'asset_href') IS NOT NULL",
+    ),
+    (
+        "ix_datasets_source_url",
+        "source_url",
+        "source_url IS NOT NULL",
+    ),
+)
+
+
+def upgrade() -> None:
+    for index_name, expr_sql, where_sql in _ORIGIN_REF_INDEXES:
+        op.execute(
+            f'CREATE INDEX IF NOT EXISTS "{index_name}" '
+            f'ON catalog."datasets" USING hash ({expr_sql}) '
+            f"WHERE {where_sql}"
+        )
+
+
+def downgrade() -> None:
+    for index_name, _expr_sql, _where_sql in reversed(_ORIGIN_REF_INDEXES):
+        op.execute(f'DROP INDEX IF EXISTS catalog."{index_name}"')

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -416,6 +416,63 @@ class Dataset(Base):
             "origin_uri",
             postgresql_where=text("origin_uri IS NOT NULL"),
         ),
+        # perf(#1324): backs the origin_ref-keyed duplicate-source guards in
+        # sources/router.py (service preview) and stac_router.py (STAC
+        # import) — migration 0036 indexed origin_uri only, so PR #1320's
+        # re-key onto origin_ref left both guards doing a seq scan with
+        # per-row JSONB extraction. Declared here so `alembic check` sees
+        # them; migration 0040_dataset_origin_ref_indexes is the source of
+        # truth for the actual (concurrent, resumable) DDL and carries the
+        # full history of why every index below is USING hash.
+        #
+        # Scoped with IS NOT NULL on the indexed expression itself rather
+        # than on source_format, so the partial predicate stays provable
+        # under a generic query plan (source_format arrives as a bound
+        # parameter, and postgres cannot prove `source_format = $1` implies
+        # `source_format IN (...)` without knowing $1's value once the plan
+        # cache promotes the query past a custom plan).
+        #
+        # The `::text` casts and inner parens are not stylistic — they are
+        # what postgres reflects back for a `->>'` expression index, which is
+        # what autogenerate compares against (see ix_records_title_trgm above
+        # for the same trap on a different operator).
+        #
+        # USING hash, single-column only (codex review rounds 2 and 4): a
+        # btree index stores the value itself and has a ~2704-byte
+        # tuple-size ceiling; a multibyte-heavy origin_ref->>'url' combined
+        # with a multibyte origin_ref->>'layer_id' (WFS/OGC API layer names
+        # allow up to 500 characters, no charset restriction) can exceed it
+        # in the composite key. `layer_id` is therefore NOT part of this
+        # index — postgres hash indexes are single-column — and the
+        # service-preview guard's layer_id check becomes a residual Filter
+        # instead of an Index Cond; url alone is the selective key.
+        Index(
+            "ix_datasets_origin_ref_url",
+            text("(origin_ref ->> 'url'::text)"),
+            postgresql_using="hash",
+            postgresql_where=text("(origin_ref ->> 'url'::text) IS NOT NULL"),
+        ),
+        Index(
+            "ix_datasets_origin_ref_asset_href",
+            text("(origin_ref ->> 'asset_href'::text)"),
+            postgresql_using="hash",
+            postgresql_where=text("(origin_ref ->> 'asset_href'::text) IS NOT NULL"),
+        ),
+        # perf(#1324 / codex review): not one of the two shapes the issue
+        # named, but required for the two above to do anything -- both guard
+        # queries are `(origin_ref match) OR (origin_ref incomplete AND
+        # source_url = ...)`, and postgres only folds an OR into a bitmap
+        # index scan when every disjunct has an index path. Without this,
+        # the origin_ref indexes are never chosen for either guard's real
+        # query. With it, postgres builds a BitmapOr of this index and the
+        # matching origin_ref index. See migration
+        # 0040_dataset_origin_ref_indexes for the EXPLAIN evidence.
+        Index(
+            "ix_datasets_source_url",
+            "source_url",
+            postgresql_using="hash",
+            postgresql_where=text("source_url IS NOT NULL"),
+        ),
         Index(
             "uq_datasets_table_name_global",
             "table_name",

--- a/backend/tests/test_origin_ref_indexes.py
+++ b/backend/tests/test_origin_ref_indexes.py
@@ -1,0 +1,394 @@
+"""EXPLAIN verification for the origin_ref duplicate-source guard indexes.
+
+perf(#1324). Follow-up to #1286 / PR #1320, which re-keyed the
+service-preview guard (``catalog/sources/router.py``) and the STAC-import
+guard (``catalog/sources/stac_router.py``) from ``origin_uri`` onto the
+structured ``origin_ref`` identity. Migration 0040_dataset_origin_ref_indexes
+adds the two partial expression indexes the issue named, plus a third on
+plain ``source_url`` (see that migration's docstring, and the codex review on
+PR #1365, for why the third one is required for the first two to matter).
+This file proves the FULL guard queries -- exactly as written in production,
+including their legacy source_url fallback branch -- actually hit the new
+indexes via a ``BitmapOr``, not just that the indexes exist (that narrower
+check lives in ``TestOrmAndMigrationShape`` in ``test_dataset_source_state.py``
+for the sibling ``ix_datasets_origin_uri`` index) and not just that the
+origin_ref branch is indexable in isolation.
+
+``SET LOCAL enable_seqscan = off`` forces the planner to prefer an index scan
+even though the test table is far too small for the index to win on cost
+alone -- see ``test_search_simple_regconfig.py`` for the same technique and
+its rationale.
+
+History, for anyone re-deriving why there are three indexes here: both guard
+queries are shaped ``WHERE (origin_ref match) OR (legacy source_url
+fallback) AND source_format = ... AND created_by = ...``. Postgres only
+folds a top-level OR into a bitmap index scan when EVERY disjunct has an
+index path of its own. An earlier version of this migration indexed only
+the origin_ref keys #1324 named, leaving the source_url fallback disjunct
+unindexed -- codex's round-1 review on PR #1365 caught that this made both
+new indexes dead weight against the real queries (confirmed by EXPLAIN: the
+full guard predicate still resolved to a sequential scan). Adding
+``ix_datasets_source_url`` gives the fallback disjunct an index path too, so
+postgres builds a BitmapOr combining it with the matching origin_ref index --
+which is what the tests below assert.
+
+Round 2 then caught that a PLAIN (btree) `source_url` index carries its own
+risk -- see the test class below -- resolved by making it `USING hash`.
+Round 4 caught the same class on the two `origin_ref` indexes: WFS/OGC API
+`layer_name` allows up to 500 multibyte characters and flows into
+`origin_ref->>'layer_id'`, so a long multibyte `url` combined with a long
+multibyte `layer_id` can exceed the btree ceiling in the COMPOSITE key even
+when a single-column index would not have. All three are now `USING hash`,
+which closes the class rather than patching it per column -- postgres hash
+indexes store only a fixed-size hash, never the value, so none of them has
+a size ceiling at all. The tradeoff: hash indexes are single-column, so
+`layer_id` is no longer part of any index -- the service-preview guard's
+`layer_id` check becomes a residual Filter, confirmed acceptable by EXPLAIN
+(url alone remains the selective key).
+"""
+
+import json
+import uuid
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import and_, or_, text
+from sqlalchemy.dialects import postgresql
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from tests.factories import get_user_id
+
+_ORIGIN_REF_INDEX_NAMES = (
+    "ix_datasets_origin_ref_url",
+    "ix_datasets_origin_ref_asset_href",
+    "ix_datasets_source_url",
+)
+
+
+def _walk_plan(node: dict, results: list) -> None:
+    """Recursively walk a Postgres JSON EXPLAIN plan, collecting all node dicts."""
+    results.append(node)
+    for child in node.get("Plans", []):
+        _walk_plan(child, results)
+
+
+async def _explain_index_names(session, stmt) -> set[str]:
+    """Run EXPLAIN (FORMAT JSON) on ``stmt`` and collect every Index Name used."""
+    compiled = stmt.compile(
+        dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+    )
+    await session.execute(text("SET LOCAL enable_seqscan = off"))
+    result = await session.execute(text(f"EXPLAIN (FORMAT JSON) {compiled}"))
+    row = result.fetchone()
+    assert row is not None, "EXPLAIN returned no rows"
+    plan_json = row[0]
+    plan_list = json.loads(plan_json) if isinstance(plan_json, str) else plan_json
+    all_nodes: list[dict] = []
+    for top in plan_list:
+        _walk_plan(top["Plan"], all_nodes)
+    return {node.get("Index Name") for node in all_nodes if "Index Name" in node}
+
+
+class _SeededRow:
+    """A Record + Dataset pair this module owns, deleted by id in teardown.
+
+    Not the shared ``clean_tables`` fixture: that TRUNCATEs the whole
+    catalog.datasets/catalog.records tables, which is safe against CI's
+    per-worker database but not against a developer's shared host-side test
+    database (this suite is regularly run that way -- see AGENTS.md). A
+    delete scoped to exactly the ids this fixture created is safe either way.
+    """
+
+    def __init__(self, record: Record, dataset: Dataset) -> None:
+        self.record = record
+        self.dataset = dataset
+
+
+@pytest.fixture
+async def seeded_rows(test_db_session):
+    created: list[_SeededRow] = []
+
+    async def _seed(*, created_by, source_format, origin_ref, source_url=None):
+        tag = uuid.uuid4().hex[:12]
+        record = Record(
+            title=f"origin-ref-index test {tag}",
+            visibility="public",
+            record_status="published",
+            record_type="vector_dataset",
+            created_by=created_by,
+        )
+        test_db_session.add(record)
+        await test_db_session.flush()
+        dataset = Dataset(
+            record_id=record.id,
+            table_name=f"ds_{tag}",
+            source_format=source_format,
+            origin_ref=origin_ref,
+            source_url=source_url,
+        )
+        test_db_session.add(dataset)
+        await test_db_session.flush()
+        row = _SeededRow(record, dataset)
+        created.append(row)
+        return row
+
+    await test_db_session.commit()
+    yield _seed
+
+    for row in created:
+        await test_db_session.execute(
+            sa.delete(Dataset).where(Dataset.id == row.dataset.id)
+        )
+        await test_db_session.execute(
+            sa.delete(Record).where(Record.id == row.record.id)
+        )
+    await test_db_session.commit()
+
+
+@pytest.mark.anyio
+async def test_origin_ref_indexes_exist(test_db_session):
+    """All three indexes from migration 0040 must be present."""
+    result = await test_db_session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE schemaname = 'catalog' AND tablename = 'datasets' "
+            "AND indexname = ANY(:names)"
+        ),
+        {"names": list(_ORIGIN_REF_INDEX_NAMES)},
+    )
+    names = {row[0] for row in result.fetchall()}
+    assert names == set(_ORIGIN_REF_INDEX_NAMES), (
+        "Expected all three origin_ref/source_url indexes in pg_indexes; did "
+        "migration 0040_dataset_origin_ref_indexes apply?"
+    )
+
+
+@pytest.mark.anyio
+async def test_service_guard_full_query_uses_bitmap_or(test_db_session, seeded_rows):
+    """The service-preview guard's FULL WHERE clause -- the real OR of the
+    origin_ref match and the legacy source_url fallback, exactly as built in
+    sources/router.py's preview_service_layer -- must resolve through a
+    BitmapOr of ix_datasets_origin_ref_url and ix_datasets_source_url, not a
+    table-wide scan.
+
+    Deliberately a datasets-only probe, dropping the guard's Record join and
+    created_by filter (CI finding, batch run 31417356444): a joined query's
+    plan can depend on relative table statistics, which pytest-xdist worker
+    databases don't control -- other tests running in the same worker leave
+    an arbitrary number of records/datasets rows behind, and at some ratio
+    the planner can prefer driving from records_pkey over the origin_ref/
+    source_url predicate this test exists to check. The Dataset-only WHERE
+    clause below is the part these indexes actually serve; created_by
+    filtering rides on ix_records_created_by regardless and isn't what this
+    file verifies.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    target_url = f"https://gis.example.test/wfs/{uuid.uuid4().hex[:8]}"
+    target_layer = f"topp:{uuid.uuid4().hex[:8]}"
+
+    await seeded_rows(
+        created_by=admin_id,
+        source_format="wfs",
+        origin_ref={
+            "kind": "service",
+            "service_type": "wfs",
+            "url": target_url,
+            "layer_id": target_layer,
+        },
+    )
+
+    # Mirrors the full WHERE clause built in sources/router.py's
+    # preview_service_layer (the ``canonical_layer_id is not None`` arm),
+    # including the legacy source_url fallback disjunct -- minus the join,
+    # see the docstring above.
+    origin_ref_url = Dataset.origin_ref["url"].astext
+    origin_ref_layer_id = Dataset.origin_ref["layer_id"].astext
+    stmt = sa.select(Dataset.id).where(
+        or_(
+            and_(
+                Dataset.origin_ref["service_type"].astext == "wfs",
+                origin_ref_url == target_url,
+                origin_ref_layer_id == target_layer,
+            ),
+            and_(
+                or_(origin_ref_url.is_(None), origin_ref_layer_id.is_(None)),
+                Dataset.source_url == target_url,
+            ),
+        ),
+        Dataset.source_format == "wfs",
+    )
+
+    index_names = await _explain_index_names(test_db_session, stmt)
+    assert {"ix_datasets_origin_ref_url", "ix_datasets_source_url"} <= index_names, (
+        f"Expected both ix_datasets_origin_ref_url and ix_datasets_source_url "
+        f"in the plan (as a BitmapOr), got: {index_names}"
+    )
+
+
+@pytest.mark.anyio
+async def test_stac_guard_full_query_uses_bitmap_or(test_db_session, seeded_rows):
+    """The STAC-import guard's FULL WHERE clause -- the real OR of the
+    origin_ref->>'asset_href' match and the legacy source_url fallback,
+    exactly as built in stac_router.py's batch duplicate check -- must
+    resolve through a BitmapOr of ix_datasets_origin_ref_asset_href and
+    ix_datasets_source_url, not a table-wide scan.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    target_href = f"https://stac.example.test/assets/{uuid.uuid4().hex[:8]}.tif"
+
+    await seeded_rows(
+        created_by=admin_id,
+        source_format="stac",
+        origin_ref={"kind": "stac", "asset_href": target_href},
+    )
+
+    # Mirrors the batch duplicate-check in stac_router.py's import handler:
+    # origin_ref->>'asset_href' IN (hrefs) OR (origin_uri IS NULL AND
+    # source_url IN (hrefs)), scoped to source_format = 'stac'.
+    stmt = sa.select(
+        Dataset.origin_ref["asset_href"].astext.label("asset_href"),
+        Dataset.source_url,
+    ).where(
+        or_(
+            Dataset.origin_ref["asset_href"].astext.in_([target_href]),
+            and_(
+                Dataset.origin_uri.is_(None),
+                Dataset.source_url.in_([target_href]),
+            ),
+        ),
+        Dataset.source_format == "stac",
+    )
+
+    index_names = await _explain_index_names(test_db_session, stmt)
+    assert {
+        "ix_datasets_origin_ref_asset_href",
+        "ix_datasets_source_url",
+    } <= index_names, (
+        f"Expected both ix_datasets_origin_ref_asset_href and "
+        f"ix_datasets_source_url in the plan (as a BitmapOr), got: {index_names}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# All three indexes are USING hash, not btree (codex review rounds 2 and 4).
+# A btree index stores the value itself and has a ~2704-byte tuple limit on
+# standard 8kB pages; VARCHAR(2000) caps source_url's CHARACTER count, not
+# bytes, and WFS/OGC API layer_name (up to 500 multibyte characters) flows
+# into origin_ref->>'layer_id', so a multibyte-heavy value can pass every
+# length check that exists and still break a btree index (reproduced during
+# development: 2000 random astral-plane characters is 8000 UTF-8 bytes, and
+# a scratch btree index on such a row fails with "index row size exceeds
+# btree ... maximum"). A hash index stores only a fixed-size hash of the
+# value, so it has no such ceiling regardless of source string length --
+# these three tests prove that holds for each of the real indexes, not just
+# a scratch table.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_source_url_hash_index_tolerates_byte_oversize_value(
+    test_db_session, seeded_rows
+):
+    """A source_url whose UTF-8 encoding would break a btree index (see the
+    module docstring above) must insert and index cleanly under
+    ix_datasets_source_url's hash access method, and still be found by an
+    equality lookup mirroring the guards' own predicate.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    # 722 characters total -- comfortably inside the column's VARCHAR(2000)
+    # CHARACTER cap -- but 2822 UTF-8 bytes, over the btree ceiling. This is
+    # exactly the shape the round-2 finding described: a value the column
+    # (and any character-length validation) accepts without complaint.
+    oversize_url = "https://example.test/" + ("\U0001f000" * 700)
+    assert len(oversize_url) <= 2000, "fixture must satisfy VARCHAR(2000)"
+    assert len(oversize_url.encode("utf-8")) > 2704, (
+        "fixture must exceed the btree ceiling to be a meaningful regression check"
+    )
+
+    await seeded_rows(
+        created_by=admin_id,
+        source_format="wfs",
+        origin_ref=None,
+        source_url=oversize_url,
+    )
+
+    stmt = sa.select(Dataset.id).where(Dataset.source_url == oversize_url)
+    index_names = await _explain_index_names(test_db_session, stmt)
+    assert "ix_datasets_source_url" in index_names, (
+        f"Expected the hash index to serve an equality lookup on an "
+        f"oversize source_url, got: {index_names}"
+    )
+
+    result = await test_db_session.execute(stmt)
+    assert result.scalar_one_or_none() is not None, (
+        "the oversize row must actually be findable via the index, not just "
+        "planned through it"
+    )
+
+
+@pytest.mark.anyio
+async def test_origin_ref_url_hash_index_tolerates_byte_oversize_value(
+    test_db_session, seeded_rows
+):
+    """The round-4 finding's exact shape: a long multibyte
+    origin_ref->>'url' combined with a multibyte layer_id (WFS/OGC API
+    layer_name allows up to 500 characters, no charset restriction) --
+    which would have exceeded a composite btree's tuple limit even though
+    neither value alone might -- must insert and index cleanly under
+    ix_datasets_origin_ref_url's hash access method.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    oversize_url = "https://example.test/" + ("\U0001f000" * 700)
+    oversize_layer = "テスト" * 100  # 300 chars, well under 500
+    assert len(oversize_url.encode("utf-8")) > 2704
+
+    await seeded_rows(
+        created_by=admin_id,
+        source_format="wfs",
+        origin_ref={
+            "kind": "service",
+            "service_type": "wfs",
+            "url": oversize_url,
+            "layer_id": oversize_layer,
+        },
+    )
+
+    stmt = sa.select(Dataset.id).where(Dataset.origin_ref["url"].astext == oversize_url)
+    index_names = await _explain_index_names(test_db_session, stmt)
+    assert "ix_datasets_origin_ref_url" in index_names, (
+        f"Expected the hash index to serve an equality lookup on an "
+        f"oversize origin_ref->>'url', got: {index_names}"
+    )
+
+    result = await test_db_session.execute(stmt)
+    assert result.scalar_one_or_none() is not None
+
+
+@pytest.mark.anyio
+async def test_origin_ref_asset_href_hash_index_tolerates_byte_oversize_value(
+    test_db_session, seeded_rows
+):
+    """Same shape as the two tests above, for the STAC guard's
+    origin_ref->>'asset_href' hash index.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    oversize_href = "https://example.test/" + ("\U0001f000" * 700)
+    assert len(oversize_href.encode("utf-8")) > 2704
+
+    await seeded_rows(
+        created_by=admin_id,
+        source_format="stac",
+        origin_ref={"kind": "stac", "asset_href": oversize_href},
+    )
+
+    stmt = sa.select(Dataset.id).where(
+        Dataset.origin_ref["asset_href"].astext == oversize_href
+    )
+    index_names = await _explain_index_names(test_db_session, stmt)
+    assert "ix_datasets_origin_ref_asset_href" in index_names, (
+        f"Expected the hash index to serve an equality lookup on an "
+        f"oversize origin_ref->>'asset_href', got: {index_names}"
+    )
+
+    result = await test_db_session.execute(stmt)
+    assert result.scalar_one_or_none() is not None


### PR DESCRIPTION
## What

Adds migration `0040_dataset_origin_ref_indexes`: three **hash** indexes on `catalog.datasets` backing the JSONB/string predicates the duplicate-source guards actually filter on (PR #1320 re-keyed those guards onto `origin_ref`):

- `ix_datasets_origin_ref_url` — `USING hash` on `(origin_ref->>'url')` — the service-preview guard in `sources/router.py`.
- `ix_datasets_origin_ref_asset_href` — `USING hash` on `(origin_ref->>'asset_href')` — the STAC-import guard in `stac_router.py`.
- `ix_datasets_source_url` — `USING hash` on plain `source_url` — required for the two above to matter at all (round 1 finding, see below).

All three are scoped with `IS NOT NULL` on the indexed expression itself (mirroring `ix_datasets_origin_uri` from migration 0036) rather than a `source_format IN (...)` partial predicate, and built with plain transactional `CREATE INDEX` (round 6 finding, see below).

## Why

Migration 0036 indexed only `origin_uri`; PR #1320's re-key onto `origin_ref` left both guards doing a sequential scan with per-row JSONB extraction (Codex round 2 on that PR).

## Schema / API / config impact

Schema only — three new indexes, no column/table changes, no API surface change.

## Six review rounds, five real findings, all fixed, all index-only

1. **BitmapOr eligibility** — shipping only the two `origin_ref` indexes left the *full* guard query (with its legacy `source_url` fallback branch) still sequential-scanning, since Postgres only folds an `OR` into a bitmap index scan when every disjunct has an index path. Fixed with a third index on `source_url`.
2. **Btree tuple-size ceiling on `source_url`** — `VARCHAR(2000)` caps character count, not bytes, so a multibyte-heavy value can pass that check and still exceed Postgres's ~2704-byte btree tuple limit (reproduced: 2000 random astral-plane characters is 8000 bytes, `index row size 8016 exceeds btree version 4 maximum 2704`).
3. **Same ceiling on the two `origin_ref` btrees** — WFS/OGC API `layer_name` allows up to 500 multibyte characters and flows into `origin_ref->>'layer_id'`, so the *composite* `(url, layer_id)` key could exceed the ceiling even where a single column wouldn't. Findings 2 and 3 resolved together by switching every index to `USING hash`: a hash index stores a fixed-size hash rather than the value, so it has no size ceiling regardless of input length, and both guards compare these columns with pure equality only (Postgres decomposes an `IN` list into an OR of `=` at plan time, confirmed by EXPLAIN a hash index serves it identically to a btree). Hash indexes are single-column, so `layer_id` is no longer part of any index — the service-preview guard's `layer_id` check becomes a residual `Filter` rather than an `Index Cond`, confirmed by EXPLAIN to still produce the same `BitmapOr` plan shape.
4. **`CREATE INDEX CONCURRENTLY` invalid-index race under CI's parallel migration bootstrap** — the PR passed branch CI and codex review clean, then was evicted from the merge queue twice: the queue-batch run failed `test_email_verification_migration.py`'s `alembic check` drift test (all three indexes reported as missing) and this PR's own EXPLAIN tests (plan showed no origin_ref/source_url index in use). Root cause: pytest-xdist migrates each worker's database with `alembic.command.upgrade` running several workers against one Postgres instance in parallel; a `CREATE INDEX CONCURRENTLY` build interrupted mid-way (lock contention from a sibling worker's migration) leaves an INVALID index, and `IF NOT EXISTS` then silently keeps that husk rather than repairing it — invisible to SQLAlchemy reflection (drift) and never chosen by the planner (EXPLAIN failure), which is exactly what both CI failures showed. The post-squash migration chain has no other `CONCURRENTLY` migration, so this bootstrap path had no prior green run to catch the pattern. Fixed by switching to plain transactional `CREATE INDEX` — `catalog.datasets` is small enough in any realistic install that the brief `SHARE` lock is cheap (the Clean-DB CI job's own log shows the whole migration chain completing in ~1.5s), and a transactional `CREATE INDEX` either fully commits or the whole migration rolls back, so there's no invalid-index state to leave behind. Dropped the now-unnecessary `_index_state()`/`autocommit_block()` resumability machinery that existed only to manage `CONCURRENTLY`'s failure modes.
5. **EXPLAIN test determinism under arbitrary sibling-test data** — the service-guard EXPLAIN test joined `Dataset` to `Record` to filter by `created_by`, and a joined query's plan can depend on relative table statistics that a shared pytest-xdist worker database doesn't control (other tests leave an unpredictable number of rows behind). Fixed by dropping the join — the test now asserts index usage on a datasets-only probe of exactly the predicate these indexes serve; `created_by` filtering rides on `ix_records_created_by` regardless and isn't what this test file verifies. Stress-tested locally with 3000+ unrelated sibling rows present to confirm the dataset-only probe has no alternate join-order path to go wrong.

### EXPLAIN evidence (final all-hash, plain-DDL shape)

Both full guard queries — service-preview (`sources/router.py`) and STAC-import (`stac_router.py`) — resolve through a `BitmapOr` combining the relevant `origin_ref` hash index with `ix_datasets_source_url`, pinned as `tests/test_origin_ref_indexes.py::test_service_guard_full_query_uses_bitmap_or` / `::test_stac_guard_full_query_uses_bitmap_or`. Byte-oversize regression coverage for all three columns: `test_source_url_hash_index_tolerates_byte_oversize_value`, `test_origin_ref_url_hash_index_tolerates_byte_oversize_value`, `test_origin_ref_asset_href_hash_index_tolerates_byte_oversize_value` — each seeds a value under every character-length check but over the btree byte ceiling and asserts it indexes and is findable via the hash index.

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .` — pass.
- Host-side, `.env.test` sourced: `alembic downgrade -1` / `alembic upgrade head` / `alembic check` — repeated across every revision of this PR, always clean, DB left at head. Final verification explicitly exercised the downgrade path first (since `:5434` already held the old CONCURRENTLY-built indexes) to prove the new plain-DDL upgrade recreates all three with `indisvalid = t`.
- `uv run pytest tests/test_layering.py -q` — 40 collected, 40 passed, re-verified fresh at 18:35Z UTC (outside the wave's advisory `pkill -f pytest` incident window).
- `uv run pytest tests/test_origin_ref_indexes.py tests/test_dataset_source_state.py tests/test_services_endpoints.py tests/test_validation.py tests/test_api_contract_openapi.py -q` — 187 collected, 187 passed.
- Local stress test: seeded 3000+ unrelated sibling records before re-running the EXPLAIN probe, confirmed the `BitmapOr` plan shape is unaffected by sibling-data volume.
- Squashed the branch to one commit and rebased cleanly onto current `origin/main` (several other wave PRs merged in the interim; zero file overlap with this PR).

Closes #1324