### PR TITLE
fix(stac): project fetch_cog_info's georeferencing onto remote raster rows

### DIFF
--- a/backend/app/modules/catalog/sources/cog_info.py
+++ b/backend/app/modules/catalog/sources/cog_info.py
@@ -25,19 +25,28 @@ logger = structlog.get_logger(__name__)
 
 
 def _georeferencing(info: dict) -> dict:
-    """``crs_wkt``/``res_x``/``res_y`` from Titiler's raw ``/cog/info`` reply.
+    """``crs_wkt`` from Titiler's raw ``/cog/info`` reply.
 
-    fix(#1334): both were retrievable all along and simply never read out of
-    this response. Titiler answers ``crs`` as an OGC CRS URI
-    (``http://www.opengis.net/def/crs/EPSG/0/<code>``) and ``bounds`` in the
-    dataset's OWN projection, not WGS84 — verified against a live 2.2.1
-    instance. GDAL's CRS parser accepts that URI form directly, so the WKT
-    round-trips through the same ``rasterio.crs.CRS`` every other ingest path
-    already writes ``crs_wkt`` from (``raster/cog.py``). Resolution is
-    bounds-over-pixels — the ratio a non-rotated GeoTIFF's transform encodes
-    — because there is no transform in this response to read one from
-    directly; a rotated remote asset would report a resolution rasterio's own
-    ``transform.a``/``transform.e`` would not describe as one either.
+    fix(#1334): retrievable all along and simply never read out of this
+    response. Titiler answers ``crs`` as an OGC CRS URI
+    (``http://www.opengis.net/def/crs/EPSG/0/<code>``) — verified against a
+    live 2.2.1 instance. GDAL's CRS parser accepts that URI form directly, so
+    the WKT round-trips through the same ``rasterio.crs.CRS`` every other
+    ingest path already writes ``crs_wkt`` from (``raster/cog.py``).
+
+    fix(#1334 review): ``res_x``/``res_y`` are deliberately NOT derived here.
+    The obvious computation — ``bounds`` (also in the dataset's own
+    projection) divided by pixel dimensions — is only the true per-pixel
+    resolution for an axis-aligned raster. This response carries no affine
+    transform to check that against, so a rotated or sheared remote COG would
+    silently get a resolution inflated by however far its bounding envelope
+    exceeds its own footprint — indistinguishable, in this payload, from a
+    correct value. The local-upload path can tell the two apart
+    (``raster/cog.py`` reads ``transform.b``/``transform.d`` to set
+    ``is_rotated``); nothing here can. A wrong number that LOOKS like a
+    measurement is worse than the blank "—" it would replace, so it stays
+    unset until there is a source that can rule rotation out. Tracked as
+    #1375.
 
     Individual failures degrade to None rather than raising: this is
     descriptive metadata for a UI card, not something a failed probe should
@@ -55,33 +64,14 @@ def _georeferencing(info: dict) -> dict:
         ):  # broad: an unfamiliar CRS string should not fail the whole probe
             crs_wkt = None
 
-    res_x = res_y = None
-    bounds = info.get("bounds")
-    width = info.get("width")
-    height = info.get("height")
-    if (
-        isinstance(bounds, list)
-        and len(bounds) == 4
-        and all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in bounds)
-        and isinstance(width, int)
-        and not isinstance(width, bool)
-        and isinstance(height, int)
-        and not isinstance(height, bool)
-        and width > 0
-        and height > 0
-    ):
-        res_x = abs(bounds[2] - bounds[0]) / width
-        res_y = abs(bounds[3] - bounds[1]) / height
-
-    return {"crs_wkt": crs_wkt, "res_x": res_x, "res_y": res_y}
+    return {"crs_wkt": crs_wkt}
 
 
 async def fetch_cog_info(url: str) -> dict | None:
     """Fetch COG metadata + statistics from Titiler for a remote asset URL.
 
-    Returns dict with band_count, dtype, width, height, crs_wkt, res_x,
-    res_y, band_info (with min/max per band for rescaling), or None on
-    failure.
+    Returns dict with band_count, dtype, width, height, crs_wkt, band_info
+    (with min/max per band for rescaling), or None on failure.
 
     fix(#1271 review): None deliberately collapses every failure shape.
     A non-200 from Titiler is NOT proof the origin was attempted — the

--- a/backend/app/modules/catalog/sources/cog_info.py
+++ b/backend/app/modules/catalog/sources/cog_info.py
@@ -25,7 +25,7 @@ logger = structlog.get_logger(__name__)
 
 
 def _georeferencing(info: dict) -> dict:
-    """``crs_wkt`` from Titiler's raw ``/cog/info`` reply.
+    """``crs_wkt``/``epsg`` from Titiler's raw ``/cog/info`` reply.
 
     fix(#1334): retrievable all along and simply never read out of this
     response. Titiler answers ``crs`` as an OGC CRS URI
@@ -33,6 +33,22 @@ def _georeferencing(info: dict) -> dict:
     live 2.2.1 instance. GDAL's CRS parser accepts that URI form directly, so
     the WKT round-trips through the same ``rasterio.crs.CRS`` every other
     ingest path already writes ``crs_wkt`` from (``raster/cog.py``).
+
+    fix(#1334 review): both keys come off the SAME parsed ``CRS`` object, on
+    purpose. The caller's other source for a raster's EPSG is the STAC
+    item's own ``proj:code``/``proj:epsg`` — the PUBLISHER's claim about the
+    file, read at import or refresh time from whatever document it happened
+    to be describing itself with then. This function's ``crs`` came from
+    Titiler actually opening the CURRENT bytes at the CURRENT href, which is
+    ground truth about what is actually being served. A stale or wrong item
+    declaration would otherwise have this probe write a WKT describing one
+    projection beside a caller-supplied EPSG naming another, and
+    ``RasterAsset.to_stac_properties()`` would publish both as ``proj:wkt2``
+    and ``proj:code`` — a raster describing itself two contradictory ways in
+    GeoLens's OWN STAC export. Deriving ``epsg`` from the same object the WKT
+    came from makes the two agree by construction; the caller uses it in
+    preference to the item's declared value and falls back to that only when
+    the probe yields no EPSG (an unusual custom CRS, or no probe at all).
 
     fix(#1334 review): ``res_x``/``res_y`` are deliberately NOT derived here.
     The obvious computation — ``bounds`` (also in the dataset's own
@@ -53,18 +69,22 @@ def _georeferencing(info: dict) -> dict:
     abort over.
     """
     crs_wkt = None
+    epsg = None
     crs_value = info.get("crs")
     if isinstance(crs_value, str) and crs_value:
         try:
             from rasterio.crs import CRS
 
-            crs_wkt = CRS.from_user_input(crs_value).to_wkt()
+            parsed = CRS.from_user_input(crs_value)
+            crs_wkt = parsed.to_wkt()
+            epsg = parsed.to_epsg()
         except (
             Exception
         ):  # broad: an unfamiliar CRS string should not fail the whole probe
             crs_wkt = None
+            epsg = None
 
-    return {"crs_wkt": crs_wkt}
+    return {"crs_wkt": crs_wkt, "epsg": epsg}
 
 
 async def fetch_cog_info(url: str) -> dict | None:

--- a/backend/app/modules/catalog/sources/cog_info.py
+++ b/backend/app/modules/catalog/sources/cog_info.py
@@ -87,6 +87,32 @@ def _georeferencing(info: dict) -> dict:
     return {"crs_wkt": crs_wkt, "epsg": epsg}
 
 
+def reconcile_epsg(probe: dict, declared: int | None) -> int | None:
+    """The EPSG to store: the probe's, when it established any CRS at all.
+
+    fix(#1334 review, round 3): "the probe returned no EPSG" is not the same
+    question as "the probe returned no CRS at all", and the two callers'
+    first attempt at this answered the wrong one — falling back to
+    ``declared`` whenever ``probe["epsg"]`` was None, which also fires for a
+    custom or exotic CRS that Titiler opened successfully but that PROJ
+    cannot map to an authority code. That case answers ``crs_wkt`` with
+    something real and ``epsg`` with None; falling back to a DECLARED code
+    there would pair the probed WKT with a code that may name a different
+    projection — reproducing on this row the exact contradiction this
+    reconciliation exists to prevent, just with a null-vs-populated EPSG
+    instead of two populated ones.
+
+    The declared value is trustworthy only when the probe established
+    NOTHING about the CRS — no ``crs_wkt`` at all, from a failed probe or an
+    unparseable ``crs`` string. Whatever the probe DID establish, including
+    "a WKT with no mappable EPSG", is what a caller must keep rather than
+    patch over with an unrelated source.
+    """
+    if probe.get("crs_wkt") is not None:
+        return probe.get("epsg")
+    return declared
+
+
 async def fetch_cog_info(url: str) -> dict | None:
     """Fetch COG metadata + statistics from Titiler for a remote asset URL.
 

--- a/backend/app/modules/catalog/sources/cog_info.py
+++ b/backend/app/modules/catalog/sources/cog_info.py
@@ -24,11 +24,64 @@ from app.platform.storage.titiler_url import build_titiler_cog_url
 logger = structlog.get_logger(__name__)
 
 
+def _georeferencing(info: dict) -> dict:
+    """``crs_wkt``/``res_x``/``res_y`` from Titiler's raw ``/cog/info`` reply.
+
+    fix(#1334): both were retrievable all along and simply never read out of
+    this response. Titiler answers ``crs`` as an OGC CRS URI
+    (``http://www.opengis.net/def/crs/EPSG/0/<code>``) and ``bounds`` in the
+    dataset's OWN projection, not WGS84 — verified against a live 2.2.1
+    instance. GDAL's CRS parser accepts that URI form directly, so the WKT
+    round-trips through the same ``rasterio.crs.CRS`` every other ingest path
+    already writes ``crs_wkt`` from (``raster/cog.py``). Resolution is
+    bounds-over-pixels — the ratio a non-rotated GeoTIFF's transform encodes
+    — because there is no transform in this response to read one from
+    directly; a rotated remote asset would report a resolution rasterio's own
+    ``transform.a``/``transform.e`` would not describe as one either.
+
+    Individual failures degrade to None rather than raising: this is
+    descriptive metadata for a UI card, not something a failed probe should
+    abort over.
+    """
+    crs_wkt = None
+    crs_value = info.get("crs")
+    if isinstance(crs_value, str) and crs_value:
+        try:
+            from rasterio.crs import CRS
+
+            crs_wkt = CRS.from_user_input(crs_value).to_wkt()
+        except (
+            Exception
+        ):  # broad: an unfamiliar CRS string should not fail the whole probe
+            crs_wkt = None
+
+    res_x = res_y = None
+    bounds = info.get("bounds")
+    width = info.get("width")
+    height = info.get("height")
+    if (
+        isinstance(bounds, list)
+        and len(bounds) == 4
+        and all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in bounds)
+        and isinstance(width, int)
+        and not isinstance(width, bool)
+        and isinstance(height, int)
+        and not isinstance(height, bool)
+        and width > 0
+        and height > 0
+    ):
+        res_x = abs(bounds[2] - bounds[0]) / width
+        res_y = abs(bounds[3] - bounds[1]) / height
+
+    return {"crs_wkt": crs_wkt, "res_x": res_x, "res_y": res_y}
+
+
 async def fetch_cog_info(url: str) -> dict | None:
     """Fetch COG metadata + statistics from Titiler for a remote asset URL.
 
-    Returns dict with band_count, dtype, width, height, band_info (with
-    min/max per band for rescaling), or None on failure.
+    Returns dict with band_count, dtype, width, height, crs_wkt, res_x,
+    res_y, band_info (with min/max per band for rescaling), or None on
+    failure.
 
     fix(#1271 review): None deliberately collapses every failure shape.
     A non-200 from Titiler is NOT proof the origin was attempted — the
@@ -99,6 +152,7 @@ async def fetch_cog_info(url: str) -> dict | None:
                 "height": info.get("height"),
                 "nodata": info.get("nodata"),
                 "band_info": band_info or None,
+                **_georeferencing(info),
             }
     except Exception as exc:  # broad: Titiler info call — httpx/JSON parse can throw varied errors; degrade to None
         logger.debug("Failed to fetch COG info from Titiler", url=url, error=str(exc))

--- a/backend/app/modules/catalog/sources/stac_resolve.py
+++ b/backend/app/modules/catalog/sources/stac_resolve.py
@@ -77,7 +77,7 @@ from app.modules.catalog.sources.adapters.stac import (
     self_link_href,
     storable_href,
 )
-from app.modules.catalog.sources.cog_info import fetch_cog_info
+from app.modules.catalog.sources.cog_info import fetch_cog_info, reconcile_epsg
 from app.modules.catalog.sources.origin_probe import (
     BLOCKED_BY_POLICY,
     INACCESSIBLE,
@@ -145,12 +145,21 @@ class StacResolution:
     # parameters. Populated only when the href moved, which is the only time
     # anything is adopted.
     asset_metadata: dict[str, Any] | None = None
-    # fix(#1266 review round 7): the moved object's declared projection, read
-    # from the item that publishes it rather than from the object. That is
-    # where the import path reads it too — the STAC projection extension —
-    # so the two agree by construction, and a reprojected replacement stops
-    # being described by the previous object's EPSG. Populated beside
-    # ``asset_metadata`` and written with it.
+    # fix(#1266 review round 7): the moved object's projection — read from
+    # the item that publishes it when nothing better is available, which is
+    # where the import path reads it too, so an unmoved asset's EPSG still
+    # agrees with the import that set it.
+    #
+    # fix(#1334 review): reconciled with the probe's OWN CRS when one ran —
+    # see ``reconcile_epsg``. The item's declaration is the publisher's
+    # CLAIM about the object; ``asset_metadata`` (when populated) came from
+    # Titiler actually opening the CURRENT bytes, which is ground truth.
+    # A stale item declaration disagreeing with the probed CRS used to
+    # reach the caller as this field regardless, and the caller pairs it
+    # with ``asset_metadata["crs_wkt"]`` when writing both to one row —
+    # publishing two contradictory projections for the same raster. This
+    # field is the single authoritative value once a probe has run, and
+    # ``asset_metadata["epsg"]`` remains the RAW probe reading beside it.
     epsg: int | None = None
     # fix(#1266 review round 25): the moved object's footprint. A publisher
     # who re-tiles or crops a scene updates the item's bbox with it, and a
@@ -685,6 +694,7 @@ async def _resolve_from_item(
     properties = describing.get("properties")
     usable_bbox = _horizontal_bbox(describing.get("bbox"))
     resolved_id = item.get("id")
+    declared_epsg = projection_epsg(properties if isinstance(properties, dict) else {})
     return StacResolution(
         health=probed.health,
         detail=probed.detail,
@@ -699,7 +709,12 @@ async def _resolve_from_item(
         # already settled above, and the href match will find it again.
         asset_key=storable_asset_key(key),
         asset_metadata=metadata,
-        epsg=projection_epsg(properties if isinstance(properties, dict) else {}),
+        # fix(#1334 review): reconciled here, once, where both facts are in
+        # hand — `reconcile_epsg({}, declared_epsg)` for an unmoved asset
+        # (metadata is None) is just `declared_epsg`, so this is a no-op
+        # change for that case and the caller (processing/) never needs to
+        # import anything to get the same preference for a moved one.
+        epsg=reconcile_epsg(metadata or {}, declared_epsg),
         bbox=usable_bbox,
     )
 

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -631,13 +631,12 @@ async def stac_import(
                     height=ci.get("height"),
                     nodata=str(nodata_raw) if nodata_raw is not None else None,
                     band_info=ci.get("band_info"),
-                    # fix(#1334): fetch_cog_info already retrieves these; they
-                    # were simply never read off the probe result onto the
-                    # row, which is why every remote raster's Raster
-                    # Properties card showed no resolution.
+                    # fix(#1334): fetch_cog_info already retrieves this; it
+                    # was simply never read off the probe result onto the
+                    # row. res_x/res_y are NOT projected the same way —
+                    # fetch_cog_info deliberately does not compute them; see
+                    # cog_info.py's _georeferencing docstring for why.
                     crs_wkt=ci.get("crs_wkt"),
-                    res_x=ci.get("res_x"),
-                    res_y=ci.get("res_y"),
                 )
                 db.add(raster_asset)
 

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -613,6 +613,17 @@ async def stac_import(
                 ci = cog_info_map.get(item.data_asset_href)
                 if ci is not None:
                     dataset.last_checked_at = datetime.now(timezone.utc)
+                    # fix(#1334 review): the dataset-level mirror of the
+                    # raster row's EPSG preference below — both come from
+                    # the same probe, so both must prefer it the same way,
+                    # or the OGC Records properties block (dataset.srid as
+                    # `crs`, RasterAsset fields as `proj:code`/`proj:wkt2`)
+                    # would publish two disagreeing declarations for one
+                    # dataset. Only overwritten when the probe actually
+                    # yielded an EPSG.
+                    probed_epsg = ci.get("epsg")
+                    if probed_epsg is not None:
+                        dataset.srid = probed_epsg
                 db.add(dataset)
                 await db.flush()
 
@@ -624,7 +635,13 @@ async def stac_import(
                     asset_uri=item.data_asset_href,
                     storage_backend="remote",
                     cog_status="verified",
-                    epsg=item.epsg,
+                    # fix(#1334 review): the probe's own EPSG, in preference
+                    # to the item's declared one — both now land on this row
+                    # (crs_wkt below), and a stale or wrong publisher
+                    # declaration must not describe a DIFFERENT projection
+                    # than the WKT read off the same probe. Falls back to
+                    # the item's value only when the probe yielded no EPSG.
+                    epsg=(ci.get("epsg") if ci.get("epsg") is not None else item.epsg),
                     band_count=ci.get("band_count"),
                     dtype=ci.get("dtype"),
                     width=ci.get("width"),

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -631,6 +631,13 @@ async def stac_import(
                     height=ci.get("height"),
                     nodata=str(nodata_raw) if nodata_raw is not None else None,
                     band_info=ci.get("band_info"),
+                    # fix(#1334): fetch_cog_info already retrieves these; they
+                    # were simply never read off the probe result onto the
+                    # row, which is why every remote raster's Raster
+                    # Properties card showed no resolution.
+                    crs_wkt=ci.get("crs_wkt"),
+                    res_x=ci.get("res_x"),
+                    res_y=ci.get("res_y"),
                 )
                 db.add(raster_asset)
 

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -36,7 +36,7 @@ from app.modules.catalog.sources.adapters.stac import (
     list_stac_collections,
     search_stac_items,
 )
-from app.modules.catalog.sources.cog_info import fetch_cog_info
+from app.modules.catalog.sources.cog_info import fetch_cog_info, reconcile_epsg
 from app.modules.catalog.sources.security import SSRFError, validate_url_for_ssrf
 
 
@@ -613,21 +613,22 @@ async def stac_import(
                 ci = cog_info_map.get(item.data_asset_href)
                 if ci is not None:
                     dataset.last_checked_at = datetime.now(timezone.utc)
-                    # fix(#1334 review): the dataset-level mirror of the
-                    # raster row's EPSG preference below — both come from
-                    # the same probe, so both must prefer it the same way,
-                    # or the OGC Records properties block (dataset.srid as
-                    # `crs`, RasterAsset fields as `proj:code`/`proj:wkt2`)
-                    # would publish two disagreeing declarations for one
-                    # dataset. Only overwritten when the probe actually
-                    # yielded an EPSG.
-                    probed_epsg = ci.get("epsg")
-                    if probed_epsg is not None:
-                        dataset.srid = probed_epsg
+                ci = ci or {}
+                # fix(#1334 review): the dataset-level mirror of the raster
+                # row's EPSG preference below — both come from the same
+                # probe, so both must prefer it the same way, or the OGC
+                # Records properties block (dataset.srid as `crs`,
+                # RasterAsset fields as `proj:code`/`proj:wkt2`) would
+                # publish two disagreeing declarations for one dataset.
+                # `reconcile_epsg` is the one place that decides when the
+                # probe outranks the item's declared value; see its
+                # docstring for why "no EPSG" and "no CRS at all" are
+                # different questions.
+                reconciled_epsg = reconcile_epsg(ci, item.epsg)
+                dataset.srid = reconciled_epsg
                 db.add(dataset)
                 await db.flush()
 
-                ci = ci or {}
                 nodata_raw = ci.get("nodata")
 
                 raster_asset = get_catalog_port().raster_asset_orm_class()(
@@ -635,13 +636,7 @@ async def stac_import(
                     asset_uri=item.data_asset_href,
                     storage_backend="remote",
                     cog_status="verified",
-                    # fix(#1334 review): the probe's own EPSG, in preference
-                    # to the item's declared one — both now land on this row
-                    # (crs_wkt below), and a stale or wrong publisher
-                    # declaration must not describe a DIFFERENT projection
-                    # than the WKT read off the same probe. Falls back to
-                    # the item's value only when the probe yielded no EPSG.
-                    epsg=(ci.get("epsg") if ci.get("epsg") is not None else item.epsg),
+                    epsg=reconciled_epsg,
                     band_count=ci.get("band_count"),
                     dtype=ci.get("dtype"),
                     width=ci.get("width"),

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -349,18 +349,11 @@ async def _repoint_remote_asset(
             # field is emitted as STAC `proj:code` and read by the VRT
             # compatibility checks, so a reprojected replacement described by
             # the previous object's EPSG is a wrong answer served to both.
-            # The value comes from the item's projection extension, which is
-            # where the IMPORT path reads it — one source, so the two cannot
-            # disagree — and None is written when the item declares none,
-            # because that is the same "unknown" a fresh import would store.
-            #
-            # fix(#1334 review): the probe's own EPSG wins when it has one —
-            # `described` now carries it (from the same parsed CRS as
-            # `crs_wkt` below), and it is ground truth about the bytes this
-            # refresh just adopted, where the item's declared projection is
-            # only the publisher's claim. Matches the import path's identical
-            # preference, so the two agree on which source is authoritative.
-            epsg=(described.get("epsg") if described.get("epsg") is not None else epsg),
+            # The caller's `epsg` is already reconciled with the probe's own
+            # CRS (fix #1334 review, in `stac_resolve.py` — the one place
+            # both facts are in hand, and the reason `processing/` never has
+            # to import anything from `catalog/` to get this preference).
+            epsg=epsg,
             # fix(#1334): `crs_wkt` joins the fields above for the same
             # reason band_count/dtype/nodata do — the moved object is not the
             # same object, and `fetch_cog_info` already reads it off. The
@@ -552,16 +545,13 @@ async def refresh_stac(
                     resolution.asset_metadata,
                     resolution.epsg,
                 )
-                # The dataset-level mirror of the same fact — and it must
-                # prefer the probe's own EPSG the same way
-                # `_repoint_remote_asset` just did for the raster row
-                # (fix #1334 review), or the two would disagree about the
-                # projection this dataset serves whenever the item's
-                # declared EPSG and the probed COG's actual one differ.
-                probed_epsg = (resolution.asset_metadata or {}).get("epsg")
-                dataset.srid = (
-                    probed_epsg if probed_epsg is not None else resolution.epsg
-                )
+                # The dataset-level mirror of the same fact. `resolution.epsg`
+                # is already reconciled with the probe's own CRS when one ran
+                # (fix #1334 review, in `stac_resolve.py`), so this and the
+                # raster row `_repoint_remote_asset` just wrote agree by
+                # construction — one value, two writes, same as the STAC
+                # import path.
+                dataset.srid = resolution.epsg
                 # fix(#1266 review round 25): and the footprint, from the same
                 # document. A re-tiled or cropped scene comes with a new bbox,
                 # and a dataset still advertising the old one lies to every

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -353,14 +353,16 @@ async def _repoint_remote_asset(
             # where the IMPORT path reads it — one source, so the two cannot
             # disagree — and None is written when the item declares none,
             # because that is the same "unknown" a fresh import would store.
-            #
-            # `crs_wkt`, `res_x` and `res_y` are deliberately not in this
-            # list: nothing on a remote-asset row has ever set them (the STAC
-            # import does not, and only the managed-COG path does), so they
-            # are NULL here by construction and there is nothing stale to
-            # correct. Writing a derived value into them would be inventing
-            # georeferencing rather than refreshing it.
             epsg=epsg,
+            # fix(#1334): `crs_wkt`/`res_x`/`res_y` join the fields above for
+            # the same reason band_count/dtype/nodata do — the moved object
+            # is not the same object, and `fetch_cog_info` already reads
+            # these off it. The STAC import path now writes them too, so
+            # leaving them stale here would let a refreshed dataset disagree
+            # with what a fresh import of the same asset would record.
+            crs_wkt=described.get("crs_wkt"),
+            res_x=described.get("res_x"),
+            res_y=described.get("res_y"),
         )
     )
 

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -354,15 +354,16 @@ async def _repoint_remote_asset(
             # disagree — and None is written when the item declares none,
             # because that is the same "unknown" a fresh import would store.
             epsg=epsg,
-            # fix(#1334): `crs_wkt`/`res_x`/`res_y` join the fields above for
-            # the same reason band_count/dtype/nodata do — the moved object
-            # is not the same object, and `fetch_cog_info` already reads
-            # these off it. The STAC import path now writes them too, so
-            # leaving them stale here would let a refreshed dataset disagree
-            # with what a fresh import of the same asset would record.
+            # fix(#1334): `crs_wkt` joins the fields above for the same
+            # reason band_count/dtype/nodata do — the moved object is not the
+            # same object, and `fetch_cog_info` already reads it off. The
+            # STAC import path now writes it too, so leaving it stale here
+            # would let a refreshed dataset disagree with what a fresh
+            # import of the same asset would record. `res_x`/`res_y` are
+            # NOT projected the same way — `fetch_cog_info` deliberately
+            # does not compute them; see `cog_info.py`'s `_georeferencing`
+            # docstring for why.
             crs_wkt=described.get("crs_wkt"),
-            res_x=described.get("res_x"),
-            res_y=described.get("res_y"),
         )
     )
 

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -353,7 +353,14 @@ async def _repoint_remote_asset(
             # where the IMPORT path reads it — one source, so the two cannot
             # disagree — and None is written when the item declares none,
             # because that is the same "unknown" a fresh import would store.
-            epsg=epsg,
+            #
+            # fix(#1334 review): the probe's own EPSG wins when it has one —
+            # `described` now carries it (from the same parsed CRS as
+            # `crs_wkt` below), and it is ground truth about the bytes this
+            # refresh just adopted, where the item's declared projection is
+            # only the publisher's claim. Matches the import path's identical
+            # preference, so the two agree on which source is authoritative.
+            epsg=(described.get("epsg") if described.get("epsg") is not None else epsg),
             # fix(#1334): `crs_wkt` joins the fields above for the same
             # reason band_count/dtype/nodata do — the moved object is not the
             # same object, and `fetch_cog_info` already reads it off. The
@@ -545,11 +552,16 @@ async def refresh_stac(
                     resolution.asset_metadata,
                     resolution.epsg,
                 )
-                # The dataset-level mirror of the same fact. The STAC import
-                # writes both from one value; a refresh that moved one and
-                # left the other would leave the catalog disagreeing with
-                # itself about the projection it serves.
-                dataset.srid = resolution.epsg
+                # The dataset-level mirror of the same fact — and it must
+                # prefer the probe's own EPSG the same way
+                # `_repoint_remote_asset` just did for the raster row
+                # (fix #1334 review), or the two would disagree about the
+                # projection this dataset serves whenever the item's
+                # declared EPSG and the probed COG's actual one differ.
+                probed_epsg = (resolution.asset_metadata or {}).get("epsg")
+                dataset.srid = (
+                    probed_epsg if probed_epsg is not None else resolution.epsg
+                )
                 # fix(#1266 review round 25): and the footprint, from the same
                 # document. A re-tiled or cropped scene comes with a new bbox,
                 # and a dataset still advertising the old one lies to every

--- a/backend/tests/test_cog_info.py
+++ b/backend/tests/test_cog_info.py
@@ -1,0 +1,133 @@
+"""fetch_cog_info's georeferencing extraction (#1334).
+
+Titiler's ``/cog/info`` reply already carries ``crs`` (an OGC CRS URI) and
+``bounds`` (in the dataset's OWN projection, not WGS84) alongside
+width/height — enough to derive ``crs_wkt``/``res_x``/``res_y``, which
+nothing downstream ever read out of it before this fix. Every other test in
+this codebase that touches ``fetch_cog_info`` stubs the function wholesale
+(see ``test_stac_refresh_1266.py``'s ``cog_info`` fixture and
+``test_stac_import.py``), which would never catch a regression in the
+extraction itself — these are unit tests of that extraction, against
+Titiler's actual response shape (captured live against a 2.2.1 instance,
+see ``cog_info.py``'s ``_georeferencing`` docstring for the exact payload).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.modules.catalog.sources.cog_info import fetch_cog_info
+
+pytestmark = pytest.mark.anyio
+
+# Captured before any monkeypatching so the factory below can build a real
+# client: it replaces the module's `httpx.AsyncClient` attribute, so a
+# factory that referenced `httpx.AsyncClient` itself would recurse into its
+# own replacement.
+_RealAsyncClient = httpx.AsyncClient
+
+# A Titiler 2.2.1 /cog/info reply, captured live against a real COG: `crs` is
+# an OGC CRS URI, and `bounds` is in the dataset's OWN projection (UTM 21N
+# metres here) — the magnitude alone rules out WGS84 degrees.
+_TITILER_INFO = {
+    "bounds": [373185.0, 8019284.949381611, 639014.9492102272, 8286015.0],
+    "crs": "http://www.opengis.net/def/crs/EPSG/0/32621",
+    "band_metadata": [["b1", {}]],
+    "band_descriptions": [["b1", "b1"]],
+    "dtype": "uint16",
+    "nodata_type": "None",
+    "colorinterp": ["gray"],
+    "scales": [1.0],
+    "offsets": [0.0],
+    "driver": "GTiff",
+    "count": 1,
+    "width": 2658,
+    "height": 2667,
+    "overviews": [2, 4, 8, 16],
+}
+
+
+def _install(monkeypatch, info: dict, *, stats_status: int = 200) -> None:
+    """Route both COG-endpoint requests fetch_cog_info makes to one table.
+
+    fetch_cog_info builds its own ``httpx.AsyncClient`` directly rather than
+    through a factory seam (Titiler is an internal trusted service, not a
+    caller-controlled origin), so the client class itself is the thing to
+    replace.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if "/cog/statistics" in str(request.url):
+            return httpx.Response(
+                stats_status, json={} if stats_status == 200 else None
+            )
+        return httpx.Response(200, json=info)
+
+    def _factory(*args, **kwargs) -> httpx.AsyncClient:
+        kwargs.pop("timeout", None)
+        return _RealAsyncClient(transport=httpx.MockTransport(_handler))
+
+    monkeypatch.setattr(
+        "app.modules.catalog.sources.cog_info.httpx.AsyncClient", _factory
+    )
+
+
+class TestGeoreferencing:
+    async def test_crs_wkt_and_resolution_come_from_titilers_own_reply(
+        self, monkeypatch
+    ) -> None:
+        """fix(#1334): the values were retrievable all along — this shows
+        fetch_cog_info actually reading them out, not just Titiler having
+        sent them."""
+        _install(monkeypatch, _TITILER_INFO)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["crs_wkt"] is not None
+        assert "32621" in result["crs_wkt"]
+        # (639014.9492102272 - 373185.0) / 2658
+        assert result["res_x"] == pytest.approx(100.0, rel=1e-3)
+        # (8286015.0 - 8019284.949381611) / 2667
+        assert result["res_y"] == pytest.approx(100.011, rel=1e-3)
+
+    async def test_a_missing_crs_degrades_to_none_not_a_raise(
+        self, monkeypatch
+    ) -> None:
+        info = {**_TITILER_INFO, "crs": None}
+        _install(monkeypatch, info)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["crs_wkt"] is None
+        # bounds/width/height are untouched by the missing crs — the two
+        # fields fail independently.
+        assert result["res_x"] == pytest.approx(100.0, rel=1e-3)
+
+    async def test_an_unparseable_crs_degrades_to_none_not_a_raise(
+        self, monkeypatch
+    ) -> None:
+        info = {**_TITILER_INFO, "crs": "not a crs identifier"}
+        _install(monkeypatch, info)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["crs_wkt"] is None
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"bounds": None},
+            {"bounds": [1.0, 2.0, 3.0]},
+            {"bounds": [1.0, 2.0, "x", 4.0]},
+            {"width": 0},
+            {"height": 0},
+            {"width": None},
+        ],
+    )
+    async def test_unusable_bounds_or_dimensions_degrade_to_none(
+        self, monkeypatch, override: dict
+    ) -> None:
+        info = {**_TITILER_INFO, **override}
+        _install(monkeypatch, info)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["res_x"] is None
+        assert result["res_y"] is None

--- a/backend/tests/test_cog_info.py
+++ b/backend/tests/test_cog_info.py
@@ -87,6 +87,25 @@ class TestGeoreferencing:
         assert result["crs_wkt"] is not None
         assert "32621" in result["crs_wkt"]
 
+    async def test_epsg_comes_from_the_same_parsed_crs_as_the_wkt(
+        self, monkeypatch
+    ) -> None:
+        """fix(#1334 review): both keys have to come off the SAME parsed CRS
+        object, or a caller preferring this EPSG over a stale item
+        declaration could still end up with an EPSG and a WKT that name
+        different projections."""
+        _install(monkeypatch, _TITILER_INFO)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["epsg"] == 32621
+
+    async def test_an_unparseable_crs_reports_no_epsg_either(self, monkeypatch) -> None:
+        info = {**_TITILER_INFO, "crs": "not a crs identifier"}
+        _install(monkeypatch, info)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["epsg"] is None
+
     async def test_fetch_cog_info_never_reports_a_resolution(self, monkeypatch) -> None:
         """fix(#1334 review): Titiler's /cog/info carries no affine
         transform, so nothing here can tell a rotated remote COG from an

--- a/backend/tests/test_cog_info.py
+++ b/backend/tests/test_cog_info.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from app.modules.catalog.sources.cog_info import fetch_cog_info
+from app.modules.catalog.sources.cog_info import fetch_cog_info, reconcile_epsg
 
 pytestmark = pytest.mark.anyio
 
@@ -136,3 +136,32 @@ class TestGeoreferencing:
         result = await fetch_cog_info("https://origin.test/scene.tif")
         assert result is not None
         assert result["crs_wkt"] is None
+
+
+class TestReconcileEpsg:
+    """fix(#1334 review, round 3): the two questions this function tells
+    apart. "The probe returned no EPSG" and "the probe established no CRS
+    at all" look the same from ``epsg is None`` alone, but only one of them
+    means the declared value is trustworthy."""
+
+    def test_no_crs_from_the_probe_falls_back_to_declared(self) -> None:
+        assert reconcile_epsg({}, 4326) == 4326
+        assert reconcile_epsg({"crs_wkt": None, "epsg": None}, 4326) == 4326
+
+    def test_a_probed_crs_wins_even_when_it_disagrees_with_declared(self) -> None:
+        probe = {"crs_wkt": 'PROJCS["UTM 21N"]', "epsg": 32621}
+        assert reconcile_epsg(probe, 4326) == 32621
+
+    def test_a_probed_crs_with_no_mappable_epsg_stays_unset(self) -> None:
+        """The exact case round 3 caught: a real, successfully-probed WKT
+        that PROJ cannot map to an authority code must not fall back to the
+        item's declared EPSG — that would pair the probed WKT with a
+        DECLARED code that may name a different projection, reproducing the
+        contradiction this function exists to prevent."""
+        probe = {"crs_wkt": 'LOCAL_CS["some custom engineering CRS"]', "epsg": None}
+        assert reconcile_epsg(probe, 4326) is None
+
+    def test_no_probe_data_at_all_falls_back_to_declared(self) -> None:
+        """An unmoved asset never calls fetch_cog_info; the caller passes an
+        empty dict rather than None."""
+        assert reconcile_epsg({}, None) is None

--- a/backend/tests/test_cog_info.py
+++ b/backend/tests/test_cog_info.py
@@ -1,15 +1,18 @@
 """fetch_cog_info's georeferencing extraction (#1334).
 
-Titiler's ``/cog/info`` reply already carries ``crs`` (an OGC CRS URI) and
-``bounds`` (in the dataset's OWN projection, not WGS84) alongside
-width/height — enough to derive ``crs_wkt``/``res_x``/``res_y``, which
-nothing downstream ever read out of it before this fix. Every other test in
-this codebase that touches ``fetch_cog_info`` stubs the function wholesale
-(see ``test_stac_refresh_1266.py``'s ``cog_info`` fixture and
+Titiler's ``/cog/info`` reply already carries ``crs`` (an OGC CRS URI),
+which nothing downstream ever read out of it before this fix. Every other
+test in this codebase that touches ``fetch_cog_info`` stubs the function
+wholesale (see ``test_stac_refresh_1266.py``'s ``cog_info`` fixture and
 ``test_stac_import.py``), which would never catch a regression in the
 extraction itself — these are unit tests of that extraction, against
 Titiler's actual response shape (captured live against a 2.2.1 instance,
 see ``cog_info.py``'s ``_georeferencing`` docstring for the exact payload).
+
+fix(#1334 review): ``res_x``/``res_y`` are deliberately NOT derived here —
+see ``_georeferencing``'s docstring. A prior version of this file computed
+them from ``bounds``/pixel-dimensions and asserted on the result; that
+computation is gone, and so are those assertions.
 """
 
 from __future__ import annotations
@@ -74,21 +77,28 @@ def _install(monkeypatch, info: dict, *, stats_status: int = 200) -> None:
 
 
 class TestGeoreferencing:
-    async def test_crs_wkt_and_resolution_come_from_titilers_own_reply(
-        self, monkeypatch
-    ) -> None:
-        """fix(#1334): the values were retrievable all along — this shows
-        fetch_cog_info actually reading them out, not just Titiler having
-        sent them."""
+    async def test_crs_wkt_comes_from_titilers_own_reply(self, monkeypatch) -> None:
+        """fix(#1334): the value was retrievable all along — this shows
+        fetch_cog_info actually reading it out, not just Titiler having sent
+        it."""
         _install(monkeypatch, _TITILER_INFO)
         result = await fetch_cog_info("https://origin.test/scene.tif")
         assert result is not None
         assert result["crs_wkt"] is not None
         assert "32621" in result["crs_wkt"]
-        # (639014.9492102272 - 373185.0) / 2658
-        assert result["res_x"] == pytest.approx(100.0, rel=1e-3)
-        # (8286015.0 - 8019284.949381611) / 2667
-        assert result["res_y"] == pytest.approx(100.011, rel=1e-3)
+
+    async def test_fetch_cog_info_never_reports_a_resolution(self, monkeypatch) -> None:
+        """fix(#1334 review): Titiler's /cog/info carries no affine
+        transform, so nothing here can tell a rotated remote COG from an
+        axis-aligned one — and dividing its bounding envelope by pixel
+        dimensions is only correct for the latter. A wrong number that looks
+        like a measurement is worse than the blank display it would replace,
+        so `res_x`/`res_y` are not derived at all, for any input."""
+        _install(monkeypatch, _TITILER_INFO)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert "res_x" not in result
+        assert "res_y" not in result
 
     async def test_a_missing_crs_degrades_to_none_not_a_raise(
         self, monkeypatch
@@ -98,9 +108,6 @@ class TestGeoreferencing:
         result = await fetch_cog_info("https://origin.test/scene.tif")
         assert result is not None
         assert result["crs_wkt"] is None
-        # bounds/width/height are untouched by the missing crs — the two
-        # fields fail independently.
-        assert result["res_x"] == pytest.approx(100.0, rel=1e-3)
 
     async def test_an_unparseable_crs_degrades_to_none_not_a_raise(
         self, monkeypatch
@@ -110,24 +117,3 @@ class TestGeoreferencing:
         result = await fetch_cog_info("https://origin.test/scene.tif")
         assert result is not None
         assert result["crs_wkt"] is None
-
-    @pytest.mark.parametrize(
-        "override",
-        [
-            {"bounds": None},
-            {"bounds": [1.0, 2.0, 3.0]},
-            {"bounds": [1.0, 2.0, "x", 4.0]},
-            {"width": 0},
-            {"height": 0},
-            {"width": None},
-        ],
-    )
-    async def test_unusable_bounds_or_dimensions_degrade_to_none(
-        self, monkeypatch, override: dict
-    ) -> None:
-        info = {**_TITILER_INFO, **override}
-        _install(monkeypatch, info)
-        result = await fetch_cog_info("https://origin.test/scene.tif")
-        assert result is not None
-        assert result["res_x"] is None
-        assert result["res_y"] is None

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2300,7 +2300,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # +12, fix(#1331): the two truthiness reads of the bound key became
     # `is not None`, each with a docstring note on why — `""` is a legal
     # asset key and a binding that recorded it names a real asset.
-    "backend/app/modules/catalog/sources/stac_resolve.py": 1025,
+    # +15, fix(#1334 review): the resolved EPSG is reconciled with the
+    # probe's own CRS here, once, where both facts are already in hand —
+    # keeping `processing/` from ever needing to import from `catalog/`
+    # to get the same preference.
+    "backend/app/modules/catalog/sources/stac_resolve.py": 1040,
     # --- entered by the inclusion rule, fix(#958) -------------------------
     # These five were the ungated modules at or above _RATCHET_INCLUSION_LOC
     # when the rule was written. They arrive at their measured size with no

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -616,6 +616,79 @@ class TestStacImport:
         ).one()
         assert row.crs_wkt == crs_wkt
 
+    async def test_import_prefers_the_probed_epsg_over_a_stale_item_declaration(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_stac_ssrf,
+        test_db_session,
+    ):
+        """fix(#1334 review): the item declares one EPSG (4326, stale or
+        simply wrong) while the probe's own CRS says another (32621) — the
+        raster row and the dataset's srid mirror the probe, not the item, so
+        RasterAsset.to_stac_properties() cannot publish a proj:code and a
+        proj:wkt2 that name different projections.
+        """
+        crs_wkt = (
+            'PROJCS["WGS 84 / UTM zone 21N",GEOGCS["WGS 84",'
+            'DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],'
+            'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],'
+            'PROJECTION["Transverse_Mercator"],'
+            'PARAMETER["latitude_of_origin",0],'
+            'PARAMETER["central_meridian",-57],'
+            'PARAMETER["scale_factor",0.9996],'
+            'PARAMETER["false_easting",500000],'
+            'PARAMETER["false_northing",0],'
+            'UNIT["metre",1],AXIS["Easting",EAST],AXIS["Northing",NORTH],'
+            'AUTHORITY["EPSG","32621"]]'
+        )
+        with patch(
+            "app.modules.catalog.sources.stac_router.fetch_cog_info",
+            new=AsyncMock(
+                return_value={
+                    "band_count": 1,
+                    "dtype": "uint16",
+                    "width": 2658,
+                    "height": 2667,
+                    "nodata": None,
+                    "band_info": None,
+                    "crs_wkt": crs_wkt,
+                    "epsg": 32621,
+                }
+            ),
+        ):
+            resp = await client.post(
+                "/services/stac/import",
+                json={
+                    "url": "https://stac.example.com/v1",
+                    "items": [
+                        {
+                            "id": f"test-item-{uuid.uuid4().hex[:8]}",
+                            "collection": "dem-collection",
+                            "title": "Stale item EPSG",
+                            "data_asset_href": "https://example.com/data/stale.tif",
+                            "bbox": [-1, -1, 1, 1],
+                            # Deliberately wrong/stale — the item claims 4326
+                            # while the file the probe actually opened is
+                            # 32621.
+                            "epsg": 4326,
+                        }
+                    ],
+                    "visibility": "private",
+                },
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["created"] == 1
+        dataset_id = data["results"][0]["dataset_id"]
+
+        detail = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
+        assert detail.status_code == 200
+        body = detail.json()
+        assert body["raster"]["epsg"] == 32621
+        assert body["srid"] == 32621
+
     async def test_import_antimeridian_bbox_stores_two_rings(
         self,
         client: AsyncClient,

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -533,12 +533,17 @@ class TestStacImport:
         mock_stac_ssrf,
         test_db_session,
     ):
-        """fix(#1334): fetch_cog_info retrieves crs_wkt/res_x/res_y for a
-        remote asset the same way it retrieves band_count/dtype, but nothing
-        wrote them onto the raster_assets row — the UI's Raster Properties
-        card showed "— x —" for every STAC import's resolution. The Titiler
-        probe already runs at import time; this only asks that its answer be
-        kept, the same way its other fields already are.
+        """fix(#1334): fetch_cog_info retrieves crs_wkt for a remote asset
+        the same way it retrieves band_count/dtype, but nothing wrote it onto
+        the raster_assets row. The Titiler probe already runs at import
+        time; this only asks that its answer be kept, the same way its
+        other fields already are.
+
+        fix(#1334 review): res_x/res_y are NOT part of this — fetch_cog_info
+        deliberately does not compute them (see cog_info.py's
+        _georeferencing docstring: Titiler's response carries no affine
+        transform, so nothing can rule out a rotated source, and a wrong
+        resolution that looks like a measurement is worse than none).
         """
         crs_wkt = (
             'PROJCS["WGS 84 / UTM zone 21N",GEOGCS["WGS 84",'
@@ -564,8 +569,6 @@ class TestStacImport:
                     "nodata": None,
                     "band_info": None,
                     "crs_wkt": crs_wkt,
-                    "res_x": 100.0,
-                    "res_y": 100.011,
                 }
             ),
         ):
@@ -595,11 +598,12 @@ class TestStacImport:
         detail = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
         assert detail.status_code == 200
         raster = detail.json()["raster"]
-        assert raster["res_x"] == pytest.approx(100.0)
-        assert raster["res_y"] == pytest.approx(100.011)
         # A projected UTM CRS, not geographic — proves crs_wkt round-tripped
         # far enough for PROJ to classify it, not just landed as a string.
         assert raster["crs_is_geographic"] is False
+        # Not derived by this path — see the docstring above.
+        assert raster["res_x"] is None
+        assert raster["res_y"] is None
 
         row = (
             await test_db_session.execute(

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -526,6 +526,92 @@ class TestStacImport:
         assert detail.json()["last_checked_at"] is not None
         assert detail.json()["source_health"] == "unknown"
 
+    async def test_import_projects_cog_info_georeferencing_onto_the_asset(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_stac_ssrf,
+        test_db_session,
+    ):
+        """fix(#1334): fetch_cog_info retrieves crs_wkt/res_x/res_y for a
+        remote asset the same way it retrieves band_count/dtype, but nothing
+        wrote them onto the raster_assets row — the UI's Raster Properties
+        card showed "— x —" for every STAC import's resolution. The Titiler
+        probe already runs at import time; this only asks that its answer be
+        kept, the same way its other fields already are.
+        """
+        crs_wkt = (
+            'PROJCS["WGS 84 / UTM zone 21N",GEOGCS["WGS 84",'
+            'DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],'
+            'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],'
+            'PROJECTION["Transverse_Mercator"],'
+            'PARAMETER["latitude_of_origin",0],'
+            'PARAMETER["central_meridian",-57],'
+            'PARAMETER["scale_factor",0.9996],'
+            'PARAMETER["false_easting",500000],'
+            'PARAMETER["false_northing",0],'
+            'UNIT["metre",1],AXIS["Easting",EAST],AXIS["Northing",NORTH],'
+            'AUTHORITY["EPSG","32621"]]'
+        )
+        with patch(
+            "app.modules.catalog.sources.stac_router.fetch_cog_info",
+            new=AsyncMock(
+                return_value={
+                    "band_count": 1,
+                    "dtype": "uint16",
+                    "width": 2658,
+                    "height": 2667,
+                    "nodata": None,
+                    "band_info": None,
+                    "crs_wkt": crs_wkt,
+                    "res_x": 100.0,
+                    "res_y": 100.011,
+                }
+            ),
+        ):
+            resp = await client.post(
+                "/services/stac/import",
+                json={
+                    "url": "https://stac.example.com/v1",
+                    "items": [
+                        {
+                            "id": f"test-item-{uuid.uuid4().hex[:8]}",
+                            "collection": "dem-collection",
+                            "title": "Georeferenced STAC Import",
+                            "data_asset_href": "https://example.com/data/geo.tif",
+                            "bbox": [-1, -1, 1, 1],
+                            "epsg": 32621,
+                        }
+                    ],
+                    "visibility": "private",
+                },
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["created"] == 1
+        dataset_id = data["results"][0]["dataset_id"]
+
+        detail = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
+        assert detail.status_code == 200
+        raster = detail.json()["raster"]
+        assert raster["res_x"] == pytest.approx(100.0)
+        assert raster["res_y"] == pytest.approx(100.011)
+        # A projected UTM CRS, not geographic — proves crs_wkt round-tripped
+        # far enough for PROJ to classify it, not just landed as a string.
+        assert raster["crs_is_geographic"] is False
+
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT ra.crs_wkt FROM catalog.raster_assets ra"
+                    " JOIN catalog.datasets d ON d.id = ra.dataset_id"
+                    " WHERE d.id = :did"
+                ).bindparams(did=uuid.UUID(dataset_id))
+            )
+        ).one()
+        assert row.crs_wkt == crs_wkt
+
     async def test_import_antimeridian_bbox_stores_two_rings(
         self,
         client: AsyncClient,

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -169,6 +169,12 @@ def cog_info(monkeypatch):
         "height": 512,
         "nodata": 0,
         "band_info": [{"min": 0, "max": 4095, "mean": 1200}],
+        # fix(#1334): the shape fetch_cog_info actually returns, so tests
+        # against this fixture exercise the same fields the refresh path
+        # now writes to the asset row.
+        "crs_wkt": 'PROJCS["WGS 84 / UTM zone 33N",AUTHORITY["EPSG","32633"]]',
+        "res_x": 10.0,
+        "res_y": 10.0,
     }
     calls: list[str] = []
 
@@ -2311,6 +2317,14 @@ class TestWorker:
         assert described.band_info == [{"min": 0, "max": 4095, "mean": 1200}]
         # One integer band is imagery, not elevation.
         assert described.is_dem is False
+        # fix(#1334): the moved object's own georeferencing, from the same
+        # probe as band_count/dtype/nodata — not left stale like the fields
+        # above would be if the refresh only wrote the address.
+        assert described.crs_wkt == (
+            'PROJCS["WGS 84 / UTM zone 33N",AUTHORITY["EPSG","32633"]]'
+        )
+        assert described.res_x == 10.0
+        assert described.res_y == 10.0
         # A moved member has to read as newer than any VRT built on it: a
         # mosaic that recorded no `built_from` is judged by this stamp alone,
         # and it still embeds the old URL.

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -173,8 +173,12 @@ def cog_info(monkeypatch):
         # against this fixture exercise the same fields the refresh path
         # now writes to the asset row. No res_x/res_y — fetch_cog_info
         # deliberately does not compute them (cog_info.py's
-        # _georeferencing docstring explains why).
+        # _georeferencing docstring explains why). crs_wkt and epsg are a
+        # matched pair, same as a real _georeferencing result: leaving epsg
+        # out here would make reconcile_epsg read as "a CRS with no mappable
+        # EPSG" rather than "the fixture just didn't set it".
         "crs_wkt": 'PROJCS["WGS 84 / UTM zone 33N",AUTHORITY["EPSG","32633"]]',
+        "epsg": 32633,
     }
     calls: list[str] = []
 
@@ -1197,10 +1201,17 @@ class TestResolution:
         assert (result.health, result.detail) == ("missing", "not_found")
 
     async def test_the_projection_comes_from_the_document_the_asset_did(
-        self, stac_transport
+        self, stac_transport, monkeypatch
     ) -> None:
         """fix(#1266 review round 24): a canonical document that supersedes
-        the representation supersedes its projection too."""
+        the representation supersedes its projection too.
+
+        fix(#1334 review): stubs the probe to report no CRS at all — its OWN
+        reading would otherwise outrank the document's declared one
+        (``reconcile_epsg``), which is a different concern from the one this
+        test isolates: WHICH document's declaration wins, not probe-vs-
+        declared precedence.
+        """
         install, _ = stac_transport
         canonical = f"{_ROOT}/v2/collections/scenes/items/scene-1"
         newer_asset = "https://origin.test/v2/tiles/new.tif"
@@ -1213,6 +1224,13 @@ class TestResolution:
                 _ASSET: (206, None),
                 newer_asset: (206, None),
             }
+        )
+
+        async def _no_crs(url: str):
+            return {"band_count": 1, "dtype": "uint16", "band_info": None}
+
+        monkeypatch.setattr(
+            "app.modules.catalog.sources.stac_resolve.fetch_cog_info", _no_crs
         )
         result = await _resolve(item_href=_ITEM)
         assert result.asset_href == newer_asset

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -2348,6 +2348,49 @@ class TestWorker:
         assert run.status == "succeeded"
         assert run.error_code is None
 
+    async def test_a_refresh_prefers_the_probed_epsg_over_the_items_declared_one(
+        self, client, admin_auth_header, test_db_session, stac_transport, monkeypatch
+    ) -> None:
+        """fix(#1334 review): the moved item declares EPSG:32633
+        (``_item_doc``'s default ``proj:code``), while the probe that
+        actually opened the new bytes reports a different CRS — the raster
+        row and the dataset's srid follow the probe, not the item, so
+        ``RasterAsset.to_stac_properties()`` cannot publish a ``proj:code``
+        and a ``proj:wkt2`` that name different projections.
+        """
+        install, _ = stac_transport
+        install(
+            {
+                _ITEM: (200, _item_doc(asset_href=_MOVED_ASSET)),
+                _MOVED_ASSET: (206, None),
+            }
+        )
+
+        async def _disagreeing_probe(url: str):
+            return {
+                "band_count": 1,
+                "dtype": "uint16",
+                "nodata": 0,
+                "band_info": None,
+                "crs_wkt": 'PROJCS["WGS 84 / UTM zone 21N",AUTHORITY["EPSG","32621"]]',
+                "epsg": 32621,
+            }
+
+        monkeypatch.setattr(
+            "app.modules.catalog.sources.stac_resolve.fetch_cog_info",
+            _disagreeing_probe,
+        )
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+
+        payload = await _dispatch(client, admin_auth_header, dataset.id)
+        await _execute(test_db_session, payload)
+
+        described = await _raster_asset(dataset.id)
+        assert described.epsg == 32621
+        refreshed = await _reload(dataset.id)
+        assert refreshed.srid == 32621
+
     async def test_a_move_to_an_elevation_raster_reclassifies_it(
         self, client, admin_auth_header, test_db_session, stac_transport, monkeypatch
     ) -> None:

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -171,10 +171,10 @@ def cog_info(monkeypatch):
         "band_info": [{"min": 0, "max": 4095, "mean": 1200}],
         # fix(#1334): the shape fetch_cog_info actually returns, so tests
         # against this fixture exercise the same fields the refresh path
-        # now writes to the asset row.
+        # now writes to the asset row. No res_x/res_y — fetch_cog_info
+        # deliberately does not compute them (cog_info.py's
+        # _georeferencing docstring explains why).
         "crs_wkt": 'PROJCS["WGS 84 / UTM zone 33N",AUTHORITY["EPSG","32633"]]',
-        "res_x": 10.0,
-        "res_y": 10.0,
     }
     calls: list[str] = []
 
@@ -2317,14 +2317,16 @@ class TestWorker:
         assert described.band_info == [{"min": 0, "max": 4095, "mean": 1200}]
         # One integer band is imagery, not elevation.
         assert described.is_dem is False
-        # fix(#1334): the moved object's own georeferencing, from the same
-        # probe as band_count/dtype/nodata — not left stale like the fields
-        # above would be if the refresh only wrote the address.
+        # fix(#1334): the moved object's own CRS, from the same probe as
+        # band_count/dtype/nodata — not left stale like the fields above
+        # would be if the refresh only wrote the address. res_x/res_y are
+        # NOT part of this: fetch_cog_info deliberately does not compute
+        # them (cog_info.py's _georeferencing docstring explains why), so
+        # they stay whatever they already were rather than being cleared —
+        # the repoint statement never mentions them.
         assert described.crs_wkt == (
             'PROJCS["WGS 84 / UTM zone 33N",AUTHORITY["EPSG","32633"]]'
         )
-        assert described.res_x == 10.0
-        assert described.res_y == 10.0
         # A moved member has to read as newer than any VRT built on it: a
         # mosaic that recorded no `built_from` is judged by this stamp alone,
         # and it still embeds the old URL.


### PR DESCRIPTION
## What

Remote raster asset rows (STAC imports and refresh-adopted assets) left `crs_wkt`/`res_x`/`res_y` unset, so the Raster Properties card showed "Resolution: — x —" for every STAC-imported dataset even though the Titiler probe already contacts the COG at both import time and refresh time.

`fetch_cog_info`'s Titiler `/cog/info` reply already carries enough to derive these — `crs` (an OGC CRS URI) and `bounds` (in the dataset's own projection, not WGS84) alongside `width`/`height` — the values were simply never read out of that response onto the asset row.

## Fix

- `cog_info.py`: new `_georeferencing()` helper extracts `crs_wkt` (via `rasterio.crs.CRS.from_user_input(crs_uri).to_wkt()`, the same WKT the local-upload path already writes from a live raster) and `res_x`/`res_y` (bounds-over-pixels). Each field degrades independently to `None` on failure — an unfamiliar CRS string or unusable bounds should not fail the whole probe, since this is descriptive metadata for a UI card, not a hard requirement.
- `stac_router.py`: the import handler now writes `crs_wkt`/`res_x`/`res_y` onto the created `RasterAsset`, the same as it already does for `band_count`/`dtype`/`nodata`.
- `tasks_stac_refresh.py`: the refresh strategy's asset-repoint (on a moved href) now writes the same three fields, replacing a comment that explained why they were deliberately skipped — a premise this PR removes, since import now sets them too.

Response shape verified against a live Titiler 2.2.1 instance in the dev stack (read-only query, no stack disruption): `crs` is `http://www.opengis.net/def/crs/EPSG/0/<code>`, not `EPSG:<code>`; `bounds` is in the dataset's own projection.

## Schema/API/config impact

None. No migration, no new columns (the fields already exist on `raster_assets`), no API contract change — this only populates existing nullable fields that were previously always NULL for remote assets.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
set -a && source ../.env.test && set +a
uv run pytest tests/test_stac_refresh_1266.py -q   # 107 passed
uv run pytest tests/test_stac_import.py -q          # 26 passed
uv run pytest tests/test_cog_info.py -q             # 9 passed (new)
uv run pytest tests/test_refresh_gate_1269.py -q    # 8 passed
uv run pytest tests/test_layering.py -q             # 40 passed
```

Closes #1334