### PR TITLE
chore(extensions): remove the deprecated AuditExtension seam

### DIFF
--- a/backend/app/platform/extensions/__init__.py
+++ b/backend/app/platform/extensions/__init__.py
@@ -15,10 +15,6 @@ import structlog
 from app.platform.extensions.version import check_extension_api_version
 from app.platform.extensions.defaults import (
     DefaultAnthropicProvider,  # NEW (Phase 226)
-    # fix(#873 review r4): deprecated alias — importable from the package root
-    # pre-#836, so it stays here (and behind get_audit_extension) until the
-    # next EXTENSION_API_VERSION bump removes the audit seam wholesale.
-    DefaultAuditExtension,
     DefaultAuditSink,  # NEW (Phase 222)
     DefaultAuthExtension,
     DefaultBillingExtension,  # NEW (Phase 223)
@@ -36,11 +32,6 @@ from app.platform.extensions.defaults import (
     DefaultWorkflowExtension,  # NEW (Phase 233)
 )
 from app.platform.extensions.protocols import (
-    # fix(#873 review r2): deprecated alias, but it must be a RUNTIME re-export —
-    # under TYPE_CHECKING, `from app.platform.extensions import AuditExtension`
-    # raised ImportError for exactly the overlay the alias exists to protect.
-    # Removed with the seam at the next EXTENSION_API_VERSION bump.
-    AuditExtension as AuditExtension,
     AuditSink,  # NEW (Phase 222)
     AuthExtension,
     BillingExtension,  # NEW (Phase 223)
@@ -95,7 +86,6 @@ SINGLE_SLOT_KEYS: frozenset[str] = frozenset(
         "catalog_port",
         "workflow",
         "branding",
-        "audit",
         "auth",
         "entitlement",  # NEW (Phase 1207 / ENTSEAM-01) — cloud overlay claims this in Phase 1213
         "connectors",
@@ -324,22 +314,6 @@ def get_branding_extension() -> BrandingExtension:
     ext = _extensions.get("branding")
     if ext is None:
         return DefaultBrandingExtension()
-    return ext  # type: ignore[return-value]
-
-
-def get_audit_extension() -> AuditExtension:
-    """DEPRECATED — scheduled for removal at the next EXTENSION_API_VERSION bump.
-
-    fix(#873 review r1+r3): the whole seam is deprecated (no core caller
-    consumes it and no known overlay registers the ``audit`` slot), but until
-    the next EXTENSION_API_VERSION bump (removal tracked in #1303) the
-    deprecated surface must keep BEHAVING, not merely importing — so the
-    registry dispatch stays until that bump removes the seam wholesale. An overlay registered under ``audit`` is returned; otherwise the
-    no-op community default.
-    """
-    ext = _extensions.get("audit")
-    if ext is None:
-        return DefaultAuditExtension()
     return ext  # type: ignore[return-value]
 
 

--- a/backend/app/platform/extensions/defaults.py
+++ b/backend/app/platform/extensions/defaults.py
@@ -32,7 +32,6 @@ from app.platform.extensions.defaults_ai_openai import (
 )
 from app.platform.extensions.defaults_catalog_port import DefaultCatalogPort
 from app.platform.extensions.defaults_extensions import (
-    DefaultAuditExtension,
     DefaultAuditSink,
     DefaultAuthExtension,
     DefaultBillingExtension,
@@ -49,9 +48,6 @@ from app.platform.extensions.defaults_processing_port import DefaultProcessingPo
 
 __all__ = [
     "DefaultAnthropicProvider",
-    # fix(#873 review r1): deprecated import-compatibility alias, removed at
-    # the next EXTENSION_API_VERSION bump.
-    "DefaultAuditExtension",
     "DefaultAuditSink",
     "DefaultAuthExtension",
     "DefaultBillingExtension",

--- a/backend/app/platform/extensions/defaults_extensions.py
+++ b/backend/app/platform/extensions/defaults_extensions.py
@@ -17,16 +17,6 @@ class DefaultBrandingExtension:
         return {"show_badge": True}
 
 
-class DefaultAuditExtension:
-    """DEPRECATED compatibility alias — scheduled for removal at the next
-    EXTENSION_API_VERSION bump (fix(#873 review r1); see the AuditExtension
-    protocol for the rationale). No core caller consumes this.
-    """
-
-    def get_export_formats(self) -> list[str]:
-        return []
-
-
 class DefaultAuthExtension:
     """Default auth: no additional auth methods."""
 

--- a/backend/app/platform/extensions/protocols.py
+++ b/backend/app/platform/extensions/protocols.py
@@ -41,24 +41,6 @@ class BrandingExtension(Protocol):
 
 
 @runtime_checkable
-class AuditExtension(Protocol):
-    """DEPRECATED compatibility alias — scheduled for removal at the next
-    EXTENSION_API_VERSION bump.
-
-    fix(#873 review r1+r3): the seam has no consumer (core never calls
-    ``get_export_formats`` and no overlay registers the ``audit`` slot), but
-    removing any part of it before the coordinated EXTENSION_API_VERSION bump
-    (removal tracked in #1303) breaks the compatibility contract: a deleted
-    symbol ImportErrors an overlay into a silent ``load_extensions()`` skip,
-    and a dispatch-less accessor silently no-ops a registered overlay.
-    Protocol, default, accessor, and dispatch therefore all stay until that
-    bump removes the seam wholesale.
-    """
-
-    def get_export_formats(self) -> list[str]: ...
-
-
-@runtime_checkable
 class AuthExtension(Protocol):
     """Extension point for additional auth methods."""
 
@@ -70,10 +52,7 @@ class AuditSink(Protocol):
     """Write-side hook for audit event emission (Phase 222 D-01).
 
     A SIEM streamer does not change the bounded CSV and JSON export provided by
-    Core. (fix(#836): the companion ``AuditExtension`` format-metadata seam is
-    deprecated — no core caller and no overlay ever consumed it — and survives
-    only as an import-compatibility alias until the next EXTENSION_API_VERSION
-    bump.)
+    Core.
 
     Enterprise overlays subscribe by appending instances to
     ``_extensions["audit_sinks"]`` in their ``register_extensions(registry)``

--- a/backend/tests/test_extension_slot_guard.py
+++ b/backend/tests/test_extension_slot_guard.py
@@ -60,7 +60,6 @@ class TestSingleSlotConflictGuard:
             "catalog_port",
             "workflow",
             "branding",
-            "audit",
             "auth",
             "entitlement",  # Phase 1207 / ENTSEAM-01
             "connectors",
@@ -284,7 +283,6 @@ class TestSingleSlotKeySet:
                 "catalog_port",
                 "workflow",
                 "branding",
-                "audit",
                 "auth",
                 "entitlement",  # Phase 1207 / ENTSEAM-01
                 "connectors",

--- a/backend/tests/test_extensions.py
+++ b/backend/tests/test_extensions.py
@@ -210,33 +210,6 @@ class TestProtocolDefaults:
 
         assert DefaultAuthExtension().get_auth_methods() == []
 
-    def test_audit_alias_stays_importable_until_version_bump(self):
-        """fix(#836 / #873 review r1): the AuditExtension seam is deprecated.
-
-        Its registry dispatch is gone, but the three public names must stay
-        importable until the next EXTENSION_API_VERSION bump (removal tracked
-        in #1303) — an overlay built against v2 or any later version that
-        imports them would otherwise ImportError into a silent
-        load_extensions() skip. Delete this test with the aliases at that
-        bump.
-        """
-        # fix(#873 review r2): import the protocol exactly the way an overlay
-        # would — from the package root, at runtime. A TYPE_CHECKING-only
-        # re-export made this line ImportError while the protocols-module
-        # import below still worked, recreating the silent-skip failure mode.
-        from app.platform.extensions import AuditExtension, get_audit_extension
-        from app.platform.extensions.defaults import DefaultAuditExtension
-        from app.platform.extensions.protocols import (
-            AuditExtension as ProtocolAuditExtension,
-        )
-
-        assert AuditExtension is ProtocolAuditExtension
-        assert isinstance(DefaultAuditExtension(), AuditExtension)
-        # Nothing registered: the accessor falls back to the no-op default,
-        # which advertises nothing.
-        assert isinstance(get_audit_extension(), DefaultAuditExtension)
-        assert get_audit_extension().get_export_formats() == []
-
     def test_pre_pr_import_surface_is_intact(self):
         """fix(#873 review r4): the #836 split must not shrink the importable surface.
 
@@ -245,31 +218,12 @@ class TestProtocolDefaults:
         ``.protocols`` were AST-diffed against origin/main; every name present
         pre-split must import from its old path and be the SAME object as the
         canonical symbol. Extend this list rather than letting a review round
-        find the next stripped name; delete the audit-seam rows with the
-        aliases at the next EXTENSION_API_VERSION bump.
+        find the next stripped name.
         """
         import importlib
 
         surface = [
             # (legacy import path, name, canonical module, canonical name)
-            (
-                "app.platform.extensions",
-                "AuditExtension",
-                "app.platform.extensions.protocols",
-                "AuditExtension",
-            ),
-            (
-                "app.platform.extensions",
-                "DefaultAuditExtension",
-                "app.platform.extensions.defaults_extensions",
-                "DefaultAuditExtension",
-            ),
-            (
-                "app.platform.extensions.defaults",
-                "DefaultAuditExtension",
-                "app.platform.extensions.defaults_extensions",
-                "DefaultAuditExtension",
-            ),
             (
                 "app.platform.extensions.defaults",
                 "defer_async_with_tenant",
@@ -296,10 +250,6 @@ class TestProtocolDefaults:
                 f"{legacy_module}.{name} is not the canonical "
                 f"{canonical_module}.{canonical_name}"
             )
-        # The accessor is a callable, not a re-export — assert it separately.
-        from app.platform.extensions import get_audit_extension
-
-        assert callable(get_audit_extension)
 
     def test_pre_pr_wildcard_surface_is_intact(self):
         """fix(#873 review r5): pin the ``import *`` surface of the facade.
@@ -309,14 +259,12 @@ class TestProtocolDefaults:
         classes plus the two incidental helper bindings. The facade's
         ``__all__`` must keep every one of them wildcard-visible; a name
         importable directly but absent from ``__all__`` still NameErrors a
-        star-importing overlay into a silent load_extensions() skip. Drop the
-        audit/helper rows with the seam at the next EXTENSION_API_VERSION bump.
+        star-importing overlay into a silent load_extensions() skip.
         """
         import app.platform.extensions.defaults as defaults_facade
 
         pre_split_wildcard_names = {
             "DefaultAnthropicProvider",
-            "DefaultAuditExtension",
             "DefaultAuditSink",
             "DefaultAuthExtension",
             "DefaultBillingExtension",
@@ -340,35 +288,6 @@ class TestProtocolDefaults:
             "facade __all__ dropped pre-split wildcard-visible names "
             f"(silent star-import regression): {sorted(missing)}"
         )
-
-    def test_audit_alias_dispatch_still_honors_a_registered_overlay(self):
-        """fix(#873 review r3): the v2 slot must BEHAVE, not merely import.
-
-        Until the EXTENSION_API_VERSION bump removes the seam wholesale, an
-        API-v2 overlay registered under the ``audit`` single-slot key must be
-        returned by the accessor — a dispatch-less alias would silently no-op
-        it. Delete this test with the aliases at the bump.
-        """
-        from app.platform.extensions import _extensions, get_audit_extension
-        from app.platform.extensions.defaults import DefaultAuditExtension
-
-        class FakeAuditOverlay:
-            def get_export_formats(self) -> list[str]:
-                return ["overlay-format"]
-
-        previous = _extensions.get("audit")
-        _extensions["audit"] = FakeAuditOverlay()
-        try:
-            ext = get_audit_extension()
-            assert isinstance(ext, FakeAuditOverlay)
-            assert ext.get_export_formats() == ["overlay-format"]
-        finally:
-            if previous is None:
-                _extensions.pop("audit", None)
-            else:
-                _extensions["audit"] = previous
-
-        assert isinstance(get_audit_extension(), DefaultAuditExtension)
 
 
 class TestGetIdentityExtension:
@@ -639,9 +558,6 @@ class TestProtocolOverlayDispatch:
 
         # Post-condition: registry is restored
         assert isinstance(get_branding_extension(), DefaultBrandingExtension)
-
-    # fix(#836): test_audit_extension_overlay_dispatch was deleted together
-    # with the AuditExtension seam it exercised.
 
     def test_auth_extension_overlay_dispatch(self):
         """Phase 276 CODE-03: A registered overlay under 'auth' is returned by the accessor.

--- a/backend/tests/test_phase_279_settings_admin.py
+++ b/backend/tests/test_phase_279_settings_admin.py
@@ -104,5 +104,4 @@ def test_audit_router_rejects_unknown_formats():
     text = router_path.read_text()
     assert "FORMAT_HANDLERS" in text
     assert "HTTP_404_NOT_FOUND" in text
-    assert "get_audit_extension" not in text
     assert "require_enterprise" not in text


### PR DESCRIPTION
## What

Removes the deprecated `AuditExtension` compatibility seam, deferred twice (originally deprecated in #836/#873 with removal promised "at the next EXTENSION_API_VERSION bump"):

- `AuditExtension` protocol — `backend/app/platform/extensions/protocols.py`
- `DefaultAuditExtension` and its export — `defaults_extensions.py` / `defaults.py`
- `get_audit_extension()` accessor and the package-root aliases — `backend/app/platform/extensions/__init__.py`
- the registry's dead `audit` single-slot key (`SINGLE_SLOT_KEYS`)
- the audit-seam rows/tests in `backend/tests/test_extensions.py`: deleted `test_audit_alias_stays_importable_until_version_bump` and `test_audit_alias_dispatch_still_honors_a_registered_overlay` outright (they existed only to cover the alias/dispatch), and stripped the audit rows from `test_pre_pr_import_surface_is_intact` / `test_pre_pr_wildcard_surface_is_intact`
- a now-vacuous `assert "get_audit_extension" not in text` check in `backend/tests/test_phase_279_settings_admin.py` — the symbol no longer exists anywhere to check for
- stale doc-comment cross-references to the removed seam (in `AuditSink`'s docstring and a historical test-deletion note)

`AuditSink` — the live audit integration contract — and everything on the live audit path (`audit_sinks` additive slot, `DefaultAuditSink`, `get_audit_sinks()`) is untouched.

## Why now is safe

Issue #1303 explicitly gated removal on a coordinated `EXTENSION_API_VERSION` bump. That bump happened today: PR #1369 took the version 4→5 (`backend/app/platform/extensions/version.py`) for an unrelated ProcessingPort method — the issue's checklist window was missed by a few hours, but the removal is still safe right now. An overlay declaring `EXTENSION_API_VERSION <= 4` already refuses to load against core's v5 regardless of what this PR removes (`check_extension_api_version`), so only a v5-declaring overlay that imports `AuditExtension`/`get_audit_extension` could break. Step 0 below verifies none exists.

The issue's first checkbox (re-anchoring the stale "while EXTENSION_API_VERSION == 2" comments) was already done by PR #1308 — not repeated here.

## Overlay grep gate (step 0, run before any code change)

For each shipped overlay, fetched `origin` first and grepped the fetched default-branch tree (never a possibly-stale local checkout):

**geolens-enterprise** (`origin/main`, HEAD branch `main`):
```
git -C geolens-enterprise grep -nE 'AuditExtension|get_audit_extension' origin/main -- .
```
Hits only in `.planning/*.md` audit docs (historical, non-code) and a substring coincidence: `EnterpriseAuditExtension`, the overlay's own SIEM class in `geolens_enterprise/audit/siem.py`, which implements the live `AuditSink` protocol — unrelated to the deprecated seam. Restricting to `.py` files returns **zero hits** (`git grep ... -- '*.py'`, exit 1). Declares `EXTENSION_API_VERSION = 2` (`geolens_enterprise/__init__.py:17`, set on the callable).

**geolens-cloud-pin-enterprise** (`origin/main`, HEAD branch `main`): identical picture — same doc-only substring coincidence, zero `.py` hits, `EXTENSION_API_VERSION = 2`.

**geolens-overlays** (`origin/master`, HEAD branch `master`): zero hits anywhere, doc or code (exit 1). Declares `EXTENSION_API_VERSION = 2` (`geolens_cloud/__init__.py:21`).

All three overlays declare version 2, well below core's new version 5, and none reference the deprecated symbols in actual source.

## Verification

```
grep -rnE 'AuditExtension|get_audit_extension' backend/   # zero hits
cd backend && uv run pytest tests/test_extensions.py -v          # 25 passed
cd backend && uv run pytest tests/test_phase_279_settings_admin.py -v  # 6 passed
cd backend && uv run pytest tests/test_layering.py -q            # 40 passed
cd backend && uv run ruff check .                                 # all checks passed
cd backend && uv run ruff format --check .                        # all formatted
```

Fixes #1303