### PR TITLE
fix(raster): serialize crs_wkt as WKT2_2019 at both ingest paths and backfill

### DIFF
--- a/backend/alembic/versions/0041_raster_assets_crs_wkt2.py
+++ b/backend/alembic/versions/0041_raster_assets_crs_wkt2.py
@@ -1,0 +1,130 @@
+"""Convert stored raster_assets.crs_wkt from WKT1_GDAL to WKT2:2019.
+
+fix(#1376): ``RasterAsset.to_stac_properties()`` publishes ``crs_wkt``
+verbatim as the STAC Projection Extension's ``proj:wkt2``, but both writers
+of the column asked rasterio for its DEFAULT serialization, which is
+WKT1_GDAL (``PROJCS[...]``, not ``PROJCRS[...]``). Both now request
+``version="WKT2_2019"`` — ``processing/raster/cog.py`` for local uploads and
+``modules/catalog/sources/cog_info.py`` for the remote-asset probe.
+
+Why the rows get backfilled rather than left to drift. Fixing only the
+writers would make the dialect a function of INGEST ERA: a consumer reading
+``proj:wkt2`` off this catalog could no longer assume one format for the
+field, and nothing in a row says which era wrote it. Re-ingest is the only
+other way a row would ever change, and a stable raster has no reason to be
+re-ingested. So the conversion happens once, here, and the column means one
+thing afterwards.
+
+Idempotent by construction: the predicate matches WKT1 root keywords only,
+and every row this migration rewrites leaves that predicate (WKT2 roots are
+``PROJCRS``/``GEOGCRS``/``GEODCRS``/``ENGCRS``/``COMPOUNDCRS``/``VERTCRS``).
+A row whose stored WKT PROJ cannot parse is left exactly as it was — an
+unreadable CRS is not a reason to fail a deployment, and the value is no
+worse off than before.
+
+Downgrade is a deliberate no-op. WKT1 is the strictly less expressive
+dialect, so the pre-migration bytes are not faithfully recoverable, and
+nothing reads this column expecting WKT1: the two consumers
+(``core/geo.py``'s ``wkt_is_geographic``/``wkt_has_degree_unit``) hand it to
+PROJ and their keyword fallback already recognises both dialects.
+
+Revision ID: 0041_raster_assets_crs_wkt2
+Revises: 0040_dataset_origin_ref_indexes
+Create Date: 2026-08-10
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0041_raster_assets_crs_wkt2"
+down_revision: Union[str, None] = "0040_dataset_origin_ref_indexes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Every WKT1 root keyword, not just the projected/geographic pair: each has a
+# DISTINCT WKT2 counterpart, so matching the whole set converts the column
+# completely instead of leaving a second dialect behind on the rarer CRS
+# kinds. The ``\[`` anchor is what keeps ``GEOGCS`` from also matching a
+# ``GEOGCRS[`` prefix (likewise PROJCS/PROJCRS). Case-insensitive because WKT
+# keywords are case-insensitive per spec, even though GDAL writes them upper.
+_WKT1_ROOT_RE = r"^\s*(PROJCS|GEOGCS|GEOCCS|LOCAL_CS|COMPD_CS|VERT_CS|FITTED_CS)\s*\["
+
+# Keyset-paged rather than read whole. raster_assets holds one row per raster
+# dataset and each WKT is a few kB, which is small on any install this project
+# has seen — but a single SELECT of the entire matching set is the kind of
+# thing that only fails on the largest catalog, i.e. the one where a failed
+# migration costs the most. Paging by ``id`` also steps PAST rows this
+# migration deliberately leaves unconverted, so an unparseable row cannot be
+# re-selected forever.
+_BATCH_SIZE = 500
+
+
+def upgrade() -> None:
+    import logging
+
+    from rasterio.crs import CRS
+
+    log = logging.getLogger("alembic.runtime.migration")
+    conn = op.get_bind()
+
+    converted = 0
+    unparseable: list[str] = []
+    last_id = None
+
+    while True:
+        sql = (
+            "SELECT id, crs_wkt FROM catalog.raster_assets "
+            "WHERE crs_wkt IS NOT NULL AND crs_wkt ~* :wkt1_root"
+        )
+        params: dict = {"wkt1_root": _WKT1_ROOT_RE, "batch": _BATCH_SIZE}
+        if last_id is not None:
+            sql += " AND id > :last_id"
+            params["last_id"] = last_id
+        sql += " ORDER BY id LIMIT :batch"
+
+        rows = conn.execute(sa.text(sql), params).all()
+        if not rows:
+            break
+        last_id = rows[-1][0]
+
+        for asset_id, wkt1 in rows:
+            try:
+                wkt2 = CRS.from_wkt(wkt1).to_wkt(version="WKT2_2019")
+            except Exception:  # broad: crs_wkt is whatever GDAL wrote at ingest — any PROJ failure means "leave this row alone", not "abort the deployment"
+                wkt2 = None
+            # The equality check keeps the promise the predicate makes: only a
+            # value that actually CHANGED gets written, so a hypothetical CRS
+            # whose WKT2 export still carries a WKT1 root keyword is recorded
+            # as unconverted rather than rewritten to itself on every run.
+            if not wkt2 or wkt2 == wkt1:
+                unparseable.append(str(asset_id))
+                continue
+            conn.execute(
+                sa.text(
+                    "UPDATE catalog.raster_assets SET crs_wkt = :wkt WHERE id = :id"
+                ),
+                {"wkt": wkt2, "id": asset_id},
+            )
+            converted += 1
+
+    log.info("raster_assets.crs_wkt converted to WKT2:2019: %d row(s)", converted)
+    if unparseable:
+        log.warning(
+            "raster_assets.crs_wkt left as WKT1 on %d row(s) PROJ could not "
+            "convert (ids: %s). These publish a WKT1 string under proj:wkt2 "
+            "until the raster is re-ingested.",
+            len(unparseable),
+            ", ".join(unparseable),
+        )
+
+
+def downgrade() -> None:
+    """No-op — see the module docstring.
+
+    WKT1 cannot express everything WKT2 can, so re-serializing these values
+    back would not restore the bytes this migration replaced, and no reader of
+    the column requires WKT1.
+    """

--- a/backend/app/modules/catalog/sources/cog_info.py
+++ b/backend/app/modules/catalog/sources/cog_info.py
@@ -34,6 +34,12 @@ def _georeferencing(info: dict) -> dict:
     the WKT round-trips through the same ``rasterio.crs.CRS`` every other
     ingest path already writes ``crs_wkt`` from (``raster/cog.py``).
 
+    fix(#1376): the version is explicit because ``crs_wkt`` is published as
+    the STAC Projection Extension's ``proj:wkt2`` and rasterio's default
+    export is WKT1_GDAL. ``raster/cog.py`` asks for the same version, and
+    migration ``0041`` converted the rows written before either did, so the
+    column carries one dialect no matter which path or era produced a row.
+
     fix(#1334 review): both keys come off the SAME parsed ``CRS`` object, on
     purpose. The caller's other source for a raster's EPSG is the STAC
     item's own ``proj:code``/``proj:epsg`` — the PUBLISHER's claim about the
@@ -76,7 +82,7 @@ def _georeferencing(info: dict) -> dict:
             from rasterio.crs import CRS
 
             parsed = CRS.from_user_input(crs_value)
-            crs_wkt = parsed.to_wkt()
+            crs_wkt = parsed.to_wkt(version="WKT2_2019")
             epsg = parsed.to_epsg()
         except (
             Exception

--- a/backend/app/processing/raster/cog.py
+++ b/backend/app/processing/raster/cog.py
@@ -284,7 +284,16 @@ def extract_raster_metadata(file_path: str) -> dict:
 
     with rasterio.open(file_path) as src:
         crs = src.crs
-        crs_wkt = crs.to_wkt() if crs else None
+        # fix(#1376): explicitly WKT2, because this value is what
+        # RasterAsset.to_stac_properties() publishes as the STAC Projection
+        # Extension's `proj:wkt2`. rasterio's default is WKT1_GDAL
+        # (`PROJCS[...]`), which a strict consumer of a wkt2-named field may
+        # reject. The remote-asset probe (catalog/sources/cog_info.py) asks
+        # for the same version, so the column is one dialect regardless of
+        # how the raster was ingested. WKT2 also expresses strictly more than
+        # WKT1 — nothing GDAL can open exports here but not there — so this
+        # narrows no input.
+        crs_wkt = crs.to_wkt(version="WKT2_2019") if crs else None
         epsg = crs.to_epsg() if crs else None
 
         bounds_wgs84 = _wgs84_bbox(src)

--- a/backend/tests/test_cog_info.py
+++ b/backend/tests/test_cog_info.py
@@ -87,6 +87,17 @@ class TestGeoreferencing:
         assert result["crs_wkt"] is not None
         assert "32621" in result["crs_wkt"]
 
+    async def test_crs_wkt_is_serialized_as_wkt2(self, monkeypatch) -> None:
+        """fix(#1376): this value reaches ``RasterAsset.crs_wkt``, which
+        ``to_stac_properties()`` publishes as ``proj:wkt2``. rasterio's
+        default export is WKT1_GDAL, so the version has to be asked for —
+        and the root keyword is the whole difference a strict consumer sees
+        (``PROJCS[`` vs ``PROJCRS[``)."""
+        _install(monkeypatch, _TITILER_INFO)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["crs_wkt"].startswith("PROJCRS[")
+
     async def test_epsg_comes_from_the_same_parsed_crs_as_the_wkt(
         self, monkeypatch
     ) -> None:

--- a/backend/tests/test_crs_wkt2_backfill_1376.py
+++ b/backend/tests/test_crs_wkt2_backfill_1376.py
@@ -1,0 +1,202 @@
+"""Migration 0041's backfill of raster_assets.crs_wkt (#1376).
+
+The two writers of the column now ask rasterio for ``WKT2_2019``
+(``processing/raster/cog.py`` for local uploads, ``catalog/sources/
+cog_info.py`` for the remote probe; each is pinned in its own test file).
+This file covers the OTHER half of the single-dialect claim: the rows that
+were already stored when those writers still emitted WKT1_GDAL.
+
+The round trip is real — ``alembic downgrade -1`` (0041's downgrade is a
+documented no-op) followed by ``alembic upgrade head`` re-runs the backfill
+over rows this test committed first, through the same alembic.ini/env.py
+stack CI uses. Testing the conversion helper in isolation would prove PROJ
+converts WKT, which was never in doubt; what needs proving is that the
+migration's predicate SELECTS the right rows and its loop survives one it
+cannot convert.
+
+Run with: cd backend && set -a && source ../.env.test && set +a &&
+          uv run pytest tests/test_crs_wkt2_backfill_1376.py -x -q
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import sqlalchemy as sa
+
+from tests.alembic_helpers import run_alembic as _run_alembic
+from tests.factories import create_dataset, get_user_id
+
+pytestmark = pytest.mark.anyio
+
+
+def _enterprise_migrations_present() -> bool:
+    """Mirror the sibling migration files' overlay skip: a multi-head alembic
+    cannot disambiguate ``head`` / ``-1``, so the round trip runs in the
+    no-overlay job."""
+    import pathlib
+    from importlib.metadata import entry_points
+
+    for ep in entry_points(group="geolens.migrations"):
+        try:
+            fn = ep.load()
+            if callable(fn) and any(pathlib.Path(p).is_dir() for p in fn()):
+                return True
+        except Exception:
+            pass
+    return False
+
+
+_SKIP_UNDER_OVERLAY = pytest.mark.skipif(
+    _enterprise_migrations_present(),
+    reason=(
+        "OSS migration round trip; multi-head under the enterprise overlay — "
+        "runs in the no-overlay Pytest Parallel Isolation job instead."
+    ),
+)
+
+# A real WKT1_GDAL string of the shape every pre-#1376 ingest wrote.
+_WKT1_UTM_21N = (
+    'PROJCS["WGS 84 / UTM zone 21N",GEOGCS["WGS 84",DATUM["WGS_1984",'
+    'SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],'
+    'AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],'
+    'UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],'
+    'AUTHORITY["EPSG","4326"]],PROJECTION["Transverse_Mercator"],'
+    'PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-57],'
+    'PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],'
+    'PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],'
+    'AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","32621"]]'
+)
+
+# WKT1-SHAPED but not parseable as a CRS: it matches the migration's
+# predicate and must still be left exactly as stored. Truncated rather than
+# invented, because PROJ is far more tolerant than it looks — a made-up
+# ``LOCAL_CS["...",NONSENSE[1,2,3]]`` parses fine and converts to ``ENGCRS``,
+# so only a structurally broken string reaches the skip branch. Same shape
+# ``test_wkt_is_geographic.py`` uses for its unparseable case.
+_WKT1_SHAPED_GARBAGE = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84"'
+
+
+async def _fresh_query(query: str, params: dict | None = None):
+    """Read committed state on an autocommit connection.
+
+    The alembic subprocess commits outside the test session's transaction, so
+    the session's snapshot cannot see what the migration wrote (same reason
+    ``test_email_verification_migration.py`` carries this helper).
+    """
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.core.config import settings
+
+    engine = create_async_engine(
+        settings.test_database_url, isolation_level="AUTOCOMMIT"
+    )
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(sa.text(query), params or {})
+            return result.fetchall() if result.returns_rows else []
+    finally:
+        await engine.dispose()
+
+
+async def _seed_raster_asset(session, admin_id: uuid.UUID, crs_wkt: str) -> uuid.UUID:
+    """Commit one dataset + raster_asset pair holding ``crs_wkt``.
+
+    One dataset per asset: ``uq_raster_assets_dataset`` allows a dataset only
+    one raster asset.
+    """
+    dataset = await create_dataset(
+        session,
+        created_by=admin_id,
+        name=f"wkt2 backfill {uuid.uuid4().hex[:8]}",
+        source_format="geotiff",
+        source_filename="scene.tif",
+    )
+    asset_id = uuid.uuid4()
+    await session.execute(
+        sa.text(
+            "INSERT INTO catalog.raster_assets (id, dataset_id, asset_uri, crs_wkt) "
+            "VALUES (:id, :dataset_id, :asset_uri, :crs_wkt)"
+        ),
+        {
+            "id": asset_id,
+            "dataset_id": dataset.id,
+            "asset_uri": f"rasters/{asset_id}/source.cog.tif",
+            "crs_wkt": crs_wkt,
+        },
+    )
+    await session.commit()
+    return asset_id
+
+
+@_SKIP_UNDER_OVERLAY
+class TestCrsWkt2Backfill:
+    async def test_backfill_converts_wkt1_and_leaves_the_rest_alone(
+        self, test_db_session
+    ):
+        """One round trip, three row shapes.
+
+        They share a migration run on purpose: the interesting question is
+        not how each row fares alone but whether the row PROJ cannot convert
+        stops the loop before it reaches the others.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+
+        wkt1_id = await _seed_raster_asset(test_db_session, admin_id, _WKT1_UTM_21N)
+        garbage_id = await _seed_raster_asset(
+            test_db_session, admin_id, _WKT1_SHAPED_GARBAGE
+        )
+        # Already WKT2 — the state a post-#1376 ingest writes, and the state
+        # every converted row is in on a second run. It must come out byte
+        # identical, which is what makes the migration re-runnable.
+        from rasterio.crs import CRS
+
+        already_wkt2 = CRS.from_wkt(_WKT1_UTM_21N).to_wkt(version="WKT2_2019")
+        wkt2_id = await _seed_raster_asset(test_db_session, admin_id, already_wkt2)
+
+        try:
+            down = _run_alembic("downgrade", "-1")
+            assert down.returncode == 0, (
+                f"alembic downgrade -1 failed (rc={down.returncode}):\n"
+                f"stdout: {down.stdout}\nstderr: {down.stderr}"
+            )
+            up = _run_alembic("upgrade", "head")
+            assert up.returncode == 0, (
+                f"alembic upgrade head failed (rc={up.returncode}):\n"
+                f"stdout: {up.stdout}\nstderr: {up.stderr}"
+            )
+
+            rows = await _fresh_query(
+                "SELECT id, crs_wkt FROM catalog.raster_assets "
+                "WHERE id IN (:a, :b, :c)",
+                {"a": wkt1_id, "b": garbage_id, "c": wkt2_id},
+            )
+            stored = {row.id: row.crs_wkt for row in rows}
+
+            assert stored[wkt1_id].startswith("PROJCRS["), (
+                "the WKT1 row is what the backfill exists for"
+            )
+            assert "32621" in stored[wkt1_id], (
+                "converting the dialect must not lose the CRS identity"
+            )
+            assert stored[garbage_id] == _WKT1_SHAPED_GARBAGE, (
+                "a row PROJ cannot parse is left as stored, not blanked"
+            )
+            assert stored[wkt2_id] == already_wkt2, (
+                "an already-WKT2 row is outside the predicate and untouched"
+            )
+        finally:
+            restore = _run_alembic("upgrade", "head")
+            # The unconvertible row is deliberately hostile input; leaving it
+            # in a per-worker database that later tests share would hand them
+            # a WKT no reader can parse. Their datasets stay — an ordinary
+            # committed dataset is fixture noise every test here leaves.
+            await _fresh_query(
+                "DELETE FROM catalog.raster_assets WHERE id IN (:a, :b, :c)",
+                {"a": wkt1_id, "b": garbage_id, "c": wkt2_id},
+            )
+            assert restore.returncode == 0, (
+                f"alembic upgrade head (restore) failed (rc={restore.returncode}):\n"
+                f"stdout: {restore.stdout}\nstderr: {restore.stderr}"
+            )

--- a/backend/tests/test_crs_wkt2_backfill_1376.py
+++ b/backend/tests/test_crs_wkt2_backfill_1376.py
@@ -130,6 +130,75 @@ async def _seed_raster_asset(session, admin_id: uuid.UUID, crs_wkt: str) -> uuid
     return asset_id
 
 
+def _wkt1_root_re() -> str:
+    """The migration's predicate, loaded from the migration itself.
+
+    Copying the pattern here would let the two drift, and a predicate that
+    silently stopped matching would show up as a migration that converts
+    nothing — which looks exactly like a database that had nothing to
+    convert.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "0041_raster_assets_crs_wkt2.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0041", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module._WKT1_ROOT_RE
+
+
+class TestWkt1Predicate:
+    """Which rows the backfill claims, evaluated by postgres rather than by
+    a Python re-implementation of its regex dialect.
+
+    The round trip above proves the loop; this proves its WHERE clause, on
+    the CRS kinds too rare to seed a row for. The pairs that matter are the
+    WKT1/WKT2 near-twins — ``GEOGCS`` against ``GEOGCRS``, ``PROJCS``
+    against ``PROJCRS`` — where only the ``\\[`` anchor separates a match
+    from a prefix match, and getting that wrong would rewrite already-WKT2
+    rows on every run.
+    """
+
+    @pytest.mark.parametrize(
+        ("value", "matches"),
+        [
+            ('PROJCS["x"]', True),
+            ('GEOGCS["x"]', True),
+            ('GEOCCS["x"]', True),
+            ('LOCAL_CS["x"]', True),
+            ('COMPD_CS["x"]', True),
+            ('VERT_CS["x"]', True),
+            ('FITTED_CS["x"]', True),
+            ('  \n GEOGCS["leading whitespace"]', True),
+            ('geogcs["lowercase — WKT keywords are case-insensitive"]', True),
+            ('GEOGCS ["space before the bracket"]', True),
+            ('PROJCRS["x"]', False),
+            ('GEOGCRS["x"]', False),
+            ('GEODCRS["x"]', False),
+            ('ENGCRS["x"]', False),
+            ('COMPOUNDCRS["x"]', False),
+            ('VERTCRS["x"]', False),
+            # Already WKT2 at the root, with a WKT1-spelled CRS nested
+            # inside it. The predicate reads the ROOT keyword, so this is
+            # correctly left alone — converting it would be a no-op at best.
+            ('BOUNDCRS[SOURCECRS[GEOGCS["nested"]]]', False),
+        ],
+    )
+    async def test_the_predicate_matches_wkt1_roots_only(self, value, matches):
+        rows = await _fresh_query(
+            "SELECT :value ~* :pattern AS matched",
+            {"value": value, "pattern": _wkt1_root_re()},
+        )
+        assert rows[0].matched is matches
+
+
 @_SKIP_UNDER_OVERLAY
 class TestCrsWkt2Backfill:
     async def test_backfill_converts_wkt1_and_leaves_the_rest_alone(

--- a/backend/tests/test_raster_ingest.py
+++ b/backend/tests/test_raster_ingest.py
@@ -147,6 +147,28 @@ class TestExtractRasterMetadata:
         finally:
             tif.unlink(missing_ok=True)
 
+    @pytest.mark.parametrize(
+        ("epsg", "wkt2_root"),
+        [(4326, "GEOGCRS["), (3857, "PROJCRS[")],
+    )
+    def test_crs_wkt_is_serialized_as_wkt2(self, epsg, wkt2_root, tmp_path):
+        """fix(#1376): the local-upload path stores this in
+        ``RasterAsset.crs_wkt``, which ``to_stac_properties()`` publishes as
+        the STAC Projection Extension's ``proj:wkt2``. rasterio's default
+        export is WKT1_GDAL (``GEOGCS[``/``PROJCS[``), so the version has to
+        be asked for. Both CRS classes are covered because WKT1 and WKT2 use
+        a different root keyword for each, and the remote-asset probe
+        (``test_cog_info.py``) pins the same property on the other writer —
+        between them the column is one dialect whichever path filled it."""
+        tif = _write_tmp_tif(crs=CRS.from_epsg(epsg))
+        try:
+            from app.processing.raster.cog import extract_raster_metadata
+
+            meta = extract_raster_metadata(str(tif))
+            assert meta["crs_wkt"].startswith(wkt2_root)
+        finally:
+            tif.unlink(missing_ok=True)
+
     def test_nodata_captured(self, tmp_path):
         tif = _write_tmp_tif(nodata=255.0)
         try:


### PR DESCRIPTION
## What

`RasterAsset.to_stac_properties()` publishes `raster_assets.crs_wkt` verbatim as the STAC Projection Extension's `proj:wkt2`, but both writers of the column asked rasterio for its default serialization — which is WKT1_GDAL (`PROJCS[...]`), not WKT2 (`PROJCRS[...]`). A strict consumer parsing a `wkt2`-named field as WKT2 can reject or misinterpret it.

Both call sites change together, because fixing either alone splits the column into two dialects with nothing on a row to say which one it holds:

- `backend/app/processing/raster/cog.py` — the local-upload path, which has written WKT1 for as long as `crs_wkt` has existed (every raster GeoLens has ever ingested locally).
- `backend/app/modules/catalog/sources/cog_info.py` — the remote-asset probe added in #1374.

## Backfill

Migration `0041_raster_assets_crs_wkt2` converts the rows already stored, so the dialect is not a function of ingest era either. Re-ingest is the only other way a row would ever change, and a stable raster has no reason to be re-ingested.

- Plain transactional statements only — no `CREATE INDEX CONCURRENTLY`, no autocommit block.
- Predicate matches the full set of WKT1 root keywords (`PROJCS`/`GEOGCS`/`GEOCCS`/`LOCAL_CS`/`COMPD_CS`/`VERT_CS`/`FITTED_CS`), anchored with `\[` so `GEOGCS` cannot also match a `GEOGCRS[` prefix.
- Idempotent by construction: every rewritten row leaves the predicate, since WKT2 roots are `PROJCRS`/`GEOGCRS`/`GEODCRS`/`ENGCRS`/`COMPOUNDCRS`/`VERTCRS`.
- Keyset-paged by `id`, which also steps past rows it deliberately leaves alone.
- A row PROJ cannot parse is left exactly as stored and logged as a warning; an unreadable CRS is not a reason to fail a deployment.
- Downgrade is a documented no-op: WKT1 is the less expressive dialect, so the original bytes are not recoverable, and both readers of the column (`core/geo.py`'s `wkt_is_geographic` / `wkt_has_degree_unit`) already handle either dialect.

Verified on the test database: the migration converted 64 pre-existing rows.

## Tests

- `tests/test_raster_ingest.py` — the local path stores a WKT2 root keyword, parametrized over a geographic and a projected CRS (`GEOGCRS[` / `PROJCRS[`), since WKT1 and WKT2 differ in the root keyword for each class.
- `tests/test_cog_info.py` — the same property on the remote probe.
- `tests/test_crs_wkt2_backfill_1376.py` (new) — a real `alembic downgrade -1` / `upgrade head` round trip over three committed row shapes in one migration run: a WKT1 row converts and keeps its EPSG identity, a structurally broken WKT1-shaped row survives untouched (and does not stop the loop before the others), and an already-WKT2 row comes out byte-identical.

Worth recording from writing that last one: PROJ is far more tolerant than it looks. An invented `LOCAL_CS["...",NONSENSE[1,2,3]]` parses cleanly and converts to `ENGCRS[...]`; only a structurally broken string (truncated mid-record) reaches the skip branch.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && \
  uv run pytest tests/test_cog_info.py tests/test_raster_ingest.py \
    tests/test_crs_wkt2_backfill_1376.py -q                      # 35 passed
  uv run pytest tests/test_layering.py tests/test_rule1_structural.py \
    tests/test_rule2_structural.py -q                            # 122 passed
  uv run pytest tests/test_stac_import.py tests/test_stac_refresh_1266.py \
    tests/test_raster_tiles.py tests/test_wkt_is_geographic.py \
    tests/test_crs_degree_agreement.py tests/test_vrt_rewrite.py \
    tests/test_regenerate_vrt_integration.py tests/test_raster_schema.py -q   # 256 passed
  uv run pytest tests/test_email_verification_migration.py tests/test_alembic_helpers.py \
    tests/test_origin_ref_indexes.py tests/test_dataset_source_state.py \
    tests/test_raster_replace_1221.py tests/test_cog_band_unit_capture.py \
    tests/test_raster_antimeridian_887.py -q                     # 376 passed
  PYTHONPATH=. uv run alembic upgrade head                       # applied 0041
  PYTHONPATH=. uv run alembic check                              # no new upgrade operations
  uv run ruff check . && uv run ruff format --check .            # clean
```

No schema change, so no `openapi.json` / SDK regeneration.

Fixes #1376