### PR TITLE
feat(frontend): set-primary control in DistributionsList

### DIFF
--- a/frontend/src/api/records.ts
+++ b/frontend/src/api/records.ts
@@ -4,6 +4,8 @@ import type {
   ContactResponse,
   ContactListResponse,
   DistributionListResponse,
+  DistributionResponse,
+  DistributionUpdate,
   KeywordCreate,
   KeywordResponse,
   KeywordListResponse,
@@ -50,8 +52,21 @@ export async function deleteKeyword(recordId: string, keywordId: string): Promis
   await apiFetch(`/records/${recordId}/keywords/${keywordId}/`, { method: 'DELETE' });
 }
 
-// Distributions (read-only surface — the UI has no distribution editor;
-// chore(#835) deleted the callerless create/update/delete mutations)
+// Distributions
 export async function listDistributions(recordId: string): Promise<DistributionListResponse> {
   return apiFetch<DistributionListResponse>(`/records/${recordId}/distributions/`);
+}
+
+// feat(#1395): the set-primary control — the only mutation the UI issues
+// against this resource. Manual distributions only: the backend rejects any
+// update (`is_primary` included) to an auto_generated row with a 400.
+export async function updateDistribution(
+  recordId: string,
+  distributionId: string,
+  data: DistributionUpdate,
+): Promise<DistributionResponse> {
+  return apiFetch<DistributionResponse>(`/records/${recordId}/distributions/${distributionId}/`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
 }

--- a/frontend/src/components/dataset/DistributionsList.tsx
+++ b/frontend/src/components/dataset/DistributionsList.tsx
@@ -97,31 +97,43 @@ function CopyableUrl({ url, publicApiUrl }: { url: string; publicApiUrl: string 
  * control on those rows could never do anything but fail. The currently
  * primary manual row renders checked and disabled; clicking any other one
  * PATCHes it to `is_primary: true`, which the backend applies as a
- * last-write-wins demote of every other row on the record (#1383). */
+ * last-write-wins demote of every other row on the record (#1383).
+ *
+ * fix(#1395 codex round 1): `isMutating` disables every sibling control
+ * while any promotion is in flight, not just the clicked one — two manual
+ * rows both idle-looking would otherwise let a second click fire a
+ * concurrent PATCH, and since both transactions demote-then-promote against
+ * `uq_record_distribution_primary`, which one wins is transaction order, not
+ * click order. `isPendingThisRow` only decides which button shows the
+ * spinner. The accessible name interpolates the row's own title/format so a
+ * screen reader can tell two "Set as primary" buttons apart. */
 function SetPrimaryControl({
   distribution,
   onSelect,
-  pending,
+  isMutating,
+  isPendingThisRow,
 }: {
   distribution: DistributionResponse;
   onSelect: (distributionId: string) => void;
-  pending: boolean;
+  isMutating: boolean;
+  isPendingThisRow: boolean;
 }) {
   const { t } = useTranslation('dataset');
+  const name = distribution.title || distribution.format || distribution.distribution_type;
   const label = distribution.is_primary
-    ? t('distributions.currentPrimary')
-    : t('distributions.setPrimary');
+    ? t('distributions.currentPrimary', { name })
+    : t('distributions.setPrimary', { name });
 
   return (
     <Button
       variant="ghost"
       size="icon-xs"
       onClick={() => onSelect(distribution.id)}
-      disabled={distribution.is_primary || pending}
+      disabled={distribution.is_primary || isMutating}
       aria-label={label}
       title={label}
     >
-      {pending ? (
+      {isPendingThisRow ? (
         <Loader2 className="h-3 w-3 animate-spin" />
       ) : distribution.is_primary ? (
         <CircleDot className="h-3 w-3" />
@@ -208,7 +220,8 @@ export function DistributionsList({ recordId, canEdit = false }: DistributionsLi
                     <SetPrimaryControl
                       distribution={dist}
                       onSelect={(distributionId) => setPrimary.mutate(distributionId)}
-                      pending={setPrimary.isPending && setPrimary.variables === dist.id}
+                      isMutating={setPrimary.isPending}
+                      isPendingThisRow={setPrimary.isPending && setPrimary.variables === dist.id}
                     />
                   )}
                 </div>

--- a/frontend/src/components/dataset/DistributionsList.tsx
+++ b/frontend/src/components/dataset/DistributionsList.tsx
@@ -3,18 +3,18 @@ import { useTranslation } from 'react-i18next';
 import {
   useDistributions,
   useSetPrimaryDistribution,
+  useClearPrimaryDistribution,
 } from '@/components/dataset/hooks/use-records';
 import { useTileConfig } from '@/hooks/use-settings';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Copy, Check, Circle, CircleDot, Loader2 } from 'lucide-react';
+import { Copy, Check, Circle, CircleDot, Loader2, X } from 'lucide-react';
 import { LoadingState } from '@/components/layout/LoadingState';
 import {
   getPublicApiBaseUrl,
   resolveDistributionUrl,
 } from '@/lib/dataset-access';
-import { truncateGraphemes } from '@/lib/text';
 import type { DistributionResponse } from '@/types/api';
 
 interface DistributionsListProps {
@@ -92,15 +92,16 @@ function CopyableUrl({ url, publicApiUrl }: { url: string; publicApiUrl: string 
   );
 }
 
-/** fix(#1395 codex round 2): title alone can collide — `uq_record_distribution`
+/** fix(#1395 codex round 3): title alone can collide — `uq_record_distribution`
  * covers (record_id, distribution_type, format, url), not title, so two
- * manual rows are free to share one. The URL is always part of that
- * constraint, so appending it (truncated) is what actually guarantees two
- * rows never produce the same accessible name. */
+ * manual rows are free to share one, and a truncated URL is only unique
+ * up to whatever the truncation cuts off (round 2's fix). The row's own
+ * `id` is the one field the database actually guarantees is unique — use it
+ * untruncated instead of a heuristic. */
 function distributionLabel(distribution: DistributionResponse): string {
   const base =
     distribution.title?.trim() || distribution.format || distribution.distribution_type;
-  return `${base} (${truncateGraphemes(distribution.url, 40)})`;
+  return `${base} (${distribution.id})`;
 }
 
 /** feat(#1395): radio-style set-primary control. Rendered only for manual
@@ -156,6 +157,44 @@ function SetPrimaryControl({
   );
 }
 
+/** fix(#1395 codex round 3): once a manual row is promoted, nothing in this
+ * view could give the flag back — `update_distribution` rejects any write
+ * against an auto_generated row, so there is no "set the GeoPackage primary
+ * again" PATCH to send. `is_primary: false` is the one write the backend
+ * documents as safe here (it demotes, not deletes — the row and its URL
+ * stay put): the record goes back to having no primary until the next
+ * ingest/refresh reconcile fills the generated default back in (#1383's
+ * `update_distribution` docstring: "a record with no primary is a
+ * representable state the next reconcile fills"). Rendered only on the
+ * currently-primary manual row, so at most one exists at a time. */
+function ClearPrimaryControl({
+  distribution,
+  onClear,
+  isMutating,
+  isPendingThisRow,
+}: {
+  distribution: DistributionResponse;
+  onClear: (distributionId: string) => void;
+  isMutating: boolean;
+  isPendingThisRow: boolean;
+}) {
+  const { t } = useTranslation('dataset');
+  const label = t('distributions.clearPrimary', { name: distributionLabel(distribution) });
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      onClick={() => onClear(distribution.id)}
+      disabled={isMutating}
+      aria-label={label}
+      title={label}
+    >
+      {isPendingThisRow ? <Loader2 className="h-3 w-3 animate-spin" /> : <X className="h-3 w-3" />}
+    </Button>
+  );
+}
+
 export function getDistributionGroup(distributionType: string): DistributionGroup {
   return DISTRIBUTION_GROUPS[distributionType] ?? 'other';
 }
@@ -179,6 +218,11 @@ export function DistributionsList({ recordId, canEdit = false }: DistributionsLi
   const { data: tileConfig } = useTileConfig();
   const publicApiBaseUrl = getPublicApiBaseUrl(tileConfig);
   const setPrimary = useSetPrimaryDistribution(recordId);
+  const clearPrimary = useClearPrimaryDistribution(recordId);
+  // fix(#1395 codex round 3): one shared "in flight" flag across both
+  // mutations — a set-primary and a clear-primary PATCH would otherwise be
+  // free to race each other the same way two set-primary clicks could.
+  const isMutatingPrimary = setPrimary.isPending || clearPrimary.isPending;
 
   if (isLoading) {
     return <LoadingState className="py-6" />;
@@ -232,8 +276,16 @@ export function DistributionsList({ recordId, canEdit = false }: DistributionsLi
                     <SetPrimaryControl
                       distribution={dist}
                       onSelect={(distributionId) => setPrimary.mutate(distributionId)}
-                      isMutating={setPrimary.isPending}
+                      isMutating={isMutatingPrimary}
                       isPendingThisRow={setPrimary.isPending && setPrimary.variables === dist.id}
+                    />
+                  )}
+                  {canEdit && !dist.auto_generated && dist.is_primary && (
+                    <ClearPrimaryControl
+                      distribution={dist}
+                      onClear={(distributionId) => clearPrimary.mutate(distributionId)}
+                      isMutating={isMutatingPrimary}
+                      isPendingThisRow={clearPrimary.isPending && clearPrimary.variables === dist.id}
                     />
                   )}
                 </div>

--- a/frontend/src/components/dataset/DistributionsList.tsx
+++ b/frontend/src/components/dataset/DistributionsList.tsx
@@ -3,13 +3,12 @@ import { useTranslation } from 'react-i18next';
 import {
   useDistributions,
   useSetPrimaryDistribution,
-  useClearPrimaryDistribution,
 } from '@/components/dataset/hooks/use-records';
 import { useTileConfig } from '@/hooks/use-settings';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Copy, Check, Circle, CircleDot, Loader2, X } from 'lucide-react';
+import { Copy, Check, Circle, CircleDot, Loader2 } from 'lucide-react';
 import { LoadingState } from '@/components/layout/LoadingState';
 import {
   getPublicApiBaseUrl,
@@ -157,44 +156,6 @@ function SetPrimaryControl({
   );
 }
 
-/** fix(#1395 codex round 3): once a manual row is promoted, nothing in this
- * view could give the flag back — `update_distribution` rejects any write
- * against an auto_generated row, so there is no "set the GeoPackage primary
- * again" PATCH to send. `is_primary: false` is the one write the backend
- * documents as safe here (it demotes, not deletes — the row and its URL
- * stay put): the record goes back to having no primary until the next
- * ingest/refresh reconcile fills the generated default back in (#1383's
- * `update_distribution` docstring: "a record with no primary is a
- * representable state the next reconcile fills"). Rendered only on the
- * currently-primary manual row, so at most one exists at a time. */
-function ClearPrimaryControl({
-  distribution,
-  onClear,
-  isMutating,
-  isPendingThisRow,
-}: {
-  distribution: DistributionResponse;
-  onClear: (distributionId: string) => void;
-  isMutating: boolean;
-  isPendingThisRow: boolean;
-}) {
-  const { t } = useTranslation('dataset');
-  const label = t('distributions.clearPrimary', { name: distributionLabel(distribution) });
-
-  return (
-    <Button
-      variant="ghost"
-      size="icon-xs"
-      onClick={() => onClear(distribution.id)}
-      disabled={isMutating}
-      aria-label={label}
-      title={label}
-    >
-      {isPendingThisRow ? <Loader2 className="h-3 w-3 animate-spin" /> : <X className="h-3 w-3" />}
-    </Button>
-  );
-}
-
 export function getDistributionGroup(distributionType: string): DistributionGroup {
   return DISTRIBUTION_GROUPS[distributionType] ?? 'other';
 }
@@ -218,11 +179,6 @@ export function DistributionsList({ recordId, canEdit = false }: DistributionsLi
   const { data: tileConfig } = useTileConfig();
   const publicApiBaseUrl = getPublicApiBaseUrl(tileConfig);
   const setPrimary = useSetPrimaryDistribution(recordId);
-  const clearPrimary = useClearPrimaryDistribution(recordId);
-  // fix(#1395 codex round 3): one shared "in flight" flag across both
-  // mutations — a set-primary and a clear-primary PATCH would otherwise be
-  // free to race each other the same way two set-primary clicks could.
-  const isMutatingPrimary = setPrimary.isPending || clearPrimary.isPending;
 
   if (isLoading) {
     return <LoadingState className="py-6" />;
@@ -276,16 +232,8 @@ export function DistributionsList({ recordId, canEdit = false }: DistributionsLi
                     <SetPrimaryControl
                       distribution={dist}
                       onSelect={(distributionId) => setPrimary.mutate(distributionId)}
-                      isMutating={isMutatingPrimary}
+                      isMutating={setPrimary.isPending}
                       isPendingThisRow={setPrimary.isPending && setPrimary.variables === dist.id}
-                    />
-                  )}
-                  {canEdit && !dist.auto_generated && dist.is_primary && (
-                    <ClearPrimaryControl
-                      distribution={dist}
-                      onClear={(distributionId) => clearPrimary.mutate(distributionId)}
-                      isMutating={isMutatingPrimary}
-                      isPendingThisRow={clearPrimary.isPending && clearPrimary.variables === dist.id}
                     />
                   )}
                 </div>

--- a/frontend/src/components/dataset/DistributionsList.tsx
+++ b/frontend/src/components/dataset/DistributionsList.tsx
@@ -1,11 +1,14 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDistributions } from '@/components/dataset/hooks/use-records';
+import {
+  useDistributions,
+  useSetPrimaryDistribution,
+} from '@/components/dataset/hooks/use-records';
 import { useTileConfig } from '@/hooks/use-settings';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Copy, Check } from 'lucide-react';
+import { Copy, Check, Circle, CircleDot, Loader2 } from 'lucide-react';
 import { LoadingState } from '@/components/layout/LoadingState';
 import {
   getPublicApiBaseUrl,
@@ -15,6 +18,10 @@ import type { DistributionResponse } from '@/types/api';
 
 interface DistributionsListProps {
   recordId: string;
+  /** Owner-or-admin editor: mirrors the backend `require_permission("edit_metadata")`
+   * + `_check_record_ownership` guard on the distribution PATCH endpoint.
+   * Everyone else keeps the read-only view (#1395). */
+  canEdit?: boolean;
 }
 
 const TYPE_ORDER = ['download', 'api', 'tiles', 'other'] as const;
@@ -84,6 +91,47 @@ function CopyableUrl({ url, publicApiUrl }: { url: string; publicApiUrl: string 
   );
 }
 
+/** feat(#1395): radio-style set-primary control. Rendered only for manual
+ * (non-auto_generated) rows — `update_distribution` rejects any write,
+ * `is_primary` included, against an auto_generated row with a 400, so a
+ * control on those rows could never do anything but fail. The currently
+ * primary manual row renders checked and disabled; clicking any other one
+ * PATCHes it to `is_primary: true`, which the backend applies as a
+ * last-write-wins demote of every other row on the record (#1383). */
+function SetPrimaryControl({
+  distribution,
+  onSelect,
+  pending,
+}: {
+  distribution: DistributionResponse;
+  onSelect: (distributionId: string) => void;
+  pending: boolean;
+}) {
+  const { t } = useTranslation('dataset');
+  const label = distribution.is_primary
+    ? t('distributions.currentPrimary')
+    : t('distributions.setPrimary');
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      onClick={() => onSelect(distribution.id)}
+      disabled={distribution.is_primary || pending}
+      aria-label={label}
+      title={label}
+    >
+      {pending ? (
+        <Loader2 className="h-3 w-3 animate-spin" />
+      ) : distribution.is_primary ? (
+        <CircleDot className="h-3 w-3" />
+      ) : (
+        <Circle className="h-3 w-3" />
+      )}
+    </Button>
+  );
+}
+
 export function getDistributionGroup(distributionType: string): DistributionGroup {
   return DISTRIBUTION_GROUPS[distributionType] ?? 'other';
 }
@@ -101,11 +149,12 @@ function groupByType(
   return groups;
 }
 
-export function DistributionsList({ recordId }: DistributionsListProps) {
+export function DistributionsList({ recordId, canEdit = false }: DistributionsListProps) {
   const { t } = useTranslation('dataset');
   const { data, isLoading, error } = useDistributions(recordId);
   const { data: tileConfig } = useTileConfig();
   const publicApiBaseUrl = getPublicApiBaseUrl(tileConfig);
+  const setPrimary = useSetPrimaryDistribution(recordId);
 
   if (isLoading) {
     return <LoadingState className="py-6" />;
@@ -154,6 +203,13 @@ export function DistributionsList({ recordId }: DistributionsListProps) {
                     <span className="text-xs text-muted-foreground">
                       ({t('distributions.auto')})
                     </span>
+                  )}
+                  {canEdit && !dist.auto_generated && (
+                    <SetPrimaryControl
+                      distribution={dist}
+                      onSelect={(distributionId) => setPrimary.mutate(distributionId)}
+                      pending={setPrimary.isPending && setPrimary.variables === dist.id}
+                    />
                   )}
                 </div>
                 {dist.title && (

--- a/frontend/src/components/dataset/DistributionsList.tsx
+++ b/frontend/src/components/dataset/DistributionsList.tsx
@@ -14,6 +14,7 @@ import {
   getPublicApiBaseUrl,
   resolveDistributionUrl,
 } from '@/lib/dataset-access';
+import { truncateGraphemes } from '@/lib/text';
 import type { DistributionResponse } from '@/types/api';
 
 interface DistributionsListProps {
@@ -91,6 +92,17 @@ function CopyableUrl({ url, publicApiUrl }: { url: string; publicApiUrl: string 
   );
 }
 
+/** fix(#1395 codex round 2): title alone can collide — `uq_record_distribution`
+ * covers (record_id, distribution_type, format, url), not title, so two
+ * manual rows are free to share one. The URL is always part of that
+ * constraint, so appending it (truncated) is what actually guarantees two
+ * rows never produce the same accessible name. */
+function distributionLabel(distribution: DistributionResponse): string {
+  const base =
+    distribution.title?.trim() || distribution.format || distribution.distribution_type;
+  return `${base} (${truncateGraphemes(distribution.url, 40)})`;
+}
+
 /** feat(#1395): radio-style set-primary control. Rendered only for manual
  * (non-auto_generated) rows — `update_distribution` rejects any write,
  * `is_primary` included, against an auto_generated row with a 400, so a
@@ -105,7 +117,7 @@ function CopyableUrl({ url, publicApiUrl }: { url: string; publicApiUrl: string 
  * concurrent PATCH, and since both transactions demote-then-promote against
  * `uq_record_distribution_primary`, which one wins is transaction order, not
  * click order. `isPendingThisRow` only decides which button shows the
- * spinner. The accessible name interpolates the row's own title/format so a
+ * spinner. The accessible name (`distributionLabel`) identifies the row so a
  * screen reader can tell two "Set as primary" buttons apart. */
 function SetPrimaryControl({
   distribution,
@@ -119,7 +131,7 @@ function SetPrimaryControl({
   isPendingThisRow: boolean;
 }) {
   const { t } = useTranslation('dataset');
-  const name = distribution.title || distribution.format || distribution.distribution_type;
+  const name = distributionLabel(distribution);
   const label = distribution.is_primary
     ? t('distributions.currentPrimary', { name })
     : t('distributions.setPrimary', { name });

--- a/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
@@ -1,5 +1,8 @@
 import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
-import { useDistributions } from '@/components/dataset/hooks/use-records';
+import {
+  useDistributions,
+  useSetPrimaryDistribution,
+} from '@/components/dataset/hooks/use-records';
 import { useUpdateDataset } from '@/components/dataset/hooks/use-dataset';
 import { useTileConfig } from '@/hooks/use-settings';
 import { listKeywords } from '@/api/records';
@@ -9,6 +12,10 @@ import type { DatasetResponse } from '@/types/api';
 
 vi.mock('@/components/dataset/hooks/use-records', () => ({
   useDistributions: vi.fn(),
+  // feat(#1395): DistributionsList calls this unconditionally; AccessTab's
+  // own tests don't exercise the set-primary control, so a stable no-op
+  // mutate is enough to keep it from throwing.
+  useSetPrimaryDistribution: vi.fn(),
 }));
 
 // feat(#1070): the visibility change probes the keywords endpoint for
@@ -30,6 +37,7 @@ vi.mock('sonner', () => ({
 }));
 
 const mockUseDistributions = vi.mocked(useDistributions);
+const mockUseSetPrimaryDistribution = vi.mocked(useSetPrimaryDistribution);
 const mockUseTileConfig = vi.mocked(useTileConfig);
 const mockUseUpdateDataset = vi.mocked(useUpdateDataset);
 const mockListKeywords = vi.mocked(listKeywords);
@@ -118,6 +126,11 @@ describe('AccessTab', () => {
       },
       isLoading: false,
     } as unknown as ReturnType<typeof useDistributions>);
+    mockUseSetPrimaryDistribution.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useSetPrimaryDistribution>);
     mutate.mockReset();
     mockListKeywords.mockReset();
     mockListKeywords.mockResolvedValue({

--- a/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
 import {
   useDistributions,
   useSetPrimaryDistribution,
+  useClearPrimaryDistribution,
 } from '@/components/dataset/hooks/use-records';
 import { useUpdateDataset } from '@/components/dataset/hooks/use-dataset';
 import { useTileConfig } from '@/hooks/use-settings';
@@ -12,10 +13,11 @@ import type { DatasetResponse } from '@/types/api';
 
 vi.mock('@/components/dataset/hooks/use-records', () => ({
   useDistributions: vi.fn(),
-  // feat(#1395): DistributionsList calls this unconditionally; AccessTab's
-  // own tests don't exercise the set-primary control, so a stable no-op
-  // mutate is enough to keep it from throwing.
+  // feat(#1395): DistributionsList calls these unconditionally; AccessTab's
+  // own tests don't exercise the set/clear-primary controls, so a stable
+  // no-op mutate is enough to keep them from throwing.
   useSetPrimaryDistribution: vi.fn(),
+  useClearPrimaryDistribution: vi.fn(),
 }));
 
 // feat(#1070): the visibility change probes the keywords endpoint for
@@ -38,6 +40,7 @@ vi.mock('sonner', () => ({
 
 const mockUseDistributions = vi.mocked(useDistributions);
 const mockUseSetPrimaryDistribution = vi.mocked(useSetPrimaryDistribution);
+const mockUseClearPrimaryDistribution = vi.mocked(useClearPrimaryDistribution);
 const mockUseTileConfig = vi.mocked(useTileConfig);
 const mockUseUpdateDataset = vi.mocked(useUpdateDataset);
 const mockListKeywords = vi.mocked(listKeywords);
@@ -131,6 +134,11 @@ describe('AccessTab', () => {
       isPending: false,
       variables: undefined,
     } as unknown as ReturnType<typeof useSetPrimaryDistribution>);
+    mockUseClearPrimaryDistribution.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useClearPrimaryDistribution>);
     mutate.mockReset();
     mockListKeywords.mockReset();
     mockListKeywords.mockResolvedValue({

--- a/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AccessTab.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
 import {
   useDistributions,
   useSetPrimaryDistribution,
-  useClearPrimaryDistribution,
 } from '@/components/dataset/hooks/use-records';
 import { useUpdateDataset } from '@/components/dataset/hooks/use-dataset';
 import { useTileConfig } from '@/hooks/use-settings';
@@ -13,11 +12,10 @@ import type { DatasetResponse } from '@/types/api';
 
 vi.mock('@/components/dataset/hooks/use-records', () => ({
   useDistributions: vi.fn(),
-  // feat(#1395): DistributionsList calls these unconditionally; AccessTab's
-  // own tests don't exercise the set/clear-primary controls, so a stable
-  // no-op mutate is enough to keep them from throwing.
+  // feat(#1395): DistributionsList calls this unconditionally; AccessTab's
+  // own tests don't exercise the set-primary control, so a stable no-op
+  // mutate is enough to keep it from throwing.
   useSetPrimaryDistribution: vi.fn(),
-  useClearPrimaryDistribution: vi.fn(),
 }));
 
 // feat(#1070): the visibility change probes the keywords endpoint for
@@ -40,7 +38,6 @@ vi.mock('sonner', () => ({
 
 const mockUseDistributions = vi.mocked(useDistributions);
 const mockUseSetPrimaryDistribution = vi.mocked(useSetPrimaryDistribution);
-const mockUseClearPrimaryDistribution = vi.mocked(useClearPrimaryDistribution);
 const mockUseTileConfig = vi.mocked(useTileConfig);
 const mockUseUpdateDataset = vi.mocked(useUpdateDataset);
 const mockListKeywords = vi.mocked(listKeywords);
@@ -134,11 +131,6 @@ describe('AccessTab', () => {
       isPending: false,
       variables: undefined,
     } as unknown as ReturnType<typeof useSetPrimaryDistribution>);
-    mockUseClearPrimaryDistribution.mockReturnValue({
-      mutate: vi.fn(),
-      isPending: false,
-      variables: undefined,
-    } as unknown as ReturnType<typeof useClearPrimaryDistribution>);
     mutate.mockReset();
     mockListKeywords.mockReset();
     mockListKeywords.mockResolvedValue({

--- a/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen } from '@/test/test-utils';
 import {
   useDistributions,
   useSetPrimaryDistribution,
-  useClearPrimaryDistribution,
 } from '@/components/dataset/hooks/use-records';
 import { useTileConfig } from '@/hooks/use-settings';
 import { resolveDistributionUrl } from '@/lib/dataset-access';
@@ -14,7 +13,6 @@ import {
 vi.mock('@/components/dataset/hooks/use-records', () => ({
   useDistributions: vi.fn(),
   useSetPrimaryDistribution: vi.fn(),
-  useClearPrimaryDistribution: vi.fn(),
 }));
 
 vi.mock('@/hooks/use-settings', () => ({
@@ -23,10 +21,8 @@ vi.mock('@/hooks/use-settings', () => ({
 
 const mockUseDistributions = vi.mocked(useDistributions);
 const mockUseSetPrimaryDistribution = vi.mocked(useSetPrimaryDistribution);
-const mockUseClearPrimaryDistribution = vi.mocked(useClearPrimaryDistribution);
 const mockUseTileConfig = vi.mocked(useTileConfig);
 const mutate = vi.fn();
-const clearMutate = vi.fn();
 
 /** A manual, non-primary "Viewer App" row alongside the three generated ones
  * used throughout this file — the only shape #1395's control can act on. */
@@ -90,17 +86,11 @@ describe('DistributionsList', () => {
       },
     } as ReturnType<typeof useTileConfig>);
     mutate.mockReset();
-    clearMutate.mockReset();
     mockUseSetPrimaryDistribution.mockReturnValue({
       mutate,
       isPending: false,
       variables: undefined,
     } as unknown as ReturnType<typeof useSetPrimaryDistribution>);
-    mockUseClearPrimaryDistribution.mockReturnValue({
-      mutate: clearMutate,
-      isPending: false,
-      variables: undefined,
-    } as unknown as ReturnType<typeof useClearPrimaryDistribution>);
   });
 
   it('maps backend distribution types into stable UI groups', () => {
@@ -365,93 +355,6 @@ describe('DistributionsList', () => {
 
       fireEvent.click(buttons[1]);
       expect(mutate).toHaveBeenCalledWith('mirror-2');
-    });
-  });
-
-  // fix(#1395 codex round 3): a way back once a manual row has claimed
-  // is_primary — update_distribution rejects any write against an
-  // auto_generated row, so there is no "promote the GeoPackage again" PATCH.
-  describe('clear-primary control', () => {
-    // "Cover Sheet" is the current manual primary; "Backup Mirror" is a
-    // second manual, non-primary row used to test cross-mutation disabling.
-    const DISTRIBUTIONS_WITH_MANUAL_PRIMARY = [
-      {
-        ...DISTRIBUTIONS_WITH_MANUAL_ROW[0],
-        is_primary: false, // the manual row demoted the generated GeoPackage
-      },
-      DISTRIBUTIONS_WITH_MANUAL_ROW[1],
-      {
-        id: 'cover-1',
-        record_id: 'record-1',
-        distribution_type: 'webApp',
-        format: 'html',
-        url: 'https://example.com/cover',
-        title: 'Cover Sheet',
-        description: null,
-        protocol: 'HTTPS',
-        media_type: 'text/html',
-        is_primary: true,
-        auto_generated: false,
-      },
-      {
-        id: 'backup-1',
-        record_id: 'record-1',
-        distribution_type: 'offlineAccess',
-        format: 'zip',
-        url: 'https://example.com/backup.zip',
-        title: 'Backup Mirror',
-        description: null,
-        protocol: 'HTTPS',
-        media_type: 'application/zip',
-        is_primary: false,
-        auto_generated: false,
-      },
-    ];
-
-    beforeEach(() => {
-      mockUseDistributions.mockReturnValue({
-        data: { distributions: DISTRIBUTIONS_WITH_MANUAL_PRIMARY, total: 4 },
-        isLoading: false,
-      } as unknown as ReturnType<typeof useDistributions>);
-    });
-
-    it('is not rendered for a reader', () => {
-      render(<DistributionsList recordId="record-1" />);
-
-      expect(screen.queryByRole('button', { name: /clear primary/i })).not.toBeInTheDocument();
-    });
-
-    it('renders only on the currently-primary manual row, for an owner', () => {
-      render(<DistributionsList recordId="record-1" canEdit />);
-
-      expect(screen.getAllByRole('button', { name: /clear primary/i })).toHaveLength(1);
-      expect(
-        screen.getByRole('button', { name: 'Clear primary status from Cover Sheet (cover-1)' }),
-      ).toBeInTheDocument();
-    });
-
-    it('PATCHes is_primary: false for the clicked row', () => {
-      render(<DistributionsList recordId="record-1" canEdit />);
-
-      fireEvent.click(screen.getByRole('button', { name: /clear primary/i }));
-
-      expect(clearMutate).toHaveBeenCalledTimes(1);
-      expect(clearMutate).toHaveBeenCalledWith('cover-1');
-    });
-
-    // fix(#1395 codex round 3): a set-primary and a clear-primary PATCH must
-    // not be free to race each other any more than two set-primary clicks are.
-    it('disables both its own control and sibling set-primary controls while a clear is in flight', () => {
-      mockUseClearPrimaryDistribution.mockReturnValue({
-        mutate: clearMutate,
-        isPending: true,
-        variables: 'cover-1',
-      } as unknown as ReturnType<typeof useClearPrimaryDistribution>);
-
-      render(<DistributionsList recordId="record-1" canEdit />);
-
-      expect(screen.getByRole('button', { name: /clear primary/i })).toBeDisabled();
-      expect(screen.getByRole('button', { name: /^Set Backup Mirror/ })).toBeDisabled();
     });
   });
 });

--- a/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
@@ -207,14 +207,14 @@ describe('DistributionsList', () => {
     it('is not rendered for a reader (canEdit unset)', () => {
       render(<DistributionsList recordId="record-1" />);
 
-      expect(screen.queryByRole('button', { name: 'Set as primary' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Primary distribution' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /as primary/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /primary distribution/i })).not.toBeInTheDocument();
     });
 
     it('is not rendered for a reader (canEdit explicitly false)', () => {
       render(<DistributionsList recordId="record-1" canEdit={false} />);
 
-      expect(screen.queryByRole('button', { name: 'Set as primary' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /as primary/i })).not.toBeInTheDocument();
     });
 
     it('renders for an owner, only on the manual non-primary row', () => {
@@ -223,24 +223,27 @@ describe('DistributionsList', () => {
       // The two auto-generated rows (the primary GeoPackage and the
       // non-primary OGC Features row) never get the control — the backend
       // rejects any PATCH against an auto_generated distribution.
-      expect(screen.getAllByRole('button', { name: 'Set as primary' })).toHaveLength(1);
+      expect(screen.getAllByRole('button', { name: /as primary/i })).toHaveLength(1);
+      expect(screen.getByRole('button', { name: 'Set Viewer App as primary' })).toBeInTheDocument();
     });
 
-    it('has an accessible name distinct from any surrounding label text', () => {
+    // fix(#1395 codex round 1): the accessible name names the row, so two
+    // "Set as primary" buttons on the same page are distinguishable.
+    it('has an accessible name that names the distribution, not a label-for that could steal it', () => {
       render(<DistributionsList recordId="record-1" canEdit />);
 
       // getByRole computes the accessible name; a <label for> stealing a
       // button's name (as opposed to a plain aria-label) would make this
       // query fail even though the button is visible.
-      const button = screen.getByRole('button', { name: 'Set as primary' });
+      const button = screen.getByRole('button', { name: 'Set Viewer App as primary' });
       expect(button).toBeInTheDocument();
-      expect(button).toHaveAccessibleName('Set as primary');
+      expect(button).toHaveAccessibleName('Set Viewer App as primary');
     });
 
     it('PATCHes the clicked row when an owner sets it primary', () => {
       render(<DistributionsList recordId="record-1" canEdit />);
 
-      fireEvent.click(screen.getByRole('button', { name: 'Set as primary' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Set Viewer App as primary' }));
 
       expect(mutate).toHaveBeenCalledTimes(1);
       expect(mutate).toHaveBeenCalledWith('app-1');
@@ -255,7 +258,48 @@ describe('DistributionsList', () => {
 
       render(<DistributionsList recordId="record-1" canEdit />);
 
-      expect(screen.getByRole('button', { name: 'Set as primary' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Set Viewer App as primary' })).toBeDisabled();
+    });
+
+    // fix(#1395 codex round 1): a second manual, non-primary row must go
+    // disabled too while ANY promotion is in flight — not just the row that
+    // was clicked — so a second click can't fire a concurrent PATCH that
+    // races the first against uq_record_distribution_primary.
+    it('disables every sibling set-primary control while one promotion is in flight', () => {
+      mockUseDistributions.mockReturnValue({
+        data: {
+          distributions: [
+            ...DISTRIBUTIONS_WITH_MANUAL_ROW,
+            {
+              id: 'app-2',
+              record_id: 'record-1',
+              distribution_type: 'offlineAccess',
+              format: 'zip',
+              url: 'https://example.com/offline.zip',
+              title: 'Offline Bundle',
+              description: null,
+              protocol: 'HTTPS',
+              media_type: 'application/zip',
+              is_primary: false,
+              auto_generated: false,
+            },
+          ],
+          total: 4,
+        },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useDistributions>);
+      // "Viewer App" is the one being promoted; "Offline Bundle" is idle but
+      // must still go disabled.
+      mockUseSetPrimaryDistribution.mockReturnValue({
+        mutate,
+        isPending: true,
+        variables: 'app-1',
+      } as unknown as ReturnType<typeof useSetPrimaryDistribution>);
+
+      render(<DistributionsList recordId="record-1" canEdit />);
+
+      expect(screen.getByRole('button', { name: 'Set Viewer App as primary' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Set Offline Bundle as primary' })).toBeDisabled();
     });
   });
 });

--- a/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
@@ -224,7 +224,9 @@ describe('DistributionsList', () => {
       // non-primary OGC Features row) never get the control — the backend
       // rejects any PATCH against an auto_generated distribution.
       expect(screen.getAllByRole('button', { name: /as primary/i })).toHaveLength(1);
-      expect(screen.getByRole('button', { name: 'Set Viewer App as primary' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Set Viewer App (https://example.com/app) as primary' }),
+      ).toBeInTheDocument();
     });
 
     // fix(#1395 codex round 1): the accessible name names the row, so two
@@ -235,15 +237,15 @@ describe('DistributionsList', () => {
       // getByRole computes the accessible name; a <label for> stealing a
       // button's name (as opposed to a plain aria-label) would make this
       // query fail even though the button is visible.
-      const button = screen.getByRole('button', { name: 'Set Viewer App as primary' });
+      const button = screen.getByRole('button', { name: /^Set Viewer App/ });
       expect(button).toBeInTheDocument();
-      expect(button).toHaveAccessibleName('Set Viewer App as primary');
+      expect(button).toHaveAccessibleName('Set Viewer App (https://example.com/app) as primary');
     });
 
     it('PATCHes the clicked row when an owner sets it primary', () => {
       render(<DistributionsList recordId="record-1" canEdit />);
 
-      fireEvent.click(screen.getByRole('button', { name: 'Set Viewer App as primary' }));
+      fireEvent.click(screen.getByRole('button', { name: /^Set Viewer App/ }));
 
       expect(mutate).toHaveBeenCalledTimes(1);
       expect(mutate).toHaveBeenCalledWith('app-1');
@@ -258,7 +260,7 @@ describe('DistributionsList', () => {
 
       render(<DistributionsList recordId="record-1" canEdit />);
 
-      expect(screen.getByRole('button', { name: 'Set Viewer App as primary' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /^Set Viewer App/ })).toBeDisabled();
     });
 
     // fix(#1395 codex round 1): a second manual, non-primary row must go
@@ -298,8 +300,59 @@ describe('DistributionsList', () => {
 
       render(<DistributionsList recordId="record-1" canEdit />);
 
-      expect(screen.getByRole('button', { name: 'Set Viewer App as primary' })).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'Set Offline Bundle as primary' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /^Set Viewer App/ })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /^Set Offline Bundle/ })).toBeDisabled();
+    });
+
+    // fix(#1395 codex round 2): uq_record_distribution covers
+    // (record_id, distribution_type, format, url), not title — two manual
+    // rows are free to share a title, and the accessible name must still
+    // tell them apart.
+    it('gives two manual rows with the same title distinct accessible names', () => {
+      mockUseDistributions.mockReturnValue({
+        data: {
+          distributions: [
+            {
+              id: 'mirror-1',
+              record_id: 'record-1',
+              distribution_type: 'download',
+              format: 'zip',
+              url: 'https://mirror-a.example.com/archive.zip',
+              title: 'Mirror',
+              description: null,
+              protocol: 'HTTPS',
+              media_type: 'application/zip',
+              is_primary: false,
+              auto_generated: false,
+            },
+            {
+              id: 'mirror-2',
+              record_id: 'record-1',
+              distribution_type: 'download',
+              format: 'zip',
+              url: 'https://mirror-b.example.com/archive.zip',
+              title: 'Mirror',
+              description: null,
+              protocol: 'HTTPS',
+              media_type: 'application/zip',
+              is_primary: false,
+              auto_generated: false,
+            },
+          ],
+          total: 2,
+        },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useDistributions>);
+
+      render(<DistributionsList recordId="record-1" canEdit />);
+
+      const buttons = screen.getAllByRole('button', { name: /^Set Mirror/ });
+      expect(buttons).toHaveLength(2);
+      const names = buttons.map((b) => b.getAttribute('aria-label'));
+      expect(new Set(names).size).toBe(2);
+
+      fireEvent.click(buttons[1]);
+      expect(mutate).toHaveBeenCalledWith('mirror-2');
     });
   });
 });

--- a/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@/test/test-utils';
 import {
   useDistributions,
   useSetPrimaryDistribution,
+  useClearPrimaryDistribution,
 } from '@/components/dataset/hooks/use-records';
 import { useTileConfig } from '@/hooks/use-settings';
 import { resolveDistributionUrl } from '@/lib/dataset-access';
@@ -13,6 +14,7 @@ import {
 vi.mock('@/components/dataset/hooks/use-records', () => ({
   useDistributions: vi.fn(),
   useSetPrimaryDistribution: vi.fn(),
+  useClearPrimaryDistribution: vi.fn(),
 }));
 
 vi.mock('@/hooks/use-settings', () => ({
@@ -21,8 +23,10 @@ vi.mock('@/hooks/use-settings', () => ({
 
 const mockUseDistributions = vi.mocked(useDistributions);
 const mockUseSetPrimaryDistribution = vi.mocked(useSetPrimaryDistribution);
+const mockUseClearPrimaryDistribution = vi.mocked(useClearPrimaryDistribution);
 const mockUseTileConfig = vi.mocked(useTileConfig);
 const mutate = vi.fn();
+const clearMutate = vi.fn();
 
 /** A manual, non-primary "Viewer App" row alongside the three generated ones
  * used throughout this file — the only shape #1395's control can act on. */
@@ -86,11 +90,17 @@ describe('DistributionsList', () => {
       },
     } as ReturnType<typeof useTileConfig>);
     mutate.mockReset();
+    clearMutate.mockReset();
     mockUseSetPrimaryDistribution.mockReturnValue({
       mutate,
       isPending: false,
       variables: undefined,
     } as unknown as ReturnType<typeof useSetPrimaryDistribution>);
+    mockUseClearPrimaryDistribution.mockReturnValue({
+      mutate: clearMutate,
+      isPending: false,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useClearPrimaryDistribution>);
   });
 
   it('maps backend distribution types into stable UI groups', () => {
@@ -225,12 +235,14 @@ describe('DistributionsList', () => {
       // rejects any PATCH against an auto_generated distribution.
       expect(screen.getAllByRole('button', { name: /as primary/i })).toHaveLength(1);
       expect(
-        screen.getByRole('button', { name: 'Set Viewer App (https://example.com/app) as primary' }),
+        screen.getByRole('button', { name: 'Set Viewer App (app-1) as primary' }),
       ).toBeInTheDocument();
     });
 
     // fix(#1395 codex round 1): the accessible name names the row, so two
     // "Set as primary" buttons on the same page are distinguishable.
+    // fix(#1395 codex round 3): the discriminator is the row's own id, not a
+    // (possibly-colliding, possibly-truncated) URL fragment.
     it('has an accessible name that names the distribution, not a label-for that could steal it', () => {
       render(<DistributionsList recordId="record-1" canEdit />);
 
@@ -239,7 +251,7 @@ describe('DistributionsList', () => {
       // query fail even though the button is visible.
       const button = screen.getByRole('button', { name: /^Set Viewer App/ });
       expect(button).toBeInTheDocument();
-      expect(button).toHaveAccessibleName('Set Viewer App (https://example.com/app) as primary');
+      expect(button).toHaveAccessibleName('Set Viewer App (app-1) as primary');
     });
 
     it('PATCHes the clicked row when an owner sets it primary', () => {
@@ -353,6 +365,93 @@ describe('DistributionsList', () => {
 
       fireEvent.click(buttons[1]);
       expect(mutate).toHaveBeenCalledWith('mirror-2');
+    });
+  });
+
+  // fix(#1395 codex round 3): a way back once a manual row has claimed
+  // is_primary — update_distribution rejects any write against an
+  // auto_generated row, so there is no "promote the GeoPackage again" PATCH.
+  describe('clear-primary control', () => {
+    // "Cover Sheet" is the current manual primary; "Backup Mirror" is a
+    // second manual, non-primary row used to test cross-mutation disabling.
+    const DISTRIBUTIONS_WITH_MANUAL_PRIMARY = [
+      {
+        ...DISTRIBUTIONS_WITH_MANUAL_ROW[0],
+        is_primary: false, // the manual row demoted the generated GeoPackage
+      },
+      DISTRIBUTIONS_WITH_MANUAL_ROW[1],
+      {
+        id: 'cover-1',
+        record_id: 'record-1',
+        distribution_type: 'webApp',
+        format: 'html',
+        url: 'https://example.com/cover',
+        title: 'Cover Sheet',
+        description: null,
+        protocol: 'HTTPS',
+        media_type: 'text/html',
+        is_primary: true,
+        auto_generated: false,
+      },
+      {
+        id: 'backup-1',
+        record_id: 'record-1',
+        distribution_type: 'offlineAccess',
+        format: 'zip',
+        url: 'https://example.com/backup.zip',
+        title: 'Backup Mirror',
+        description: null,
+        protocol: 'HTTPS',
+        media_type: 'application/zip',
+        is_primary: false,
+        auto_generated: false,
+      },
+    ];
+
+    beforeEach(() => {
+      mockUseDistributions.mockReturnValue({
+        data: { distributions: DISTRIBUTIONS_WITH_MANUAL_PRIMARY, total: 4 },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useDistributions>);
+    });
+
+    it('is not rendered for a reader', () => {
+      render(<DistributionsList recordId="record-1" />);
+
+      expect(screen.queryByRole('button', { name: /clear primary/i })).not.toBeInTheDocument();
+    });
+
+    it('renders only on the currently-primary manual row, for an owner', () => {
+      render(<DistributionsList recordId="record-1" canEdit />);
+
+      expect(screen.getAllByRole('button', { name: /clear primary/i })).toHaveLength(1);
+      expect(
+        screen.getByRole('button', { name: 'Clear primary status from Cover Sheet (cover-1)' }),
+      ).toBeInTheDocument();
+    });
+
+    it('PATCHes is_primary: false for the clicked row', () => {
+      render(<DistributionsList recordId="record-1" canEdit />);
+
+      fireEvent.click(screen.getByRole('button', { name: /clear primary/i }));
+
+      expect(clearMutate).toHaveBeenCalledTimes(1);
+      expect(clearMutate).toHaveBeenCalledWith('cover-1');
+    });
+
+    // fix(#1395 codex round 3): a set-primary and a clear-primary PATCH must
+    // not be free to race each other any more than two set-primary clicks are.
+    it('disables both its own control and sibling set-primary controls while a clear is in flight', () => {
+      mockUseClearPrimaryDistribution.mockReturnValue({
+        mutate: clearMutate,
+        isPending: true,
+        variables: 'cover-1',
+      } as unknown as ReturnType<typeof useClearPrimaryDistribution>);
+
+      render(<DistributionsList recordId="record-1" canEdit />);
+
+      expect(screen.getByRole('button', { name: /clear primary/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /^Set Backup Mirror/ })).toBeDisabled();
     });
   });
 });

--- a/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
@@ -1,5 +1,8 @@
-import { render, screen } from '@/test/test-utils';
-import { useDistributions } from '@/components/dataset/hooks/use-records';
+import { fireEvent, render, screen } from '@/test/test-utils';
+import {
+  useDistributions,
+  useSetPrimaryDistribution,
+} from '@/components/dataset/hooks/use-records';
 import { useTileConfig } from '@/hooks/use-settings';
 import { resolveDistributionUrl } from '@/lib/dataset-access';
 import {
@@ -9,6 +12,7 @@ import {
 
 vi.mock('@/components/dataset/hooks/use-records', () => ({
   useDistributions: vi.fn(),
+  useSetPrimaryDistribution: vi.fn(),
 }));
 
 vi.mock('@/hooks/use-settings', () => ({
@@ -16,7 +20,53 @@ vi.mock('@/hooks/use-settings', () => ({
 }));
 
 const mockUseDistributions = vi.mocked(useDistributions);
+const mockUseSetPrimaryDistribution = vi.mocked(useSetPrimaryDistribution);
 const mockUseTileConfig = vi.mocked(useTileConfig);
+const mutate = vi.fn();
+
+/** A manual, non-primary "Viewer App" row alongside the three generated ones
+ * used throughout this file — the only shape #1395's control can act on. */
+const DISTRIBUTIONS_WITH_MANUAL_ROW = [
+  {
+    id: 'download-1',
+    record_id: 'record-1',
+    distribution_type: 'download',
+    format: 'gpkg',
+    url: '/datasets/1/export?format=gpkg',
+    title: 'GeoPackage Download',
+    description: null,
+    protocol: 'HTTP',
+    media_type: 'application/geopackage+sqlite3',
+    is_primary: true,
+    auto_generated: true,
+  },
+  {
+    id: 'ogc-1',
+    record_id: 'record-1',
+    distribution_type: 'ogc_features',
+    format: 'geojson',
+    url: '/collections/1/items',
+    title: 'OGC API Features',
+    description: null,
+    protocol: 'OGC:OAFeat',
+    media_type: 'application/geo+json',
+    is_primary: false,
+    auto_generated: true,
+  },
+  {
+    id: 'app-1',
+    record_id: 'record-1',
+    distribution_type: 'webApp',
+    format: 'html',
+    url: 'https://example.com/app',
+    title: 'Viewer App',
+    description: null,
+    protocol: 'HTTPS',
+    media_type: 'text/html',
+    is_primary: false,
+    auto_generated: false,
+  },
+];
 
 describe('DistributionsList', () => {
   beforeEach(() => {
@@ -35,6 +85,12 @@ describe('DistributionsList', () => {
         public_base_url: 'https://catalog.example.com',
       },
     } as ReturnType<typeof useTileConfig>);
+    mutate.mockReset();
+    mockUseSetPrimaryDistribution.mockReturnValue({
+      mutate,
+      isPending: false,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useSetPrimaryDistribution>);
   });
 
   it('maps backend distribution types into stable UI groups', () => {
@@ -137,5 +193,69 @@ describe('DistributionsList', () => {
     expect(screen.getByText('https://catalog.example.com/api/collections/1/items')).toBeInTheDocument();
     expect(screen.getByText('https://catalog.example.com/api/tiles/data.example/{z}/{x}/{y}.pbf')).toBeInTheDocument();
     expect(screen.getByText('https://example.com/app')).toBeInTheDocument();
+  });
+
+  // feat(#1395): set-primary control.
+  describe('set-primary control', () => {
+    beforeEach(() => {
+      mockUseDistributions.mockReturnValue({
+        data: { distributions: DISTRIBUTIONS_WITH_MANUAL_ROW, total: 3 },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useDistributions>);
+    });
+
+    it('is not rendered for a reader (canEdit unset)', () => {
+      render(<DistributionsList recordId="record-1" />);
+
+      expect(screen.queryByRole('button', { name: 'Set as primary' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Primary distribution' })).not.toBeInTheDocument();
+    });
+
+    it('is not rendered for a reader (canEdit explicitly false)', () => {
+      render(<DistributionsList recordId="record-1" canEdit={false} />);
+
+      expect(screen.queryByRole('button', { name: 'Set as primary' })).not.toBeInTheDocument();
+    });
+
+    it('renders for an owner, only on the manual non-primary row', () => {
+      render(<DistributionsList recordId="record-1" canEdit />);
+
+      // The two auto-generated rows (the primary GeoPackage and the
+      // non-primary OGC Features row) never get the control — the backend
+      // rejects any PATCH against an auto_generated distribution.
+      expect(screen.getAllByRole('button', { name: 'Set as primary' })).toHaveLength(1);
+    });
+
+    it('has an accessible name distinct from any surrounding label text', () => {
+      render(<DistributionsList recordId="record-1" canEdit />);
+
+      // getByRole computes the accessible name; a <label for> stealing a
+      // button's name (as opposed to a plain aria-label) would make this
+      // query fail even though the button is visible.
+      const button = screen.getByRole('button', { name: 'Set as primary' });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveAccessibleName('Set as primary');
+    });
+
+    it('PATCHes the clicked row when an owner sets it primary', () => {
+      render(<DistributionsList recordId="record-1" canEdit />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Set as primary' }));
+
+      expect(mutate).toHaveBeenCalledTimes(1);
+      expect(mutate).toHaveBeenCalledWith('app-1');
+    });
+
+    it('disables the control and shows a spinner while its own PATCH is pending', () => {
+      mockUseSetPrimaryDistribution.mockReturnValue({
+        mutate,
+        isPending: true,
+        variables: 'app-1',
+      } as unknown as ReturnType<typeof useSetPrimaryDistribution>);
+
+      render(<DistributionsList recordId="record-1" canEdit />);
+
+      expect(screen.getByRole('button', { name: 'Set as primary' })).toBeDisabled();
+    });
   });
 });

--- a/frontend/src/components/dataset/hooks/__tests__/use-records.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-records.test.ts
@@ -1,5 +1,7 @@
 import { renderHook, waitFor } from '@/test/test-utils';
 import { vi } from 'vitest';
+import { useRef } from 'react';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
 
 vi.mock('@/api/records', () => ({
   listContacts: vi.fn(),
@@ -9,20 +11,29 @@ vi.mock('@/api/records', () => ({
   createKeyword: vi.fn(),
   deleteKeyword: vi.fn(),
   listDistributions: vi.fn(),
+  updateDistribution: vi.fn(),
 }));
 
 vi.mock('@/api/datasets', () => ({
   fetchRelatedDatasets: vi.fn(),
 }));
 
-import { listContacts, createContact, listKeywords } from '@/api/records';
+import { listContacts, createContact, listKeywords, updateDistribution } from '@/api/records';
 import { fetchRelatedDatasets } from '@/api/datasets';
-import { useContacts, useCreateContact, useKeywords, useRelatedDatasets } from '@/components/dataset/hooks/use-records';
+import {
+  useContacts,
+  useCreateContact,
+  useKeywords,
+  useRelatedDatasets,
+  useSetPrimaryDistribution,
+} from '@/components/dataset/hooks/use-records';
+import { queryKeys } from '@/lib/query-keys';
 
 const mockListContacts = vi.mocked(listContacts);
 const mockCreateContact = vi.mocked(createContact);
 const mockListKeywords = vi.mocked(listKeywords);
 const mockFetchRelatedDatasets = vi.mocked(fetchRelatedDatasets);
+const mockUpdateDistribution = vi.mocked(updateDistribution);
 
 describe('useContacts', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -110,5 +121,61 @@ describe('useRelatedDatasets', () => {
     const { result } = renderHook(() => useRelatedDatasets('ds-1'));
 
     await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+// feat(#1395): set-primary control.
+describe('useSetPrimaryDistribution', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /**
+   * Capture the QueryClient from inside the renderHook wrapper so we can
+   * spy on invalidateQueries — see useReuploadCommit in use-dataset.test.ts
+   * for the same pattern.
+   */
+  function renderWithClient(recordId: string | undefined) {
+    let captured: QueryClient | null = null;
+    const { result } = renderHook(() => {
+      const qc = useQueryClient();
+      const ref = useRef<QueryClient | null>(null);
+      if (ref.current === null) ref.current = qc;
+      captured = ref.current;
+      return useSetPrimaryDistribution(recordId);
+    });
+    if (!captured) throw new Error('QueryClient capture failed');
+    return { result, qc: captured as QueryClient };
+  }
+
+  it('PATCHes the chosen distribution with is_primary: true', async () => {
+    mockUpdateDistribution.mockResolvedValueOnce({ id: 'dist-2', is_primary: true } as never);
+    const { result } = renderWithClient('rec-1');
+
+    await result.current.mutateAsync('dist-2');
+
+    expect(mockUpdateDistribution).toHaveBeenCalledWith('rec-1', 'dist-2', { is_primary: true });
+  });
+
+  it('invalidates the distributions list on success, so the badge moves on refetch', async () => {
+    mockUpdateDistribution.mockResolvedValueOnce({ id: 'dist-2', is_primary: true } as never);
+    const { result, qc } = renderWithClient('rec-1');
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+
+    await result.current.mutateAsync('dist-2');
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: queryKeys.records.distributions('rec-1'),
+    });
+  });
+
+  it('does not invalidate when the PATCH is rejected (e.g. an auto-generated row)', async () => {
+    mockUpdateDistribution.mockRejectedValueOnce(
+      new Error('Cannot update auto-generated distributions'),
+    );
+    const { result, qc } = renderWithClient('rec-1');
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+
+    await expect(result.current.mutateAsync('dist-1')).rejects.toThrow();
+
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/dataset/hooks/__tests__/use-records.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-records.test.ts
@@ -26,6 +26,7 @@ import {
   useKeywords,
   useRelatedDatasets,
   useSetPrimaryDistribution,
+  useClearPrimaryDistribution,
 } from '@/components/dataset/hooks/use-records';
 import { queryKeys } from '@/lib/query-keys';
 
@@ -171,6 +172,56 @@ describe('useSetPrimaryDistribution', () => {
     mockUpdateDistribution.mockRejectedValueOnce(
       new Error('Cannot update auto-generated distributions'),
     );
+    const { result, qc } = renderWithClient('rec-1');
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+
+    await expect(result.current.mutateAsync('dist-1')).rejects.toThrow();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+// fix(#1395 codex round 3): clear-primary — the one write that gives an
+// owner back a way to undo a set-primary PATCH without deleting the row.
+describe('useClearPrimaryDistribution', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function renderWithClient(recordId: string | undefined) {
+    let captured: QueryClient | null = null;
+    const { result } = renderHook(() => {
+      const qc = useQueryClient();
+      const ref = useRef<QueryClient | null>(null);
+      if (ref.current === null) ref.current = qc;
+      captured = ref.current;
+      return useClearPrimaryDistribution(recordId);
+    });
+    if (!captured) throw new Error('QueryClient capture failed');
+    return { result, qc: captured as QueryClient };
+  }
+
+  it('PATCHes the chosen distribution with is_primary: false', async () => {
+    mockUpdateDistribution.mockResolvedValueOnce({ id: 'dist-2', is_primary: false } as never);
+    const { result } = renderWithClient('rec-1');
+
+    await result.current.mutateAsync('dist-2');
+
+    expect(mockUpdateDistribution).toHaveBeenCalledWith('rec-1', 'dist-2', { is_primary: false });
+  });
+
+  it('invalidates the distributions list on success', async () => {
+    mockUpdateDistribution.mockResolvedValueOnce({ id: 'dist-2', is_primary: false } as never);
+    const { result, qc } = renderWithClient('rec-1');
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+
+    await result.current.mutateAsync('dist-2');
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: queryKeys.records.distributions('rec-1'),
+    });
+  });
+
+  it('does not invalidate when the PATCH is rejected', async () => {
+    mockUpdateDistribution.mockRejectedValueOnce(new Error('boom'));
     const { result, qc } = renderWithClient('rec-1');
     const spy = vi.spyOn(qc, 'invalidateQueries');
 

--- a/frontend/src/components/dataset/hooks/__tests__/use-records.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-records.test.ts
@@ -26,7 +26,6 @@ import {
   useKeywords,
   useRelatedDatasets,
   useSetPrimaryDistribution,
-  useClearPrimaryDistribution,
 } from '@/components/dataset/hooks/use-records';
 import { queryKeys } from '@/lib/query-keys';
 
@@ -179,54 +178,27 @@ describe('useSetPrimaryDistribution', () => {
 
     expect(spy).not.toHaveBeenCalled();
   });
-});
 
-// fix(#1395 codex round 3): clear-primary — the one write that gives an
-// owner back a way to undo a set-primary PATCH without deleting the row.
-describe('useClearPrimaryDistribution', () => {
-  beforeEach(() => vi.clearAllMocks());
-
-  function renderWithClient(recordId: string | undefined) {
-    let captured: QueryClient | null = null;
-    const { result } = renderHook(() => {
-      const qc = useQueryClient();
-      const ref = useRef<QueryClient | null>(null);
-      if (ref.current === null) ref.current = qc;
-      captured = ref.current;
-      return useClearPrimaryDistribution(recordId);
-    });
-    if (!captured) throw new Error('QueryClient capture failed');
-    return { result, qc: captured as QueryClient };
-  }
-
-  it('PATCHes the chosen distribution with is_primary: false', async () => {
-    mockUpdateDistribution.mockResolvedValueOnce({ id: 'dist-2', is_primary: false } as never);
-    const { result } = renderWithClient('rec-1');
-
-    await result.current.mutateAsync('dist-2');
-
-    expect(mockUpdateDistribution).toHaveBeenCalledWith('rec-1', 'dist-2', { is_primary: false });
-  });
-
-  it('invalidates the distributions list on success', async () => {
-    mockUpdateDistribution.mockResolvedValueOnce({ id: 'dist-2', is_primary: false } as never);
+  // fix(#1395 codex round 4): onSuccess must stay pending through the
+  // refetch, not just the PATCH — otherwise isPending flips back to false
+  // (re-enabling the disabled-while-mutating guard) while the list still
+  // shows pre-PATCH data.
+  it('does not resolve until the invalidated query has refetched', async () => {
+    mockUpdateDistribution.mockResolvedValueOnce({ id: 'dist-2', is_primary: true } as never);
     const { result, qc } = renderWithClient('rec-1');
-    const spy = vi.spyOn(qc, 'invalidateQueries');
+    let resolveInvalidate: (() => void) | undefined;
+    vi.spyOn(qc, 'invalidateQueries').mockImplementation(
+      () => new Promise<void>((resolve) => { resolveInvalidate = resolve; }),
+    );
 
-    await result.current.mutateAsync('dist-2');
+    const mutation = result.current.mutateAsync('dist-2');
+    await waitFor(() => expect(resolveInvalidate).toBeDefined());
+    // The PATCH resolved (mockUpdateDistribution above), but invalidation
+    // hasn't — the mutation must still be pending.
+    await waitFor(() => expect(result.current.isPending).toBe(true));
 
-    expect(spy).toHaveBeenCalledWith({
-      queryKey: queryKeys.records.distributions('rec-1'),
-    });
-  });
-
-  it('does not invalidate when the PATCH is rejected', async () => {
-    mockUpdateDistribution.mockRejectedValueOnce(new Error('boom'));
-    const { result, qc } = renderWithClient('rec-1');
-    const spy = vi.spyOn(qc, 'invalidateQueries');
-
-    await expect(result.current.mutateAsync('dist-1')).rejects.toThrow();
-
-    expect(spy).not.toHaveBeenCalled();
+    resolveInvalidate!();
+    await mutation;
+    await waitFor(() => expect(result.current.isPending).toBe(false));
   });
 });

--- a/frontend/src/components/dataset/hooks/use-records.ts
+++ b/frontend/src/components/dataset/hooks/use-records.ts
@@ -109,6 +109,25 @@ export function useSetPrimaryDistribution(recordId: string | undefined) {
   });
 }
 
+// fix(#1395 codex round 3): the only write DistributionsList offers back
+// once a manual row has claimed is_primary. `is_primary: false` demotes the
+// row without deleting it — `update_distribution` rejects any other write
+// against an auto_generated row, so there is no PATCH that hands the flag
+// straight back to the generated GeoPackage/CSV default. The record is left
+// with no primary until the next ingest/refresh reconcile fills one back in.
+export function useClearPrimaryDistribution(recordId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (distributionId: string) =>
+      updateDistribution(recordId!, distributionId, { is_primary: false }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.records.distributions(recordId) });
+      toast.success(i18n.t('dataset:distributions.primaryCleared'));
+    },
+    onError: (err) => { toast.error(formatMutationError('dataset:distributions.clearPrimaryFailed', err)); },
+  });
+}
+
 export function useRelatedDatasets(datasetId: string) {
   return useQuery({
     queryKey: queryKeys.datasets.related(datasetId),

--- a/frontend/src/components/dataset/hooks/use-records.ts
+++ b/frontend/src/components/dataset/hooks/use-records.ts
@@ -96,35 +96,23 @@ export function useDistributions(recordId: string | undefined) {
 // feat(#1395): set-primary control. mutationFn's argument is the
 // distributionId being promoted — the row that ends up carrying is_primary
 // after the backend demotes every other row on the record in the same write.
+//
+// fix(#1395 codex round 4): onSuccess returns the invalidateQueries promise
+// so the mutation stays pending until the refetch lands, not just until the
+// PATCH resolves — DistributionsList's disabled-while-mutating guard reads
+// isPending, and an onSuccess that fires-and-forgets the invalidation would
+// let it flip back to enabled while the list still shows the pre-PATCH
+// primary, opening a window for a second click to race the first.
 export function useSetPrimaryDistribution(recordId: string | undefined) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (distributionId: string) =>
       updateDistribution(recordId!, distributionId, { is_primary: true }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: queryKeys.records.distributions(recordId) });
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: queryKeys.records.distributions(recordId) });
       toast.success(i18n.t('dataset:distributions.primaryUpdated'));
     },
     onError: (err) => { toast.error(formatMutationError('dataset:distributions.setPrimaryFailed', err)); },
-  });
-}
-
-// fix(#1395 codex round 3): the only write DistributionsList offers back
-// once a manual row has claimed is_primary. `is_primary: false` demotes the
-// row without deleting it — `update_distribution` rejects any other write
-// against an auto_generated row, so there is no PATCH that hands the flag
-// straight back to the generated GeoPackage/CSV default. The record is left
-// with no primary until the next ingest/refresh reconcile fills one back in.
-export function useClearPrimaryDistribution(recordId: string | undefined) {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (distributionId: string) =>
-      updateDistribution(recordId!, distributionId, { is_primary: false }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: queryKeys.records.distributions(recordId) });
-      toast.success(i18n.t('dataset:distributions.primaryCleared'));
-    },
-    onError: (err) => { toast.error(formatMutationError('dataset:distributions.clearPrimaryFailed', err)); },
   });
 }
 

--- a/frontend/src/components/dataset/hooks/use-records.ts
+++ b/frontend/src/components/dataset/hooks/use-records.ts
@@ -9,6 +9,7 @@ import {
   createKeyword,
   deleteKeyword,
   listDistributions,
+  updateDistribution,
 } from '@/api/records';
 import { fetchRelatedDatasets } from '@/api/datasets';
 import type { ContactCreate, KeywordCreate } from '@/types/api';
@@ -89,6 +90,22 @@ export function useDistributions(recordId: string | undefined) {
     queryFn: () => listDistributions(recordId!),
     enabled: !!recordId,
     staleTime: 5 * 60_000,
+  });
+}
+
+// feat(#1395): set-primary control. mutationFn's argument is the
+// distributionId being promoted — the row that ends up carrying is_primary
+// after the backend demotes every other row on the record in the same write.
+export function useSetPrimaryDistribution(recordId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (distributionId: string) =>
+      updateDistribution(recordId!, distributionId, { is_primary: true }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.records.distributions(recordId) });
+      toast.success(i18n.t('dataset:distributions.primaryUpdated'));
+    },
+    onError: (err) => { toast.error(formatMutationError('dataset:distributions.setPrimaryFailed', err)); },
   });
 }
 

--- a/frontend/src/components/dataset/tabs/AccessTab.tsx
+++ b/frontend/src/components/dataset/tabs/AccessTab.tsx
@@ -355,7 +355,7 @@ export function AccessTab({ dataset, canEdit = false }: AccessTabProps) {
         </CardHeader>
         <CardContent>
           {dataset.record_id ? (
-            <DistributionsList recordId={dataset.record_id} />
+            <DistributionsList recordId={dataset.record_id} canEdit={canEdit} />
           ) : (
             <p className="text-sm text-muted-foreground">
               {t('distributions.noDistributions')}

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -590,10 +590,7 @@
     "setPrimary": "{{name}} als primär festlegen",
     "currentPrimary": "{{name}} ist die primäre Distribution",
     "primaryUpdated": "Primäre Distribution aktualisiert.",
-    "setPrimaryFailed": "Primäre Distribution konnte nicht festgelegt werden.",
-    "clearPrimary": "Primärstatus von {{name}} entfernen",
-    "primaryCleared": "Primärstatus entfernt. Die Standarddistribution wird bei der nächsten Aktualisierung wiederhergestellt.",
-    "clearPrimaryFailed": "Primäre Distribution konnte nicht entfernt werden."
+    "setPrimaryFailed": "Primäre Distribution konnte nicht festgelegt werden."
   },
   "publish": {
     "publish": "Veröffentlichen",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -586,7 +586,11 @@
     "auto": "auto",
     "primary": "Primär",
     "copyUrl": "URL kopieren",
-    "loadError": "Verteilungen konnten nicht geladen werden."
+    "loadError": "Verteilungen konnten nicht geladen werden.",
+    "setPrimary": "Als primär festlegen",
+    "currentPrimary": "Primäre Distribution",
+    "primaryUpdated": "Primäre Distribution aktualisiert.",
+    "setPrimaryFailed": "Primäre Distribution konnte nicht festgelegt werden."
   },
   "publish": {
     "publish": "Veröffentlichen",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -587,8 +587,8 @@
     "primary": "Primär",
     "copyUrl": "URL kopieren",
     "loadError": "Verteilungen konnten nicht geladen werden.",
-    "setPrimary": "Als primär festlegen",
-    "currentPrimary": "Primäre Distribution",
+    "setPrimary": "{{name}} als primär festlegen",
+    "currentPrimary": "{{name}} ist die primäre Distribution",
     "primaryUpdated": "Primäre Distribution aktualisiert.",
     "setPrimaryFailed": "Primäre Distribution konnte nicht festgelegt werden."
   },

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -590,7 +590,10 @@
     "setPrimary": "{{name}} als primär festlegen",
     "currentPrimary": "{{name}} ist die primäre Distribution",
     "primaryUpdated": "Primäre Distribution aktualisiert.",
-    "setPrimaryFailed": "Primäre Distribution konnte nicht festgelegt werden."
+    "setPrimaryFailed": "Primäre Distribution konnte nicht festgelegt werden.",
+    "clearPrimary": "Primärstatus von {{name}} entfernen",
+    "primaryCleared": "Primärstatus entfernt. Die Standarddistribution wird bei der nächsten Aktualisierung wiederhergestellt.",
+    "clearPrimaryFailed": "Primäre Distribution konnte nicht entfernt werden."
   },
   "publish": {
     "publish": "Veröffentlichen",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -541,10 +541,7 @@
     "setPrimary": "Set {{name}} as primary",
     "currentPrimary": "{{name}} is the primary distribution",
     "primaryUpdated": "Primary distribution updated.",
-    "setPrimaryFailed": "Failed to set primary distribution.",
-    "clearPrimary": "Clear primary status from {{name}}",
-    "primaryCleared": "Primary status cleared. The default distribution will be restored on the next refresh.",
-    "clearPrimaryFailed": "Failed to clear primary distribution."
+    "setPrimaryFailed": "Failed to set primary distribution."
   },
   "publish": {
     "publish": "Publish",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -538,8 +538,8 @@
     "primary": "Primary",
     "copyUrl": "Copy URL",
     "loadError": "Failed to load distributions.",
-    "setPrimary": "Set as primary",
-    "currentPrimary": "Primary distribution",
+    "setPrimary": "Set {{name}} as primary",
+    "currentPrimary": "{{name}} is the primary distribution",
     "primaryUpdated": "Primary distribution updated.",
     "setPrimaryFailed": "Failed to set primary distribution."
   },

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -537,7 +537,11 @@
     "auto": "auto",
     "primary": "Primary",
     "copyUrl": "Copy URL",
-    "loadError": "Failed to load distributions."
+    "loadError": "Failed to load distributions.",
+    "setPrimary": "Set as primary",
+    "currentPrimary": "Primary distribution",
+    "primaryUpdated": "Primary distribution updated.",
+    "setPrimaryFailed": "Failed to set primary distribution."
   },
   "publish": {
     "publish": "Publish",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -541,7 +541,10 @@
     "setPrimary": "Set {{name}} as primary",
     "currentPrimary": "{{name}} is the primary distribution",
     "primaryUpdated": "Primary distribution updated.",
-    "setPrimaryFailed": "Failed to set primary distribution."
+    "setPrimaryFailed": "Failed to set primary distribution.",
+    "clearPrimary": "Clear primary status from {{name}}",
+    "primaryCleared": "Primary status cleared. The default distribution will be restored on the next refresh.",
+    "clearPrimaryFailed": "Failed to clear primary distribution."
   },
   "publish": {
     "publish": "Publish",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -590,10 +590,7 @@
     "setPrimary": "Establecer {{name}} como primario",
     "currentPrimary": "{{name}} es la distribución primaria",
     "primaryUpdated": "Distribución primaria actualizada.",
-    "setPrimaryFailed": "No se pudo establecer la distribución primaria.",
-    "clearPrimary": "Quitar el estado primario de {{name}}",
-    "primaryCleared": "Estado primario eliminado. La distribución predeterminada se restaurará en la próxima actualización.",
-    "clearPrimaryFailed": "No se pudo quitar la distribución primaria."
+    "setPrimaryFailed": "No se pudo establecer la distribución primaria."
   },
   "publish": {
     "publish": "Publicar",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -587,8 +587,8 @@
     "primary": "Primario",
     "copyUrl": "Copiar URL",
     "loadError": "No se pudieron cargar las distribuciones.",
-    "setPrimary": "Establecer como primario",
-    "currentPrimary": "Distribución primaria",
+    "setPrimary": "Establecer {{name}} como primario",
+    "currentPrimary": "{{name}} es la distribución primaria",
     "primaryUpdated": "Distribución primaria actualizada.",
     "setPrimaryFailed": "No se pudo establecer la distribución primaria."
   },

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -586,7 +586,11 @@
     "auto": "auto",
     "primary": "Primario",
     "copyUrl": "Copiar URL",
-    "loadError": "No se pudieron cargar las distribuciones."
+    "loadError": "No se pudieron cargar las distribuciones.",
+    "setPrimary": "Establecer como primario",
+    "currentPrimary": "Distribución primaria",
+    "primaryUpdated": "Distribución primaria actualizada.",
+    "setPrimaryFailed": "No se pudo establecer la distribución primaria."
   },
   "publish": {
     "publish": "Publicar",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -590,7 +590,10 @@
     "setPrimary": "Establecer {{name}} como primario",
     "currentPrimary": "{{name}} es la distribución primaria",
     "primaryUpdated": "Distribución primaria actualizada.",
-    "setPrimaryFailed": "No se pudo establecer la distribución primaria."
+    "setPrimaryFailed": "No se pudo establecer la distribución primaria.",
+    "clearPrimary": "Quitar el estado primario de {{name}}",
+    "primaryCleared": "Estado primario eliminado. La distribución predeterminada se restaurará en la próxima actualización.",
+    "clearPrimaryFailed": "No se pudo quitar la distribución primaria."
   },
   "publish": {
     "publish": "Publicar",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -587,8 +587,8 @@
     "primary": "Principal",
     "copyUrl": "Copier l'URL",
     "loadError": "Impossible de charger les distributions.",
-    "setPrimary": "Définir comme principal",
-    "currentPrimary": "Distribution principale",
+    "setPrimary": "Définir {{name}} comme principal",
+    "currentPrimary": "{{name}} est la distribution principale",
     "primaryUpdated": "Distribution principale mise à jour.",
     "setPrimaryFailed": "Impossible de définir la distribution principale."
   },

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -586,7 +586,11 @@
     "auto": "auto",
     "primary": "Principal",
     "copyUrl": "Copier l'URL",
-    "loadError": "Impossible de charger les distributions."
+    "loadError": "Impossible de charger les distributions.",
+    "setPrimary": "Définir comme principal",
+    "currentPrimary": "Distribution principale",
+    "primaryUpdated": "Distribution principale mise à jour.",
+    "setPrimaryFailed": "Impossible de définir la distribution principale."
   },
   "publish": {
     "publish": "Publier",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -590,7 +590,10 @@
     "setPrimary": "Définir {{name}} comme principal",
     "currentPrimary": "{{name}} est la distribution principale",
     "primaryUpdated": "Distribution principale mise à jour.",
-    "setPrimaryFailed": "Impossible de définir la distribution principale."
+    "setPrimaryFailed": "Impossible de définir la distribution principale.",
+    "clearPrimary": "Retirer le statut principal de {{name}}",
+    "primaryCleared": "Statut principal retiré. La distribution par défaut sera restaurée lors de la prochaine actualisation.",
+    "clearPrimaryFailed": "Impossible de retirer la distribution principale."
   },
   "publish": {
     "publish": "Publier",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -590,10 +590,7 @@
     "setPrimary": "Définir {{name}} comme principal",
     "currentPrimary": "{{name}} est la distribution principale",
     "primaryUpdated": "Distribution principale mise à jour.",
-    "setPrimaryFailed": "Impossible de définir la distribution principale.",
-    "clearPrimary": "Retirer le statut principal de {{name}}",
-    "primaryCleared": "Statut principal retiré. La distribution par défaut sera restaurée lors de la prochaine actualisation.",
-    "clearPrimaryFailed": "Impossible de retirer la distribution principale."
+    "setPrimaryFailed": "Impossible de définir la distribution principale."
   },
   "publish": {
     "publish": "Publier",

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -428,6 +428,13 @@ export interface DistributionListResponse {
   total: number;
 }
 
+/** feat(#1395): the only field the set-primary control writes. The backend
+ * `DistributionUpdate` schema accepts the full row (title/url/etc.), but this
+ * UI never edits those — a distribution editor is a separate feature. */
+export interface DistributionUpdate {
+  is_primary?: boolean;
+}
+
 export interface AttributeMetadataResponse {
   id: string;
   dataset_id: string;


### PR DESCRIPTION
## What

Adds an owner-or-admin set-primary control to `DistributionsList`. Follow-up
from #1383/#1393, which gave the backend a coherent last-write-wins rule for
`is_primary` (writing it demotes the record's other distributions; deleting
the primary hands the flag back to the generated default).

- A "Set as primary" icon button PATCHes the chosen distribution with
  `is_primary: true` through `apiFetch()`, then invalidates the distributions
  query so the previous "Primary" badge moves in the same refresh.
- Owner-or-admin only: `DistributionsList` takes a new `canEdit` prop, passed
  down from `AccessTab` (which already mirrors the backend's
  `check_dataset_write_access` guard for its visibility control).
- The control renders only on manual (non-`auto_generated`) rows.
  `update_distribution` on the backend rejects any write — `is_primary`
  included — against an auto-generated row with a 400, so a control on those
  rows could never do anything but fail; hiding it avoids a false affordance.
  The currently-primary manual row renders checked and disabled.
- New `t()` keys (`distributions.setPrimary`, `currentPrimary`,
  `primaryUpdated`, `setPrimaryFailed`) added to all four locales (en/es/fr/de).
- Accessible name comes from `aria-label`/`title` on the `<button>` itself —
  no `<label for>` involved, since that would override rather than compose
  with a button's accessible name.

## Verification

Run from `frontend/`:

```
npm ci
npm run typecheck
npm run lint
npx vitest run src/components/dataset/__tests__/DistributionsList.test.tsx \
  src/components/dataset/hooks/__tests__/use-records.test.ts \
  src/components/dataset/__tests__/AccessTab.test.tsx
npm run test:coverage   # 385 files / 4777 tests passed
npm run test:i18n
npm run build
```

Closes #1395