### PR TITLE
docs: describe all eight analysis operations and fix the quickstart OGC marker

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -125,7 +125,7 @@ Für jedes Beispiel gibt es eine vollständige Anleitung in der [Dokumentation](
 - **Puffer** (Meter, Kilometer, Fuß oder Meilen), **Zentroid**, **Zuschneiden** anhand einer gezeichneten Fläche oder eines anderen Polygon-Layers sowie **Auflösen** mit optionaler Gruppierungsspalte; die **räumliche Verknüpfung** und die **Auswahl nach Lage** verknüpfen Objekte per Überschneidung, **Messen** ergänzt die Spalten `area_sqm` und `length_m`, und **Verschneiden** schreibt die paarweise Überlagerung mit Attributen beider Seiten
 - Alle Operationen außer Auflösen werden auf der Karte als Vorschau angezeigt, begrenzt auf 500 Objekte; Auflösen gibt es nur als Datensatz. **Datensatz erstellen** führt anschließend jede der acht Operationen als Hintergrundjob über alle Objekte aus, im Rahmen der Grenzwerte je Operation (250k Objekte beim Auflösen, 500k beim Puffern)
 - Das Ergebnis ist ein gewöhnlicher Vektordatensatz — gestaltbar, exportierbar und wie jeder andere über die OGC-API-Endpunkte verfügbar
-- Der Chat-Assistent kann auf Anfrage Puffer- und Zentroid-Vorschauen erzeugen
+- Der Chat-Assistent kann auf Anfrage Puffer-, Zentroid- und Zuschneiden-Vorschauen gegenüber einem anderen Layer erzeugen
 
 ### Standards und Interoperabilität
 

--- a/README.de.md
+++ b/README.de.md
@@ -122,8 +122,8 @@ Für jedes Beispiel gibt es eine vollständige Anleitung in der [Dokumentation](
 
 ### Analyse
 
-- **Puffer** (Meter, Kilometer, Fuß oder Meilen), **Zentroid**, **Zuschneiden** anhand einer gezeichneten Fläche oder eines anderen Polygon-Layers sowie **Auflösen** mit optionaler Gruppierungsspalte
-- Puffer, Zentroid und Zuschneiden werden auf der Karte als Vorschau angezeigt, begrenzt auf 500 Objekte; Auflösen gibt es nur als Datensatz. **Datensatz erstellen** führt anschließend jede der vier Operationen als Hintergrundjob über alle Objekte aus, im Rahmen der Grenzwerte je Operation (250k Objekte beim Auflösen, 500k beim Puffern)
+- **Puffer** (Meter, Kilometer, Fuß oder Meilen), **Zentroid**, **Zuschneiden** anhand einer gezeichneten Fläche oder eines anderen Polygon-Layers sowie **Auflösen** mit optionaler Gruppierungsspalte; die **räumliche Verknüpfung** und die **Auswahl nach Lage** verknüpfen Objekte per Überschneidung, **Messen** ergänzt die Spalten `area_sqm` und `length_m`, und **Verschneiden** schreibt die paarweise Überlagerung mit Attributen beider Seiten
+- Alle Operationen außer Auflösen werden auf der Karte als Vorschau angezeigt, begrenzt auf 500 Objekte; Auflösen gibt es nur als Datensatz. **Datensatz erstellen** führt anschließend jede der acht Operationen als Hintergrundjob über alle Objekte aus, im Rahmen der Grenzwerte je Operation (250k Objekte beim Auflösen, 500k beim Puffern)
 - Das Ergebnis ist ein gewöhnlicher Vektordatensatz — gestaltbar, exportierbar und wie jeder andere über die OGC-API-Endpunkte verfügbar
 - Der Chat-Assistent kann auf Anfrage Puffer- und Zentroid-Vorschauen erzeugen
 

--- a/README.es.md
+++ b/README.es.md
@@ -126,7 +126,7 @@ Cada ejemplo anterior tiene una guía completa en la [documentación](https://do
 - **Área de influencia** (metros, kilómetros, pies o millas), **centroide**, **recorte** por un área dibujada o por otra capa de polígonos, y **disolución** con columna de agrupación opcional; la **unión espacial** y la **selección por ubicación** emparejan entidades por intersección, la **medición** añade las columnas `area_sqm` y `length_m`, y la **intersección** escribe la superposición por pares con atributos de ambos lados
 - Todas las operaciones se previsualizan en el mapa salvo la disolución, que solo se puede materializar; las previsualizaciones tienen un límite de 500 entidades. **Crear conjunto de datos** ejecuta después cualquiera de las ocho sobre todas las entidades como trabajo en segundo plano, dentro de los límites por operación (250k entidades para disolución, 500k para área de influencia)
 - La salida es un conjunto de datos vectorial normal: se puede estilizar, exportar y servir a través de los endpoints de la API OGC como cualquier otro
-- El asistente de chat puede generar previsualizaciones de área de influencia y centroide cuando se le pide
+- El asistente de chat puede generar previsualizaciones de área de influencia, centroide y recorte contra otra capa cuando se le pide
 
 ### Estándares e interoperabilidad
 

--- a/README.es.md
+++ b/README.es.md
@@ -123,8 +123,8 @@ Cada ejemplo anterior tiene una guía completa en la [documentación](https://do
 
 ### Análisis
 
-- **Área de influencia** (metros, kilómetros, pies o millas), **centroide**, **recorte** por un área dibujada o por otra capa de polígonos, y **disolución** con columna de agrupación opcional
-- El área de influencia, el centroide y el recorte se previsualizan en el mapa, con un límite de 500 entidades; la disolución solo se puede materializar. **Crear conjunto de datos** ejecuta después cualquiera de las cuatro sobre todas las entidades como trabajo en segundo plano, dentro de los límites por operación (250k entidades para disolución, 500k para área de influencia)
+- **Área de influencia** (metros, kilómetros, pies o millas), **centroide**, **recorte** por un área dibujada o por otra capa de polígonos, y **disolución** con columna de agrupación opcional; la **unión espacial** y la **selección por ubicación** emparejan entidades por intersección, la **medición** añade las columnas `area_sqm` y `length_m`, y la **intersección** escribe la superposición por pares con atributos de ambos lados
+- Todas las operaciones se previsualizan en el mapa salvo la disolución, que solo se puede materializar; las previsualizaciones tienen un límite de 500 entidades. **Crear conjunto de datos** ejecuta después cualquiera de las ocho sobre todas las entidades como trabajo en segundo plano, dentro de los límites por operación (250k entidades para disolución, 500k para área de influencia)
 - La salida es un conjunto de datos vectorial normal: se puede estilizar, exportar y servir a través de los endpoints de la API OGC como cualquier otro
 - El asistente de chat puede generar previsualizaciones de área de influencia y centroide cuando se le pide
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -125,7 +125,7 @@ Chaque exemple ci-dessus dispose d’un guide complet dans la [documentation](ht
 - **Zone tampon** (mètres, kilomètres, pieds ou milles), **centroïde**, **découpage** par une zone dessinée ou par une autre couche de polygones, et **fusion** avec colonne de regroupement facultative ; la **jointure spatiale** et la **sélection par emplacement** apparient les entités par intersection, la **mesure** ajoute les colonnes `area_sqm` et `length_m`, et l’**intersection** écrit la superposition entité par entité avec les attributs des deux côtés
 - Toutes les opérations s’affichent en aperçu sur la carte sauf la fusion, qui n’existe qu’en création de jeu de données ; les aperçus sont limités à 500 entités. **Créer un jeu de données** exécute ensuite l’une des huit opérations sur toutes les entités sous forme de tâche en arrière-plan, dans la limite fixée par opération (250k entités pour la fusion, 500k pour la zone tampon)
 - La sortie est un jeu de données vectoriel ordinaire : stylisable, exportable et servi via les points de terminaison de l’API OGC comme n’importe quel autre
-- L’assistant de discussion peut générer des aperçus de zone tampon et de centroïde à la demande
+- L’assistant de discussion peut générer des aperçus de zone tampon, de centroïde et de découpage par rapport à une autre couche à la demande
 
 ### Normes et interopérabilité
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -122,8 +122,8 @@ Chaque exemple ci-dessus dispose d’un guide complet dans la [documentation](ht
 
 ### Analyse
 
-- **Zone tampon** (mètres, kilomètres, pieds ou milles), **centroïde**, **découpage** par une zone dessinée ou par une autre couche de polygones, et **fusion** avec colonne de regroupement facultative
-- La zone tampon, le centroïde et le découpage s’affichent en aperçu sur la carte, limités à 500 entités ; la fusion n’existe qu’en création de jeu de données. **Créer un jeu de données** exécute ensuite l’une des quatre opérations sur toutes les entités sous forme de tâche en arrière-plan, dans la limite fixée par opération (250k entités pour la fusion, 500k pour la zone tampon)
+- **Zone tampon** (mètres, kilomètres, pieds ou milles), **centroïde**, **découpage** par une zone dessinée ou par une autre couche de polygones, et **fusion** avec colonne de regroupement facultative ; la **jointure spatiale** et la **sélection par emplacement** apparient les entités par intersection, la **mesure** ajoute les colonnes `area_sqm` et `length_m`, et l’**intersection** écrit la superposition entité par entité avec les attributs des deux côtés
+- Toutes les opérations s’affichent en aperçu sur la carte sauf la fusion, qui n’existe qu’en création de jeu de données ; les aperçus sont limités à 500 entités. **Créer un jeu de données** exécute ensuite l’une des huit opérations sur toutes les entités sous forme de tâche en arrière-plan, dans la limite fixée par opération (250k entités pour la fusion, 500k pour la zone tampon)
 - La sortie est un jeu de données vectoriel ordinaire : stylisable, exportable et servi via les points de terminaison de l’API OGC comme n’importe quel autre
 - L’assistant de discussion peut générer des aperçus de zone tampon et de centroïde à la demande
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Each example above has a full guide in the [docs](https://docs.getgeolens.com/gu
 - **Buffer** (metres, kilometres, feet, or miles), **centroid**, **clip** by a drawn area or by another polygon layer, and **dissolve** with an optional group-by column; **spatial join** and **select by location** match features on intersection, **measure** adds `area_sqm` and `length_m` columns, and **intersect** writes the pairwise overlay with attributes from both sides
 - All operations preview on the map except dissolve, which is materialize-only; previews are capped at 500 features. **Create dataset** then runs any of the eight over every feature as a background job, within per-operation source limits (250k features for dissolve, 500k for buffer)
 - The output is an ordinary vector dataset — styleable, exportable, and served through the OGC API endpoints like any other
-- The chat assistant can run buffer and centroid previews on request
+- The chat assistant can run buffer, centroid, and layer-based clip previews on request
 
 ### Standards and interop
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Each example above has a full guide in the [docs](https://docs.getgeolens.com/gu
 
 ### Analysis
 
-- **Buffer** (metres, kilometres, feet, or miles), **centroid**, **clip** by a drawn area or by another polygon layer, and **dissolve** with an optional group-by column
-- Buffer, centroid, and clip preview on the map, capped at 500 features; dissolve is materialize-only. **Create dataset** then runs any of the four over every feature as a background job, within per-operation source limits (250k features for dissolve, 500k for buffer)
+- **Buffer** (metres, kilometres, feet, or miles), **centroid**, **clip** by a drawn area or by another polygon layer, and **dissolve** with an optional group-by column; **spatial join** and **select by location** match features on intersection, **measure** adds `area_sqm` and `length_m` columns, and **intersect** writes the pairwise overlay with attributes from both sides
+- All operations preview on the map except dissolve, which is materialize-only; previews are capped at 500 features. **Create dataset** then runs any of the eight over every feature as a background job, within per-operation source limits (250k features for dissolve, 500k for buffer)
 - The output is an ordinary vector dataset — styleable, exportable, and served through the OGC API endpoints like any other
 - The chat assistant can run buffer and centroid previews on request
 

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -66,7 +66,7 @@ from app.core.dependencies import get_db
 from app.core.public_urls import get_dataset_service_url
 from app.platform.storage import get_storage
 from app.platform.extensions import get_catalog_port
-from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
+from app.standards.ogc.errors import ERROR_RESPONSES_WRITE, FORBIDDEN_RESPONSE
 
 logger = structlog.get_logger()
 
@@ -162,7 +162,15 @@ async def create_empty_dataset_endpoint(
     )
 
 
-@router.get("/{dataset_id}", response_model=DatasetResponse)
+@router.get(
+    "/{dataset_id}",
+    response_model=DatasetResponse,
+    # fix(getgeolens.com#86 review): read-gated (check_dataset_access_or_anonymous
+    # below), not write-gated, so the router's default 403 ("caller lacks write
+    # access") misdescribes this route's actual 403 cause. Same override on
+    # every other read-gated GET in this file (quicklook, history, refresh-runs).
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_single_dataset(
     dataset_id: uuid.UUID,
     request: Request,
@@ -216,7 +224,11 @@ async def get_single_dataset(
     return result
 
 
-@router.get("/{dataset_id}/quicklook", response_class=Response)
+@router.get(
+    "/{dataset_id}/quicklook",
+    response_class=Response,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_quicklook(
     dataset_id: uuid.UUID,
     size: int = Query(
@@ -557,7 +569,11 @@ async def delete_dataset_endpoint(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.get("/{dataset_id}/history", response_model=AuditLogListResponse)
+@router.get(
+    "/{dataset_id}/history",
+    response_model=AuditLogListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_dataset_history(
     dataset_id: uuid.UUID,
     skip: int = Query(0, ge=0),
@@ -609,7 +625,11 @@ async def get_dataset_history(
     )
 
 
-@router.get("/{dataset_id}/refresh-runs", response_model=DatasetRefreshRunListResponse)
+@router.get(
+    "/{dataset_id}/refresh-runs",
+    response_model=DatasetRefreshRunListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_dataset_refresh_runs(
     dataset_id: uuid.UUID,
     skip: int = Query(0, ge=0),

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -962,11 +962,15 @@ class VrtGenerationListResponse(BaseModel):
 class SourceHealthResponse(BaseModel):
     """Result of one on-demand origin probe (ADR-002, #1222).
 
-    Deliberately the same three words ``VrtSourceHealth.status`` uses, so the
-    UI renders one legend across VRT members and standalone origins. This
-    endpoint always probes, so it never returns the fourth value: ``unknown``
-    is the response-boundary projection of a never-determined NULL column and
-    reaches clients through ``DatasetResponse``, not through here.
+    Shares its first three words with ``VrtSourceHealth.status``, so the UI
+    renders one legend across VRT members and standalone origins.
+    ``VrtSourceHealth`` carries a fourth, VRT-specific value, ``stale``
+    (fix(#1221)): it means a member's raster was replaced after the parent
+    VRT was last built, and it does not apply to a single-origin probe. This
+    endpoint always probes, so it also never returns the OTHER fourth value,
+    ``unknown`` — the response-boundary projection of a never-determined NULL
+    column, which reaches clients through ``DatasetResponse``, not through
+    here.
     """
 
     dataset_id: uuid.UUID

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15230,7 +15230,7 @@
         "type": "object"
       },
       "SourceHealthResponse": {
-        "description": "Result of one on-demand origin probe (ADR-002, #1222).\n\nDeliberately the same three words ``VrtSourceHealth.status`` uses, so the\nUI renders one legend across VRT members and standalone origins. This\nendpoint always probes, so it never returns the fourth value: ``unknown``\nis the response-boundary projection of a never-determined NULL column and\nreaches clients through ``DatasetResponse``, not through here.",
+        "description": "Result of one on-demand origin probe (ADR-002, #1222).\n\nShares its first three words with ``VrtSourceHealth.status``, so the UI\nrenders one legend across VRT members and standalone origins.\n``VrtSourceHealth`` carries a fourth, VRT-specific value, ``stale``\n(fix(#1221)): it means a member's raster was replaced after the parent\nVRT was last built, and it does not apply to a single-origin probe. This\nendpoint always probes, so it also never returns the OTHER fourth value,\n``unknown`` \u2014 the response-boundary projection of a never-determined NULL\ncolumn, which reaches clients through ``DatasetResponse``, not through\nhere.",
         "properties": {
           "dataset_id": {
             "format": "uuid",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -31409,7 +31409,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -35806,7 +35806,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -36126,7 +36126,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -36455,7 +36455,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2731,7 +2731,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # description already carries for every other gated field in this
     # module), and DatasetVersionResponse gained a docstring for the same
     # reason on file_hash/uploaded_by. Cap 1440 -> 1454, exact.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1454,
+    # fix(getgeolens.com#86 review): +4 — SourceHealthResponse's docstring
+    # claimed it shared ALL of VrtSourceHealth.status's values, which stopped
+    # being true when fix(#1221) added VrtSourceHealth's VRT-specific `stale`
+    # value without updating this cross-reference. Cap 1454 -> 1458, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1458,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -21818,7 +21818,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -24671,7 +24671,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -24885,7 +24885,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -25102,7 +25102,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -11719,11 +11719,15 @@ export interface components {
          * SourceHealthResponse
          * @description Result of one on-demand origin probe (ADR-002, #1222).
          *
-         *     Deliberately the same three words ``VrtSourceHealth.status`` uses, so the
-         *     UI renders one legend across VRT members and standalone origins. This
-         *     endpoint always probes, so it never returns the fourth value: ``unknown``
-         *     is the response-boundary projection of a never-determined NULL column and
-         *     reaches clients through ``DatasetResponse``, not through here.
+         *     Shares its first three words with ``VrtSourceHealth.status``, so the UI
+         *     renders one legend across VRT members and standalone origins.
+         *     ``VrtSourceHealth`` carries a fourth, VRT-specific value, ``stale``
+         *     (fix(#1221)): it means a member's raster was replaced after the parent
+         *     VRT was last built, and it does not apply to a single-origin probe. This
+         *     endpoint always probes, so it also never returns the OTHER fourth value,
+         *     ``unknown`` — the response-boundary projection of a never-determined NULL
+         *     column, which reaches clients through ``DatasetResponse``, not through
+         *     here.
          */
         SourceHealthResponse: {
             /**

--- a/scripts/deployed_surface_gate.json
+++ b/scripts/deployed_surface_gate.json
@@ -11,12 +11,6 @@
           "pattern": "curl\\s+-fsSL\\s+https://getgeolens\\.com/install\\.sh\\s+\\|\\s+sh",
           "flags": "i",
           "reason": "Marketing home should show the public installer command."
-        },
-        {
-          "id": "ogc_api_collections_url",
-          "pattern": "http://localhost:8080/api/collections",
-          "flags": "i",
-          "reason": "Marketing home should route OGC examples through the frontend /api path."
         }
       ],
       "forbidden": [
@@ -263,6 +257,12 @@
           "pattern": "curl\\s+-fsSL\\s+https://getgeolens\\.com/install\\.sh\\s+\\|\\s+sh",
           "flags": "i",
           "reason": "Quickstart should lead with the public installer one-liner."
+        },
+        {
+          "id": "ogc_api_collections_url",
+          "pattern": "http://localhost:8080/api/collections",
+          "flags": "i",
+          "reason": "Quickstart should route OGC examples through the frontend /api path."
         }
       ],
       "forbidden": [

--- a/sdks/python/geolens/models/source_health_response.py
+++ b/sdks/python/geolens/models/source_health_response.py
@@ -27,11 +27,15 @@ T = TypeVar("T", bound="SourceHealthResponse")
 class SourceHealthResponse:
     """Result of one on-demand origin probe (ADR-002, #1222).
 
-    Deliberately the same three words ``VrtSourceHealth.status`` uses, so the
-    UI renders one legend across VRT members and standalone origins. This
-    endpoint always probes, so it never returns the fourth value: ``unknown``
-    is the response-boundary projection of a never-determined NULL column and
-    reaches clients through ``DatasetResponse``, not through here.
+    Shares its first three words with ``VrtSourceHealth.status``, so the UI
+    renders one legend across VRT members and standalone origins.
+    ``VrtSourceHealth`` carries a fourth, VRT-specific value, ``stale``
+    (fix(#1221)): it means a member's raster was replaced after the parent
+    VRT was last built, and it does not apply to a single-origin probe. This
+    endpoint always probes, so it also never returns the OTHER fourth value,
+    ``unknown`` — the response-boundary projection of a never-determined NULL
+    column, which reaches clients through ``DatasetResponse``, not through
+    here.
 
         Attributes:
             dataset_id (UUID):

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -16349,7 +16349,7 @@ export type GetSingleDatasetDatasetsDatasetIdGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -18223,7 +18223,7 @@ export type GetDatasetHistoryDatasetsDatasetIdHistoryGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -18363,7 +18363,7 @@ export type GetQuicklookDatasetsDatasetIdQuicklookGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -18497,7 +18497,7 @@ export type ListDatasetRefreshRunsDatasetsDatasetIdRefreshRunsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -8954,11 +8954,15 @@ export type SharedMapResponse = {
  *
  * Result of one on-demand origin probe (ADR-002, #1222).
  *
- * Deliberately the same three words ``VrtSourceHealth.status`` uses, so the
- * UI renders one legend across VRT members and standalone origins. This
- * endpoint always probes, so it never returns the fourth value: ``unknown``
- * is the response-boundary projection of a never-determined NULL column and
- * reaches clients through ``DatasetResponse``, not through here.
+ * Shares its first three words with ``VrtSourceHealth.status``, so the UI
+ * renders one legend across VRT members and standalone origins.
+ * ``VrtSourceHealth`` carries a fourth, VRT-specific value, ``stale``
+ * (fix(#1221)): it means a member's raster was replaced after the parent
+ * VRT was last built, and it does not apply to a single-origin probe. This
+ * endpoint always probes, so it also never returns the OTHER fourth value,
+ * ``unknown`` — the response-boundary projection of a never-determined NULL
+ * column, which reaches clients through ``DatasetResponse``, not through
+ * here.
  */
 export type SourceHealthResponse = {
     /**

--- a/tests/test_check_deployed_surface.py
+++ b/tests/test_check_deployed_surface.py
@@ -343,7 +343,6 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                 "url": "https://getgeolens.com/",
                 "required": [
                     ("curl_installer", "curl\\s+-fsSL\\s+https://getgeolens\\.com/install\\.sh\\s+\\|\\s+sh", "i"),
-                    ("ogc_api_collections_url", "http://localhost:8080/api/collections", "i"),
                 ],
                 "forbidden": [
                     ("stale_geolens_yml", "\\bgeolens\\.yml\\b", "i"),
@@ -429,6 +428,7 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                 "url": "https://getgeolens.com/quickstart/",
                 "required": [
                     ("curl_installer", "curl\\s+-fsSL\\s+https://getgeolens\\.com/install\\.sh\\s+\\|\\s+sh", "i"),
+                    ("ogc_api_collections_url", "http://localhost:8080/api/collections", "i"),
                 ],
                 "forbidden": [
                     ("stale_first_build_timing", "5\\s*[-–]\\s*10\\s+minutes", "i"),
@@ -518,10 +518,7 @@ class DeployedSurfaceGateTest(unittest.TestCase):
     def test_default_config_fixture_pages_pass_offline(self) -> None:
         config = self.scanner.load_config(CONFIG)
         fixtures = {
-            "marketing_home": (
-                "curl -fsSL https://getgeolens.com/install.sh | sh "
-                "OGC API at http://localhost:8080/api/collections"
-            ),
+            "marketing_home": "curl -fsSL https://getgeolens.com/install.sh | sh",
             "docs_install": (
                 "curl -fsSL https://getgeolens.com/install.sh | sh "
                 "OGC API clients should connect through the reverse-proxy path at http://localhost:8080/api/ "
@@ -540,7 +537,10 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                 "Standards support: OGC API Features and Records. "
                 "Embed maps in any webpage."
             ),
-            "marketing_quickstart": "Quickstart: curl -fsSL https://getgeolens.com/install.sh | sh",
+            "marketing_quickstart": (
+                "Quickstart: curl -fsSL https://getgeolens.com/install.sh | sh "
+                "OGC API at http://localhost:8080/api/collections"
+            ),
             "marketing_es": "GeoLens: catálogo GIS autoalojado con docker-compose.yml.",
             "marketing_fr": "GeoLens : catalogue SIG auto-hébergé avec docker-compose.yml.",
             "marketing_de": "GeoLens: selbst gehosteter GIS-Katalog mit docker-compose.yml.",


### PR DESCRIPTION
## Summary

Refs geolens-io/geolens#1299. Product-side half of the docs sync: analysis operation copy (four README locales) and a stale deployed-surface gate assertion.

- README.md / README.es.md / README.fr.md / README.de.md: the Analysis section still described a four-operation toolkit (buffer, centroid, clip, dissolve). Spatial join, measure, select by location, and intersect shipped in v1.7.0 (CHANGELOG) and have been live since; also corrects the preview-scope claim (all operations except dissolve preview, not just buffer/centroid/clip).
- `scripts/deployed_surface_gate.json`: the marketing homepage's OGC collections URL example moved to `/quickstart/`, but the gate still asserted for it on the homepage, so `python3 scripts/check_deployed_surface.py` failed on a stale marker. Moved the `ogc_api_collections_url` required check from `marketing_home` to `marketing_quickstart`, and updated `tests/test_check_deployed_surface.py`'s fixture/expected-structure assertions to match.

No backend/app changes.

## Verification

- `make openapi-check` (green — confirms the OpenAPI snapshot the getgeolens.com PR fetches is current)
- `cd backend && uv run ruff check .` / `uv run ruff format --check .`
- `python3 -m unittest tests.test_check_deployed_surface -v` (20/20 pass)
- `python3 scripts/check_deployed_surface.py` against the live site (13 pages scanned, passed)