### PR TITLE
fix(catalog): stop user-authored distributions suppressing built-in export rows

### DIFF
--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -720,11 +720,9 @@ async def reconcile_distributions(
 
     Normalization spans the generated rows only, which is the same boundary as
     every other bullet here. A user who flags their OWN row primary keeps that
-    flag through a reconcile; that record advertises two primaries, and it
-    could already do so before #1370 put a generated row beside a user row for
-    one format — a single ``POST /records/{id}/distributions/`` with
-    ``is_primary=true`` reaches it, and nothing in ``create_distribution``
-    demotes the incumbent.
+    flag through a reconcile, so that record advertises two primaries — see
+    #1383, which is reachable from a single POST on any dataset and predates
+    #1370 rather than being introduced by it.
 
     The lost-edit case is narrower than it reads: ``update_distribution`` and
     ``delete_distribution`` both refuse to touch a row with

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -496,6 +496,13 @@ _DISTRIBUTION_TEMPLATES = [
 # generated set, so reconcile has to see it.
 _VECTOR_TILES_PAIR = ("vector_tiles", "pbf")
 
+# The four-column unique constraint on ``record_distributions``
+# (record_id, distribution_type, format, url) — see RecordDistribution's
+# ``__table_args__``. Named here because the generated-row insert has to be
+# conflict-tolerant against it; a rename that missed this constant fails loudly
+# on the next insert ("constraint ... does not exist") rather than silently.
+_DISTRIBUTION_UNIQUE_CONSTRAINT = "uq_record_distribution"
+
 # Every (distribution_type, format) pair this module owns. A row outside this
 # set was written by something else — the raster and VRT ingest tails add their
 # own ``download`` rows — and reconcile must leave those alone even when they
@@ -520,7 +527,7 @@ def _pair_applies(dist_type: str, fmt: str, geometry_type: str | None) -> bool:
 # the template table marks primary; CSV is the fallback, both for a modality
 # that generates no GeoPackage row at all and — on reconcile — for a promote
 # where no generated GeoPackage row exists to promote because a user's own row
-# already occupies that pair.
+# already sits at the exact url the GeoPackage template would have inserted.
 _PRIMARY_PREFERENCE: tuple[tuple[str, str], ...] = (
     ("download", "gpkg"),
     ("download", "csv"),
@@ -549,9 +556,20 @@ async def generate_distributions(
     For non-spatial datasets (geometry_type is None): creates only csv download
     + OGC features (2 rows).
 
-    All are marked auto_generated=True. Uses merge semantics: existing rows with
-    the same (record_id, distribution_type, format) are left untouched (INSERT ON
-    CONFLICT DO NOTHING equivalent via check-then-insert).
+    All are marked auto_generated=True. Merge semantics: an AUTO-GENERATED row
+    already holding a (distribution_type, format) pair is left untouched, and
+    the insert itself is ``ON CONFLICT DO NOTHING`` against
+    ``uq_record_distribution``.
+
+    fix(#1370): the existence probe reads only auto-generated rows. It used to
+    read every row, so a distribution a user authored through
+    ``create_distribution`` counted as "the pair is taken" — and once somebody
+    added their own ``download``/``gpkg`` entry, the built-in
+    ``/datasets/{id}/export?format=gpkg`` row could never be generated for that
+    record again, by this call or by a later ``reconcile_distributions``
+    promote. The export endpoint kept working; the catalog record, the DCAT
+    feeds and the STAC assets simply stopped naming it. Two rows advertising
+    one format is the intended end state: one the user's, one the platform's.
 
     Args:
         dataset_id: Dataset PK (used in URL paths).
@@ -559,19 +577,22 @@ async def generate_distributions(
         table_name: Dataset table name (used in vector tile URL).
         geometry_type: Geometry type string, or None for non-spatial datasets.
     """
-    # Fetch all existing distributions for this record in a single query
+    # Fetch the pairs this function owns for this record in a single query.
+    # Anything a user wrote is deliberately invisible here — see above.
     existing_result = await session.execute(
         select(
             RecordDistribution.distribution_type,
             RecordDistribution.format,
-        ).where(RecordDistribution.record_id == record_id)
+        ).where(
+            RecordDistribution.record_id == record_id,
+            RecordDistribution.auto_generated.is_(True),
+        )
     )
     existing_set = {(row[0], row[1]) for row in existing_result.all()}
 
-    # Build all new distributions in one list so they can be flushed in a
-    # single batch rather than as individual INSERT statements. SQLAlchemy 2.0
-    # batches `add_all()` + `flush()` via insertmanyvalues when supported.
-    to_add: list[RecordDistribution] = []
+    # Build all new distributions in one list so they go out as a single
+    # multi-VALUES INSERT rather than one statement per row.
+    to_add: list[dict] = []
     primary_pair = _primary_pair(geometry_type)
 
     for (
@@ -597,17 +618,17 @@ async def generate_distributions(
         effective_primary = (dist_type, fmt) == primary_pair
 
         to_add.append(
-            RecordDistribution(
-                record_id=record_id,
-                distribution_type=dist_type,
-                format=fmt,
-                url=url,
-                title=title,
-                protocol=protocol,
-                media_type=media_type,
-                is_primary=effective_primary,
-                auto_generated=True,
-            )
+            {
+                "record_id": record_id,
+                "distribution_type": dist_type,
+                "format": fmt,
+                "url": url,
+                "title": title,
+                "protocol": protocol,
+                "media_type": media_type,
+                "is_primary": effective_primary,
+                "auto_generated": True,
+            }
         )
 
     # Vector tiles (uses table_name, not dataset_id) — skip for non-spatial datasets
@@ -616,23 +637,45 @@ async def generate_distributions(
         and _VECTOR_TILES_PAIR not in existing_set
     ):
         to_add.append(
-            RecordDistribution(
-                record_id=record_id,
-                distribution_type="vector_tiles",
-                format="pbf",
-                url=f"/tiles/data.{table_name}/{{z}}/{{x}}/{{y}}.pbf",
-                title="Vector Tiles",
-                protocol="OGC:WMTS",
-                media_type="application/vnd.mapbox-vector-tile",
-                is_primary=False,
-                auto_generated=True,
-            )
+            {
+                "record_id": record_id,
+                "distribution_type": "vector_tiles",
+                "format": "pbf",
+                "url": f"/tiles/data.{table_name}/{{z}}/{{x}}/{{y}}.pbf",
+                "title": "Vector Tiles",
+                "protocol": "OGC:WMTS",
+                "media_type": "application/vnd.mapbox-vector-tile",
+                "is_primary": False,
+                "auto_generated": True,
+            }
         )
 
-    if to_add:
-        session.add_all(to_add)
-        await session.flush()
-    return to_add
+    if not to_add:
+        return []
+
+    # fix(#1370): ON CONFLICT DO NOTHING, not check-then-insert. Now that a
+    # user's row no longer hides its pair from the probe above, a user row
+    # whose url happens to equal the template's is a live collision on
+    # `uq_record_distribution` rather than a skipped pair — and
+    # `/datasets/{id}/export?format=gpkg` is a guessable thing to type. Catching
+    # IntegrityError instead would be a worse mechanism than it looks: the
+    # reconcile caller runs inside the write transaction of a registered-PostGIS
+    # refresh or a reupload swap, and a raised constraint violation aborts that
+    # whole transaction, turning a metadata correction into a failed job. A
+    # conflict resolved in the statement never opens that hole.
+    #
+    # Skipped rows are absent from RETURNING, so `created` stays a truthful
+    # list of what was inserted — which is what reconcile's is_primary
+    # normalization picks the primary from.
+    result = await session.execute(
+        insert(RecordDistribution)
+        .values(to_add)
+        .on_conflict_do_nothing(constraint=_DISTRIBUTION_UNIQUE_CONSTRAINT)
+        .returning(RecordDistribution)
+    )
+    created = list(result.scalars().all())
+    await session.flush()
+    return created
 
 
 async def reconcile_distributions(
@@ -672,8 +715,16 @@ async def reconcile_distributions(
       there is geometry, CSV when there is not). A promote that left the old
       CSV primary beside a new primary GeoPackage would advertise two. The
       winner is picked from the rows that exist rather than from the modality
-      alone — if a user's own row occupies the preferred pair there is no
-      generated row to promote, and the fallback takes it.
+      alone — a generated row the conflict-tolerant insert skipped is not
+      there to promote, and the fallback takes it.
+
+    Normalization spans the generated rows only, which is the same boundary as
+    every other bullet here. A user who flags their OWN row primary keeps that
+    flag through a reconcile; that record advertises two primaries, and it
+    could already do so before #1370 put a generated row beside a user row for
+    one format — a single ``POST /records/{id}/distributions/`` with
+    ``is_primary=true`` reaches it, and nothing in ``create_distribution``
+    demotes the incumbent.
 
     The lost-edit case is narrower than it reads: ``update_distribution`` and
     ``delete_distribution`` both refuse to touch a row with
@@ -713,12 +764,12 @@ async def reconcile_distributions(
     )
 
     # fix(#1314 review round 1): chosen from the rows that ACTUALLY exist, not
-    # from the modality alone. `generate_distributions` skips any pair a row
-    # already occupies, including a user-authored one — so a promote of a
-    # dataset whose owner had added their own GeoPackage entry generates no
-    # GeoPackage row for the preferred pair to name. Naming it anyway cleared
-    # the CSV flag and promoted nothing, leaving the record with no primary
-    # distribution at all.
+    # from the modality alone. Naming a pair with no generated row behind it
+    # cleared the CSV flag and promoted nothing, leaving the record with no
+    # primary distribution at all. fix(#1370) narrowed when that happens — a
+    # user's own GeoPackage entry no longer suppresses the generated one — but
+    # did not remove it: a user row sitting at the exact template url makes the
+    # insert a no-op, and then there is again no GeoPackage row to name.
     generated = [
         row
         for row in survivors + created

--- a/backend/tests/test_distribution_reconcile_1314.py
+++ b/backend/tests/test_distribution_reconcile_1314.py
@@ -10,6 +10,12 @@ The preservation policy is stated on ``reconcile_distributions``' docstring.
 These tests are what stop it from being only a docstring — including the
 limitation it admits to, which is pinned here deliberately so that relaxing it
 later fails a test instead of quietly changing behaviour.
+
+fix(#1370) extends the file to the other half of "merges rather than replaces":
+whose rows the merge is allowed to see. A row the user authored is no longer a
+reason to withhold the platform's own export link for that format, so a record
+can carry two rows for one format — see ``TestUserRowsDoNotSuppressGenerated``
+and ``TestTwoRowsForOneFormat``.
 """
 
 from __future__ import annotations
@@ -19,9 +25,15 @@ import uuid
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
-from app.modules.catalog.datasets.domain.models import RecordDistribution
+from app.modules.catalog.datasets.domain.models import (
+    Dataset,
+    Record,
+    RecordDistribution,
+)
 from app.modules.catalog.records.service import (
+    _DISTRIBUTION_UNIQUE_CONSTRAINT,
     create_distribution,
     generate_distributions,
     reconcile_distributions,
@@ -72,6 +84,26 @@ async def _row(
             )
         )
     ).scalar_one_or_none()
+
+
+async def _reload_for_serialization(session: AsyncSession, dataset_id: uuid.UUID):
+    """Re-fetch a dataset with everything the DCAT/OGC serializers read.
+
+    They walk record relationships directly, and a lazy load on an async
+    session raises rather than emitting SQL.
+    """
+    result = await session.execute(
+        select(Dataset)
+        .where(Dataset.id == dataset_id)
+        .options(
+            selectinload(Dataset.record).selectinload(Record.distributions),
+            selectinload(Dataset.record).selectinload(Record.contacts),
+            selectinload(Dataset.record).selectinload(Record.keywords),
+            selectinload(Dataset.record).selectinload(Record.translations),
+        )
+        .execution_options(populate_existing=True)
+    )
+    return result.scalar_one()
 
 
 async def _tabular_dataset(session: AsyncSession):
@@ -341,16 +373,17 @@ class TestPrimaryFlag:
             ("download", "gpkg")
         }
 
-    async def test_a_promote_falls_back_to_csv_when_a_user_row_holds_geopackage(
+    async def test_a_promote_falls_back_to_csv_when_a_user_row_holds_the_template_url(
         self, test_db_session: AsyncSession
     ) -> None:
         """fix(#1314 review round 1): the record must never end up with none.
 
-        ``generate_distributions`` skips any pair a row already occupies, and
-        it does not care whether that row is auto-generated. So a promote of a
-        dataset whose owner added their own GeoPackage entry generates no
-        GeoPackage row — and picking the primary from the modality alone
-        cleared the CSV flag to promote a row that was never created.
+        Picking the primary from the modality alone cleared the CSV flag to
+        promote a row that was never created. fix(#1370) narrowed the way in —
+        a user's own GeoPackage entry at their own url now gets the generated
+        row beside it — but left this one: a user row sitting at the exact url
+        the template would insert makes the insert a no-op, so there is again
+        no generated GeoPackage row for the preferred pair to name.
         """
         dataset = await _tabular_dataset(test_db_session)
         await create_distribution(
@@ -358,7 +391,7 @@ class TestPrimaryFlag:
             dataset.record_id,
             distribution_type="download",
             format="gpkg",
-            url="https://example.org/mine.gpkg",
+            url=f"/datasets/{dataset.id}/export?format=gpkg",
         )
         await test_db_session.commit()
 
@@ -396,3 +429,339 @@ class TestPrimaryFlag:
         assert await self._primary_pairs(test_db_session, dataset.record_id) == {
             ("download", "csv")
         }
+
+
+class TestTheConstraintTheInsertTargets:
+    """``generate_distributions`` names ``uq_record_distribution`` by string.
+
+    A conflict clause aimed at a constraint that has been renamed or narrowed
+    is not a compile error, so the coupling is pinned here: the name and the
+    exact four columns, from the model the migration built.
+    """
+
+    def test_the_unique_constraint_is_the_four_column_one(self) -> None:
+        from sqlalchemy import UniqueConstraint
+
+        constraints = {
+            c.name: c
+            for c in RecordDistribution.__table__.constraints
+            if isinstance(c, UniqueConstraint)
+        }
+        assert _DISTRIBUTION_UNIQUE_CONSTRAINT in constraints
+        assert [
+            c.name for c in constraints[_DISTRIBUTION_UNIQUE_CONSTRAINT].columns
+        ] == [
+            "record_id",
+            "distribution_type",
+            "format",
+            "url",
+        ]
+
+
+class TestUserRowsDoNotSuppressGenerated:
+    """fix(#1370): the existence probe reads only the rows this module owns.
+
+    The probe used to match on ``(distribution_type, format)`` across every
+    row, so one ``POST /records/{id}/distributions/`` for ``download``/``gpkg``
+    retired the built-in ``/datasets/{id}/export?format=gpkg`` row for the life
+    of the record. Nothing recreated it: not a later ``generate_distributions``
+    call, not the ``reconcile_distributions`` promote. The export endpoint went
+    on working while the catalog record, the DCAT feeds and the STAC assets
+    stopped naming it.
+    """
+
+    async def _rows(
+        self, session: AsyncSession, record_id: uuid.UUID, dist_type: str, fmt: str
+    ) -> list[RecordDistribution]:
+        return list(
+            (
+                await session.execute(
+                    select(RecordDistribution).where(
+                        RecordDistribution.record_id == record_id,
+                        RecordDistribution.distribution_type == dist_type,
+                        RecordDistribution.format == fmt,
+                    )
+                )
+            ).scalars()
+        )
+
+    async def test_generate_still_creates_the_builtin_export_beside_a_user_row(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The issue's headline case, at the call site the create path uses."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(test_db_session, created_by=admin_id)
+        await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+            title="My own extract",
+        )
+        await test_db_session.commit()
+
+        await generate_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        rows = await self._rows(test_db_session, dataset.record_id, "download", "gpkg")
+        assert {(row.auto_generated, row.url) for row in rows} == {
+            (False, "https://example.org/mine.gpkg"),
+            (True, f"/datasets/{dataset.id}/export?format=gpkg"),
+        }
+
+    async def test_a_promote_creates_the_builtin_export_beside_a_user_row(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The path #1369 added, which inherited the same probe."""
+        dataset = await _tabular_dataset(test_db_session)
+        await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+        )
+        await test_db_session.commit()
+
+        created, _removed = await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        assert ("download", "gpkg") in {
+            (c.distribution_type, c.format) for c in created
+        }
+        rows = await self._rows(test_db_session, dataset.record_id, "download", "gpkg")
+        assert len(rows) == 2
+        # The generated row is the one that can be reconciled, so it takes the
+        # primary flag back from CSV — the promote no longer has to fall back.
+        generated = [row for row in rows if row.auto_generated]
+        assert [row.is_primary for row in generated] == [True]
+        assert await _pairs(test_db_session, dataset.record_id) == _SPATIAL_PAIRS
+
+
+class TestATemplateUrlCollisionDoesNotRaise:
+    """The reason a changed probe alone was not safe (#1370).
+
+    ``uq_record_distribution`` is ``(record_id, distribution_type, format,
+    url)``. A user row at ``/datasets/{id}/export?format=gpkg`` — a guessable
+    thing to type — no longer hides the pair, so the generated insert lands on
+    the constraint. It resolves in the statement rather than raising, because
+    the reconcile caller runs inside the write transaction of a
+    registered-PostGIS refresh or a reupload swap, where an IntegrityError
+    aborts every write the job has already made.
+    """
+
+    async def _user_row_at_the_template_url(
+        self, session: AsyncSession, dataset
+    ) -> None:
+        await create_distribution(
+            session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url=f"/datasets/{dataset.id}/export?format=gpkg",
+        )
+        await session.commit()
+
+    async def test_generate_does_not_raise_and_writes_no_duplicate(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Also the create path: ``create_dataset_from_ingest`` reaches the
+        same statement through this function (``service_create.py``), on a
+        Record it has just created — so the collision is unreachable there and
+        the guarantee is this one."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(test_db_session, created_by=admin_id)
+        await self._user_row_at_the_template_url(test_db_session, dataset)
+
+        created = await generate_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        assert ("download", "gpkg") not in {
+            (row.distribution_type, row.format) for row in created
+        }
+        rows = (
+            await test_db_session.execute(
+                select(RecordDistribution).where(
+                    RecordDistribution.record_id == dataset.record_id,
+                    RecordDistribution.distribution_type == "download",
+                    RecordDistribution.format == "gpkg",
+                )
+            )
+        ).scalars()
+        assert [row.auto_generated for row in rows] == [False]
+
+    async def test_reconcile_does_not_raise_and_leaves_the_job_transaction_usable(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        dataset = await _tabular_dataset(test_db_session)
+        await self._user_row_at_the_template_url(test_db_session, dataset)
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        # The transaction the caller's job is holding is still writable: an
+        # IntegrityError above would have poisoned it, and this write is what
+        # says so.
+        await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="api",
+            format="json",
+            url="https://example.org/after",
+        )
+        await test_db_session.commit()
+
+        assert await _pairs(test_db_session, dataset.record_id) == _SPATIAL_PAIRS | {
+            ("api", "json")
+        }
+
+    async def test_repeated_reconciles_stay_idempotent_over_the_collision(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The skipped insert is retried every call; it must stay a no-op."""
+        dataset = await _tabular_dataset(test_db_session)
+        await self._user_row_at_the_template_url(test_db_session, dataset)
+
+        for _ in range(3):
+            await reconcile_distributions(
+                test_db_session,
+                dataset.id,
+                dataset.record_id,
+                dataset.table_name,
+                geometry_type="POLYGON",
+            )
+        await test_db_session.commit()
+
+        rows = (
+            await test_db_session.execute(
+                select(RecordDistribution).where(
+                    RecordDistribution.record_id == dataset.record_id,
+                    RecordDistribution.distribution_type == "download",
+                    RecordDistribution.format == "gpkg",
+                )
+            )
+        ).scalars()
+        assert [row.auto_generated for row in rows] == [False]
+
+
+class TestTwoRowsForOneFormat:
+    """What the state #1370 creates looks like to the standards feeds.
+
+    Two distributions advertising one format is legal DCAT — ``dcat:
+    distribution`` is a set of Distribution nodes, and these two differ by
+    ``accessURL``. STAC is the one worth checking rather than assuming, since
+    its assets ARE a keyed object; the check below is what says the keys do not
+    come from ``record_distributions`` at all.
+    """
+
+    async def _record_with_two_gpkg_rows(self, session: AsyncSession):
+        admin_id = await get_user_id(session, "admin")
+        dataset = await create_dataset(session, created_by=admin_id)
+        await create_distribution(
+            session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+            title="My own extract",
+        )
+        await generate_distributions(
+            session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await session.commit()
+        return await _reload_for_serialization(session, dataset.id)
+
+    async def test_exactly_one_generated_row_is_primary(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The user's row defaults to non-primary, so the record advertises one.
+
+        ``is_primary`` normalization spans the generated rows; a user who
+        explicitly flags their own row primary keeps that flag, which is
+        stated on ``reconcile_distributions`` and predates this change.
+        """
+        dataset = await self._record_with_two_gpkg_rows(test_db_session)
+        primaries = [d for d in dataset.record.distributions if d.is_primary]
+        assert [(d.distribution_type, d.format) for d in primaries] == [
+            ("download", "gpkg")
+        ]
+        assert primaries[0].auto_generated is True
+
+    async def test_dcat_carries_both_rows(self, test_db_session: AsyncSession) -> None:
+        from app.standards.dcat.service import record_to_dcat
+
+        dataset = await self._record_with_two_gpkg_rows(test_db_session)
+        doc = record_to_dcat(dataset, "https://example.test")
+
+        gpkg = [
+            d for d in doc["dcat:distribution"] if d.get("dcterms:format") == "gpkg"
+        ]
+        assert {d["dcat:accessURL"] for d in gpkg} == {
+            "https://example.org/mine.gpkg",
+            f"https://example.test/datasets/{dataset.id}/export?format=gpkg",
+        }
+
+    async def test_the_ogc_record_and_its_stac_item_drop_neither_row(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """STAC asset keys are derived from the dataset, not from these rows.
+
+        ``build_assets`` builds ``download_<fmt>`` from the dataset id and the
+        modality; ``ogc_record_to_stac_item`` copies that dict through
+        untouched and never reads ``properties.distributions``. So two rows for
+        one format cannot collide on an asset key — there is no key to collide
+        on — and neither row is dropped: both survive in the OGC Record
+        properties, which is the representation that carries them.
+        """
+        from app.modules.catalog.search.service import dataset_to_ogc_record
+        from app.standards.stac.serializer import ogc_record_to_stac_item
+
+        dataset = await self._record_with_two_gpkg_rows(test_db_session)
+        ogc_record = dataset_to_ogc_record(dataset, "https://example.test")
+
+        gpkg = [
+            d
+            for d in ogc_record["properties"]["distributions"]
+            if d["format"] == "gpkg"
+        ]
+        assert {d["url"] for d in gpkg} == {
+            "https://example.org/mine.gpkg",
+            f"https://example.test/datasets/{dataset.id}/export?format=gpkg",
+        }
+
+        item = ogc_record_to_stac_item(
+            ogc_record, stac_api_url="https://example.test/stac"
+        )
+        assert item["assets"]["download_gpkg"]["href"] == (
+            f"https://example.test/datasets/{dataset.id}/export?format=gpkg"
+        )
+        assert not any(
+            key for key in item["assets"] if "mine.gpkg" in str(item["assets"][key])
+        )

--- a/backend/tests/test_distribution_reconcile_1314.py
+++ b/backend/tests/test_distribution_reconcile_1314.py
@@ -746,8 +746,8 @@ class TestTwoRowsForOneFormat:
         """The user's row defaults to non-primary, so the record advertises one.
 
         ``is_primary`` normalization spans the generated rows; a user who
-        explicitly flags their own row primary keeps that flag, which is
-        stated on ``reconcile_distributions`` and predates this change.
+        explicitly flags their own row primary keeps that flag, which is #1383
+        and predates this change.
         """
         dataset = await self._record_with_two_gpkg_rows(test_db_session)
         primaries = [d for d in dataset.record.distributions if d.is_primary]

--- a/backend/tests/test_distribution_reconcile_1314.py
+++ b/backend/tests/test_distribution_reconcile_1314.py
@@ -638,6 +638,48 @@ class TestATemplateUrlCollisionDoesNotRaise:
             ("api", "json")
         }
 
+    async def test_the_fallback_primary_lands_on_a_row_the_insert_returned(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The normalization has to be able to WRITE to a just-inserted row.
+
+        Every other promote flips a survivor's flag or accepts the one the
+        template already inserted as primary, so nothing else exercises this:
+        the fallback is only reached when the preferred pair was skipped, and
+        the CSV that takes it is a row this call created. Those rows come back
+        from ``INSERT ... RETURNING`` rather than from ``session.add``, and one
+        that was not session-persistent would take ``is_primary = True``
+        silently and never emit the UPDATE.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(test_db_session, created_by=admin_id)
+        await self._user_row_at_the_template_url(test_db_session, dataset)
+
+        created, _removed = await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        # CSV was created with is_primary=False (the template marks GeoPackage
+        # primary), and GeoPackage is the row the conflict skipped.
+        assert ("download", "csv") in {(c.distribution_type, c.format) for c in created}
+        primaries = (
+            await test_db_session.execute(
+                select(
+                    RecordDistribution.distribution_type, RecordDistribution.format
+                ).where(
+                    RecordDistribution.record_id == dataset.record_id,
+                    RecordDistribution.auto_generated.is_(True),
+                    RecordDistribution.is_primary.is_(True),
+                )
+            )
+        ).all()
+        assert [(row[0], row[1]) for row in primaries] == [("download", "csv")]
+
     async def test_repeated_reconciles_stay_idempotent_over_the_collision(
         self, test_db_session: AsyncSession
     ) -> None:


### PR DESCRIPTION
## The bug

`generate_distributions()` probed for existing rows by `(distribution_type, format)` with no filter on `auto_generated`, so a row a user added through `POST /records/{id}/distributions/` counted as "the pair is taken". Once somebody added their own `download`/`gpkg` entry, the built-in `/datasets/{id}/export?format=gpkg` row could never be generated for that record again — not by a later call, and not by the `reconcile_distributions()` promote #1369 added. The export endpoint kept working; the catalog record, the DCAT feeds and the STAC assets simply stopped naming it.

## The change

1. The existence probe reads only `auto_generated=True` rows, so a user row no longer withholds the platform's own export link for that format. Two rows advertising one format is the intended end state: one the user's, one the platform's.
2. The generated-row insert is `INSERT ... ON CONFLICT DO NOTHING` against `uq_record_distribution`, via `sqlalchemy.dialects.postgresql.insert(...).on_conflict_do_nothing(...)`. Rows skipped by a conflict are absent from `RETURNING`, so the returned `created` list stays a truthful record of what was inserted — which is what reconcile's `is_primary` normalization picks from.

All three paths that insert generated rows go through that one statement: dataset create (`service_create.py` calls `generate_distributions`), the direct call, and the reconcile promote.

### Why the probe change alone is unsafe

The unique constraint is four columns — `(record_id, distribution_type, format, url)` — verified in `RecordDistribution.__table_args__` and in `0001_baseline.py`, and pinned by a new test. With user rows dropped from the probe, a user row whose url happens to equal the template's (`/datasets/{id}/export?format=gpkg` is a guessable thing to type) stops being a skipped pair and becomes a live constraint violation. Catching `IntegrityError` and passing would be a worse mechanism than it looks: the reconcile caller runs inside the write transaction of a registered-PostGIS refresh or a reupload swap, so a raised violation aborts every write that job has already made, turning a metadata correction into a failed job. Resolving the conflict inside the statement never opens that hole.

This is measured, not asserted. With the probe fixed and `on_conflict_do_nothing` removed, three collision tests plus the #1314 fallback test fail; with `on_conflict_do_nothing` in place and the probe unfixed, five suppression tests fail.

### `is_primary` re-checked against the two-rows state

Normalization spans the generated rows, so exactly one auto-generated row is primary in the new state, and a promote beside a user row now promotes the real GeoPackage row instead of falling back to CSV. #1314's fallback is still reachable and still tested — the url-collision case leaves no generated GeoPackage row to promote — so the test that covered it was retargeted rather than deleted.

One thing the change does not alter: a user who flags their **own** row `is_primary=true` keeps that flag, and that record advertises two primaries. That is reachable today with a single POST on any dataset (nothing in `create_distribution` demotes the incumbent), so it predates this PR and fixing it here would widen scope mid-review. Filed as #1383 and referenced from `reconcile_distributions`' docstring.

The fallback is also where the new insert mechanism gets exercised hardest, so it has its own test. It is the only path that flips `is_primary` on a row `generate_distributions` just inserted — everywhere else the normalization writes to a survivor, or accepts the flag the template already carried. Those rows now arrive from `INSERT ... RETURNING` rather than `session.add`, and one that was not session-persistent would take the assignment and never emit the UPDATE.

## DCAT / STAC verification (checked, not assumed)

- **DCAT 3, DCAT-US 3.0, GeoDCAT-AP** each serialize `record.distributions` as a plain list of Distribution nodes (`dcat/service.py:346`, `dcat_us/service.py:107`, `geodcat_ap/service.py:170`). Nothing is keyed, and the two rows differ by `accessURL`, so both appear. Covered by a test asserting both gpkg URLs are in the DCAT output.
- **STAC** was the one worth checking, since assets are a keyed object. They are not built from `record_distributions`: `build_assets()` (`search/service_records.py:57`) derives `download_<fmt>` from the dataset id and the modality, and `ogc_record_to_stac_item()` copies that dict through and never reads `properties.distributions`. So there is no asset key for two rows to collide on, no last-writer-wins overwrite, and no suffixing needed. Both rows do survive in the OGC Record `properties.distributions`, which is the representation that carries them. Covered by a test that walks `dataset_to_ogc_record` → `ogc_record_to_stac_item`.

## Verification

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_distribution_reconcile_1314.py -v                  # 20 passed
uv run pytest tests/test_dataset_source_state.py tests/test_dcat.py \
              tests/test_geodcat_ap.py -q                                   # 182 passed (with the above at 19)
uv run pytest tests/test_metadata_roundtrip.py tests/test_ogc_collection_metadata.py \
              tests/test_ogc_record_enrichment.py tests/test_postgis_refresh_1265.py \
              tests/test_processing_port.py tests/test_records_authz_sec001.py \
              tests/test_record_subresource_edits.py tests/test_records_related.py \
              tests/test_stac_record_output.py -q                           # 168 passed
uv run pytest tests/test_ingest.py tests/test_raster_ingest.py \
              tests/test_raster_replace_1221.py tests/test_regenerate_vrt_integration.py \
              tests/test_vrt_catalog_175.py tests/test_quicklook_predicate.py \
              tests/test_raster_dataset_assets_bug041.py -q                 # 214 passed
uv run pytest tests/test_layering.py -q                                     # 40 passed
uv run ruff check . && uv run ruff format --check .                         # clean
```

No migration: the constraint the insert targets already exists (`0001_baseline.py`). No schema, API or config impact — `record_distributions` gains rows on records that were missing them, and every response shape is unchanged.

Fixes #1370
