### PR TITLE
fix(ingest): derive effective geometry and record type on reupload swap

### DIFF
--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1770,9 +1770,21 @@ def _effective_geometry_type(
     - a sampled row is what the data actually is;
     - no rows but a specific declared column type is what the column accepts;
     - no rows and a generic ``geometry`` column establishes only that the
-      relation is spatial, so the catalog keeps what it last measured;
+      relation is spatial, so the catalog keeps what it last measured, and
+      falls back to the generic sentinel when it has measured nothing;
     - no ``geom`` column at all is genuinely not spatial, and the only case
       that yields None.
+
+    fix(#1382 review r1): that fallback is the difference between the rule and
+    its own first sentence. Returning ``stored`` unconditionally meant a
+    generic empty column over a dataset the catalog had never measured (an
+    empty mixed-geometry file over a tabular dataset, or a retry against a row
+    the old bug had already NULLed) resolved to None and stayed classified
+    ``table`` — locked out of feature writes, against a relation that plainly
+    has a geometry column. ``GEOMETRY`` is how this codebase already spells
+    "spatial, subtype unknown": ``chk_datasets_geometry_type`` admits it,
+    ``_validate_geometry_type`` accepts every subtype under it (#430 BA-32),
+    and the builder routes it to the mixed adapter (#430 r23).
     """
     if measured is not None:
         return measured
@@ -1780,7 +1792,7 @@ def _effective_geometry_type(
         return None
     if declared != _GENERIC_GEOMETRY_TYPE:
         return declared
-    return stored
+    return stored if stored is not None else _GENERIC_GEOMETRY_TYPE
 
 
 def _derived_record_type(current: str | None, geometry_type: str | None) -> str | None:

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1710,6 +1710,86 @@ async def invalidate_tile_cache_for_table(table_name: str) -> None:
         await tile_cache.invalidate_table(table_name)
 
 
+# What PostGIS records in ``geometry_columns.type`` for an untyped column.
+# A specific value ("POLYGON", "MULTILINESTRING", ...) describes what the
+# column will accept; this one describes nothing.
+_GENERIC_GEOMETRY_TYPE = "GEOMETRY"
+
+# The record types ``service_create.py`` derives from "does this dataset have
+# geometry". Raster and VRT records carry their own modality and must never be
+# re-derived from a geometry column they do not have.
+_DERIVED_RECORD_TYPES: frozenset[str] = frozenset({"table", "vector_dataset"})
+
+
+async def _declared_geometry_type(
+    session: Any, *, schema: str, table: str
+) -> str | None:
+    """The geom column's DECLARED type, or None when the relation has no geom.
+
+    fix(#1313 review round 5): ``extract_metadata`` derives the geometry type
+    by sampling a row (``GeometryType(geom) ... LIMIT 1``), so a spatial table
+    that has been emptied reports None — indistinguishable, from the
+    measurement alone, from a table that never had geometry at all. Writing
+    that None reclassified the dataset as tabular, and the consequences are
+    not cosmetic: ``_require_feature_table`` refuses feature writes to a
+    dataset whose ``geometry_type`` is None, so a refresh of an emptied table
+    would lock the API out of ever repopulating it, and the builder drops its
+    layers as unsupported.
+
+    ``geometry_columns`` answers the question the rows cannot: it describes
+    the COLUMN. A row here means the relation is spatial whatever it
+    currently holds; no row means it genuinely is not.
+
+    fix(#1373): lives here rather than in ``tasks_postgis_refresh`` because the
+    reupload swap reaches the identical trap from the other direction — an
+    empty spatial FILE stages a relation whose geom column is right there — and
+    two spellings of this question are how the two paths end up disagreeing
+    about the same dataset.
+    """
+    from sqlalchemy import text
+
+    return await session.scalar(
+        text(
+            "SELECT type FROM geometry_columns "
+            "WHERE f_table_schema = :schema AND f_table_name = :table "
+            "AND f_geometry_column = 'geom'"
+        ),
+        {"schema": schema, "table": table},
+    )
+
+
+def _effective_geometry_type(
+    *, measured: str | None, declared: str | None, stored: str | None
+) -> str | None:
+    """The geometry type this measurement establishes, from the best evidence.
+
+    One rule in one place: the write applies it and the quality score is
+    computed under it, and a second spelling of this precedence is how those
+    two end up describing different datasets.
+
+    - a sampled row is what the data actually is;
+    - no rows but a specific declared column type is what the column accepts;
+    - no rows and a generic ``geometry`` column establishes only that the
+      relation is spatial, so the catalog keeps what it last measured;
+    - no ``geom`` column at all is genuinely not spatial, and the only case
+      that yields None.
+    """
+    if measured is not None:
+        return measured
+    if declared is None:
+        return None
+    if declared != _GENERIC_GEOMETRY_TYPE:
+        return declared
+    return stored
+
+
+def _derived_record_type(current: str | None, geometry_type: str | None) -> str | None:
+    """``record_type`` as ``service_create.py`` derives it, for the two it owns."""
+    if current not in _DERIVED_RECORD_TYPES:
+        return current
+    return "table" if geometry_type is None else "vector_dataset"
+
+
 async def _apply_reupload_swap(
     session,
     *,
@@ -1744,7 +1824,6 @@ async def _apply_reupload_swap(
     )  # LAZY — preserved per D-17
     from app.platform.extensions import get_processing_port
     from app.processing.ingest.metadata import (
-        _table_has_geometry,
         compute_quality_score,
         refresh_attribute_metadata,
     )
@@ -1852,21 +1931,54 @@ async def _apply_reupload_swap(
             retry_timeout_seconds=15,
         )
 
+    # fix(#1373): resolve the geometry type ONCE, from the relation the swap
+    # just installed, and use that one value everywhere below.
+    #
+    # `extract_metadata` samples a row (`GeometryType(geom) ... LIMIT 1`), so a
+    # spatial file carrying zero features — or only NULL geometries — measures
+    # None while the relation it staged still has its geometry column. Writing
+    # that None reclassified the dataset as tabular: `_require_feature_table`
+    # then refuses feature writes, so the API could never repopulate the table
+    # through GeoLens, and the builder drops its layers as unsupported.
+    # `_declared_geometry_type` supplies the evidence the rows cannot, and the
+    # precedence is the refresh path's — the same helpers, imported, not a
+    # second spelling of the rule (#1313 fell into this trap first).
+    #
+    # Read before the write below, because `stored` is the PRE-swap value: a
+    # generic `geometry` column with no rows establishes only that the relation
+    # is spatial, so the honest answer is what the catalog last measured.
+    previous_geometry_type = dataset.geometry_type
+    effective_geometry_type = _effective_geometry_type(
+        measured=metadata["geometry_type"],
+        declared=await _declared_geometry_type(
+            session, schema=_tenant_schema, table=table_name
+        ),
+        stored=previous_geometry_type,
+    )
+
     # fix(#448): belt-and-braces after the swap — the staging pipeline is
     # responsible for the GIST index, but a re-ingest of a table that already
     # lost its index (the IF-NOT-EXISTS name-collision regression) must
     # self-heal here rather than serve full-scan tiles until the next audit.
-    if metadata.get("geometry_type") is not None:
+    if effective_geometry_type is not None:
         from app.processing.ingest.metadata import ensure_geom_4326_gist_index
 
         await ensure_geom_4326_gist_index(session, table_name, schema=_tenant_schema)
 
     # Update dataset metadata in the same transaction as swap
     dataset.srid = metadata["srid"]
-    # fix(#1314): read before the overwrite — the reconcile below is the only
-    # thing that needs the PRE-swap modality, and one line later it is gone.
-    previous_geometry_type = dataset.geometry_type
-    dataset.geometry_type = metadata["geometry_type"]
+    dataset.geometry_type = effective_geometry_type
+    # fix(#1361): modality is derived, so keep deriving it. `service_create.py`
+    # sets `record_type` from whether the dataset has geometry, and a reupload
+    # is one of the two operations that can change the answer afterwards.
+    # `build_assets` reads it live, so leaving it stale means a de-spatialized
+    # dataset goes on advertising vector-tile and OGC-Features links against a
+    # relation with no geometry column, and a newly-spatial one never advertises
+    # them at all. Fed the EFFECTIVE type rather than the sampled one, or an
+    # empty spatial reupload would flip a still-spatial dataset to `table`.
+    dataset.record.record_type = _derived_record_type(
+        dataset.record.record_type, effective_geometry_type
+    )
     dataset.feature_count = metadata["feature_count"]
     if metadata["extent_wkt"] is not None:
         dataset.record.spatial_extent = func.ST_GeomFromText(
@@ -1879,9 +1991,17 @@ async def _apply_reupload_swap(
         session,
         dataset.id,
         metadata["column_info"],
-        geometry_type=metadata.get("geometry_type"),
+        geometry_type=effective_geometry_type,
         sample_values=sample_values,
     )
+    # NOT fixed here, and filed as #1380: that helper touches the synthetic
+    # `geom` attribute row only when geometry_type is non-null and excludes it
+    # from the removed-column sweep by name, so a de-spatializing reupload
+    # leaves the row current against a relation with no geometry. The refresh
+    # path retires it explicitly (#1313 review round 7); this one still does
+    # not. It is a row this swap has never written, unlike the two fields
+    # #1373 and #1361 asked for, so folding it in would widen the change past
+    # both issues.
 
     # fix(#1314): a reupload can replace a spatial dataset with a non-spatial
     # one (or the reverse), and the auto-generated `record_distributions` rows
@@ -1890,47 +2010,30 @@ async def _apply_reupload_swap(
     # for the same reason as there: reconcile normalizes `is_primary`, and a
     # reupload that kept the modality has no business rewriting it.
     #
-    # NOT fixed here, and filed as #1361: this path leaves
-    # `dataset.record.record_type` at whatever creation derived, so a
-    # de-spatialized reupload still reads as a `vector_dataset` and
-    # `build_assets` still emits tile links from it. That is a different field
-    # with a different derivation (the refresh path owns the only copy of it),
-    # and folding it in would widen this change past the distributions #1314
-    # asked for.
+    # fix(#1373): the flip is read off the EFFECTIVE type, which is also the
+    # value written to `geometry_type` and `record_type` above — so the three
+    # cannot disagree about one swap. #1314 review round 2 reached the same
+    # answer for the demote alone by asking `_table_has_geometry` whether the
+    # relation still had its geom column, because reconciling on the sampled
+    # None would DELETE the GeoPackage, GeoJSON, Shapefile, GeoParquet and
+    # vector-tile rows of a still-spatial dataset. That question is now
+    # subsumed: `_declared_geometry_type` returns None exactly when there is no
+    # geom column, which is the only case the precedence resolves to None.
     #
-    # fix(#1314 review round 2): the demote needs positive evidence, and
-    # `metadata["geometry_type"]` is not it. `extract_metadata` derives the
-    # type by sampling a row (`GeometryType(geom) ... LIMIT 1`), so a spatial
-    # reupload carrying zero features — or only NULL geometries — reports None
-    # while the relation it just installed still has its geometry column.
-    # Reconciling on that would DELETE the GeoPackage, GeoJSON, Shapefile,
-    # GeoParquet and vector-tile rows of a dataset that is still spatial.
-    # #1313 hit the identical trap on the refresh path (review round 5) and
-    # answered it by deriving the type from the COLUMN rather than the rows;
-    # here the column's presence is the entire question, and
-    # `_table_has_geometry` is the codebase's existing way to ask it.
-    #
-    # Only the demote pays for that query, and the third case falls through
-    # deliberately: a TABULAR dataset reuploaded from an empty spatial file
-    # measures None, so there is no type to promote to and no distribution set
-    # to promote it into. Nothing changes until a reupload or a refresh
-    # actually measures geometry, which is the same answer
-    # `dataset.geometry_type` gets on that path.
-    measured_geometry_type = metadata["geometry_type"]
+    # The promote widens accordingly, and deliberately: #1314 let a TABULAR
+    # dataset reuploaded from an empty spatial file fall through, on the
+    # grounds that nothing measured a type so `dataset.geometry_type` stayed
+    # None too. It no longer does — a specific declared column type is now
+    # written — so the distributions follow it.
     was_spatial = previous_geometry_type is not None
-    demoted = (
-        was_spatial
-        and measured_geometry_type is None
-        and not await _table_has_geometry(session, table_name, schema=_tenant_schema)
-    )
-    promoted = not was_spatial and measured_geometry_type is not None
-    if demoted or promoted:
+    is_spatial = effective_geometry_type is not None
+    if was_spatial != is_spatial:
         await port.reconcile_distributions(
             session,
             dataset.id,
             dataset.record_id,
             table_name,
-            geometry_type=measured_geometry_type,
+            geometry_type=effective_geometry_type,
         )
 
     dataset.source_format = source_format
@@ -1998,7 +2101,9 @@ async def _apply_reupload_swap(
         source_format=source_format,
         feature_count=metadata["feature_count"],
         srid=metadata["srid"],
-        geometry_type=metadata["geometry_type"],
+        # The effective type, so the version history and the dataset row it
+        # describes never disagree about what this swap installed (#1373).
+        geometry_type=effective_geometry_type,
         file_hash=file_hash,
         uploaded_by=actor_id,
     )

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -61,6 +61,9 @@ from app.platform.refresh.service import (
 from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
     _current_tenant_schema,
+    _declared_geometry_type,
+    _derived_record_type,
+    _effective_geometry_type,
     invalidate_tile_cache_for_table,
     stamp_failed_origin_health,
     task_app,
@@ -91,16 +94,6 @@ _ERROR_CODE_MISSING = "source_missing"
 _ERROR_CODE_INACCESSIBLE = "source_inaccessible"
 _ERROR_CODE_GENERIC = "postgis_refresh_failed"
 _ERROR_CODE_SUPERSEDED = "superseded"
-
-# What PostGIS records in ``geometry_columns.type`` for an untyped column.
-# A specific value ("POLYGON", "MULTILINESTRING", ...) describes what the
-# column will accept; this one describes nothing.
-_GENERIC_GEOMETRY_TYPE = "GEOMETRY"
-
-# The record types ``service_create.py`` derives from "does this dataset have
-# geometry". Raster and VRT records carry their own modality and must never be
-# re-derived from a geometry column they do not have.
-_DERIVED_RECORD_TYPES: frozenset[str] = frozenset({"table", "vector_dataset"})
 
 
 class _Verdict(NamedTuple):
@@ -316,38 +309,6 @@ async def _relation_exists(session: Any, *, schema: str, table: str) -> bool:
     )
 
 
-def _effective_geometry_type(
-    *, measured: str | None, declared: str | None, stored: str | None
-) -> str | None:
-    """The geometry type this measurement establishes, from the best evidence.
-
-    One rule in one place: the write applies it and the quality score is
-    computed under it, and a second spelling of this precedence is how those
-    two end up describing different datasets.
-
-    - a sampled row is what the data actually is;
-    - no rows but a specific declared column type is what the column accepts;
-    - no rows and a generic ``geometry`` column establishes only that the
-      relation is spatial, so the catalog keeps what it last measured;
-    - no ``geom`` column at all is genuinely not spatial, and the only case
-      that yields None.
-    """
-    if measured is not None:
-        return measured
-    if declared is None:
-        return None
-    if declared != _GENERIC_GEOMETRY_TYPE:
-        return declared
-    return stored
-
-
-def _derived_record_type(current: str | None, geometry_type: str | None) -> str | None:
-    """``record_type`` as ``service_create.py`` derives it, for the two it owns."""
-    if current not in _DERIVED_RECORD_TYPES:
-        return current
-    return "table" if geometry_type is None else "vector_dataset"
-
-
 class _RecordAs:
     """The record as the measurement implies it, for scoring only.
 
@@ -368,35 +329,6 @@ class _RecordAs:
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._record, name)
-
-
-async def _declared_geometry_type(
-    session: Any, *, schema: str, table: str
-) -> str | None:
-    """The geom column's DECLARED type, or None when the relation has no geom.
-
-    fix(#1313 review round 5): ``extract_metadata`` derives the geometry type
-    by sampling a row (``GeometryType(geom) ... LIMIT 1``), so a spatial table
-    that has been emptied reports None — indistinguishable, from the
-    measurement alone, from a table that never had geometry at all. Writing
-    that None reclassified the dataset as tabular, and the consequences are
-    not cosmetic: ``_require_feature_table`` refuses feature writes to a
-    dataset whose ``geometry_type`` is None, so a refresh of an emptied table
-    would lock the API out of ever repopulating it, and the builder drops its
-    layers as unsupported.
-
-    ``geometry_columns`` answers the question the rows cannot: it describes
-    the COLUMN. A row here means the relation is spatial whatever it
-    currently holds; no row means it genuinely is not.
-    """
-    return await session.scalar(
-        text(
-            "SELECT type FROM geometry_columns "
-            "WHERE f_table_schema = :schema AND f_table_name = :table "
-            "AND f_geometry_column = 'geom'"
-        ),
-        {"schema": schema, "table": table},
-    )
 
 
 def _apply_measurement(

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -29,6 +29,7 @@ from pathlib import Path
 import pytest
 import sqlalchemy as sa
 from httpx import AsyncClient
+from sqlalchemy.orm import joinedload
 
 import app.modules.catalog.datasets.domain.models  # noqa: F401
 from app.core.db import Base
@@ -1487,6 +1488,7 @@ async def _run_reupload_swap(
     admin_id,
     metadata: dict | None = None,
     staging_has_geometry: bool = True,
+    staging_geometry_type: str = "Point",
     **kwargs,
 ) -> None:
     """Drive _apply_reupload_swap against a real staging table.
@@ -1500,6 +1502,10 @@ async def _run_reupload_swap(
     separate from ``metadata`` on purpose: the pair (measurement says
     non-spatial, relation still has a geom column) is exactly the empty-spatial
     reupload the demote must not act on.
+
+    ``staging_geometry_type`` is what the geom column is DECLARED as, which is
+    the evidence the sampled rows cannot supply (#1373). ``"Geometry"`` stages
+    the untyped column that establishes only that the relation is spatial.
     """
     from unittest.mock import AsyncMock, patch
 
@@ -1507,7 +1513,8 @@ async def _run_reupload_swap(
 
     staging_table = f"{dataset.table_name}_staging"
     geometry_columns = (
-        "geom geometry(Point, 4326), geom_4326 geometry(Geometry, 4326), "
+        f"geom geometry({staging_geometry_type}, 4326), "
+        "geom_4326 geometry(Geometry, 4326), "
         if staging_has_geometry
         else ""
     )
@@ -1821,6 +1828,311 @@ class TestReuploadReconcilesDistributions:
         await test_db_session.commit()
 
         assert await self._pairs(test_db_session, record_id) == before
+
+
+class TestReuploadDerivesTheEffectiveModality:
+    """fix(#1373) / fix(#1361): the swap writes what the RELATION is.
+
+    ``extract_metadata`` derives the geometry type by sampling a row, so an
+    empty spatial file measures None against a relation whose geom column is
+    right there. The registered-PostGIS refresh resolved that first (#1313);
+    these pin that the reupload path resolves it the same way, and that
+    ``record_type`` — which ``build_assets`` branches on live — follows the
+    resolved value rather than the sampled one.
+    """
+
+    async def _seed(self, session, *, admin_id, geometry_type, record_type):
+        ds = await _create_dataset(
+            session,
+            created_by=admin_id,
+            name="Reupload Modality",
+            # Private: these rows outlive the test on the shared per-worker
+            # DB, so keep them out of public-list assertions.
+            visibility="private",
+            source_format="geojson",
+            geometry_type=geometry_type,
+        )
+        ds.record.record_type = record_type
+        await session.commit()
+        return ds
+
+    async def _reload(self, session, dataset_id) -> Dataset:
+        """Read the pair back past the identity map, with the record joined."""
+        session.expire_all()
+        return (
+            await session.execute(
+                sa.select(Dataset)
+                .options(joinedload(Dataset.record))
+                .where(Dataset.id == dataset_id)
+            )
+        ).scalar_one()
+
+    async def test_an_empty_spatial_reupload_keeps_the_dataset_spatial(
+        self, test_db_session
+    ) -> None:
+        """fix(#1373): zero rows is not evidence that the column is gone.
+
+        Writing the sampled None reclassified a still-spatial dataset as
+        tabular, and the consequences are not cosmetic: feature writes are
+        refused, so the API could never repopulate the table it just emptied,
+        and the builder drops its layers as unsupported.
+        """
+        from app.modules.catalog.features.router import _require_feature_table
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type="POINT",
+            record_type="vector_dataset",
+        )
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            metadata={
+                **_SWAP_METADATA,
+                "geometry_type": None,
+                "extent_wkt": None,
+                "feature_count": 0,
+            },
+            source_filename="empty.geojson",
+            source_format="geojson",
+            origin_ref={"filename": "empty.geojson"},
+        )
+        await test_db_session.commit()
+
+        reloaded = await self._reload(test_db_session, ds.id)
+        assert reloaded.geometry_type == "POINT", "the declared column type"
+        assert reloaded.record.record_type == "vector_dataset"
+        # The lockout the issue is actually about, asserted against the guard
+        # itself rather than a restatement of it.
+        _require_feature_table(reloaded)
+
+    async def test_an_empty_generic_column_keeps_what_was_already_known(
+        self, test_db_session
+    ) -> None:
+        """The branch where neither the rows nor the column say anything.
+
+        An untyped ``geometry`` column carrying no rows establishes only that
+        the relation is spatial, so the catalog keeps the type it last
+        measured — which is the PRE-swap value, and reading it after the write
+        would silently resolve to None.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type="MULTIPOLYGON",
+            record_type="vector_dataset",
+        )
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            metadata={
+                **_SWAP_METADATA,
+                "geometry_type": None,
+                "extent_wkt": None,
+                "feature_count": 0,
+            },
+            staging_geometry_type="Geometry",
+            source_filename="empty.gpkg",
+            source_format="gpkg",
+            origin_ref={"filename": "empty.gpkg"},
+        )
+        await test_db_session.commit()
+
+        reloaded = await self._reload(test_db_session, ds.id)
+        assert reloaded.geometry_type == "MULTIPOLYGON"
+        assert reloaded.record.record_type == "vector_dataset"
+
+    async def test_a_non_spatial_reupload_demotes_the_record_type(
+        self, test_db_session
+    ) -> None:
+        """fix(#1361): a CSV over a shapefile leaves nothing to tile.
+
+        Without the re-derivation the record stays a ``vector_dataset``, and
+        ``build_assets`` goes on advertising vector-tile and OGC-Features
+        hrefs against a relation with no geometry column.
+        """
+        from app.modules.catalog.search.service_records import build_assets
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type="POINT",
+            record_type="vector_dataset",
+        )
+        assert "vector_tiles" in build_assets(ds, "https://api.test")
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            metadata={**_SWAP_METADATA, "geometry_type": None, "extent_wkt": None},
+            staging_has_geometry=False,
+            source_filename="rows.csv",
+            source_format="csv",
+            origin_ref={"filename": "rows.csv"},
+        )
+        await test_db_session.commit()
+
+        reloaded = await self._reload(test_db_session, ds.id)
+        assert reloaded.geometry_type is None
+        assert reloaded.record.record_type == "table"
+        assets = build_assets(reloaded, "https://api.test")
+        assert "vector_tiles" not in assets
+        assert "ogc_features" not in assets
+
+    async def test_a_reupload_that_adds_geometry_promotes_the_record_type(
+        self, test_db_session
+    ) -> None:
+        """The inverse: a tabular dataset that gains a geometry column."""
+        from app.modules.catalog.search.service_records import build_assets
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type=None,
+            record_type="table",
+        )
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            source_filename="points.geojson",
+            source_format="geojson",
+            origin_ref={"filename": "points.geojson"},
+        )
+        await test_db_session.commit()
+
+        reloaded = await self._reload(test_db_session, ds.id)
+        assert reloaded.geometry_type == "POINT"
+        assert reloaded.record.record_type == "vector_dataset"
+        assert "vector_tiles" in build_assets(reloaded, "https://api.test")
+
+    async def test_an_empty_spatial_file_over_a_table_promotes_it_too(
+        self, test_db_session
+    ) -> None:
+        """Where #1373 deliberately widens what #1314 let fall through.
+
+        #1314 left this case alone because nothing measured a type, so
+        ``geometry_type`` stayed None either way. It no longer does — a
+        specific declared column type is now written — so the record type and
+        the distribution rows have to follow it rather than describe a
+        dataset the catalog no longer claims to hold.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type=None,
+            record_type="table",
+        )
+        record_id = ds.record_id
+        await generate_distributions(
+            test_db_session, ds.id, record_id, ds.table_name, geometry_type=None
+        )
+        await test_db_session.commit()
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            metadata={
+                **_SWAP_METADATA,
+                "geometry_type": None,
+                "extent_wkt": None,
+                "feature_count": 0,
+            },
+            source_filename="empty.geojson",
+            source_format="geojson",
+            origin_ref={"filename": "empty.geojson"},
+        )
+        await test_db_session.commit()
+
+        reloaded = await self._reload(test_db_session, ds.id)
+        assert reloaded.geometry_type == "POINT"
+        assert reloaded.record.record_type == "vector_dataset"
+        pairs = {
+            (row[0], row[1])
+            for row in (
+                await test_db_session.execute(
+                    sa.select(
+                        RecordDistribution.distribution_type,
+                        RecordDistribution.format,
+                    ).where(RecordDistribution.record_id == record_id)
+                )
+            ).all()
+        }
+        assert ("vector_tiles", "pbf") in pairs
+
+    @pytest.mark.parametrize("record_type", ["raster_dataset", "vrt_dataset"])
+    async def test_the_raster_family_is_never_re_derived(
+        self, test_db_session, record_type: str
+    ) -> None:
+        """Only the two record types the create path derives are derivable.
+
+        A raster or VRT record carries its own modality, and re-deriving it
+        from a geometry column it never had would reclassify it. Pinned at the
+        derivation rather than through the API, which refuses the combination
+        a layer earlier (``_assert_compatible_record_type`` in
+        ``router_reupload``, covered by ``test_reupload_record_type_guard``):
+        the guard here is what keeps a future caller of this swap — the raster
+        tails already build their own version rows beside it — from inheriting
+        a derivation that has no business running on them.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type="POINT",
+            record_type=record_type,
+        )
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            metadata={**_SWAP_METADATA, "geometry_type": None, "extent_wkt": None},
+            staging_has_geometry=False,
+            source_filename="rows.csv",
+            source_format="csv",
+            origin_ref={"filename": "rows.csv"},
+        )
+        await test_db_session.commit()
+
+        reloaded = await self._reload(test_db_session, ds.id)
+        assert reloaded.record.record_type == record_type
+
+    def test_both_paths_share_one_derivation(self) -> None:
+        """The acceptance criterion of both issues, pinned by identity.
+
+        A second spelling of this precedence is how the reupload swap and the
+        registered-PostGIS refresh end up describing the same dataset
+        differently. Identity rather than a file path, so moving the helpers
+        again is a refactor rather than a test failure.
+        """
+        from app.processing.ingest import tasks_common, tasks_postgis_refresh
+
+        assert (
+            tasks_postgis_refresh._effective_geometry_type
+            is tasks_common._effective_geometry_type
+        )
+        assert (
+            tasks_postgis_refresh._declared_geometry_type
+            is tasks_common._declared_geometry_type
+        )
+        assert (
+            tasks_postgis_refresh._derived_record_type
+            is tasks_common._derived_record_type
+        )
 
 
 class TestFirstIngestStampsLastRefreshed:

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -2111,6 +2111,84 @@ class TestReuploadDerivesTheEffectiveModality:
         reloaded = await self._reload(test_db_session, ds.id)
         assert reloaded.record.record_type == record_type
 
+    async def test_an_empty_generic_column_over_a_table_is_still_spatial(
+        self, test_db_session
+    ) -> None:
+        """fix(#1382 review r1): the case where nothing has ever been measured.
+
+        A generic column with no rows and no stored type used to resolve to
+        None, which classified a relation that plainly has a geometry column
+        as tabular and left feature writes refused — so the dataset could
+        never be given the first row that would have named its type. The
+        generic sentinel is what this codebase spells that state as, and it
+        survives write validation (#430 BA-32) and the builder (#430 r23).
+        """
+        from app.modules.catalog.features.router import _require_feature_table
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type=None,
+            record_type="table",
+        )
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            metadata={
+                **_SWAP_METADATA,
+                "geometry_type": None,
+                "extent_wkt": None,
+                "feature_count": 0,
+            },
+            staging_geometry_type="Geometry",
+            source_filename="empty-mixed.gpkg",
+            source_format="gpkg",
+            origin_ref={"filename": "empty-mixed.gpkg"},
+        )
+        await test_db_session.commit()
+
+        reloaded = await self._reload(test_db_session, ds.id)
+        assert reloaded.geometry_type == "GEOMETRY"
+        assert reloaded.record.record_type == "vector_dataset"
+        _require_feature_table(reloaded)
+
+    @pytest.mark.parametrize(
+        ("measured", "declared", "stored", "expected"),
+        [
+            # A sampled row wins over everything else.
+            ("POINT", "GEOMETRY", "MULTIPOLYGON", "POINT"),
+            ("POINT", None, None, "POINT"),
+            # No rows, but the column says what it accepts.
+            (None, "MULTIPOLYGON", "POINT", "MULTIPOLYGON"),
+            # Generic column, no rows: keep the last measurement...
+            (None, "GEOMETRY", "POINT", "POINT"),
+            # ...or say "spatial, subtype unknown" when there is none.
+            (None, "GEOMETRY", None, "GEOMETRY"),
+            # No geom column at all is the only genuinely non-spatial case.
+            (None, None, "POINT", None),
+            (None, None, None, None),
+        ],
+    )
+    def test_the_precedence_in_full(
+        self,
+        measured: str | None,
+        declared: str | None,
+        stored: str | None,
+        expected: str | None,
+    ) -> None:
+        """The whole truth table, since both paths now resolve through it."""
+        from app.processing.ingest.tasks_common import _effective_geometry_type
+
+        assert (
+            _effective_geometry_type(
+                measured=measured, declared=declared, stored=stored
+            )
+            == expected
+        )
+
     def test_both_paths_share_one_derivation(self) -> None:
         """The acceptance criterion of both issues, pinned by identity.
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2238,7 +2238,20 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # measures None while its geom column is still there. Most of the lines are
     # the note saying why the sampled value is not that evidence, which is the
     # same trap #1313 fell into on the refresh path. Cap 1994 -> 2022, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2022,
+    # fix(#1373 x #1361): +97 — the effective-geometry precedence and the
+    # record_type derivation MOVED here from tasks_postgis_refresh (which
+    # already imports from this module, so the dependency runs the right way)
+    # and _apply_reupload_swap now resolves both. Roughly half the lines are
+    # the three helpers and their docstrings arriving intact — that file shrank
+    # by 68 — and the rest is the swap's own note recording why the sampled
+    # geometry type is not evidence about the COLUMN, and why record_type must
+    # consume the RESOLVED value or an empty spatial reupload flips a still-
+    # spatial dataset to `table`. Cap 2022 -> 2119, exact. +8 more: the note
+    # recording what this swap still does NOT retire when it de-spatializes a
+    # dataset (the synthetic `geom` attribute row, filed as #1380), so the
+    # remaining asymmetry with the refresh path is a decision. Cap 2119 ->
+    # 2127, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2127,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2250,8 +2250,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # recording what this swap still does NOT retire when it de-spatializes a
     # dataset (the synthetic `geom` attribute row, filed as #1380), so the
     # remaining asymmetry with the refresh path is a decision. Cap 2119 ->
-    # 2127, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2127,
+    # 2127, exact. +12 more (#1382 review r1): a generic empty column over a
+    # dataset nothing had ever measured resolved to None and classified a
+    # spatial relation as tabular, so the precedence falls back to the generic
+    # sentinel; the lines are the note recording that `GEOMETRY` is how the
+    # rest of the codebase already spells "spatial, subtype unknown".
+    # Cap 2127 -> 2139, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2139,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_postgis_refresh_1265.py
+++ b/backend/tests/test_postgis_refresh_1265.py
@@ -1031,6 +1031,39 @@ class TestPostgisRefreshExecution:
         refreshed = await _reload(test_db_session, dataset.id)
         assert refreshed.geometry_type == "POLYGON"  # the stored value, kept
 
+    async def test_an_emptied_generic_column_with_nothing_known_stays_spatial(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        """fix(#1382 review r1): the sub-case with no last measurement.
+
+        Same branch as above, minus the stored value to fall back on: a table
+        registered while it was empty and generic has never had a type
+        measured. Resolving that to None classified a relation with a geometry
+        column as tabular and refused the feature writes that would have given
+        it a row to measure. The generic sentinel says what is actually known.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _registered_dataset(test_db_session, created_by=admin_id)
+        await test_db_session.execute(
+            text(  # noqa: S608
+                f"ALTER TABLE data.{dataset.table_name} "
+                f"ALTER COLUMN geom TYPE geometry(Geometry, 4326)"
+            )
+        )
+        await test_db_session.execute(
+            text(f"DELETE FROM data.{dataset.table_name}")  # noqa: S608
+        )
+        dataset.geometry_type = None
+        dataset.record.record_type = "table"
+        await test_db_session.commit()
+
+        payload = await _dispatch(client, admin_auth_header, dataset.id)
+        await _execute(test_db_session, payload)
+
+        refreshed = await _reload(test_db_session, dataset.id)
+        assert refreshed.geometry_type == "GEOMETRY"
+        assert refreshed.record.record_type == "vector_dataset"
+
     async def test_a_table_that_gains_geometry_becomes_a_vector_dataset(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
     ) -> None:

--- a/backend/tests/test_reupload_swap_lock_retry.py
+++ b/backend/tests/test_reupload_swap_lock_retry.py
@@ -64,9 +64,12 @@ class TestIsLockTimeoutError:
 
 def _make_dataset_stub(table_name: str):
     """Build a minimal dataset object satisfying the attributes ``_apply_reupload_swap`` reads."""
+    # fix(#1361): the swap re-derives record_type from the geometry the swapped
+    # relation actually has, so the stub has to carry one to re-derive.
     record = types.SimpleNamespace(
         spatial_extent=None,
         updated_by=None,
+        record_type="vector_dataset",
     )
     dataset = types.SimpleNamespace(
         id=uuid.uuid4(),


### PR DESCRIPTION
## Why one PR

Both issues edit `_apply_reupload_swap` in `backend/app/processing/ingest/tasks_common.py`, both are closed by moving the same three helpers out of the registered-PostGIS refresh, and the second depends on the first: `record_type` has to be derived from the *resolved* geometry type, or an empty spatial reupload flips a still-spatial dataset to `table`.

## #1373: an empty spatial reupload de-spatialized the dataset

`extract_metadata` derives the geometry type by sampling a row (`GeometryType(geom) ... LIMIT 1`), so a spatial file carrying zero features, or only NULL geometries, reports None against a relation whose geometry column is right there. The swap wrote that value onto `dataset.geometry_type`, and the consequences are not cosmetic: `_require_feature_table` refuses feature writes to a dataset whose `geometry_type` is None, so the API could never repopulate the table through GeoLens, and the map builder drops the layer as unsupported.

## #1361: `record_type` was never re-derived

The swap wrote `geometry_type` and never touched `dataset.record.record_type`, so a CSV reupload over a shapefile left the record classified `vector_dataset` and `build_assets` kept emitting vector-tile and OGC-Features hrefs against a table with no geometry column. The reverse left a now-spatial dataset classified `table`, advertising nothing.

## What changed

`_declared_geometry_type`, `_effective_geometry_type` and `_derived_record_type` move from `tasks_postgis_refresh.py` into `tasks_common.py` and are imported back. `tasks_postgis_refresh` already imported from `tasks_common`, so the dependency runs the right way. The acceptance criterion of both issues, one shared implementation rather than a second copy, is pinned by identity (`tasks_postgis_refresh._effective_geometry_type is tasks_common._effective_geometry_type`) rather than by file path, so a later move is a refactor instead of a test failure.

`_apply_reupload_swap` resolves the effective type once, immediately after the swap DDL, and every downstream site reads that one value: the GIST index heal, `dataset.geometry_type`, the new `record_type` derivation, `refresh_attribute_metadata`, the distributions reconcile, and the `DatasetVersion` row. `metadata["geometry_type"]` now appears exactly once, as the `measured=` argument.

Two consequences are worth calling out, both deliberate. First, the distributions gate simplifies: #1314 review round 2 gave the demote positive evidence by asking `_table_has_geometry` whether the relation still had its geom column, and `_declared_geometry_type` returns None in exactly that case, which is the only case the precedence resolves to None, so the extra query is subsumed rather than kept beside it. Second, the promote widens: #1314 let a tabular dataset reuploaded from an empty spatial file fall through, on the stated grounds that `dataset.geometry_type` stayed None either way. It no longer does, because a specific declared column type is now written, so the record type and the generated distribution rows follow it.

No schema, API-contract or config impact.

## Follow-up filed

**#1380**: the swap still does not retire the synthetic `geom` attribute row when it de-spatializes a dataset. The refresh path does (#1313 review round 7). That is a row this swap has never written, unlike the two fields these issues asked for, so it is recorded as a decision in an inline comment rather than folded in.

## Verification

The focused tests were written failing-first: all six new cases fail on the pre-fix code (app change stashed), pass after it.

```
uv run pytest tests/test_dataset_source_state.py -q          # 122 passed
uv run pytest tests/test_postgis_refresh_1265.py -q          # the refresh path, unchanged
uv run pytest tests/test_reupload_swap_lock_retry.py \
              tests/test_provenance_attribution.py -q
uv run pytest tests/test_reupload.py tests/test_reupload_service.py \
              tests/test_reupload_completion_contract_1207.py \
              tests/test_reupload_record_type_guard.py \
              tests/test_staging_pipeline_integration.py \
              tests/test_attribute_metadata.py -q            # 104 passed
uv run pytest tests/test_service_refresh_1220.py tests/test_refresh_gate_1269.py \
              tests/test_stac_refresh_1266.py tests/test_raster_replace_1221.py \
              tests/test_service_column_info_1359.py -q      # 296 passed
uv run pytest tests/test_layering.py -q                      # 40 passed
uv run ruff check . && uv run ruff format --check .
```

`_MODULE_LOC_CAPS` for `tasks_common.py` is raised 2022 to 2127 in the same commit, with the comment recording what the lines bought. `tasks_postgis_refresh.py` shrank by 68 and stays below the ratchet inclusion threshold.

New tests, all in `backend/tests/test_dataset_source_state.py` beside the existing reupload-swap coverage:

- an empty spatial reupload keeps the dataset spatial, asserted against `_require_feature_table` itself rather than a restatement of it
- an empty untyped `geometry` column keeps what the catalog last measured, the branch that catches reading `stored` after the write instead of before
- a non-spatial reupload demotes `record_type`, and `build_assets` stops emitting `vector_tiles` / `ogc_features`
- a reupload that adds geometry promotes it
- an empty spatial file over a tabular dataset promotes it too (the widened case)
- `raster_dataset` / `vrt_dataset` are never re-derived
- the identity pin that both paths share one derivation

Fixes #1373
Fixes #1361
