### PR TITLE
docs(quota): state the ownerless-dataset exemption policy and pin it

### DIFF
--- a/backend/app/core/catalog_port.py
+++ b/backend/app/core/catalog_port.py
@@ -53,6 +53,10 @@ class CatalogPort(Protocol):
         job_id: uuid.UUID,
     ) -> None: ...
 
+    # Here and on `finalize_presigned_object`, `user_id` is the dataset OWNER
+    # when the flow is a replacement and the uploader when it is a creation, so
+    # it is nullable: an ownerless dataset has no owner to name (#1293 — the
+    # policy is stated in app.modules.quota.service).
     async def verify_completed_presigned_upload(
         self,
         *,
@@ -60,7 +64,7 @@ class CatalogPort(Protocol):
         storage: Any,
         key: str,
         expected_size: Any,
-        user_id: uuid.UUID,
+        user_id: uuid.UUID | None,
         request: Any,
         job_id: uuid.UUID,
     ) -> int: ...
@@ -93,7 +97,7 @@ class CatalogPort(Protocol):
         logical_key: str,
         expected_size: Any,
         filename: str,
-        user_id: uuid.UUID,
+        user_id: uuid.UUID | None,
         request: Any,
     ) -> str: ...
 

--- a/backend/app/modules/quota/service.py
+++ b/backend/app/modules/quota/service.py
@@ -3,6 +3,65 @@
 Core check is authoritative for community and enterprise editions.
 The EntitlementPort enforce_limit calls are an additive cloud seam (QUOTA-03):
 in OSS/Enterprise the DefaultEntitlementPort is grant-all and never raises.
+
+Ownerless datasets are exempt (policy, #1293)
+---------------------------------------------
+Every seam in this module resolves the billed identity from
+``catalog.records.created_by``, and that column is nullable. A dataset whose
+``created_by`` is NULL is EXEMPT from quota accounting at every seam: its bytes
+and its dataset row count against nobody, and no seam substitutes a stand-in
+identity for it. That is the decided policy, not an accident of the SQL.
+
+The exemption is one mechanism repeated rather than six special cases.
+``get_user_quota_usage`` filters ``records.created_by = :user_id``, and
+``= NULL`` is never true, so the aggregate returns zeros for a NULL identity
+and skips ownerless rows for every real one. Every other function here reads
+its usage through that aggregate, so all of them inherit the same answer;
+``reserve_replacement_bytes`` in ``app.processing.ingest.tasks_raster_swap``
+inherits it by delegating to ``reserve_storage_bytes``. Nothing needs an
+``if owner_id is None`` branch, and adding one to a single seam is how the
+seams would start to disagree.
+
+Ownerless is a LIVE state, not only a pre-0019 legacy one:
+``records.created_by`` is ``ON DELETE SET NULL``, so hard-deleting a user
+orphans every dataset they created (``AdminService.delete_user`` relies on
+exactly that) while the datasets themselves survive and keep serving.
+
+Why not the alternatives:
+
+- *Refuse mutation until ownership is assigned.* There is no
+  ownership-assignment surface in the product, and the migration-0019 adoption
+  path is not reachable without a destructive downgrade (#998) — so a refusal
+  has no remedy the operator can actually apply. It would permanently brick
+  every legacy dataset, and, because of the SET NULL above, deleting one user
+  would freeze their datasets for everyone forever.
+- *Bill the instance-admin pool.* That misattributes storage rather than
+  measuring it: the admin user list reads ``get_user_quota_usage_bulk``, so one
+  operator would appear to hold the entire orphaned catalog, and once caps are
+  enabled that phantom usage would refuse the admin's own legitimate uploads.
+- *Leave it exempt (chosen).* Both caps default to 0 (unlimited), so only an
+  instance that opts into enforcement has a gap at all, and the gap has a
+  ceiling: creation always carries an authenticated uploader, so no NEW dataset
+  can be born into it. It is not frozen, though, and this is the cost being
+  accepted rather than a claim of harmlessness — replacing an
+  already-orphaned dataset writes uncounted bytes, so the exempt pool can grow
+  by the size of the datasets already in it, times however often an operator
+  replaces them.
+
+Scope of the exemption, stated precisely so nobody "simplifies" it into an
+early return: usage reads zero, which is not the same as a seam
+short-circuiting. Accumulated ownerless storage is never charged to anyone, and
+the dataset-count cap can never refuse a NULL owner (a zero count is below every
+positive cap). The byte cap still measures the INCOMING amount on its own,
+though — net of whatever credit the seam applies — so one reservation larger
+than the whole cap is still refused for a NULL owner. Nothing accumulates; an
+oversized single file is still oversized. An early return would drop that and
+change behaviour.
+
+The durable fix is ownership adoption, tracked by #998. When it lands, this
+section, the seams that point at it, and
+``TestOwnerlessDatasetsAreExemptAtEverySeam`` in
+``backend/tests/test_raster_replace_1221.py`` are what has to change together.
 """
 
 from __future__ import annotations
@@ -23,7 +82,7 @@ from app.platform.extensions.entitlement import enforce_limit
 
 async def get_user_quota_usage(
     db: AsyncSession,
-    user_id: uuid.UUID,
+    user_id: uuid.UUID | None,
 ) -> UserQuotaUsage:
     """Return current bytes-used and dataset-count for a user in one SQL round-trip.
 
@@ -41,6 +100,12 @@ async def get_user_quota_usage(
     ``file.size`` regardless of type.  A true cross-type storage total (e.g.
     ``pg_total_relation_size`` per vector table + VRT source attribution) is
     intentionally deferred to the metered/per-tenant (cloud) quota work.
+
+    This is where the ownerless-dataset exemption physically lives: the
+    ``created_by = :user_id`` filter is never true for NULL, so an ownerless
+    dataset counts against nobody and a NULL ``user_id`` reads zero. Every
+    other seam inherits that answer through this function. See the module
+    docstring for the policy and #998 for the adoption path that ends it.
 
     T-1224-01 mitigation: user_id is bound via SQLAlchemy parameterisation —
     never string-formatted into the SQL text.
@@ -226,13 +291,11 @@ async def check_replacement_quota(
     and admissions the worker's authoritative reserve then failed. One identity,
     one authority, no disagreement possible.
 
-    ``owner_id`` may be None for a legacy ownerless dataset. That is not
-    special-cased, deliberately: ``get_user_quota_usage`` filters
-    ``records.created_by = :user_id``, which matches nothing for NULL, so usage
-    reads zero and the cap is effectively unenforced — exactly what
-    ``reserve_storage_bytes`` does with the same value at publish time. Mirrored
-    rather than corrected so the two cannot diverge; changing the policy means
-    changing both.
+    ``owner_id`` may be None for an ownerless dataset, and is passed straight
+    through: see the module docstring's ownerless-dataset policy, which
+    ``reserve_storage_bytes`` reaches by the same route at publish time. Door
+    and worker inherit one mechanism rather than mirroring two rules, so
+    changing the policy is one edit there, not a hunt through the seams.
     """
     usage = await get_user_quota_usage(db, owner_id)
     counted = await db.scalar(
@@ -269,7 +332,7 @@ class DatasetQuotaExceededError(Exception):
     """
 
 
-async def reserve_dataset_slot(db: AsyncSession, user_id: uuid.UUID) -> None:
+async def reserve_dataset_slot(db: AsyncSession, user_id: uuid.UUID | None) -> None:
     """Atomically reserve a dataset-count slot for ``user_id`` (fix #302).
 
     ``check_upload_quota`` runs at upload time, but the ``Record`` rows the
@@ -282,6 +345,14 @@ async def reserve_dataset_slot(db: AsyncSession, user_id: uuid.UUID) -> None:
     The lock is released automatically at commit/rollback.
 
     No-op when the cap is 0 (the default unlimited config).
+
+    ``user_id`` is nullable for the same reason as on every other seam here —
+    it is a ``records.created_by`` value — though no current caller passes None,
+    because a Record is only ever created on behalf of an authenticated
+    uploader. Should an adoption or re-ingest path reach it, the
+    ownerless-dataset policy in the module docstring applies unchanged and this
+    seam cannot refuse: a NULL identity aggregates to a count of zero, which is
+    below every positive cap.
     """
     cap = await MAX_DATASETS_PER_USER.get(db)
     if cap <= 0:
@@ -311,7 +382,7 @@ class StorageQuotaExceededError(Exception):
 
 
 async def reserve_storage_bytes(
-    db: AsyncSession, user_id: uuid.UUID, incoming_bytes: int
+    db: AsyncSession, user_id: uuid.UUID | None, incoming_bytes: int
 ) -> None:
     """Atomically reserve ``incoming_bytes`` against the per-user byte cap (BA-23).
 
@@ -324,6 +395,12 @@ async def reserve_storage_bytes(
     overshoot ``max_storage_bytes_per_user``.
 
     No-op when the cap is 0 (the default unlimited config).
+
+    ``user_id`` is None for an ownerless dataset (the replacement path passes
+    ``record.created_by`` through unchanged). Nothing accumulates against that
+    identity — see the module docstring's ownerless-dataset policy for why, and
+    for the one thing the exemption does not cover: the recount reads zero, so
+    ``incoming_bytes`` is still weighed against the cap on its own.
     """
     cap = await MAX_STORAGE_BYTES_PER_USER.get(db)
     if cap <= 0:

--- a/backend/app/processing/ingest/presigned.py
+++ b/backend/app/processing/ingest/presigned.py
@@ -187,7 +187,7 @@ async def verify_completed_presigned_upload(
     storage: StorageProvider,
     key: str,
     expected_size: object,
-    user_id: uuid.UUID,
+    user_id: uuid.UUID | None,
     request: Request,
     job_id: uuid.UUID,
     replacing_dataset_id: uuid.UUID | None = None,
@@ -203,6 +203,11 @@ async def verify_completed_presigned_upload(
 
     ``replacing_dataset_id`` is the reupload doors' way of saying which it is.
     None means a genuine creation and keeps the original check.
+
+    ``user_id`` is the OWNER on the replacement path (the reupload door passes
+    ``dataset.record.created_by``) and the uploader on the creation path. Only
+    the first can be None, for an ownerless dataset — see the ownerless-dataset
+    policy in ``app.modules.quota.service``'s module docstring (#1293).
     """
     actual_size = await storage.size(key)
     max_size_mb = await UPLOAD_MAX_SIZE_MB.get(db)
@@ -427,7 +432,7 @@ async def finalize_presigned_object(
     logical_key: str,
     expected_size: object,
     filename: str,
-    user_id: uuid.UUID,
+    user_id: uuid.UUID | None,
     request: Request,
     replacing_dataset_id: uuid.UUID | None = None,
 ) -> str:

--- a/backend/app/processing/ingest/tasks_raster_swap.py
+++ b/backend/app/processing/ingest/tasks_raster_swap.py
@@ -402,7 +402,7 @@ async def reserve_replacement_bytes(
     session,
     *,
     dataset_id: uuid.UUID,
-    owner_id: uuid.UUID,
+    owner_id: uuid.UUID | None,
     new_size: int,
     archived_bytes: int = 0,
     archived_asset_key: str | None = None,
@@ -432,6 +432,12 @@ async def reserve_replacement_bytes(
 
     A shrinking replacement reserves nothing and needs no special case — usage
     is a live sum, so it self-corrects the moment the smaller row commits.
+
+    ``owner_id`` is None for an ownerless dataset and is handed to
+    ``reserve_storage_bytes`` unexamined, which is what makes this seam and the
+    request-time door reach the same answer through the same code. The policy
+    those two share, and why it is an exemption rather than a bug, is stated
+    once in ``app.modules.quota.service``'s module docstring (#1293).
     """
     from sqlalchemy import text
 

--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -34,6 +34,7 @@ block, because this suite runs against the shared dev Postgres.
 
 from __future__ import annotations
 
+import contextlib
 import io
 import json as _json
 import re
@@ -41,11 +42,11 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from rasterio.crs import CRS
 from rasterio.io import MemoryFile
 from rasterio.transform import from_bounds
@@ -455,6 +456,76 @@ async def _purge(session, *, dataset_id: uuid.UUID, record_id: uuid.UUID) -> Non
     await session.execute(delete(Dataset).where(Dataset.id == dataset_id))
     await session.execute(delete(Record).where(Record.id == record_id))
     await session.commit()
+
+
+async def _make_owner(session) -> uuid.UUID:
+    """Commit a throwaway user and return its id.
+
+    The quota tests measure one identity's usage exactly, and `admin` is shared
+    with every other suite running against this database — so they own their
+    subject rather than borrowing it.
+    """
+    from app.modules.auth.models import User as UserModel
+
+    suffix = uuid.uuid4().hex[:8]
+    user = UserModel(
+        username=f"quota_owner_{suffix}",
+        email=f"quota_owner_{suffix}@example.invalid",
+        password_hash="x",
+    )
+    session.add(user)
+    await session.commit()
+    return user.id
+
+
+async def _drop_owner(session, user_id: uuid.UUID) -> None:
+    """Remove a throwaway user once its datasets are gone.
+
+    Order matters and is the point: `records.created_by` is ON DELETE SET NULL,
+    so deleting the user first would orphan the very rows the test is about
+    rather than remove them.
+    """
+    from app.modules.auth.models import User as UserModel
+
+    await session.execute(delete(UserModel).where(UserModel.id == user_id))
+    await session.commit()
+
+
+async def _set_counted_data_bytes(session, dataset_id: uuid.UUID, size: int) -> None:
+    """Give a dataset `size` bytes of QUOTA-COUNTED storage.
+
+    The `data` row in `dataset_assets` is what `get_user_quota_usage` sums, so
+    this is the only way to make a dataset weigh anything as far as the caps are
+    concerned — the RasterAsset's own `size_bytes` is not counted.
+    """
+    await session.execute(
+        text(
+            "INSERT INTO catalog.dataset_assets (dataset_id, key, href, size_bytes) "
+            "VALUES (:id, 'data', 'x', :size) "
+            "ON CONFLICT ON CONSTRAINT uq_dataset_assets_key "
+            "DO UPDATE SET size_bytes = EXCLUDED.size_bytes"
+        ),
+        {"id": dataset_id, "size": size},
+    )
+    await session.commit()
+
+
+@contextlib.contextmanager
+def _capped(*, storage_cap: int = 0, count_cap: int = 0):
+    """Run the block with both quota caps forced (0 is the unlimited default)."""
+    with (
+        patch(
+            "app.modules.quota.service.MAX_STORAGE_BYTES_PER_USER.get",
+            new_callable=AsyncMock,
+            return_value=storage_cap,
+        ),
+        patch(
+            "app.modules.quota.service.MAX_DATASETS_PER_USER.get",
+            new_callable=AsyncMock,
+            return_value=count_cap,
+        ),
+    ):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -3128,22 +3199,328 @@ class TestDoorAdmitsAgainstTheOwner:
             )
             await test_db_session.commit()
 
-    async def test_an_ownerless_dataset_reads_as_zero_usage_on_both_sides(
-        self, test_db_session
-    ) -> None:
-        """The NULL-owner policy, pinned so door and worker cannot diverge.
 
-        `get_user_quota_usage` filters `records.created_by = :user_id`, which
-        matches nothing for NULL — so an ownerless dataset counts against
-        nobody and the cap is effectively unenforced. That is what
-        `reserve_storage_bytes` already does with the same value at publish
-        time; the door mirrors it rather than inventing a stricter rule.
+class TestOwnerlessDatasetsAreExemptAtEverySeam:
+    """The ownerless-dataset policy (#1293), pinned seam by seam.
+
+    A dataset whose `records.created_by` is NULL is exempt from quota
+    accounting everywhere: its bytes and its row count against nobody, and no
+    seam substitutes a stand-in identity for it. The policy, and why it beats
+    refusing the mutation or billing the instance admin, is stated once in
+    `app.modules.quota.service`'s module docstring; these tests hold the
+    behaviour to it so that changing the policy has to be deliberate rather
+    than a side effect. #998 tracks the ownership adoption that would end it.
+
+    Ownerless is reachable today and not only from pre-0019 legacy rows:
+    `catalog.records.created_by` is ON DELETE SET NULL, so hard-deleting a user
+    leaves every dataset they created ownerless and still serving.
+    """
+
+    async def test_a_null_identity_reads_as_zero_usage(self, test_db_session) -> None:
+        """The mechanism the whole policy rests on, at its source.
+
+        `get_user_quota_usage` filters `records.created_by = :user_id`, and
+        `= NULL` is never true, so a NULL identity matches no rows at all. Every
+        other seam reads its usage through this aggregate, which is why one
+        filter delivers the exemption to all of them without an `is None`
+        branch anywhere.
         """
         from app.modules.quota.service import get_user_quota_usage
 
         usage = await get_user_quota_usage(test_db_session, None)
         assert usage.bytes_used == 0
         assert usage.dataset_count == 0
+
+    async def test_an_ownerless_datasets_bytes_are_charged_to_no_user(
+        self, test_db_session, raster_storage
+    ) -> None:
+        """Exempt means charged to NOBODY, not quietly reassigned to someone.
+
+        Two datasets of identical size sit side by side, one owned and one
+        orphaned. The owner's usage must come to exactly the owned one — the
+        orphan lands neither on the user beside it nor on the NULL identity.
+        Asserted through the bulk aggregate as well as the single-user read,
+        because the bulk one backs the admin user list and resolves the same
+        column by GROUP BY, so a misattribution would surface there first.
+        """
+        from app.modules.quota.service import (
+            get_user_quota_usage,
+            get_user_quota_usage_bulk,
+        )
+
+        owner_id = await _make_owner(test_db_session)
+        orphaned = await _make_live_raster(
+            test_db_session, raster_storage, created_by=None
+        )
+        owned = await _make_live_raster(
+            test_db_session, raster_storage, created_by=owner_id
+        )
+        await _set_counted_data_bytes(test_db_session, orphaned.dataset.id, 5_000_000)
+        await _set_counted_data_bytes(test_db_session, owned.dataset.id, 5_000_000)
+
+        try:
+            usage = await get_user_quota_usage(test_db_session, owner_id)
+            assert usage.bytes_used == 5_000_000, (
+                "the orphaned dataset's bytes landed on the user beside it — "
+                "the exemption reassigns storage instead of exempting it "
+                f"(#1293): {usage.bytes_used}"
+            )
+            assert usage.dataset_count == 1
+
+            bulk = await get_user_quota_usage_bulk(test_db_session, [owner_id])
+            assert bulk[owner_id].bytes_used == 5_000_000, (
+                "the admin user list bills the orphan to a user while the "
+                "single-user read does not — the two seams disagree"
+            )
+            assert bulk[owner_id].dataset_count == 1
+
+            assert (await get_user_quota_usage(test_db_session, None)).bytes_used == 0
+        finally:
+            for live in (orphaned, owned):
+                await _purge(
+                    test_db_session,
+                    dataset_id=live.dataset.id,
+                    record_id=live.dataset.record_id,
+                )
+            await _drop_owner(test_db_session, owner_id)
+
+    async def test_the_door_admits_what_it_would_refuse_for_a_real_owner(
+        self, test_db_session, raster_storage
+    ) -> None:
+        """Door admission, with ownership as the only variable.
+
+        The same two datasets, the same cap, the same replacement — judged once
+        while a real user owns them and once after they are orphaned, which is
+        the transition an admin deleting that user actually performs. Owned,
+        the ballast puts the owner over the cap and the replacement is refused;
+        ownerless, the same bytes count against nobody and it is admitted.
+        """
+        from app.modules.quota.service import check_replacement_quota
+
+        owner_id = await _make_owner(test_db_session)
+        target = await _make_live_raster(
+            test_db_session, raster_storage, created_by=owner_id
+        )
+        ballast = await _make_live_raster(
+            test_db_session, raster_storage, created_by=owner_id
+        )
+        await _set_counted_data_bytes(test_db_session, target.dataset.id, 100)
+        await _set_counted_data_bytes(test_db_session, ballast.dataset.id, 5_000_000)
+
+        request = MagicMock(spec=Request)
+
+        try:
+            with _capped(storage_cap=1_000_000):
+                with pytest.raises(HTTPException) as exc_info:
+                    await check_replacement_quota(
+                        test_db_session,
+                        owner_id,
+                        100,
+                        request,
+                        dataset_id=target.dataset.id,
+                    )
+                assert exc_info.value.status_code == 413
+
+                await test_db_session.execute(
+                    text(
+                        "UPDATE catalog.records SET created_by = NULL "
+                        "WHERE id IN (:a, :b)"
+                    ),
+                    {"a": target.dataset.record_id, "b": ballast.dataset.record_id},
+                )
+                await test_db_session.commit()
+
+                await check_replacement_quota(
+                    test_db_session,
+                    None,
+                    100,
+                    request,
+                    dataset_id=target.dataset.id,
+                )
+        finally:
+            for live in (target, ballast):
+                await _purge(
+                    test_db_session,
+                    dataset_id=live.dataset.id,
+                    record_id=live.dataset.record_id,
+                )
+            await _drop_owner(test_db_session, owner_id)
+
+    async def test_reserve_storage_bytes_accumulates_nothing_for_a_null_owner(
+        self, test_db_session, raster_storage
+    ) -> None:
+        """The publish-time seam, and the one edge the exemption does NOT cover.
+
+        Ownerless bytes never accumulate, so a reservation that fits under the
+        cap on its own is admitted no matter how much orphaned storage exists.
+        But the recount reading zero is not the same as the seam
+        short-circuiting: `incoming_bytes` is still weighed against the cap by
+        itself, so a single reservation larger than the whole cap is still
+        refused. Pinned because an `if user_id is None: return` would look
+        equivalent and is not.
+        """
+        from app.modules.quota.service import (
+            StorageQuotaExceededError,
+            reserve_storage_bytes,
+        )
+
+        owner_id = await _make_owner(test_db_session)
+        orphaned = await _make_live_raster(
+            test_db_session, raster_storage, created_by=None
+        )
+        owned = await _make_live_raster(
+            test_db_session, raster_storage, created_by=owner_id
+        )
+        await _set_counted_data_bytes(test_db_session, orphaned.dataset.id, 5_000_000)
+        await _set_counted_data_bytes(test_db_session, owned.dataset.id, 5_000_000)
+
+        try:
+            with _capped(storage_cap=1_000_000):
+                await reserve_storage_bytes(test_db_session, None, 900_000)
+
+                with pytest.raises(StorageQuotaExceededError):
+                    await reserve_storage_bytes(test_db_session, owner_id, 900_000)
+
+                with pytest.raises(StorageQuotaExceededError):
+                    await reserve_storage_bytes(test_db_session, None, 1_000_001)
+        finally:
+            for live in (orphaned, owned):
+                await _purge(
+                    test_db_session,
+                    dataset_id=live.dataset.id,
+                    record_id=live.dataset.record_id,
+                )
+            await _drop_owner(test_db_session, owner_id)
+
+    async def test_reserve_dataset_slot_cannot_refuse_a_null_owner(
+        self, test_db_session, raster_storage
+    ) -> None:
+        """The count seam answers the same way, and cannot refuse at all.
+
+        Zero is below every positive cap, so the count cap has no residual edge
+        the way the byte cap does. Not reachable today — every caller creates a
+        Record for an authenticated uploader — but pinned so the two caps give
+        one answer if an adoption or re-ingest path ever reaches it.
+        """
+        from app.modules.quota.service import (
+            DatasetQuotaExceededError,
+            reserve_dataset_slot,
+        )
+
+        owner_id = await _make_owner(test_db_session)
+        orphaned = await _make_live_raster(
+            test_db_session, raster_storage, created_by=None
+        )
+        owned = await _make_live_raster(
+            test_db_session, raster_storage, created_by=owner_id
+        )
+
+        try:
+            with _capped(count_cap=1):
+                await reserve_dataset_slot(test_db_session, None)
+
+                with pytest.raises(DatasetQuotaExceededError):
+                    await reserve_dataset_slot(test_db_session, owner_id)
+        finally:
+            for live in (orphaned, owned):
+                await _purge(
+                    test_db_session,
+                    dataset_id=live.dataset.id,
+                    record_id=live.dataset.record_id,
+                )
+            await _drop_owner(test_db_session, owner_id)
+
+    async def test_the_worker_reserve_hands_a_null_owner_straight_through(
+        self, test_db_session, raster_storage
+    ) -> None:
+        """The worker-side replacement seam substitutes no identity of its own.
+
+        `reserve_replacement_bytes` computes the net increase and delegates the
+        cap decision, so it must pass the owner it was given — including None.
+        Resolving a fallback here is exactly how the worker would start
+        refusing replacements the door already admitted.
+        """
+        from app.processing.ingest.tasks_raster_swap import reserve_replacement_bytes
+
+        orphaned = await _make_live_raster(
+            test_db_session, raster_storage, created_by=None
+        )
+        dataset_id = orphaned.dataset.id
+        await _set_counted_data_bytes(test_db_session, dataset_id, 400)
+
+        seen: list[tuple] = []
+
+        async def _spy(session, user_id, incoming_bytes):
+            seen.append((user_id, incoming_bytes))
+
+        try:
+            with patch("app.modules.quota.service.reserve_storage_bytes", new=_spy):
+                await reserve_replacement_bytes(
+                    test_db_session,
+                    dataset_id=dataset_id,
+                    owner_id=None,
+                    new_size=1000,
+                )
+            assert seen == [(None, 600)], (
+                "the worker named an identity the door never used — door and "
+                "worker can now disagree about an ownerless replacement (#1293)"
+            )
+        finally:
+            await _purge(
+                test_db_session,
+                dataset_id=dataset_id,
+                record_id=orphaned.dataset.record_id,
+            )
+
+    def test_every_replacement_admission_point_bills_the_datasets_owner(self) -> None:
+        """Why the exemption reaches all three doors: they resolve one column.
+
+        Structural, because the third admission point is the presigned
+        FINALIZER — reached only after a real multipart upload completes, which
+        is why it was the one that drifted in #1290 round 8. Each door has to
+        bill `dataset.record.created_by`, the nullable column the policy is
+        about; a door that resolved the REQUESTER instead would both break the
+        owner rule and quietly opt out of the exemption.
+        """
+        import ast
+        import inspect
+
+        from app.modules.catalog.datasets.api import router_reupload
+        from app.processing.ingest import presigned
+
+        owner_expr = "dataset.record.created_by"
+        billed: list[str] = []
+        for node in ast.walk(ast.parse(inspect.getsource(router_reupload))):
+            if not isinstance(node, ast.Call):
+                continue
+            if getattr(node.func, "id", None) == "check_replacement_quota":
+                billed.append(ast.unparse(node.args[1]))
+            elif getattr(node.func, "attr", None) == "finalize_presigned_object":
+                billed.extend(
+                    ast.unparse(kw.value) for kw in node.keywords if kw.arg == "user_id"
+                )
+
+        assert len(billed) == 3, (
+            "expected the two request-time doors plus the completion "
+            f"finalizer to bill an identity, found {billed}"
+        )
+        assert set(billed) == {owner_expr}, (
+            f"a replacement admission point bills someone other than the "
+            f"dataset owner: {billed}"
+        )
+
+        # The finalizer must not re-resolve an identity of its own either: it
+        # bills the one the door handed it, nullable and all.
+        finalizer_billed = [
+            ast.unparse(node.args[1])
+            for node in ast.walk(ast.parse(inspect.getsource(presigned)))
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", None) == "check_replacement_quota"
+        ]
+        assert finalizer_billed == ["user_id"], (
+            "the presigned finalizer resolves its own identity instead of "
+            f"passing through the owner the door named: {finalizer_billed}"
+        )
 
 
 class TestEveryKeptOriginalIsCounted:


### PR DESCRIPTION
Closes #1293.

## The question, and the answer

#1293 asked which policy datasets with `records.created_by IS NULL` should get at the quota seams: bill the instance-admin pool, refuse mutation until ownership is assigned, or leave them exempt and say so. The answer is **exempt**, and this PR makes that a stated policy with tests behind it rather than a property of a SQL filter nobody wrote down.

An ownerless dataset's bytes and its dataset row count against nobody at every seam, and no seam substitutes a stand-in identity for it.

## Why exempt

**Refusing mutation has no remedy.** There is no ownership-assignment surface in the product, and 0019's adoption path is not reachable without a destructive downgrade (#998), so an operator told "assign an owner first" has nothing to do. It would permanently brick legacy datasets. Worse, ownerless is not only a legacy state — `catalog.records.created_by` is `ON DELETE SET NULL` and `AdminService.delete_user` relies on exactly that, so deleting one user orphans every dataset they created. Under a refusal policy, deleting a user would freeze their datasets for everyone, forever.

**Billing the admin misattributes storage.** The admin user list reads `get_user_quota_usage_bulk`, so one operator would appear to hold the entire orphaned catalog — and once caps are enabled, that phantom usage would refuse the admin's own legitimate uploads.

**Exempt is cheap.** Both caps default to 0 (unlimited), so only an instance that opts into enforcement has a gap at all. The code already mirrored the exemption at both seams deliberately (the `check_replacement_quota` docstring says so) so they could not diverge — this keeps that property and names it.

The durable fix is ownership adoption, tracked by #998.

## What changed

The policy is stated once, in `backend/app/modules/quota/service.py`'s module docstring. The per-seam docstrings (`check_replacement_quota`, `reserve_storage_bytes`, `reserve_dataset_slot`, `get_user_quota_usage`) and `reserve_replacement_bytes` in `tasks_raster_swap.py` point at it instead of each re-deriving it.

Two things the statement records that were not written down anywhere before:

- **The gap is capped but not frozen.** Creation always carries an authenticated uploader, so no new dataset can be born ownerless — but replacing an already-orphaned one writes uncounted bytes, so the exempt pool can grow by the size of what is already in it. Stated as a cost being accepted, not as harmlessness.
- **Usage reading zero is not a short-circuit.** Nothing accumulates, and the count cap can never refuse a NULL owner, but the byte cap still weighs the incoming reservation on its own — so one reservation larger than the whole cap is still refused. An `if user_id is None: return` would look equivalent and would change behaviour. There is a test on that boundary.

Signatures now admit the nullability they already had at runtime: `get_user_quota_usage`, `reserve_storage_bytes`, `reserve_dataset_slot`, `reserve_replacement_bytes`, and both presigned completion functions (plus their `CatalogPort` protocol declarations) annotated `user_id: uuid.UUID` while three callers already passed `dataset.record.created_by`.

## Seam coverage

`TestOwnerlessDatasetsAreExemptAtEverySeam` in `backend/tests/test_raster_replace_1221.py` — extending the suite that already pinned the door/worker mirroring rather than starting a parallel one. Seven tests: the aggregate that the exemption physically lives in, attribution (an orphan next to an identical owned dataset lands on neither the user nor the NULL identity), door admission (the same two datasets judged before and after orphaning — ownership is the only variable), `reserve_storage_bytes` including the residual edge, `reserve_dataset_slot`, the worker-side `reserve_replacement_bytes` pass-through, and a structural pin that all three replacement admission points bill `dataset.record.created_by`.

**A seam #1293 did not list:** `get_user_quota_usage_bulk`, the aggregate behind the admin user list. It resolves the same column by `GROUP BY`, so ownerless datasets appear in no user's row there either — that is the surface where a misattribution would show up first, and it is covered by the attribution test.

## Impact

**No behaviour change. No schema, API, or config impact.** Docstrings, widened type annotations, and tests only. No new endpoints, no migration, no OpenAPI or SDK regeneration.

## Verification

- `cd backend && uv run ruff check .` — pass
- `cd backend && uv run ruff format --check .` — pass
- `uv run pytest tests/test_raster_replace_1221.py` — 108 passed
- `uv run pytest tests/test_1224_quota_service.py tests/test_302_quota_reservation.py tests/test_quota_bulk_usage.py tests/test_1224_ingest_quota_enforcement.py tests/test_me_usage.py` — 30 passed
- `uv run pytest tests/test_reupload.py tests/test_tenant_staging_storage_keys.py tests/test_manifest_apply_service.py` — 92 passed
- `uv run pytest tests/test_presigned.py tests/test_presigned_completion_size.py tests/test_presigned_content_validation_1202.py tests/test_presigned_staging_reap_1202.py tests/test_reupload_idor.py tests/test_extension_slot_guard.py tests/test_openapi_overlay_boundary.py` — 108 passed, 1 skipped
- `uv run pytest tests/test_rule1_structural.py tests/test_rule2_structural.py` — 82 passed
- `uv run pytest tests/test_layering.py` — 40 passed