### PR TITLE
fix(worker): initialize the tile cache in the shared bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -648,6 +648,11 @@ FRONTEND_PORT=8080
 # --- Cache Provider ---
 # [OPTIONAL] Redis/Valkey connection URL for cross-instance caching
 # Leave unset to use in-memory caching (single-instance default).
+# Note (#1315): "single-instance" still means two processes. With this unset,
+# the API's MVT tile cache is process-local, so the worker cannot purge it
+# after a re-upload or PostGIS refresh — the API keeps serving pre-swap tiles
+# until they expire (TILE_CACHE_TTL). The worker says so at boot. Set this if
+# you re-upload datasets and cannot wait out the TTL.
 # Type: string | No default
 # Example: redis://redis:6379/0
 # REDIS_URL=

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -28,7 +28,6 @@ from app.observability.metrics import (
     shutdown_worker_metrics,
     sweep_dead_worker_metrics,
 )
-from app.platform.cache.provider import init_tile_cache
 
 # settings already imported above for the tempdir override — do NOT reimport
 # fix(#909): async_session/engine are late-bound inside each function that
@@ -325,7 +324,6 @@ async def lifespan(app: FastAPI):
     # the worker's age-aware sweeper instead.
     sweep_orphaned_exports(exports_dir)
 
-    init_tile_cache()
     await init_tile_pool()
     await task_app.open_async()
 

--- a/backend/app/platform/cache/provider.py
+++ b/backend/app/platform/cache/provider.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol
 
+import structlog
+
 if TYPE_CHECKING:
     from app.platform.cache.tile_cache import (
         InMemoryTileCacheProvider,
         TileCacheProvider,
     )
+
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class CacheProvider(Protocol):
@@ -63,13 +67,21 @@ def get_cache() -> CacheProvider:
 _tile_cache: "TileCacheProvider | InMemoryTileCacheProvider | None" = None
 
 
-def init_tile_cache() -> None:
+def init_tile_cache(*, in_memory_fallback: bool = True) -> None:
     """Initialize the tile cache singleton.
 
     Uses the Redis-backed binary provider when ``REDIS_URL`` is set;
     otherwise falls back to an in-memory LRU provider (PERF-01,
     Phase 274) so smaller single-VPS deployments still get tile-cache
     benefits without running Redis.
+
+    fix(#1315): pass ``in_memory_fallback=False`` from a process that only
+    ever INVALIDATES tiles and never reads them — the Procrastinate worker.
+    A process-local LRU there holds nothing, because nothing in that process
+    ever caches a tile, so the post-swap purge would evict zero entries while
+    logging ``tile_cache_invalidated`` — a no-op wearing a success message.
+    Leaving the singleton unset instead makes the gap legible: the caller sees
+    ``None`` and the warning below says what is lost and how to fix it.
     """
     global _tile_cache
     from app.core.config import settings
@@ -80,21 +92,40 @@ def init_tile_cache() -> None:
         )
 
         _tile_cache = _TileCacheProvider(url=settings.redis_url)
-    else:
-        # PERF-01 (Phase 274): bounded in-memory LRU fallback.
-        from app.platform.cache.tile_cache import (
-            InMemoryTileCacheProvider as _InMemoryTileCacheProvider,
-        )
+        return
 
-        _tile_cache = _InMemoryTileCacheProvider()
+    if not in_memory_fallback:
+        _tile_cache = None
+        logger.warning(
+            "tile_cache_unavailable_in_worker",
+            reason="REDIS_URL is unset",
+            consequence=(
+                "worker-side MVT purges after a reupload or PostGIS refresh "
+                "cannot reach the API process's in-memory tile cache; the API "
+                "keeps serving pre-swap tiles for up to tile_cache_ttl"
+            ),
+            remediation="set REDIS_URL so both processes share one tile cache",
+        )
+        return
+
+    # PERF-01 (Phase 274): bounded in-memory LRU fallback.
+    from app.platform.cache.tile_cache import (
+        InMemoryTileCacheProvider as _InMemoryTileCacheProvider,
+    )
+
+    _tile_cache = _InMemoryTileCacheProvider()
 
 
 def get_tile_cache() -> "TileCacheProvider | InMemoryTileCacheProvider | None":
     """Return the tile cache provider.
 
-    PERF-01 (Phase 274): after ``init_tile_cache()`` has run this is
-    always non-None — the in-memory fallback is used when ``REDIS_URL``
-    is unset. ``None`` is only possible if ``init_tile_cache()`` was
-    never called (e.g. inside a unit test before app startup).
+    PERF-01 (Phase 274): in the API process this is non-None after
+    ``init_tile_cache()`` has run — the in-memory fallback covers an unset
+    ``REDIS_URL``.
+
+    ``None`` means one of two things: ``init_tile_cache()`` was never called
+    (a unit test before app startup), or fix(#1315) — the worker process
+    with ``REDIS_URL`` unset, where no cache this process could hold would
+    be the cache anyone reads.
     """
     return _tile_cache

--- a/backend/app/platform/extensions/bootstrap.py
+++ b/backend/app/platform/extensions/bootstrap.py
@@ -39,6 +39,7 @@ from app.platform.extensions import (
     load_extensions,
 )
 from app.platform.cache import init_cache
+from app.platform.cache.provider import init_tile_cache
 from app.platform.storage import init_storage
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -250,6 +251,8 @@ async def bootstrap(*, app: "FastAPI | None" = None) -> EditionInfo:
     8. ``get_billing_extensions().on_startup(app)`` dispatch loop — only when
        ``app`` is provided (billing startup hooks need the app object).
     9. ``init_cache()`` — register the cache provider.
+    9b. ``init_tile_cache()`` — register the binary MVT tile cache. The
+       in-memory fallback is API-only (fix #1315).
 
     Returns the ``EditionInfo`` from ``get_edition()``.
 
@@ -360,6 +363,21 @@ async def bootstrap(*, app: "FastAPI | None" = None) -> EditionInfo:
 
     # Step 9: Initialize cache.
     init_cache()
+
+    # Step 9b (fix #1315): initialize the binary tile cache. This used to live
+    # in the API lifespan alone, so get_tile_cache() returned None in the
+    # worker and every post-swap MVT purge — reupload_file, reupload_service,
+    # refresh_postgis — returned without evicting anything. fix(#394) B-019
+    # added those purges because a swap replaces a table's contents under the
+    # same name and the tile cache key has no content-version dimension; from
+    # the worker they had never once taken effect.
+    #
+    # The worker gets no in-memory fallback (see init_tile_cache): it never
+    # reads tiles, so a process-local LRU there would be a purge that evicts
+    # nothing and says it worked. `app is not None` is the right discriminator
+    # because the FastAPI app IS the tile-serving surface — the process holding
+    # one is the only process a process-local tile cache could ever serve.
+    init_tile_cache(in_memory_fallback=app is not None)
 
     # Step 10 (ISO-02): Mode-gated idempotent RLS enablement (Phase 1208-02).
     # In single_tenant: no-op (zero SQL, zero planner cost).

--- a/backend/tests/test_event_ingest.py
+++ b/backend/tests/test_event_ingest.py
@@ -44,6 +44,9 @@ def _fake_settings(*, complete: bool = False, failed: bool = False) -> SimpleNam
         notification_webhook_url=None,
         # bootstrap() Step 7 — skip S3 health probe when "local"
         storage_provider="local",
+        # bootstrap() Step 9b (fix #1315) — init_tile_cache reads redis_url.
+        # None takes the worker branch: no provider, one boot warning.
+        redis_url=None,
     )
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1961,7 +1961,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # renewal and cannot import the API app module. main.py is a thin caller
     # again, so the cap drops below where round 3 left it.
     # Cap 1390 -> 1332, exact.
-    "backend/app/api/main.py": 1332,
+    # fix(#1315): -2 — init_tile_cache() and its import move into the shared
+    # bootstrap(). The lifespan owning a second copy is how the API and the
+    # worker ended up with different tile-cache states in the first place.
+    # Cap 1332 -> 1330, exact.
+    "backend/app/api/main.py": 1330,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_worker_tile_cache_1315.py
+++ b/backend/tests/test_worker_tile_cache_1315.py
@@ -1,0 +1,462 @@
+"""fix(#1315): the Procrastinate worker gets a live MVT tile cache.
+
+``invalidate_tile_cache_for_table()`` resolves its provider through the
+``get_tile_cache()`` singleton, and that singleton used to be set only by the
+API lifespan.  The worker is a separate process, so ``get_tile_cache()``
+returned ``None`` there and every post-swap MVT purge -- both reupload paths
+and the PostGIS refresh -- was a silent no-op.  Stale tiles kept being served
+for up to ``tile_cache_ttl`` after every re-upload, which is exactly what
+fix(#394) B-019/VT-01 added the purge to prevent.
+
+The fix moves ``init_tile_cache()`` into the shared ``bootstrap()`` so both
+entrypoints take it from one place.  The worker deliberately does NOT take the
+PERF-01 in-memory fallback: it never reads tiles, so a per-process LRU there
+holds nothing, and purging it would evict nothing while logging that it had
+succeeded -- the current no-op with extra steps.  With ``REDIS_URL`` unset the
+worker leaves the singleton unset and says why at boot.
+
+The live-provider half of this file needs a reachable Redis/Valkey.  Start one
+with::
+
+    docker run -d --rm --name w6-valkey -p 16379:6379 valkey/valkey
+
+Override the endpoint with ``GEOLENS_TEST_REDIS_URL``.  Those tests skip when
+nothing is listening; they cannot pass vacuously, because each asserts the
+tile is readable BEFORE the purge, and ``TileCacheProvider`` swallows backend
+errors into cache misses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+import socket
+import uuid
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import pytest
+import structlog
+
+LIVE_REDIS_URL = os.environ.get("GEOLENS_TEST_REDIS_URL", "redis://localhost:16379/0")
+
+
+def _redis_reachable(url: str) -> bool:
+    """True when something accepts TCP at ``url``'s host/port."""
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6379
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+requires_live_redis = pytest.mark.skipif(
+    not _redis_reachable(LIVE_REDIS_URL),
+    reason=(
+        f"no Redis/Valkey listening at {LIVE_REDIS_URL} -- start one with "
+        "`docker run -d --rm --name w6-valkey -p 16379:6379 valkey/valkey`"
+    ),
+)
+
+
+def _table() -> str:
+    """A fresh `data.*`-shaped table name, so runs cannot collide in Valkey."""
+    return f"w6_{uuid.uuid4().hex[:12]}"
+
+
+@pytest.fixture
+def restore_tile_cache():
+    """Restore the tile-cache singleton so a test cannot leak its provider."""
+    from app.platform.cache import provider as cache_provider
+
+    saved = cache_provider._tile_cache
+    yield
+    cache_provider._tile_cache = saved
+
+
+# ---------------------------------------------------------------------------
+# bootstrap() wiring -- the bug itself
+# ---------------------------------------------------------------------------
+
+
+def _reset_registry():
+    import app.platform.extensions as ext_mod
+
+    ext_mod._extensions.clear()
+    ext_mod._routers.clear()
+    ext_mod._loaded = False
+    ext_mod._slot_owners.clear()
+
+
+def _reset_edition():
+    import app.core.edition as ed_mod
+
+    ed_mod._info = None
+
+
+@pytest.fixture
+def bootstrappable():
+    """Run ``bootstrap()`` with its heavy steps stubbed out.
+
+    Mirrors ``test_worker_bootstrap_parity._clean_state``: storage, the JSON
+    cache and the tenancy RLS pass are patched, entry points are emptied.
+    ``init_tile_cache`` is deliberately NOT patched -- it is under test.
+    """
+    _reset_registry()
+    _reset_edition()
+    with (
+        patch("app.platform.extensions.entry_points", return_value=[]),
+        patch("app.platform.extensions.bootstrap.init_storage"),
+        patch("app.platform.extensions.bootstrap.init_cache"),
+        patch("app.core.db.rls.apply_tenancy_rls_from_engine"),
+    ):
+        yield
+    _reset_registry()
+    _reset_edition()
+
+
+def test_worker_bootstrap_initializes_redis_backed_tile_cache(
+    bootstrappable, restore_tile_cache, monkeypatch
+):
+    """bootstrap(app=None) must leave a Redis-backed tile cache behind.
+
+    This is the #1315 regression: with no tile cache in the worker process,
+    ``invalidate_tile_cache_for_table`` found ``None`` and returned without
+    evicting anything.
+    """
+    from app.core import config as cfg
+    from app.platform.cache import provider as cache_provider
+    from app.platform.cache.tile_cache import TileCacheProvider
+    from app.platform.extensions.bootstrap import bootstrap
+
+    monkeypatch.setattr(cfg.settings, "redis_url", "redis://localhost:6379/0")
+    cache_provider._tile_cache = None
+
+    asyncio.run(bootstrap(app=None))
+
+    assert isinstance(cache_provider.get_tile_cache(), TileCacheProvider), (
+        "fix(#1315): the worker must end bootstrap with the Redis-backed tile "
+        "cache live, or every post-swap MVT purge is a silent no-op."
+    )
+
+
+def test_api_bootstrap_initializes_redis_backed_tile_cache(
+    bootstrappable, restore_tile_cache, monkeypatch
+):
+    """The API keeps the provider it always had -- now via the shared path."""
+    from fastapi import FastAPI
+
+    from app.core import config as cfg
+    from app.platform.cache import provider as cache_provider
+    from app.platform.cache.tile_cache import TileCacheProvider
+    from app.platform.extensions.bootstrap import bootstrap
+
+    monkeypatch.setattr(cfg.settings, "redis_url", "redis://localhost:6379/0")
+    cache_provider._tile_cache = None
+
+    asyncio.run(bootstrap(app=FastAPI()))
+
+    assert isinstance(cache_provider.get_tile_cache(), TileCacheProvider)
+
+
+def test_api_bootstrap_keeps_in_memory_fallback_without_redis(
+    bootstrappable, restore_tile_cache, monkeypatch
+):
+    """PERF-01 is unchanged for the API: no REDIS_URL still gets the LRU.
+
+    The API both writes and reads tiles in one process, so a process-local
+    cache is a real cache there.
+    """
+    from fastapi import FastAPI
+
+    from app.core import config as cfg
+    from app.platform.cache import provider as cache_provider
+    from app.platform.cache.tile_cache import InMemoryTileCacheProvider
+    from app.platform.extensions.bootstrap import bootstrap
+
+    monkeypatch.setattr(cfg.settings, "redis_url", None)
+    cache_provider._tile_cache = None
+
+    asyncio.run(bootstrap(app=FastAPI()))
+
+    assert isinstance(cache_provider.get_tile_cache(), InMemoryTileCacheProvider)
+
+
+def test_worker_bootstrap_refuses_in_memory_fallback_without_redis(
+    bootstrappable, restore_tile_cache, monkeypatch
+):
+    """No REDIS_URL in the worker leaves the singleton unset, on purpose.
+
+    The worker never reads tiles, so an LRU here would hold nothing and
+    purging it would evict nothing -- while logging that it had succeeded.
+    Leaving it unset keeps the honest answer honest.
+    """
+    from app.core import config as cfg
+    from app.platform.cache import provider as cache_provider
+    from app.platform.extensions.bootstrap import bootstrap
+
+    monkeypatch.setattr(cfg.settings, "redis_url", None)
+    cache_provider._tile_cache = None
+
+    asyncio.run(bootstrap(app=None))
+
+    assert cache_provider.get_tile_cache() is None
+
+
+def test_worker_bootstrap_without_redis_logs_why_purges_cannot_land(
+    bootstrappable, restore_tile_cache, monkeypatch
+):
+    """The unset-REDIS_URL worker states the consequence at boot.
+
+    Acceptance (b): a stated behaviour rather than a silent no-op.
+    """
+    from app.core import config as cfg
+    from app.platform.cache import provider as cache_provider
+    from app.platform.extensions.bootstrap import bootstrap
+
+    monkeypatch.setattr(cfg.settings, "redis_url", None)
+    cache_provider._tile_cache = None
+
+    with structlog.testing.capture_logs() as captured:
+        asyncio.run(bootstrap(app=None))
+
+    events = [
+        record
+        for record in captured
+        if record.get("event") == "tile_cache_unavailable_in_worker"
+    ]
+    assert len(events) == 1, (
+        "Expected one tile_cache_unavailable_in_worker warning at worker boot; "
+        f"got: {captured}"
+    )
+    assert events[0]["log_level"] == "warning"
+
+
+def test_in_memory_fallback_flag_is_the_only_difference(
+    monkeypatch, restore_tile_cache
+):
+    """init_tile_cache's worker mode still takes Redis when Redis is configured.
+
+    The suppression is scoped to the fallback, not to the whole provider --
+    otherwise the fix would disable the very cache it exists to reach.
+    """
+    from app.core import config as cfg
+    from app.platform.cache import provider as cache_provider
+    from app.platform.cache.tile_cache import TileCacheProvider
+
+    monkeypatch.setattr(cfg.settings, "redis_url", "redis://localhost:6379/0")
+    cache_provider._tile_cache = None
+
+    cache_provider.init_tile_cache(in_memory_fallback=False)
+
+    assert isinstance(cache_provider.get_tile_cache(), TileCacheProvider)
+
+
+# ---------------------------------------------------------------------------
+# Cross-process eviction -- acceptance (a)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=["fakeredis", "live"])
+def two_process_providers(request):
+    """Yield a factory of tile providers sharing one backend.
+
+    ``fakeredis`` keeps this covered in CI (one ``FakeServer``, two clients);
+    ``live`` is the honest proof against a real Valkey and skips when none is
+    running.
+    """
+    from app.platform.cache.tile_cache import TileCacheProvider
+
+    if request.param == "fakeredis":
+        import fakeredis
+        import fakeredis.aioredis
+
+        server = fakeredis.FakeServer()
+
+        def make() -> TileCacheProvider:
+            provider = TileCacheProvider(url="redis://unused:6379/0")
+            provider._client = fakeredis.aioredis.FakeRedis(
+                server=server, decode_responses=False
+            )
+            return provider
+
+        yield make
+        return
+
+    if not _redis_reachable(LIVE_REDIS_URL):
+        pytest.skip(f"no Redis/Valkey listening at {LIVE_REDIS_URL}")
+
+    def make() -> TileCacheProvider:
+        return TileCacheProvider(url=LIVE_REDIS_URL)
+
+    yield make
+
+
+@pytest.mark.asyncio
+async def test_worker_purge_evicts_tiles_another_process_cached(
+    two_process_providers, restore_tile_cache, monkeypatch
+):
+    """The worker's purge evicts entries the API process wrote.
+
+    Acceptance (a).  Two provider instances stand in for the two processes;
+    only a shared backend can carry the eviction between them.  The pre-purge
+    read is a control: ``TileCacheProvider`` turns every backend error into a
+    cache miss, so without it an unreachable backend would make this pass
+    while proving nothing.
+    """
+    from app.platform.cache import provider as cache_provider
+    from app.processing.ingest.tasks_common import invalidate_tile_cache_for_table
+
+    swapped, untouched = _table(), _table()
+    api_cache = two_process_providers()
+    worker_cache = two_process_providers()
+    monkeypatch.setattr(cache_provider, "_tile_cache", worker_cache)
+
+    await api_cache.set(swapped, 3, 1, 2, b"pre-swap-mvt", ttl=300)
+    await api_cache.set(untouched, 3, 1, 2, b"other-dataset-mvt", ttl=300)
+    assert await api_cache.get(swapped, 3, 1, 2) == b"pre-swap-mvt", (
+        "control: the tile must be readable before the purge, else this test "
+        "cannot distinguish an eviction from an unreachable cache backend"
+    )
+
+    await invalidate_tile_cache_for_table(swapped)
+
+    assert await api_cache.get(swapped, 3, 1, 2) is None, (
+        "fix(#1315): the worker's post-swap purge must evict the tiles the API "
+        "process cached for the swapped table"
+    )
+    assert await api_cache.get(untouched, 3, 1, 2) == b"other-dataset-mvt", (
+        "the purge is scoped to one table; it must not flush the whole cache"
+    )
+
+
+@requires_live_redis
+@pytest.mark.asyncio
+async def test_worker_bootstrap_provider_evicts_api_tiles_live(
+    restore_tile_cache, monkeypatch
+):
+    """End to end against a real Valkey, through the worker's own wiring.
+
+    The provider doing the evicting is the one the worker's bootstrap decision
+    builds (``in_memory_fallback=False``), not a hand-made instance.
+    """
+    from app.core import config as cfg
+    from app.platform.cache import provider as cache_provider
+    from app.platform.cache.tile_cache import TileCacheProvider
+    from app.processing.ingest.tasks_common import invalidate_tile_cache_for_table
+
+    swapped = _table()
+    api_cache = TileCacheProvider(url=LIVE_REDIS_URL)
+    await api_cache.set(swapped, 6, 17, 24, b"pre-swap-mvt", ttl=300)
+    assert await api_cache.get(swapped, 6, 17, 24) == b"pre-swap-mvt", (
+        "control: live Valkey must actually hold the tile before the purge"
+    )
+
+    monkeypatch.setattr(cfg.settings, "redis_url", LIVE_REDIS_URL)
+    cache_provider._tile_cache = None
+    cache_provider.init_tile_cache(in_memory_fallback=False)
+    assert isinstance(cache_provider.get_tile_cache(), TileCacheProvider)
+
+    await invalidate_tile_cache_for_table(swapped)
+
+    assert await api_cache.get(swapped, 6, 17, 24) is None
+
+
+@requires_live_redis
+@pytest.mark.asyncio
+async def test_in_memory_worker_cache_would_not_have_evicted_anything(
+    restore_tile_cache, monkeypatch
+):
+    """Why the worker refuses the LRU fallback, asserted rather than argued.
+
+    Same scenario with an ``InMemoryTileCacheProvider`` as the worker's
+    singleton: the purge reports success and the API's tile survives.  That is
+    the failure mode #1315 declined to ship.
+    """
+    from app.platform.cache import provider as cache_provider
+    from app.platform.cache.tile_cache import (
+        InMemoryTileCacheProvider,
+        TileCacheProvider,
+    )
+    from app.processing.ingest.tasks_common import invalidate_tile_cache_for_table
+
+    swapped = _table()
+    api_cache = TileCacheProvider(url=LIVE_REDIS_URL)
+    await api_cache.set(swapped, 6, 17, 24, b"pre-swap-mvt", ttl=300)
+    assert await api_cache.get(swapped, 6, 17, 24) == b"pre-swap-mvt"
+
+    monkeypatch.setattr(cache_provider, "_tile_cache", InMemoryTileCacheProvider())
+    await invalidate_tile_cache_for_table(swapped)
+
+    assert await api_cache.get(swapped, 6, 17, 24) == b"pre-swap-mvt", (
+        "a per-process LRU in the worker cannot reach the API's cache -- if "
+        "this ever evicts, the fallback suppression is no longer needed"
+    )
+    await api_cache.invalidate_table(swapped)
+
+
+# ---------------------------------------------------------------------------
+# Call-site coverage -- acceptance (c)
+# ---------------------------------------------------------------------------
+
+
+def test_every_worker_swap_path_purges_the_tile_cache():
+    """All three post-swap paths call the purge (acceptance (c)).
+
+    A fourth swap path added without a purge, or one of these three losing it,
+    fails here rather than in production tiles.
+
+    ``test_mvt_audit_fixes.test_reupload_tasks_invalidate_tile_cache_after_commit``
+    overlaps on the two reupload sites. It is left alone deliberately: that one
+    is fix(#394)'s guard over its own two call sites, this one is #1315's over
+    the set that has to reach a live provider, and the PostGIS site only exists
+    in the second.
+    """
+    from app.processing.ingest import (
+        tasks_postgis_refresh,
+        tasks_reupload,
+    )
+
+    call = "await invalidate_tile_cache_for_table(live_table_name)"
+    counts = {
+        "tasks_reupload": inspect.getsource(tasks_reupload).count(call),
+        "tasks_postgis_refresh": inspect.getsource(tasks_postgis_refresh).count(call),
+    }
+    assert counts == {"tasks_reupload": 2, "tasks_postgis_refresh": 1}, (
+        f"fix(#1315) acceptance (c): expected the three post-swap purge call "
+        f"sites (reupload_file, reupload_service, refresh_postgis); got {counts}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift guards -- bootstrap owns the tile cache for both entrypoints
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_initializes_the_tile_cache():
+    """bootstrap() is where the tile cache comes from now."""
+    from app.platform.extensions import bootstrap as bootstrap_module
+
+    assert "init_tile_cache(" in inspect.getsource(bootstrap_module.bootstrap), (
+        "fix(#1315): bootstrap() must own init_tile_cache() so the API and the "
+        "worker cannot drift into different tile-cache states again."
+    )
+
+
+def test_api_lifespan_does_not_init_the_tile_cache_directly():
+    """The lifespan must not re-inline what bootstrap() owns.
+
+    Mirrors the existing init_storage()/init_cache() drift guards in
+    test_worker_bootstrap_parity.py: a second call site here is how the API
+    and the worker diverged in the first place.
+    """
+    from app.api import main as main_module
+
+    assert "init_tile_cache(" not in inspect.getsource(main_module.lifespan), (
+        "WORK-01 / fix(#1315): the lifespan must not call init_tile_cache() "
+        "directly -- bootstrap() is the single source of truth."
+    )


### PR DESCRIPTION
## What

`invalidate_tile_cache_for_table()` resolves its provider through the `get_tile_cache()` singleton, and `init_tile_cache()` ran in the API lifespan only. The Procrastinate worker is a separate process, so `get_tile_cache()` returned `None` there and all three post-swap MVT purges returned without evicting anything.

`init_tile_cache()` moves into the shared `bootstrap()` that both entrypoints already call, and the lifespan's copy goes away so the two cannot drift apart again.

## Step 0: the reading is confirmed

The issue asked for confirmation before building anything, in case some indirect bootstrap import already initialized the tile cache in the worker. It does not.

Statically, on `origin/main` at e515e0150, `init_tile_cache` had exactly one call site in the whole repo: `backend/app/api/main.py:328`. The shared `bootstrap()` calls `init_cache()` (the JSON cache) and never the tile cache. `worker.py:main()` calls `bootstrap(app=None)`, and the worker's only other startup surface is a bare Starlette health app (`observability/health/worker.py`) with no lifespan to hang an init off. `scripts/worker-entrypoint.sh` execs `python -m app.worker`, a shim over `app.platform.jobs.worker.main`.

Empirically, importing the worker's full module chain and asking:

```
bootstrap module mentions init_tile_cache: False
worker module mentions init_tile_cache: False
get_tile_cache() after worker-module import chain: None
```

And 8 of the 13 new tests fail on the unfixed tree, including the live-Valkey one.

## REDIS_URL unset

The worker deliberately does not take the PERF-01 in-memory fallback. It never reads tiles, so a process-local LRU there holds nothing; purging it evicts zero entries and logs `tile_cache_invalidated` anyway, which is the same no-op with a success message attached. With `REDIS_URL` unset the worker leaves the singleton unset and warns once at boot:

```
tile_cache_unavailable_in_worker
  reason="REDIS_URL is unset"
  consequence="worker-side MVT purges after a reupload or PostGIS refresh cannot
               reach the API process's in-memory tile cache; the API keeps serving
               pre-swap tiles for up to tile_cache_ttl"
  remediation="set REDIS_URL so both processes share one tile cache"
```

At boot rather than per purge, because the condition is a static deployment property. Repeating it on every swap would be the same line carrying no new information. `.env.example` gets the operator-facing version, since "leave unset to use in-memory caching (single-instance default)" was already glossing over the fact that a single instance is still two processes.

The API's behaviour with `REDIS_URL` unset is unchanged. It still gets the LRU, and a test pins that.

## Acceptance

**(a) A live provider, not a mock.** `test_worker_bootstrap_provider_evicts_api_tiles_live` caches a tile through one `TileCacheProvider`, builds the worker's singleton the way `bootstrap(app=None)` builds it, runs the real `invalidate_tile_cache_for_table`, and asserts the first provider's read now misses. It runs against a real Valkey (`docker run -d --rm --name w6-valkey -p 16379:6379 valkey/valkey`) and skips when nothing is listening.

Every live test asserts the tile is readable *before* the purge. That control is load-bearing: `TileCacheProvider` turns backend errors into cache misses, so without it an unreachable Valkey would be indistinguishable from a successful eviction and the test could pass while proving nothing.

The cross-process test also runs under `fakeredis` with a shared `FakeServer`, which is what covers this in CI, where no Valkey runs. Residual gap: CI exercises the eviction logic but never a real Redis wire.

Because the test suite still shares one process, I also ran it as three separate OS processes against the live Valkey, with the middle one calling the real `bootstrap(app=None)` rather than any test helper:

```
[A api]    cached tile -> b'pre-swap-mvt-bytes'
--- separate process ---
[B worker] get_tile_cache() after bootstrap -> <class '...tile_cache.TileCacheProvider'>
           tile_cache_invalidated  table=w6_crossproc_demo
[B worker] invalidate_tile_cache_for_table done
--- separate process ---
[C api]    read back -> None
           OK: the worker's purge evicted the API's cached tile
```

An earlier run where B aborted before the purge gave the negative control for free: C reported `read back -> b'pre-swap-mvt-bytes'` and failed. Booting B with `REDIS_URL` unset produces `get_tile_cache() -> NoneType` plus the warning quoted above.

**(b) REDIS_URL unset is stated and tested.** `test_worker_bootstrap_without_redis_logs_why_purges_cannot_land` asserts the warning event, `test_worker_bootstrap_refuses_in_memory_fallback_without_redis` asserts the singleton stays unset, and `test_in_memory_worker_cache_would_not_have_evicted_anything` asserts the rejected alternative genuinely fails: a live API-cached tile survives an in-memory worker purge.

**(c) All three call sites.** The fix is at the singleton, so all three are covered at once. `test_every_worker_swap_path_purges_the_tile_cache` pins the counts per module (2 in `tasks_reupload`, 1 in `tasks_postgis_refresh`), so a fourth swap path added without a purge fails there rather than in production tiles. The `refresh_postgis` site is now `tasks_postgis_refresh.py:840`, not the `:891` the issue cites.

## Schema, API and config impact

Schema: none, no migration. API: none, and `backend/openapi.json` is untouched. Config: no new variables. `REDIS_URL` is already plumbed into the worker service in both compose files (`docker-compose.yml`, `docker-compose.prod.yml:363`), so nothing there changes either.

Runtime: a worker with `REDIS_URL` set now holds a second Redis client, the binary tile-cache one. It is not the worker's first: `bootstrap()` step 9 has always given it a `RedisCacheProvider` for the JSON cache under the same setting. Neither provider exposes a close method and the API lifespan does not close its own either, so worker shutdown is symmetric with what the API already does.

## Verification

- `cd backend && uv run ruff check .` and `uv run ruff format --check .`: pass
- `uv run pytest tests/test_worker_tile_cache_1315.py -v`: 13 passed, with the live-Valkey tests confirmed running rather than skipped
- the same file on the unfixed tree: 8 failed, 5 passed
- `uv run pytest tests/test_layering.py -q`: 40 passed
- `uv run pytest -n 4 -q` (whole backend suite): result in a comment below
- `uv run python scripts/check_env_doc_drift.py`: aligned

## For review

`tasks_common.py` is deliberately untouched, because #1359 is in flight there.

`test_event_ingest.py` needed one line. Its `_fake_settings()` is a `SimpleNamespace` standing in for `Settings`, and `TestWorkerDeliveryProof` stubs out `init_cache` but now reaches the new `init_tile_cache`, which reads `settings.redis_url`. The whole-tree run caught it; the fake gains `redis_url=None`, which takes the worker branch. Nothing about the assertion changes. That stub's docstring already tracks which bootstrap fields it has to carry, so this is the same maintenance the S3 gate needed.

Multi-tenancy is fine. All three call sites sit inside `@tenant_task`, so `current_tenant_var` is set and `_invalidation_table_segment` resolves the tenant-scoped key prefix in the worker exactly as it does in the API. No cross-tenant eviction is introduced.

`backend/app/api/main.py` shrinks by 2 lines, so its exact `_MODULE_LOC_CAPS` entry drops from 1332 to 1330.

Closes #1315
