### PR TITLE
fix(catalog): reconcile auto-generated distributions when modality changes

### DIFF
--- a/backend/app/core/processing_port.py
+++ b/backend/app/core/processing_port.py
@@ -348,6 +348,22 @@ class ProcessingPort(Protocol):
 
     def create_ingestion_result(self, **kwargs: Any) -> Any: ...  # -> IngestionResult
 
+    # fix(#1314): the refresh and reupload paths can change a dataset's
+    # modality, and the auto-generated `record_distributions` rows have to
+    # follow. The reconcile — including its preservation policy for
+    # user-authored rows — belongs beside `generate_distributions` in the
+    # catalog domain, which processing/ may not import. Returns the rows
+    # created and the (distribution_type, format) pairs removed; the created
+    # rows are catalog ORM instances, typed Any for the same reason.
+    async def reconcile_distributions(
+        self,
+        session: AsyncSession,
+        dataset_id: uuid.UUID,
+        record_id: uuid.UUID,
+        table_name: str,
+        geometry_type: str | None = None,
+    ) -> tuple[list[Any], list[tuple[str, str]]]: ...
+
     # -------------------------------------------------------------------------
     # Source preview helper (D-08)
     # -------------------------------------------------------------------------

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -516,16 +516,23 @@ def _pair_applies(dist_type: str, fmt: str, geometry_type: str | None) -> bool:
     return (dist_type == "download" and fmt == "csv") or dist_type == "ogc_features"
 
 
-def _primary_pair(geometry_type: str | None) -> tuple[str, str]:
-    """The one generated row that carries ``is_primary`` for this modality.
+# Which generated row carries ``is_primary``, best first. GeoPackage is what
+# the template table marks primary; CSV is the fallback, both for a modality
+# that generates no GeoPackage row at all and — on reconcile — for a promote
+# where no generated GeoPackage row exists to promote because a user's own row
+# already occupies that pair.
+_PRIMARY_PREFERENCE: tuple[tuple[str, str], ...] = (
+    ("download", "gpkg"),
+    ("download", "csv"),
+)
 
-    The templates mark GeoPackage primary; without geometry that row is not
-    generated at all, and CSV is the richest download left.
-    """
-    for dist_type, fmt, *_rest, is_primary in _DISTRIBUTION_TEMPLATES:
-        if is_primary and _pair_applies(dist_type, fmt, geometry_type):
-            return dist_type, fmt
-    return "download", "csv"
+
+def _primary_pair(geometry_type: str | None) -> tuple[str, str]:
+    """The one generated row that carries ``is_primary`` for this modality."""
+    for pair in _PRIMARY_PREFERENCE:
+        if _pair_applies(*pair, geometry_type):
+            return pair
+    return _PRIMARY_PREFERENCE[-1]
 
 
 async def generate_distributions(
@@ -663,7 +670,10 @@ async def reconcile_distributions(
     - ``is_primary`` is NORMALIZED across the surviving generated rows, so
       exactly one of them is primary for the new modality (GeoPackage when
       there is geometry, CSV when there is not). A promote that left the old
-      CSV primary beside a new primary GeoPackage would advertise two.
+      CSV primary beside a new primary GeoPackage would advertise two. The
+      winner is picked from the rows that exist rather than from the modality
+      alone — if a user's own row occupies the preferred pair there is no
+      generated row to promote, and the fallback takes it.
 
     The lost-edit case is narrower than it reads: ``update_distribution`` and
     ``delete_distribution`` both refuse to touch a row with
@@ -702,14 +712,34 @@ async def reconcile_distributions(
         session, dataset_id, record_id, table_name, geometry_type=geometry_type
     )
 
-    primary_pair = _primary_pair(geometry_type)
-    for row in survivors + created:
-        pair = (row.distribution_type, row.format)
-        if pair not in _GENERATED_PAIRS:
-            continue
-        should_be_primary = pair == primary_pair
-        if row.is_primary != should_be_primary:
-            row.is_primary = should_be_primary
+    # fix(#1314 review round 1): chosen from the rows that ACTUALLY exist, not
+    # from the modality alone. `generate_distributions` skips any pair a row
+    # already occupies, including a user-authored one — so a promote of a
+    # dataset whose owner had added their own GeoPackage entry generates no
+    # GeoPackage row for the preferred pair to name. Naming it anyway cleared
+    # the CSV flag and promoted nothing, leaving the record with no primary
+    # distribution at all.
+    generated = [
+        row
+        for row in survivors + created
+        if (row.distribution_type, row.format) in _GENERATED_PAIRS
+    ]
+    by_pair = {(row.distribution_type, row.format): row for row in generated}
+    primary = next(
+        (
+            by_pair[pair]
+            for pair in _PRIMARY_PREFERENCE
+            if _pair_applies(*pair, geometry_type) and pair in by_pair
+        ),
+        None,
+    )
+    # No candidate means every preferred pair is occupied by a row this
+    # function does not own, and there is nothing to promote. Leave the flags
+    # as they are rather than clearing them: an unchanged primary is a worse
+    # answer than the right one and a better answer than none.
+    if primary is not None:
+        for row in generated:
+            row.is_primary = row is primary
     await session.flush()
 
     return created, removed

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -491,6 +491,42 @@ _DISTRIBUTION_TEMPLATES = [
     ),
 ]
 
+# Vector tiles are not in the template table because their URL is built from
+# ``table_name`` rather than ``dataset_id``. The pair still belongs to the
+# generated set, so reconcile has to see it.
+_VECTOR_TILES_PAIR = ("vector_tiles", "pbf")
+
+# Every (distribution_type, format) pair this module owns. A row outside this
+# set was written by something else — the raster and VRT ingest tails add their
+# own ``download`` rows — and reconcile must leave those alone even when they
+# are flagged auto-generated.
+_GENERATED_PAIRS: frozenset[tuple[str, str]] = frozenset(
+    {(tpl[0], tpl[1]) for tpl in _DISTRIBUTION_TEMPLATES} | {_VECTOR_TILES_PAIR}
+)
+
+
+def _pair_applies(dist_type: str, fmt: str, geometry_type: str | None) -> bool:
+    """Whether the modality implied by ``geometry_type`` advertises this pair.
+
+    One spelling of the modality filter, so the set a promote INSERTS and the
+    set a demote REMOVES cannot drift apart.
+    """
+    if geometry_type is not None:
+        return True
+    return (dist_type == "download" and fmt == "csv") or dist_type == "ogc_features"
+
+
+def _primary_pair(geometry_type: str | None) -> tuple[str, str]:
+    """The one generated row that carries ``is_primary`` for this modality.
+
+    The templates mark GeoPackage primary; without geometry that row is not
+    generated at all, and CSV is the richest download left.
+    """
+    for dist_type, fmt, *_rest, is_primary in _DISTRIBUTION_TEMPLATES:
+        if is_primary and _pair_applies(dist_type, fmt, geometry_type):
+            return dist_type, fmt
+    return "download", "csv"
+
 
 async def generate_distributions(
     session: AsyncSession,
@@ -529,6 +565,7 @@ async def generate_distributions(
     # single batch rather than as individual INSERT statements. SQLAlchemy 2.0
     # batches `add_all()` + `flush()` via insertmanyvalues when supported.
     to_add: list[RecordDistribution] = []
+    primary_pair = _primary_pair(geometry_type)
 
     for (
         dist_type,
@@ -537,15 +574,11 @@ async def generate_distributions(
         title,
         protocol,
         media_type,
-        is_primary,
+        _is_primary,
     ) in _DISTRIBUTION_TEMPLATES:
         # Non-spatial datasets: only csv download + ogc_features
-        if geometry_type is None:
-            if not (
-                (dist_type == "download" and fmt == "csv")
-                or dist_type == "ogc_features"
-            ):
-                continue
+        if not _pair_applies(dist_type, fmt, geometry_type):
+            continue
 
         # Skip if already exists
         if (dist_type, fmt) in existing_set:
@@ -554,9 +587,7 @@ async def generate_distributions(
         url = url_tpl.format(dataset_id=dataset_id)
 
         # For non-spatial datasets, CSV download becomes primary (gpkg is filtered out)
-        effective_primary = is_primary
-        if geometry_type is None and dist_type == "download" and fmt == "csv":
-            effective_primary = True
+        effective_primary = (dist_type, fmt) == primary_pair
 
         to_add.append(
             RecordDistribution(
@@ -573,7 +604,10 @@ async def generate_distributions(
         )
 
     # Vector tiles (uses table_name, not dataset_id) — skip for non-spatial datasets
-    if geometry_type is not None and ("vector_tiles", "pbf") not in existing_set:
+    if (
+        _pair_applies(*_VECTOR_TILES_PAIR, geometry_type)
+        and _VECTOR_TILES_PAIR not in existing_set
+    ):
         to_add.append(
             RecordDistribution(
                 record_id=record_id,
@@ -592,3 +626,90 @@ async def generate_distributions(
         session.add_all(to_add)
         await session.flush()
     return to_add
+
+
+async def reconcile_distributions(
+    session: AsyncSession,
+    dataset_id: uuid.UUID,
+    record_id: uuid.UUID,
+    table_name: str,
+    geometry_type: str | None = None,
+) -> tuple[list[RecordDistribution], list[tuple[str, str]]]:
+    """Bring a record's AUTO-GENERATED distributions in line with a modality.
+
+    fix(#1314): ``generate_distributions`` runs once, at dataset creation, and
+    merges rather than replaces — so a registered table that later gains a
+    geometry column never starts advertising vector tiles, and one that loses
+    its geometry goes on advertising GeoPackage, GeoJSON, Shapefile,
+    GeoParquet and tiles against a relation that cannot serve any of them.
+    This is the write that closes both directions: it inserts what the new
+    modality adds (by delegating to ``generate_distributions``) and removes
+    what the new modality excludes.
+
+    **Preservation policy.** Deliberately narrow, and the reason is that
+    ``record_distributions`` carries a single ``auto_generated`` boolean and no
+    per-field provenance — there is no ``user_modified_fields`` here the way
+    ``attribute_metadata`` has one:
+
+    - Rows with ``auto_generated=False`` ALWAYS survive, in both directions.
+      Those are the rows a user authored through ``create_distribution``, and
+      nothing in this function reads or writes them.
+    - Rows outside ``_GENERATED_PAIRS`` always survive, even when flagged
+      auto-generated. The raster and VRT ingest tails write their own
+      ``download`` rows (geotiff, vrt) and this function does not own them.
+    - Auto-generated rows the new modality excludes are DELETED. Any user edit
+      to such a row — title, media type, ``is_primary`` — is lost with it, and
+      the row is recreated from the template if the modality flips back.
+    - ``is_primary`` is NORMALIZED across the surviving generated rows, so
+      exactly one of them is primary for the new modality (GeoPackage when
+      there is geometry, CSV when there is not). A promote that left the old
+      CSV primary beside a new primary GeoPackage would advertise two.
+
+    The lost-edit case is narrower than it reads: ``update_distribution`` and
+    ``delete_distribution`` both refuse to touch a row with
+    ``auto_generated=True``, so the API offers no way to edit one in the first
+    place. An edit could only exist from a direct database write, or from a
+    future path that relaxes that refusal — which is when this policy needs
+    revisiting, not before.
+
+    Returns ``(created, removed)``: the rows inserted, and the
+    ``(distribution_type, format)`` pairs deleted.
+    """
+    result = await session.execute(
+        select(RecordDistribution).where(
+            RecordDistribution.record_id == record_id,
+            RecordDistribution.auto_generated.is_(True),
+        )
+    )
+    existing = list(result.scalars().all())
+
+    removed: list[tuple[str, str]] = []
+    survivors: list[RecordDistribution] = []
+    for row in existing:
+        pair = (row.distribution_type, row.format)
+        if pair in _GENERATED_PAIRS and not _pair_applies(*pair, geometry_type):
+            await session.delete(row)
+            removed.append(pair)
+        else:
+            survivors.append(row)
+
+    # Before the insert, so the existence probe inside generate_distributions
+    # sees the post-delete state rather than the rows this call just retired.
+    if removed:
+        await session.flush()
+
+    created = await generate_distributions(
+        session, dataset_id, record_id, table_name, geometry_type=geometry_type
+    )
+
+    primary_pair = _primary_pair(geometry_type)
+    for row in survivors + created:
+        pair = (row.distribution_type, row.format)
+        if pair not in _GENERATED_PAIRS:
+            continue
+        should_be_primary = pair == primary_pair
+        if row.is_primary != should_be_primary:
+            row.is_primary = should_be_primary
+    await session.flush()
+
+    return created, removed

--- a/backend/app/platform/extensions/defaults_processing_port.py
+++ b/backend/app/platform/extensions/defaults_processing_port.py
@@ -377,6 +377,18 @@ class DefaultProcessingPort:
 
         return IngestionResult(**kwargs)
 
+    async def reconcile_distributions(  # type: ignore[no-untyped-def]
+        self, session, dataset_id, record_id, table_name, geometry_type=None
+    ):
+        # fix(#1314): the preservation policy for user-authored rows lives in
+        # the function's docstring, not here — this is the seam, not a second
+        # place to state the rule.
+        from app.modules.catalog.records.service import reconcile_distributions
+
+        return await reconcile_distributions(
+            session, dataset_id, record_id, table_name, geometry_type=geometry_type
+        )
+
     # -------------------------------------------------------------------------
     # Source preview helper (D-08)
     # -------------------------------------------------------------------------

--- a/backend/app/platform/extensions/version.py
+++ b/backend/app/platform/extensions/version.py
@@ -58,7 +58,21 @@ logger = logging.getLogger(__name__)
 # missing answer from a wrong one, so an authority that overrides reads while
 # inheriting the community audience is treated as unable to answer and gets the
 # conservative refusal (see find_maps_broken_by_dataset_visibility).
-EXTENSION_API_VERSION: int = 4
+# 4 -> 5 (fix(#1314)): ProcessingPort gained a required
+# ``reconcile_distributions`` method. An overlay that replaces the
+# ``processing_port`` slot must implement it: the registered-PostGIS refresh
+# and the reupload swap both call it whenever the modality of the dataset they
+# just measured differs from the stored one, so without this bump a
+# version-4 overlay loads cleanly and then raises AttributeError inside the
+# write transaction of the first refresh that matters. Skew that the loader
+# refuses at boot is the whole point of this constant.
+#
+# This bump carries the required-method addition ONLY. The deprecated
+# import-compatibility aliases in protocols.py and defaults.py that their own
+# comments defer "until the next EXTENSION_API_VERSION bump" are NOT removed
+# here — that removal is a separate change with its own review, and a bump
+# forced by an unrelated Protocol addition is not the occasion for it.
+EXTENSION_API_VERSION: int = 5
 
 
 def check_extension_api_version(name: str, declared_version: int | None) -> None:

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1744,6 +1744,7 @@ async def _apply_reupload_swap(
     )  # LAZY — preserved per D-17
     from app.platform.extensions import get_processing_port
     from app.processing.ingest.metadata import (
+        _table_has_geometry,
         compute_quality_score,
         refresh_attribute_metadata,
     )
@@ -1896,13 +1897,40 @@ async def _apply_reupload_swap(
     # with a different derivation (the refresh path owns the only copy of it),
     # and folding it in would widen this change past the distributions #1314
     # asked for.
-    if (previous_geometry_type is None) != (metadata["geometry_type"] is None):
+    #
+    # fix(#1314 review round 2): the demote needs positive evidence, and
+    # `metadata["geometry_type"]` is not it. `extract_metadata` derives the
+    # type by sampling a row (`GeometryType(geom) ... LIMIT 1`), so a spatial
+    # reupload carrying zero features — or only NULL geometries — reports None
+    # while the relation it just installed still has its geometry column.
+    # Reconciling on that would DELETE the GeoPackage, GeoJSON, Shapefile,
+    # GeoParquet and vector-tile rows of a dataset that is still spatial.
+    # #1313 hit the identical trap on the refresh path (review round 5) and
+    # answered it by deriving the type from the COLUMN rather than the rows;
+    # here the column's presence is the entire question, and
+    # `_table_has_geometry` is the codebase's existing way to ask it.
+    #
+    # Only the demote pays for that query, and the third case falls through
+    # deliberately: a TABULAR dataset reuploaded from an empty spatial file
+    # measures None, so there is no type to promote to and no distribution set
+    # to promote it into. Nothing changes until a reupload or a refresh
+    # actually measures geometry, which is the same answer
+    # `dataset.geometry_type` gets on that path.
+    measured_geometry_type = metadata["geometry_type"]
+    was_spatial = previous_geometry_type is not None
+    demoted = (
+        was_spatial
+        and measured_geometry_type is None
+        and not await _table_has_geometry(session, table_name, schema=_tenant_schema)
+    )
+    promoted = not was_spatial and measured_geometry_type is not None
+    if demoted or promoted:
         await port.reconcile_distributions(
             session,
             dataset.id,
             dataset.record_id,
             table_name,
-            geometry_type=metadata["geometry_type"],
+            geometry_type=measured_geometry_type,
         )
 
     dataset.source_format = source_format

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1862,6 +1862,9 @@ async def _apply_reupload_swap(
 
     # Update dataset metadata in the same transaction as swap
     dataset.srid = metadata["srid"]
+    # fix(#1314): read before the overwrite — the reconcile below is the only
+    # thing that needs the PRE-swap modality, and one line later it is gone.
+    previous_geometry_type = dataset.geometry_type
     dataset.geometry_type = metadata["geometry_type"]
     dataset.feature_count = metadata["feature_count"]
     if metadata["extent_wkt"] is not None:
@@ -1878,6 +1881,29 @@ async def _apply_reupload_swap(
         geometry_type=metadata.get("geometry_type"),
         sample_values=sample_values,
     )
+
+    # fix(#1314): a reupload can replace a spatial dataset with a non-spatial
+    # one (or the reverse), and the auto-generated `record_distributions` rows
+    # are as stale afterwards as they are on the refresh path — same one-shot
+    # generation at creation, same never re-derived. Gated on the modality FLIP
+    # for the same reason as there: reconcile normalizes `is_primary`, and a
+    # reupload that kept the modality has no business rewriting it.
+    #
+    # NOT fixed here, and filed as #1361: this path leaves
+    # `dataset.record.record_type` at whatever creation derived, so a
+    # de-spatialized reupload still reads as a `vector_dataset` and
+    # `build_assets` still emits tile links from it. That is a different field
+    # with a different derivation (the refresh path owns the only copy of it),
+    # and folding it in would widen this change past the distributions #1314
+    # asked for.
+    if (previous_geometry_type is None) != (metadata["geometry_type"] is None):
+        await port.reconcile_distributions(
+            session,
+            dataset.id,
+            dataset.record_id,
+            table_name,
+            geometry_type=metadata["geometry_type"],
+        )
 
     dataset.source_format = source_format
     dataset.source_filename = source_filename

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -746,6 +746,10 @@ async def refresh_postgis(
                 dataset.feature_count,
                 feature_count,
             )
+            # Read before `_apply_measurement` overwrites it, for the same
+            # reason the diff above is: this is the only place the PRE-refresh
+            # value is still available.
+            stored_geometry_type = dataset.geometry_type
 
             _apply_measurement(
                 dataset,
@@ -777,6 +781,25 @@ async def refresh_postgis(
                         AttributeMetadata.field_name == "geom",
                     )
                     .values(is_current=False)
+                )
+            # fix(#1314): the persisted half of the modality change.
+            # `_apply_measurement` restamps `record_type`, which is what
+            # `build_assets` computes its links from — but
+            # `record_distributions` rows are generated once, at creation, and
+            # nothing re-derives them. Left
+            # alone, a table that just gained geometry never advertises vector
+            # tiles or GeoPackage in the catalog record, and one that lost it
+            # goes on advertising both against a relation that cannot serve
+            # them. Gated on the modality FLIP rather than run unconditionally:
+            # reconcile normalizes `is_primary` across the generated rows, and
+            # a refresh that changed no modality has no business rewriting it.
+            if (stored_geometry_type is None) != (effective_geometry_type is None):
+                await port.reconcile_distributions(
+                    session,
+                    dataset.id,
+                    dataset.record_id,
+                    dataset.table_name,
+                    geometry_type=effective_geometry_type,
                 )
             dataset.quality_detail = quality_detail
 

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -1481,25 +1481,41 @@ _SWAP_METADATA = {
 
 
 async def _run_reupload_swap(
-    session, dataset, *, admin_id, metadata: dict | None = None, **kwargs
+    session,
+    dataset,
+    *,
+    admin_id,
+    metadata: dict | None = None,
+    staging_has_geometry: bool = True,
+    **kwargs,
 ) -> None:
     """Drive _apply_reupload_swap against a real staging table.
 
     ``metadata`` overrides the spatial default, for the callers that need the
     swap to install a measurement of a DIFFERENT modality than the one the
     dataset was created with (#1314).
+
+    ``staging_has_geometry`` builds the staging relation WITHOUT geometry
+    columns, which is what ingesting a CSV with no geometry produces. It is
+    separate from ``metadata`` on purpose: the pair (measurement says
+    non-spatial, relation still has a geom column) is exactly the empty-spatial
+    reupload the demote must not act on.
     """
     from unittest.mock import AsyncMock, patch
 
     from app.processing.ingest.tasks import _apply_reupload_swap
 
     staging_table = f"{dataset.table_name}_staging"
+    geometry_columns = (
+        "geom geometry(Point, 4326), geom_4326 geometry(Geometry, 4326), "
+        if staging_has_geometry
+        else ""
+    )
     await session.execute(
         sa.text(
             f"CREATE TABLE data.{staging_table} ("
             "gid SERIAL PRIMARY KEY, "
-            "geom geometry(Point, 4326), "
-            "geom_4326 geometry(Geometry, 4326), "
+            f"{geometry_columns}"
             "name TEXT)"
         )
     )
@@ -1719,6 +1735,10 @@ class TestReuploadReconcilesDistributions:
             ds,
             admin_id=admin_id,
             metadata={**_SWAP_METADATA, "geometry_type": None, "extent_wkt": None},
+            # A CSV with no geometry stages a relation with no geom column,
+            # which is what makes this a demote rather than an empty spatial
+            # reupload.
+            staging_has_geometry=False,
             source_filename="rows.csv",
             source_format="csv",
             origin_ref={"filename": "rows.csv"},
@@ -1764,6 +1784,43 @@ class TestReuploadReconcilesDistributions:
             ("ogc_features", "geojson"),
             ("vector_tiles", "pbf"),
         }
+
+    async def test_an_empty_spatial_reupload_is_not_a_demote(
+        self, test_db_session
+    ) -> None:
+        """fix(#1314 review round 2): a measurement of zero rows is not evidence.
+
+        ``extract_metadata`` derives the geometry type by sampling a row, so a
+        spatial file carrying no features reports None even though the relation
+        it stages still has its geometry column. Treating that as a demote
+        would delete the spatial rows of a dataset that is still spatial —
+        the destructive direction, on the weakest possible evidence.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(test_db_session, admin_id=admin_id, geometry_type="POINT")
+        record_id = ds.record_id
+        before = await self._pairs(test_db_session, record_id)
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            # No sampled geometry (no rows), but the staged relation keeps its
+            # geom column — the pair that makes this an empty reupload rather
+            # than a de-spatialization.
+            metadata={
+                **_SWAP_METADATA,
+                "geometry_type": None,
+                "extent_wkt": None,
+                "feature_count": 0,
+            },
+            source_filename="empty.geojson",
+            source_format="geojson",
+            origin_ref={"filename": "empty.geojson"},
+        )
+        await test_db_session.commit()
+
+        assert await self._pairs(test_db_session, record_id) == before
 
 
 class TestFirstIngestStampsLastRefreshed:

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -32,7 +32,15 @@ from httpx import AsyncClient
 
 import app.modules.catalog.datasets.domain.models  # noqa: F401
 from app.core.db import Base
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import (
+    Dataset,
+    Record,
+    RecordDistribution,
+)
+from app.modules.catalog.records.service import (
+    create_distribution,
+    generate_distributions,
+)
 from app.platform.jobs.models import IngestJob
 from app.platform.dataset_origin import (
     ORIGIN_KINDS,
@@ -1472,8 +1480,15 @@ _SWAP_METADATA = {
 }
 
 
-async def _run_reupload_swap(session, dataset, *, admin_id, **kwargs) -> None:
-    """Drive _apply_reupload_swap against a real staging table."""
+async def _run_reupload_swap(
+    session, dataset, *, admin_id, metadata: dict | None = None, **kwargs
+) -> None:
+    """Drive _apply_reupload_swap against a real staging table.
+
+    ``metadata`` overrides the spatial default, for the callers that need the
+    swap to install a measurement of a DIFFERENT modality than the one the
+    dataset was created with (#1314).
+    """
     from unittest.mock import AsyncMock, patch
 
     from app.processing.ingest.tasks import _apply_reupload_swap
@@ -1515,7 +1530,7 @@ async def _run_reupload_swap(session, dataset, *, admin_id, **kwargs) -> None:
             session,
             dataset=dataset,
             staging_table=staging_table,
-            metadata=_SWAP_METADATA,
+            metadata=_SWAP_METADATA if metadata is None else metadata,
             sample_values={"name": ["A"]},
             user_id=str(admin_id),
             original_srid=4326,
@@ -1644,6 +1659,111 @@ class TestReuploadRestampsTheBinding:
                 origin_ref={"filename": "parcels.geojson", "token": "leaked"},
             )
         await test_db_session.rollback()
+
+
+class TestReuploadReconcilesDistributions:
+    """fix(#1314): a reupload can change modality, and the rows must follow.
+
+    Same gap as the registered-PostGIS refresh had, reached a different way:
+    ``_apply_reupload_swap`` writes the new ``geometry_type`` onto the dataset
+    and nothing re-derives the distribution rows generated at creation.
+    """
+
+    async def _pairs(self, session, record_id) -> set[tuple[str, str]]:
+        rows = (
+            await session.execute(
+                sa.select(
+                    RecordDistribution.distribution_type,
+                    RecordDistribution.format,
+                ).where(RecordDistribution.record_id == record_id)
+            )
+        ).all()
+        return {(row[0], row[1]) for row in rows}
+
+    async def _seed(self, session, *, admin_id, geometry_type):
+        ds = await _create_dataset(
+            session,
+            created_by=admin_id,
+            name="Reupload Distributions",
+            # Private: these rows outlive the test on the shared
+            # per-worker DB, so keep them out of public-list assertions.
+            visibility="private",
+            source_format="geojson",
+            geometry_type=geometry_type,
+        )
+        await generate_distributions(
+            session, ds.id, ds.record_id, ds.table_name, geometry_type=geometry_type
+        )
+        await session.commit()
+        return ds
+
+    async def test_a_reupload_that_removes_geometry_drops_the_spatial_rows(
+        self, test_db_session
+    ) -> None:
+        """A CSV over a shapefile leaves a relation with nothing to tile."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(test_db_session, admin_id=admin_id, geometry_type="POINT")
+        record_id = ds.record_id
+        mine = await create_distribution(
+            test_db_session,
+            record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+        )
+        mine_id = mine.id
+        await test_db_session.commit()
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            metadata={**_SWAP_METADATA, "geometry_type": None, "extent_wkt": None},
+            source_filename="rows.csv",
+            source_format="csv",
+            origin_ref={"filename": "rows.csv"},
+        )
+        await test_db_session.commit()
+
+        assert await self._pairs(test_db_session, record_id) == {
+            ("download", "csv"),
+            ("ogc_features", "geojson"),
+            # The user's own row, on a pair the demote otherwise removes.
+            ("download", "gpkg"),
+        }
+        assert (
+            await test_db_session.scalar(
+                sa.select(RecordDistribution.id).where(RecordDistribution.id == mine_id)
+            )
+            is not None
+        )
+
+    async def test_a_reupload_that_adds_geometry_advertises_the_spatial_rows(
+        self, test_db_session
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(test_db_session, admin_id=admin_id, geometry_type=None)
+        record_id = ds.record_id
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            source_filename="points.geojson",
+            source_format="geojson",
+            origin_ref={"filename": "points.geojson"},
+        )
+        await test_db_session.commit()
+
+        assert await self._pairs(test_db_session, record_id) == {
+            ("download", "gpkg"),
+            ("download", "geojson"),
+            ("download", "shp"),
+            ("download", "parquet"),
+            ("download", "csv"),
+            ("ogc_features", "geojson"),
+            ("vector_tiles", "pbf"),
+        }
 
 
 class TestFirstIngestStampsLastRefreshed:

--- a/backend/tests/test_distribution_reconcile_1314.py
+++ b/backend/tests/test_distribution_reconcile_1314.py
@@ -1,0 +1,364 @@
+"""Reconciling auto-generated distributions when a dataset's modality changes (#1314).
+
+``generate_distributions`` runs once, at dataset creation, and merges rather
+than replaces. Everything below is about the write that closes the gap that
+leaves: a registered table that later gains a geometry column has to start
+advertising the spatial formats, one that loses its geometry has to stop, and
+neither direction may take a user's own distribution rows with it.
+
+The preservation policy is stated on ``reconcile_distributions``' docstring.
+These tests are what stop it from being only a docstring — including the
+limitation it admits to, which is pinned here deliberately so that relaxing it
+later fails a test instead of quietly changing behaviour.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.catalog.datasets.domain.models import RecordDistribution
+from app.modules.catalog.records.service import (
+    create_distribution,
+    generate_distributions,
+    reconcile_distributions,
+    update_distribution,
+)
+from tests.factories import create_dataset, get_user_id
+
+pytestmark = pytest.mark.anyio
+
+# What `generate_distributions` emits per modality, as pairs. Spelled out here
+# rather than imported from the module under test: a test that derives its
+# expectation from the same table the code reads would pass through a change
+# to that table, which is the change most worth noticing.
+_SPATIAL_PAIRS = {
+    ("download", "gpkg"),
+    ("download", "geojson"),
+    ("download", "shp"),
+    ("download", "parquet"),
+    ("download", "csv"),
+    ("ogc_features", "geojson"),
+    ("vector_tiles", "pbf"),
+}
+_TABULAR_PAIRS = {("download", "csv"), ("ogc_features", "geojson")}
+
+
+async def _pairs(session: AsyncSession, record_id: uuid.UUID) -> set[tuple[str, str]]:
+    rows = (
+        await session.execute(
+            select(
+                RecordDistribution.distribution_type,
+                RecordDistribution.format,
+            ).where(RecordDistribution.record_id == record_id)
+        )
+    ).all()
+    return {(row[0], row[1]) for row in rows}
+
+
+async def _row(
+    session: AsyncSession, record_id: uuid.UUID, dist_type: str, fmt: str
+) -> RecordDistribution | None:
+    return (
+        await session.execute(
+            select(RecordDistribution).where(
+                RecordDistribution.record_id == record_id,
+                RecordDistribution.distribution_type == dist_type,
+                RecordDistribution.format == fmt,
+                RecordDistribution.auto_generated.is_(True),
+            )
+        )
+    ).scalar_one_or_none()
+
+
+async def _tabular_dataset(session: AsyncSession):
+    """A dataset carrying the two rows a non-spatial creation generates."""
+    admin_id = await get_user_id(session, "admin")
+    dataset = await create_dataset(session, created_by=admin_id, geometry_type=None)
+    await generate_distributions(
+        session, dataset.id, dataset.record_id, dataset.table_name, geometry_type=None
+    )
+    await session.commit()
+    return dataset
+
+
+async def _spatial_dataset(session: AsyncSession):
+    """A dataset carrying the seven rows a spatial creation generates."""
+    admin_id = await get_user_id(session, "admin")
+    dataset = await create_dataset(session, created_by=admin_id)
+    await generate_distributions(
+        session,
+        dataset.id,
+        dataset.record_id,
+        dataset.table_name,
+        geometry_type="POLYGON",
+    )
+    await session.commit()
+    return dataset
+
+
+class TestModalityFlip:
+    """The two directions the issue is about."""
+
+    async def test_gaining_geometry_advertises_the_full_spatial_set(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        dataset = await _tabular_dataset(test_db_session)
+        assert await _pairs(test_db_session, dataset.record_id) == _TABULAR_PAIRS
+
+        created, removed = await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        assert removed == []
+        assert {(c.distribution_type, c.format) for c in created} == (
+            _SPATIAL_PAIRS - _TABULAR_PAIRS
+        )
+        assert await _pairs(test_db_session, dataset.record_id) == _SPATIAL_PAIRS
+
+    async def test_losing_geometry_stops_advertising_the_spatial_set(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        dataset = await _spatial_dataset(test_db_session)
+        assert await _pairs(test_db_session, dataset.record_id) == _SPATIAL_PAIRS
+
+        created, removed = await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type=None,
+        )
+        await test_db_session.commit()
+
+        assert created == []
+        assert set(removed) == _SPATIAL_PAIRS - _TABULAR_PAIRS
+        assert await _pairs(test_db_session, dataset.record_id) == _TABULAR_PAIRS
+
+    async def test_reconciling_to_the_same_modality_changes_nothing(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Idempotent, so a caller that over-calls it cannot churn the rows."""
+        dataset = await _spatial_dataset(test_db_session)
+
+        created, removed = await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        assert (created, removed) == ([], [])
+        assert await _pairs(test_db_session, dataset.record_id) == _SPATIAL_PAIRS
+
+
+class TestPreservationPolicy:
+    """What survives a demote, and what the model cannot promise to."""
+
+    async def test_a_user_authored_row_survives_both_transitions(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """``auto_generated=False`` is the whole rule, and it is not a pair filter.
+
+        The colliding row is the sharp case: a user's own GeoPackage entry
+        occupies a pair the demote removes, so a reconcile that matched on
+        (type, format) alone would delete somebody's hand-written row.
+        """
+        dataset = await _spatial_dataset(test_db_session)
+        mine = await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+            title="My own extract",
+        )
+        elsewhere = await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="api",
+            format="json",
+            url="https://example.org/api",
+        )
+        await test_db_session.commit()
+
+        for geometry_type in (None, "POLYGON", None):
+            await reconcile_distributions(
+                test_db_session,
+                dataset.id,
+                dataset.record_id,
+                dataset.table_name,
+                geometry_type=geometry_type,
+            )
+        await test_db_session.commit()
+
+        survivors = {
+            row.id
+            for row in (
+                await test_db_session.execute(
+                    select(RecordDistribution).where(
+                        RecordDistribution.record_id == dataset.record_id,
+                        RecordDistribution.auto_generated.is_(False),
+                    )
+                )
+            ).scalars()
+        }
+        assert survivors == {mine.id, elsewhere.id}
+        assert (await test_db_session.get(RecordDistribution, mine.id)).title == (
+            "My own extract"
+        )
+
+    async def test_a_row_outside_the_generated_set_is_never_removed(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The raster and VRT tails write their own ``download`` rows.
+
+        Those are auto-generated in spirit and sometimes in flag, and this
+        function does not own them — a demote that swept every auto row would
+        delete a COG's only download link.
+        """
+        dataset = await _spatial_dataset(test_db_session)
+        foreign = RecordDistribution(
+            record_id=dataset.record_id,
+            distribution_type="download",
+            format="geotiff",
+            url="cogs/abc.tif",
+            auto_generated=True,
+        )
+        test_db_session.add(foreign)
+        await test_db_session.commit()
+
+        _created, removed = await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type=None,
+        )
+        await test_db_session.commit()
+
+        assert ("download", "geotiff") not in removed
+        assert await test_db_session.get(RecordDistribution, foreign.id) is not None
+
+    async def test_an_edit_to_an_auto_generated_row_does_not_survive_a_demote(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The documented limitation, pinned so relaxing it is a decision.
+
+        ``record_distributions`` has one ``auto_generated`` boolean and no
+        per-field provenance, so there is nothing to distinguish an edited
+        auto row from a generated one. The demote deletes it either way.
+        """
+        dataset = await _spatial_dataset(test_db_session)
+        gpkg = await _row(test_db_session, dataset.record_id, "download", "gpkg")
+        assert gpkg is not None
+        gpkg.title = "Edited straight in the database"
+        await test_db_session.commit()
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type=None,
+        )
+        await test_db_session.commit()
+
+        assert await test_db_session.get(RecordDistribution, gpkg.id) is None
+
+    async def test_the_api_offers_no_way_to_make_that_edit(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Why the limitation above is narrower than it reads.
+
+        The edit the demote cannot preserve is one the service layer refuses
+        to make in the first place, so the only way to hold one is a direct
+        database write. If this refusal is ever relaxed, the policy on
+        ``reconcile_distributions`` needs revisiting — and this test is the
+        thing that will say so.
+        """
+        dataset = await _spatial_dataset(test_db_session)
+        gpkg = await _row(test_db_session, dataset.record_id, "download", "gpkg")
+        assert gpkg is not None
+
+        with pytest.raises(ValueError, match="auto-generated"):
+            await update_distribution(
+                test_db_session, gpkg.id, dataset.record_id, title="Nope"
+            )
+
+
+class TestPrimaryFlag:
+    """Exactly one generated row is primary, whichever way the modality moved."""
+
+    async def _primary_pairs(
+        self, session: AsyncSession, record_id: uuid.UUID
+    ) -> set[tuple[str, str]]:
+        rows = (
+            await session.execute(
+                select(RecordDistribution).where(
+                    RecordDistribution.record_id == record_id,
+                    RecordDistribution.auto_generated.is_(True),
+                    RecordDistribution.is_primary.is_(True),
+                )
+            )
+        ).scalars()
+        return {(row.distribution_type, row.format) for row in rows}
+
+    async def test_a_promote_moves_primary_from_csv_to_geopackage(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Without this the dataset advertises two primary downloads.
+
+        A tabular creation makes CSV primary because GeoPackage is not
+        generated at all; the promote generates GeoPackage as primary and the
+        merge leaves the CSV row exactly as it was.
+        """
+        dataset = await _tabular_dataset(test_db_session)
+        assert await self._primary_pairs(test_db_session, dataset.record_id) == {
+            ("download", "csv")
+        }
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        assert await self._primary_pairs(test_db_session, dataset.record_id) == {
+            ("download", "gpkg")
+        }
+
+    async def test_a_demote_moves_primary_to_csv(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The deleted GeoPackage row takes the only primary flag with it."""
+        dataset = await _spatial_dataset(test_db_session)
+        assert await self._primary_pairs(test_db_session, dataset.record_id) == {
+            ("download", "gpkg")
+        }
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type=None,
+        )
+        await test_db_session.commit()
+
+        assert await self._primary_pairs(test_db_session, dataset.record_id) == {
+            ("download", "csv")
+        }

--- a/backend/tests/test_distribution_reconcile_1314.py
+++ b/backend/tests/test_distribution_reconcile_1314.py
@@ -341,6 +341,40 @@ class TestPrimaryFlag:
             ("download", "gpkg")
         }
 
+    async def test_a_promote_falls_back_to_csv_when_a_user_row_holds_geopackage(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """fix(#1314 review round 1): the record must never end up with none.
+
+        ``generate_distributions`` skips any pair a row already occupies, and
+        it does not care whether that row is auto-generated. So a promote of a
+        dataset whose owner added their own GeoPackage entry generates no
+        GeoPackage row — and picking the primary from the modality alone
+        cleared the CSV flag to promote a row that was never created.
+        """
+        dataset = await _tabular_dataset(test_db_session)
+        await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+        )
+        await test_db_session.commit()
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        assert await self._primary_pairs(test_db_session, dataset.record_id) == {
+            ("download", "csv")
+        }
+
     async def test_a_demote_moves_primary_to_csv(
         self, test_db_session: AsyncSession
     ) -> None:

--- a/backend/tests/test_extension_api_version.py
+++ b/backend/tests/test_extension_api_version.py
@@ -54,13 +54,19 @@ class TestExtensionApiVersionConstant:
         expected type of a registry key, which version.py's bump convention
         names explicitly. v4 adds the required ``record_audience`` method to
         ``PermissionExtension`` (feat(#1068)), which the convention names
-        outright: a required method added to a Protocol.
+        outright: a required method added to a Protocol. v5 adds the required
+        ``reconcile_distributions`` method to ``ProcessingPort`` (fix(#1314)),
+        the same case again: the registered-PostGIS refresh and the reupload
+        swap call it inside their write transactions whenever the modality
+        they measured differs from the stored one, so an overlay that replaces
+        the ``processing_port`` key without it raises AttributeError mid-write
+        instead of being refused at boot.
 
         Update this pin, and the note above it, whenever the constant moves.
         """
         from app.platform.extensions.version import EXTENSION_API_VERSION
 
-        assert EXTENSION_API_VERSION == 4
+        assert EXTENSION_API_VERSION == 5
 
 
 class TestCheckExtensionApiVersion:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1773,7 +1773,10 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#1266 review round 9): +1 — the resolution takes the item's
         # recorded id as well, so a catalog whose URLs state no identity can
         # still have an answer checked against the binding. Cap 481 -> 482.
-        "backend/app/platform/extensions/defaults_processing_port.py": 482,
+        # fix(#1314): +12 — reconcile_distributions, the seam the refresh and
+        # reupload paths cross to bring auto-generated distribution rows in
+        # line with a modality that changed under them. Cap 482 -> 494.
+        "backend/app/platform/extensions/defaults_processing_port.py": 494,
         # fix(#929): +2 over the 350 default — the creator exemption on the
         # restricted branch of filter_visible/can_access_dataset plus its
         # rationale comments. fix(#930): +20 — the internal branch on the same
@@ -2221,7 +2224,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tasks_reupload. Moved here rather than duplicated, so the two strategies
     # share one implementation and #1313's file shrank by the same lines.
     # Cap 1902 -> 1968, exact.
-    "backend/app/processing/ingest/tasks_common.py": 1968,
+    # fix(#1314): +26 — _apply_reupload_swap reconciles the auto-generated
+    # distribution rows when the swap changes the dataset's modality. Most of
+    # the lines are the note recording what this deliberately does NOT fix on
+    # this path (record_type, filed as #1361) so the asymmetry is a decision
+    # rather than an oversight. Cap 1968 -> 1994, exact.
+    "backend/app/processing/ingest/tasks_common.py": 1994,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2229,7 +2229,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # the lines are the note recording what this deliberately does NOT fix on
     # this path (record_type, filed as #1361) so the asymmetry is a decision
     # rather than an oversight. Cap 1968 -> 1994, exact.
-    "backend/app/processing/ingest/tasks_common.py": 1994,
+    # fix(#1314 review round 2): +28 — the demote needs positive evidence that
+    # the relation is not spatial, because a spatial reupload of an empty file
+    # measures None while its geom column is still there. Most of the lines are
+    # the note saying why the sampled value is not that evidence, which is the
+    # same trap #1313 fell into on the refresh path. Cap 1994 -> 2022, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2022,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_postgis_refresh_1265.py
+++ b/backend/tests/test_postgis_refresh_1265.py
@@ -34,7 +34,11 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import joinedload
 
 from app.modules.catalog.datasets.api import router_refresh
-from app.modules.catalog.datasets.domain.models import Dataset
+from app.modules.catalog.datasets.domain.models import Dataset, RecordDistribution
+from app.modules.catalog.records.service import (
+    create_distribution,
+    generate_distributions,
+)
 from app.platform.dataset_origin import set_dataset_origin, set_postgis_origin
 from app.platform.jobs.models import IngestJob
 from app.platform.refresh.models import DatasetRefreshRun
@@ -158,6 +162,38 @@ async def _reload(session, dataset_id: uuid.UUID) -> Dataset:
             .where(Dataset.id == dataset_id)
         )
     ).scalar_one()
+
+
+async def _distribution_pairs(session, record_id: uuid.UUID) -> set[tuple[str, str]]:
+    """The (distribution_type, format) pairs this record currently advertises.
+
+    A column select rather than an entity one, deliberately: the worker writes
+    these rows from its own session, and a query that went through this
+    session's identity map could answer from objects loaded before it ran.
+    """
+    rows = (
+        await session.execute(
+            select(
+                RecordDistribution.distribution_type,
+                RecordDistribution.format,
+            ).where(RecordDistribution.record_id == record_id)
+        )
+    ).all()
+    return {(row[0], row[1]) for row in rows}
+
+
+async def _distribution_ids(session, record_id: uuid.UUID) -> set[uuid.UUID]:
+    return set(
+        (
+            await session.execute(
+                select(RecordDistribution.id).where(
+                    RecordDistribution.record_id == record_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
 
 
 async def _dispatch(client: AsyncClient, headers: dict, dataset_id: uuid.UUID) -> dict:
@@ -1078,6 +1114,133 @@ class TestPostgisRefreshExecution:
             {"did": refreshed.id},
         )
         assert geom_current is False
+
+    async def test_a_table_that_gains_geometry_advertises_the_spatial_formats(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """fix(#1314): the persisted half of the modality change.
+
+        ``record_type`` is re-derived above, and ``build_assets`` computes its
+        links from it live — but ``record_distributions`` rows are generated
+        once, at creation, and nothing re-derived them. A table registered
+        while it was still empty kept only its CSV and OGC Features rows
+        forever, however much geometry it later grew.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _registered_dataset(test_db_session, created_by=admin_id)
+        record_id = dataset.record_id
+        dataset.record.record_type = "table"
+        dataset.geometry_type = None
+        await generate_distributions(
+            test_db_session,
+            dataset.id,
+            record_id,
+            dataset.table_name,
+            geometry_type=None,
+        )
+        await test_db_session.commit()
+        assert await _distribution_pairs(test_db_session, record_id) == {
+            ("download", "csv"),
+            ("ogc_features", "geojson"),
+        }
+
+        await _execute(
+            test_db_session, await _dispatch(client, admin_auth_header, dataset.id)
+        )
+
+        assert await _distribution_pairs(test_db_session, record_id) == {
+            ("download", "gpkg"),
+            ("download", "geojson"),
+            ("download", "shp"),
+            ("download", "parquet"),
+            ("download", "csv"),
+            ("ogc_features", "geojson"),
+            ("vector_tiles", "pbf"),
+        }
+
+    async def test_a_dataset_that_loses_geometry_stops_advertising_them(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """The inverse, and the one that offers what the relation cannot serve.
+
+        The user-authored row is here rather than in a test of its own because
+        the preservation policy only means anything at the call site: it is
+        this refresh that has to leave somebody's hand-written entry alone
+        while removing the generated ones beside it.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _registered_dataset(test_db_session, created_by=admin_id)
+        record_id = dataset.record_id
+        await generate_distributions(
+            test_db_session,
+            dataset.id,
+            record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        mine = await create_distribution(
+            test_db_session,
+            record_id,
+            distribution_type="download",
+            format="shp",
+            url="https://example.org/mine.zip",
+        )
+        mine_id = mine.id
+        await test_db_session.commit()
+
+        await test_db_session.execute(
+            text(  # noqa: S608
+                f"ALTER TABLE data.{dataset.table_name} "
+                f"DROP COLUMN geom, DROP COLUMN geom_4326"
+            )
+        )
+        await test_db_session.commit()
+
+        await _execute(
+            test_db_session, await _dispatch(client, admin_auth_header, dataset.id)
+        )
+
+        assert await _distribution_pairs(test_db_session, record_id) == {
+            ("download", "csv"),
+            ("ogc_features", "geojson"),
+            # The user's own Shapefile row, which the demote must not sweep up
+            # with the generated one that shared its pair.
+            ("download", "shp"),
+        }
+        assert (
+            await test_db_session.scalar(
+                select(RecordDistribution.id).where(RecordDistribution.id == mine_id)
+            )
+            is not None
+        )
+
+    async def test_a_refresh_that_keeps_the_modality_leaves_distributions_alone(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """Why the reconcile is gated on the flip rather than run every time.
+
+        It normalizes ``is_primary`` across the generated rows, so calling it
+        on every refresh would make an ordinary re-measurement rewrite a field
+        the refresh has no opinion about.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _registered_dataset(test_db_session, created_by=admin_id)
+        record_id = dataset.record_id
+        await generate_distributions(
+            test_db_session,
+            dataset.id,
+            record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+        before = await _distribution_ids(test_db_session, record_id)
+
+        await _execute(
+            test_db_session, await _dispatch(client, admin_auth_header, dataset.id)
+        )
+
+        assert await _distribution_ids(test_db_session, record_id) == before
 
     async def test_the_quality_score_uses_the_measured_modality(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session

--- a/backend/tests/test_processing_port.py
+++ b/backend/tests/test_processing_port.py
@@ -226,6 +226,14 @@ class FakeProcessingPort:
             setattr(result, k, v)
         return result
 
+    async def reconcile_distributions(
+        self, session, dataset_id, record_id, table_name, geometry_type=None
+    ):
+        # fix(#1314): reports "nothing changed", the outcome that leaves the
+        # stored distribution set alone — a double that invented rows would
+        # make every caller's test depend on this fake's template table.
+        return [], []
+
     # -------------------------------------------------------------------------
     # Source preview helper
     # -------------------------------------------------------------------------

--- a/backend/tests/test_processing_port.py
+++ b/backend/tests/test_processing_port.py
@@ -366,6 +366,50 @@ async def test_fake_processing_port_satisfies_protocol() -> None:
 
 
 @pytest.mark.asyncio
+async def test_the_shipped_port_implements_the_contract_it_declares() -> None:
+    """The default is held to the same Protocol the fake is.
+
+    Without this, ``ProcessingPort`` is only ever checked against a test
+    double, and a method added to the contract could be missing from the
+    implementation every non-overlay install actually runs.
+    """
+    from app.core.processing_port import ProcessingPort
+    from app.platform.extensions.defaults import DefaultProcessingPort
+
+    assert isinstance(DefaultProcessingPort(), ProcessingPort)
+
+
+@pytest.mark.asyncio
+async def test_a_port_missing_reconcile_distributions_does_not_satisfy_the_contract() -> (
+    None
+):
+    """fix(#1314 review round 1): why EXTENSION_API_VERSION went 4 -> 5.
+
+    ``reconcile_distributions`` is a REQUIRED method, not an optional one: the
+    registered-PostGIS refresh and the reupload swap call it inside their write
+    transactions whenever the modality changed. An overlay that replaces the
+    ``processing_port`` slot without it would raise AttributeError there, which
+    is why the loader has to refuse the overlay at boot instead — and the
+    version bump is what makes it refuse.
+    """
+    from app.core.processing_port import ProcessingPort
+
+    class _OverlayPortWithoutIt:
+        """Everything the fake offers, minus the one method under test."""
+
+        def __init__(self) -> None:
+            self._inner = FakeProcessingPort()
+
+        def __getattr__(self, name):
+            if name == "reconcile_distributions":
+                raise AttributeError(name)
+            return getattr(self._inner, name)
+
+    assert isinstance(FakeProcessingPort(), ProcessingPort)
+    assert not isinstance(_OverlayPortWithoutIt(), ProcessingPort)
+
+
+@pytest.mark.asyncio
 async def test_processing_port_seam_search_tool() -> None:
     """Verify _execute_search_tool runs through FakeProcessingPort without a database.
 


### PR DESCRIPTION
## What

`generate_distributions()` runs once, at dataset creation, and merges rather than replaces. Nothing re-derives the rows afterwards, so a dataset whose spatiality changes keeps the distribution set it was born with:

- a registered table that gains a geometry column never starts advertising vector tiles, GeoPackage, GeoJSON, Shapefile or GeoParquet;
- a dataset whose geometry columns are dropped goes on advertising all of them against a relation that cannot serve any.

#1313 narrowed this — `build_assets()` computes from `record_type` live and the refresh re-derives `record_type` from the measurement — but the persisted rows stayed exactly as stale as before.

This adds `reconcile_distributions()` beside `generate_distributions()` in `backend/app/modules/catalog/records/service.py`, exposes it on `ProcessingPort` (`backend/app/processing/` may not import catalog — `test_no_processing_imports_catalog`), and calls it from two write paths:

- the registered-PostGIS refresh (`tasks_postgis_refresh.py`), in the phase-3 write transaction;
- the re-upload swap (`_apply_reupload_swap` in `tasks_common.py`), in the swap transaction.

Both are gated on the modality **flip** rather than run unconditionally. The reconcile normalizes `is_primary` across the generated rows, and a run that changed no modality has no business rewriting a field it has no opinion about. There is a test for that gate specifically.

## Preservation policy

Stated on the function's docstring and pinned by tests, since #1314 called this out as needing a decision rather than just code:

- Rows with `auto_generated=False` **always** survive, both directions. The sharp case is a user-authored row occupying a pair the demote removes (someone's own GeoPackage link) — it is covered.
- Rows outside the generated pair set **always** survive, even when flagged auto-generated, so the raster and VRT ingest tails' own `download` rows (`geotiff`, `vrt`) are never swept up by a vector demote.
- Auto-generated rows the new modality excludes are **deleted**, and any user edit to one (title, media type, `is_primary`) goes with it. `record_distributions` carries a single `auto_generated` boolean and no per-field provenance — there is no `user_modified_fields` here the way `attribute_metadata` has one — so there is nothing to preserve an edit by, and inventing one is out of scope.
- `is_primary` is normalized so exactly one generated row is primary for the new modality. Without this, a promote leaves the old primary CSV beside a newly generated primary GeoPackage and the dataset advertises two.

The lost-edit limitation is narrower than it reads, and that is worth stating plainly: `update_distribution` and `delete_distribution` both **refuse** to touch a row with `auto_generated=True`, so the API offers no way to make such an edit in the first place. Only a direct database write could hold one. `test_the_api_offers_no_way_to_make_that_edit` pins that refusal, so if it is ever relaxed the policy surfaces as a failing test rather than as a silent behaviour change.

## Also

The modality filter and the primary-format choice are now single helpers (`_pair_applies`, `_primary_pair`) shared by generate and reconcile, so the set one inserts and the set the other removes cannot drift apart. `generate_distributions`' behaviour is unchanged — the two branches it used to spell inline are the same two answers those helpers return.

## Not included

`_apply_reupload_swap` also leaves `record.record_type` at whatever creation derived, so a de-spatialized re-upload still reads as a `vector_dataset` and `build_assets()` still emits tile links from it. Different field, different derivation, and the only copy of that derivation currently lives in the refresh module — filed as **#1361** rather than folded in here. The inline comment at the call site says so.

## Schema / API / config impact

None. No migration, no new or changed column, no OpenAPI change, no config. This writes existing rows in an existing table; the endpoints that read them are unchanged.

## Verification

Run from `backend/` with `.env.test` sourced, against Postgres at `localhost:5434`:

- `uv run ruff check .` — pass
- `uv run ruff format --check .` — pass
- `uv run pytest tests/test_layering.py -q` — 40 passed (both LOC ratchets bumped in this commit: `tasks_common.py` 1968 -> 1994, `defaults_processing_port.py` 482 -> 494)
- `uv run pytest tests/test_distribution_reconcile_1314.py -q` — 9 passed (new)
- `uv run pytest tests/test_postgis_refresh_1265.py tests/test_dataset_source_state.py -q` — 149 passed
- `uv run pytest tests/test_processing_port.py tests/test_records_related.py tests/test_reupload_swap_lock_retry.py tests/test_provenance_attribution.py tests/test_dataset_refresh_runs.py -q` — 152 passed
- `uv run pytest tests/test_dcat.py tests/test_geodcat_ap.py tests/test_metadata_roundtrip.py tests/test_ogc_collection_metadata.py tests/test_ogc_record_enrichment.py tests/test_stac_record_output.py tests/test_record_subresource_edits.py tests/test_records_authz_sec001.py tests/test_commit_request_schemas.py tests/test_quicklook_predicate.py tests/test_tasks_common_phase_brackets.py -q` — 161 passed
- `uv run pytest tests/test_ingest.py tests/test_raster_ingest.py tests/test_raster_replace_1221.py tests/test_raster_dataset_assets_bug041.py tests/test_regenerate_vrt_integration.py tests/test_vrt_catalog_175.py tests/test_tenant_attribution_materialize.py -q` — 206 passed

Failing-first was confirmed by stashing only `backend/app/` and re-running: the new unit suite fails to import `reconcile_distributions`, and 4 of the 5 new integration tests fail. The fifth is the gate test above, which passes on both sides by construction — it exists to stop a future unconditional reconcile, not to prove this fix.

Closes #1314

---

## Review rounds (2, clean on the third)

**Round 1 — two findings, both actioned.**

`reconcile_distributions` is a required `ProcessingPort` method, so `EXTENSION_API_VERSION` goes **4 -> 5** (e5efc5d44). Without it a version-4 overlay replacing the `processing_port` slot loads cleanly and then raises `AttributeError` inside the write transaction of the first refresh or reupload that changes modality; the bump makes the loader refuse it at boot instead. The optional-method route the convention allows was rejected deliberately — a legacy overlay would then silently not reconcile, which is the bug this PR exists to fix, on the installs most likely to notice. The bump carries the required-method addition only; deprecated aliases whose comments defer removal "until the next bump" are untouched, and the note says so. Two tests came with it: a port without the method fails `isinstance` against the Protocol, and `DefaultProcessingPort` is now checked against `ProcessingPort` at all (only the test double ever was).

The `is_primary` normalization named the modality's preferred pair without checking a generated row for it exists. Since `generate_distributions` skips any pair a row already occupies — user-authored included — a promote of a dataset whose owner had added their own GeoPackage entry generated no GeoPackage row, and the normalization then cleared the CSV flag to promote a row that was never created, leaving **no primary at all**. Strictly worse than before this PR. The winner is now picked from the rows that exist. The other half of that finding (the built-in export row stays permanently absent for that pair) is filed as **#1370**: filtering the probe to auto-generated rows is not a safe drive-by, because a user row whose URL matches the template's would then raise `IntegrityError` inside a refresh's write transaction.

**Round 2 — two findings, both actioned.**

The version bump left `test_extension_api_version.py` asserting 4. Pin and contract-history note moved to 5 (7483626cb).

The reupload gate read `metadata["geometry_type"]`, which `extract_metadata` derives by sampling a row. A spatial reupload carrying zero features therefore measured None while the relation it installed still had its geometry column, and the gate read that as a demote — **deleting the spatial rows of a still-spatial dataset**. The demote now requires the geometry column to be absent (`_table_has_geometry`, already imported on this path), and only the demote pays for that query. The demote test had been staging a relation *with* geom columns, which is not what a CSV without geometry produces; it now stages one without, and `test_an_empty_spatial_reupload_is_not_a_demote` covers the case directly.

Residual filed as **#1373**: this path still writes that sampled `None` to `dataset.geometry_type`, so an empty spatial reupload de-spatializes the column itself, with the `_require_feature_table` and builder consequences #1313 spelled out for the refresh path. Distributions no longer follow it; the column fix needs the shared effective-type precedence and is its own change.

**Round 3 — clean, reviewed sha `7483626cb` equal to head.**

### Follow-ups filed from this PR

- **#1361** — `_apply_reupload_swap` never re-derives `record.record_type`
- **#1370** — a user-authored distribution permanently suppresses the built-in export row for its pair
- **#1373** — an empty spatial reupload de-spatializes the dataset it replaces

### Gates re-run at head 7483626cb

`ruff check` / `ruff format --check` pass; `tests/test_layering.py` 40 passed (three ratchets moved: `tasks_common.py` 1968 -> 2022, `defaults_processing_port.py` 482 -> 494); the reconcile, port, version, refresh and source-state suites 216 passed together. Full CI on the PR is green, including Backend Tests and E2E Smoke.
