### PR TITLE
feat(stac): give remote raster rows a measured resolution and rotation flag

### DIFF
--- a/backend/app/core/geo.py
+++ b/backend/app/core/geo.py
@@ -707,6 +707,52 @@ def wkt_has_degree_unit(crs_wkt: str | None) -> bool | None:
     return crs_has_degree_unit(_parse_crs(crs_wkt))
 
 
+def crs_metres_per_unit(crs: object | None) -> float | None:
+    """Metres per linear unit of a PROJECTED CRS, or None when that is not a
+    question with an answer.
+
+    fix(#1375 review): STAC's ``gsd`` is defined in metres, but a stored
+    resolution is in whatever unit its CRS measures. PROJ answers the
+    conversion for projected CRSs directly — ``units_factor`` reports
+    ``('metre', 1.0)`` for UTM and Web Mercator and ``('US survey foot',
+    0.3048006...)`` for the state-plane systems, so a foot-based raster
+    converts as readily as a metre-based one.
+
+    Returns None for a GEOGRAPHIC CRS on purpose, rather than a factor.
+    ``units_factor`` reports RADIANS per unit there, and an angular
+    resolution has no fixed length: a degree of longitude is 111 km at the
+    equator and nothing at the pole, so the conversion needs a latitude this
+    function is not given. Callers must read None as "cannot be expressed in
+    metres" and omit the value rather than publish it unconverted — see
+    ``RasterAsset.to_stac_properties``.
+    """
+    if crs is None:
+        return None
+    try:
+        if not crs.is_projected:
+            return None
+        _, metres_per_unit = crs.units_factor
+    except Exception:  # broad: exotic CRSs raise from PROJ rather than answering, and "no answer" is exactly the None case
+        return None
+    if not metres_per_unit or metres_per_unit <= 0:
+        return None
+    return float(metres_per_unit)
+
+
+def wkt_metres_per_unit(crs_wkt: str | None) -> float | None:
+    """:func:`crs_metres_per_unit` plus the WKT parse.
+
+    Same shape as :func:`wkt_has_degree_unit` over
+    :func:`crs_has_degree_unit`: one implementation, two entry points, so a
+    caller holding a live ``rasterio.crs.CRS`` need not round-trip through
+    WKT to reach it. None covers every uncertainty — no WKT, an unparseable
+    one, or a CRS whose units PROJ will not report.
+    """
+    if not isinstance(crs_wkt, str) or not crs_wkt:
+        return None
+    return crs_metres_per_unit(_parse_crs(crs_wkt))
+
+
 def pixel_size_from_affine(
     a: float, b: float, d: float, e: float
 ) -> tuple[float, float]:

--- a/backend/app/core/geo.py
+++ b/backend/app/core/geo.py
@@ -705,3 +705,30 @@ def wkt_has_degree_unit(crs_wkt: str | None) -> bool | None:
     if not isinstance(crs_wkt, str) or not crs_wkt:
         return None
     return crs_has_degree_unit(_parse_crs(crs_wkt))
+
+
+def pixel_size_from_affine(
+    a: float, b: float, d: float, e: float
+) -> tuple[float, float]:
+    """Per-pixel ground distances along a raster's OWN axes, from its affine.
+
+    fix(#1375 review): not ``abs(a)``/``abs(e)``. Those are the pixel vectors'
+    COMPONENTS on the world axes, which equal the pixel sizes only when the
+    raster is axis-aligned. A geotransform maps pixel (col, row) to world
+    ``x = a*col + b*row + c``, ``y = d*col + e*row + f``, so one step along the
+    column axis moves the world point by the vector ``(a, d)`` and one step
+    along the row axis by ``(b, e)``. The LENGTHS of those two vectors are the
+    resolutions; ``a`` and ``e`` alone are their projections onto x and y.
+
+    Rotate a 10 m-pixel raster by 30° and the affine reads ``a=8.66, d=5.0``:
+    ``abs(a)`` reports 8.66 m for a pixel that is 10 m across, a 13%
+    understatement that reaches the UI and STAC's ``gsd``. Confirmed against
+    the distance between adjacent pixel centres, which is 10.0.
+
+    For an axis-aligned raster ``b`` and ``d`` are zero and this returns
+    exactly ``abs(a)``/``abs(e)`` — it agrees with the old form everywhere the
+    old form was right, and differs only where it was wrong. Both raster
+    ingest paths call this so a rotated scene reports the same resolution
+    whether it was uploaded or imported from a remote catalog.
+    """
+    return math.hypot(a, d), math.hypot(b, e)

--- a/backend/app/modules/catalog/sources/cog_info.py
+++ b/backend/app/modules/catalog/sources/cog_info.py
@@ -63,12 +63,9 @@ def _georeferencing(info: dict) -> dict:
     transform to check that against, so a rotated or sheared remote COG would
     silently get a resolution inflated by however far its bounding envelope
     exceeds its own footprint — indistinguishable, in this payload, from a
-    correct value. The local-upload path can tell the two apart
-    (``raster/cog.py`` reads ``transform.b``/``transform.d`` to set
-    ``is_rotated``); nothing here can. A wrong number that LOOKS like a
-    measurement is worse than the blank "—" it would replace, so it stays
-    unset until there is a source that can rule rotation out. Tracked as
-    #1375.
+    correct value. fix(#1375): they now come from ``_geotransform`` and a
+    SECOND Titiler endpoint that does carry the transform, which is why this
+    one still refuses to guess at them.
 
     Individual failures degrade to None rather than raising: this is
     descriptive metadata for a UI card, not something a failed probe should
@@ -91,6 +88,53 @@ def _georeferencing(info: dict) -> dict:
             epsg = None
 
     return {"crs_wkt": crs_wkt, "epsg": epsg}
+
+
+def _geotransform(item: dict) -> dict:
+    """``res_x``/``res_y``/``is_rotated`` from a Titiler-generated STAC item.
+
+    fix(#1375): ``/cog/info`` carries no affine transform, which is why
+    ``_georeferencing`` refuses to derive a resolution from its bounding
+    envelope. ``/cog/stac`` does carry one — rio-stac writes the projection
+    extension's ``proj:transform`` as the 9-element affine — and it is the
+    SAME six numbers ``raster/cog.py`` reads off ``rasterio``'s
+    ``src.transform`` on the local-upload path. So this is not an
+    approximation of what a local ingest would have stored; element 0 and
+    element 4 are exactly its ``abs(transform.a)``/``abs(transform.e)``, and
+    elements 1 and 3 are exactly the ``transform.b``/``transform.d`` it tests
+    to set ``is_rotated``. A rotated remote COG is now recorded as rotated
+    rather than defaulting to the column's ``false``.
+
+    Endpoint choice, since two of them expose georeferencing: ``/cog/validate``
+    (rio-cogeo) reports ``GEO.Resolution`` and it is the same
+    ``(transform.a, transform.e)`` pair, but it publishes no ``b``/``d``, so
+    it cannot answer the rotation question this function exists to settle.
+    Verified against titiler 2.2.1 / rio-tiler 9.4.2 / rio-stac, the pinned
+    image: a 30°-rotated COG returns
+    ``[8.66, -5.0, ..., 5.0, -8.66, ...]`` where the axis-aligned twin
+    returns ``[10.0, 0.0, ..., 0.0, -10.0, ...]``, while ``/cog/info``'s
+    ``bounds`` for that same rotated file describe a 3497 m envelope around a
+    2560 m footprint (the 37% overstatement #1334 declined to publish).
+
+    Returns an EMPTY dict, not one full of Nones, when the transform is
+    missing or malformed: absent keys leave the row's columns untouched,
+    where a None would assert "measured, and there is no value".
+    """
+    props = item.get("properties") or {}
+    transform = props.get("proj:transform")
+    # 9 elements in practice (the affine's bottom row is included); the first
+    # six are the only ones with content, and >= 6 accepts either spelling.
+    if not isinstance(transform, (list, tuple)) or len(transform) < 6:
+        return {}
+    try:
+        scale_x, shear_x, _, shear_y, scale_y, _ = (float(v) for v in transform[:6])
+    except (TypeError, ValueError):
+        return {}
+    return {
+        "res_x": abs(scale_x),
+        "res_y": abs(scale_y),
+        "is_rotated": shear_x != 0.0 or shear_y != 0.0,
+    }
 
 
 def reconcile_epsg(probe: dict, declared: int | None) -> int | None:
@@ -123,7 +167,9 @@ async def fetch_cog_info(url: str) -> dict | None:
     """Fetch COG metadata + statistics from Titiler for a remote asset URL.
 
     Returns dict with band_count, dtype, width, height, crs_wkt, band_info
-    (with min/max per band for rescaling), or None on failure.
+    (with min/max per band for rescaling), res_x/res_y/is_rotated, or None on
+    failure. The georeferencing keys are absent rather than None when their
+    endpoint could not be read — see ``_georeferencing`` and ``_geotransform``.
 
     fix(#1271 review): None deliberately collapses every failure shape.
     A non-200 from Titiler is NOT proof the origin was attempted — the
@@ -151,7 +197,10 @@ async def fetch_cog_info(url: str) -> dict | None:
     non-raster file extensions.
 
     Removing Gate 1 OR loosening Gate 2 must be a deliberate audit-tracked
-    decision, not a refactor side-effect.
+    decision, not a refactor side-effect. fix(#1375) added a third request to
+    the same internal Titiler service for the same already-validated ``url``,
+    inside both gates and adding no origin this function did not already
+    reach; a caller that reached a new origin would need its own Gate 1.
     """
     try:
         async with httpx.AsyncClient(
@@ -187,6 +236,31 @@ async def fetch_cog_info(url: str) -> dict | None:
             except Exception:  # broad: per-band stats optional — Titiler payload shape varies; defaults are fine
                 pass  # stats are optional — rendering will fall back to defaults
 
+            # fix(#1375): the affine transform, from the one COG endpoint
+            # that publishes it. `with_raster`/`with_eo` are OFF because
+            # their defaults make this a PIXEL read — rio-stac downsamples
+            # to `max_size` to compute per-band statistics, which this call
+            # has no use for and which fetch_cog_info already has its own
+            # /cog/statistics request for. Measured against the pinned 2.2.1
+            # image on a 2048x2048 3-band COG: 7 ms with them off, 90 ms
+            # with them on.
+            geotransform: dict = {}
+            try:
+                stac_resp = await client.get(
+                    build_titiler_cog_url(
+                        "stac",
+                        query={
+                            "url": url,
+                            "with_raster": "false",
+                            "with_eo": "false",
+                        },
+                    )
+                )
+                if stac_resp.status_code == 200:
+                    geotransform = _geotransform(stac_resp.json())
+            except Exception:  # broad: same contract as the stats call above — a resolution GeoLens could not measure is a blank display, not a failed probe
+                pass
+
             return {
                 "band_count": band_count,
                 "dtype": dtype,
@@ -195,6 +269,7 @@ async def fetch_cog_info(url: str) -> dict | None:
                 "nodata": info.get("nodata"),
                 "band_info": band_info or None,
                 **_georeferencing(info),
+                **geotransform,
             }
     except Exception as exc:  # broad: Titiler info call — httpx/JSON parse can throw varied errors; degrade to None
         logger.debug("Failed to fetch COG info from Titiler", url=url, error=str(exc))

--- a/backend/app/modules/catalog/sources/cog_info.py
+++ b/backend/app/modules/catalog/sources/cog_info.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import httpx
 import structlog
 
+from app.core.geo import pixel_size_from_affine
 from app.platform.storage.titiler_url import build_titiler_cog_url
 
 logger = structlog.get_logger(__name__)
@@ -99,11 +100,17 @@ def _geotransform(item: dict) -> dict:
     extension's ``proj:transform`` as the 9-element affine — and it is the
     SAME six numbers ``raster/cog.py`` reads off ``rasterio``'s
     ``src.transform`` on the local-upload path. So this is not an
-    approximation of what a local ingest would have stored; element 0 and
-    element 4 are exactly its ``abs(transform.a)``/``abs(transform.e)``, and
-    elements 1 and 3 are exactly the ``transform.b``/``transform.d`` it tests
-    to set ``is_rotated``. A rotated remote COG is now recorded as rotated
-    rather than defaulting to the column's ``false``.
+    approximation of what a local ingest would have stored: both paths hand
+    those numbers to the same ``pixel_size_from_affine``, and elements 1 and 3
+    are the ``transform.b``/``transform.d`` both test to set ``is_rotated``. A
+    rotated remote COG is now recorded as rotated rather than defaulting to
+    the column's ``false``.
+
+    fix(#1375 review): the resolution is the pixel VECTORS' lengths, not
+    elements 0 and 4 on their own — see ``pixel_size_from_affine`` for why
+    those two understate a rotated raster by 13% at 30°. The review caught it
+    here; the local path had the same shape and was corrected with it, so the
+    two agree on the right number rather than on the wrong one.
 
     Endpoint choice, since two of them expose georeferencing: ``/cog/validate``
     (rio-cogeo) reports ``GEO.Resolution`` and it is the same
@@ -130,9 +137,10 @@ def _geotransform(item: dict) -> dict:
         scale_x, shear_x, _, shear_y, scale_y, _ = (float(v) for v in transform[:6])
     except (TypeError, ValueError):
         return {}
+    res_x, res_y = pixel_size_from_affine(scale_x, shear_x, shear_y, scale_y)
     return {
-        "res_x": abs(scale_x),
-        "res_y": abs(scale_y),
+        "res_x": res_x,
+        "res_y": res_y,
         "is_rotated": shear_x != 0.0 or shear_y != 0.0,
     }
 

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -630,6 +630,11 @@ async def stac_import(
                 await db.flush()
 
                 nodata_raw = ci.get("nodata")
+                pixel_geometry = (
+                    {k: ci[k] for k in ("res_x", "res_y", "is_rotated")}
+                    if "res_x" in ci
+                    else {}
+                )
 
                 raster_asset = get_catalog_port().raster_asset_orm_class()(
                     dataset_id=dataset.id,
@@ -648,18 +653,21 @@ async def stac_import(
                     # row.
                     crs_wkt=ci.get("crs_wkt"),
                     # fix(#1375): the resolution pair, and the rotation flag
-                    # that makes it readable. Both come off /cog/stac's
+                    # that makes it readable. All three come off /cog/stac's
                     # proj:transform, the same six affine numbers the
                     # local-upload path reads from rasterio — see
-                    # cog_info.py's _geotransform. Absent when the transform
-                    # probe found nothing, which leaves the columns NULL and
-                    # the UI's "—" rather than asserting a measurement.
-                    res_x=ci.get("res_x"),
-                    res_y=ci.get("res_y"),
-                    # The column is NOT NULL; False is what it defaulted to
-                    # before this probe existed, so an unanswered probe keeps
-                    # the historical value rather than inventing a new one.
-                    is_rotated=ci.get("is_rotated", False),
+                    # cog_info.py's _geotransform.
+                    #
+                    # fix(#1375 review): they are ONE fact, so they are
+                    # written together or not at all. A probe that read no
+                    # transform leaves all three to their column defaults
+                    # rather than asserting `is_rotated=False`, which the
+                    # NOT NULL column cannot distinguish from a measurement.
+                    # The refresh path states the full argument at
+                    # `_pixel_geometry` in processing/ingest/tasks_stac_refresh.py;
+                    # the two cannot share a helper because `processing/` may
+                    # not import `catalog/` and this module is the catalog side.
+                    **pixel_geometry,
                 )
                 db.add(raster_asset)
 

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -645,10 +645,21 @@ async def stac_import(
                     band_info=ci.get("band_info"),
                     # fix(#1334): fetch_cog_info already retrieves this; it
                     # was simply never read off the probe result onto the
-                    # row. res_x/res_y are NOT projected the same way —
-                    # fetch_cog_info deliberately does not compute them; see
-                    # cog_info.py's _georeferencing docstring for why.
+                    # row.
                     crs_wkt=ci.get("crs_wkt"),
+                    # fix(#1375): the resolution pair, and the rotation flag
+                    # that makes it readable. Both come off /cog/stac's
+                    # proj:transform, the same six affine numbers the
+                    # local-upload path reads from rasterio — see
+                    # cog_info.py's _geotransform. Absent when the transform
+                    # probe found nothing, which leaves the columns NULL and
+                    # the UI's "—" rather than asserting a measurement.
+                    res_x=ci.get("res_x"),
+                    res_y=ci.get("res_y"),
+                    # The column is NOT NULL; False is what it defaulted to
+                    # before this probe existed, so an unanswered probe keeps
+                    # the historical value rather than inventing a new one.
+                    is_rotated=ci.get("is_rotated", False),
                 )
                 db.add(raster_asset)
 

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -359,11 +359,17 @@ async def _repoint_remote_asset(
             # same object, and `fetch_cog_info` already reads it off. The
             # STAC import path now writes it too, so leaving it stale here
             # would let a refreshed dataset disagree with what a fresh
-            # import of the same asset would record. `res_x`/`res_y` are
-            # NOT projected the same way — `fetch_cog_info` deliberately
-            # does not compute them; see `cog_info.py`'s `_georeferencing`
-            # docstring for why.
+            # import of the same asset would record.
             crs_wkt=described.get("crs_wkt"),
+            # fix(#1375): the resolution pair and the rotation flag join the
+            # fields above for that same reason, and they are the ones a
+            # move is MOST likely to change — a re-tiled or reprojected
+            # replacement is exactly where the old pixel size stops
+            # describing the new object. Like its siblings, an absent value
+            # writes NULL: the number described bytes that are gone.
+            res_x=described.get("res_x"),
+            res_y=described.get("res_y"),
+            is_rotated=described.get("is_rotated", False),
         )
     )
 

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -268,6 +268,40 @@ def _rebind(dataset: Any, resolution: Any, *, collection_id: str | None) -> None
     )
 
 
+def _pixel_geometry(described: dict) -> dict:
+    """The affine-derived columns, written only when the affine was READ.
+
+    fix(#1375 review): these three are one fact, so they move together or not
+    at all. ``fetch_cog_info``'s transform probe is optional — ``/cog/info``
+    can answer while ``/cog/stac`` fails — and an earlier version of this
+    turned that partial result into ``is_rotated=False``, which is not a
+    missing value but a WRONG measurement: the column is NOT NULL and cannot
+    say "unknown", so writing it from a probe that measured nothing asserts
+    axis-alignment on an object nothing looked at. ``_check_rotation``
+    (VAL-07) rejects a VRT source only when the flag is true, so that
+    fabricated ``False`` would have let a rotated replacement through a gate
+    built to stop it — and a remote asset IS an eligible VRT source
+    (``router_vrt.py`` handles ``storage_backend='remote'`` members).
+
+    Same argument as ``crs_wkt``/``epsg`` in ``sources/cog_info.py``, which
+    come off one parsed CRS object for the same reason: half a fact, written
+    from a source that produced none of it, leaves a row that is neither the
+    old truth nor the new one.
+
+    Absent keys leave the previous values in place. That is stale for a moved
+    object, and it is the lesser wrong: a scene previously measured as
+    rotated stays flagged rotated, which is the conservative direction for
+    every consumer of these columns.
+    """
+    if "res_x" not in described:
+        return {}
+    return {
+        "res_x": described["res_x"],
+        "res_y": described["res_y"],
+        "is_rotated": described["is_rotated"],
+    }
+
+
 async def _repoint_remote_asset(
     session: Any,
     dataset_uuid: uuid.UUID,
@@ -365,11 +399,8 @@ async def _repoint_remote_asset(
             # fields above for that same reason, and they are the ones a
             # move is MOST likely to change — a re-tiled or reprojected
             # replacement is exactly where the old pixel size stops
-            # describing the new object. Like its siblings, an absent value
-            # writes NULL: the number described bytes that are gone.
-            res_x=described.get("res_x"),
-            res_y=described.get("res_y"),
-            is_rotated=described.get("is_rotated", False),
+            # describing the new object.
+            **_pixel_geometry(described),
         )
     )
 

--- a/backend/app/processing/raster/cog.py
+++ b/backend/app/processing/raster/cog.py
@@ -5,7 +5,12 @@ import math
 import tempfile
 from pathlib import Path
 
-from app.core.geo import LON_EPSILON_DEGREES, bbox_to_extent_wkt, wrap_longitude
+from app.core.geo import (
+    LON_EPSILON_DEGREES,
+    bbox_to_extent_wkt,
+    pixel_size_from_affine,
+    wrap_longitude,
+)
 from app.processing.raster.vrt import gdal_safe_env, run_gdal
 
 
@@ -299,8 +304,15 @@ def extract_raster_metadata(file_path: str) -> dict:
         bounds_wgs84 = _wgs84_bbox(src)
         bbox_wkt = bbox_to_extent_wkt(*bounds_wgs84)
 
-        res_x = abs(src.transform.a)
-        res_y = abs(src.transform.e)
+        # fix(#1375 review): the pixel VECTOR lengths, not their world-axis
+        # components. Identical to the old abs(a)/abs(e) for the axis-aligned
+        # rasters that are almost all of them, and correct for the rotated
+        # ones those two silently understated. The remote-asset probe
+        # (catalog/sources/cog_info.py) derives its pair through the same
+        # helper, so one scene reports one resolution either way in.
+        res_x, res_y = pixel_size_from_affine(
+            src.transform.a, src.transform.b, src.transform.d, src.transform.e
+        )
         is_rotated = src.transform.b != 0.0 or src.transform.d != 0.0
 
         dtype = src.dtypes[0] if src.dtypes else None

--- a/backend/app/processing/raster/models.py
+++ b/backend/app/processing/raster/models.py
@@ -18,6 +18,7 @@ from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.db import Base
+from app.core.geo import wkt_metres_per_unit
 
 
 class RasterAsset(Base):
@@ -115,7 +116,26 @@ class RasterAsset(Base):
         if self.width is not None and self.height is not None:
             props["proj:shape"] = [self.height, self.width]
         if self.res_x is not None and self.res_y is not None:
-            props["gsd"] = min(abs(self.res_x), abs(self.res_y))
+            # fix(#1375 review): STAC defines `gsd` in METRES, while
+            # `res_x`/`res_y` are in whatever unit the raster's CRS measures.
+            # Publishing them raw made a 0.0001-degree EPSG:4326 pixel — an
+            # ~11 m one, and 4326 is ordinary in the STAC catalogs #1375 now
+            # reads resolutions from — export as `gsd: 0.0001`, which a
+            # conforming consumer reads as a tenth of a millimetre. PROJ's
+            # metres-per-unit converts every projected CRS, including the
+            # foot-based state-plane systems this used to overstate by 3.28x.
+            #
+            # A geographic CRS yields None and the field is OMITTED, because
+            # an angular resolution has no fixed length without a latitude
+            # and `gsd` carries no unit of its own to qualify it. Omitting an
+            # optional field is always conformant; a wrong number is not.
+            # The OGC Records serializer deliberately keeps the CRS-unit
+            # value (`service_records.py`, fix(#569)) — it ships a
+            # `crs_is_geographic` flag beside it so its one consumer, the
+            # GeoLens UI, can format the number. STAC has no such companion.
+            metres_per_unit = wkt_metres_per_unit(self.crs_wkt)
+            if metres_per_unit is not None:
+                props["gsd"] = min(abs(self.res_x), abs(self.res_y)) * metres_per_unit
 
         # Bands (STAC Raster Extension v1.1 format)
         if self.band_info:

--- a/backend/tests/test_cog_info.py
+++ b/backend/tests/test_cog_info.py
@@ -57,8 +57,10 @@ _TITILER_INFO = {
 # affine is a real 30°-rotated one, captured from the pinned image against a
 # synthetic rotated COG with 10 m pixels: element 0 is cos(30°)*10 and the
 # shear terms are sin(30°)*10, which is why the numbers below are 8.66/5.0
-# rather than a round 10. An axis-aligned file returns the same shape with
-# both shear terms exactly 0.
+# rather than a round 10. The PIXELS are still 10 m — hypot(8.66, 5.0) — which
+# is the whole point of the #1375 review finding. An axis-aligned file returns
+# the same shape with both shear terms exactly 0, where element 0 IS the
+# resolution.
 _TITILER_STAC_ITEM = {
     "type": "Feature",
     "stac_version": "1.1.0",
@@ -191,16 +193,36 @@ class TestGeotransform:
     async def test_resolution_comes_from_the_affine_not_the_envelope(
         self, monkeypatch
     ) -> None:
-        """The proving case. This item's raster is rotated 30°, so its
-        bounding envelope is much wider than its footprint: deriving from
-        ``/cog/info``'s ``bounds`` would report ~100 m where the affine says
-        the pixels are 8.66 m on the transform's own axes — the same number
-        ``raster/cog.py`` stores for a local upload of the same file."""
+        """The proving case. This item's raster is rotated 30° with 10 m
+        pixels, so its bounding envelope is wider than its footprint and a
+        figure derived from ``/cog/info``'s ``bounds`` would overstate the
+        resolution. 10.0 is also what ``raster/cog.py`` stores for a local
+        upload of the same file — both paths run these six numbers through
+        ``pixel_size_from_affine``."""
         _install(monkeypatch, _TITILER_INFO)
         result = await fetch_cog_info("https://origin.test/scene.tif")
         assert result is not None
-        assert result["res_x"] == pytest.approx(8.660254037844387)
-        assert result["res_y"] == pytest.approx(8.660254037844387)
+        assert result["res_x"] == pytest.approx(10.0)
+        assert result["res_y"] == pytest.approx(10.0)
+
+    async def test_a_rotated_resolution_is_the_pixel_vector_not_its_x_component(
+        self, monkeypatch
+    ) -> None:
+        """fix(#1375 review): the finding this file exists to keep fixed.
+
+        Element 0 of this fixture's affine is 8.66 — the x-COMPONENT of a
+        pixel vector whose length is 10. Reading the resolution off elements
+        0 and 4 understates a 30°-rotated raster by 13%, and that number
+        reaches the UI and STAC's ``gsd``. The assertion is written as the
+        contrast so a regression to ``abs(a)`` fails here rather than
+        silently shipping the smaller number."""
+        _install(monkeypatch, _TITILER_INFO)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        element_0 = _TITILER_STAC_ITEM["properties"]["proj:transform"][0]
+        assert element_0 == pytest.approx(8.660254037844387)
+        assert result["res_x"] != pytest.approx(element_0)
+        assert result["res_x"] == pytest.approx(10.0)
 
     async def test_a_rotated_transform_sets_is_rotated(self, monkeypatch) -> None:
         """The flag the local path sets from ``transform.b``/``transform.d``

--- a/backend/tests/test_cog_info.py
+++ b/backend/tests/test_cog_info.py
@@ -9,10 +9,13 @@ extraction itself — these are unit tests of that extraction, against
 Titiler's actual response shape (captured live against a 2.2.1 instance,
 see ``cog_info.py``'s ``_georeferencing`` docstring for the exact payload).
 
-fix(#1334 review): ``res_x``/``res_y`` are deliberately NOT derived here —
-see ``_georeferencing``'s docstring. A prior version of this file computed
-them from ``bounds``/pixel-dimensions and asserted on the result; that
-computation is gone, and so are those assertions.
+fix(#1334 review): ``res_x``/``res_y`` are still not derived from
+``/cog/info`` — a prior version of this file computed them from
+``bounds``/pixel-dimensions and asserted on the result, and that computation
+is gone. fix(#1375): they come instead from ``/cog/stac``'s
+``proj:transform``, an endpoint that publishes the real affine, so
+``TestGeotransform`` below asserts on measured numbers rather than on their
+absence.
 """
 
 from __future__ import annotations
@@ -50,9 +53,46 @@ _TITILER_INFO = {
     "overviews": [2, 4, 8, 16],
 }
 
+# A Titiler 2.2.1 /cog/stac reply, trimmed to what _geotransform reads. The
+# affine is a real 30°-rotated one, captured from the pinned image against a
+# synthetic rotated COG with 10 m pixels: element 0 is cos(30°)*10 and the
+# shear terms are sin(30°)*10, which is why the numbers below are 8.66/5.0
+# rather than a round 10. An axis-aligned file returns the same shape with
+# both shear terms exactly 0.
+_TITILER_STAC_ITEM = {
+    "type": "Feature",
+    "stac_version": "1.1.0",
+    "id": "scene",
+    "properties": {
+        "proj:epsg": 32621,
+        "proj:shape": [2667, 2658],
+        "proj:transform": [
+            8.660254037844387,
+            -4.999999999999999,
+            373185.0,
+            4.999999999999999,
+            -8.660254037844387,
+            8286015.0,
+            0.0,
+            0.0,
+            1.0,
+        ],
+    },
+    "assets": {"data": {"href": "https://origin.test/scene.tif"}},
+}
 
-def _install(monkeypatch, info: dict, *, stats_status: int = 200) -> None:
-    """Route both COG-endpoint requests fetch_cog_info makes to one table.
+_AXIS_ALIGNED_TRANSFORM = [100.0, 0.0, 373185.0, 0.0, -100.0, 8286015.0, 0.0, 0.0, 1.0]
+
+
+def _install(
+    monkeypatch,
+    info: dict,
+    *,
+    stats_status: int = 200,
+    stac_item: dict | None = _TITILER_STAC_ITEM,
+    stac_status: int = 200,
+) -> None:
+    """Route the three COG-endpoint requests fetch_cog_info makes to one table.
 
     fetch_cog_info builds its own ``httpx.AsyncClient`` directly rather than
     through a factory seam (Titiler is an internal trusted service, not a
@@ -61,10 +101,13 @@ def _install(monkeypatch, info: dict, *, stats_status: int = 200) -> None:
     """
 
     def _handler(request: httpx.Request) -> httpx.Response:
-        if "/cog/statistics" in str(request.url):
+        url = str(request.url)
+        if "/cog/statistics" in url:
             return httpx.Response(
                 stats_status, json={} if stats_status == 200 else None
             )
+        if "/cog/stac" in url:
+            return httpx.Response(stac_status, json=stac_item)
         return httpx.Response(200, json=info)
 
     def _factory(*args, **kwargs) -> httpx.AsyncClient:
@@ -117,19 +160,6 @@ class TestGeoreferencing:
         assert result is not None
         assert result["epsg"] is None
 
-    async def test_fetch_cog_info_never_reports_a_resolution(self, monkeypatch) -> None:
-        """fix(#1334 review): Titiler's /cog/info carries no affine
-        transform, so nothing here can tell a rotated remote COG from an
-        axis-aligned one — and dividing its bounding envelope by pixel
-        dimensions is only correct for the latter. A wrong number that looks
-        like a measurement is worse than the blank display it would replace,
-        so `res_x`/`res_y` are not derived at all, for any input."""
-        _install(monkeypatch, _TITILER_INFO)
-        result = await fetch_cog_info("https://origin.test/scene.tif")
-        assert result is not None
-        assert "res_x" not in result
-        assert "res_y" not in result
-
     async def test_a_missing_crs_degrades_to_none_not_a_raise(
         self, monkeypatch
     ) -> None:
@@ -147,6 +177,116 @@ class TestGeoreferencing:
         result = await fetch_cog_info("https://origin.test/scene.tif")
         assert result is not None
         assert result["crs_wkt"] is None
+
+
+class TestGeotransform:
+    """fix(#1375): the resolution pair and the rotation flag, from
+    ``/cog/stac``'s ``proj:transform``.
+
+    ``/cog/info`` still carries no transform — that is why #1334 refused to
+    divide its bounding envelope by pixel dimensions, and why the numbers
+    come from a second endpoint rather than a smarter reading of the first.
+    """
+
+    async def test_resolution_comes_from_the_affine_not_the_envelope(
+        self, monkeypatch
+    ) -> None:
+        """The proving case. This item's raster is rotated 30°, so its
+        bounding envelope is much wider than its footprint: deriving from
+        ``/cog/info``'s ``bounds`` would report ~100 m where the affine says
+        the pixels are 8.66 m on the transform's own axes — the same number
+        ``raster/cog.py`` stores for a local upload of the same file."""
+        _install(monkeypatch, _TITILER_INFO)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["res_x"] == pytest.approx(8.660254037844387)
+        assert result["res_y"] == pytest.approx(8.660254037844387)
+
+    async def test_a_rotated_transform_sets_is_rotated(self, monkeypatch) -> None:
+        """The flag the local path sets from ``transform.b``/``transform.d``
+        and that a remote row could never answer before — it defaulted to
+        the column's ``false``, asserting axis-alignment with no evidence."""
+        _install(monkeypatch, _TITILER_INFO)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["is_rotated"] is True
+
+    async def test_an_axis_aligned_transform_clears_is_rotated(
+        self, monkeypatch
+    ) -> None:
+        item = {
+            **_TITILER_STAC_ITEM,
+            "properties": {
+                **_TITILER_STAC_ITEM["properties"],
+                "proj:transform": _AXIS_ALIGNED_TRANSFORM,
+            },
+        }
+        _install(monkeypatch, _TITILER_INFO, stac_item=item)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["is_rotated"] is False
+        assert result["res_x"] == pytest.approx(100.0)
+        assert result["res_y"] == pytest.approx(100.0)
+
+    async def test_resolution_is_positive_for_a_north_up_transform(
+        self, monkeypatch
+    ) -> None:
+        """``transform.e`` is negative for the usual north-up raster; the
+        stored resolution is a magnitude, matching ``abs(src.transform.e)``
+        on the local path."""
+        _install(
+            monkeypatch,
+            _TITILER_INFO,
+            stac_item={
+                **_TITILER_STAC_ITEM,
+                "properties": {
+                    **_TITILER_STAC_ITEM["properties"],
+                    "proj:transform": _AXIS_ALIGNED_TRANSFORM,
+                },
+            },
+        )
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["res_y"] > 0
+
+    @pytest.mark.parametrize(
+        "properties",
+        [
+            {},
+            {"proj:transform": None},
+            {"proj:transform": [10.0, 0.0, 1.0]},
+            {"proj:transform": "10,0,1,0,-10,2"},
+            {"proj:transform": [10.0, 0.0, 1.0, 0.0, "not a number", 2.0]},
+        ],
+        ids=["absent", "null", "too-short", "not-a-list", "unparseable-member"],
+    )
+    async def test_a_transform_it_cannot_read_leaves_the_keys_absent(
+        self, monkeypatch, properties
+    ) -> None:
+        """Absent, not None. The two callers write these straight onto the
+        row, so a None would assert "measured, and there is no value" where
+        an absent key leaves the column as it was."""
+        _install(
+            monkeypatch,
+            _TITILER_INFO,
+            stac_item={**_TITILER_STAC_ITEM, "properties": properties},
+        )
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert "res_x" not in result
+        assert "res_y" not in result
+        assert "is_rotated" not in result
+
+    async def test_a_failing_stac_endpoint_does_not_fail_the_probe(
+        self, monkeypatch
+    ) -> None:
+        """Same contract as the optional statistics call: the rest of the
+        probe is still worth having."""
+        _install(monkeypatch, _TITILER_INFO, stac_item=None, stac_status=500)
+        result = await fetch_cog_info("https://origin.test/scene.tif")
+        assert result is not None
+        assert result["crs_wkt"] is not None
+        assert "res_x" not in result
 
 
 class TestReconcileEpsg:

--- a/backend/tests/test_raster_ingest.py
+++ b/backend/tests/test_raster_ingest.py
@@ -169,6 +169,78 @@ class TestExtractRasterMetadata:
         finally:
             tif.unlink(missing_ok=True)
 
+    def test_rotated_resolution_is_the_pixel_vector_not_its_x_component(self, tmp_path):
+        """fix(#1375 review): a rotated raster's pixel size is the length of
+        its pixel vector, not that vector's component on the world x axis.
+
+        This raster is rotated 30° with 10 m pixels, so its affine reads
+        ``a=8.66, d=5.0``. Reading ``abs(a)`` — which this path did until the
+        review — reports 8.66 m for a pixel that is 10 m across, and that
+        number reaches the UI and STAC's ``gsd``. The remote probe asserts
+        the same property against the same 30° affine in
+        ``test_cog_info.py``, because the two paths now share one helper and
+        must not drift back apart.
+        """
+        import math
+
+        from rasterio.transform import Affine
+
+        angle = math.radians(30)
+        transform = Affine(
+            math.cos(angle) * 10.0,
+            -math.sin(angle) * 10.0,
+            500000.0,
+            math.sin(angle) * 10.0,
+            -math.cos(angle) * 10.0,
+            8000000.0,
+        )
+        buf = io.BytesIO()
+        with MemoryFile() as mem:
+            with mem.open(
+                driver="GTiff",
+                dtype="uint8",
+                width=64,
+                height=64,
+                count=1,
+                crs=CRS.from_epsg(32621),
+                transform=transform,
+            ) as ds:
+                ds.write(np.zeros((64, 64), dtype="uint8"), 1)
+            buf.write(mem.read())
+        tmp = tempfile.NamedTemporaryFile(suffix=".tif", delete=False)
+        tmp.write(buf.getvalue())
+        tmp.close()
+        try:
+            from app.processing.raster.cog import extract_raster_metadata
+
+            meta = extract_raster_metadata(tmp.name)
+            assert meta["is_rotated"] is True
+            assert meta["res_x"] == pytest.approx(10.0)
+            assert meta["res_y"] == pytest.approx(10.0)
+            # Stated as the contrast so a regression to abs(transform.a)
+            # fails here instead of quietly shipping the smaller number.
+            assert meta["res_x"] != pytest.approx(abs(transform.a))
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+
+    def test_axis_aligned_resolution_is_unchanged_by_the_vector_form(self, tmp_path):
+        """The other half of the same claim: for the axis-aligned rasters
+        that are almost all of them, the shear terms are zero and the vector
+        length collapses to exactly the old ``abs(a)``/``abs(e)``. The review
+        fix had to be inert here or it would have moved every existing
+        raster's stored resolution."""
+        tif = _write_tmp_tif(crs=CRS.from_epsg(4326))
+        try:
+            from app.processing.raster.cog import extract_raster_metadata
+
+            meta = extract_raster_metadata(str(tif))
+            # _write_tmp_tif spans -180..180 / -90..90 over 64x64 pixels.
+            assert meta["is_rotated"] is False
+            assert meta["res_x"] == pytest.approx(360.0 / 64)
+            assert meta["res_y"] == pytest.approx(180.0 / 64)
+        finally:
+            tif.unlink(missing_ok=True)
+
     def test_nodata_captured(self, tmp_path):
         tif = _write_tmp_tif(nodata=255.0)
         try:

--- a/backend/tests/test_stac_asset_model.py
+++ b/backend/tests/test_stac_asset_model.py
@@ -139,6 +139,63 @@ class TestDatasetAssetCRUD:
 # ---------------------------------------------------------------------------
 
 
+class TestGsdUnits:
+    """fix(#1375 review): ``gsd`` is metres by STAC's definition, and
+    ``res_x``/``res_y`` are in the CRS's own unit.
+
+    #1375 made this reachable for remote rasters — it is the change that
+    starts populating their resolutions — and EPSG:4326 is ordinary in the
+    STAC catalogs those resolutions now come from, so the degree case is not
+    an exotic one. These are pure model-level unit tests: no DB row, because
+    ``to_stac_properties`` reads only the fields set here.
+    """
+
+    @staticmethod
+    def _asset(crs_wkt: str | None, res: float) -> RasterAsset:
+        return RasterAsset(
+            dataset_id=uuid.uuid4(),
+            asset_uri="/app/storage/x.tif",
+            crs_wkt=crs_wkt,
+            res_x=res,
+            res_y=-res,
+        )
+
+    def test_a_metre_based_projection_publishes_the_resolution_unchanged(self):
+        from rasterio.crs import CRS
+
+        wkt = CRS.from_epsg(32621).to_wkt(version="WKT2_2019")
+        props = self._asset(wkt, 10.0).to_stac_properties()
+        assert props["gsd"] == pytest.approx(10.0)
+
+    def test_a_foot_based_projection_is_converted_to_metres(self):
+        """EPSG:2263 (NY Long Island) measures in US survey feet. A 10-foot
+        pixel is 3.048 m, and publishing the raw 10 overstated it by 3.28x."""
+        from rasterio.crs import CRS
+
+        wkt = CRS.from_epsg(2263).to_wkt(version="WKT2_2019")
+        props = self._asset(wkt, 10.0).to_stac_properties()
+        assert props["gsd"] == pytest.approx(3.048006, rel=1e-4)
+
+    def test_a_geographic_crs_omits_gsd_rather_than_publishing_degrees(self):
+        """The case the review named: a 0.0001° pixel is roughly 11 m, and
+        publishing 0.0001 into a metres field reads as a tenth of a
+        millimetre. An optional field left out is always conformant."""
+        from rasterio.crs import CRS
+
+        wkt = CRS.from_epsg(4326).to_wkt(version="WKT2_2019")
+        props = self._asset(wkt, 0.0001).to_stac_properties()
+        assert "gsd" not in props
+        # The resolution itself still reaches CRS-aware consumers through the
+        # row; it is only this metres-defined export that declines to guess.
+        assert props["proj:wkt2"] == wkt
+
+    def test_an_unknown_crs_omits_gsd(self):
+        """No WKT, so no unit, so no defensible number. Covers the
+        unparseable case too — both resolve to None."""
+        assert "gsd" not in self._asset(None, 10.0).to_stac_properties()
+        assert "gsd" not in self._asset("GEOGCS[...]", 10.0).to_stac_properties()
+
+
 class TestToStacProperties:
     async def test_to_stac_properties_full(self, client, test_db_session):
         """to_stac_properties() with full metadata returns complete STAC dict."""
@@ -169,7 +226,11 @@ class TestToStacProperties:
         assert props["proj:code"] == "EPSG:4326"
         assert props["proj:wkt2"] == "GEOGCS[...]"
         assert props["proj:shape"] == [2048, 1024]  # [height, width]
-        assert props["gsd"] == pytest.approx(0.001)
+        # fix(#1375 review): this raster's resolution is 0.001 DEGREES and
+        # STAC's gsd is metres, so the field is omitted rather than published
+        # as 0.001 — which a conforming consumer would read as a millimetre.
+        # This assertion used to pin that exact wrong number.
+        assert "gsd" not in props
         assert len(props["raster:bands"]) == 3
         assert props["raster:bands"][0] == {
             "data_type": "uint8",

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -539,11 +539,9 @@ class TestStacImport:
         time; this only asks that its answer be kept, the same way its
         other fields already are.
 
-        fix(#1334 review): res_x/res_y are NOT part of this — fetch_cog_info
-        deliberately does not compute them (see cog_info.py's
-        _georeferencing docstring: Titiler's response carries no affine
-        transform, so nothing can rule out a rotated source, and a wrong
-        resolution that looks like a measurement is worse than none).
+        fix(#1375): this probe result carries no transform, which is the
+        case where res_x/res_y stay NULL. The sibling test below covers the
+        one that does carry it.
         """
         crs_wkt = (
             'PROJCS["WGS 84 / UTM zone 21N",GEOGCS["WGS 84",'
@@ -601,7 +599,8 @@ class TestStacImport:
         # A projected UTM CRS, not geographic — proves crs_wkt round-tripped
         # far enough for PROJ to classify it, not just landed as a string.
         assert raster["crs_is_geographic"] is False
-        # Not derived by this path — see the docstring above.
+        # A probe that established no transform leaves these NULL rather
+        # than guessing — see the docstring above.
         assert raster["res_x"] is None
         assert raster["res_y"] is None
 
@@ -615,6 +614,79 @@ class TestStacImport:
             )
         ).one()
         assert row.crs_wkt == crs_wkt
+
+    async def test_import_records_the_probed_resolution_and_rotation(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_stac_ssrf,
+        test_db_session,
+    ):
+        """fix(#1375): remote raster rows showed "Resolution: — x —" and
+        exported no ``gsd``, because #1334 had no source for a resolution it
+        could trust. ``fetch_cog_info`` now reads the affine off
+        ``/cog/stac``; this asks that the numbers reach the row and the API,
+        including the rotation flag, which a remote row could previously
+        only report as the column's default ``false``.
+
+        The values are a rotated raster's on purpose: it is the case the
+        envelope-division shortcut would have got wrong, so seeing 8.66 here
+        rather than a figure derived from ``bounds`` is what proves the row
+        came from the transform.
+        """
+        with patch(
+            "app.modules.catalog.sources.stac_router.fetch_cog_info",
+            new=AsyncMock(
+                return_value={
+                    "band_count": 1,
+                    "dtype": "uint16",
+                    "width": 2658,
+                    "height": 2667,
+                    "nodata": None,
+                    "band_info": None,
+                    "crs_wkt": None,
+                    "res_x": 8.660254037844387,
+                    "res_y": 8.660254037844387,
+                    "is_rotated": True,
+                }
+            ),
+        ):
+            resp = await client.post(
+                "/services/stac/import",
+                json={
+                    "url": "https://stac.example.com/v1",
+                    "items": [
+                        {
+                            "id": f"test-item-{uuid.uuid4().hex[:8]}",
+                            "collection": "dem-collection",
+                            "title": "Rotated STAC Import",
+                            "data_asset_href": "https://example.com/data/rot.tif",
+                            "bbox": [-1, -1, 1, 1],
+                            "epsg": 32621,
+                        }
+                    ],
+                    "visibility": "private",
+                },
+                headers=admin_auth_header,
+            )
+        assert resp.status_code == 200
+        dataset_id = resp.json()["results"][0]["dataset_id"]
+
+        detail = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
+        assert detail.status_code == 200
+        raster = detail.json()["raster"]
+        assert raster["res_x"] == pytest.approx(8.660254037844387)
+        assert raster["res_y"] == pytest.approx(8.660254037844387)
+
+        row = (
+            await test_db_session.execute(
+                text(
+                    "SELECT ra.is_rotated FROM catalog.raster_assets ra"
+                    " WHERE ra.dataset_id = :did"
+                ).bindparams(did=uuid.UUID(dataset_id))
+            )
+        ).one()
+        assert row.is_rotated is True
 
     async def test_import_prefers_the_probed_epsg_over_a_stale_item_declaration(
         self,

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -630,9 +630,10 @@ class TestStacImport:
         only report as the column's default ``false``.
 
         The values are a rotated raster's on purpose: it is the case the
-        envelope-division shortcut would have got wrong, so seeing 8.66 here
-        rather than a figure derived from ``bounds`` is what proves the row
-        came from the transform.
+        envelope-division shortcut would have got wrong. 10.0 is the pixel
+        size of the same 30°-rotated fixture ``test_cog_info.py`` probes —
+        its affine's element 0 is 8.66, and the difference between those two
+        numbers is the #1375 review finding.
         """
         with patch(
             "app.modules.catalog.sources.stac_router.fetch_cog_info",
@@ -645,8 +646,8 @@ class TestStacImport:
                     "nodata": None,
                     "band_info": None,
                     "crs_wkt": None,
-                    "res_x": 8.660254037844387,
-                    "res_y": 8.660254037844387,
+                    "res_x": 10.0,
+                    "res_y": 10.0,
                     "is_rotated": True,
                 }
             ),
@@ -675,8 +676,8 @@ class TestStacImport:
         detail = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
         assert detail.status_code == 200
         raster = detail.json()["raster"]
-        assert raster["res_x"] == pytest.approx(8.660254037844387)
-        assert raster["res_y"] == pytest.approx(8.660254037844387)
+        assert raster["res_x"] == pytest.approx(10.0)
+        assert raster["res_y"] == pytest.approx(10.0)
 
         row = (
             await test_db_session.execute(

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -2352,6 +2352,7 @@ class TestWorker:
         assert described.res_x == pytest.approx(30.0)
         assert described.res_y == pytest.approx(30.0)
         assert described.is_rotated is False
+
         # A moved member has to read as newer than any VRT built on it: a
         # mosaic that recorded no `built_from` is judged by this stamp alone,
         # and it still embeds the old URL.
@@ -2372,6 +2373,80 @@ class TestWorker:
         run = await _run_for(dataset.id)
         assert run.status == "succeeded"
         assert run.error_code is None
+
+    async def test_a_refresh_without_a_transform_leaves_pixel_geometry_alone(
+        self, client, admin_auth_header, test_db_session, stac_transport, monkeypatch
+    ) -> None:
+        """fix(#1375 review): the three affine-derived columns are one fact.
+
+        ``fetch_cog_info``'s transform probe is optional — ``/cog/info`` can
+        answer while ``/cog/stac`` fails — and an earlier version of this
+        change turned that partial result into ``is_rotated=False``. That is
+        not a missing value but a wrong measurement: the column is NOT NULL
+        and cannot say "unknown", and ``_check_rotation`` (VAL-07) rejects a
+        VRT source only when the flag is TRUE, so a fabricated ``False``
+        would walk a rotated replacement straight through the gate built to
+        stop it. A remote asset is an eligible VRT source, so that path is
+        reachable rather than theoretical.
+
+        The row here is seeded as rotated with a known resolution, then
+        refreshed by a probe that establishes no transform. All three must
+        survive: stale is the lesser wrong, and it is the conservative
+        direction for every consumer of these columns.
+        """
+        install, _ = stac_transport
+        install(
+            {
+                _ITEM: (200, _item_doc(asset_href=_MOVED_ASSET)),
+                _MOVED_ASSET: (206, None),
+            }
+        )
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(
+            test_db_session, created_by=admin_id, source_health="missing"
+        )
+        await test_db_session.execute(
+            text(
+                "UPDATE catalog.raster_assets SET is_rotated = true, "
+                "res_x = 30.0, res_y = 30.0 WHERE dataset_id = :did"
+            ).bindparams(did=dataset.id)
+        )
+        await test_db_session.commit()
+
+        # A probe that read the COG but not its transform: /cog/info answered,
+        # /cog/stac did not. The three affine keys are ABSENT, which is the
+        # shape fetch_cog_info actually returns in that case.
+        async def _no_transform(url: str):
+            return {
+                "band_count": 1,
+                "dtype": "uint16",
+                "width": 512,
+                "height": 512,
+                "nodata": 0,
+                "band_info": [{"min": 0, "max": 4095, "mean": 1200}],
+                "crs_wkt": 'PROJCS["WGS 84 / UTM zone 33N",AUTHORITY["EPSG","32633"]]',
+                "epsg": 32633,
+            }
+
+        monkeypatch.setattr(
+            "app.modules.catalog.sources.stac_resolve.fetch_cog_info", _no_transform
+        )
+
+        payload = await _dispatch(client, admin_auth_header, dataset.id)
+        await _execute(test_db_session, payload)
+
+        # The move itself still happens — a missing transform degrades the
+        # description, it does not block adoption.
+        assert await _asset_uri(dataset.id) == _MOVED_ASSET
+        described = await _raster_asset(dataset.id)
+        assert described.band_count == 1
+
+        assert described.is_rotated is True, (
+            "an unmeasured probe must not assert axis-alignment — VAL-07 only "
+            "rejects a rotated VRT source when this flag is true"
+        )
+        assert described.res_x == pytest.approx(30.0)
+        assert described.res_y == pytest.approx(30.0)
 
     async def test_a_refresh_prefers_the_probed_epsg_over_the_items_declared_one(
         self, client, admin_auth_header, test_db_session, stac_transport, monkeypatch

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -171,14 +171,18 @@ def cog_info(monkeypatch):
         "band_info": [{"min": 0, "max": 4095, "mean": 1200}],
         # fix(#1334): the shape fetch_cog_info actually returns, so tests
         # against this fixture exercise the same fields the refresh path
-        # now writes to the asset row. No res_x/res_y — fetch_cog_info
-        # deliberately does not compute them (cog_info.py's
-        # _georeferencing docstring explains why). crs_wkt and epsg are a
+        # now writes to the asset row. crs_wkt and epsg are a
         # matched pair, same as a real _georeferencing result: leaving epsg
         # out here would make reconcile_epsg read as "a CRS with no mappable
         # EPSG" rather than "the fixture just didn't set it".
         "crs_wkt": 'PROJCS["WGS 84 / UTM zone 33N",AUTHORITY["EPSG","32633"]]',
         "epsg": 32633,
+        # fix(#1375): res_x/res_y/is_rotated join them for the same reason —
+        # _geotransform reads all three off /cog/stac's proj:transform, so a
+        # fixture without them would exercise only the degraded path.
+        "res_x": 30.0,
+        "res_y": 30.0,
+        "is_rotated": False,
     }
     calls: list[str] = []
 
@@ -2337,14 +2341,17 @@ class TestWorker:
         assert described.is_dem is False
         # fix(#1334): the moved object's own CRS, from the same probe as
         # band_count/dtype/nodata — not left stale like the fields above
-        # would be if the refresh only wrote the address. res_x/res_y are
-        # NOT part of this: fetch_cog_info deliberately does not compute
-        # them (cog_info.py's _georeferencing docstring explains why), so
-        # they stay whatever they already were rather than being cleared —
-        # the repoint statement never mentions them.
+        # would be if the refresh only wrote the address.
         assert described.crs_wkt == (
             'PROJCS["WGS 84 / UTM zone 33N",AUTHORITY["EPSG","32633"]]'
         )
+        # fix(#1375): and the pixel geometry, which a move is more likely to
+        # change than anything else here — a re-tiled or reprojected
+        # replacement is exactly where the old resolution stops describing
+        # the new object.
+        assert described.res_x == pytest.approx(30.0)
+        assert described.res_y == pytest.approx(30.0)
+        assert described.is_rotated is False
         # A moved member has to read as newer than any VRT built on it: a
         # mosaic that recorded no `built_from` is judged by this stamp alone,
         # and it still embeds the old URL.


### PR DESCRIPTION
## What

#1334 left `res_x`/`res_y` unset on remote raster assets, because Titiler's `/cog/info` carries no affine transform and dividing its bounding envelope by pixel dimensions is only correct for an axis-aligned raster. Remote rows therefore showed "Resolution: — x —" in the Raster Properties card and exported no `gsd`.

`/cog/stac` does publish the transform. rio-stac writes the projection extension's `proj:transform`, and its first six elements are the same six numbers `processing/raster/cog.py` reads off rasterio's `src.transform` on the local-upload path:

| affine elements | read as | how |
|---|---|---|
| 0, 3 (`a`, `d`) | `res_x` | `hypot(a, d)` — the column-step pixel vector's length |
| 1, 4 (`b`, `e`) | `res_y` | `hypot(b, e)` — the row-step pixel vector's length |
| 1, 3 (`b`, `d`) | `is_rotated` | nonzero shear in either term |

So this is parity with the local-upload path on identical inputs, not an approximation of it. Both paths now run those six numbers through one helper, `pixel_size_from_affine` in `core/geo.py`.

### The resolution formula changed under review

The first version of this PR read `res_x`/`res_y` straight off elements 0 and 4, matching what `raster/cog.py` had always done. Codex review caught that those are the pixel vectors' **components on the world axes**, which equal the pixel sizes only when the raster is axis-aligned — and that matching the local path's existing calculation merely reproduced its error on a newly supported path.

It is right. For the 30°-rotated 10 m fixture below the affine reads `a=8.66, d=5.0`, so the old form stored 8.66 m for a pixel that is 10 m across: a 13% understatement reaching the UI and STAC's `gsd`. Verified against the measured distance between adjacent pixel centres, which is 10.0.

**Both** paths are corrected here, not just the remote one this PR adds. Fixing only the remote half would leave the same scene reporting two different resolutions depending on how it was ingested, which is the exact contradiction this PR exists to remove. The change is inert for axis-aligned rasters — with `b` and `d` zero the vector length collapses to exactly `abs(a)`/`abs(e)` — so no existing raster's stored resolution moves, and rotated rasters are already barred from VRT sources by `_check_rotation` (VAL-07), so the new values cannot perturb VRT grid maths.

## Measured, against the pinned image

titiler 2.2.1 (`ghcr.io/developmentseed/titiler:2.2.1`, the tag `docker-compose.yml` pins) → rio-tiler 9.4.2, rio-cogeo 7.0.2, rasterio 1.5.0. A synthetic COG with 10 m pixels and its 30°-rotated twin:

```
axis-aligned  /cog/stac  proj:transform = [10.0,     0.0,  500000.0,  0.0,    -10.0,     8000000.0, 0, 0, 1]
rotated 30°   /cog/stac  proj:transform = [8.660254, -5.0, 500000.0,  5.0,    -8.660254, 8000000.0, 0, 0, 1]
```

`/cog/info` for that same rotated file returns `bounds` spanning 498720–502217 — a 3497 m envelope around a 2560 m footprint. Envelope-over-pixels would report ~13.7 m where the affine says 10 m, a 37% overstatement with nothing in that payload to distinguish it from a correct value. That is the number #1334 declined to publish, and it is why the resolution comes from a second endpoint rather than a smarter reading of the first.

`/cog/validate` (rio-cogeo) reports `GEO.Resolution`, and it is the same `(transform.a, transform.e)` pair — but it publishes no shear terms, so it cannot answer the rotation question, and it does a full COG-structure validation to report less. Not used.

## Cost

`/cog/stac` defaults to `with_raster=true&with_eo=true`, which makes it a **pixel** read — rio-stac downsamples to `max_size` to compute per-band statistics. The call sets both false, leaving a header-only read that still carries the whole projection block. Measured on a 2048x2048 3-band COG against the pinned image:

| request | latency | extensions returned |
|---|---|---|
| `/cog/stac` defaults | 90 ms | proj + raster + eo |
| `/cog/stac?with_raster=false&with_eo=false` | 7 ms | proj |

`fetch_cog_info` already makes its own `/cog/statistics` request, so the statistics half was redundant regardless.

## Availability

Not incidental: `titiler.application` 2.2.1 declares a hard dependency on `titiler-extensions[cogeo,stac]==2.2.1`, so `/cog/stac` ships in every deployment of the pinned tag rather than only where someone opted into an extra. No version bump, no compose change.

## Security

SSRF stance unchanged. This is a third request to the same internal Titiler service, for the same URL the function's caller already validated, from the same function, inside both gates of the SEC-OBSV-02 contract — Gate 1 caller-side `validate_url_for_ssrf`, Gate 2 Titiler's `CPL_VSIL_CURL_ALLOWED_EXTENSIONS` clamp. It reaches no origin `fetch_cog_info` did not already reach, and GDAL still never sees a caller-controlled URL inside GeoLens's own process, which is what AGENTS.md Rule 2 forbids.

## A correctness fix, not only display polish

`raster_assets.is_rotated` is `NOT NULL DEFAULT false`. Every remote row today therefore asserts axis-alignment with nothing behind it — a rotated remote COG is silently recorded as unrotated, and `processing/raster/validation.py` reads that flag. The transform closes that gap in the same change.

## Degradation

The georeferencing keys are **absent**, not `None`, when the transform cannot be read: the two callers write them straight onto the row, so an absent key leaves the column as it was where a `None` would assert "measured, and there is no value". A failing or missing `/cog/stac` leaves the rest of the probe intact, the same contract the optional `/cog/statistics` call already follows.

## Tests

- `tests/test_cog_info.py` — new `TestGeotransform`: resolution comes off the affine and not the envelope (asserted on the rotated fixture, the case the shortcut gets wrong), the rotated resolution is the pixel vector's length and explicitly *not* element 0, rotation set and cleared, magnitudes positive for a north-up transform, five malformed-transform shapes that must leave the keys absent, and a failing endpoint that must not fail the probe.
- `tests/test_raster_ingest.py` — the same vector-length property on the local path, against a real 30°-rotated GeoTIFF, plus an axis-aligned case pinning that the review fix is inert where the old form was already right.
- `tests/test_stac_import.py` — the import records the probed resolution and rotation onto the row and the API; its sibling keeps covering the no-transform case where they stay NULL.
- `tests/test_stac_refresh_1266.py` — the refresh repoint carries all three onto the moved object, beside the fields it already moved.

## Verification

```
cd backend && set -a && source ../.env.test && set +a && \
  uv run pytest tests/test_cog_info.py tests/test_raster_ingest.py \
    tests/test_stac_import.py tests/test_stac_refresh_1266.py -q             # 182 passed
  uv run pytest tests/test_layering.py tests/test_rule1_structural.py \
    tests/test_rule2_structural.py tests/test_wkt_is_geographic.py \
    tests/test_crs_degree_agreement.py tests/test_raster_tiles.py \
    tests/test_raster_validation.py -q                                       # 255 passed
  uv run pytest tests/test_raster_antimeridian_887.py tests/test_vrt_rewrite.py \
    tests/test_regenerate_vrt_integration.py tests/test_raster_replace_1221.py \
    tests/test_cog_band_unit_capture.py tests/test_crs_wkt2_backfill_1376.py \
    tests/test_vrt_source_management_174.py -q                               # 308 passed
  uv run ruff check . && uv run ruff format --check .            # clean
```

No migration, no schema change, no `openapi.json` / SDK regeneration — `res_x`/`res_y` were already in the API response and were simply always null for remote rows.

Closes #1375
