### PR TITLE
fix(vrt): fail validation when pixel geometry was never measured

### DIFF
--- a/backend/app/processing/raster/validation.py
+++ b/backend/app/processing/raster/validation.py
@@ -1,8 +1,9 @@
 """Source compatibility validation for VRT creation.
 
 Validates candidate COG sources for VRT creation by running a series of
-checks (CRS, dtype, nodata, rotation, band count, grid alignment) and
-returning structured per-source errors.  All checks always run — no fail-fast.
+checks (CRS, dtype, nodata, rotation, band count, grid alignment, pixel
+geometry) and returning structured per-source errors.  All checks always
+run — no fail-fast.
 
 Usage::
 
@@ -149,7 +150,13 @@ def _check_nodata_consistency(sources: list[Any]) -> list[SourceValidationError]
 
 
 def _check_rotation(sources: list[Any]) -> list[SourceValidationError]:
-    """VAL-07: Rotated rasters are rejected."""
+    """VAL-07: Rotated rasters are rejected.
+
+    fix(#1385): `is_rotated` is `NOT NULL DEFAULT false`, so it cannot
+    represent "never measured" — a source whose geometry probe never ran
+    looks identical to one confirmed unrotated. `_check_pixel_geometry_known`
+    (VAL-08) catches that case via the NULL `res_x`/`res_y` it leaves behind.
+    """
     errors: list[SourceValidationError] = []
     for src in sources:
         if src.is_rotated:
@@ -164,11 +171,40 @@ def _check_rotation(sources: list[Any]) -> list[SourceValidationError]:
     return errors
 
 
+def _check_pixel_geometry_known(sources: list[Any]) -> list[SourceValidationError]:
+    """VAL-08: Pixel geometry (resolution) must have been measured.
+
+    fix(#1385): a source with NULL `res_x` or `res_y` was never probed, so
+    it cannot be proven unrotated (VAL-07) or grid-aligned (VAL-05) — both
+    checks silently treat "unknown" as "passing" without this. Raise a
+    distinct code instead of letting an unverifiable source through.
+    """
+    errors: list[SourceValidationError] = []
+    for src in sources:
+        if src.res_x is None or src.res_y is None:
+            errors.append(
+                SourceValidationError(
+                    source_id=src.id,
+                    code="unknown_pixel_geometry",
+                    message=(
+                        "Pixel resolution was never measured for this source; "
+                        "cannot verify it is unrotated and grid-aligned"
+                    ),
+                    field="res_x" if src.res_x is None else "res_y",
+                )
+            )
+    return errors
+
+
 def _check_grid_alignment(sources: list[Any]) -> list[SourceValidationError]:
     """VAL-05: Band-stack sources must share identical grid dimensions and resolution.
 
     Float comparison for res_x/res_y uses 1e-10 absolute tolerance.
     Returns one error per mismatched dimension per source.
+
+    fix(#1385): a NULL res_x/res_y still skips the comparison here (it can't
+    be compared), but `_check_pixel_geometry_known` (VAL-08) now raises
+    `unknown_pixel_geometry` for that source instead of letting it pass.
     """
     _FLOAT_TOL = 1e-10
     errors: list[SourceValidationError] = []
@@ -248,6 +284,7 @@ def validate_sources(vrt_type: str, sources: list[Any]) -> list[SourceValidation
     errors.extend(_check_dtype(sources))
     errors.extend(_check_nodata_consistency(sources))
     errors.extend(_check_rotation(sources))
+    errors.extend(_check_pixel_geometry_known(sources))
 
     # Mosaic-only checks
     if vrt_type == "mosaic":

--- a/backend/tests/test_raster_validation.py
+++ b/backend/tests/test_raster_validation.py
@@ -382,6 +382,126 @@ class TestGridAlignmentCheck:
 
 
 # ---------------------------------------------------------------------------
+# TestPixelGeometryCheck
+# ---------------------------------------------------------------------------
+
+
+class TestPixelGeometryCheck:
+    """VAL-08 (#1385): unmeasured pixel geometry (NULL res_x/res_y) fails distinctly.
+
+    Neither VAL-05 (grid alignment) nor VAL-07 (rotation) can distinguish
+    "measured and fine" from "never measured" on their own, so a source
+    with NULL res_x/res_y must raise `unknown_pixel_geometry` instead of
+    silently passing both.
+    """
+
+    def test_null_res_x_fails(self):
+        sources = [FakeRasterAsset(), FakeRasterAsset(res_x=None)]
+        with patch("app.processing.raster.validation.rasterio"):
+            errors = validate_sources("mosaic", sources)
+        pg_errors = [e for e in errors if e.code == "unknown_pixel_geometry"]
+        assert len(pg_errors) == 1
+        assert pg_errors[0].source_id == sources[1].id
+        assert pg_errors[0].field == "res_x"
+
+    def test_null_res_y_fails(self):
+        sources = [FakeRasterAsset(), FakeRasterAsset(res_y=None)]
+        with patch("app.processing.raster.validation.rasterio"):
+            errors = validate_sources("mosaic", sources)
+        pg_errors = [e for e in errors if e.code == "unknown_pixel_geometry"]
+        assert len(pg_errors) == 1
+        assert pg_errors[0].source_id == sources[1].id
+        assert pg_errors[0].field == "res_y"
+
+    def test_both_null_reports_single_error(self):
+        """Both res_x and res_y NULL still yields one error, not two."""
+        sources = [FakeRasterAsset(), FakeRasterAsset(res_x=None, res_y=None)]
+        with patch("app.processing.raster.validation.rasterio"):
+            errors = validate_sources("mosaic", sources)
+        pg_errors = [e for e in errors if e.code == "unknown_pixel_geometry"]
+        assert len(pg_errors) == 1
+        assert pg_errors[0].field == "res_x"
+
+    def test_first_source_null_also_flagged(self):
+        """Applies to all sources, including the first — mirrors rotation (VAL-07)."""
+        src1 = FakeRasterAsset(res_x=None)
+        src2 = FakeRasterAsset()
+        with patch("app.processing.raster.validation.rasterio"):
+            errors = validate_sources("mosaic", [src1, src2])
+        pg_errors = [e for e in errors if e.code == "unknown_pixel_geometry"]
+        assert len(pg_errors) == 1
+        assert pg_errors[0].source_id == src1.id
+
+    def test_checked_for_band_stack(self):
+        sources = [FakeRasterAsset(), FakeRasterAsset(res_x=None)]
+        with patch("app.processing.raster.validation.rasterio"):
+            errors = validate_sources("band_stack", sources)
+        pg_errors = [e for e in errors if e.code == "unknown_pixel_geometry"]
+        assert len(pg_errors) == 1
+
+    def test_checked_for_mosaic_even_though_grid_alignment_is_not(self):
+        """VAL-05 (grid alignment) only runs for band_stack, but VAL-08 must
+        still run for mosaic — it also guards the always-on rotation check.
+        """
+        sources = [FakeRasterAsset(), FakeRasterAsset(res_x=None, res_y=None)]
+        with patch("app.processing.raster.validation.rasterio"):
+            errors = validate_sources("mosaic", sources)
+        pg_errors = [e for e in errors if e.code == "unknown_pixel_geometry"]
+        assert len(pg_errors) == 1
+
+    def test_measured_unrotated_aligned_source_passes(self):
+        """A fully measured, unrotated, grid-aligned pair passes cleanly."""
+        sources = [
+            FakeRasterAsset(
+                res_x=1.0, res_y=1.0, is_rotated=False, width=256, height=256
+            ),
+            FakeRasterAsset(
+                res_x=1.0, res_y=1.0, is_rotated=False, width=256, height=256
+            ),
+        ]
+        mock_crs = MagicMock()
+        mock_crs.equals.return_value = True
+        with patch("app.processing.raster.validation.rasterio") as mock_rasterio:
+            mock_rasterio.CRS.from_wkt.return_value = mock_crs
+            errors = validate_sources("band_stack", sources)
+        assert errors == []
+
+    def test_existing_grid_misalignment_still_fires_when_geometry_known(self):
+        """VAL-05 still fires unchanged when res_x/res_y are measured but differ."""
+        sources = [
+            FakeRasterAsset(res_x=1.0, res_y=1.0),
+            FakeRasterAsset(res_x=2.0, res_y=1.0),
+        ]
+        with patch("app.processing.raster.validation.rasterio"):
+            errors = validate_sources("band_stack", sources)
+        codes = {e.code for e in errors}
+        assert "grid_misaligned" in codes
+        assert "unknown_pixel_geometry" not in codes
+
+    def test_existing_rotation_failure_still_fires_when_geometry_known(self):
+        """VAL-07 still fires unchanged for a rotated source with measured geometry."""
+        src_rotated = FakeRasterAsset(is_rotated=True, res_x=1.0, res_y=1.0)
+        sources = [FakeRasterAsset(is_rotated=False), src_rotated]
+        with patch("app.processing.raster.validation.rasterio"):
+            errors = validate_sources("mosaic", sources)
+        codes = {e.code for e in errors if e.source_id == src_rotated.id}
+        assert "rotated_raster" in codes
+        assert "unknown_pixel_geometry" not in codes
+
+    def test_null_resolution_does_not_mask_rotation(self):
+        """A source that is both unmeasured AND rotated reports both codes —
+        VAL-08 does not suppress VAL-07.
+        """
+        src_bad = FakeRasterAsset(is_rotated=True, res_x=None)
+        sources = [FakeRasterAsset(), src_bad]
+        with patch("app.processing.raster.validation.rasterio"):
+            errors = validate_sources("mosaic", sources)
+        codes = {e.code for e in errors if e.source_id == src_bad.id}
+        assert "rotated_raster" in codes
+        assert "unknown_pixel_geometry" in codes
+
+
+# ---------------------------------------------------------------------------
 # TestAllChecksRun
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`validate_sources()` in `backend/app/processing/raster/validation.py` could not distinguish "measured and fine" from "never measured" for a candidate VRT source:

- `_check_rotation` (VAL-07) only errors when `is_rotated` is `true`, but that column is `NOT NULL DEFAULT false` — a source whose geometry probe never ran looks identical to one confirmed unrotated.
- `_check_grid_alignment` (VAL-05) skips the `res_x`/`res_y` comparison entirely when either is `NULL`, instead of failing it.

A remote asset is an eligible VRT source with no storage-backend filter in `validate_sources`, so a remote raster with unmeasured pixel geometry could pass both gates and end up mosaicked despite being possibly rotated or grid-misaligned — exactly what VAL-05/VAL-07 exist to prevent.

Adds **VAL-08** (`unknown_pixel_geometry`): a source with NULL `res_x` or `res_y` now raises this distinct code instead of silently passing. It runs for both `mosaic` and `band_stack`, mirroring VAL-07 (which applies to both), not just VAL-05 (band-stack only). This is the direction from #1385 — `is_rotated` stays `NOT NULL`, no migration.

## Behavior change (release note material)

Remote rasters with unmeasured pixel geometry that previously passed VRT admission now fail with **422** (`unknown_pixel_geometry`) on both `POST /ingest/vrt/create` and the add-source endpoint. This is intentional — the gate's purpose is to refuse unverifiable sources — but it is user-visible: any existing flow that mosaics remote rasters with no measured resolution will start being rejected.

## Frontend

Checked how VAL-05/VAL-07 currently reach the user. The backend returns `SourceValidationError` objects (`source_id`/`code`/`message`/`field`/`severity`) as a raw array under the 422 `detail`. `error-map.ts`'s `classifyApiError()` array-detail branch expects FastAPI/Pydantic validation-error shape (`loc`/`type`/`ctx`); `SourceValidationError` doesn't match it, so **every** VAL-0X code — including the pre-existing `grid_misaligned` and `rotated_raster` — collapses to the generic `errors.validationFailed` ("The submitted values are invalid.") fallback today, not a code-specific string. (Separately, `VrtCreatorForm.tsx` runs its own pre-submission client-side heuristic from search-result metadata with local i18n keys for 5 of the 7 codes — but that never sees the actual backend response, and already has no equivalent for `single_band_required`/`rotated_raster`.)

Since none of VAL-08's siblings are wired to a code-specific i18n string in the actual backend-response path, `unknown_pixel_geometry` behaves consistently with them (same generic fallback) and needs no frontend change here. Wiring the `SourceValidationError` array shape into `error-map.ts` — mirroring the STAC refusal taxonomy pattern from #1333 — is a separate frontend follow-up worth filing on its own.

## Verification

- `cd backend && uv run pytest tests/test_raster_validation.py -q` — 48 passed (10 new VAL-08 tests: NULL res_x, NULL res_y, both NULL → single error, applies to first source, applies to mosaic and band_stack, measured/unrotated/aligned source passes, existing grid_misaligned/rotated_raster failures still fire unchanged and aren't masked by VAL-08).
- `cd backend && uv run pytest tests/test_layering.py -q` — 40 passed.
- `cd backend && uv run ruff check app/processing/raster/validation.py tests/test_raster_validation.py` — passed.
- `cd backend && uv run ruff format --check app/processing/raster/validation.py tests/test_raster_validation.py` — passed.
- `cd backend && uv run pytest tests/test_vrt_creation_173.py tests/test_vrt_source_management_174.py tests/test_vrt_schema_171.py tests/test_vrt_catalog_175.py tests/test_vrt_source_authz_1172.py tests/test_regenerate_vrt_integration.py tests/test_manifest_apply_vrt.py tests/test_vrt_ingest_tasks.py tests/test_raster_ingest.py tests/test_raster_replace_1221.py tests/test_stac_refresh_1266.py tests/test_refresh_gate_1269.py tests/test_vrt_stale_sweep_gap002.py -q` — 398 passed (no regressions; existing fixtures already use measured resolution).

Closes #1385
