### PR TITLE
chore(release): v1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-08-10
+
+### Added
+
+- **Raster replace is now reachable from the reupload dialog.** The
+  in-place COG replacement that shipped in 1.11.0 gets its frontend door:
+  the reupload dialog offers replace for raster datasets (#1362).
+- **Remote rasters now report a measured resolution and rotation flag.**
+  STAC-imported and refreshed raster assets read the affine transform from
+  Titiler, so `res_x`/`res_y`/`is_rotated` are populated the same way a
+  local upload populates them instead of staying blank (#1374, #1384).
+
+### Fixed
+
+- **Raster tiles stop serving stale imagery after a replace.** Tile URLs
+  now carry the dataset's content version, so a raster replace, reupload,
+  or source refresh rolls the shared nginx tile cache instead of serving
+  the old pixels until the cache expired. A mismatched or duplicated
+  version parameter is served uncached rather than rejected, so open tabs
+  keep rendering (#1372).
+- **Rotated rasters report their true pixel size.** Resolution was
+  computed from the affine's axis components, understating a 30°-rotated
+  raster by 13%; it now uses the pixel vector lengths on both ingest
+  paths. Axis-aligned rasters are unaffected; a rotated raster's stored
+  resolution corrects on its next ingest or refresh (#1384).
+- **STAC `gsd` is published in metres, as the spec defines it.** Exports
+  used to emit the raw CRS-unit value (degrees for EPSG:4326, feet for
+  state-plane systems). Projected CRSs now convert through PROJ's
+  metres-per-unit; geographic CRSs omit the field rather than publish an
+  angular value as a length. The OGC Records surface is unchanged (#1384).
+- **Reupload keeps geometry and record type honest.** Swapping a
+  dataset's file re-derives the effective geometry type and record type
+  from the new data instead of carrying the old ones forward (#1361,
+  #1373).
+- **User-authored distributions no longer hide the built-in export
+  rows** on a record's distribution list (#1370).
+- **CRS WKT is stored as WKT2:2019 at both raster ingest paths**, with a
+  data migration converting existing WKT1 rows (#1376).
+- **STAC assets keyed by an empty string are recovered after the item
+  moves** instead of failing the refresh (#1363).
+- **ArcGIS imports request every field**, so service imports keep their
+  full attribute set (#1368).
+- **The worker initializes the tile cache in its shared bootstrap**, so
+  cache invalidation from worker-side jobs works on a fresh boot (#1371).
+- **Auto-generated distributions reconcile when a dataset's modality
+  changes** (#1369).
+- **First-ingest raster origins record their file hash**, so a later
+  replace can verify what it is replacing (#1360).
+- **Single-dataset delete errors are sanitized** before reaching the
+  client (#1358).
+
+### Performance
+
+- **Duplicate-source guards use an index** on the origin-reference keys
+  they query instead of scanning (#1365).
+
+### Operations
+
+- **Migration 0041 is a data migration**: it rewrites stored WKT1 CRS
+  definitions to WKT2:2019 in batches. Deploy logs report
+  `converted to WKT2:2019: N row(s)`; the downgrade is a no-op.
+
 ## [1.11.0] - 2026-08-10
 
 ### Added
@@ -1911,7 +1973,9 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.11.1...HEAD
+[1.11.1]: https://github.com/geolens-io/geolens/compare/v1.11.0...v1.11.1
+[1.11.0]: https://github.com/geolens-io/geolens/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/geolens-io/geolens/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/geolens-io/geolens/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/geolens-io/geolens/compare/v1.7.1...v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,23 +38,27 @@ and releases use semantic versioning.
   metres-per-unit; geographic CRSs omit the field rather than publish an
   angular value as a length. The OGC Records surface is unchanged (#1384).
 - **Reupload keeps geometry and record type honest.** Swapping a
-  dataset's file re-derives the effective geometry type and record type
-  from the new data instead of carrying the old ones forward (#1361,
-  #1373).
+  dataset's file derives the effective geometry and record type through
+  a precedence of measured, declared, and stored values, so an empty or
+  all-NULL-geometry file no longer reclassifies a still-spatial dataset
+  as tabular (#1361, #1373).
 - **User-authored distributions no longer hide the built-in export
   rows** on a record's distribution list (#1370).
 - **CRS WKT is stored as WKT2:2019 at both raster ingest paths**, with a
   data migration converting existing WKT1 rows (#1376).
 - **STAC assets keyed by an empty string are recovered after the item
-  moves** instead of failing the refresh (#1363).
+  moves** instead of being reported unidentified (#1363).
 - **ArcGIS imports request every field**, so service imports keep their
   full attribute set (#1368).
-- **The worker initializes the tile cache in its shared bootstrap**, so
-  cache invalidation from worker-side jobs works on a fresh boot (#1371).
+- **Vector tile purges after a reupload or PostGIS refresh now take
+  effect.** The tile cache was only initialized in the API process, so the
+  worker's post-swap purges silently evicted nothing and stale tiles could
+  serve until the cache TTL expired; the cache is now initialized in the
+  bootstrap both processes share (#1371).
 - **Auto-generated distributions reconcile when a dataset's modality
   changes** (#1369).
-- **First-ingest raster origins record their file hash**, so a later
-  replace can verify what it is replacing (#1360).
+- **A raster's origin carries its provenance hash from first ingest**
+  instead of only gaining one after its first replace (#1360).
 - **Single-dataset delete errors are sanitized** before reaching the
   client (#1358).
 

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -628,7 +628,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.11.0"
+_FALLBACK_APP_VERSION = "1.11.1"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18360,7 +18360,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.11.0"
+    "version": "1.11.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.11.0"
+version = "1.11.1"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.11.0"
+version = "1.11.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.11.0"
+version = "1.11.1"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.11.0"
+version = "1.11.1"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.11.0"
+version = "1.11.1"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.11.0"
+version = "1.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.11.0
+package_version_override: 1.11.1
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.11.0"
+version = "1.11.1"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Version bump to 1.11.1 across all 19 version sites (`make bump VERSION=1.11.1`) plus the CHANGELOG section.

Patch release carrying the post-1.11.0 fix wave:

- Raster tile cache staleness after replace/refresh (#1372) — tile URLs now carry the dataset content version so the shared nginx cache rolls.
- Reupload swap re-derives effective geometry and record type (#1361, #1373).
- Remote raster rows get measured `res_x`/`res_y`/`is_rotated` from Titiler's transform (#1374, #1384), rotated-raster pixel size corrected on both ingest paths, STAC `gsd` now published in metres or omitted for geographic CRSs (#1384).
- WKT2:2019 CRS serialization at both ingest paths + data migration 0041 backfill (#1376).
- User-authored distributions no longer suppress built-in export rows (#1370); auto-generated distributions reconcile on modality change (#1369).
- AuditExtension seam removed (#1303), origin_ref index (#1365), ArcGIS full-field imports (#1368), empty-string STAC asset key recovery (#1363), worker tile-cache bootstrap (#1371), first-ingest file_hash (#1360), sanitized delete errors (#1358), raster replace exposed in the reupload dialog (#1362).

No schema changes in this PR itself; migration 0041 (data migration, WKT1→WKT2 rewrite) already landed via #1378. Deploy logs will report `converted to WKT2:2019: N row(s)`.

Verification: `make version-check` green (19/19 sites at 1.11.1).

The changelog also picks up the missing `[1.11.0]` compare link that the last release bump omitted.