### PR TITLE
fix(catalog): demote the incumbent when a distribution is written with is_primary

### DIFF
--- a/backend/alembic/versions/0042_record_distribution_single_primary.py
+++ b/backend/alembic/versions/0042_record_distribution_single_primary.py
@@ -37,6 +37,19 @@ Everything else on that record has ``is_primary`` cleared. No row is deleted:
 a demoted distribution is still a distribution, and the DCAT/GeoDCAT-AP feeds
 never serialized the flag at all, so nothing disappears from them.
 
+**No window between the repair and the index.** The migration takes
+``LOCK TABLE catalog.record_distributions IN SHARE MODE`` before it repairs
+anything. Without it, a rolling deployment leaves the PRE-upgrade API writable
+while this runs, and that code stores ``is_primary`` verbatim: a POST that
+commits after the repair statement's snapshot — or one already in flight and
+therefore invisible to it — puts a second primary back on a record the repair
+had just cleaned. ``CREATE UNIQUE INDEX`` then waits for that writer, scans the
+duplicated rows and fails, turning a deploy migration into an aborted one. The
+lock closes the window at both ends: it waits out the in-flight writers, and it
+blocks new ones until this transaction commits. SHARE is the mode
+``CREATE INDEX`` acquires anyway, so this only moves the acquisition earlier —
+by one small UPDATE — rather than holding a stronger lock.
+
 Plain, transactional ``CREATE UNIQUE INDEX`` — not ``CONCURRENTLY``, following
 0040's reasoning verbatim: a CIC interrupted mid-build (lock contention from a
 sibling pytest-xdist worker migrating its own database, a killed process)
@@ -102,8 +115,15 @@ ON catalog.record_distributions (record_id)
 WHERE is_primary
 """
 
+# Excludes writers for the whole migration — see the module docstring's
+# "no window between the repair and the index" paragraph. SHARE is exactly
+# what `CREATE INDEX` takes on its own; taking it up front only moves the
+# acquisition earlier, it does not escalate.
+_LOCK_SQL = "LOCK TABLE catalog.record_distributions IN SHARE MODE"
+
 
 def upgrade() -> None:
+    op.execute(_LOCK_SQL)
     # Repair first: the index cannot be built over a record that still has two.
     op.execute(_REPAIR_SQL)
     op.execute(_CREATE_INDEX_SQL)

--- a/backend/alembic/versions/0042_record_distribution_single_primary.py
+++ b/backend/alembic/versions/0042_record_distribution_single_primary.py
@@ -1,0 +1,113 @@
+"""At most one primary distribution per record.
+
+fix(#1383). ``record_distributions.is_primary`` is read as "THE primary
+distribution" — it is emitted per distribution in the OGC Record's
+``properties.distributions`` (``search/service_records.py``), which is what the
+dataset detail response and the STAC item's source record carry. Nothing kept
+it singular: ``create_distribution`` and ``update_distribution`` stored the flag
+verbatim, and every dataset already carries a generated primary (GeoPackage
+when it has geometry, CSV when it does not), so a single
+``POST /records/{id}/distributions/`` with ``is_primary: true`` left the record
+with two rows claiming it and no tiebreak.
+
+The write paths now demote the incumbent (last write wins, stated on
+``create_distribution``'s docstring). This index is what the API cannot route
+around, and it is also what fixes the records already in the bad state — the
+demote alone would leave every pre-existing double untouched.
+
+**The repair rule, and why it is this one.** ``record_distributions`` carries
+no ``created_at``/``updated_at``, so "keep the most recently updated row" is
+not expressible. Per record, of the rows flagged primary, keep exactly one,
+ordered by:
+
+1. USER-AUTHORED before generated (``auto_generated`` ascending, false first).
+   This is the same precedence the service layer applies going forward — an
+   explicit ``is_primary: true`` from a caller outranks the platform default,
+   and it is the row that produced the double in the first place, so keeping
+   it preserves what the caller asked for.
+2. Then the generated preference order the code normalizes with: the
+   ``download``/``gpkg`` row, then ``download``/``csv``, then anything else.
+   This matters only when several GENERATED rows are primary (a state that
+   predates the reconcile normalization in #1314); it lands on the row a fresh
+   ``generate_distributions`` would have picked.
+3. Then ``id``, so the outcome is total and repeatable — re-running the
+   repair on the same data always keeps the same row.
+
+Everything else on that record has ``is_primary`` cleared. No row is deleted:
+a demoted distribution is still a distribution, and the DCAT/GeoDCAT-AP feeds
+never serialized the flag at all, so nothing disappears from them.
+
+Plain, transactional ``CREATE UNIQUE INDEX`` — not ``CONCURRENTLY``, following
+0040's reasoning verbatim: a CIC interrupted mid-build (lock contention from a
+sibling pytest-xdist worker migrating its own database, a killed process)
+leaves an INVALID index that ``IF NOT EXISTS`` then treats as already there,
+invisible to reflection and never chosen by the planner. Plain DDL participates
+in this migration's transaction, so the repair and the index either both land
+or neither does — which also means the index can never be created over rows the
+repair failed to clean.
+
+Downgrade drops the index. It cannot restore the flags the repair cleared, and
+does not try: those rows were ambiguous by construction, and nothing recorded
+which of the two any consumer had been reading.
+
+Revision ID: 0042_record_distribution_single_primary
+Revises: 0041_raster_assets_crs_wkt2
+Create Date: 2026-08-10
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0042_record_distribution_single_primary"
+down_revision: Union[str, None] = "0041_raster_assets_crs_wkt2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = "uq_record_distribution_primary"
+
+# Deterministic demotion of every primary row but the winner — see the module
+# docstring for the ordering and why each term is in it. Imported by
+# tests/test_distribution_primary_1383.py so the test exercises this exact SQL
+# rather than a paraphrase of it.
+_REPAIR_SQL = """
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY record_id
+               ORDER BY
+                   auto_generated,
+                   CASE
+                       WHEN distribution_type = 'download' AND format = 'gpkg'
+                           THEN 0
+                       WHEN distribution_type = 'download' AND format = 'csv'
+                           THEN 1
+                       ELSE 2
+                   END,
+                   id
+           ) AS rn
+    FROM catalog.record_distributions
+    WHERE is_primary
+)
+UPDATE catalog.record_distributions AS d
+SET is_primary = false
+FROM ranked
+WHERE d.id = ranked.id
+  AND ranked.rn > 1
+"""
+
+_CREATE_INDEX_SQL = f"""
+CREATE UNIQUE INDEX IF NOT EXISTS {_INDEX_NAME}
+ON catalog.record_distributions (record_id)
+WHERE is_primary
+"""
+
+
+def upgrade() -> None:
+    # Repair first: the index cannot be built over a record that still has two.
+    op.execute(_REPAIR_SQL)
+    op.execute(_CREATE_INDEX_SQL)
+
+
+def downgrade() -> None:
+    op.execute(f"DROP INDEX IF EXISTS catalog.{_INDEX_NAME}")

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -731,6 +731,18 @@ class RecordDistribution(Base):
             "'webApp', 'offlineAccess', 'vector_tiles')",
             name="chk_distribution_type",
         ),
+        # fix(#1383): at most one primary distribution per record. The write
+        # paths in catalog/records/service.py demote the incumbent so callers
+        # never meet this, but `is_primary` is read as "THE primary" by the
+        # OGC Record properties and by the dataset detail response, and the
+        # API is not the only writer. Partial, so the unflagged rows (all but
+        # one per record) are not in the index at all.
+        Index(
+            "uq_record_distribution_primary",
+            "record_id",
+            unique=True,
+            postgresql_where=text("is_primary"),
+        ),
         {"schema": "catalog"},
     )
 

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -691,6 +691,20 @@ async def list_distributions_endpoint(
     )
 
 
+def _distribution_conflict_detail(exc: IntegrityError) -> str:
+    """Name the unique index the write actually hit.
+
+    fix(#1383): ``uq_record_distribution_primary`` allows one primary row per
+    record. The service demotes the incumbent first, so the only way to reach
+    the index is two concurrent writes both claiming the flag — a retry
+    succeeds, where "same record, type, and format" would send the caller
+    hunting for a duplicate that does not exist.
+    """
+    if "uq_record_distribution_primary" in str(getattr(exc, "orig", exc)):
+        return "Another distribution was concurrently marked primary; retry"
+    return "Duplicate distribution (same record, type, and format)"
+
+
 @router.post(
     "/{record_id}/distributions/",
     response_model=DistributionResponse,
@@ -724,11 +738,11 @@ async def create_distribution_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Record not found"
         )
-    except IntegrityError:
+    except IntegrityError as exc:
         await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="Duplicate distribution (same record, type, and format)",
+            detail=_distribution_conflict_detail(exc),
         )
     await _propagate_record_write(
         record_id,
@@ -773,11 +787,11 @@ async def update_distribution_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Distribution not found"
         )
-    except IntegrityError:
+    except IntegrityError as exc:
         await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="Duplicate distribution (same record, type, and format)",
+            detail=_distribution_conflict_detail(exc),
         )
     await _propagate_record_write(
         record_id,

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -691,17 +691,21 @@ async def list_distributions_endpoint(
     )
 
 
+# fix(#1383): reachable only from concurrent writes to one record's primary
+# flag — the service demotes the incumbent first, so a lone caller never gets
+# here — and a retry succeeds because the winner is settled by then.
+_PRIMARY_CONFLICT_DETAIL = "Another distribution was concurrently marked primary; retry"
+
+
 def _distribution_conflict_detail(exc: IntegrityError) -> str:
     """Name the unique index the write actually hit.
 
-    fix(#1383): ``uq_record_distribution_primary`` allows one primary row per
-    record. The service demotes the incumbent first, so the only way to reach
-    the index is two concurrent writes both claiming the flag — a retry
-    succeeds, where "same record, type, and format" would send the caller
-    hunting for a duplicate that does not exist.
+    ``uq_record_distribution_primary`` allows one primary row per record, and
+    "same record, type, and format" would send a caller who tripped it hunting
+    for a duplicate that does not exist.
     """
     if "uq_record_distribution_primary" in str(getattr(exc, "orig", exc)):
-        return "Another distribution was concurrently marked primary; retry"
+        return _PRIMARY_CONFLICT_DETAIL
     return "Duplicate distribution (same record, type, and format)"
 
 
@@ -830,6 +834,18 @@ async def delete_distribution_endpoint(
             )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Distribution not found"
+        )
+    except IntegrityError:
+        # fix(#1383): deleting the primary hands the flag back to the generated
+        # default, and a write that claimed it concurrently gets there first.
+        # No other constraint on this table is reachable from a delete, so the
+        # detail is stated rather than sniffed. A retry succeeds: the flag is
+        # spoken for by then and the restore is skipped. 409 rather than the
+        # 500 an uncaught IntegrityError would produce.
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=_PRIMARY_CONFLICT_DETAIL,
         )
     await _propagate_record_write(
         record_id,

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -6,7 +6,7 @@ the single authoritative metadata path. No dual-write to legacy JSONB/tags colum
 
 import uuid
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -337,6 +337,56 @@ async def count_distributions(session: AsyncSession, record_id: uuid.UUID) -> in
     return result.scalar_one()
 
 
+async def _demote_other_primaries(
+    session: AsyncSession,
+    record_id: uuid.UUID,
+    *,
+    keep_id: uuid.UUID | None = None,
+    generated_only: bool = False,
+) -> None:
+    """Clear ``is_primary`` on the record's other distributions (#1383).
+
+    One UPDATE, issued BEFORE the row that claims the flag is written, and the
+    ordering is the whole point. ``uq_record_distribution_primary`` (migration
+    0042) is a plain, non-deferrable partial unique index, so a second primary
+    fails at statement time rather than at COMMIT; leaving the demote to the
+    ORM's unit of work would make that failure depend on flush ordering
+    between an UPDATE and an INSERT that SQLAlchemy is free to choose.
+
+    ``generated_only`` restricts the demote to ``auto_generated`` rows. It is
+    what lets ``reconcile_distributions`` normalize its own rows without
+    writing a user's — see the preservation policy on its docstring.
+    """
+    stmt = update(RecordDistribution).where(
+        RecordDistribution.record_id == record_id,
+        RecordDistribution.is_primary.is_(True),
+    )
+    if keep_id is not None:
+        stmt = stmt.where(RecordDistribution.id != keep_id)
+    if generated_only:
+        stmt = stmt.where(RecordDistribution.auto_generated.is_(True))
+    await session.execute(
+        stmt.values(is_primary=False),
+        execution_options={"synchronize_session": "fetch"},
+    )
+
+
+async def _record_has_primary(
+    session: AsyncSession,
+    record_id: uuid.UUID,
+    *,
+    user_authored_only: bool = False,
+) -> bool:
+    """Whether some row on the record already holds ``is_primary``."""
+    stmt = select(RecordDistribution.id).where(
+        RecordDistribution.record_id == record_id,
+        RecordDistribution.is_primary.is_(True),
+    )
+    if user_authored_only:
+        stmt = stmt.where(RecordDistribution.auto_generated.is_(False))
+    return (await session.execute(stmt.limit(1))).scalar_one_or_none() is not None
+
+
 async def create_distribution(
     session: AsyncSession,
     record_id: uuid.UUID,
@@ -351,11 +401,35 @@ async def create_distribution(
     is_primary: bool = False,
     record: Record | None = None,
 ) -> RecordDistribution:
-    """Create a manual distribution for a record."""
+    """Create a manual distribution for a record.
+
+    **Primary semantics (#1383): the last write wins.** A row written with
+    ``is_primary=True`` demotes every other distribution on the record, the
+    generated ones included, in this transaction. Before this, the flag was
+    stored verbatim and every dataset already carries a generated primary
+    (GeoPackage when it has geometry, CSV when it does not), so one POST left
+    the record advertising two primaries with no tiebreak for the OGC Record
+    and STAC consumers that read ``properties.distributions``.
+
+    Rejecting the write with a 409 while another row holds the flag was the
+    alternative. It was not taken: the API has no demote verb, so "make this
+    one primary" would become a two-request dance with an unavoidable window
+    where the record has no primary at all, and every existing caller sending
+    ``is_primary=true`` would start failing. Demoting keeps the request
+    meaning what it says.
+
+    Enforcement does not live here. ``uq_record_distribution_primary``
+    (migration 0042) is the invariant — at most one primary row per record,
+    in the database, where no API path can route around it. The demote is
+    what keeps well-behaved callers from ever meeting it.
+    """
     if record is None:
         record = await get_record(session, record_id)
     if record is None:
         raise ValueError(f"Record {record_id} not found")
+
+    if is_primary:
+        await _demote_other_primaries(session, record_id)
 
     dist = RecordDistribution(
         record_id=record_id,
@@ -383,6 +457,13 @@ async def update_distribution(
     """Update a distribution. Explicitly-set fields are applied, nulls included.
 
     Auto-generated distributions cannot be updated (raises ValueError).
+
+    ``is_primary=True`` follows the same last-write-wins rule
+    ``create_distribution`` states (#1383): the record's other distributions
+    are demoted here, in this transaction. Clearing the flag
+    (``is_primary=False``) promotes nothing — a caller saying "this is not the
+    primary" is not saying which one is, and a record with no primary is a
+    representable state that the next ``reconcile_distributions`` fills.
     """
     result = await session.execute(
         select(RecordDistribution).where(
@@ -396,6 +477,11 @@ async def update_distribution(
 
     if dist.auto_generated:
         raise ValueError("Cannot update auto-generated distributions")
+
+    # Before the setattr loop, so the demote UPDATE is on the wire ahead of
+    # the promote this flush will emit — see _demote_other_primaries.
+    if kwargs.get("is_primary") is True:
+        await _demote_other_primaries(session, record_id, keep_id=distribution_id)
 
     # fix(#458 E-46): apply explicitly-set nulls too — see update_contact.
     for key, value in kwargs.items():
@@ -411,6 +497,14 @@ async def delete_distribution(
     """Delete a distribution by ID.
 
     Auto-generated distributions cannot be deleted (raises ValueError).
+
+    Deleting the row that holds ``is_primary`` hands the flag back to the
+    generated default (#1383). Without that, the demote-on-write rule would
+    make "no primary at all" reachable in one more request than it used to
+    be: the user's row took the flag off the generated GeoPackage when it was
+    created, and deleting it would leave nothing holding it. Withdrawing a
+    row withdraws its claim; the platform's own default is what the record
+    had before the claim.
     """
     result = await session.execute(
         select(RecordDistribution).where(
@@ -425,8 +519,46 @@ async def delete_distribution(
     if dist.auto_generated:
         raise ValueError("Cannot delete auto-generated distributions")
 
+    was_primary = dist.is_primary
     await session.delete(dist)
     await session.flush()
+
+    if was_primary:
+        await _restore_generated_primary(session, record_id)
+
+
+async def _restore_generated_primary(
+    session: AsyncSession, record_id: uuid.UUID
+) -> RecordDistribution | None:
+    """Give ``is_primary`` back to the best generated row, if there is one.
+
+    Same preference order ``reconcile_distributions`` normalizes with
+    (GeoPackage, then CSV), restricted to generated rows that actually exist —
+    a record whose modality generates neither is simply left without a
+    primary, the state it was in before. Called only after the flush that
+    removed the previous holder, and it re-checks that nothing else holds the
+    flag, so it can never be the write that trips
+    ``uq_record_distribution_primary``.
+    """
+    if await _record_has_primary(session, record_id):
+        return None
+
+    rows = (
+        await session.execute(
+            select(RecordDistribution).where(
+                RecordDistribution.record_id == record_id,
+                RecordDistribution.auto_generated.is_(True),
+            )
+        )
+    ).scalars()
+    by_pair = {(row.distribution_type, row.format): row for row in rows}
+    for pair in _PRIMARY_PREFERENCE:
+        row = by_pair.get(pair)
+        if row is not None:
+            row.is_primary = True
+            await session.flush()
+            return row
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -561,6 +693,11 @@ async def generate_distributions(
     the insert itself is ``ON CONFLICT DO NOTHING`` against
     ``uq_record_distribution``.
 
+    fix(#1383): the template's ``is_primary`` is inserted only when no row on
+    the record already holds the flag. At creation none does; on a reconcile
+    the holder is a survivor or a user's own row, and the caller's
+    normalization step is what moves the flag afterwards.
+
     fix(#1370): the existence probe reads only auto-generated rows. It used to
     read every row, so a distribution a user authored through
     ``create_distribution`` counted as "the pair is taken" — and once somebody
@@ -590,6 +727,17 @@ async def generate_distributions(
     )
     existing_set = {(row[0], row[1]) for row in existing_result.all()}
 
+    # fix(#1383): the template's primary flag yields to whoever already holds
+    # it. At dataset creation nothing does and the GeoPackage (or CSV) row
+    # takes it exactly as before; on a reconcile the holder is a surviving
+    # generated row or a user's own, and inserting a second primary would
+    # violate `uq_record_distribution_primary` — aborting the refresh
+    # transaction the caller runs inside, which is the failure mode the
+    # ON CONFLICT clause below exists to avoid for the other unique index.
+    # Moving the flag afterwards is reconcile's normalization step, which
+    # demotes before it promotes.
+    record_has_primary = await _record_has_primary(session, record_id)
+
     # Build all new distributions in one list so they go out as a single
     # multi-VALUES INSERT rather than one statement per row.
     to_add: list[dict] = []
@@ -615,7 +763,7 @@ async def generate_distributions(
         url = url_tpl.format(dataset_id=dataset_id)
 
         # For non-spatial datasets, CSV download becomes primary (gpkg is filtered out)
-        effective_primary = (dist_type, fmt) == primary_pair
+        effective_primary = (dist_type, fmt) == primary_pair and not record_has_primary
 
         to_add.append(
             {
@@ -718,11 +866,26 @@ async def reconcile_distributions(
       alone — a generated row the conflict-tolerant insert skipped is not
       there to promote, and the fallback takes it.
 
-    Normalization spans the generated rows only, which is the same boundary as
-    every other bullet here. A user who flags their OWN row primary keeps that
-    flag through a reconcile, so that record advertises two primaries — see
-    #1383, which is reachable from a single POST on any dataset and predates
-    #1370 rather than being introduced by it.
+    **Where the primary flag fits the policy (#1383).** ``is_primary`` is a
+    per-RECORD invariant, not a per-row field: ``uq_record_distribution_primary``
+    (migration 0042) allows one primary row per record, and
+    ``create_distribution``/``update_distribution`` hold it up by demoting
+    everything else when a user claims the flag. That crosses this function's
+    boundary in exactly one place, and the boundary holds:
+
+    - The demote this normalization issues is scoped to ``auto_generated``
+      rows, so a user's row is still never written here. It does span
+      generated rows OUTSIDE ``_GENERATED_PAIRS`` — those survive, as the
+      bullet above promises, but they cannot keep a primary flag the record's
+      new winner needs, because the invariant is per record.
+    - A USER-authored primary outranks this normalization entirely: when one
+      exists, no generated row is promoted and the flags are left alone. The
+      explicit choice wins over the platform default, and a background
+      refresh never takes back what a user asked for.
+
+    Deleting that user row is what hands the flag back — see
+    ``delete_distribution`` — so the record does not sit primary-less waiting
+    for a refresh that may never come.
 
     The lost-edit case is narrower than it reads: ``update_distribution`` and
     ``delete_distribution`` both refuse to touch a row with
@@ -782,13 +945,25 @@ async def reconcile_distributions(
         ),
         None,
     )
+    # fix(#1383): a user's own row holding the flag outranks this
+    # normalization, and skipping is what keeps the preservation policy above
+    # literally true — the demote below is scoped to generated rows, so it
+    # could not clear a user's flag anyway, and promoting beside one would
+    # advertise two primaries (now a `uq_record_distribution_primary`
+    # violation rather than a silent ambiguity).
+    user_primary = await _record_has_primary(
+        session, record_id, user_authored_only=True
+    )
     # No candidate means every preferred pair is occupied by a row this
     # function does not own, and there is nothing to promote. Leave the flags
     # as they are rather than clearing them: an unchanged primary is a worse
     # answer than the right one and a better answer than none.
-    if primary is not None:
-        for row in generated:
-            row.is_primary = row is primary
+    if primary is not None and not user_primary:
+        # Demote first, promote second — one statement each, in that order.
+        await _demote_other_primaries(
+            session, record_id, keep_id=primary.id, generated_only=True
+        )
+        primary.is_primary = True
     await session.flush()
 
     return created, removed

--- a/backend/tests/test_crs_wkt2_backfill_1376.py
+++ b/backend/tests/test_crs_wkt2_backfill_1376.py
@@ -130,13 +130,13 @@ async def _seed_raster_asset(session, admin_id: uuid.UUID, crs_wkt: str) -> uuid
     return asset_id
 
 
-def _wkt1_root_re() -> str:
-    """The migration's predicate, loaded from the migration itself.
+def _migration_0041():
+    """The migration module this file is about, loaded for its own constants.
 
-    Copying the pattern here would let the two drift, and a predicate that
-    silently stopped matching would show up as a migration that converts
-    nothing — which looks exactly like a database that had nothing to
-    convert.
+    Copying anything out of it by hand would let the two drift, and a
+    predicate that silently stopped matching would show up as a migration
+    that converts nothing — which looks exactly like a database that had
+    nothing to convert.
     """
     import importlib.util
     from pathlib import Path
@@ -151,7 +151,27 @@ def _wkt1_root_re() -> str:
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return module._WKT1_ROOT_RE
+    return module
+
+
+def _wkt1_root_re() -> str:
+    """The migration's predicate, loaded from the migration itself."""
+    return _migration_0041()._WKT1_ROOT_RE
+
+
+def _revision_below_0041() -> str:
+    """The revision 0041 sits on, read from 0041's own ``down_revision``.
+
+    fix(#1383): this round trip used ``downgrade -1``, which reverts whatever
+    the CURRENT head is — 0041 only while nothing sat above it. The moment a
+    new migration landed (0042, the distribution primary-flag index), the
+    downgrade stepped over THAT one and the re-upgrade re-ran nothing, so the
+    WKT1 row came back unconverted and this test failed for a reason that had
+    nothing to do with the backfill. Naming the target keeps the test about
+    its own migration whatever else is stacked on top; reading it from the
+    module keeps it correct if 0041 is ever re-chained.
+    """
+    return _migration_0041().down_revision
 
 
 class TestWkt1Predicate:
@@ -225,9 +245,10 @@ class TestCrsWkt2Backfill:
         wkt2_id = await _seed_raster_asset(test_db_session, admin_id, already_wkt2)
 
         try:
-            down = _run_alembic("downgrade", "-1")
+            target = _revision_below_0041()
+            down = _run_alembic("downgrade", target)
             assert down.returncode == 0, (
-                f"alembic downgrade -1 failed (rc={down.returncode}):\n"
+                f"alembic downgrade {target} failed (rc={down.returncode}):\n"
                 f"stdout: {down.stdout}\nstderr: {down.stderr}"
             )
             up = _run_alembic("upgrade", "head")

--- a/backend/tests/test_distribution_primary_1383.py
+++ b/backend/tests/test_distribution_primary_1383.py
@@ -610,6 +610,10 @@ class TestMigrationRepair:
                     )
                     assert await self._primary_count(conn, record_id) == 2
 
+                    # Same three statements ``upgrade()`` issues, in the same
+                    # order: the lock is what stops a writer from putting a
+                    # second primary back between the repair and the index.
+                    await conn.execute(sa.text(migration._LOCK_SQL))
                     await conn.execute(sa.text(migration._REPAIR_SQL))
 
                     rows = (
@@ -696,6 +700,7 @@ class TestMigrationRepair:
                         {"rid": record_id},
                     )
 
+                    await conn.execute(sa.text(migration._LOCK_SQL))
                     await conn.execute(sa.text(migration._REPAIR_SQL))
 
                     rows = (

--- a/backend/tests/test_distribution_primary_1383.py
+++ b/backend/tests/test_distribution_primary_1383.py
@@ -1,0 +1,728 @@
+"""One primary distribution per record (#1383).
+
+``is_primary`` is read as "THE primary distribution" — the OGC Record's
+``properties.distributions`` emits it per row, and that is what the dataset
+detail response and the STAC item's source record carry. Nothing kept it
+singular: every dataset is created with a generated primary (GeoPackage when it
+has geometry, CSV when it does not), and one
+``POST /records/{id}/distributions/`` carrying ``is_primary: true`` added a
+second, leaving consumers two answers and no tiebreak.
+
+Two layers, tested as two things, because they fail differently:
+
+- The service layer DEMOTES on write, so ordinary callers get what they asked
+  for (last write wins) and never see an error.
+- ``uq_record_distribution_primary`` (migration 0042) is the invariant, in the
+  database, where a writer that skips the service cannot route around it — and
+  it is what repairs the records that were already double at migration time.
+
+The reconcile side is pinned here too: a user-authored primary outranks
+``reconcile_distributions``' normalization, which is what keeps that function's
+preservation policy ("never writes a user-authored row") true rather than
+merely stated.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from httpx import AsyncClient
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from app.modules.catalog.datasets.domain.models import RecordDistribution
+from app.modules.catalog.records.router import _distribution_conflict_detail
+from app.modules.catalog.records.service import (
+    create_distribution,
+    delete_distribution,
+    generate_distributions,
+    reconcile_distributions,
+    update_distribution,
+)
+from tests.factories import create_dataset, get_user_id
+
+pytestmark = pytest.mark.anyio
+
+_INDEX_NAME = "uq_record_distribution_primary"
+
+
+def _migration_0042():
+    """The migration module, loaded for its SQL.
+
+    The repair test runs the migration's own statements rather than a
+    paraphrase: a repair that stopped matching the rows it is meant to fix
+    would otherwise still pass a test that re-implements it.
+    """
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "0042_record_distribution_single_primary.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_0042", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+async def _primaries(
+    session: AsyncSession, record_id: uuid.UUID
+) -> list[RecordDistribution]:
+    """Every row on the record currently flagged primary, generated or not."""
+    rows = (
+        await session.execute(
+            sa.select(RecordDistribution)
+            .where(
+                RecordDistribution.record_id == record_id,
+                RecordDistribution.is_primary.is_(True),
+            )
+            .order_by(RecordDistribution.id)
+        )
+    ).scalars()
+    return list(rows)
+
+
+async def _spatial_dataset(session: AsyncSession):
+    """A dataset carrying the seven rows a spatial creation generates."""
+    admin_id = await get_user_id(session, "admin")
+    dataset = await create_dataset(session, created_by=admin_id)
+    await generate_distributions(
+        session,
+        dataset.id,
+        dataset.record_id,
+        dataset.table_name,
+        geometry_type="POLYGON",
+    )
+    await session.commit()
+    return dataset
+
+
+async def _tabular_dataset(session: AsyncSession):
+    """A dataset carrying the two rows a non-spatial creation generates."""
+    admin_id = await get_user_id(session, "admin")
+    dataset = await create_dataset(session, created_by=admin_id, geometry_type=None)
+    await generate_distributions(
+        session, dataset.id, dataset.record_id, dataset.table_name, geometry_type=None
+    )
+    await session.commit()
+    return dataset
+
+
+class TestDemoteOnWrite:
+    """The write paths keep the flag singular, so callers never meet the index."""
+
+    async def test_creating_a_primary_demotes_the_generated_incumbent(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The reproduction from the issue, at the service layer."""
+        dataset = await _spatial_dataset(test_db_session)
+        incumbent = await _primaries(test_db_session, dataset.record_id)
+        assert [(d.distribution_type, d.format) for d in incumbent] == [
+            ("download", "gpkg")
+        ]
+        assert incumbent[0].auto_generated is True
+
+        mine = await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+            is_primary=True,
+        )
+        await test_db_session.commit()
+
+        after = await _primaries(test_db_session, dataset.record_id)
+        assert [d.id for d in after] == [mine.id]
+        assert after[0].auto_generated is False
+
+    async def test_the_post_from_the_issue_leaves_one_primary(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ) -> None:
+        """The exact request the issue reproduces with, over HTTP.
+
+        Through the router, so the 201 and the demote are shown to be the same
+        transaction — a demote that only worked when the service was called
+        directly would still leave the API able to write the second primary.
+        """
+        dataset = await _spatial_dataset(test_db_session)
+
+        resp = await client.post(
+            f"/records/{dataset.record_id}/distributions/",
+            json={
+                "distribution_type": "download",
+                "format": "gpkg",
+                "url": "https://example.org/mine.gpkg",
+                "is_primary": True,
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["is_primary"] is True
+
+        listed = await client.get(
+            f"/records/{dataset.record_id}/distributions/", headers=admin_auth_header
+        )
+        assert listed.status_code == 200, listed.text
+        primaries = [d for d in listed.json()["distributions"] if d["is_primary"]]
+        assert [d["id"] for d in primaries] == [resp.json()["id"]]
+
+    async def test_updating_a_row_to_primary_demotes_the_incumbent(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Same rule on the update path — it had the same shape as create."""
+        dataset = await _spatial_dataset(test_db_session)
+        mine = await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+        )
+        await test_db_session.commit()
+        assert [
+            d.auto_generated
+            for d in await _primaries(test_db_session, dataset.record_id)
+        ] == [True]
+
+        await update_distribution(
+            test_db_session, mine.id, dataset.record_id, is_primary=True
+        )
+        await test_db_session.commit()
+
+        after = await _primaries(test_db_session, dataset.record_id)
+        assert [d.id for d in after] == [mine.id]
+
+    async def test_a_write_that_does_not_claim_the_flag_moves_nothing(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Only ``is_primary=True`` demotes. Everything else is untouched."""
+        dataset = await _spatial_dataset(test_db_session)
+        before = await _primaries(test_db_session, dataset.record_id)
+
+        mine = await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+        )
+        await update_distribution(
+            test_db_session, mine.id, dataset.record_id, title="Renamed"
+        )
+        await test_db_session.commit()
+
+        after = await _primaries(test_db_session, dataset.record_id)
+        assert [d.id for d in after] == [d.id for d in before]
+
+    async def test_clearing_the_flag_promotes_nothing(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Pinned because it is a decision, not an accident.
+
+        A caller saying "this is not the primary" is not saying which one is,
+        so the record is left with none until the next reconcile. Restoring
+        the generated default here would silently overrule a caller who
+        cleared the flag on purpose.
+        """
+        dataset = await _spatial_dataset(test_db_session)
+        mine = await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+            is_primary=True,
+        )
+        await test_db_session.commit()
+
+        await update_distribution(
+            test_db_session, mine.id, dataset.record_id, is_primary=False
+        )
+        await test_db_session.commit()
+
+        assert await _primaries(test_db_session, dataset.record_id) == []
+
+
+class TestTheConflictMessage:
+    """A 409 that names the right conflict.
+
+    Reachable only from two concurrent writes both claiming the flag (the
+    service demotes first, so a lone caller never gets here), and the generic
+    duplicate message would send that caller looking for a row that does not
+    exist.
+    """
+
+    def test_the_primary_index_gets_its_own_wording(self) -> None:
+        detail = _distribution_conflict_detail(
+            IntegrityError(
+                "INSERT",
+                {},
+                Exception(
+                    "duplicate key value violates unique constraint "
+                    '"uq_record_distribution_primary"'
+                ),
+            )
+        )
+        assert "primary" in detail
+        assert "retry" in detail
+
+    def test_the_four_column_constraint_keeps_the_old_wording(self) -> None:
+        detail = _distribution_conflict_detail(
+            IntegrityError(
+                "INSERT",
+                {},
+                Exception(
+                    "duplicate key value violates unique constraint "
+                    '"uq_record_distribution"'
+                ),
+            )
+        )
+        assert detail == "Duplicate distribution (same record, type, and format)"
+
+
+class TestTheDatabaseInvariant:
+    """What the API cannot route around."""
+
+    async def test_the_index_is_partial_on_record_id(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Shape pinned: one row per record WHERE is_primary, nothing wider.
+
+        A non-partial unique index on ``record_id`` would allow one
+        distribution per record, full stop — the same DDL statement minus four
+        words, and a mistake no functional test above would notice, because
+        every record they build has one primary anyway.
+        """
+        rows = (
+            await test_db_session.execute(
+                sa.text(
+                    "SELECT indexdef FROM pg_indexes "
+                    "WHERE schemaname = 'catalog' "
+                    "AND tablename = 'record_distributions' "
+                    "AND indexname = :name"
+                ),
+                {"name": _INDEX_NAME},
+            )
+        ).fetchall()
+        assert rows, f"{_INDEX_NAME} is missing from catalog.record_distributions"
+        indexdef = rows[0][0]
+        assert "CREATE UNIQUE INDEX" in indexdef, indexdef
+        assert "(record_id)" in indexdef, indexdef
+        assert "WHERE is_primary" in indexdef, indexdef
+
+    async def test_a_second_primary_written_around_the_service_is_rejected(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The service is not the only writer; the index is the backstop."""
+        dataset = await _spatial_dataset(test_db_session)
+
+        test_db_session.add(
+            RecordDistribution(
+                record_id=dataset.record_id,
+                distribution_type="download",
+                format="gpkg",
+                url="https://example.org/second-primary.gpkg",
+                is_primary=True,
+            )
+        )
+        with pytest.raises(IntegrityError) as excinfo:
+            await test_db_session.flush()
+        assert _INDEX_NAME in str(excinfo.value)
+        await test_db_session.rollback()
+
+    async def test_two_records_may_each_have_their_own_primary(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The index partitions by record — it is not a global singleton."""
+        first = await _spatial_dataset(test_db_session)
+        second = await _spatial_dataset(test_db_session)
+
+        assert len(await _primaries(test_db_session, first.record_id)) == 1
+        assert len(await _primaries(test_db_session, second.record_id)) == 1
+
+
+class TestDeleteHandsTheFlagBack:
+    """Withdrawing the row withdraws the claim (#1383)."""
+
+    async def test_deleting_the_user_primary_restores_the_geopackage(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        dataset = await _spatial_dataset(test_db_session)
+        mine = await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+            is_primary=True,
+        )
+        await test_db_session.commit()
+
+        await delete_distribution(test_db_session, mine.id, dataset.record_id)
+        await test_db_session.commit()
+
+        after = await _primaries(test_db_session, dataset.record_id)
+        assert [(d.distribution_type, d.format) for d in after] == [
+            ("download", "gpkg")
+        ]
+        assert after[0].auto_generated is True
+
+    async def test_the_restore_follows_the_modality(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """A tabular record generates no GeoPackage row, so CSV takes it back."""
+        dataset = await _tabular_dataset(test_db_session)
+        mine = await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="geojson",
+            url="https://example.org/mine.geojson",
+            is_primary=True,
+        )
+        await test_db_session.commit()
+
+        await delete_distribution(test_db_session, mine.id, dataset.record_id)
+        await test_db_session.commit()
+
+        after = await _primaries(test_db_session, dataset.record_id)
+        assert [(d.distribution_type, d.format) for d in after] == [("download", "csv")]
+
+    async def test_deleting_a_row_that_was_not_primary_moves_nothing(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        dataset = await _spatial_dataset(test_db_session)
+        before = await _primaries(test_db_session, dataset.record_id)
+        mine = await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="gpkg",
+            url="https://example.org/mine.gpkg",
+        )
+        await test_db_session.commit()
+
+        await delete_distribution(test_db_session, mine.id, dataset.record_id)
+        await test_db_session.commit()
+
+        after = await _primaries(test_db_session, dataset.record_id)
+        assert [d.id for d in after] == [d.id for d in before]
+
+
+class TestReconcileYieldsToAUserPrimary:
+    """``reconcile_distributions`` still never writes a user-authored row.
+
+    Its normalization promotes a generated row for the new modality. With a
+    user's own row holding the flag, promoting would either advertise two
+    primaries (before) or violate the index (after) — so it yields, which is
+    the boundary its preservation policy now names.
+    """
+
+    async def _dataset_with_a_user_primary(self, session: AsyncSession):
+        dataset = await _tabular_dataset(session)
+        mine = await create_distribution(
+            session,
+            dataset.record_id,
+            distribution_type="download",
+            format="geojson",
+            url="https://example.org/mine.geojson",
+            is_primary=True,
+        )
+        await session.commit()
+        return dataset, mine
+
+    async def test_a_promote_does_not_take_the_flag_back(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        dataset, mine = await self._dataset_with_a_user_primary(test_db_session)
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        after = await _primaries(test_db_session, dataset.record_id)
+        assert [d.id for d in after] == [mine.id]
+
+    async def test_the_generated_geopackage_still_gets_created(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Yielding is about the flag only — the promote still adds its rows."""
+        dataset, _ = await self._dataset_with_a_user_primary(test_db_session)
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        rows = (
+            await test_db_session.execute(
+                sa.select(RecordDistribution).where(
+                    RecordDistribution.record_id == dataset.record_id,
+                    RecordDistribution.distribution_type == "download",
+                    RecordDistribution.format == "gpkg",
+                )
+            )
+        ).scalars()
+        gpkg = list(rows)
+        assert len(gpkg) == 1
+        assert gpkg[0].auto_generated is True
+        assert gpkg[0].is_primary is False
+
+    async def test_the_job_transaction_stays_usable(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Reconcile runs inside a refresh job's write transaction.
+
+        An IntegrityError raised there aborts the whole job, turning a
+        metadata correction into a failed refresh — the same failure mode the
+        ON CONFLICT clause in ``generate_distributions`` exists to avoid.
+        """
+        dataset, _ = await self._dataset_with_a_user_primary(test_db_session)
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        # Same transaction, still writable.
+        await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="download",
+            format="shp",
+            url="https://example.org/after.zip",
+        )
+        await test_db_session.commit()
+
+    async def test_a_demote_still_normalizes_the_generated_rows(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """With no user primary, the old behaviour is unchanged.
+
+        Spatial to tabular deletes the GeoPackage row that held the flag; CSV
+        has to take it, and the demote-before-promote ordering is what lets
+        the tabular-to-spatial direction move it back without tripping the
+        index.
+        """
+        dataset = await _spatial_dataset(test_db_session)
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type=None,
+        )
+        await test_db_session.commit()
+        assert [
+            (d.distribution_type, d.format)
+            for d in await _primaries(test_db_session, dataset.record_id)
+        ] == [("download", "csv")]
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+        assert [
+            (d.distribution_type, d.format)
+            for d in await _primaries(test_db_session, dataset.record_id)
+        ] == [("download", "gpkg")]
+
+
+class TestMigrationRepair:
+    """Migration 0042 fixes the records that were already double.
+
+    The whole test runs in ONE transaction that is rolled back, on its own
+    connection: reaching the pre-migration state means dropping the index, and
+    postgres DDL is transactional, so nothing here is ever visible to another
+    test or left behind. It deliberately does not take ``test_db_session`` —
+    ``DROP INDEX`` needs the table's ACCESS EXCLUSIVE lock, which a second
+    open transaction on the same table would hold.
+    """
+
+    async def test_the_repair_keeps_one_primary_and_the_index_then_builds(
+        self,
+    ) -> None:
+        from app.core.config import settings
+
+        migration = _migration_0042()
+        engine = create_async_engine(settings.test_database_url)
+        try:
+            async with engine.connect() as conn:
+                trans = await conn.begin()
+                try:
+                    await conn.execute(sa.text("SET LOCAL lock_timeout = '10s'"))
+                    record_id = (
+                        await conn.execute(
+                            sa.text(
+                                "INSERT INTO catalog.records "
+                                "(title, visibility, record_status) "
+                                "VALUES ('1383 repair', 'public', 'published') "
+                                "RETURNING id"
+                            )
+                        )
+                    ).scalar_one()
+
+                    await conn.execute(
+                        sa.text(f"DROP INDEX catalog.{migration._INDEX_NAME}")
+                    )
+
+                    # The state the bug produced: the generated GeoPackage row
+                    # the platform wrote at dataset creation, and the user's
+                    # own row that claimed the flag beside it.
+                    await conn.execute(
+                        sa.text(
+                            "INSERT INTO catalog.record_distributions "
+                            "(record_id, distribution_type, format, url, "
+                            " is_primary, auto_generated) VALUES "
+                            "(:rid, 'download', 'gpkg', '/generated.gpkg', "
+                            " true, true), "
+                            "(:rid, 'download', 'gpkg', "
+                            " 'https://example.org/mine.gpkg', true, false), "
+                            "(:rid, 'download', 'csv', '/generated.csv', "
+                            " false, true)"
+                        ),
+                        {"rid": record_id},
+                    )
+                    assert await self._primary_count(conn, record_id) == 2
+
+                    await conn.execute(sa.text(migration._REPAIR_SQL))
+
+                    rows = (
+                        await conn.execute(
+                            sa.text(
+                                "SELECT url, auto_generated FROM "
+                                "catalog.record_distributions "
+                                "WHERE record_id = :rid AND is_primary"
+                            ),
+                            {"rid": record_id},
+                        )
+                    ).fetchall()
+                    assert len(rows) == 1, rows
+                    # The user-authored row wins — the same precedence the
+                    # service layer applies from now on.
+                    assert rows[0][0] == "https://example.org/mine.gpkg"
+                    assert rows[0][1] is False
+
+                    # Nothing was deleted: a demoted distribution is still a
+                    # distribution.
+                    total = (
+                        await conn.execute(
+                            sa.text(
+                                "SELECT count(*) FROM "
+                                "catalog.record_distributions "
+                                "WHERE record_id = :rid"
+                            ),
+                            {"rid": record_id},
+                        )
+                    ).scalar_one()
+                    assert total == 3
+
+                    # Would raise if the repair had left any record double.
+                    await conn.execute(sa.text(migration._CREATE_INDEX_SQL))
+                finally:
+                    await trans.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_the_repair_is_deterministic_across_generated_rows_only(
+        self,
+    ) -> None:
+        """No user row among the primaries: the preference order decides.
+
+        ``record_distributions`` has no timestamps, so "keep the most recent"
+        is not available — the rule is user-authored first, then the pair a
+        fresh ``generate_distributions`` would have made primary, then ``id``.
+        """
+        from app.core.config import settings
+
+        migration = _migration_0042()
+        engine = create_async_engine(settings.test_database_url)
+        try:
+            async with engine.connect() as conn:
+                trans = await conn.begin()
+                try:
+                    await conn.execute(sa.text("SET LOCAL lock_timeout = '10s'"))
+                    record_id = (
+                        await conn.execute(
+                            sa.text(
+                                "INSERT INTO catalog.records "
+                                "(title, visibility, record_status) "
+                                "VALUES ('1383 repair generated', 'public', "
+                                "'published') RETURNING id"
+                            )
+                        )
+                    ).scalar_one()
+
+                    await conn.execute(
+                        sa.text(f"DROP INDEX catalog.{migration._INDEX_NAME}")
+                    )
+                    await conn.execute(
+                        sa.text(
+                            "INSERT INTO catalog.record_distributions "
+                            "(record_id, distribution_type, format, url, "
+                            " is_primary, auto_generated) VALUES "
+                            "(:rid, 'download', 'csv', '/generated.csv', "
+                            " true, true), "
+                            "(:rid, 'download', 'geojson', "
+                            " '/generated.geojson', true, true), "
+                            "(:rid, 'download', 'gpkg', '/generated.gpkg', "
+                            " true, true)"
+                        ),
+                        {"rid": record_id},
+                    )
+
+                    await conn.execute(sa.text(migration._REPAIR_SQL))
+
+                    rows = (
+                        await conn.execute(
+                            sa.text(
+                                "SELECT format FROM catalog.record_distributions "
+                                "WHERE record_id = :rid AND is_primary"
+                            ),
+                            {"rid": record_id},
+                        )
+                    ).fetchall()
+                    assert [r[0] for r in rows] == ["gpkg"]
+
+                    await conn.execute(sa.text(migration._CREATE_INDEX_SQL))
+                finally:
+                    await trans.rollback()
+        finally:
+            await engine.dispose()
+
+    @staticmethod
+    async def _primary_count(conn, record_id) -> int:
+        return (
+            await conn.execute(
+                sa.text(
+                    "SELECT count(*) FROM catalog.record_distributions "
+                    "WHERE record_id = :rid AND is_primary"
+                ),
+                {"rid": record_id},
+            )
+        ).scalar_one()


### PR DESCRIPTION
## What

`is_primary` on `record_distributions` is read as "THE primary distribution" — the OGC Record's `properties.distributions` emits it per row, which is what the dataset detail response and the STAC item's source record carry. Nothing kept it singular. `create_distribution` and `update_distribution` stored the flag verbatim, and every dataset already carries a generated primary (GeoPackage when it has geometry, CSV when it does not), so the single POST in #1383 left the record with two rows claiming it and no tiebreak.

Two layers, because they fail differently.

**The write paths demote (last write wins).** A distribution created or updated with `is_primary=true` clears the flag on the record's other rows — the generated ones included — in the same transaction. The choice is stated on `create_distribution`'s docstring, along with why the alternative was not taken: rejecting the write with a 409 while another row holds the flag makes "make this one primary" a two-request dance the API has no demote verb for, with a window where the record has no primary at all, and it would start failing every existing caller that sends `is_primary=true`.

**The database holds the invariant.** Migration `0042_record_distribution_single_primary` adds `uq_record_distribution_primary`, a partial unique index on `(record_id) WHERE is_primary`, so no writer — API or otherwise — can produce a second primary. It repairs existing violators first, deterministically: per record, keep one row ordered by user-authored before generated (the same precedence the service now applies), then the generated pair a fresh `generate_distributions` would have made primary (gpkg, then csv), then `id`. `record_distributions` carries no `created_at`/`updated_at`, so "keep the most recently updated" was not expressible — the docstring says so rather than leaving the rule looking arbitrary. Nothing is deleted; the losers are demoted.

**Reconciled with `reconcile_distributions`' preservation policy** ("never writes a user-authored row"). It still does not, and the docstring now names the boundary instead of admitting to the bug:

- Its normalization demote is scoped to `auto_generated` rows.
- A user-authored primary outranks the promote entirely — a background refresh never takes the flag back from an explicit choice.
- `generate_distributions` yields the template's primary flag when the record already has one, so a reconcile running inside a refresh job's write transaction can never insert a second primary and abort the job (the same failure mode its `ON CONFLICT DO NOTHING` exists to avoid for the other unique index).

**One consequence handled.** Demote-on-write makes "no primary at all" newly reachable — the user's row took the flag off the generated GeoPackage, then gets deleted. `delete_distribution` hands the flag back to the generated default. Clearing the flag through PATCH deliberately does not: a caller saying "this is not the primary" is not saying which one is.

**One test outside the feature.** `test_crs_wkt2_backfill_1376` did its round trip with `alembic downgrade -1`, which reverts whatever the current head is — 0041 only while nothing sat above it. With 0042 on top, the downgrade stepped over the backfill and the re-upgrade re-ran nothing, so the test failed on an unconverted WKT1 row for a reason unrelated to what it covers. It now names its target, read from 0041's own `down_revision`, which stays correct however the chain grows.

## Schema impact

New partial unique index `catalog.uq_record_distribution_primary` on `record_distributions (record_id) WHERE is_primary`, declared on the ORM model as well (`alembic check` clean). Plain transactional `CREATE UNIQUE INDEX`, not `CONCURRENTLY`, following 0040's reasoning — a CIC interrupted by a sibling xdist worker leaves an INVALID index that `IF NOT EXISTS` then treats as present. Repair and index land in one transaction, so the index can never be built over rows the repair missed.

The migration takes `LOCK TABLE catalog.record_distributions IN SHARE MODE` before the repair and holds it through the index build (review round 2). A rolling deployment leaves the pre-upgrade API writable while this runs, and that code stores `is_primary` verbatim: a POST committing after the repair's snapshot would put a second primary back on a record just cleaned, and `CREATE UNIQUE INDEX` would then fail and abort the deploy migration. SHARE is the mode `CREATE INDEX` acquires anyway, so the acquisition only moves earlier by one small UPDATE.

No API shape change: `is_primary` already exists on the create/update/response models, so `backend/openapi.json` and the SDKs are untouched. The one behavioural change at the edge is the 409 detail text — an `IntegrityError` naming the new index now says "concurrently marked primary; retry" instead of the duplicate-row message, which would send the caller hunting for a duplicate that does not exist.

## Verification

Host-side, from `backend/` with `.env.test` sourced:

- `uv run pytest tests/test_distribution_primary_1383.py -q` — 19 passed (new file)
- `uv run pytest tests/test_distribution_reconcile_1314.py tests/test_record_subresource_edits.py tests/test_records_related.py tests/test_ogc_record_enrichment.py tests/test_dcat.py tests/test_geodcat_ap.py tests/test_metadata_roundtrip.py -q` — passed unchanged
- `uv run pytest tests/test_email_verification_migration.py tests/test_crs_wkt2_backfill_1376.py -q` — the `alembic check` drift gate plus both migration round trips across the new head
- `uv run pytest tests/test_ingest.py tests/test_postgis_refresh_1265.py -q` — the reconcile call sites
- `uv run pytest tests/test_layering.py -q` — 40 passed
- `uv run pytest -n 4 -q` — full backend suite: 8315 passed, and the one failure it surfaced is the `downgrade -1` breakage fixed above
- `uv run ruff check .` / `uv run ruff format --check .` — clean

The new tests are not vacuous: with the demote in `create_distribution` disabled, `test_creating_a_primary_demotes_the_generated_incumbent` fails with `UniqueViolationError: ... "uq_record_distribution_primary"`, which is the index doing the job the issue asks for.

Closes #1383
