### PR TITLE
fix(sources): request every ArcGIS field so imports keep their attributes

### DIFF
--- a/backend/app/modules/catalog/sources/preview.py
+++ b/backend/app/modules/catalog/sources/preview.py
@@ -47,7 +47,17 @@ def build_gdal_source(
             raise ValueError("ArcGIS layer preview requires a layer ID")
         safe_base_url = _encode_url_for_gdal(base_url.rstrip("/"))
         safe_layer_id = quote(str(layer_id).strip("/"), safe="")
-        params: dict[str, str | int] = {"f": "json", "where": "1=1"}
+        # fix(#1359): a /query with no outFields returns the layer's display
+        # field alone, so the import landed geometry plus ONE attribute column
+        # and dropped every other field. The preview reads the layer's ?f=json
+        # field list and therefore promised columns this fetch never asked
+        # for. urlencode renders the value as `outFields=%2A`, which ArcGIS
+        # decodes back to `*`.
+        params: dict[str, str | int] = {
+            "f": "json",
+            "where": "1=1",
+            "outFields": "*",
+        }
         if order_field:
             params["orderByFields"] = f"{order_field} ASC"
         if result_limit is not None:

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -617,7 +617,6 @@ async def register_existing_table(
     # (_current_tenant_schema()='data', _current_tenant_role()='geolens_reader').
     _grant_role = _current_tenant_role()
 
-    metadata = {}
     if has_geom:
         if not has_4326:
             srid = await get_table_srid(session, table_name, schema=_schema)
@@ -648,11 +647,16 @@ async def register_existing_table(
                     f"Failed to linearize geom_4326 on '{table_name}': {exc}"
                 ) from exc
 
-        await grant_reader_access(session, table_name, schema=_schema, role=_grant_role)
-        metadata = await extract_metadata(session, table_name, schema=_schema)
-    else:
-        # Non-spatial table -- grant access but skip spatial metadata
-        await grant_reader_access(session, table_name, schema=_schema, role=_grant_role)
+    await grant_reader_access(session, table_name, schema=_schema, role=_grant_role)
+
+    # fix(#1359): one derivation for every registration, spatial or not. The
+    # non-spatial branch used to skip this entirely and register the table
+    # with column_info and feature_count NULL — the same "the stats bar
+    # contradicts the schema" state the ArcGIS import produced, reached a
+    # different way. extract_metadata already reports srid, geometry_type,
+    # and extent_wkt as None for a table with no geom column, so the spatial
+    # fields land exactly as they did before.
+    metadata = await extract_metadata(session, table_name, schema=_schema)
 
     # Extract sample values for attribute metadata example_values
     col_info = metadata.get("column_info", [])

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2623,7 +2623,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # applies. Deriving from the raw filename split the key: the logical URI
     # kept a path component the write stripped, so the counted row pointed at
     # nothing. Cap 1059 -> 1073, exact.
-    "backend/app/processing/ingest/service.py": 1073,
+    # fix(#1359): +4 — register_existing_table now derives metadata for every
+    # table it registers instead of only the spatial ones, so a non-spatial
+    # registration stops landing with column_info and feature_count NULL. The
+    # added lines are the comment explaining why the branch is gone.
+    # Cap 1073 -> 1077, exact.
+    "backend/app/processing/ingest/service.py": 1077,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_service_column_info_1359.py
+++ b/backend/tests/test_service_column_info_1359.py
@@ -1,0 +1,511 @@
+"""fix(#1359): every ingest path must land the source's real attribute columns.
+
+The reported symptom was ``column_info == ['id']`` on an ArcGIS
+FeatureServer import whose preview listed ~29 fields. The stored value was
+not wrong about the table — the TABLE only had one attribute column,
+because ``build_gdal_source`` composed the ArcGIS ``/query`` URL without
+``outFields``. An ArcGIS ``/query`` with no ``outFields`` answers with the
+layer's display field alone, so ogr2ogr faithfully loaded geometry plus
+that one field and every other attribute was dropped before PostGIS ever
+saw it.
+
+The two other symptoms in the issue follow from that one:
+
+* the materialized analysis output showed the same single column because
+  it carries its source's live columns, and its source was the broken
+  import (``test_materialize_output_column_info_matches_carried_columns``
+  pins that the carry itself is sound);
+* refresh-from-source "did not repopulate" because it re-fetched through
+  the same builder and recomputed the same one-column answer — the swap
+  has always rewritten ``column_info``.
+"""
+
+import uuid as _uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.catalog.datasets.domain.models import Dataset
+from app.modules.catalog.sources.preview import build_gdal_source
+from app.platform.jobs.models import IngestJob
+
+from tests.factories import get_user_id
+from tests.test_analysis_preview import _create_polygon_dataset
+
+# The attribute columns a real ArcGIS layer answers with once the query asks
+# for them. `id` is the display field — the ONE column the pre-fix URL got
+# back, which is why the "no attribute columns at all" fallback in
+# `_finalize_ingest` never fired to cover for it.
+_DISPLAY_FIELD = "id"
+_ATTRIBUTE_COLUMNS = ("id", "mag", "eventtype", "place", "depth")
+
+
+def _requests_all_fields(gdal_source: str) -> bool:
+    """Does this ESRIJSON source ask the service for every field?"""
+    query = parse_qs(urlsplit(gdal_source.removeprefix("ESRIJSON:")).query)
+    return query.get("outFields") == ["*"]
+
+
+def _columns_for(gdal_source: str) -> tuple[str, ...]:
+    """The columns the service would answer this query with.
+
+    Mirrors the live behaviour verified against
+    ``services9.arcgis.com/.../USGS_Seismic_Data_v1/FeatureServer/0``: with
+    ``outFields=*`` the response carries every field; without it, only the
+    layer's display field comes back.
+    """
+    return (
+        _ATTRIBUTE_COLUMNS if _requests_all_fields(gdal_source) else (_DISPLAY_FIELD,)
+    )
+
+
+def _create_table_sql(schema: str, table: str, columns: tuple[str, ...]) -> str:
+    cols = ", ".join(f'"{c}" text' for c in columns)
+    return f'CREATE TABLE "{schema}"."{table}" (gid serial PRIMARY KEY, {cols})'
+
+
+# ---------------------------------------------------------------------------
+# 1. The builder — the single site every service path composes its URL at
+# ---------------------------------------------------------------------------
+
+
+def test_arcgis_gdal_source_requests_every_field():
+    """The ArcGIS query must name ``outFields``; the default is not "all"."""
+    source, layer_name = build_gdal_source(
+        "ArcGIS FeatureServer",
+        "https://services.example.com/svc/FeatureServer",
+        "quakes",
+        layer_id=0,
+    )
+
+    assert layer_name == ""
+    # urlencode renders `*` as %2A, which the service decodes back to `*`.
+    assert "outFields=%2A" in source
+    assert _requests_all_fields(source)
+
+
+def test_arcgis_gdal_source_requests_every_field_when_paging():
+    """A chunked import asks for all fields on every page, not just the first."""
+    source, _ = build_gdal_source(
+        "ArcGIS FeatureServer",
+        "https://services.example.com/svc/FeatureServer",
+        "quakes",
+        layer_id=0,
+        order_field="OBJECTID",
+        result_limit=2000,
+        result_offset=4000,
+    )
+
+    assert _requests_all_fields(source)
+    assert "resultOffset=4000" in source
+
+
+# ---------------------------------------------------------------------------
+# 2. First import — the path the issue was filed against
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_arcgis_service_import_lands_every_attribute_column(
+    client: AsyncClient,  # ensures app.core.db.async_session points at the test DB
+    test_db_session: AsyncSession,
+    monkeypatch,
+):
+    """A service import stores the layer's full attribute list, not one column.
+
+    Drives the real ``ingest_service`` worker with a stand-in for ogr2ogr
+    that materialises exactly the columns the composed URL asked for, so the
+    assertion below fails with ``['id']`` whenever the URL stops requesting
+    every field.
+    """
+    from app.processing.ingest import tasks_vector
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"tbl_quakes_{_uuid.uuid4().hex[:8]}"
+
+    job = IngestJob(
+        source_filename="USGS Earthquakes",
+        source_url="https://services.example.com/svc/FeatureServer",
+        source_layer="0",
+        created_by=admin_id,
+        status="pending",
+        user_metadata={
+            "title": "USGS Earthquakes",
+            "visibility": "private",
+            "service_type": "ArcGIS FeatureServer",
+            "layer_id": "0",
+            # Non-spatial keeps the fixture to the attribute contract under
+            # test; the geometry pipeline has its own coverage.
+            "geometry_type": None,
+            # What the preview stored. It lists every field, which is exactly
+            # the promise the import used to break — and the fallback in
+            # `_finalize_ingest` only consults it when the table has NO
+            # attribute columns, so a one-column table slips past it.
+            "source_columns": [
+                {"name": c, "type": "esriFieldTypeString"} for c in _ATTRIBUTE_COLUMNS
+            ],
+        },
+    )
+    test_db_session.add(job)
+    await test_db_session.flush()
+    await test_db_session.commit()
+    job_id = job.id
+    attempt_id = job.attempt_id
+    assert attempt_id is not None
+
+    class _FakeProcessingPort:
+        def __getattr__(self, name):
+            from app.platform.extensions.defaults_processing_port import (
+                DefaultProcessingPort,
+            )
+
+            return getattr(DefaultProcessingPort(), name)
+
+        def build_gdal_source(self, *args, **kwargs):
+            return build_gdal_source(*args, **kwargs)
+
+    async def _validate_url_noop(_url: str) -> None:
+        return None
+
+    async def _fake_generate_table_name(*args, **kwargs):
+        return table_name, None
+
+    async def _fake_page_info(*args, **kwargs):
+        return None, 1000, False, "OBJECTID"
+
+    async def _fake_run_ogr2ogr_service(
+        gdal_source: str,
+        layer_name: str,
+        target_table: str,
+        db_conn_str: str,
+        service_type: str,
+        **kwargs,
+    ) -> None:
+        import app.core.db as db_module
+
+        async with db_module.async_session() as session:
+            await session.execute(text(f'DROP TABLE IF EXISTS data."{target_table}"'))
+            await session.execute(
+                text(_create_table_sql("data", target_table, _columns_for(gdal_source)))
+            )
+            await session.execute(
+                text(
+                    f'INSERT INTO data."{target_table}" '  # noqa: S608
+                    f"DEFAULT VALUES"
+                )
+            )
+            await session.commit()
+
+    async def _fake_emit_billing_event(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "app.modules.catalog.sources.security.validate_url_for_ssrf",
+        _validate_url_noop,
+    )
+    monkeypatch.setattr(
+        "app.platform.extensions.get_processing_port",
+        lambda: _FakeProcessingPort(),
+    )
+    monkeypatch.setattr("app.processing.ingest.ogr.build_pg_conn_str", lambda: "PG:")
+    monkeypatch.setattr(
+        "app.processing.ingest.service.generate_table_name",
+        _fake_generate_table_name,
+    )
+    monkeypatch.setattr(tasks_vector, "_fetch_arcgis_import_page_info", _fake_page_info)
+    monkeypatch.setattr(
+        "app.processing.ingest.ogr.run_ogr2ogr_service", _fake_run_ogr2ogr_service
+    )
+    monkeypatch.setattr(tasks_vector, "_emit_billing_event", _fake_emit_billing_event)
+
+    try:
+        await tasks_vector.ingest_service.func(
+            job_id=str(job_id),
+            attempt_id=str(attempt_id),
+            source_url="https://services.example.com/svc/FeatureServer",
+            source_layer="0",
+            user_id=str(admin_id),
+        )
+
+        dataset = (
+            await test_db_session.execute(
+                select(Dataset).where(Dataset.table_name == table_name)
+            )
+        ).scalar_one()
+
+        names = [c["name"] for c in (dataset.column_info or [])]
+        assert names == list(_ATTRIBUTE_COLUMNS), (
+            "the import stored only what the URL asked the service for"
+        )
+    finally:
+        await test_db_session.rollback()
+        await test_db_session.execute(
+            text(f'DROP TABLE IF EXISTS data."{table_name}" CASCADE')
+        )
+        await test_db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# 3. Refresh — the repopulation the issue asked for
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_service_refresh_repopulates_wrong_stored_column_info(
+    client: AsyncClient,  # ensures app.core.db.async_session points at the test DB
+    test_db_session: AsyncSession,
+):
+    """Refresh rewrites ``column_info`` from the fetch it just installed.
+
+    Seeded with the exact broken value from the issue, so a dataset already
+    stored with ``['id']`` is repaired by a refresh rather than keeping it
+    forever.
+    """
+    from app.modules.catalog.datasets.domain.models import Record
+    from app.processing.ingest.tasks import reupload_service
+
+    admin_id = await get_user_id(test_db_session, "admin")
+
+    table_name = f"ds_{_uuid.uuid4().hex[:12]}"
+    record = Record(
+        title="Stale Service Dataset",
+        summary="stored with the display field alone",
+        visibility="private",
+        record_status="published",
+        created_by=admin_id,
+    )
+    test_db_session.add(record)
+    await test_db_session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        feature_count=1,
+        source_format="arcgis_featureserver",
+        source_filename="quakes",
+        source_url="https://services.example.com/svc/FeatureServer/0",
+        column_info=[
+            {
+                "name": _DISPLAY_FIELD,
+                "type": "text",
+                "ordinal_position": 2,
+                "is_nullable": True,
+            }
+        ],
+    )
+    test_db_session.add(dataset)
+    await test_db_session.commit()
+    await test_db_session.refresh(dataset)
+    dataset_id = dataset.id
+
+    job = IngestJob(
+        dataset_id=dataset_id,
+        source_filename="quakes",
+        source_url="https://services.example.com/svc/FeatureServer",
+        source_layer="0",
+        created_by=admin_id,
+        status="pending",
+        user_metadata={
+            "reupload": True,
+            "dataset_id": str(dataset_id),
+            "service_type": "ArcGIS FeatureServer",
+            "layer_id": 0,
+            "source_type": "service_url",
+        },
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+    await test_db_session.refresh(job)
+
+    async def _fake_run_ogr2ogr_service(
+        gdal_source: str,
+        layer_name: str,
+        staging_table: str,
+        db_conn_str: str,
+        service_type: str,
+        **kwargs,
+    ) -> None:
+        on_spawn = kwargs.get("on_spawn")
+        if on_spawn is not None:
+            on_spawn()
+        import app.core.db as db_module
+
+        async with db_module.async_session() as session:
+            await session.execute(text(f'DROP TABLE IF EXISTS data."{staging_table}"'))
+            await session.execute(
+                text(
+                    _create_table_sql("data", staging_table, _columns_for(gdal_source))
+                )
+            )
+            await session.execute(
+                text(f'INSERT INTO data."{staging_table}" DEFAULT VALUES')  # noqa: S608
+            )
+            await session.commit()
+
+    try:
+        with (
+            patch(
+                "app.modules.catalog.sources.security.validate_url_for_ssrf",
+                new=AsyncMock(),
+            ),
+            patch(
+                "app.processing.ingest.ogr.run_ogr2ogr_service",
+                new=_fake_run_ogr2ogr_service,
+            ),
+            patch(
+                "app.processing.ingest.tasks_reupload.invalidate_catalog_cache",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await reupload_service(
+                job_id=str(job.id),
+                attempt_id=str(job.attempt_id),
+                dataset_id=str(dataset_id),
+                source_url=job.source_url or "",
+                source_layer=job.source_layer or "",
+                user_id=str(admin_id),
+            )
+
+        await test_db_session.refresh(job)
+        assert job.status == "complete", job.error_message
+        await test_db_session.refresh(dataset)
+
+        names = [c["name"] for c in (dataset.column_info or [])]
+        assert names == list(_ATTRIBUTE_COLUMNS)
+    finally:
+        await test_db_session.rollback()
+        await test_db_session.execute(
+            text(f'DROP TABLE IF EXISTS data."{table_name}" CASCADE')
+        )
+        await test_db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# 4. Registration — the shared derivation the analysis output goes through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_register_non_spatial_table_populates_column_info(
+    test_db_session: AsyncSession,
+):
+    """A non-spatial registration derives its columns like every other path.
+
+    ``register_existing_table`` used to run ``extract_metadata`` only for
+    tables with a geometry column, so an attribute-only table was catalogued
+    with no ``column_info`` and no ``feature_count`` at all — the same
+    contradiction the ArcGIS import produced, reached a different way.
+    """
+    from app.processing.ingest.schemas import RegisterRequest
+    from app.processing.ingest.service import register_existing_table
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"tbl_plain_{_uuid.uuid4().hex[:10]}"
+
+    await test_db_session.execute(
+        text(
+            f'CREATE TABLE data."{table_name}" '
+            f"(gid serial PRIMARY KEY, code text, population integer)"
+        )
+    )
+    await test_db_session.execute(
+        text(
+            f'INSERT INTO data."{table_name}" (code, population) '  # noqa: S608
+            f"VALUES ('a', 1), ('b', 2)"
+        )
+    )
+    await test_db_session.commit()
+
+    try:
+        dataset = await register_existing_table(
+            test_db_session,
+            RegisterRequest(table_name=table_name, title="Plain Table"),
+            SimpleNamespace(id=admin_id),
+        )
+        await test_db_session.commit()
+
+        assert [c["name"] for c in (dataset.column_info or [])] == [
+            "code",
+            "population",
+        ]
+        assert dataset.feature_count == 2
+        # A table with no geometry stays a table: the spatial fields the
+        # skipped branch used to leave unset are still None.
+        assert dataset.geometry_type is None
+        assert dataset.srid is None
+    finally:
+        await test_db_session.rollback()
+        await test_db_session.execute(
+            text(f'DROP TABLE IF EXISTS data."{table_name}" CASCADE')
+        )
+        await test_db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# 5. Analysis materialize — the cascade, pinned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_materialize_output_column_info_matches_carried_columns(
+    test_db_session: AsyncSession,
+):
+    """A saved analysis output catalogues the columns it actually carried.
+
+    The issue saw ``['id']`` here too, which read as a second defect. It is
+    not one: the output carries its SOURCE's live columns, and the source was
+    the one-column import. Given a healthy source the carry and the catalogue
+    agree, so this is the guard that keeps the two from drifting apart on
+    their own.
+    """
+    from app.processing.analysis.tasks import _materialize
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    src = await _create_polygon_dataset(test_db_session, created_by=admin_id)
+    await test_db_session.execute(
+        text(f'ALTER TABLE data.{src.table_name} ADD COLUMN "mag" REAL')
+    )
+    await test_db_session.commit()
+
+    job = IngestJob(
+        source_filename="analysis-1359",
+        created_by=admin_id,
+        status="pending",
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+    await test_db_session.refresh(job)
+
+    await _materialize(
+        job_id=str(job.id),
+        dataset_id=str(src.id),
+        user_id=str(admin_id),
+        operation="centroid",
+        title=f"Quake centroids {_uuid.uuid4().hex[:6]}",
+    )
+
+    await test_db_session.refresh(job)
+    assert job.status == "complete", job.error_message
+
+    out = await test_db_session.get(Dataset, job.dataset_id)
+    live = (
+        (
+            await test_db_session.execute(
+                text(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_schema='data' AND table_name=:t "
+                    "AND column_name NOT IN ('gid','geom','geom_4326') "
+                    "ORDER BY ordinal_position"
+                ).bindparams(t=out.table_name)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert [c["name"] for c in (out.column_info or [])] == list(live)
+    assert set(live) == {"name", "mag"}


### PR DESCRIPTION
Closes #1359

## Root cause

The issue reported `column_info == ['id']` on an ArcGIS FeatureServer import whose preview listed ~29 fields. The stored value was **not** wrong about the table — the table itself only had one attribute column.

`build_gdal_source` (`backend/app/modules/catalog/sources/preview.py`) composed the ArcGIS `/query` URL as `?f=json&where=1=1[&orderByFields=…]` with no `outFields`. An ArcGIS `/query` with no `outFields` answers with the layer's **display field alone**, so ogr2ogr faithfully loaded geometry plus that one field and every other attribute was dropped before PostGIS ever saw it.

Verified against the exact service from the report:

```
$ curl '…/USGS_Seismic_Data_v1/FeatureServer/0/query?f=json&where=1%3D1&resultRecordCount=1'
"fields":[{"name":"id",…}]           # one field

$ curl '…/query?f=json&where=1%3D1&outFields=%2A&resultRecordCount=1'
fields: OBJECTID, id, mag, eventType, sig, alert, place, hoursOld, …   # 31 fields
```

And against the dev database that produced the report — the live table matches its stored `column_info` exactly:

```
 column_name |     data_type     
-------------+-------------------
 gid         | integer
 id          | character varying
 geom        | USER-DEFINED
 geom_4326   | USER-DEFINED
```

The preview reads the layer's native `?f=json` field list (`adapters/arcgis.py`) rather than this URL, which is why it promised 29 columns the import never asked for.

**The other two symptoms in the issue are consequences of this one, not separate defects:**

- The materialized `select_by_location` output showed one column because `_list_carry_columns` carries the source's *live* columns, and its source was the broken import. An analysis output built from a healthy source has always catalogued its full column list (the dev DB's `buildings_selected` has 9). A guard test now pins that.
- Refresh "never repopulated" because it re-fetched through the same builder and recomputed the same one-column answer. `_apply_reupload_swap` has always written `dataset.column_info` from the fresh staging metadata — so with this fix, a refresh now *repairs* an already-broken dataset rather than needing a new hook.

## What changed

**`backend/app/modules/catalog/sources/preview.py`** — the ArcGIS branch of `build_gdal_source` now sends `outFields=*`. This is the single site every service path composes its URL at, so first import (single-shot and paginated), refresh-from-source, and the ogrinfo preview are all fixed at once. `urlencode` renders the value as `outFields=%2A`, which ArcGIS decodes back to `*` (verified live, above).

**`backend/app/processing/ingest/service.py`** — `register_existing_table` derived no metadata at all for a non-spatial table, cataloguing it with `column_info` and `feature_count` NULL: the same "the stats bar contradicts the schema" state, reached a different way. Registration now runs the one derivation for every table it registers. `extract_metadata` already returns `srid`/`geometry_type`/`extent_wkt` as `None` when there is no geom column, so the spatial fields land exactly as before.

Deliberately **not** changed: the `source_columns` fallback in `_finalize_ingest` still fires only when the landed table has *no* attribute columns. Broadening it to cover a partial column set would write names from the upstream API schema that don't exist in the table, and `column_info` is what `validate_where_clause` and the feature-write property allowlist check against. It must keep describing the live table.

## Impact

- **Schema:** none. No migration, no model change.
- **API:** none. No route, request, or response shape changes; `backend/openapi.json` is untouched.
- **Config:** none.
- **Behavioural:** ArcGIS imports and refreshes now fetch every field, so the response payload per page grows to the layer's full width — which is what the preview always promised. Existing broken datasets are repaired by running Refresh from source; they are not backfilled automatically.

## Tests

New file `backend/tests/test_service_column_info_1359.py`. Five of the six fail on `main` with the issue's exact symptom and pass with the fix; the sixth passes on both, which is the evidence that the analysis symptom was a cascade:

| test | pre-fix |
|---|---|
| `test_arcgis_gdal_source_requests_every_field` | FAIL |
| `test_arcgis_gdal_source_requests_every_field_when_paging` | FAIL |
| `test_arcgis_service_import_lands_every_attribute_column` | FAIL — `['id'] != ['id','mag','eventtype','place','depth']` |
| `test_service_refresh_repopulates_wrong_stored_column_info` | FAIL — same |
| `test_register_non_spatial_table_populates_column_info` | FAIL — `[] != ['code','population']` |
| `test_materialize_output_column_info_matches_carried_columns` | PASS (guard) |

The two worker-driven tests stand in for ogr2ogr with a fake that materialises exactly the columns the composed URL asked the service for, so they fail the moment the URL stops requesting every field.

`backend/tests/test_layering.py` — `_MODULE_LOC_CAPS` for `processing/ingest/service.py` raised 1073 → 1077 (exact), with a comment recording what the four lines bought.

## Verification

All run from the worktree against Postgres at `localhost:5434`.

```
cd backend && uv run ruff check .                                    # All checks passed
cd backend && uv run ruff format --check .                           # 941 files already formatted
uv run pytest tests/test_service_column_info_1359.py                 # 6 passed
uv run pytest tests/test_layering.py                                 # 40 passed
uv run pytest tests/test_arcgis_auth.py tests/test_services_endpoints.py \
             tests/test_ingest_progress.py                           # 58 passed
uv run pytest tests/test_reupload_service.py tests/test_service_refresh_1220.py \
             tests/test_dataset_refresh_runs.py                      # 145 passed
uv run pytest tests/test_ingest.py tests/test_dataset_source_state.py \
             tests/test_staging_pipeline.py \
             tests/test_staging_pipeline_integration.py              # 180 passed
uv run pytest tests/test_analysis_materialize.py                     # 99 passed
uv run pytest tests/test_rule1_structural.py tests/test_rule2_structural.py \
             tests/test_postgis_refresh_1265.py \
             tests/test_tenant_attribution_materialize.py \
             tests/test_analysis_curved_sources.py \
             tests/test_service_token_redaction_1277.py \
             tests/test_url_redaction_sec.py                         # 305 passed
uv run pytest tests/test_processing_port.py tests/test_preview_token_sec021.py \
             tests/test_reupload_idor.py tests/test_reupload.py      # 62 passed
```

Pre-fix failure reproduction: `git stash` of the two source files, rerun of the new file — 5 failed, 1 passed, with the assertion messages quoted in the table above.