### PR TITLE
fix(ingest): retire the synthetic geom row when a reupload de-spatializes

### DIFF
--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1802,6 +1802,46 @@ def _derived_record_type(current: str | None, geometry_type: str | None) -> str 
     return "table" if geometry_type is None else "vector_dataset"
 
 
+async def _retire_geometry_attribute_row(
+    session: Any, dataset_id: uuid.UUID, *, geometry_type: str | None
+) -> None:
+    """Retire the synthetic ``geom`` attribute row of a de-spatialized dataset.
+
+    ``refresh_attribute_metadata`` touches that row only when it is handed a
+    non-null ``geometry_type``, and excludes ``geom`` from its removed-column
+    sweep by name. That is right for a caller that replaces a table's contents
+    while keeping its shape, and wrong for the two callers whose relation can
+    lose its geometry column while keeping its identity: the
+    registered-PostGIS refresh, whose owner can drop the column out from under
+    the catalog, and the reupload swap, which installs a CSV over a shapefile.
+    Left current, the attributes API and the validation service go on
+    advertising a geometry field the relation no longer has.
+
+    fix(#1313 review round 7) established the retirement on the refresh path;
+    fix(#1380) gives the reupload swap the same behaviour from this one
+    function rather than a second copy of it. Feed it the EFFECTIVE geometry
+    type — the same value handed to ``refresh_attribute_metadata`` — and call
+    it unconditionally: the null check lives in here so that a caller cannot
+    hold one half of the pair and forget the other, which is exactly how the
+    two paths came to disagree.
+    """
+    if geometry_type is not None:
+        return
+
+    from app.platform.extensions import get_processing_port
+    from sqlalchemy import update
+
+    AttributeMetadata = get_processing_port().get_attribute_metadata_orm_class()
+    await session.execute(
+        update(AttributeMetadata)
+        .where(
+            AttributeMetadata.dataset_id == dataset_id,
+            AttributeMetadata.field_name == "geom",
+        )
+        .values(is_current=False)
+    )
+
+
 async def _apply_reupload_swap(
     session,
     *,
@@ -2006,14 +2046,13 @@ async def _apply_reupload_swap(
         geometry_type=effective_geometry_type,
         sample_values=sample_values,
     )
-    # NOT fixed here, and filed as #1380: that helper touches the synthetic
-    # `geom` attribute row only when geometry_type is non-null and excludes it
-    # from the removed-column sweep by name, so a de-spatializing reupload
-    # leaves the row current against a relation with no geometry. The refresh
-    # path retires it explicitly (#1313 review round 7); this one still does
-    # not. It is a row this swap has never written, unlike the two fields
-    # #1373 and #1361 asked for, so folding it in would widen the change past
-    # both issues.
+    # fix(#1380): the one row that helper will not retire. Fed the EFFECTIVE
+    # type, like the refresh above it, so a reupload that empties a still-
+    # spatial table cannot retire the row of a relation whose geom column is
+    # right there.
+    await _retire_geometry_attribute_row(
+        session, dataset.id, geometry_type=effective_geometry_type
+    )
 
     # fix(#1314): a reupload can replace a spatial dataset with a non-spatial
     # one (or the reverse), and the auto-generated `record_distributions` rows

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -40,7 +40,7 @@ from types import SimpleNamespace
 from typing import Any, NamedTuple
 
 import structlog
-from sqlalchemy import func, select, text, update
+from sqlalchemy import func, select, text
 from sqlalchemy.exc import DBAPIError
 
 from app.core.db.sqlstate import sqlstate
@@ -64,6 +64,7 @@ from app.processing.ingest.tasks_common import (
     _declared_geometry_type,
     _derived_record_type,
     _effective_geometry_type,
+    _retire_geometry_attribute_row,
     invalidate_tile_cache_for_table,
     stamp_failed_origin_health,
     task_app,
@@ -697,23 +698,12 @@ async def refresh_postgis(
                 sample_values=sample_values,
             )
             # fix(#1313 review round 7): the one row that helper will not
-            # retire. It touches the synthetic `geom` attribute only when
-            # `geometry_type` is non-null, and excludes `geom` from the
-            # removed-column sweep by name — reasonable for every caller that
-            # replaces a table's contents, and wrong for the one caller whose
-            # relation can lose its geometry column while keeping its
-            # identity. Left alone, the attributes API and the validation
-            # service go on advertising a geometry field that is gone.
-            if effective_geometry_type is None:
-                AttributeMetadata = port.get_attribute_metadata_orm_class()
-                await session.execute(
-                    update(AttributeMetadata)
-                    .where(
-                        AttributeMetadata.dataset_id == dataset.id,
-                        AttributeMetadata.field_name == "geom",
-                    )
-                    .values(is_current=False)
-                )
+            # retire, and since fix(#1380) the reupload swap retires it through
+            # the same function — two paths whose relation can lose its
+            # geometry column while keeping its identity, one retirement.
+            await _retire_geometry_attribute_row(
+                session, dataset.id, geometry_type=effective_geometry_type
+            )
             # fix(#1314): the persisted half of the modality change.
             # `_apply_measurement` restamps `record_type`, which is what
             # `build_assets` computes its links from — but

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -2213,6 +2213,189 @@ class TestReuploadDerivesTheEffectiveModality:
         )
 
 
+class TestReuploadRetiresTheGeometryAttributeRow:
+    """fix(#1380): the attribute row follows the relation.
+
+    ``refresh_attribute_metadata`` touches the synthetic ``geom`` row only
+    when it is handed a non-null geometry type, and excludes ``geom`` from its
+    removed-column sweep by name — so a CSV reupload over a shapefile left the
+    row at ``is_current = true`` and the attributes API went on advertising a
+    geometry field the relation no longer has. The registered-PostGIS refresh
+    retired it from #1313 review round 7; this path did not.
+    """
+
+    async def _seed(self, session, *, admin_id, geometry_type, record_type):
+        ds = await _create_dataset(
+            session,
+            created_by=admin_id,
+            name="Reupload Geom Attribute",
+            # Private: these rows outlive the test on the shared per-worker
+            # DB, so keep them out of public-list assertions.
+            visibility="private",
+            source_format="geojson",
+            geometry_type=geometry_type,
+        )
+        ds.record.record_type = record_type
+        # The synthetic row as `refresh_attribute_metadata` writes it, seeded
+        # rather than measured: the swap harness mocks that helper out, so
+        # without this the assertions below would pass against a dataset that
+        # simply never had a geometry row.
+        await session.execute(
+            sa.text(
+                "INSERT INTO catalog.attribute_metadata "
+                "(dataset_id, field_name, title, data_type, "
+                "semantic_role, domain_type) "
+                "VALUES (:did, 'geom', 'Geometry', :dtype, "
+                "'geometry', 'geometry')"
+            ),
+            {"did": ds.id, "dtype": geometry_type or "geometry"},
+        )
+        await session.commit()
+        assert await self._geom_is_current(session, ds.id) is True
+        return ds
+
+    async def _geom_is_current(self, session, dataset_id) -> bool | None:
+        """Read the stored flag straight from the row, past the identity map."""
+        return await session.scalar(
+            sa.text(
+                "SELECT is_current FROM catalog.attribute_metadata "
+                "WHERE dataset_id = :did AND field_name = 'geom'"
+            ),
+            {"did": dataset_id},
+        )
+
+    async def test_a_non_spatial_reupload_retires_the_row(
+        self, test_db_session
+    ) -> None:
+        """A CSV over a shapefile: the geometry field is gone, so say so."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type="POINT",
+            record_type="vector_dataset",
+        )
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            metadata={**_SWAP_METADATA, "geometry_type": None, "extent_wkt": None},
+            staging_has_geometry=False,
+            source_filename="rows.csv",
+            source_format="csv",
+            origin_ref={"filename": "rows.csv"},
+        )
+        await test_db_session.commit()
+
+        assert await self._geom_is_current(test_db_session, ds.id) is False
+
+    async def test_a_spatial_reupload_leaves_the_row_current(
+        self, test_db_session
+    ) -> None:
+        """The dataset still has geometry, so the row still describes it."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type="POINT",
+            record_type="vector_dataset",
+        )
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            source_filename="points.geojson",
+            source_format="geojson",
+            origin_ref={"filename": "points.geojson"},
+        )
+        await test_db_session.commit()
+
+        assert await self._geom_is_current(test_db_session, ds.id) is True
+
+    async def test_an_empty_spatial_reupload_leaves_the_row_current(
+        self, test_db_session
+    ) -> None:
+        """The trap #1373 named, on the row this one retires.
+
+        An empty spatial file measures None against a relation whose geom
+        column is right there, so retiring on the SAMPLED type would strike
+        the attribute row of a dataset that is still spatial — and nothing
+        would restore it, since ``refresh_attribute_metadata`` only ever sets
+        ``is_current`` back to True for a field it is handed. The retirement
+        reads the EFFECTIVE type for exactly that reason.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type="POINT",
+            record_type="vector_dataset",
+        )
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            metadata={
+                **_SWAP_METADATA,
+                "geometry_type": None,
+                "extent_wkt": None,
+                "feature_count": 0,
+            },
+            source_filename="empty.geojson",
+            source_format="geojson",
+            origin_ref={"filename": "empty.geojson"},
+        )
+        await test_db_session.commit()
+
+        assert await self._geom_is_current(test_db_session, ds.id) is True
+
+    async def test_a_reupload_that_gains_geometry_leaves_the_row_current(
+        self, test_db_session
+    ) -> None:
+        """The promote, where the stored type is the stale half.
+
+        A tabular dataset reuploaded from a spatial file: the swap resolves a
+        geometry type where the catalog held None, so nothing may be retired
+        on the strength of the value the dataset carried on the way in.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await self._seed(
+            test_db_session,
+            admin_id=admin_id,
+            geometry_type=None,
+            record_type="table",
+        )
+
+        await _run_reupload_swap(
+            test_db_session,
+            ds,
+            admin_id=admin_id,
+            source_filename="points.geojson",
+            source_format="geojson",
+            origin_ref={"filename": "points.geojson"},
+        )
+        await test_db_session.commit()
+
+        assert await self._geom_is_current(test_db_session, ds.id) is True
+
+    def test_both_paths_share_one_retirement(self) -> None:
+        """#1380's acceptance criterion, pinned the way #1382 pinned its own.
+
+        A second copy of this UPDATE is how the two paths came to disagree
+        about the same row in the first place. Identity rather than a file
+        path, so moving the helper again is a refactor rather than a failure.
+        """
+        from app.processing.ingest import tasks_common, tasks_postgis_refresh
+
+        assert (
+            tasks_postgis_refresh._retire_geometry_attribute_row
+            is tasks_common._retire_geometry_attribute_row
+        )
+
+
 class TestFirstIngestStampsLastRefreshed:
     async def test_created_dataset_carries_its_creation_instant(
         self, test_db_session

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2261,8 +2261,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # spatial relation as tabular, so the precedence falls back to the generic
     # sentinel; the lines are the note recording that `GEOMETRY` is how the
     # rest of the codebase already spells "spatial, subtype unknown".
-    # Cap 2127 -> 2139, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2139,
+    # Cap 2127 -> 2139, exact. fix(#1380): +39 — the note above becomes the
+    # thing it described. `_retire_geometry_attribute_row` MOVED here from
+    # tasks_postgis_refresh (which shrank by 10) and both de-spatializing
+    # paths call it, so the synthetic `geom` attribute row is retired once
+    # rather than by whichever path remembered to. Most of the lines are the
+    # docstring recording why `refresh_attribute_metadata` is right to leave
+    # that row alone for every other caller, and why the null check lives
+    # inside the helper. Cap 2139 -> 2178, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2178,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed


### PR DESCRIPTION
## What

`_apply_reupload_swap` now retires the synthetic `geom` attribute row when a reupload de-spatializes a dataset, through the same function the registered-PostGIS refresh uses.

`refresh_attribute_metadata` touches that row only when it is handed a non-null geometry type, and excludes `geom` from its removed-column sweep by name. That is right for a caller replacing a table's contents while keeping its shape, and wrong for the two callers whose relation can lose its geometry column while keeping its identity. The refresh path retired it inline from #1313 review round 7; the swap never did, so after #1382 a CSV reupload over a shapefile wrote `geometry_type = None` and `record_type = "table"` beside an attribute row still at `is_current = true`, and the attributes API and the validation service went on advertising a geometry field the relation no longer has.

## How

- `_retire_geometry_attribute_row` lands in `tasks_common.py`, beside `_effective_geometry_type` / `_derived_record_type` that #1382 already moved there, and `tasks_postgis_refresh` imports it in place of its inline `update(AttributeMetadata)` block. One implementation, two callers — a second copy of this UPDATE is how the two paths came to disagree about the row in the first place.
- The null check lives inside the helper, so both call sites are one unconditional line: a caller cannot hold half the pair (`refresh_attribute_metadata`) and forget the other half.
- Fed the **effective** geometry type, the same value handed to `refresh_attribute_metadata`. An empty spatial reupload measures None against a relation whose geom column is right there, and retiring on the sampled value would strike the row of a still-spatial dataset with nothing to restore it.
- `update` drops out of `tasks_postgis_refresh`'s sqlalchemy import (its only use is gone).

## Impacts

No schema, API, or config change. Behaviour change is confined to the reupload swap: a de-spatializing reupload now marks the `geom` attribute row `is_current = false`, which is what the refresh path already did. `tasks_postgis_refresh` shrank by 10 lines; the `tasks_common` cap in `_MODULE_LOC_CAPS` rises 2139 → 2178 with the note explaining what the lines bought.

## Tests

New `TestReuploadRetiresTheGeometryAttributeRow` in `backend/tests/test_dataset_source_state.py`, following the shape #1382 used:

- a non-spatial reupload (CSV over a shapefile) retires the row;
- a spatial reupload leaves it current;
- an **empty** spatial reupload leaves it current — the #1373 trap, on this row;
- a reupload that gains geometry leaves it current, so nothing is retired on the strength of the pre-swap stored value;
- `test_both_paths_share_one_retirement` pins the shared implementation by identity rather than by file path.

Negative control: with the new call commented out, `test_a_non_spatial_reupload_retires_the_row` fails and the three "leaves it current" guards still pass. The refresh path's existing retirement assertion (`test_a_dataset_that_loses_geometry_becomes_a_table` in `test_postgis_refresh_1265.py`) is unchanged and still green.

## Verification

Host-side, from `backend/` with `.env.test` sourced:

- `uv run pytest tests/test_dataset_source_state.py tests/test_postgis_refresh_1265.py tests/test_reupload_swap_lock_retry.py tests/test_attribute_metadata.py tests/test_reupload_service.py -q` → 214 passed
- `uv run pytest tests/test_tasks_common_phase_brackets.py tests/test_refresh_gate_1269.py tests/test_service_refresh_1220.py tests/test_staging_pipeline.py tests/test_phase_2_commit_boundary.py tests/test_raster_replace_1221.py -q` → 208 passed
- `uv run pytest tests/test_layering.py -q` → 40 passed
- `uv run ruff check .` / `uv run ruff format --check .` → clean

Closes #1380
