### PR TITLE
fix(tiles): roll the shared nginx raster cache when a replace bumps tile_cache_version

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -79,7 +79,14 @@ def _build_raster_metadata(
     # desktop GIS tools cannot send headers — this placeholder is the sanctioned
     # remaining use of the lane.
     tile_url_path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
-    tile_url_meta = tile_url_path
+    # fix(#1372): `v` is the tile_cache_version — nginx's raster_cache keys on
+    # $arg_v, so a raster replace rolls the shared cache immediately. The
+    # connect URL stays unversioned: it is copied once into desktop GIS tools,
+    # where a frozen `v` would pin exactly the staleness it exists to bust.
+    tile_version = getattr(dataset, "tile_cache_version", None)
+    tile_url_meta = (
+        f"{tile_url_path}?v={tile_version}" if tile_version else tile_url_path
+    )
 
     if base_url:
         tile_url_connect = f"{base_url}{tile_url_path}?api_key={{your_key}}"

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -419,6 +419,10 @@ def _build_shared_layer_dict(
     is_public = ds_visibility == "public"
     if ds_record_type in RASTER_FAMILY_RECORD_TYPES:
         tile_url = f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png"
+        # fix(#1372): version the raster template so nginx's $arg_v cache-key
+        # segment rolls the shared tile cache when a replace bumps the version.
+        if ds_tile_version:
+            tile_url = f"{tile_url}?v={ds_tile_version}"
     else:
         # Phase 273 SEC-16 / L-62: previous public-vs-private branch produced
         # `/tiles/public/data.{table_name}/...`, but no such route is mounted

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -370,7 +370,12 @@ def _tile_url_for_layer(layer: MapLayerResponse) -> str:
         layer.layer_type == "raster_geolens"
         or layer.dataset_record_type in RASTER_FAMILY_RECORD_TYPES
     ):
-        return f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png"
+        url = f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png"
+        # fix(#1372): version the raster template so nginx's $arg_v cache-key
+        # segment rolls the shared tile cache when a replace bumps the version.
+        if layer.tile_version:
+            url = f"{url}?v={layer.tile_version}"
+        return url
     port = get_catalog_port()
     exp = port.round_tile_expiry()
     scope = tenant_bound_scope(layer.dataset_table_name)

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -848,11 +848,16 @@ async def list_collections(
                 }
             )
         else:
+            # fix(#1372 codex r2): versioned like every rendered template so a
+            # refetching client stops sharing the unversioned cache entry.
+            raster_tiles_path = f"/raster-tiles/{ds.id}/tiles/{{z}}/{{x}}/{{y}}.png"
+            if ds.tile_cache_version:
+                raster_tiles_path = f"{raster_tiles_path}?v={ds.tile_cache_version}"
             links.append(
                 {
                     "rel": "tiles",
                     "href": build_url(
-                        f"/raster-tiles/{ds.id}/tiles/{{z}}/{{x}}/{{y}}.png",
+                        raster_tiles_path,
                         base_url=public_app_url,
                     ),
                     "type": "image/png",

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -118,9 +118,16 @@ def build_assets(
 
     elif record_type in RASTER_FAMILY_RECORD_TYPES:
         # Raster tile endpoint -- served at the public APP origin, not /api.
+        # fix(#1372 codex r2): versioned like every rendered template — these
+        # documents are generated per request, so a refetching STAC/OGC client
+        # gets a fresh v and stops sharing the unversioned cache entry.
+        raster_tiles_path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
+        tile_version = getattr(dataset, "tile_cache_version", None)
+        if tile_version:
+            raster_tiles_path = f"{raster_tiles_path}?v={tile_version}"
         assets["raster_tiles"] = {
             "href": build_url(
-                f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png",
+                raster_tiles_path,
                 base_url=(public_app_url or public_api_url),
             ),
             "type": "image/png",

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1302,7 +1302,13 @@ def _build_tile_token_for_dataset(
         raster_scope = tenant_bound_scope(str(dataset.id))
         raster_sig = generate_tile_signature(raster_scope, raster_exp)
         tile_path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
-        query = urlencode({"sig": raster_sig, "exp": raster_exp, "scope": raster_scope})
+        # fix(#1372): `v` rides outside the signature (which binds scope+exp
+        # only, like the colormap params) and feeds nginx's $arg_v cache-key
+        # segment, so a raster replace rolls the shared tile cache.
+        query_params = {"sig": raster_sig, "exp": raster_exp, "scope": raster_scope}
+        if dataset.tile_cache_version:
+            query_params["v"] = dataset.tile_cache_version
+        query = urlencode(query_params)
 
         return RasterTileToken(
             kind="raster",

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -292,6 +292,7 @@ class _RasterMeta(NamedTuple):
     is_dem: bool | None
     band_info: list | None
     nodata: str | None
+    tile_cache_version: int
 
 
 # WR-02 (Phase 1210): bounded LRU — mirrors the vector _dataset_cache (PERF-006).
@@ -706,7 +707,8 @@ async def _resolve_raster_meta(
                 ra.dtype,
                 ra.is_dem,
                 ra.band_info,
-                ra.nodata
+                ra.nodata,
+                d.tile_cache_version
             FROM catalog.datasets d
             JOIN catalog.records r ON d.record_id = r.id
             LEFT JOIN catalog.raster_assets ra ON ra.dataset_id = d.id
@@ -744,6 +746,7 @@ async def _resolve_raster_meta(
         is_dem=row["is_dem"],
         band_info=row["band_info"],
         nodata=row["nodata"],
+        tile_cache_version=row["tile_cache_version"] or 1,
     )
     with _raster_meta_cache_lock:
         _raster_meta_cache[cache_key] = (now, meta)
@@ -922,6 +925,22 @@ async def raster_auth_check(
         if _is_publicly_cacheable(meta.visibility, meta.record_status)
         else "private"
     )
+    # fix(#1372 codex r3): a shared-cache entry must only ever be written under
+    # the dataset's CURRENT tile_cache_version. The counter is advertised in
+    # public URLs and increments predictably, so an unvalidated `v` would let a
+    # caller pre-warm the NEXT version's cache key with pre-replace bytes and
+    # defeat the invalidation for a full TTL. A mismatched `v` still serves —
+    # a stale tab keeps rendering current bytes — but as `private, no-store`,
+    # so the wrong key is never populated. Compared against the same cached
+    # meta snapshot the bytes come from (`_RASTER_META_CACHE_TTL` note above),
+    # so version and content can never disagree within one response.
+    v_param = request.query_params.get("v")
+    if (
+        cache_status == "public"
+        and v_param is not None
+        and v_param != str(meta.tile_cache_version)
+    ):
+        cache_status = "private"
     if meta.is_dem:
         # DEM terrain: use terrainrgb algorithm with NO rescale — the algorithm
         # reads raw elevation values and encodes them into RGB channels directly.

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -934,11 +934,23 @@ async def raster_auth_check(
     # so the wrong key is never populated. Compared against the same cached
     # meta snapshot the bytes come from (`_RASTER_META_CACHE_TTL` note above),
     # so version and content can never disagree within one response.
-    v_param = request.query_params.get("v")
+    #
+    # fix(#1372 codex r4): the match must mirror nginx's `$arg_v` semantics,
+    # not Starlette's. nginx keys on the FIRST occurrence and matches the
+    # param NAME case-insensitively; `QueryParams.get()` returns the LAST
+    # occurrence of an exact-case name — so `?v=<future>&v=<current>` (or
+    # `?V=<future>`) would pass a naive check while nginx keys on the future
+    # value. Cacheable requires exactly one case-insensitive `v`, equal to
+    # the current version; anything else is served no-store.
+    v_values = [
+        value
+        for name, value in request.query_params.multi_items()
+        if name.lower() == "v"
+    ]
     if (
         cache_status == "public"
-        and v_param is not None
-        and v_param != str(meta.tile_cache_version)
+        and v_values
+        and (len(v_values) != 1 or v_values[0] != str(meta.tile_cache_version))
     ):
         cache_status = "private"
     if meta.is_dem:

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -373,11 +373,16 @@ async def get_dataset_collection(
         # APP origin (/raster-tiles/...), which nginx rewrites to the internal
         # tile proxy; the /api origin has no such route, so use public_app_url.
         public_app_url = await get_public_app_url(db, request=request)
+        # fix(#1372 codex r2): versioned like every rendered template so a
+        # refetching client stops sharing the unversioned cache entry.
+        raster_tiles_path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
+        if dataset.tile_cache_version:
+            raster_tiles_path = f"{raster_tiles_path}?v={dataset.tile_cache_version}"
         links.append(
             OGCLink(
                 rel="tiles",
                 href=build_url(
-                    f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png",
+                    raster_tiles_path,
                     base_url=public_app_url,
                 ),
                 type="image/png",

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1619,7 +1619,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # through the visibility-filtered OGC search representation, including
         # JSON-safe datetime serialization for the OGC and STAC response paths.
         # Cap 505 -> 512, exact.
-        "backend/app/modules/catalog/search/service_records.py": 512,
+        # fix(#1372 codex r2): +7 — the advertised raster_tiles asset carries
+        # ?v=<tile_cache_version> like every rendered raster template.
+        "backend/app/modules/catalog/search/service_records.py": 519,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in
         # _run_rrf_merge (perf audit 2026-07-10 §2d). Cap 350 → 390
@@ -2891,7 +2893,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # payload structure; `GET /datasets/{id}` had been building its assets
     # straight off the ORM rows and leaked the archived original's href and
     # filename to every viewer. Cap 1440 -> 1450, exact.
-    "backend/app/modules/catalog/search/router.py": 1450,
+    # fix(#1372 codex r2): +5 — the collections-list raster tiles link carries
+    # ?v=<tile_cache_version> like every rendered raster template.
+    "backend/app/modules/catalog/search/router.py": 1455,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1605,7 +1605,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # raw aggregate (which is NULL, not 0, for a map with no ACTIVE embed
         # token — and the count never exceeds 1, per the partial unique index).
         # Cap 914 -> 983, exact.
-        "backend/app/modules/catalog/maps/service_public.py": 983,
+        # fix(#1372): +4 — the shared-layer raster tile template carries
+        # ?v=<tile_cache_version>, the segment nginx's raster cache keys on.
+        "backend/app/modules/catalog/maps/service_public.py": 987,
         # fix(#1290 review): +5 — PUBLIC_ASSET_KEYS and the guard that reads it.
         # _build_stac_assets published every dataset_assets row it was handed,
         # so the first INTERNAL key (archived_original, the pre-conversion
@@ -1875,7 +1877,9 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # tuple and not `Exception`: `_tile_url_for_layer` raises RuntimeError with
     # no tenant context, and swallowing that would turn a fail-closed refusal
     # into a quietly missing layer in a hosted export.
-    "backend/app/modules/catalog/maps/style_json.py": 1615,
+    # fix(#1372): +5 — exported raster/DEM sources carry ?v=<tile_cache_version>
+    # so external MapLibre consumers roll the shared nginx cache on replace.
+    "backend/app/modules/catalog/maps/style_json.py": 1620,
     "backend/app/modules/catalog/maps/style_import.py": 450,
     "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
     "backend/app/modules/catalog/maps/router_assets.py": 126,
@@ -2940,7 +2944,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # _resolve_raster_access via _has_tile_signature/_verify_raster_tile_signature).
     # Before this a client following the contract literally received an
     # unauthenticated template for a private raster. Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2154,
+    # fix(#1372): +6 — the signed raster template also carries
+    # ?v=<tile_cache_version> (outside the signature, like the colormap
+    # params) so nginx's $arg_v cache-key segment rolls on replace.
+    "backend/app/processing/tiles/router.py": 2160,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2954,7 +2954,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1372 codex r3): +19 — the auth check refuses to mark a response
     # cacheable when its `v` mismatches the dataset's current version, so a
     # predictable future key can never be pre-warmed with pre-replace bytes.
-    "backend/app/processing/tiles/router.py": 2179,
+    # fix(#1372 codex r4): +12 — the check mirrors nginx's $arg_v semantics
+    # (first occurrence, case-insensitive name), closing the duplicate-param
+    # and name-case parser-disagreement variants of the same pre-warm attack.
+    "backend/app/processing/tiles/router.py": 2191,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2951,7 +2951,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1372): +6 — the signed raster template also carries
     # ?v=<tile_cache_version> (outside the signature, like the colormap
     # params) so nginx's $arg_v cache-key segment rolls on replace.
-    "backend/app/processing/tiles/router.py": 2160,
+    # fix(#1372 codex r3): +19 — the auth check refuses to mark a response
+    # cacheable when its `v` mismatches the dataset's current version, so a
+    # predictable future key can never be pre-warmed with pre-replace bytes.
+    "backend/app/processing/tiles/router.py": 2179,
 }
 
 

--- a/backend/tests/test_modality_assets.py
+++ b/backend/tests/test_modality_assets.py
@@ -23,6 +23,22 @@ def _make_dataset(
 API_URL = "http://localhost:8080/api"
 
 
+class TestRasterTilesAssetVersion:
+    def test_raster_tiles_href_carries_tile_cache_version(self):
+        """fix(#1372 codex r2): the advertised template is versioned so a
+        refetching STAC/OGC client stops sharing the unversioned nginx cache
+        entry after a replace."""
+        ds = _make_dataset(record_type="raster_dataset", table_name=None)
+        ds.tile_cache_version = 7
+        assets = build_assets(ds, API_URL)
+        assert assets["raster_tiles"]["href"].endswith(".png?v=7")
+
+    def test_raster_tiles_href_bare_without_version(self):
+        ds = _make_dataset(record_type="raster_dataset", table_name=None)
+        assets = build_assets(ds, API_URL)
+        assert assets["raster_tiles"]["href"].endswith(".png")
+
+
 class TestModalityAssets:
     def test_vector_dataset_has_download_links(self):
         """Vector datasets should have download links, vector tiles, and OGC features."""

--- a/backend/tests/test_ogc_features.py
+++ b/backend/tests/test_ogc_features.py
@@ -525,6 +525,24 @@ async def test_raster_collection_metadata_has_tiles_link(
     assert f"/raster-tiles/{raster_dataset.id}/tiles/" in tiles_link["href"]
     # tiles are served at the app origin, not /api (which has no such route)
     assert "/api/raster-tiles/" not in tiles_link["href"]
+    # fix(#1372 codex r2): the advertised template carries the tile cache
+    # version, so a refetching client rolls the shared nginx cache on replace.
+    assert f"?v={raster_dataset.tile_cache_version}" in tiles_link["href"]
+
+
+async def test_collections_list_raster_tiles_link_is_versioned(
+    client: AsyncClient, raster_dataset: Dataset
+):
+    """fix(#1372 codex r2): the collections LIST advertises the same versioned
+    raster template as the collection detail."""
+    resp = await client.get("/collections")
+    assert resp.status_code == 200
+    entry = next(
+        c for c in resp.json()["collections"] if c["id"] == str(raster_dataset.id)
+    )
+    tiles_link = next(link for link in entry["links"] if link["rel"] == "tiles")
+    assert f"/raster-tiles/{raster_dataset.id}/tiles/" in tiles_link["href"]
+    assert f"?v={raster_dataset.tile_cache_version}" in tiles_link["href"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_raster_tile_url_version_1372.py
+++ b/backend/tests/test_raster_tile_url_version_1372.py
@@ -1,0 +1,120 @@
+"""fix(#1372): raster tile URLs carry ``v=<tile_cache_version>``.
+
+nginx's shared raster_cache keys on ``$arg_v`` (frontend/nginx.conf), so a
+raster replace — which bumps ``Dataset.tile_cache_version`` — rolls the shared
+cache immediately instead of serving pre-replace bytes for up to
+``proxy_cache_valid``. These pins cover the response builders that emit the
+versioned template; the token endpoint's pin lives in
+``tests/test_raster_tiles.py::TestRasterTokenEndpoint``.
+"""
+
+import uuid
+from types import SimpleNamespace
+
+from app.modules.catalog.datasets.domain.helpers import _build_raster_metadata
+from app.modules.catalog.maps.service_public import _build_shared_layer_dict
+from app.modules.catalog.maps.style_json import build_maplibre_style
+
+from tests.test_maps_style_json import _dem_layer, _map
+from tests.test_vrt_catalog_175 import _make_mock_dataset, _make_mock_raster_asset
+
+
+class TestRasterMetadataTileUrlVersion:
+    def test_tile_url_carries_tile_cache_version(self):
+        dataset = _make_mock_dataset("raster_dataset")
+        dataset.tile_cache_version = 7
+        asset = _make_mock_raster_asset(
+            vrt_type=None, resolution_strategy=None, status="ready"
+        )
+
+        result = _build_raster_metadata(dataset, asset, is_admin=False)
+
+        assert result.tile_url == (
+            f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png?v=7"
+        )
+
+    def test_connect_tile_url_stays_unversioned(self):
+        """The connect template is copied once into desktop GIS tools, where a
+        frozen ``v`` would pin exactly the staleness the param exists to bust."""
+        dataset = _make_mock_dataset("raster_dataset")
+        dataset.tile_cache_version = 7
+        asset = _make_mock_raster_asset(
+            vrt_type=None, resolution_strategy=None, status="ready"
+        )
+
+        result = _build_raster_metadata(
+            dataset, asset, is_admin=False, base_url="https://gis.example.com"
+        )
+
+        assert "?v=" not in result.connect.tile_url
+        assert "&v=" not in result.connect.tile_url
+        assert "api_key={your_key}" in result.connect.tile_url
+
+
+def _shared_layer() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        dataset_id=uuid.uuid4(),
+        display_name="Raster",
+        sort_order=0,
+        visible=True,
+        opacity=1.0,
+        paint={},
+        layout={},
+        layer_type="raster_geolens",
+        filter=None,
+        label_config=None,
+        popup_config=None,
+        style_config=None,
+        show_in_legend=True,
+    )
+
+
+class TestSharedLayerTileUrlVersion:
+    def _build(self, tile_version):
+        layer = _shared_layer()
+        layer_dict, _ = _build_shared_layer_dict(
+            layer,
+            ds_name="Raster",
+            ds_geom_type=None,
+            ds_table_name=None,
+            ds_column_info=None,
+            ds_visibility="public",
+            ds_record_type="raster_dataset",
+            ds_is_3d=None,
+            ds_feature_count=None,
+            ds_is_dem=None,
+            ds_dem_vertical_units=None,
+            ds_tile_version=tile_version,
+        )
+        return layer, layer_dict
+
+    def test_raster_tile_url_carries_version(self):
+        layer, layer_dict = self._build(7)
+        assert layer_dict["tile_url"] == (
+            f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png?v=7"
+        )
+
+    def test_raster_tile_url_bare_without_version(self):
+        layer, layer_dict = self._build(None)
+        assert layer_dict["tile_url"] == (
+            f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png"
+        )
+
+
+class TestStyleJsonRasterTileVersion:
+    def test_raster_dem_source_tiles_carry_version(self):
+        dem_id = uuid.uuid4()
+        layer = _dem_layer(dem_id=dem_id).model_copy(update={"tile_version": 7})
+        style = build_maplibre_style(_map(), [layer])
+        assert style["sources"][f"geolens-{dem_id}"]["tiles"][0] == (
+            f"/raster-tiles/{dem_id}/tiles/{{z}}/{{x}}/{{y}}.png?v=7"
+        )
+
+    def test_raster_dem_source_tiles_bare_without_version(self):
+        dem_id = uuid.uuid4()
+        layer = _dem_layer(dem_id=dem_id)
+        style = build_maplibre_style(_map(), [layer])
+        assert style["sources"][f"geolens-{dem_id}"]["tiles"][0] == (
+            f"/raster-tiles/{dem_id}/tiles/{{z}}/{{x}}/{{y}}.png"
+        )

--- a/backend/tests/test_raster_tiles.py
+++ b/backend/tests/test_raster_tiles.py
@@ -352,6 +352,24 @@ class TestRasterAuthCheck:
         assert resp.status_code == 200
         assert resp.headers.get("x-geolens-cache-status") == "private"
 
+        # fix(#1372 codex r4): duplicate v — nginx keys on the FIRST value,
+        # Starlette's .get() would return the LAST, so a naive check passes
+        # while nginx caches under the future key. Exactly one v is required.
+        resp = await client.get(
+            f"/tiles/raster-auth-check/?dataset_id={dataset.id}&v=999&v={current}",
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("x-geolens-cache-status") == "private"
+
+        # fix(#1372 codex r4): nginx matches the param NAME case-insensitively
+        # ($arg_v sees V=999); an exact-case backend check would miss it.
+        resp = await client.get(
+            "/tiles/raster-auth-check/",
+            params={"dataset_id": str(dataset.id), "V": "999"},
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("x-geolens-cache-status") == "private"
+
         # No v (copied connect URLs): unchanged legacy behavior.
         resp = await client.get(
             "/tiles/raster-auth-check/",

--- a/backend/tests/test_raster_tiles.py
+++ b/backend/tests/test_raster_tiles.py
@@ -736,6 +736,32 @@ class TestRasterTokenEndpoint:
         assert data["tile_size"] == 256
         assert data["format"] == "png"
 
+    async def test_raster_token_url_carries_tile_cache_version(
+        self, client: AsyncClient, test_db_session
+    ):
+        """fix(#1372): the signed template carries v=<tile_cache_version>, the
+        segment nginx's shared raster cache keys on ($arg_v) — a raster replace
+        bumps the version, so the shared cache rolls instead of serving
+        pre-replace bytes for up to proxy_cache_valid."""
+        from urllib.parse import parse_qs
+
+        admin_id = await _get_admin_id(test_db_session)
+        _record, dataset, _asset = await _create_raster_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+
+        resp = await client.get(f"/tiles/token/{dataset.id}/")
+        assert resp.status_code == 200
+        query = parse_qs(resp.json()["tile_url"].split("?", 1)[1])
+        assert query["v"] == [str(dataset.tile_cache_version)]
+
+        dataset.bump_tile_cache_version()
+        await test_db_session.commit()
+
+        resp = await client.get(f"/tiles/token/{dataset.id}/")
+        query = parse_qs(resp.json()["tile_url"].split("?", 1)[1])
+        assert query["v"] == [str(dataset.tile_cache_version)]
+
     async def test_raster_token_derives_maxzoom_from_raster_metadata(
         self, client: AsyncClient, test_db_session
     ):

--- a/backend/tests/test_raster_tiles.py
+++ b/backend/tests/test_raster_tiles.py
@@ -321,6 +321,45 @@ class TestRasterAuthCheck:
         assert open_path.endswith(asset.asset_uri)
         assert resp.headers.get("x-geolens-cache-status") == "public"
 
+    async def test_auth_check_mismatched_tile_version_is_not_cacheable(
+        self, client: AsyncClient, test_db_session
+    ):
+        """fix(#1372 codex r3): tile_cache_version is advertised in public URLs
+        and increments predictably, so a caller could pre-warm the NEXT
+        version's nginx cache key with pre-replace bytes. A `v` that does not
+        match the dataset's current version must therefore never produce a
+        cacheable response — it still serves, but as private."""
+        admin_id = await _get_admin_id(test_db_session)
+        _record, dataset, _asset = await _create_raster_dataset(
+            test_db_session, created_by=admin_id, visibility="public"
+        )
+
+        current = str(dataset.tile_cache_version)
+
+        # Matching v: cacheable, exactly like an unversioned request.
+        resp = await client.get(
+            "/tiles/raster-auth-check/",
+            params={"dataset_id": str(dataset.id), "v": current},
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("x-geolens-cache-status") == "public"
+
+        # Future/wrong v: served, but never cached under the wrong key.
+        resp = await client.get(
+            "/tiles/raster-auth-check/",
+            params={"dataset_id": str(dataset.id), "v": "999"},
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("x-geolens-cache-status") == "private"
+
+        # No v (copied connect URLs): unchanged legacy behavior.
+        resp = await client.get(
+            "/tiles/raster-auth-check/",
+            params={"dataset_id": str(dataset.id)},
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("x-geolens-cache-status") == "public"
+
     async def test_auth_check_returns_open_path_for_authenticated_user(
         self, client: AsyncClient, test_db_session
     ):

--- a/backend/tests/test_tenant_session_guc.py
+++ b/backend/tests/test_tenant_session_guc.py
@@ -1454,6 +1454,7 @@ async def test_raster_metadata_cache_is_tenant_scoped_and_filtered():
         "is_dem": False,
         "band_info": None,
         "nodata": None,
+        "tile_cache_version": 1,
     }
     result_a = MagicMock()
     result_a.mappings.return_value.one_or_none.return_value = row

--- a/backend/tests/test_vrt_catalog_175.py
+++ b/backend/tests/test_vrt_catalog_175.py
@@ -81,6 +81,8 @@ def _make_mock_dataset(record_type: str, title: str = "Test Dataset") -> MagicMo
     ds.source_health = None
     ds.source_health_detail = None
     ds.schema_drift_status = None
+    # fix(#1372): _build_raster_metadata reads this into the tile URL's `v=`.
+    ds.tile_cache_version = 1
 
     ds.record = MagicMock()
     ds.record.record_type = record_type

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -145,7 +145,12 @@ server {
         # Cache key must vary by EVERY render param the api forwards to Titiler,
         # else tiles with different bounds collide (#317 Codex P2): include
         # pmin/pmax/sigma alongside colormap_name/stretch.
-        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_colormap_name/$arg_stretch/$arg_pmin/$arg_pmax/$arg_sigma";
+        # fix(#1372): $arg_v is the dataset's tile_cache_version, emitted by the
+        # api in every raster tile URL — a raster replace bumps it, so the
+        # shared cache rolls immediately instead of serving pre-replace bytes
+        # for up to proxy_cache_valid. Unversioned clients (copied connect
+        # URLs) key on the empty segment and keep the old bounded staleness.
+        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_v/$arg_colormap_name/$arg_stretch/$arg_pmin/$arg_pmax/$arg_sigma";
         proxy_cache_valid 200 1h;
         proxy_cache_use_stale error timeout updating;
         # Honor the api's Cache-Control: nginx skips caching when the api

--- a/frontend/src/components/maps/hooks/__tests__/use-map-layers.test.ts
+++ b/frontend/src/components/maps/hooks/__tests__/use-map-layers.test.ts
@@ -150,4 +150,19 @@ describe('useMapLayers raster tile source cache-busting', () => {
     const source = addedSourceConfig(map);
     expect(source?.tiles[0]).not.toContain('?v=');
   });
+
+  // fix(#1372): the server now embeds `?v=<tile_cache_version>` in the raster
+  // tile URL (the shared nginx cache keys on it). A second client-side `v`
+  // would make nginx key on the wrong (first) value, so the append must yield
+  // to a server-versioned URL.
+  it('does not append a second v when the server URL already carries one', () => {
+    const map = runRasterHook(
+      '/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png?v=7',
+      '2026-08-10T00:00:00Z',
+    );
+    const source = addedSourceConfig(map);
+    expect(source?.tiles[0]).toBe(
+      `${window.location.origin}/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png?v=7`,
+    );
+  });
 });

--- a/frontend/src/components/maps/hooks/use-map-layers.ts
+++ b/frontend/src/components/maps/hooks/use-map-layers.ts
@@ -225,14 +225,16 @@ export function useMapLayers({
         // for an identical URL for up to an hour even after this source is
         // freshly re-added on remount. Bust that with tileVersion (the
         // dataset's updated_at) the same way the vector source already does
-        // via buildSignedTileUrl. This does NOT reach the shared nginx
-        // raster_cache — its proxy_cache_key whitelists only the Titiler
-        // render params (colormap_name/stretch/pmin/pmax/sigma), so an
-        // unlisted query param has no effect there (see #1362 follow-up
-        // filed for that separate, infra-scoped gap).
-        const versionedTileUrl = tileVersion
-          ? `${window.location.origin}${rasterTileUrl}?v=${encodeURIComponent(tileVersion)}`
-          : `${window.location.origin}${rasterTileUrl}`;
+        // via buildSignedTileUrl.
+        // fix(#1372): the server now embeds `?v=<tile_cache_version>` in the
+        // raster tile URL (nginx's shared cache keys on it) — when present,
+        // it supersedes this client-side append; appending a second `v`
+        // would make nginx key on the wrong (first) value.
+        const hasServerVersion = /[?&]v=/.test(rasterTileUrl);
+        const versionedTileUrl =
+          tileVersion && !hasServerVersion
+            ? `${window.location.origin}${rasterTileUrl}?v=${encodeURIComponent(tileVersion)}`
+            : `${window.location.origin}${rasterTileUrl}`;
         map.addSource('raster-tile-source', {
           type: 'raster',
           tiles: [versionedTileUrl],


### PR DESCRIPTION
## What

Closes the residual staleness gap #1362 filed: a completed raster replace could leave the shared nginx `raster_cache` serving pre-replace tile bytes for up to an hour, because the cache key whitelisted only the Titiler render params and ignored every cache-busting query param.

- `frontend/nginx.conf`: `proxy_cache_key` gains an `$arg_v` segment.
- The api now emits `v=<tile_cache_version>` in every raster tile URL template it builds — rendering surfaces and advertised metadata links alike: dataset detail (`datasets/domain/helpers.py`), the signed raster token (`processing/tiles/router.py`, outside the signature like the colormap params), shared/public map layers (`maps/service_public.py`), style.json export (`maps/style_json.py`), the OGC coverage-collection and collections-list links (`standards/ogc/router.py`, `search/router.py`), and the STAC/record `raster_tiles` asset (`search/service_records.py`). `tile_cache_version` is the dedicated content-version counter and is already bumped by raster replace, reupload swap, postgis/STAC refresh, and feature edits — so the shared cache rolls the moment content changes, for every surface.
- The connect template stays unversioned on purpose: it is copied once into desktop GIS tools, where a frozen `v` would pin exactly the staleness the param exists to bust. Unversioned clients keep today's bounded (≤1h) staleness.
- The hero map's client-side `?v=` append (#1362) now yields to a server-versioned URL — appending a second `v` would make nginx key on the wrong (first) value.

## Impacts

- No schema or API-shape change (tile_url fields stay strings; no OpenAPI/SDK regen needed).
- Cache-key cardinality: `v` adds one segment with the same free-form exposure the colormap/stretch params already have; the cache zone's `max_size`/LRU bounds it.
- The demo's Cloudflare tile cache keys on the full query string by default, so `v` rolls it too.
- Module LOC ratchets raised exactly (+4/+5/+6) in `test_layering.py`.

## Verification

- `backend`: `uv run pytest tests/test_raster_tile_url_version_1372.py tests/test_vrt_catalog_175.py tests/test_raster_tiles.py::TestRasterTokenEndpoint tests/test_shared_map_embed_scope.py tests/test_tile_signing.py tests/test_maps_style_json.py tests/test_layering.py` — all passing; `ruff check` + `ruff format --check` clean.
- `frontend`: `npx vitest run src/components/maps/hooks/__tests__/use-map-layers.test.ts` (7 passed), `npm run typecheck`, eslint on touched files — clean.

Fixes #1372
