### PR TITLE
test(ogc): page through /collections in the versioned-tiles-link test

### DIFF
--- a/backend/tests/test_ogc_features.py
+++ b/backend/tests/test_ogc_features.py
@@ -534,12 +534,26 @@ async def test_collections_list_raster_tiles_link_is_versioned(
     client: AsyncClient, raster_dataset: Dataset
 ):
     """fix(#1372 codex r2): the collections LIST advertises the same versioned
-    raster template as the collection detail."""
-    resp = await client.get("/collections")
-    assert resp.status_code == 200
-    entry = next(
-        c for c in resp.json()["collections"] if c["id"] == str(raster_dataset.id)
-    )
+    raster template as the collection detail.
+
+    fix(#1372 flake): the list defaults to limit=50 with unordered offset
+    pagination, and this worker's shared DB accumulates datasets from sibling
+    tests, so a single-page scan can miss the fixture dataset and the bare
+    next() raised StopIteration inside the coroutine. Page through instead.
+    """
+    entry = None
+    offset = 0
+    while entry is None:
+        resp = await client.get(f"/collections?limit=200&offset={offset}")
+        assert resp.status_code == 200
+        page = resp.json()["collections"]
+        # every page prepends the catalog Records collection; a page holding
+        # only that entry means the dataset pagination is exhausted
+        if len(page) <= 1:
+            break
+        entry = next((c for c in page if c["id"] == str(raster_dataset.id)), None)
+        offset += 200
+    assert entry is not None, "raster fixture dataset absent from /collections"
     tiles_link = next(link for link in entry["links"] if link["rel"] == "tiles")
     assert f"/raster-tiles/{raster_dataset.id}/tiles/" in tiles_link["href"]
     assert f"?v={raster_dataset.tile_cache_version}" in tiles_link["href"]


### PR DESCRIPTION
Fixes the flake that evicted #1386 (the v1.11.1 bump PR) from the merge queue.

`test_collections_list_raster_tiles_link_is_versioned` (added in #1379) scanned only the first page of `GET /collections`, which defaults to `limit=50` with unordered offset pagination. `test_ogc_features` runs in the `tenancy_global_state` xdist group, whose worker's shared DB accumulates datasets from sibling tests, so the fixture dataset can fall outside page one. The bare `next()` then raises StopIteration inside the coroutine, surfacing as `RuntimeError: coroutine raised StopIteration` (merge-group run 31439751677).

The test now pages through with `limit=200` and stops when a page carries only the catalog Records entry, which every page prepends (`collections=[catalog_collection] + dataset_collections`). Verified passing alongside its sibling detail-endpoint test; no app code touched.