### PR TITLE
refactor(sec): follow For.iter containers in Rule 2 argv extraction

### DIFF
--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1791,17 +1791,19 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
     index_in_parent: int | None = None
     container_kind: str | None = None
     while isinstance(parent, _TRANSPARENT_WRAPPERS):
-        # fix(#1394), codex round 4: `*` SPLICES rather than nests, so a display
-        # holding a starred vector holds its ELEMENTS and is itself a vector —
-        # `[*["gdalinfo", path]]` IS `["gdalinfo", path]`. Reading the display
-        # as a container of the argv made `for part in commands:` look like it
-        # handed over a command when it hands over strings. Checked on the node
-        # being climbed OUT of, so it lands on the display above the star.
-        if isinstance(current, ast.Starred):
-            container_kind = None
+        # fix(#1394), codex rounds 4 and 5: a star and the display around it
+        # are ONE level, not two. `*X` splices X's ELEMENTS into that display,
+        # which PRESERVES X's own depth rather than adding or removing one:
+        # `[*["gdalinfo", path]]` is `["gdalinfo", path]`, still the vector,
+        # while `[*(["gdalinfo", path],)]` is `[["gdalinfo", path]]`, still a
+        # container of it. Counting both nodes reported the first (iterating it
+        # yields strings, not commands); resetting to "is the vector" hid the
+        # second, which is the direction that actually matters. So neither the
+        # star nor the step out of it moves the kind.
+        starred = isinstance(parent, ast.Starred) or isinstance(current, ast.Starred)
         # Only a CONTAINER wrapper means the level above holds the vector
         # rather than being it (fix(#996 review)).
-        elif isinstance(parent, _CONTAINER_WRAPPERS):
+        if isinstance(parent, _CONTAINER_WRAPPERS) and not starred:
             container_kind = _container_iteration_kind(parent, current)
         if isinstance(parent, (ast.Tuple, ast.List)) and current in parent.elts:
             index_in_parent = parent.elts.index(current)
@@ -3324,7 +3326,7 @@ def test_guard_destructuring_loop_target_does_not_receive_the_argv():
 
 
 def test_guard_starring_an_argv_splices_it_into_the_display():
-    """fix(#1394), codex round 4: `*` flattens, so there is no container.
+    """fix(#1394), codex rounds 4 and 5: `*` preserves depth.
 
     ``commands = [*["gdalinfo", path]]`` IS ``["gdalinfo", path]``. Reading the
     outer display as a container of the argv made ``for part in commands:``
@@ -3332,6 +3334,12 @@ def test_guard_starring_an_argv_splices_it_into_the_display():
     reported, the #996 class. The vector is still a vector, so passing the
     spliced display to a subprocess is still a site (the second case), and
     nesting the star one level deeper puts a real container back (the third).
+
+    Depth PRESERVED, not removed, is the whole rule:
+    ``[*(["gdalinfo", path],)]`` splices a one-element tuple and is
+    ``[["gdalinfo", path]]``, a container of the argv either way it is read
+    (the last two cases). Collapsing that to "is the vector" hid a real argv,
+    which is the direction that matters.
     """
     inert, total = _collect_gdal_cli_violations(
         _mod(
@@ -3369,6 +3377,24 @@ def test_guard_starring_an_argv_splices_it_into_the_display():
     )
     assert total_nested == 1, (total_nested, nested)
     assert len(nested) == 1 and "(fn)" in nested[0]
+
+    wrapped, total_wrapped = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def iterated(path):\n"
+            "    commands = [*(['gdalinfo', path],)]\n"
+            "    for cmd in commands:\n"
+            "        subprocess.run(cmd)\n"
+            "def indexed(path):\n"
+            "    commands = [*(['ogrinfo', path],)]\n"
+            "    subprocess.run(commands[0])\n"
+        ),
+        {},
+    )
+    assert total_wrapped == 2, (total_wrapped, wrapped)
+    assert len(wrapped) == 2, wrapped
+    assert any("(iterated)" in v for v in wrapped)
+    assert any("(indexed)" in v for v in wrapped)
 
 
 def test_guard_conflicting_container_kinds_merge_to_the_louder():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1585,8 +1585,8 @@ def _loop_target_paths(iterable: ast.AST) -> set[str]:
 
     ``for cmd in commands:`` binds ``"cmd"``; ``async for`` and a
     comprehension's generator bind the same way. Empty when ``iterable`` is not
-    in an iterated position, or when the target is a shape ``_target_names``
-    cannot name.
+    in an iterated position, when the target is a shape ``_target_names``
+    cannot name, or when the target DESTRUCTURES.
 
     fix(#1394): ONE definition of what a loop binds, because two callers need
     it and they know different things. ``_binding_targets`` calls it for a
@@ -1595,11 +1595,22 @@ def _loop_target_paths(iterable: ast.AST) -> set[str]:
     calls it for a NAME already known to hold a container of argvs
     (``commands = (["gdalinfo", path],)`` then ``for cmd in commands:``), where
     it is not.
+
+    The destructuring rule is codex round 2 on #1394, and it predates the
+    named-container half: ``for tool, arg in commands:`` splits the element
+    apart, so each name gets a PIECE of the argv and none of them gets the
+    argv. ``_target_names`` flattens a pattern to all its names, which is the
+    right answer for an assignment — where ``_positional_targets`` then matches
+    them up by position — and the wrong one here, where the value being split
+    is the command vector rather than a tuple of unrelated values. Returning
+    nothing is the accurate answer within this model, in which the element of a
+    container IS the vector: destructuring a vector yields strings.
     """
     parent = getattr(iterable, "_rule2_parent", None)
     if (
         isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension))
         and parent.iter is iterable
+        and not isinstance(parent.target, (ast.Tuple, ast.List))
     ):
         return _target_names(parent.target)
     return set()
@@ -3220,6 +3231,31 @@ def test_guard_iterating_a_dict_yields_keys_not_the_argv():
     )
     assert total_keyed == 1, (total_keyed, keyed)
     assert len(keyed) == 1 and "(fn)" in keyed[0]
+
+
+def test_guard_destructuring_loop_target_does_not_receive_the_argv():
+    """fix(#1394), codex round 2: unpacking splits the argv into strings.
+
+    ``for tool, arg in commands:`` binds ``"gdalinfo"`` and the path, never the
+    vector, so linking the literal to either name flagged data that cannot
+    execute. Both spellings of the container are checked, because the
+    destructuring bug predates the named-container half — the inline form went
+    through the same ``_target_names`` flattening on #996.
+    """
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "def named(path):\n"
+            "    commands = [['gdalinfo', path]]\n"
+            "    for tool, arg in commands:\n"
+            "        consume(tool)\n"
+            "def inline(path):\n"
+            "    for tool, arg in (['ogrinfo', path],):\n"
+            "        consume(arg)\n"
+        ),
+        {},
+    )
+    assert total == 0, (total, violations)
+    assert violations == []
 
 
 def test_guard_container_kind_survives_an_alias_hop():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -83,7 +83,13 @@ Known limits (accepted trade-offs, same posture as the Rule-1 guard):
   target over a container of argvs — chased through alias chains and out of
   containers to a fixed point. Consuming operations stop it: a single-index
   subscript of the VECTOR yields an element, while the same subscript of a
-  CONTAINER yields the vector. Inert data
+  CONTAINER yields the vector. ITERATING one is the same question as
+  subscripting it and gets the same two answers (fix(#1394)): a ``for`` over a
+  container binds each argv to the loop target, while a ``for`` over the vector
+  binds strings. That holds whether or not the container has a name —
+  ``for cmd in (["gdalinfo", path],):`` and ``commands = (["gdalinfo", path],)``
+  then ``for cmd in commands:`` are one rule, read off the AST in the first case
+  and off the followed path in the second. Inert data
   (``SUPPORTED_TOOLS = ["gdalinfo", "ogrinfo"]``, a constant only subscripted
   or compared) is not a command vector. A literal
   whose every element names a GDAL utility is a name list rather than a
@@ -108,6 +114,18 @@ Known limits (accepted trade-offs, same posture as the Rule-1 guard):
   neither is one extracted from an ANONYMOUS container that never gets a name
   (`cmd = ({"k": ["gdalinfo", path]})["k"]`), because the path machinery keys
   on a binding and there is none to key on.
+  Three more silent residues sit next to the iteration rule (fix(#1394)), all
+  of them "no container-element tracking" wearing different clothes, and each
+  needs its own machinery rather than a wider rule: `holds_a_container` is a
+  BOOLEAN, not a depth, so a container of containers (`groups = ((["gdalinfo",
+  path],),)`) hands the inner container to the loop target as if it were the
+  vector and the second loop follows nothing; a container reached through a
+  METHOD (`for cmd in commands.values()`) is a call this analysis does not
+  model; and a comprehension TARGET is bound in the comprehension's own scope,
+  which `_use_reaches_the_binding` reads as a shadow, so
+  `[subprocess.run(cmd) for cmd in commands]` links only when the comprehension
+  itself escapes — that one predates #1394 and applies equally to the inline
+  `for cmd in (["gdalinfo", path],)` spelling.
   Extending further means writing a static analyser, and this is a CI gate —
   the escape hatch for anything it misclassifies is an allowlist entry with a
   written justification, which is the same answer #974 reached for the wrapper
@@ -201,15 +219,21 @@ Known limits (accepted trade-offs, same posture as the Rule-1 guard):
   block, so a wrapped open under ``if False:`` is conditional together with
   its wrapper and the question never arises.
 
-  Still open, and NOT something an allowlist can close: whether a GDAL-headed
-  literal is SEEN as an argv at all. ``commands = (["gdalinfo", path],)`` then
-  ``for cmd in commands: subprocess.run(cmd)`` reports zero sites, because
-  extraction follows subscript and attribute loads and not ``For.iter`` (see
-  WHERE THE ESCAPE ANALYSIS STOPS above). That is a detection gap, not a
-  credit gap. Earlier text here filed it as the third of three "credit gap
-  classes" that #1077 would close at once, which conflated two questions:
-  credit decides which DETECTED sites are exempt, and no exemption rule makes
-  an undetected site appear.
+  A separate question, and NOT something an allowlist can close: whether a
+  GDAL-headed literal is SEEN as an argv at all. ``commands = (["gdalinfo",
+  path],)`` then ``for cmd in commands: subprocess.run(cmd)`` reported zero
+  sites, because extraction followed subscript and attribute loads but not
+  ``For.iter``. That is a detection gap, not a credit gap — credit decides
+  which DETECTED sites are exempt, and no exemption rule makes an undetected
+  site appear. Earlier text here filed it as the third of three "credit gap
+  classes" #1077 would close at once, which conflated the two. fix(#1394)
+  closes it where it belongs, in the escape analysis: the shape is now an argv
+  site, credited by the ordinary rules when a safe env covers it and reported
+  when none does. Note what the two rules say together — a helper call in the
+  LOOP BODY does not credit (a loop body may run zero times, per
+  ``_EAGER_POSITIONS``), so the creditable spelling hoists the env above the
+  loop, and the inline ``for cmd in (["gdalinfo", path],):`` form has always
+  been judged that way.
 - Remote-source detection is LITERAL only (codex round 7): an open or argv
   whose argument is, or obviously leads with, a remote-prefixed string
   literal (http/https, ``/vsicurl*``, hardcoded ``/vsis3``/``/vsiaz``/
@@ -1555,6 +1579,31 @@ def _target_names(target: ast.expr) -> set[str]:
     return {path} if path else set()
 
 
+def _loop_target_paths(iterable: ast.AST) -> set[str]:
+    """The paths a loop binds when ``iterable`` is the thing being iterated.
+
+    ``for cmd in commands:`` binds ``"cmd"``; ``async for`` and a
+    comprehension's generator bind the same way. Empty when ``iterable`` is not
+    in an iterated position, or when the target is a shape ``_target_names``
+    cannot name.
+
+    fix(#1394): ONE definition of what a loop binds, because two callers need
+    it and they know different things. ``_binding_targets`` calls it for a
+    literal written directly inside the iterable (``for cmd in (["gdalinfo",
+    path],):``), where the container is visible in the AST. ``_argv_escape_kind``
+    calls it for a NAME already known to hold a container of argvs
+    (``commands = (["gdalinfo", path],)`` then ``for cmd in commands:``), where
+    it is not.
+    """
+    parent = getattr(iterable, "_rule2_parent", None)
+    if (
+        isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension))
+        and parent.iter is iterable
+    ):
+        return _target_names(parent.target)
+    return set()
+
+
 def _positional_targets(targets: list[ast.expr], index: int) -> list[ast.expr] | None:
     """The targets an unpacking assigns position ``index`` to, or None.
 
@@ -1709,14 +1758,12 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], bool]:
     # `climbed` records. `for tool in ["gdalinfo", "ogrinfo"]` binds each
     # STRING to the target, not the list, and treating the list as escaping
     # through it flagged ordinary tool-name data.
-    if (
-        climbed
-        and isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension))
-        and parent.iter is current
-    ):
+    if climbed:
         # The loop target receives an ELEMENT of the iterable, so it is the
         # vector itself, not a container of it.
-        return _target_names(parent.target), False
+        loop_targets = _loop_target_paths(current)
+        if loop_targets:
+            return loop_targets, False
     return set(), False
 
 
@@ -1866,6 +1913,22 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
                 ):
                     extracted, _ = _binding_targets(parent)
                     pending |= {(n, False) for n in extracted - seen}
+                # fix(#1394): ITERATING a container hands each element — the
+                # argv — to the loop target, exactly as subscripting it hands
+                # over one. `_binding_targets` already reads that off the AST
+                # when the container is written in place (`for cmd in
+                # (["gdalinfo", path],):`); once the container has a NAME
+                # (`commands = (["gdalinfo", path],)` then `for cmd in
+                # commands:`) the AST no longer says so, and only this loop
+                # knows that `holds` is True. Without it the shape reported
+                # ZERO argv sites: invisible to the gate, so neither creditable
+                # nor reportable — the one failure direction the #1077
+                # allowlist inversion exists to remove.
+                #
+                # `holds` gates it for the same reason #996's `climbed` does:
+                # iterating the VECTOR (`for part in cmd:`) yields strings, not
+                # commands.
+                pending |= {(n, False) for n in _loop_target_paths(used) - seen}
             best = max(best, _escape_kind(used, vector=not holds))
             if best == _ESCAPE_CALL:
                 return best
@@ -2980,6 +3043,92 @@ def test_guard_argv_reached_through_a_loop_target_is_detected():
     )
     assert total == 1, (total, violations)
     assert len(violations) == 1 and "(looped)" in violations[0]
+
+
+def test_guard_argv_iterated_from_a_named_container_is_detected():
+    """fix(#1394): the container above wearing a name.
+
+    ``commands = (["gdalinfo", path],)`` then ``for cmd in commands:`` reported
+    ZERO argv sites, because extraction followed subscript and attribute loads
+    out of a container but not ``For.iter``. A site the collector cannot see is
+    neither creditable nor reportable, which is the failure direction the
+    #1077 credit inversion exists to remove — so this is pinned as a DETECTION
+    property first: the site exists, and then the ordinary credit rules decide
+    it.
+    """
+    unclamped, total = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def looped(path):\n"
+            "    commands = (['gdalinfo', path],)\n"
+            "    for cmd in commands:\n"
+            "        subprocess.run(cmd)\n"
+        ),
+        {},
+    )
+    assert total == 1, (total, unclamped)
+    assert len(unclamped) == 1 and "(looped)" in unclamped[0]
+
+    # The same site, clamped. The env is hoisted ABOVE the loop, which is the
+    # spelling that credits: it shares the function body with the argv, so
+    # _credit_position_reaches finds them in the same field of the same
+    # ancestor.
+    clamped, total_clamped = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "from app.processing.raster.vrt import gdal_safe_env\n"
+            "def looped(path):\n"
+            "    commands = (['gdalinfo', path],)\n"
+            "    env = gdal_safe_env()\n"
+            "    for cmd in commands:\n"
+            "        subprocess.run(cmd, env=env)\n"
+        ),
+        {},
+    )
+    assert total_clamped == 1, (total_clamped, clamped)
+    assert clamped == []
+
+    # An env built INSIDE the loop body still reports, because a loop body may
+    # run zero times (#1077, `_EAGER_POSITIONS`). Pinned so the two rules are
+    # read together: this is the verdict the inline `for cmd in (["gdalinfo",
+    # path],):` spelling has always had, not a new class of false positive.
+    in_loop, total_in_loop = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "from app.processing.raster.vrt import gdal_safe_env\n"
+            "def looped(path):\n"
+            "    commands = (['gdalinfo', path],)\n"
+            "    for cmd in commands:\n"
+            "        subprocess.run(cmd, env=gdal_safe_env())\n"
+        ),
+        {},
+    )
+    assert total_in_loop == 1, (total_in_loop, in_loop)
+    assert len(in_loop) == 1 and "(looped)" in in_loop[0]
+
+
+def test_guard_iterating_the_vector_itself_binds_strings_not_argvs():
+    """The control for fix(#1394): the follow is gated on holding a CONTAINER.
+
+    ``for part in cmd:`` walks the argv's own elements, and a named tool-name
+    list is the same shape — binding either to the loop target would flag
+    ordinary data, the #996 false-positive class. Both stay inert.
+    """
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "def elements(path):\n"
+            "    cmd = ['gdalinfo', path]\n"
+            "    for part in cmd:\n"
+            "        consume(part)\n"
+            "def names():\n"
+            "    tools = ['gdalinfo', 'ogrinfo']\n"
+            "    for tool in tools:\n"
+            "        consume(tool)\n"
+        ),
+        {},
+    )
+    assert total == 0, (total, violations)
+    assert violations == []
 
 
 def test_guard_unpacking_binds_by_position_not_by_all_names():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1908,6 +1908,9 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
     parent = getattr(current, "_rule2_parent", None)
     index_in_parent: int | None = None
     container_kind: str | None = None
+    # The kind as it was BELOW the wrapper `index_in_parent` names, which is
+    # what a positional unpacking of that wrapper hands its targets.
+    unpacked_kind: str | None = None
     while isinstance(parent, _TRANSPARENT_WRAPPERS):
         # fix(#1394), codex round 8: a VALUE wrapper only carries the value in
         # a position it can evaluate to. `empty = [] if commands else ()` never
@@ -1930,14 +1933,22 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
         # second, which is the direction that actually matters. So neither the
         # star nor the step out of it moves the kind.
         starred = isinstance(parent, ast.Starred) or isinstance(current, ast.Starred)
+        kind_below = container_kind
         # Only a CONTAINER wrapper means the level above holds the vector
         # rather than being it (fix(#996 review)).
         if isinstance(parent, _CONTAINER_WRAPPERS) and not starred:
             container_kind = _container_iteration_kind(parent, current)
         if isinstance(parent, (ast.Tuple, ast.List)) and current in parent.elts:
             index_in_parent = parent.elts.index(current)
+            # fix(#1394), codex round 11: a positional UNPACKING consumes
+            # exactly the wrapper just climbed. `alias, = (["gdalinfo", path],)`
+            # takes the tuple apart, so `alias` is the vector, not a container
+            # of it, and `for part in alias:` then yields strings. Keeping the
+            # wrapper's kind read that loop as handing over a command.
+            unpacked_kind = kind_below
         else:
             index_in_parent = None
+            unpacked_kind = None
         current = parent
         parent = getattr(current, "_rule2_parent", None)
 
@@ -1947,7 +1958,7 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
             if positional is not None:
                 return {
                     n for target in positional for n in _target_names(target)
-                }, container_kind
+                }, unpacked_kind
         return {
             n for target in parent.targets for n in _target_names(target)
         }, container_kind
@@ -3675,6 +3686,42 @@ def test_guard_a_wrapped_iterable_is_still_the_same_loop():
     assert any("(walrus)" in v for v in violations), violations
     for quiet in ("(condition_only)", "(and_guarded)", "(walrus_vector)"):
         assert not any(quiet in v for v in violations), (quiet, violations)
+
+
+def test_guard_positional_unpacking_consumes_the_wrapper():
+    """fix(#1394), codex round 11: unpacking takes the container apart.
+
+    ``alias, = (["gdalinfo", path],)`` binds the vector itself, so
+    ``for part in alias:`` yields strings and reporting it was a false positive
+    on inert data. The kind for an unpacked target is the one from BELOW the
+    wrapper the unpacking consumed, so the same shape one level deeper still
+    hands over a container.
+
+    The control in the middle: ``alias`` is the vector, so spawning it directly
+    is still a site — the fix must not turn the unpacking into a dead end.
+    """
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def unpacked(path):\n"
+            "    alias, = (['gdalinfo', path],)\n"
+            "    for part in alias:\n"
+            "        consume(part)\n"
+            "def spawned(path):\n"
+            "    alias, = (['ogrinfo', path],)\n"
+            "    subprocess.run(alias)\n"
+            "def one_deeper(path):\n"
+            "    alias, = ((['gdalwarp', path],),)\n"
+            "    for cmd in alias:\n"
+            "        subprocess.run(cmd)\n"
+        ),
+        {},
+    )
+    assert total == 2, (total, violations)
+    assert len(violations) == 2, violations
+    for reported in ("(spawned)", "(one_deeper)"):
+        assert any(reported in v for v in violations), (reported, violations)
+    assert not any("(unpacked)" in v for v in violations), violations
 
 
 def test_guard_a_sliced_container_is_still_a_container():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1636,6 +1636,17 @@ def _intact_loop_target(target: ast.expr) -> ast.expr | None:
     a star anywhere but first, ``for tool, *rest in commands:`` — ``rest`` is a
     SUFFIX of the argv, which has no GDAL head and would be judged against the
     wrong tool if it were treated as a command.
+
+    Position decides it, not arity, and the gap that leaves is deliberate
+    (codex round 18, declined). ``for *cmd, ignored in [("gdalinfo",)]:`` binds
+    ``cmd`` to ``[]``, because the pattern's fixed names eat the only element —
+    so the site reports and nothing runs. Closing it means comparing the
+    pattern's arity against the LITERAL's, which couples a target-shape
+    question to a value this function never sees, for a shape that needs a
+    one-element argv and a starred pattern at once. It is the loud direction on
+    a literal the module already treats as a command by convention: a
+    single-element ``("gdalinfo",)`` is indistinguishable from a bare
+    invocation, per the two-element floor in ``_tool_name_list``.
     """
     if isinstance(target, (ast.Tuple, ast.List)):
         if target.elts and isinstance(target.elts[0], ast.Starred):

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1606,6 +1606,12 @@ def _is_value_position(current: ast.AST, parent: ast.AST) -> bool:
     two exclusions above are not folding — they read which FIELD an operator
     can return, with no claim about any operand's value.
     """
+    if isinstance(parent, ast.NamedExpr):
+        # A walrus BINDS its value and also evaluates to it, so
+        # `for cmd in (alias := commands):` iterates `commands` (codex round
+        # 10). The binding half is recorded elsewhere and does not help here:
+        # the target is a Store, and the alias walk only follows Loads.
+        return current is parent.value
     if isinstance(parent, ast.IfExp):
         return current is parent.body or current is parent.orelse
     if isinstance(parent, ast.BoolOp):
@@ -1640,14 +1646,14 @@ def _depth_preserving_ancestor(expr: ast.AST) -> ast.AST:
     """The outermost expression around ``expr`` that is still the same value.
 
     Same value meaning the same thing at the same container depth, so a caller
-    holding a container of argvs still holds one at the top. Two wrappers
-    qualify, both of them already named elsewhere in this module
-    (fix(#1394), codex round 6):
+    holding a container of argvs still holds one at the top. Four wrappers
+    qualify, each already named elsewhere in this module (fix(#1394), codex
+    round 6 and after):
 
     * a VALUE wrapper — ``commands or ()``, ``commands if flag else ()``,
-      ``commands + extra`` — in a position it can actually evaluate to, which
-      rules out a ternary's condition and a non-final ``and`` operand (see
-      ``_is_value_position``).
+      ``commands + extra`` — or a walrus, in a position the wrapper can
+      actually evaluate to, which rules out a ternary's condition and a
+      non-final ``and`` operand (see ``_is_value_position``).
     * a star inside a display, ``(*commands,)``, which splices ``commands``'
       elements into a new one and so preserves its depth (codex round 5). The
       pair counts once, exactly as it does in ``_binding_targets``.
@@ -3617,6 +3623,14 @@ def test_guard_a_wrapped_iterable_is_still_the_same_loop():
     assert loop_targets_of("for cmd in () or commands:\n    pass\n", "commands") == {
         "cmd"
     }
+    # codex round 10: a walrus evaluates to its value as well as binding it,
+    # and its target is a Store that the Load-only alias walk never sees.
+    assert loop_targets_of(
+        "for cmd in (alias := commands):\n    pass\n", "commands"
+    ) == {"cmd"}
+    assert loop_targets_of(
+        "for cmd in (alias := commands) or ():\n    pass\n", "commands"
+    ) == {"cmd"}
 
     violations, total = _collect_gdal_cli_violations(
         _mod(
@@ -3645,12 +3659,21 @@ def test_guard_a_wrapped_iterable_is_still_the_same_loop():
             "    commands = [['nearblack', path]]\n"
             "    for cmd in commands and ():\n"
             "        subprocess.run(cmd)\n"
+            "def walrus(path):\n"
+            "    commands = [['gdalinfo', path]]\n"
+            "    for cmd in (alias := commands):\n"
+            "        subprocess.run(cmd)\n"
+            "def walrus_vector(path):\n"
+            "    cmd = ['ogrinfo', path]\n"
+            "    for part in (alias := cmd):\n"
+            "        consume(part)\n"
         ),
         {},
     )
-    assert total == 4, (total, violations)
-    assert len(violations) == 4, violations
-    for quiet in ("(condition_only)", "(and_guarded)"):
+    assert total == 5, (total, violations)
+    assert len(violations) == 5, violations
+    assert any("(walrus)" in v for v in violations), violations
+    for quiet in ("(condition_only)", "(and_guarded)", "(walrus_vector)"):
         assert not any(quiet in v for v in violations), (quiet, violations)
 
 

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1596,8 +1596,15 @@ def _is_value_position(current: ast.AST, parent: ast.AST) -> bool:
     ``commands and ()`` can only ever be an EMPTY ``commands`` — iterating that
     runs nothing. The final operand is a possible result for both.
 
-    Everything else in ``_VALUE_WRAPPERS`` (the ``+`` chain) passes its value
-    through from any operand.
+    Everything else in ``_VALUE_WRAPPERS`` (the arithmetic chain) passes its
+    value through from any operand. That deliberately includes repetition by a
+    literal zero, ``commands * 0``, which is always empty (codex round 9,
+    declined): this gate does no constant folding ANYWHERE, by the same
+    decision #1077 made when it chose to report ``if False: gdal_safe_env()``
+    rather than evaluate the condition. Both cost a false alarm and neither
+    costs a silent pass, which is the trade this module takes everywhere. The
+    two exclusions above are not folding — they read which FIELD an operator
+    can return, with no claim about any operand's value.
     """
     if isinstance(parent, ast.IfExp):
         return current is parent.body or current is parent.orelse
@@ -1644,6 +1651,8 @@ def _depth_preserving_ancestor(expr: ast.AST) -> ast.AST:
     * a star inside a display, ``(*commands,)``, which splices ``commands``'
       elements into a new one and so preserves its depth (codex round 5). The
       pair counts once, exactly as it does in ``_binding_targets``.
+    * a SLICE, ``commands[:]``, which yields a sequence of the same things
+      (codex round 9). A single index does not: it consumes a level.
 
     A CONTAINER wrapper is deliberately absent: ``[commands]`` is a level
     deeper, and pretending otherwise is the container mistake #996 is about.
@@ -1659,6 +1668,17 @@ def _depth_preserving_ancestor(expr: ast.AST) -> ast.AST:
             if isinstance(display, (ast.List, ast.Tuple, ast.Set)):
                 current = display
                 continue
+        # A SLICE yields a sequence of the same things: `commands[:]` is still
+        # a container of argvs, `cmd[1:]` still a sequence of strings. #996
+        # already reads it that way in `_escape_kind`, where only a SINGLE
+        # index — which consumes a level — stops the walk (codex round 9).
+        if (
+            isinstance(parent, ast.Subscript)
+            and parent.value is current
+            and isinstance(parent.slice, ast.Slice)
+        ):
+            current = parent
+            continue
         return current
 
 
@@ -2061,6 +2081,15 @@ def _derived_paths(used: ast.expr, kind: str | None) -> list[tuple[str, str | No
         parent = getattr(used, "_rule2_parent", None)
         if isinstance(parent, (ast.Subscript, ast.Attribute)) and parent.value is used:
             extracted, extracted_kind = _binding_targets(parent)
+            # An INDEX of a container yields the vector, one level down. A
+            # SLICE yields a container of the same things, so `sliced =
+            # commands[:]` keeps the kind (codex round 9). Fixed here as well
+            # as in `_depth_preserving_ancestor` because the alias path went
+            # around the loop's own iterable once already (round 8).
+            if isinstance(parent, ast.Subscript) and isinstance(
+                parent.slice, ast.Slice
+            ):
+                extracted_kind = extracted_kind or kind
             derived += [(n, extracted_kind) for n in extracted]
         # fix(#1394): ITERATING a container hands each element — the argv — to
         # the loop target, exactly as subscripting it hands over one.
@@ -3623,6 +3652,47 @@ def test_guard_a_wrapped_iterable_is_still_the_same_loop():
     assert len(violations) == 4, violations
     for quiet in ("(condition_only)", "(and_guarded)"):
         assert not any(quiet in v for v in violations), (quiet, violations)
+
+
+def test_guard_a_sliced_container_is_still_a_container():
+    """fix(#1394), codex round 9: a slice yields a sequence of the same things.
+
+    ``for cmd in commands[:]:`` iterates argvs, and the loop rule could not
+    climb the subscript, so a real GDAL invocation went undetected — the silent
+    direction. #996 already reads a slice this way in ``_escape_kind``, where
+    only a SINGLE index stops the walk because it consumes a level.
+
+    Fixed on the alias path too (``sliced = commands[:]``), since that is how
+    round 8 got around the round-7 fix. The controls: an INDEX still yields the
+    vector, and slicing the vector itself still yields strings.
+    """
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def in_place(path):\n"
+            "    commands = [['gdalinfo', path]]\n"
+            "    for cmd in commands[:]:\n"
+            "        subprocess.run(cmd)\n"
+            "def aliased(path):\n"
+            "    commands = [['ogrinfo', path]]\n"
+            "    sliced = commands[:]\n"
+            "    for cmd in sliced:\n"
+            "        subprocess.run(cmd)\n"
+            "def indexed(path):\n"
+            "    commands = [['gdalwarp', path]]\n"
+            "    subprocess.run(commands[0])\n"
+            "def vector_slice(path):\n"
+            "    cmd = ['gdaladdo', path]\n"
+            "    for part in cmd[:]:\n"
+            "        consume(part)\n"
+        ),
+        {},
+    )
+    assert total == 3, (total, violations)
+    assert len(violations) == 3, violations
+    for reported in ("(in_place)", "(aliased)", "(indexed)"):
+        assert any(reported in v for v in violations), (reported, violations)
+    assert not any("(vector_slice)" in v for v in violations), violations
 
 
 def test_guard_a_dead_wrapper_alias_is_not_followed_either():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -116,16 +116,17 @@ Known limits (accepted trade-offs, same posture as the Rule-1 guard):
   on a binding and there is none to key on.
   Three more silent residues sit next to the iteration rule (fix(#1394)), all
   of them "no container-element tracking" wearing different clothes, and each
-  needs its own machinery rather than a wider rule: `holds_a_container` is a
-  BOOLEAN, not a depth, so a container of containers (`groups = ((["gdalinfo",
-  path],),)`) hands the inner container to the loop target as if it were the
-  vector and the second loop follows nothing; a container reached through a
-  METHOD (`for cmd in commands.values()`) is a call this analysis does not
-  model; and a comprehension TARGET is bound in the comprehension's own scope,
-  which `_use_reaches_the_binding` reads as a shadow, so
-  `[subprocess.run(cmd) for cmd in commands]` links only when the comprehension
-  itself escapes — that one predates #1394 and applies equally to the inline
-  `for cmd in (["gdalinfo", path],)` spelling.
+  needs its own machinery rather than a wider rule: the container kind names
+  what ONE wrapper yields, not a depth, so a container of containers
+  (`groups = ((["gdalinfo", path],),)`) hands the inner container to the loop
+  target as if it were the vector and the second loop follows nothing; a
+  container reached through a METHOD (`for cmd in commands.values()`) is a call
+  this analysis does not model, which is also why a dict holding argvs as
+  values only ever reaches them by subscript here; and a comprehension TARGET is
+  bound in the comprehension's own scope, which `_use_reaches_the_binding` reads
+  as a shadow, so `[subprocess.run(cmd) for cmd in commands]` links only when
+  the comprehension itself escapes — that one predates #1394 and applies equally
+  to the inline `for cmd in (["gdalinfo", path],)` spelling.
   Extending further means writing a static analyser, and this is a CI gate —
   the escape hatch for anything it misclassifies is an allowlist entry with a
   written justification, which is the same answer #974 reached for the wrapper
@@ -1660,6 +1661,32 @@ _VALUE_WRAPPERS = (
 )
 _TRANSPARENT_WRAPPERS = (*_CONTAINER_WRAPPERS, *_VALUE_WRAPPERS)
 
+# What ITERATING a path that holds the vector hands to a loop target
+# (fix(#1394), codex round 1). "Holds a container" is one bit and iteration
+# needs two, because the containers do not agree: a list, tuple or set yields
+# its elements, so `for cmd in commands:` receives the argv, while a dict
+# yields its KEYS, so the same line over `{"inspect": ["gdalinfo", path]}`
+# receives the string "inspect" and the argv never moves — flagging it would be
+# a false positive on inert data, the #996 class. Note the rule is about WHERE
+# in the dict the literal sits, not about `dict` as a type: a literal used as a
+# KEY is exactly what iteration yields.
+#
+# Every other question this analysis asks still only wants the one bit, and
+# asks it as `kind is not None`.
+_ITER_YIELDS_VECTOR = "vector"
+_ITER_YIELDS_OTHER = "other"
+
+
+def _container_iteration_kind(container: ast.AST, held: ast.AST) -> str:
+    """What iterating ``container`` yields, given that ``held`` is in it."""
+    if isinstance(container, ast.Dict):
+        return (
+            _ITER_YIELDS_VECTOR
+            if any(key is held for key in container.keys)
+            else _ITER_YIELDS_OTHER
+        )
+    return _ITER_YIELDS_VECTOR
+
 
 def _default_parameter_name(args: ast.arguments, value: ast.AST) -> str | None:
     """The parameter a default value belongs to, positionally or by keyword."""
@@ -1693,7 +1720,7 @@ def _defaults_owner(node: ast.AST) -> ast.AST | None:
     return None
 
 
-def _binding_targets(node: ast.AST) -> tuple[set[str], bool]:
+def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
     """Names this literal's value is reachable through in its own scope.
 
     Climbs out of transparent wrappers first (fix(#996 review)), so
@@ -1702,19 +1729,22 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], bool]:
     ``=`` including unpacking, annotated ``=``, the walrus, and the loop target
     of a ``for``/``async for``/comprehension over a literal.
 
-    Returns ``(names, holds_a_container)``. The flag tells the caller whether
-    those names refer to the command vector itself or to something wrapping
-    it, which changes what a subscript on them means.
+    Returns ``(names, container_kind)``. ``container_kind`` is ``None`` when
+    those names refer to the command vector ITSELF, which is what decides that
+    a subscript on them yields an element rather than the vector. When they
+    refer to something WRAPPING it, the kind additionally says what iterating
+    that wrapper hands over (fix(#1394), see ``_container_iteration_kind``);
+    callers that only need the one bit ask ``kind is not None``.
     """
     current: ast.AST = node
     parent = getattr(current, "_rule2_parent", None)
     index_in_parent: int | None = None
-    climbed = False
+    container_kind: str | None = None
     while isinstance(parent, _TRANSPARENT_WRAPPERS):
         # Only a CONTAINER wrapper means the level above holds the vector
         # rather than being it (fix(#996 review)).
         if isinstance(parent, _CONTAINER_WRAPPERS):
-            climbed = True
+            container_kind = _container_iteration_kind(parent, current)
         if isinstance(parent, (ast.Tuple, ast.List)) and current in parent.elts:
             index_in_parent = parent.elts.index(current)
         else:
@@ -1728,20 +1758,22 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], bool]:
             if positional is not None:
                 return {
                     n for target in positional for n in _target_names(target)
-                }, climbed
-        return {n for target in parent.targets for n in _target_names(target)}, climbed
+                }, container_kind
+        return {
+            n for target in parent.targets for n in _target_names(target)
+        }, container_kind
     # fix(#996 review): the same path rule as the Assign branch above. An
     # annotated `box.cmd: list[str] = [...]` binds a path exactly like the
     # unannotated form; requiring a bare Name here dropped it. A walrus target
     # is always a Name, so it rides the same branch.
     if isinstance(parent, (ast.AnnAssign, ast.NamedExpr)) and parent.value is current:
-        return _target_names(parent.target), climbed
+        return _target_names(parent.target), container_kind
     # fix(#996 review): `cmd = []` then `cmd += ["gdalinfo", path]` assembles a
     # real argv, and the literal's parent is an AugAssign that none of the
-    # branches above matched. `climbed` is False regardless: `+=` splices the
+    # branches above matched. The kind is None regardless: `+=` splices the
     # elements in, so the target holds the vector rather than a container.
     if isinstance(parent, ast.AugAssign) and parent.value is current:
-        return _target_names(parent.target), False
+        return _target_names(parent.target), None
     # fix(#996 review): `def run(cmd=("gdalinfo", "-json")): subprocess.run(cmd)`
     # executes the default on every bare call. The literal sits in the
     # signature, so the escape walk stops at the function boundary and no
@@ -1749,22 +1781,22 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], bool]:
     if isinstance(parent, ast.arguments):
         name = _default_parameter_name(parent, current)
         if name:
-            return {name}, False
+            return {name}, None
     # fix(#996 review): `for cmd in (["gdalinfo", path],): subprocess.run(cmd)`
     # reaches an exec through the loop target. Same for `async for` and for a
     # comprehension's generator.
     #
-    # Only when the literal is an ELEMENT of the iterable, which is what
-    # `climbed` records. `for tool in ["gdalinfo", "ogrinfo"]` binds each
+    # Only when the literal is an ELEMENT the iteration actually yields, which
+    # is what the kind records. `for tool in ["gdalinfo", "ogrinfo"]` binds each
     # STRING to the target, not the list, and treating the list as escaping
     # through it flagged ordinary tool-name data.
-    if climbed:
+    if container_kind == _ITER_YIELDS_VECTOR:
         # The loop target receives an ELEMENT of the iterable, so it is the
         # vector itself, not a container of it.
         loop_targets = _loop_target_paths(current)
         if loop_targets:
-            return loop_targets, False
-    return set(), False
+            return loop_targets, None
+    return set(), None
 
 
 def _enclosing_statement(node: ast.AST, body: list) -> ast.stmt | None:
@@ -1867,7 +1899,7 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
     best = _escape_kind(node)
     if best == _ESCAPE_CALL:
         return best
-    names, holds_container = _binding_targets(node)
+    names, container_kind = _binding_targets(node)
     scope = _defaults_owner(node) or _scope_root(node)
     if not names or scope is None:
         return best
@@ -1881,7 +1913,7 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
     # DIRECTLY. For a derived alias the statement that introduces it would
     # itself look like an overwrite, and over-reporting is the safe side.
     original_paths = set(names)
-    pending = {(n, holds_container) for n in names}
+    pending = {(n, container_kind) for n in names}
     while pending:
         current_batch = pending
         pending = set()
@@ -1900,7 +1932,8 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
                 continue
             if path in original_paths and _overwritten_before(used, node, path):
                 continue
-            holds = current_paths[path]
+            kind = current_paths[path]
+            holds = kind is not None
             # fix(#996 review): reading a CONTAINER through a subscript or
             # attribute yields the vector — `commands = {...}` then
             # `cmd = commands["inspect"]`. Follow that extraction, or the
@@ -1911,8 +1944,8 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
                     isinstance(parent, (ast.Subscript, ast.Attribute))
                     and parent.value is used
                 ):
-                    extracted, _ = _binding_targets(parent)
-                    pending |= {(n, False) for n in extracted - seen}
+                    extracted, extracted_kind = _binding_targets(parent)
+                    pending |= {(n, extracted_kind) for n in extracted - seen}
                 # fix(#1394): ITERATING a container hands each element — the
                 # argv — to the loop target, exactly as subscripting it hands
                 # over one. `_binding_targets` already reads that off the AST
@@ -1920,20 +1953,27 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
                 # (["gdalinfo", path],):`); once the container has a NAME
                 # (`commands = (["gdalinfo", path],)` then `for cmd in
                 # commands:`) the AST no longer says so, and only this loop
-                # knows that `holds` is True. Without it the shape reported
+                # carries what the container was. Without it the shape reported
                 # ZERO argv sites: invisible to the gate, so neither creditable
                 # nor reportable — the one failure direction the #1077
                 # allowlist inversion exists to remove.
                 #
-                # `holds` gates it for the same reason #996's `climbed` does:
-                # iterating the VECTOR (`for part in cmd:`) yields strings, not
-                # commands.
-                pending |= {(n, False) for n in _loop_target_paths(used) - seen}
+                # Gated on the kind for the same reason #996 gated its in-place
+                # twin: iterating the VECTOR (`for part in cmd:`) yields
+                # strings, and iterating a dict that holds the argv as a VALUE
+                # yields keys (codex round 1).
+                if kind == _ITER_YIELDS_VECTOR:
+                    pending |= {(n, None) for n in _loop_target_paths(used) - seen}
             best = max(best, _escape_kind(used, vector=not holds))
             if best == _ESCAPE_CALL:
                 return best
-            aliases, alias_container = _binding_targets(used)
-            pending |= {(n, holds or alias_container) for n in aliases - seen}
+            aliases, alias_kind = _binding_targets(used)
+            # A wrapper at the ALIAS site is the outermost one now, so it
+            # decides what iterating the alias yields; with no new wrapper the
+            # kind carries over unchanged. Either way the one-bit answer is
+            # preserved: the alias holds a container when this path did or the
+            # alias site added one.
+            pending |= {(n, alias_kind or kind) for n in aliases - seen}
     return best
 
 
@@ -3129,6 +3169,85 @@ def test_guard_iterating_the_vector_itself_binds_strings_not_argvs():
     )
     assert total == 0, (total, violations)
     assert violations == []
+
+
+def test_guard_iterating_a_dict_yields_keys_not_the_argv():
+    """fix(#1394), codex round 1: not every container yields its contents.
+
+    ``for key in commands:`` over a dict hands over ``"inspect"``; the argv
+    stays put, so following the loop target flagged inert data — the #996
+    false-positive class, from treating "holds a container" as one bit when
+    iteration needs two. Subscripting the same dict is unaffected and still
+    reaches the argv (the second case).
+
+    A dict is not uniformly opaque either, which is why the rule reads WHERE the
+    literal sits rather than testing for ``dict``: a literal used as a KEY is
+    exactly what iteration hands over (the third).
+    """
+    inert, total = _collect_gdal_cli_violations(
+        _mod(
+            "def fn(path):\n"
+            "    commands = {'inspect': ['gdalinfo', path]}\n"
+            "    for key in commands:\n"
+            "        consume(key)\n"
+        ),
+        {},
+    )
+    assert total == 0, (total, inert)
+    assert inert == []
+
+    subscripted, total_subscripted = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def fn(path):\n"
+            "    commands = {'inspect': ['gdalinfo', path]}\n"
+            "    subprocess.run(commands['inspect'])\n"
+        ),
+        {},
+    )
+    assert total_subscripted == 1, (total_subscripted, subscripted)
+    assert len(subscripted) == 1 and "(fn)" in subscripted[0]
+
+    keyed, total_keyed = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def fn(path):\n"
+            "    commands = {('gdalinfo', path): 'inspect'}\n"
+            "    for cmd in commands:\n"
+            "        subprocess.run(cmd)\n"
+        ),
+        {},
+    )
+    assert total_keyed == 1, (total_keyed, keyed)
+    assert len(keyed) == 1 and "(fn)" in keyed[0]
+
+
+def test_guard_container_kind_survives_an_alias_hop():
+    """fix(#1394), codex round 1: the kind travels with the path.
+
+    An alias of a container is the same container, so ``alias = commands`` then
+    ``for x in alias:`` has to reach the SAME verdict as iterating ``commands``
+    directly — reported for a list, inert for a dict. Carrying only "holds a
+    container" across the hop loses that and reports both.
+    """
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def sequence(path):\n"
+            "    commands = [['gdalinfo', path]]\n"
+            "    alias = commands\n"
+            "    for cmd in alias:\n"
+            "        subprocess.run(cmd)\n"
+            "def mapping(path):\n"
+            "    lookup = {'inspect': ['ogrinfo', path]}\n"
+            "    other = lookup\n"
+            "    for key in other:\n"
+            "        consume(key)\n"
+        ),
+        {},
+    )
+    assert total == 1, (total, violations)
+    assert len(violations) == 1 and "(sequence)" in violations[0]
 
 
 def test_guard_unpacking_binds_by_position_not_by_all_names():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1781,7 +1781,17 @@ def _all_pattern_elements(targets: list[ast.expr]) -> list[ast.expr] | None:
 
     The ``_ANY_POSITION`` counterpart of ``_positional_targets``. A starred
     element bails the same way it does there: it binds a sub-list rather than
-    an element, so no name receives a command.
+    an element, so the pattern's names do not all receive the same thing and
+    the caller keeps its conservative answer.
+
+    Keeping the non-starred names and dropping the star was the obvious
+    narrowing and is deliberately NOT taken (codex round 16, declined). In
+    ``cmd, *rest = commands`` the star's target holds a container of argvs and
+    a later ``for c in rest:`` is a real path to an exec, so dropping it trades
+    this over-report for a silent miss — the one direction that is worse.
+    Splitting the two kinds means the element pickers returning a kind per
+    target rather than a level, which is the container-element tracking #996
+    declined to build. Until a real site needs it, the loud answer stands.
     """
     matched: list[ast.expr] = []
     saw_sequence = False
@@ -1843,7 +1853,14 @@ def _unpacked_binding(
         if not adds_level:
             continue  # nothing here for a pattern to take apart
         if index is None:
-            break  # a level, but not one unpacked by position (a dict, a set)
+            # A level, but not one unpacked by position (a dict, a set). A
+            # SINGLETON set does hand its sole element over unambiguously
+            # (`cmd, = {("gdalinfo", path)}`), and reading that would need the
+            # wrapper's own arity, which the chain does not carry (codex round
+            # 16, declined). It is the loud direction, on a shape that appears
+            # nowhere: sets are unordered, so nothing here builds an argv in
+            # one.
+            break
         nxt = (
             _all_pattern_elements(current)
             if index == _ANY_POSITION

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1580,6 +1580,27 @@ def _target_names(target: ast.expr) -> set[str]:
     return {path} if path else set()
 
 
+def _intact_loop_target(target: ast.expr) -> ast.expr | None:
+    """The part of a loop target that receives an element WHOLE, or None.
+
+    A plain name or path receives it intact. So does an ALL-CONSUMING star
+    (codex round 7 on #1394): ``for *cmd, in commands:`` binds ``cmd`` to
+    ``list(element)``, the vector rebuilt, and rejecting it with the rest of
+    the patterns hid a real argv.
+
+    Ordinary positional destructuring gets nothing (codex round 2):
+    ``for tool, arg in commands:`` splits the vector into strings. Neither does
+    a PARTIAL star, ``for tool, *rest in commands:`` — ``rest`` is a suffix of
+    the argv, which is not a GDAL-headed command and would be judged against
+    the wrong tool if it were treated as one.
+    """
+    if isinstance(target, (ast.Tuple, ast.List)):
+        if len(target.elts) == 1 and isinstance(target.elts[0], ast.Starred):
+            return target.elts[0].value
+        return None
+    return target
+
+
 def _depth_preserving_ancestor(expr: ast.AST) -> ast.AST:
     """The outermost expression around ``expr`` that is still the same value.
 
@@ -1589,7 +1610,9 @@ def _depth_preserving_ancestor(expr: ast.AST) -> ast.AST:
     (fix(#1394), codex round 6):
 
     * a VALUE wrapper — ``commands or ()``, ``commands if flag else ()``,
-      ``commands + extra`` — which evaluates to the thing it wraps.
+      ``commands + extra`` — which evaluates to the thing it wraps. A ternary
+      qualifies through its two RESULTS only; its condition is not part of its
+      value (codex round 7).
     * a star inside a display, ``(*commands,)``, which splices ``commands``'
       elements into a new one and so preserves its depth (codex round 5). The
       pair counts once, exactly as it does in ``_binding_targets``.
@@ -1600,6 +1623,16 @@ def _depth_preserving_ancestor(expr: ast.AST) -> ast.AST:
     current: ast.AST = expr
     while True:
         parent = getattr(current, "_rule2_parent", None)
+        if isinstance(parent, ast.IfExp):
+            # codex round 7 on #1394: a ternary's TEST is not part of its
+            # value. `[] if commands else ()` evaluates to one of two empty
+            # displays and has nothing to do with `commands`, so climbing from
+            # the condition claimed the loop iterated the container and
+            # reported an argv that never runs.
+            if current is parent.body or current is parent.orelse:
+                current = parent
+                continue
+            return current
         if isinstance(parent, _VALUE_WRAPPERS):
             current = parent
             continue
@@ -1635,7 +1668,9 @@ def _loop_target_paths(iterable: ast.AST) -> set[str]:
     them up by position — and the wrong one here, where the value being split
     is the command vector rather than a tuple of unrelated values. Returning
     nothing is the accurate answer within this model, in which the element of a
-    container IS the vector: destructuring a vector yields strings.
+    container IS the vector: destructuring a vector yields strings. One pattern
+    is not destructuring though it is spelled like one — see
+    ``_intact_loop_target``.
 
     codex round 6 on #1394: the iterable is reached through
     ``_depth_preserving_ancestor``, so ``for cmd in commands or ():`` is the
@@ -1648,9 +1683,10 @@ def _loop_target_paths(iterable: ast.AST) -> set[str]:
     if (
         isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension))
         and parent.iter is iterated
-        and not isinstance(parent.target, (ast.Tuple, ast.List))
     ):
-        return _target_names(parent.target)
+        target = _intact_loop_target(parent.target)
+        if target is not None:
+            return _target_names(target)
     return set()
 
 
@@ -3356,11 +3392,46 @@ def test_guard_destructuring_loop_target_does_not_receive_the_argv():
             "def inline(path):\n"
             "    for tool, arg in (['ogrinfo', path],):\n"
             "        consume(arg)\n"
+            "def partial_star(path):\n"
+            "    commands = [['gdalwarp', path]]\n"
+            "    for tool, *rest in commands:\n"
+            "        consume(rest)\n"
         ),
         {},
     )
     assert total == 0, (total, violations)
     assert violations == []
+
+
+def test_guard_an_all_consuming_star_target_rebuilds_the_argv():
+    """fix(#1394), codex round 7: one pattern is not destructuring.
+
+    ``for *cmd, in commands:`` binds ``cmd`` to ``list(element)`` — the vector,
+    whole. Rejecting it with the ordinary positional patterns hid a real argv,
+    the direction that matters. Both spellings of the container, and the
+    ``[*cmd]`` spelling of the target.
+    """
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def named(path):\n"
+            "    commands = [['gdalinfo', path]]\n"
+            "    for *cmd, in commands:\n"
+            "        subprocess.run(cmd)\n"
+            "def inline(path):\n"
+            "    for *cmd, in (['ogrinfo', path],):\n"
+            "        subprocess.run(cmd)\n"
+            "def bracketed(path):\n"
+            "    commands = [['gdalwarp', path]]\n"
+            "    for [*cmd] in commands:\n"
+            "        subprocess.run(cmd)\n"
+        ),
+        {},
+    )
+    assert total == 3, (total, violations)
+    assert len(violations) == 3, violations
+    for name in ("(named)", "(inline)", "(bracketed)"):
+        assert any(name in v for v in violations), (name, violations)
 
 
 def test_guard_starring_an_argv_splices_it_into_the_display():
@@ -3468,6 +3539,14 @@ def test_guard_a_wrapped_iterable_is_still_the_same_loop():
         "cmd"
     }
     assert loop_targets_of("for held in [commands]:\n    pass\n", "commands") == set()
+    # codex round 7: the ternary qualifies through its RESULTS, not its test.
+    assert loop_targets_of(
+        "for cmd in (commands if flag else ()):\n    pass\n", "commands"
+    ) == {"cmd"}
+    assert (
+        loop_targets_of("for cmd in ([] if commands else ()):\n    pass\n", "commands")
+        == set()
+    )
 
     violations, total = _collect_gdal_cli_violations(
         _mod(
@@ -3488,11 +3567,16 @@ def test_guard_a_wrapped_iterable_is_still_the_same_loop():
             "    commands = [['gdaladdo', path]]\n"
             "    for cmd in (*commands,):\n"
             "        subprocess.run(cmd)\n"
+            "def condition_only(path):\n"
+            "    commands = [['gdal_translate', path]]\n"
+            "    for cmd in ([] if commands else ()):\n"
+            "        subprocess.run(cmd)\n"
         ),
         {},
     )
     assert total == 4, (total, violations)
     assert len(violations) == 4, violations
+    assert not any("(condition_only)" in v for v in violations), violations
 
 
 def test_guard_conflicting_container_kinds_merge_to_the_louder():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1763,40 +1763,65 @@ def _positional_targets(targets: list[ast.expr], index: int) -> list[ast.expr] |
 
 def _unpacked_binding(
     targets: list[ast.expr],
-    chain: list[tuple[int | None, str | None]],
+    chain: list[tuple[int | None, str | None, bool]],
     container_kind: str | None,
 ) -> tuple[set[str], str | None] | None:
     """Pair the wrappers a literal sits in against the patterns unpacking them.
 
     ``chain`` lists those wrappers OUTERMOST first, each with the index the
-    value occupies in it and the kind of what is INSIDE it. Every level where
-    some target is a sequence pattern consumes one wrapper and descends; the
-    first level where none is receives whatever is left, at the kind below the
-    last wrapper consumed. Returns None when nothing was unpacked at all, and
-    the caller keeps its plain-assignment answer.
+    value occupies in it, the kind of what is INSIDE it, and whether it adds a
+    level. Every level where some target is a sequence pattern consumes one
+    wrapper and descends; a target that stops being a pattern stops there,
+    holding the value at that depth. Returns None when nothing was unpacked at
+    all, and the caller keeps its plain-assignment answer.
 
-    fix(#1394), codex rounds 11 and 12. Unpacking CONSUMES the wrapper it takes
-    apart, so `alias, = (["gdalinfo", path],)` leaves `alias` holding the
-    vector, and `for part in alias:` then yields strings rather than commands.
-    Handling one level was not enough, because patterns nest as freely as
-    displays do: `((alias,),) = ((["gdalinfo", path],),)` consumes two and
-    lands in the same place, while `(alias,) = ((["gdalinfo", path],),)`
-    consumes one and leaves a container. Counting them one for one is the only
-    answer that covers both without a rule per depth.
+    fix(#1394), codex rounds 11 through 13, one shape at a time.
+
+    Unpacking CONSUMES the wrapper it takes apart, so ``alias, = (["gdalinfo",
+    path],)`` leaves ``alias`` holding the vector and ``for part in alias:``
+    yields strings rather than commands. Handling one level was not enough,
+    because patterns nest as freely as displays do: ``((alias,),) =
+    ((["gdalinfo", path],),)`` consumes two and lands in the same place, while
+    ``(alias,) = ((["gdalinfo", path],),)`` consumes one and leaves a
+    container. Counting them one for one covers every depth with no rule per
+    depth.
+
+    Two things the counting has to get right. A wrapper that adds NO level
+    (a value wrapper, a star and its display) is not a pattern's to consume, so
+    it is stepped over rather than ending the pairing — otherwise ``(alias,) =
+    ((["gdalinfo", path],) + ())`` never pairs at all. And chained targets can
+    unpack to DIFFERENT depths, so a target whose pattern ends early is kept at
+    that depth instead of being dropped when its siblings descend further.
+
+    The kinds those endpoints hold are merged, not split, because the caller
+    speaks of one path set with one kind. Merging toward the louder end keeps
+    the disagreement on the reported side, as everywhere else here.
     """
     current = targets
     kind = container_kind
+    endpoints: list[tuple[set[str], str | None]] = []
     consumed = False
-    for index, kind_below in chain:
+    for index, kind_below, adds_level in chain:
+        if not adds_level:
+            continue  # nothing here for a pattern to take apart
         if index is None:
-            break
+            break  # a level, but not one unpacked by position (a dict, a set)
         nxt = _positional_targets(current, index)
         if nxt is None:
             break
+        for target in current:
+            if not isinstance(target, (ast.Tuple, ast.List)):
+                endpoints.append((_target_names(target), kind))
         current, kind, consumed = nxt, kind_below, True
     if not consumed:
         return None
-    return {n for target in current for n in _target_names(target)}, kind
+    endpoints.extend((_target_names(target), kind) for target in current)
+    names: set[str] = set()
+    merged: str | None = None
+    for target_names, endpoint_kind in endpoints:
+        names |= target_names
+        merged = _louder_kind(merged, endpoint_kind)
+    return names, merged
 
 
 # Expression wrappers a value passes through without being consumed. A literal
@@ -1946,10 +1971,11 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
     parent = getattr(current, "_rule2_parent", None)
     container_kind: str | None = None
     # Every wrapper climbed, innermost first: the index the value occupies in
-    # it (None when the wrapper is not a positional display) and the kind of
-    # what is INSIDE it. An unpacking pattern consumes these one for one, so
-    # the pairing needs the whole chain, not just its outermost link.
-    chain: list[tuple[int | None, str | None]] = []
+    # it (None when the wrapper is not a positional display), the kind of what
+    # is INSIDE it, and whether it adds a LEVEL at all. An unpacking pattern
+    # consumes these one for one, so the pairing needs the whole chain, not
+    # just its outermost link.
+    chain: list[tuple[int | None, str | None, bool]] = []
     while isinstance(parent, _TRANSPARENT_WRAPPERS):
         # fix(#1394), codex round 8: a VALUE wrapper only carries the value in
         # a position it can evaluate to. `empty = [] if commands else ()` never
@@ -1974,13 +2000,19 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
         starred = isinstance(parent, ast.Starred) or isinstance(current, ast.Starred)
         kind_below = container_kind
         # Only a CONTAINER wrapper means the level above holds the vector
-        # rather than being it (fix(#996 review)).
-        if isinstance(parent, _CONTAINER_WRAPPERS) and not starred:
+        # rather than being it (fix(#996 review)) — which is the same thing as
+        # adding a level for an unpacking pattern to consume.
+        adds_level = isinstance(parent, _CONTAINER_WRAPPERS) and not starred
+        if adds_level:
             container_kind = _container_iteration_kind(parent, current)
-        if isinstance(parent, (ast.Tuple, ast.List)) and current in parent.elts:
-            chain.append((parent.elts.index(current), kind_below))
-        else:
-            chain.append((None, kind_below))
+        index = (
+            parent.elts.index(current)
+            if adds_level
+            and isinstance(parent, (ast.Tuple, ast.List))
+            and current in parent.elts
+            else None
+        )
+        chain.append((index, kind_below, adds_level))
         current = parent
         parent = getattr(current, "_rule2_parent", None)
     chain.reverse()  # outermost first, the order an unpacking consumes them
@@ -3766,6 +3798,45 @@ def test_guard_positional_unpacking_consumes_the_wrapper():
         assert any(reported in v for v in violations), (reported, violations)
     for quiet in ("(unpacked)", "(nested_pattern)"):
         assert not any(quiet in v for v in violations), (quiet, violations)
+
+
+def test_guard_unpacking_pairs_only_with_real_levels():
+    """fix(#1394), codex round 13: two ways the one-for-one count goes wrong.
+
+    A wrapper that adds NO level is not a pattern's to consume, so it has to be
+    stepped over rather than end the pairing: ``(alias,) = ((argv,) + ())``
+    unpacks the concatenated tuple exactly as ``(alias,) = (argv,)`` does, and
+    abandoning the match at the ``+`` left ``alias`` looking like a container.
+
+    Chained targets can unpack to DIFFERENT depths, and a target whose pattern
+    ends early was dropped the moment a sibling descended past it — so
+    ``(alias,) = ((deep,),) = ((argv,),)`` lost ``alias`` entirely and the loop
+    over it reported nothing.
+    """
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "def through_a_value_wrapper(path):\n"
+            "    (alias,) = ((['gdalinfo', path],) + ())\n"
+            "    for part in alias:\n"
+            "        consume(part)\n"
+        ),
+        {},
+    )
+    assert total == 0, (total, violations)
+    assert violations == []
+
+    uneven, total_uneven = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def uneven_chain(path):\n"
+            "    (alias,) = ((deep,),) = ((['ogrinfo', path],),)\n"
+            "    for cmd in alias:\n"
+            "        subprocess.run(cmd)\n"
+        ),
+        {},
+    )
+    assert total_uneven == 1, (total_uneven, uneven)
+    assert len(uneven) == 1 and "(uneven_chain)" in uneven[0]
 
 
 def test_guard_a_sliced_container_is_still_a_container():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1580,8 +1580,39 @@ def _target_names(target: ast.expr) -> set[str]:
     return {path} if path else set()
 
 
+def _depth_preserving_ancestor(expr: ast.AST) -> ast.AST:
+    """The outermost expression around ``expr`` that is still the same value.
+
+    Same value meaning the same thing at the same container depth, so a caller
+    holding a container of argvs still holds one at the top. Two wrappers
+    qualify, both of them already named elsewhere in this module
+    (fix(#1394), codex round 6):
+
+    * a VALUE wrapper — ``commands or ()``, ``commands if flag else ()``,
+      ``commands + extra`` — which evaluates to the thing it wraps.
+    * a star inside a display, ``(*commands,)``, which splices ``commands``'
+      elements into a new one and so preserves its depth (codex round 5). The
+      pair counts once, exactly as it does in ``_binding_targets``.
+
+    A CONTAINER wrapper is deliberately absent: ``[commands]`` is a level
+    deeper, and pretending otherwise is the container mistake #996 is about.
+    """
+    current: ast.AST = expr
+    while True:
+        parent = getattr(current, "_rule2_parent", None)
+        if isinstance(parent, _VALUE_WRAPPERS):
+            current = parent
+            continue
+        if isinstance(parent, ast.Starred):
+            display = getattr(parent, "_rule2_parent", None)
+            if isinstance(display, (ast.List, ast.Tuple, ast.Set)):
+                current = display
+                continue
+        return current
+
+
 def _loop_target_paths(iterable: ast.AST) -> set[str]:
-    """The paths a loop binds when ``iterable`` is the thing being iterated.
+    """The paths a loop binds when ``iterable`` is (part of) the thing iterated.
 
     ``for cmd in commands:`` binds ``"cmd"``; ``async for`` and a
     comprehension's generator bind the same way. Empty when ``iterable`` is not
@@ -1605,11 +1636,18 @@ def _loop_target_paths(iterable: ast.AST) -> set[str]:
     is the command vector rather than a tuple of unrelated values. Returning
     nothing is the accurate answer within this model, in which the element of a
     container IS the vector: destructuring a vector yields strings.
+
+    codex round 6 on #1394: the iterable is reached through
+    ``_depth_preserving_ancestor``, so ``for cmd in commands or ():`` is the
+    same loop as ``for cmd in commands:``. Requiring the load to be the direct
+    child of ``For.iter`` let a value wrapper — the ternary, ``+`` and ``or``
+    forms #996 already follows everywhere else — hide a real argv.
     """
-    parent = getattr(iterable, "_rule2_parent", None)
+    iterated = _depth_preserving_ancestor(iterable)
+    parent = getattr(iterated, "_rule2_parent", None)
     if (
         isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension))
-        and parent.iter is iterable
+        and parent.iter is iterated
         and not isinstance(parent.target, (ast.Tuple, ast.List))
     ):
         return _target_names(parent.target)
@@ -3395,6 +3433,66 @@ def test_guard_starring_an_argv_splices_it_into_the_display():
     assert len(wrapped) == 2, wrapped
     assert any("(iterated)" in v for v in wrapped)
     assert any("(indexed)" in v for v in wrapped)
+
+
+def test_guard_a_wrapped_iterable_is_still_the_same_loop():
+    """fix(#1394), codex round 6: the value wrappers reach the loop too.
+
+    ``for cmd in commands or ():`` iterates ``commands``. Requiring the load to
+    be the direct child of ``For.iter`` let the ternary, ``+`` and ``or`` forms
+    #996 follows everywhere else hide a real argv — a silent miss. A star into
+    a display preserves depth the same way (round 5), so it reaches the loop
+    too.
+
+    A CONTAINER wrapper must NOT reach it: ``for held in [commands]:`` binds
+    the container, one level above the argv. Pinned on the helper, because
+    end-to-end the container escapes into the loop body either way and the two
+    answers are indistinguishable from the verdict.
+    """
+
+    def loop_targets_of(src: str, name: str) -> set[str]:
+        tree = ast.parse(src)
+        _annotate_parents(tree)
+        load = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Name) and n.id == name and isinstance(n.ctx, ast.Load)
+        )
+        return _loop_target_paths(load)
+
+    assert loop_targets_of("for cmd in commands:\n    pass\n", "commands") == {"cmd"}
+    assert loop_targets_of("for cmd in commands or ():\n    pass\n", "commands") == {
+        "cmd"
+    }
+    assert loop_targets_of("for cmd in (*commands,):\n    pass\n", "commands") == {
+        "cmd"
+    }
+    assert loop_targets_of("for held in [commands]:\n    pass\n", "commands") == set()
+
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def fallback(path):\n"
+            "    commands = [['gdalinfo', path]]\n"
+            "    for cmd in commands or ():\n"
+            "        subprocess.run(cmd)\n"
+            "def ternary(path, flag):\n"
+            "    commands = [['ogrinfo', path]]\n"
+            "    for cmd in commands if flag else []:\n"
+            "        subprocess.run(cmd)\n"
+            "def concatenated(path, extra):\n"
+            "    commands = [['gdalwarp', path]]\n"
+            "    for cmd in commands + extra:\n"
+            "        subprocess.run(cmd)\n"
+            "def starred(path):\n"
+            "    commands = [['gdaladdo', path]]\n"
+            "    for cmd in (*commands,):\n"
+            "        subprocess.run(cmd)\n"
+        ),
+        {},
+    )
+    assert total == 4, (total, violations)
+    assert len(violations) == 4, violations
 
 
 def test_guard_conflicting_container_kinds_merge_to_the_louder():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1761,6 +1761,31 @@ def _positional_targets(targets: list[ast.expr], index: int) -> list[ast.expr] |
     return matched if (saw_sequence and matched) else None
 
 
+# A wrapper whose contents are known only by KIND, not by shape: which
+# position holds the argv is unknowable, and in a container of argvs every one
+# does (fix(#1394), codex round 14).
+_ANY_POSITION = -1
+
+
+def _all_pattern_elements(targets: list[ast.expr]) -> list[ast.expr] | None:
+    """Every element of the sequence patterns among ``targets``, or None.
+
+    The ``_ANY_POSITION`` counterpart of ``_positional_targets``. A starred
+    element bails the same way it does there: it binds a sub-list rather than
+    an element, so no name receives a command.
+    """
+    matched: list[ast.expr] = []
+    saw_sequence = False
+    for target in targets:
+        if not isinstance(target, (ast.Tuple, ast.List)):
+            continue
+        saw_sequence = True
+        if any(isinstance(e, ast.Starred) for e in target.elts):
+            return None
+        matched.extend(target.elts)
+    return matched if (saw_sequence and matched) else None
+
+
 def _unpacked_binding(
     targets: list[ast.expr],
     chain: list[tuple[int | None, str | None, bool]],
@@ -1806,7 +1831,11 @@ def _unpacked_binding(
             continue  # nothing here for a pattern to take apart
         if index is None:
             break  # a level, but not one unpacked by position (a dict, a set)
-        nxt = _positional_targets(current, index)
+        nxt = (
+            _all_pattern_elements(current)
+            if index == _ANY_POSITION
+            else _positional_targets(current, index)
+        )
         if nxt is None:
             break
         for target in current:
@@ -1951,7 +1980,9 @@ def _defaults_owner(node: ast.AST) -> ast.AST | None:
     return None
 
 
-def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
+def _binding_targets(
+    node: ast.AST, *, inherited: str | None = None
+) -> tuple[set[str], str | None]:
     """Names this literal's value is reachable through in its own scope.
 
     Climbs out of transparent wrappers first (fix(#996 review)), so
@@ -1966,16 +1997,29 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
     refer to something WRAPPING it, the kind additionally says what iterating
     that wrapper hands over (fix(#1394), see ``_container_iteration_kind``);
     callers that only need the one bit ask ``kind is not None``.
+
+    ``inherited`` is the kind ``node``'s value ALREADY carries when the AST
+    does not show it — a name known to hold a container of argvs, say. The
+    returned kind is relative to that, so a caller passing it must not add it
+    back (fix(#1394), codex round 14).
     """
     current: ast.AST = node
     parent = getattr(current, "_rule2_parent", None)
-    container_kind: str | None = None
+    container_kind: str | None = inherited
     # Every wrapper climbed, innermost first: the index the value occupies in
     # it (None when the wrapper is not a positional display), the kind of what
     # is INSIDE it, and whether it adds a LEVEL at all. An unpacking pattern
     # consumes these one for one, so the pairing needs the whole chain, not
     # just its outermost link.
     chain: list[tuple[int | None, str | None, bool]] = []
+    # fix(#1394), codex round 14: an INHERITED container is an unpackable level
+    # too, and the innermost one — `alias, = commands` takes `commands` apart
+    # exactly as `alias, = (["gdalinfo", path],)` takes the display apart, and
+    # leaves `alias` holding the vector. Only for a container that yields the
+    # vector: unpacking a MAPPING yields keys, which are not commands, and that
+    # falls through to the conservative answer instead.
+    if inherited == _ITER_YIELDS_VECTOR:
+        chain.append((_ANY_POSITION, None, True))
     while isinstance(parent, _TRANSPARENT_WRAPPERS):
         # fix(#1394), codex round 8: a VALUE wrapper only carries the value in
         # a position it can evaluate to. `empty = [] if commands else ()` never
@@ -2159,16 +2203,18 @@ def _derived_paths(used: ast.expr, kind: str | None) -> list[tuple[str, str | No
         # chain stops dead at the container.
         parent = getattr(used, "_rule2_parent", None)
         if isinstance(parent, (ast.Subscript, ast.Attribute)) and parent.value is used:
-            extracted, extracted_kind = _binding_targets(parent)
-            # An INDEX of a container yields the vector, one level down. A
-            # SLICE yields a container of the same things, so `sliced =
-            # commands[:]` keeps the kind (codex round 9). Fixed here as well
-            # as in `_depth_preserving_ancestor` because the alias path went
-            # around the loop's own iterable once already (round 8).
-            if isinstance(parent, ast.Subscript) and isinstance(
+            # An INDEX of a container yields the vector, one level down, so it
+            # inherits nothing. A SLICE yields a container of the same things,
+            # so `sliced = commands[:]` inherits this path's kind (codex round
+            # 9). Fixed here as well as in `_depth_preserving_ancestor` because
+            # the alias path went around the loop's own iterable once already
+            # (round 8).
+            sliced = isinstance(parent, ast.Subscript) and isinstance(
                 parent.slice, ast.Slice
-            ):
-                extracted_kind = extracted_kind or kind
+            )
+            extracted, extracted_kind = _binding_targets(
+                parent, inherited=kind if sliced else None
+            )
             derived += [(n, extracted_kind) for n in extracted]
         # fix(#1394): ITERATING a container hands each element — the argv — to
         # the loop target, exactly as subscripting it hands over one.
@@ -2187,12 +2233,13 @@ def _derived_paths(used: ast.expr, kind: str | None) -> list[tuple[str, str | No
         # round 1).
         if kind == _ITER_YIELDS_VECTOR:
             derived += [(n, None) for n in _loop_target_paths(used)]
-    aliases, alias_kind = _binding_targets(used)
     # A wrapper at the ALIAS site is the outermost one now, so it decides what
     # iterating the alias yields; with no new wrapper the kind carries over
-    # unchanged. Either way the one-bit answer is preserved: the alias holds a
-    # container when this path did or the alias site added one.
-    derived += [(n, alias_kind or kind) for n in aliases]
+    # unchanged, and an UNPACKING there takes one off. All three are the same
+    # question, so the inherited kind goes in and the answer comes back
+    # absolute rather than being re-applied here (codex round 14).
+    aliases, alias_kind = _binding_targets(used, inherited=kind)
+    derived += [(n, alias_kind) for n in aliases]
     return derived
 
 
@@ -3837,6 +3884,48 @@ def test_guard_unpacking_pairs_only_with_real_levels():
     )
     assert total_uneven == 1, (total_uneven, uneven)
     assert len(uneven) == 1 and "(uneven_chain)" in uneven[0]
+
+
+def test_guard_unpacking_a_named_container_consumes_its_kind():
+    """fix(#1394), codex round 14: the same rule one alias hop away.
+
+    ``alias, = commands`` takes ``commands`` apart exactly as
+    ``alias, = (["gdalinfo", path],)`` takes the display apart, and leaves
+    ``alias`` holding the vector. The AST shows no wrapper there — it lives in
+    the followed kind — so the alias hop restored the container and the loop
+    over ``alias`` reported strings as commands.
+
+    A container the analysis knows only by KIND has no known position, and in a
+    container of argvs every position is one. A MAPPING is different: unpacking
+    it yields keys, which are not commands, so it keeps the conservative answer
+    (the last function reports because ``holder`` still looks like a container,
+    not because a key was mistaken for a command).
+    """
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def unpacked_alias(path):\n"
+            "    commands = (['gdalinfo', path],)\n"
+            "    alias, = commands\n"
+            "    for part in alias:\n"
+            "        consume(part)\n"
+            "def unpacked_alias_spawned(path):\n"
+            "    commands = (['ogrinfo', path],)\n"
+            "    alias, = commands\n"
+            "    subprocess.run(alias)\n"
+            "def plain_alias(path):\n"
+            "    commands = (['gdalwarp', path],)\n"
+            "    alias = commands\n"
+            "    for cmd in alias:\n"
+            "        subprocess.run(cmd)\n"
+        ),
+        {},
+    )
+    assert total == 2, (total, violations)
+    assert len(violations) == 2, violations
+    for reported in ("(unpacked_alias_spawned)", "(plain_alias)"):
+        assert any(reported in v for v in violations), (reported, violations)
+    assert not any("(unpacked_alias)" in v for v in violations), violations
 
 
 def test_guard_a_sliced_container_is_still_a_container():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1624,19 +1624,21 @@ def _is_value_position(current: ast.AST, parent: ast.AST) -> bool:
 def _intact_loop_target(target: ast.expr) -> ast.expr | None:
     """The part of a loop target that receives an element WHOLE, or None.
 
-    A plain name or path receives it intact. So does an ALL-CONSUMING star
-    (codex round 7 on #1394): ``for *cmd, in commands:`` binds ``cmd`` to
-    ``list(element)``, the vector rebuilt, and rejecting it with the rest of
-    the patterns hid a real argv.
+    A plain name or path receives it intact. So does a LEADING star, which is
+    the thing that decides this: ``for *cmd, in commands:`` binds ``cmd`` to
+    ``list(element)``, the vector rebuilt (codex round 7), and ``for *cmd,
+    ignored in commands:`` binds it to everything but the tail — still an argv,
+    because it still starts with the tool name (codex round 17). Both were
+    rejected with the rest of the patterns, and both hid a real command.
 
     Ordinary positional destructuring gets nothing (codex round 2):
     ``for tool, arg in commands:`` splits the vector into strings. Neither does
-    a PARTIAL star, ``for tool, *rest in commands:`` — ``rest`` is a suffix of
-    the argv, which is not a GDAL-headed command and would be judged against
-    the wrong tool if it were treated as one.
+    a star anywhere but first, ``for tool, *rest in commands:`` — ``rest`` is a
+    SUFFIX of the argv, which has no GDAL head and would be judged against the
+    wrong tool if it were treated as a command.
     """
     if isinstance(target, (ast.Tuple, ast.List)):
-        if len(target.elts) == 1 and isinstance(target.elts[0], ast.Starred):
+        if target.elts and isinstance(target.elts[0], ast.Starred):
             return target.elts[0].value
         return None
     return target
@@ -3624,13 +3626,17 @@ def test_guard_destructuring_loop_target_does_not_receive_the_argv():
     assert violations == []
 
 
-def test_guard_an_all_consuming_star_target_rebuilds_the_argv():
-    """fix(#1394), codex round 7: one pattern is not destructuring.
+def test_guard_a_leading_star_target_keeps_the_argv():
+    """fix(#1394), codex rounds 7 and 17: a LEADING star is not destructuring.
 
     ``for *cmd, in commands:`` binds ``cmd`` to ``list(element)`` — the vector,
-    whole. Rejecting it with the ordinary positional patterns hid a real argv,
-    the direction that matters. Both spellings of the container, and the
-    ``[*cmd]`` spelling of the target.
+    whole — and ``for *cmd, ignored in commands:`` binds it to everything but
+    the tail, still a command because it still starts with the tool name.
+    Rejecting either with the ordinary positional patterns hid a real argv, the
+    direction that matters.
+
+    A star anywhere else is a suffix and keeps getting nothing, which the
+    sibling destructuring test pins.
     """
     violations, total = _collect_gdal_cli_violations(
         _mod(
@@ -3646,12 +3652,25 @@ def test_guard_an_all_consuming_star_target_rebuilds_the_argv():
             "    commands = [['gdalwarp', path]]\n"
             "    for [*cmd] in commands:\n"
             "        subprocess.run(cmd)\n"
+            "def leading_star(path):\n"
+            "    commands = [('gdaladdo', path, None)]\n"
+            "    for *cmd, ignored in commands:\n"
+            "        subprocess.run(cmd)\n"
+            "def leading_star_inline(path):\n"
+            "    for *cmd, ignored in [('gdal_translate', path, None)]:\n"
+            "        subprocess.run(cmd)\n"
         ),
         {},
     )
-    assert total == 3, (total, violations)
-    assert len(violations) == 3, violations
-    for name in ("(named)", "(inline)", "(bracketed)"):
+    assert total == 5, (total, violations)
+    assert len(violations) == 5, violations
+    for name in (
+        "(named)",
+        "(inline)",
+        "(bracketed)",
+        "(leading_star)",
+        "(leading_star_inline)",
+    ):
         assert any(name in v for v in violations), (name, violations)
 
 

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1699,6 +1699,45 @@ def _container_iteration_kind(container: ast.AST, held: ast.AST) -> str:
     return _ITER_YIELDS_VECTOR
 
 
+# How much FOLLOWING each kind licenses, so two answers for one path merge to
+# the louder rather than to whichever arrived last (fix(#1394), codex round 3).
+# `None` — the path IS the vector — follows least: a subscript on it yields an
+# element and stops the escape. Holding a container follows more, because the
+# subscript then yields the vector and the extraction is chased; and a
+# container that yields the vector when iterated follows most, because the loop
+# rule applies on top. Merging toward the loud end keeps a conflict on the
+# reported side, which is the direction this gate is built to fail in.
+_KIND_LOUDNESS: dict[str | None, int] = {
+    None: 0,
+    _ITER_YIELDS_OTHER: 1,
+    _ITER_YIELDS_VECTOR: 2,
+}
+
+
+def _louder_kind(left: str | None, right: str | None) -> str | None:
+    """The kind of two that licenses more following."""
+    return left if _KIND_LOUDNESS[left] >= _KIND_LOUDNESS[right] else right
+
+
+def _queue_path(
+    queue: dict[str, str | None],
+    resolved: dict[str, str | None],
+    path: str,
+    kind: str | None,
+) -> None:
+    """Add ``path`` to the worklist unless this kind is already covered.
+
+    Covered means a kind at least this loud has been walked (``resolved``) or
+    is already queued, so nothing is followed twice for the same reason and a
+    LOUDER kind arriving late still gets its pass. Loudness only ever rises and
+    there are three values, so a path is walked at most three times.
+    """
+    for table in (resolved, queue):
+        if path in table and _KIND_LOUDNESS[table[path]] >= _KIND_LOUDNESS[kind]:
+            return
+    queue[path] = kind
+
+
 def _default_parameter_name(args: ast.arguments, value: ast.AST) -> str | None:
     """The parameter a default value belongs to, positionally or by keyword."""
     positional = [*args.posonlyargs, *args.args]
@@ -1892,6 +1931,50 @@ def _use_reaches_the_binding(used: ast.Name, scope: ast.AST, rel: str) -> bool:
     return True
 
 
+def _derived_paths(used: ast.expr, kind: str | None) -> list[tuple[str, str | None]]:
+    """The paths one load of a tracked path hands the vector on to.
+
+    ``used`` is a load of a path the literal is reachable through, and ``kind``
+    is what that path holds (see ``_container_iteration_kind``). Returns
+    ``(path, kind)`` pairs for everything the load leads to, which the caller
+    merges into its worklist.
+    """
+    derived: list[tuple[str, str | None]] = []
+    if kind is not None:
+        # fix(#996 review): reading a CONTAINER through a subscript or
+        # attribute yields the vector — `commands = {...}` then
+        # `cmd = commands["inspect"]`. Follow that extraction, or the alias
+        # chain stops dead at the container.
+        parent = getattr(used, "_rule2_parent", None)
+        if isinstance(parent, (ast.Subscript, ast.Attribute)) and parent.value is used:
+            extracted, extracted_kind = _binding_targets(parent)
+            derived += [(n, extracted_kind) for n in extracted]
+        # fix(#1394): ITERATING a container hands each element — the argv — to
+        # the loop target, exactly as subscripting it hands over one.
+        # `_binding_targets` already reads that off the AST when the container
+        # is written in place (`for cmd in (["gdalinfo", path],):`); once the
+        # container has a NAME (`commands = (["gdalinfo", path],)` then `for cmd
+        # in commands:`) the AST no longer says so, and only the followed kind
+        # carries what the container was. Without it the shape reported ZERO
+        # argv sites: invisible to the gate, so neither creditable nor
+        # reportable — the one failure direction the #1077 allowlist inversion
+        # exists to remove.
+        #
+        # Gated on the kind for the same reason #996 gated its in-place twin:
+        # iterating the VECTOR (`for part in cmd:`) yields strings, and
+        # iterating a dict that holds the argv as a VALUE yields keys (codex
+        # round 1).
+        if kind == _ITER_YIELDS_VECTOR:
+            derived += [(n, None) for n in _loop_target_paths(used)]
+    aliases, alias_kind = _binding_targets(used)
+    # A wrapper at the ALIAS site is the outermost one now, so it decides what
+    # iterating the alias yields; with no new wrapper the kind carries over
+    # unchanged. Either way the one-bit answer is preserved: the alias holds a
+    # container when this path did or the alias site added one.
+    derived += [(n, alias_kind or kind) for n in aliases]
+    return derived
+
+
 def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
     """The strongest escape a GDAL-headed literal reaches, its bindings included.
 
@@ -1919,17 +2002,27 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
     # `alias = cmd`, `subprocess.run(alias)` reaches an exec through a name the
     # literal was never directly bound to, and stopping at the first hop lost
     # it — a regression against the pre-#996 scan, which flagged everything.
-    seen: set[str] = set()
     # The overwrite guard below applies only to paths the literal binds
     # DIRECTLY. For a derived alias the statement that introduces it would
     # itself look like an overwrite, and over-reporting is the safe side.
     original_paths = set(names)
-    pending = {(n, container_kind) for n in names}
+    # fix(#1394), codex round 3: path -> kind, MERGED, never overwritten. The
+    # worklist used to be a set of pairs collapsed with `{n: c for n, c in
+    # batch}`, so one path reached with two kinds — `x = commands` beside
+    # `x = {"label": commands}` — kept whichever the set happened to yield
+    # last, and the gate's verdict moved with PYTHONHASHSEED. It predates the
+    # kinds (the same collapse could pick either boolean) and widens with them.
+    resolved: dict[str, str | None] = {}
+    pending: dict[str, str | None] = {}
+    for name in names:
+        _queue_path(pending, resolved, name, container_kind)
     while pending:
-        current_batch = pending
-        pending = set()
-        seen |= {n for n, _ in current_batch}
-        current_paths = {n: c for n, c in current_batch}
+        current_paths = pending
+        pending = {}
+        for queued, queued_kind in current_paths.items():
+            resolved[queued] = _louder_kind(
+                resolved.get(queued, queued_kind), queued_kind
+            )
         for used in ast.walk(scope):
             if not isinstance(used, (ast.Name, ast.Attribute, ast.Subscript)):
                 continue
@@ -1944,47 +2037,11 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
             if path in original_paths and _overwritten_before(used, node, path):
                 continue
             kind = current_paths[path]
-            holds = kind is not None
-            # fix(#996 review): reading a CONTAINER through a subscript or
-            # attribute yields the vector — `commands = {...}` then
-            # `cmd = commands["inspect"]`. Follow that extraction, or the
-            # alias chain stops dead at the container.
-            if holds:
-                parent = getattr(used, "_rule2_parent", None)
-                if (
-                    isinstance(parent, (ast.Subscript, ast.Attribute))
-                    and parent.value is used
-                ):
-                    extracted, extracted_kind = _binding_targets(parent)
-                    pending |= {(n, extracted_kind) for n in extracted - seen}
-                # fix(#1394): ITERATING a container hands each element — the
-                # argv — to the loop target, exactly as subscripting it hands
-                # over one. `_binding_targets` already reads that off the AST
-                # when the container is written in place (`for cmd in
-                # (["gdalinfo", path],):`); once the container has a NAME
-                # (`commands = (["gdalinfo", path],)` then `for cmd in
-                # commands:`) the AST no longer says so, and only this loop
-                # carries what the container was. Without it the shape reported
-                # ZERO argv sites: invisible to the gate, so neither creditable
-                # nor reportable — the one failure direction the #1077
-                # allowlist inversion exists to remove.
-                #
-                # Gated on the kind for the same reason #996 gated its in-place
-                # twin: iterating the VECTOR (`for part in cmd:`) yields
-                # strings, and iterating a dict that holds the argv as a VALUE
-                # yields keys (codex round 1).
-                if kind == _ITER_YIELDS_VECTOR:
-                    pending |= {(n, None) for n in _loop_target_paths(used) - seen}
-            best = max(best, _escape_kind(used, vector=not holds))
+            best = max(best, _escape_kind(used, vector=kind is None))
             if best == _ESCAPE_CALL:
                 return best
-            aliases, alias_kind = _binding_targets(used)
-            # A wrapper at the ALIAS site is the outermost one now, so it
-            # decides what iterating the alias yields; with no new wrapper the
-            # kind carries over unchanged. Either way the one-bit answer is
-            # preserved: the alias holds a container when this path did or the
-            # alias site added one.
-            pending |= {(n, alias_kind or kind) for n in aliases - seen}
+            for name, derived_kind in _derived_paths(used, kind):
+                _queue_path(pending, resolved, name, derived_kind)
     return best
 
 
@@ -3256,6 +3313,42 @@ def test_guard_destructuring_loop_target_does_not_receive_the_argv():
     )
     assert total == 0, (total, violations)
     assert violations == []
+
+
+def test_guard_conflicting_container_kinds_merge_to_the_louder():
+    """fix(#1394), codex round 3: a path reached twice has ONE answer.
+
+    ``x = commands`` beside ``x = {"label": commands}`` puts ``x`` on the
+    worklist as both a sequence and a dict. Collapsing the pairs kept whichever
+    the set happened to yield last, so the verdict moved with
+    ``PYTHONHASHSEED``; they now merge to the kind that follows MORE, which
+    keeps a conflict on the reported side.
+
+    The merge rule is pinned directly, because the end-to-end shape below can
+    only ever catch a regression on half the seeds — which is the flake this
+    exists to prevent, not a gate.
+    """
+    assert _louder_kind(_ITER_YIELDS_VECTOR, None) == _ITER_YIELDS_VECTOR
+    assert _louder_kind(None, _ITER_YIELDS_VECTOR) == _ITER_YIELDS_VECTOR
+    assert _louder_kind(_ITER_YIELDS_VECTOR, _ITER_YIELDS_OTHER) == _ITER_YIELDS_VECTOR
+    assert _louder_kind(_ITER_YIELDS_OTHER, _ITER_YIELDS_VECTOR) == _ITER_YIELDS_VECTOR
+    assert _louder_kind(_ITER_YIELDS_OTHER, None) == _ITER_YIELDS_OTHER
+    assert _louder_kind(None, None) is None
+
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def fn(path):\n"
+            "    commands = [['gdalinfo', path]]\n"
+            "    x = commands\n"
+            "    x = {'label': commands}\n"
+            "    for cmd in x:\n"
+            "        subprocess.run(cmd)\n"
+        ),
+        {},
+    )
+    assert total == 1, (total, violations)
+    assert len(violations) == 1 and "(fn)" in violations[0]
 
 
 def test_guard_container_kind_survives_an_alias_hop():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1761,6 +1761,44 @@ def _positional_targets(targets: list[ast.expr], index: int) -> list[ast.expr] |
     return matched if (saw_sequence and matched) else None
 
 
+def _unpacked_binding(
+    targets: list[ast.expr],
+    chain: list[tuple[int | None, str | None]],
+    container_kind: str | None,
+) -> tuple[set[str], str | None] | None:
+    """Pair the wrappers a literal sits in against the patterns unpacking them.
+
+    ``chain`` lists those wrappers OUTERMOST first, each with the index the
+    value occupies in it and the kind of what is INSIDE it. Every level where
+    some target is a sequence pattern consumes one wrapper and descends; the
+    first level where none is receives whatever is left, at the kind below the
+    last wrapper consumed. Returns None when nothing was unpacked at all, and
+    the caller keeps its plain-assignment answer.
+
+    fix(#1394), codex rounds 11 and 12. Unpacking CONSUMES the wrapper it takes
+    apart, so `alias, = (["gdalinfo", path],)` leaves `alias` holding the
+    vector, and `for part in alias:` then yields strings rather than commands.
+    Handling one level was not enough, because patterns nest as freely as
+    displays do: `((alias,),) = ((["gdalinfo", path],),)` consumes two and
+    lands in the same place, while `(alias,) = ((["gdalinfo", path],),)`
+    consumes one and leaves a container. Counting them one for one is the only
+    answer that covers both without a rule per depth.
+    """
+    current = targets
+    kind = container_kind
+    consumed = False
+    for index, kind_below in chain:
+        if index is None:
+            break
+        nxt = _positional_targets(current, index)
+        if nxt is None:
+            break
+        current, kind, consumed = nxt, kind_below, True
+    if not consumed:
+        return None
+    return {n for target in current for n in _target_names(target)}, kind
+
+
 # Expression wrappers a value passes through without being consumed. A literal
 # inside one is still the value the surrounding statement binds or hands on.
 # Two kinds, and the difference is load-bearing. fix(#996 review): they shared
@@ -1906,11 +1944,12 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
     """
     current: ast.AST = node
     parent = getattr(current, "_rule2_parent", None)
-    index_in_parent: int | None = None
     container_kind: str | None = None
-    # The kind as it was BELOW the wrapper `index_in_parent` names, which is
-    # what a positional unpacking of that wrapper hands its targets.
-    unpacked_kind: str | None = None
+    # Every wrapper climbed, innermost first: the index the value occupies in
+    # it (None when the wrapper is not a positional display) and the kind of
+    # what is INSIDE it. An unpacking pattern consumes these one for one, so
+    # the pairing needs the whole chain, not just its outermost link.
+    chain: list[tuple[int | None, str | None]] = []
     while isinstance(parent, _TRANSPARENT_WRAPPERS):
         # fix(#1394), codex round 8: a VALUE wrapper only carries the value in
         # a position it can evaluate to. `empty = [] if commands else ()` never
@@ -1939,26 +1978,17 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
         if isinstance(parent, _CONTAINER_WRAPPERS) and not starred:
             container_kind = _container_iteration_kind(parent, current)
         if isinstance(parent, (ast.Tuple, ast.List)) and current in parent.elts:
-            index_in_parent = parent.elts.index(current)
-            # fix(#1394), codex round 11: a positional UNPACKING consumes
-            # exactly the wrapper just climbed. `alias, = (["gdalinfo", path],)`
-            # takes the tuple apart, so `alias` is the vector, not a container
-            # of it, and `for part in alias:` then yields strings. Keeping the
-            # wrapper's kind read that loop as handing over a command.
-            unpacked_kind = kind_below
+            chain.append((parent.elts.index(current), kind_below))
         else:
-            index_in_parent = None
-            unpacked_kind = None
+            chain.append((None, kind_below))
         current = parent
         parent = getattr(current, "_rule2_parent", None)
+    chain.reverse()  # outermost first, the order an unpacking consumes them
 
     if isinstance(parent, ast.Assign) and parent.value is current:
-        if index_in_parent is not None:
-            positional = _positional_targets(parent.targets, index_in_parent)
-            if positional is not None:
-                return {
-                    n for target in positional for n in _target_names(target)
-                }, unpacked_kind
+        unpacked = _unpacked_binding(parent.targets, chain, container_kind)
+        if unpacked is not None:
+            return unpacked
         return {
             n for target in parent.targets for n in _target_names(target)
         }, container_kind
@@ -3699,6 +3729,11 @@ def test_guard_positional_unpacking_consumes_the_wrapper():
 
     The control in the middle: ``alias`` is the vector, so spawning it directly
     is still a site — the fix must not turn the unpacking into a dead end.
+
+    codex round 12: patterns nest as freely as displays do, so the wrappers and
+    the patterns are counted one for one. ``((alias,),) = ((argv,),)`` consumes
+    two and lands where the single unpacking does, while ``(alias,) =
+    ((argv,),)`` consumes one and leaves a container — the last two functions.
     """
     violations, total = _collect_gdal_cli_violations(
         _mod(
@@ -3714,14 +3749,23 @@ def test_guard_positional_unpacking_consumes_the_wrapper():
             "    alias, = ((['gdalwarp', path],),)\n"
             "    for cmd in alias:\n"
             "        subprocess.run(cmd)\n"
+            "def nested_pattern(path):\n"
+            "    ((alias,),) = ((['gdaladdo', path],),)\n"
+            "    for part in alias:\n"
+            "        consume(part)\n"
+            "def nested_pattern_half(path):\n"
+            "    (alias,) = ((['gdal_translate', path],),)\n"
+            "    for cmd in alias:\n"
+            "        subprocess.run(cmd)\n"
         ),
         {},
     )
-    assert total == 2, (total, violations)
-    assert len(violations) == 2, violations
-    for reported in ("(spawned)", "(one_deeper)"):
+    assert total == 3, (total, violations)
+    assert len(violations) == 3, violations
+    for reported in ("(spawned)", "(one_deeper)", "(nested_pattern_half)"):
         assert any(reported in v for v in violations), (reported, violations)
-    assert not any("(unpacked)" in v for v in violations), violations
+    for quiet in ("(unpacked)", "(nested_pattern)"):
+        assert not any(quiet in v for v in violations), (quiet, violations)
 
 
 def test_guard_a_sliced_container_is_still_a_container():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1791,9 +1791,17 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
     index_in_parent: int | None = None
     container_kind: str | None = None
     while isinstance(parent, _TRANSPARENT_WRAPPERS):
+        # fix(#1394), codex round 4: `*` SPLICES rather than nests, so a display
+        # holding a starred vector holds its ELEMENTS and is itself a vector —
+        # `[*["gdalinfo", path]]` IS `["gdalinfo", path]`. Reading the display
+        # as a container of the argv made `for part in commands:` look like it
+        # handed over a command when it hands over strings. Checked on the node
+        # being climbed OUT of, so it lands on the display above the star.
+        if isinstance(current, ast.Starred):
+            container_kind = None
         # Only a CONTAINER wrapper means the level above holds the vector
         # rather than being it (fix(#996 review)).
-        if isinstance(parent, _CONTAINER_WRAPPERS):
+        elif isinstance(parent, _CONTAINER_WRAPPERS):
             container_kind = _container_iteration_kind(parent, current)
         if isinstance(parent, (ast.Tuple, ast.List)) and current in parent.elts:
             index_in_parent = parent.elts.index(current)
@@ -3313,6 +3321,54 @@ def test_guard_destructuring_loop_target_does_not_receive_the_argv():
     )
     assert total == 0, (total, violations)
     assert violations == []
+
+
+def test_guard_starring_an_argv_splices_it_into_the_display():
+    """fix(#1394), codex round 4: `*` flattens, so there is no container.
+
+    ``commands = [*["gdalinfo", path]]`` IS ``["gdalinfo", path]``. Reading the
+    outer display as a container of the argv made ``for part in commands:``
+    look like it handed over a command when it hands over strings — inert data
+    reported, the #996 class. The vector is still a vector, so passing the
+    spliced display to a subprocess is still a site (the second case), and
+    nesting the star one level deeper puts a real container back (the third).
+    """
+    inert, total = _collect_gdal_cli_violations(
+        _mod(
+            "def fn(path):\n"
+            "    commands = [*['gdalinfo', path]]\n"
+            "    for part in commands:\n"
+            "        consume(part)\n"
+        ),
+        {},
+    )
+    assert total == 0, (total, inert)
+    assert inert == []
+
+    spawned, total_spawned = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def fn(path):\n"
+            "    commands = [*['gdalinfo', path]]\n"
+            "    subprocess.run(commands)\n"
+        ),
+        {},
+    )
+    assert total_spawned == 1, (total_spawned, spawned)
+    assert len(spawned) == 1 and "(fn)" in spawned[0]
+
+    nested, total_nested = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def fn(path):\n"
+            "    commands = [[*['gdalinfo', path]]]\n"
+            "    for cmd in commands:\n"
+            "        subprocess.run(cmd)\n"
+        ),
+        {},
+    )
+    assert total_nested == 1, (total_nested, nested)
+    assert len(nested) == 1 and "(fn)" in nested[0]
 
 
 def test_guard_conflicting_container_kinds_merge_to_the_louder():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1761,9 +1761,18 @@ def _positional_targets(targets: list[ast.expr], index: int) -> list[ast.expr] |
     return matched if (saw_sequence and matched) else None
 
 
-# A wrapper whose contents are known only by KIND, not by shape: which
-# position holds the argv is unknowable, and in a container of argvs every one
-# does (fix(#1394), codex round 14).
+# A wrapper whose contents are known only by KIND, not by shape: which position
+# holds the argv is unknowable, and in a container of argvs every one does
+# (fix(#1394), codex round 14).
+#
+# So unpacking one binds EVERY name in the pattern, and where the container is
+# actually heterogeneous — `container = (argv, None)` reached through a name,
+# then `first, ignored = alias` — the inert position reports too (codex round
+# 15, declined). Positions are exactly what a kind drops, and this analysis has
+# tracked no container ELEMENTS since #996; recovering them means the static
+# analyser #996 declined to write. The alternative on the table was dropping
+# the inherited level, which reinstates the round-14 silent miss: a false alarm
+# somebody investigates traded for an all-clear nobody sees. Take the alarm.
 _ANY_POSITION = -1
 
 
@@ -1790,7 +1799,7 @@ def _unpacked_binding(
     targets: list[ast.expr],
     chain: list[tuple[int | None, str | None, bool]],
     container_kind: str | None,
-) -> tuple[set[str], str | None] | None:
+) -> dict[str, str | None] | None:
     """Pair the wrappers a literal sits in against the patterns unpacking them.
 
     ``chain`` lists those wrappers OUTERMOST first, each with the index the
@@ -1818,9 +1827,13 @@ def _unpacked_binding(
     unpack to DIFFERENT depths, so a target whose pattern ends early is kept at
     that depth instead of being dropped when its siblings descend further.
 
-    The kinds those endpoints hold are merged, not split, because the caller
-    speaks of one path set with one kind. Merging toward the louder end keeps
-    the disagreement on the reported side, as everywhere else here.
+    Those endpoints keep their OWN kinds (codex round 15). Chained targets can
+    end at different depths, so ``(alias,) = ((deep,),) = ((["gdalinfo",
+    path],),)`` leaves ``alias`` holding a container and ``deep`` holding the
+    argv, and one kind for both names could only be wrong about one of them.
+    Merging happened here because the answer was a set plus a kind; it is a
+    mapping now, and merging is left to the one case that needs it, a name that
+    really does appear at two depths.
     """
     current = targets
     kind = container_kind
@@ -1845,12 +1858,15 @@ def _unpacked_binding(
     if not consumed:
         return None
     endpoints.extend((_target_names(target), kind) for target in current)
-    names: set[str] = set()
-    merged: str | None = None
+    bound: dict[str, str | None] = {}
     for target_names, endpoint_kind in endpoints:
-        names |= target_names
-        merged = _louder_kind(merged, endpoint_kind)
-    return names, merged
+        for name in target_names:
+            bound[name] = (
+                _louder_kind(bound[name], endpoint_kind)
+                if name in bound
+                else endpoint_kind
+            )
+    return bound
 
 
 # Expression wrappers a value passes through without being consumed. A literal
@@ -1982,7 +1998,7 @@ def _defaults_owner(node: ast.AST) -> ast.AST | None:
 
 def _binding_targets(
     node: ast.AST, *, inherited: str | None = None
-) -> tuple[set[str], str | None]:
+) -> dict[str, str | None]:
     """Names this literal's value is reachable through in its own scope.
 
     Climbs out of transparent wrappers first (fix(#996 review)), so
@@ -1991,12 +2007,16 @@ def _binding_targets(
     ``=`` including unpacking, annotated ``=``, the walrus, and the loop target
     of a ``for``/``async for``/comprehension over a literal.
 
-    Returns ``(names, container_kind)``. ``container_kind`` is ``None`` when
-    those names refer to the command vector ITSELF, which is what decides that
-    a subscript on them yields an element rather than the vector. When they
-    refer to something WRAPPING it, the kind additionally says what iterating
-    that wrapper hands over (fix(#1394), see ``_container_iteration_kind``);
-    callers that only need the one bit ask ``kind is not None``.
+    Returns ``{path: container_kind}``. A kind of ``None`` means that path
+    refers to the command vector ITSELF, which is what decides that a subscript
+    on it yields an element rather than the vector. Otherwise the path refers
+    to something WRAPPING the vector, and the kind says what ITERATING that
+    wrapper hands over (fix(#1394), see ``_container_iteration_kind``); callers
+    that only need the one bit ask ``kind is not None``.
+
+    Per path, not one kind for the set (codex round 15): a chained unpacking
+    can end at different depths, and one answer for every name could only be
+    wrong about some of them.
 
     ``inherited`` is the kind ``node``'s value ALREADY carries when the AST
     does not show it — a name known to hold a container of argvs, say. The
@@ -2066,20 +2086,22 @@ def _binding_targets(
         if unpacked is not None:
             return unpacked
         return {
-            n for target in parent.targets for n in _target_names(target)
-        }, container_kind
+            n: container_kind
+            for target in parent.targets
+            for n in _target_names(target)
+        }
     # fix(#996 review): the same path rule as the Assign branch above. An
     # annotated `box.cmd: list[str] = [...]` binds a path exactly like the
     # unannotated form; requiring a bare Name here dropped it. A walrus target
     # is always a Name, so it rides the same branch.
     if isinstance(parent, (ast.AnnAssign, ast.NamedExpr)) and parent.value is current:
-        return _target_names(parent.target), container_kind
+        return {n: container_kind for n in _target_names(parent.target)}
     # fix(#996 review): `cmd = []` then `cmd += ["gdalinfo", path]` assembles a
     # real argv, and the literal's parent is an AugAssign that none of the
     # branches above matched. The kind is None regardless: `+=` splices the
     # elements in, so the target holds the vector rather than a container.
     if isinstance(parent, ast.AugAssign) and parent.value is current:
-        return _target_names(parent.target), None
+        return {n: None for n in _target_names(parent.target)}
     # fix(#996 review): `def run(cmd=("gdalinfo", "-json")): subprocess.run(cmd)`
     # executes the default on every bare call. The literal sits in the
     # signature, so the escape walk stops at the function boundary and no
@@ -2087,7 +2109,7 @@ def _binding_targets(
     if isinstance(parent, ast.arguments):
         name = _default_parameter_name(parent, current)
         if name:
-            return {name}, None
+            return {name: None}
     # fix(#996 review): `for cmd in (["gdalinfo", path],): subprocess.run(cmd)`
     # reaches an exec through the loop target. Same for `async for` and for a
     # comprehension's generator.
@@ -2101,8 +2123,8 @@ def _binding_targets(
         # vector itself, not a container of it.
         loop_targets = _loop_target_paths(current)
         if loop_targets:
-            return loop_targets, None
-    return set(), None
+            return {n: None for n in loop_targets}
+    return {}
 
 
 def _enclosing_statement(node: ast.AST, body: list) -> ast.stmt | None:
@@ -2212,10 +2234,9 @@ def _derived_paths(used: ast.expr, kind: str | None) -> list[tuple[str, str | No
             sliced = isinstance(parent, ast.Subscript) and isinstance(
                 parent.slice, ast.Slice
             )
-            extracted, extracted_kind = _binding_targets(
-                parent, inherited=kind if sliced else None
+            derived += list(
+                _binding_targets(parent, inherited=kind if sliced else None).items()
             )
-            derived += [(n, extracted_kind) for n in extracted]
         # fix(#1394): ITERATING a container hands each element — the argv — to
         # the loop target, exactly as subscripting it hands over one.
         # `_binding_targets` already reads that off the AST when the container
@@ -2238,8 +2259,7 @@ def _derived_paths(used: ast.expr, kind: str | None) -> list[tuple[str, str | No
     # unchanged, and an UNPACKING there takes one off. All three are the same
     # question, so the inherited kind goes in and the answer comes back
     # absolute rather than being re-applied here (codex round 14).
-    aliases, alias_kind = _binding_targets(used, inherited=kind)
-    derived += [(n, alias_kind) for n in aliases]
+    derived += list(_binding_targets(used, inherited=kind).items())
     return derived
 
 
@@ -2261,9 +2281,9 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
     best = _escape_kind(node)
     if best == _ESCAPE_CALL:
         return best
-    names, container_kind = _binding_targets(node)
+    bindings = _binding_targets(node)
     scope = _defaults_owner(node) or _scope_root(node)
-    if not names or scope is None:
+    if not bindings or scope is None:
         return best
 
     # fix(#996 review): follow re-aliasing to a fixed point. `cmd = [...]`,
@@ -2273,7 +2293,7 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
     # The overwrite guard below applies only to paths the literal binds
     # DIRECTLY. For a derived alias the statement that introduces it would
     # itself look like an overwrite, and over-reporting is the safe side.
-    original_paths = set(names)
+    original_paths = set(bindings)
     # fix(#1394), codex round 3: path -> kind, MERGED, never overwritten. The
     # worklist used to be a set of pairs collapsed with `{n: c for n, c in
     # batch}`, so one path reached with two kinds — `x = commands` beside
@@ -2282,8 +2302,8 @@ def _argv_escape_kind(node: ast.List | ast.Tuple, rel: str) -> int:
     # kinds (the same collapse could pick either boolean) and widens with them.
     resolved: dict[str, str | None] = {}
     pending: dict[str, str | None] = {}
-    for name in names:
-        _queue_path(pending, resolved, name, container_kind)
+    for name, name_kind in bindings.items():
+        _queue_path(pending, resolved, name, name_kind)
     while pending:
         current_paths = pending
         pending = {}
@@ -3884,6 +3904,21 @@ def test_guard_unpacking_pairs_only_with_real_levels():
     )
     assert total_uneven == 1, (total_uneven, uneven)
     assert len(uneven) == 1 and "(uneven_chain)" in uneven[0]
+
+    # codex round 15: those two endpoints hold DIFFERENT things — `alias` a
+    # container, `deep` the argv — so one kind for both names could only be
+    # wrong about one of them. Iterating `deep` yields strings.
+    per_endpoint, total_per_endpoint = _collect_gdal_cli_violations(
+        _mod(
+            "def uneven_chain(path):\n"
+            "    (alias,) = ((deep,),) = ((['gdalinfo', path],),)\n"
+            "    for part in deep:\n"
+            "        consume(part)\n"
+        ),
+        {},
+    )
+    assert total_per_endpoint == 0, (total_per_endpoint, per_endpoint)
+    assert per_endpoint == []
 
 
 def test_guard_unpacking_a_named_container_consumes_its_kind():

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -1580,6 +1580,34 @@ def _target_names(target: ast.expr) -> set[str]:
     return {path} if path else set()
 
 
+def _is_value_position(current: ast.AST, parent: ast.AST) -> bool:
+    """True when ``parent`` can EVALUATE TO ``current``.
+
+    Not every field of a value wrapper is one of its values, and the two that
+    are not both showed up as false positives (codex rounds 7 and 8).
+
+    A ternary yields one of its two RESULTS; its condition is only read for
+    truthiness, so ``[] if commands else ()`` is never ``commands``.
+
+    A boolean operator yields a non-final operand only when that operand
+    DECIDES the expression, and the two operators decide on opposite
+    truthiness. ``or`` yields it when truthy, so ``commands or ()`` really can
+    be ``commands`` with argvs in it. ``and`` yields it when FALSY, so
+    ``commands and ()`` can only ever be an EMPTY ``commands`` — iterating that
+    runs nothing. The final operand is a possible result for both.
+
+    Everything else in ``_VALUE_WRAPPERS`` (the ``+`` chain) passes its value
+    through from any operand.
+    """
+    if isinstance(parent, ast.IfExp):
+        return current is parent.body or current is parent.orelse
+    if isinstance(parent, ast.BoolOp):
+        return bool(parent.values) and (
+            isinstance(parent.op, ast.Or) or current is parent.values[-1]
+        )
+    return isinstance(parent, _VALUE_WRAPPERS)
+
+
 def _intact_loop_target(target: ast.expr) -> ast.expr | None:
     """The part of a loop target that receives an element WHOLE, or None.
 
@@ -1610,9 +1638,9 @@ def _depth_preserving_ancestor(expr: ast.AST) -> ast.AST:
     (fix(#1394), codex round 6):
 
     * a VALUE wrapper — ``commands or ()``, ``commands if flag else ()``,
-      ``commands + extra`` — which evaluates to the thing it wraps. A ternary
-      qualifies through its two RESULTS only; its condition is not part of its
-      value (codex round 7).
+      ``commands + extra`` — in a position it can actually evaluate to, which
+      rules out a ternary's condition and a non-final ``and`` operand (see
+      ``_is_value_position``).
     * a star inside a display, ``(*commands,)``, which splices ``commands``'
       elements into a new one and so preserves its depth (codex round 5). The
       pair counts once, exactly as it does in ``_binding_targets``.
@@ -1623,17 +1651,7 @@ def _depth_preserving_ancestor(expr: ast.AST) -> ast.AST:
     current: ast.AST = expr
     while True:
         parent = getattr(current, "_rule2_parent", None)
-        if isinstance(parent, ast.IfExp):
-            # codex round 7 on #1394: a ternary's TEST is not part of its
-            # value. `[] if commands else ()` evaluates to one of two empty
-            # displays and has nothing to do with `commands`, so climbing from
-            # the condition claimed the loop iterated the container and
-            # reported an argv that never runs.
-            if current is parent.body or current is parent.orelse:
-                current = parent
-                continue
-            return current
-        if isinstance(parent, _VALUE_WRAPPERS):
+        if parent is not None and _is_value_position(current, parent):
             current = parent
             continue
         if isinstance(parent, ast.Starred):
@@ -1865,6 +1883,17 @@ def _binding_targets(node: ast.AST) -> tuple[set[str], str | None]:
     index_in_parent: int | None = None
     container_kind: str | None = None
     while isinstance(parent, _TRANSPARENT_WRAPPERS):
+        # fix(#1394), codex round 8: a VALUE wrapper only carries the value in
+        # a position it can evaluate to. `empty = [] if commands else ()` never
+        # binds `commands` to `empty`, and neither does
+        # `nothing = commands and ()`; climbing anyway put an always-empty name
+        # on the follow list, where the loop rule then reported an argv that
+        # cannot run. Stopping here leaves no branch below matching, which is
+        # the accurate answer: nothing above binds this value.
+        if isinstance(parent, _VALUE_WRAPPERS) and not _is_value_position(
+            current, parent
+        ):
+            break
         # fix(#1394), codex rounds 4 and 5: a star and the display around it
         # are ONE level, not two. `*X` splices X's ELEMENTS into that display,
         # which PRESERVES X's own depth rather than adding or removing one:
@@ -3547,6 +3576,18 @@ def test_guard_a_wrapped_iterable_is_still_the_same_loop():
         loop_targets_of("for cmd in ([] if commands else ()):\n    pass\n", "commands")
         == set()
     )
+    # codex round 8: `and` yields a non-final operand only when it is FALSY,
+    # so an `and`-guarded container can never be iterated with anything in it.
+    # `or` yields it when truthy, and the final operand is a result for both.
+    assert (
+        loop_targets_of("for cmd in commands and ():\n    pass\n", "commands") == set()
+    )
+    assert loop_targets_of("for cmd in () and commands:\n    pass\n", "commands") == {
+        "cmd"
+    }
+    assert loop_targets_of("for cmd in () or commands:\n    pass\n", "commands") == {
+        "cmd"
+    }
 
     violations, total = _collect_gdal_cli_violations(
         _mod(
@@ -3571,12 +3612,59 @@ def test_guard_a_wrapped_iterable_is_still_the_same_loop():
             "    commands = [['gdal_translate', path]]\n"
             "    for cmd in ([] if commands else ()):\n"
             "        subprocess.run(cmd)\n"
+            "def and_guarded(path):\n"
+            "    commands = [['nearblack', path]]\n"
+            "    for cmd in commands and ():\n"
+            "        subprocess.run(cmd)\n"
         ),
         {},
     )
     assert total == 4, (total, violations)
     assert len(violations) == 4, violations
-    assert not any("(condition_only)" in v for v in violations), violations
+    for quiet in ("(condition_only)", "(and_guarded)"):
+        assert not any(quiet in v for v in violations), (quiet, violations)
+
+
+def test_guard_a_dead_wrapper_alias_is_not_followed_either():
+    """fix(#1394), codex round 8: the same rule one alias hop away.
+
+    ``empty = [] if commands else ()`` and ``nothing = commands and ()`` are
+    always empty, so a later ``for cmd in empty:`` runs nothing. The wrapper
+    rule lived only where the loop reads its iterable, and ``_binding_targets``
+    climbed every value wrapper unconditionally, so the alias inherited the
+    container kind and the loop rule reported an argv that cannot run. Both
+    now stop at the wrapper, and the live spellings beside them still report.
+    """
+    violations, total = _collect_gdal_cli_violations(
+        _mod(
+            "import subprocess\n"
+            "def dead_condition(path):\n"
+            "    commands = [['gdalinfo', path]]\n"
+            "    empty = [] if commands else ()\n"
+            "    for cmd in empty:\n"
+            "        subprocess.run(cmd)\n"
+            "def dead_and(path):\n"
+            "    commands = [['ogrinfo', path]]\n"
+            "    nothing = commands and ()\n"
+            "    for cmd in nothing:\n"
+            "        subprocess.run(cmd)\n"
+            "def live_result(path, flag):\n"
+            "    commands = [['gdalwarp', path]]\n"
+            "    chosen = commands if flag else ()\n"
+            "    for cmd in chosen:\n"
+            "        subprocess.run(cmd)\n"
+            "def live_or(path):\n"
+            "    commands = [['gdaladdo', path]]\n"
+            "    chosen = commands or ()\n"
+            "    for cmd in chosen:\n"
+            "        subprocess.run(cmd)\n"
+        ),
+        {},
+    )
+    assert total == 2, (total, violations)
+    assert len(violations) == 2, violations
+    for live in ("(live_result)", "(live_or)"):
+        assert any(live in v for v in violations), (live, violations)
 
 
 def test_guard_conflicting_container_kinds_merge_to_the_louder():


### PR DESCRIPTION
## The gap

`test_rule2_structural.py` decides whether a GDAL-headed literal is an argv by asking where its value goes. It follows the value out of a container through subscript and attribute loads, so this is tracked:

```python
commands = (["gdalinfo", path],)
subprocess.run(commands[0])
```

Iterating the same container was not:

```python
commands = (["gdalinfo", path],)
for cmd in commands:
    subprocess.run(cmd)          # zero argv sites
```

Zero sites means the gate never sees the call. It cannot credit it and it cannot report it — the one failure direction the #1077 credit inversion was built to remove. Detection, not credit: no exemption rule makes an undetected site appear.

The rule already existed for the spelling where the container is written in place. `for cmd in (["gdalinfo", path],):` has been detected since #996, via `_binding_targets`, which reads the `For` node straight off the AST. Giving the container a name is what broke it: at the load of `commands` the AST no longer says a container is being iterated, and only `_argv_escape_kind`'s alias walk knows.

## The fix

Iterating a container is the same question as subscripting it, so it gets the same answer, in the place that already answers it. `_argv_escape_kind`'s `if holds:` block extracted through `Subscript`/`Attribute`; it now also follows a loop target, binding each element as the vector.

`_loop_target_paths` is the single definition of what a loop binds, called by both readers: `_binding_targets` for the in-place container, `_argv_escape_kind` for the named one.

Getting that right needed four questions answered, all found in review and each with its own regression:

**What does iterating this container yield?** A list, tuple or set yields its elements, so the loop target receives the argv. A dict yields its KEYS, so `for key in {"inspect": ["gdalinfo", path]}` receives a string and the argv never moves. "Holds a container" was one bit and this needs two, so `_binding_targets` returns what iterating the wrapper hands over, and the kind travels with the path across alias hops. The rule reads WHERE the literal sits rather than testing for `dict` — a literal used as a KEY is exactly what iteration yields.

**What does the target receive?** A plain name or path receives the element whole. `for tool, arg in commands:` splits the argv into strings and gets nothing. `for *cmd, in commands:` gets everything — `list(element)`, the vector rebuilt — so it is not destructuring despite being spelled like it. A partial star (`for tool, *rest in commands:`) gets a suffix, which is not a GDAL-headed command.

**Which expression is being iterated?** `for cmd in commands or ():` iterates `commands`. `_depth_preserving_ancestor` names the property once: the outermost expression that is still the same value at the same container depth. That covers `or`, the ternary's two RESULTS (not its condition), `+`, and a star into a display. A CONTAINER wrapper is deliberately excluded — `[commands]` is a level deeper.

**How does `*` count?** Splicing PRESERVES depth. `[*argv]` is the vector; `[*(argv,)]` is a container of it. So a star and the display around it are ONE level, not two, and neither node moves the kind.

One more fix is not about loops at all. The escape worklist was a set of `(path, kind)` pairs collapsed each pass with a dict comprehension, so a path reached with two kinds kept whichever the set yielded last and the verdict moved with `PYTHONHASHSEED`. It predates this PR (the same collapse could pick either boolean). The worklist is now a path -> kind mapping merged by `_louder_kind`, which keeps the answer that licenses MORE following, so a conflict lands on the reported side. `_queue_path` re-queues only when a louder kind arrives late, so loudness rises monotonically and the walk terminates in at most three passes per path.

Credit semantics are untouched. The new sites go through the ordinary #1077 rules, which is worth reading out loud for one case: an env built in the loop BODY does not credit, because a loop body may run zero times. So the creditable spelling hoists the env above the loop, and an in-loop env reports — the same verdict the inline `for cmd in (["gdalinfo", path],):` form has had all along. That consistency is asserted rather than described.

## Site counts

Measured with the gate's own collectors on `backend/app/`:

| | before | after |
|---|---|---|
| GDAL CLI argv sites | 11 | 11 |
| `rasterio.open` sites | 6 | 6 |
| violations | 0 | 0 |
| `GDAL_CLI_CALL_ALLOWLIST` entries used | 6 | 6 |

No allowlist entry moved and neither floor (`MIN_GDAL_CLI_ARGV_SITES`, `MIN_RASTERIO_OPEN_SITES`) changed. Nothing in `app/` iterates a named container of argvs today, so the real tree is unaffected by construction — the change adds detection and removes none.

## Tests

Six new regressions, one per question above plus the determinism one:

* the issue shape three ways — unclamped reports, clamped with the env hoisted above the loop credits, clamped inside the loop body reports
* the control for the container gate: `for part in cmd:` and a named tool-name list stay inert
* the dict: inert when iterated, still reached when subscripted, reported when the argv is the KEY; and the kind surviving an alias hop, list beside dict
* destructuring inert (named, inline, partial star) and the all-consuming star reported (named, inline, `[*cmd]`)
* the wrapped iterable: `or`, ternary, `+` and star all report, the ternary CONDITION does not, and `_loop_target_paths` is pinned directly for the container-wrapper case, where end-to-end the container escapes either way
* `*` splicing: star of the vector inert when iterated, still a site when spawned, and star of a container reported both iterated and indexed
* `_louder_kind`'s table, pinned directly, because the end-to-end shape can only catch a last-wins regression on half the seeds

Mutation-checked: stubbing out the loop follow fails exactly the new detection test; making `_container_iteration_kind` uniform fails exactly the two dict tests.

## Residue

The docstring's silent-direction list gains three neighbours of this rule, all "no container-element tracking" in different clothes, each needing its own machinery rather than a wider rule:

- the container kind names what ONE wrapper yields, not a depth, so a container of containers (`groups = ((["gdalinfo", path],),)`) hands the inner container to the loop target as if it were the vector.
- a container reached through a METHOD (`for cmd in commands.values()`) is a call this analysis does not model, which is also why a dict holding argvs as values only ever reaches them by subscript here.
- a comprehension TARGET binds in the comprehension's own scope, which `_use_reaches_the_binding` reads as a shadow, so `[subprocess.run(cmd) for cmd in commands]` links only when the comprehension itself escapes. That one predates this PR and applies equally to the inline `for cmd in (["gdalinfo", path],)` spelling.

The "Still open" paragraph #1391 added to the credit section is rewritten to say this is closed and where.

## Verification

Run from `backend/` with `.env.test` sourced:

- `uv run pytest tests/test_rule2_structural.py tests/test_rule1_structural.py tests/test_layering.py -q` → 139 passed
- `uv run ruff check tests/test_rule2_structural.py` → All checks passed
- `uv run ruff format --check tests/test_rule2_structural.py` → 1 file already formatted
- the collectors over `PYTHONHASHSEED` 0,1,2,3,7,11,42,12345 on nineteen synthetic shapes plus the real tree → identical verdicts on every seed

Test infrastructure only. No `backend/app/` changes, no schema, API or config impact.

Closes #1394
