### PR TITLE
fix(ingest): reconcile orphaned presigned-upload objects against tracking rows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -715,6 +715,13 @@ FRONTEND_PORT=8080
 # Type: integer (minimum 0) | Default: 30
 # INGEST_JOBS_RETENTION_DAYS=30
 
+# How old an object under the upload staging prefix must be before the
+# reconciliation sweep deletes it for having no ingest-job row that still needs
+# it. Not an estimate of how long an upload takes — the row check decides
+# ownership; this only has to clear a listing snapshot. Floored at an hour.
+# Type: integer (minimum 3600) | Default: 86400
+# STAGING_ORPHAN_MIN_AGE_SECONDS=86400
+
 # --- Analysis Budgets ---
 # Statement timeout for the analysis materialize CTAS — the CREATE TABLE AS that
 # builds a buffer/dissolve/clip/centroid output. The default covers roughly 150k

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -366,6 +366,19 @@ class Settings(BaseSettings):
     # 0 disables the purge (keep history forever).
     ingest_jobs_retention_days: int = Field(default=30, ge=0)
 
+    # fix(#1249): how old an object under the `staging/` prefix must be before
+    # the reconciliation sweep will delete it for having no ingest_jobs row.
+    # Not a guess at how long an upload takes — the row check is what decides
+    # whether an object is owned, and this only has to be far enough past a
+    # LISTING that no object can be reported old while its own tracking row is
+    # still being written. A day is orders of magnitude past that and costs
+    # nothing but a day of leaked bytes in the rare orphan case.
+    # Floored at an hour so a misconfiguration cannot turn the sweep into a
+    # deleter of objects whose uploads are still landing.
+    # Consumer: `reconcile_orphaned_staging_objects` in
+    # platform/jobs/staging_reconcile.py.
+    staging_orphan_min_age_seconds: int = Field(default=86400, ge=3600)
+
     # ---------------------------------------------------------------------------
     # Outbound Notification channels (Phase 1229 NOTIF-02 / NOTIF-03 / NOTIF-05)
     # ---------------------------------------------------------------------------

--- a/backend/app/observability/metrics/jobs.py
+++ b/backend/app/observability/metrics/jobs.py
@@ -37,6 +37,23 @@ jobs_failed_total = Counter(
     ["queue"],
 )
 
+# fix(#1249): staging objects deleted because no ingest_jobs row tracks them.
+# A true counter rather than a polled gauge, and safe as one for a reason
+# worth stating (the concern refresh.py's module docstring raises): the
+# reconciliation pass runs under a `pg_try_advisory_xact_lock`, so at most one
+# process per interval deletes — and therefore counts — any given object,
+# where a poll-and-increment design would report N times the truth under
+# UVICORN_WORKERS>1. Incremented only after the provider delete returns, so
+# the number counts completed deletions, not intentions.
+#
+# The series matters most when it is non-zero and STAYS non-zero: a steady
+# trickle means something is leaking staging objects faster than one-off
+# incidents explain.
+staging_orphans_deleted_total = Counter(
+    "geolens_staging_orphans_deleted_total",
+    "Staging objects deleted for having no ingest-job row tracking them",
+)
+
 # Track previous snapshot for counter delta computation.
 # NOTE(#655): on the first cycle after boot this is empty, so the counters seed
 # with the full historical procrastinate_jobs row counts — raw counter values

--- a/backend/app/platform/jobs/models.py
+++ b/backend/app/platform/jobs/models.py
@@ -35,6 +35,17 @@ from app.core.db import Base
 # sweep.py) and the staging-orphan reconciliation both read it.
 STATUSES_NEEDING_STAGED_INPUT = ("pending", "running", "failed")
 
+# `user_metadata` key the post-expiry presigned sweep sets once it has finished
+# with a row's `s3_key` for good — see `_sweep_expired_presigned_staging` in
+# sweep.py, which owns the whole story of when it may be written.
+#
+# fix(#1249 review r6): it lives here because a SECOND reader now depends on
+# it. Its presence is the fact that says "the row-driven reaper will never look
+# at this key again", which is exactly when the staging-orphan reconciliation
+# may take the key over — and a copy of the string in each module is one
+# rename away from a row that shields an object forever.
+STAGING_REAPED_FINAL_MARKER = "s3_key_reaped_final"
+
 
 def owned_presigned_staging_key(
     job_id: uuid.UUID | str,

--- a/backend/app/platform/jobs/models.py
+++ b/backend/app/platform/jobs/models.py
@@ -20,6 +20,22 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.core.db import Base
 
 
+# Statuses whose row still NEEDS the staged input its `file_path` points at:
+# pending and running are reading it now, and failed keeps it for
+# /jobs/{id}/retry (a failed-only endpoint). Every other status is done with
+# the bytes — a `complete` fan-out child keeps its metadata row but not a claim
+# on the shared original, which is why a successful fan-out's input is reapable
+# at all rather than pinned forever by children that are each a dataset's
+# latest complete job.
+#
+# fix(#1249 review r4): lives here rather than inline at either consumer,
+# because two of them now ask the same question and a drift between them is a
+# leak in one direction and a deletion of live input in the other. The
+# retention purge's survivor query (`_reap_committed_staged_paths`'s feeder in
+# sweep.py) and the staging-orphan reconciliation both read it.
+STATUSES_NEEDING_STAGED_INPUT = ("pending", "running", "failed")
+
+
 def owned_presigned_staging_key(
     job_id: uuid.UUID | str,
     user_metadata: dict[str, Any] | None,

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -36,6 +36,7 @@ from app.platform.jobs.schemas import (
     ReservedRenameWarning,
     StaleCleanupResponse,
 )
+from app.platform.jobs.staging_reconcile import reconcile_orphaned_staging_objects
 from app.platform.jobs.sweep import (
     JOB_TIMEOUT_SECONDS,
     STALE_PENDING_BOUND_MESSAGE,
@@ -195,6 +196,11 @@ async def cleanup_stale_jobs(
             publish_refresh_reconciliation(outcome)
             outcome = await _reap_committed_staged_paths(outcome)
             outcome = await _sweep_expired_presigned_staging(db, outcome)
+            # fix(#1249): same object-driven reconciliation the background
+            # sweeper runs. The multi-tenant branch needs nothing here — the
+            # fleet helper runs fail_stale_jobs with its own commit per
+            # tenant, and that path already reconciles in tenant context.
+            await reconcile_orphaned_staging_objects(db)
             details = outcome.as_dict()
     except Exception as exc:  # broad: cleanup spans DB and artifact deletion
         await db.rollback()

--- a/backend/app/platform/jobs/staging_reconcile.py
+++ b/backend/app/platform/jobs/staging_reconcile.py
@@ -1,0 +1,351 @@
+"""Reconcile real staging objects against ingest-job rows (fix #1249).
+
+Every other staging reaper in this codebase starts from a ROW and asks what
+object it owns. This one starts from the OBJECT and asks whether any row still
+owns it — the only direction that can see an object no row references at all.
+
+### Why reconciliation rather than a wider margin
+
+#1235/#1236 closed the presigned-upload orphan window twice by widening the
+window a sweep waits before it may act, and review round 5 of #1236 found the
+residual gap in the approach itself: S3 validates a presigned signature when a
+request STARTS, not when it finishes transferring, so an accepted single-part
+PUT can still be writing arbitrarily long after every deadline derived from
+its URL has passed. Any margin computed from elapsed time is a guess at a
+transfer rate nothing enforces — widen it and the guess is merely rarer.
+
+A HEAD-before-delete has the symmetric problem in the other direction: it
+proves the object was absent when the check ran, not that it stays absent
+while the delete is in flight.
+
+Reconciliation removes the class instead of shrinking it. It never has to
+decide whether some upload is "probably done"; it asks a question with a
+durable answer — is there a row that owns this key? — and an object whose
+answer is no is unreachable by any future PUT, because a presigned URL for
+`staging/{job_id}/…` is only ever minted alongside the `ingest_jobs` row with
+that id, and the retention purge deliberately keeps such a row alive until
+past `MAX_PRESIGNED_URL_LIFETIME_SECONDS + _RECHECK_TRANSFER_MARGIN_SECONDS`
+(see `presigned_url_may_still_be_live` in `sweep.py`). It also catches orphans
+from causes no margin ever addressed: a delete that failed inside a
+best-effort reaper, a row purged while its object delete errored, a worker
+killed between writing an object and committing the row that names it.
+
+### The two races, handled by construction
+
+1. **An object uploaded after the listing snapshot.** Only objects whose
+   last-modified is older than ``staging_orphan_min_age_seconds`` are ever
+   candidates, and the age is re-read from the provider immediately before the
+   delete — a listing entry alone is never authority for destroying anything.
+   An object created or overwritten after the snapshot fails that re-read.
+2. **A row that lands after the batch row query.** Absence is re-checked per
+   object, immediately before that object's delete, in its own statement.
+   PostgreSQL's default READ COMMITTED gives every statement a fresh snapshot,
+   so the recheck sees rows committed since the batch query rather than
+   replaying it.
+
+Neither race can be closed by ordering alone — there is no atomic
+"delete-if-still-unreferenced" across a database and an object store. What
+makes the residue harmless is that both rechecks fail CLOSED (an ambiguous or
+unreadable answer skips the object and leaves it for the next pass), and the
+only thing a missed pass costs is a day of leaked bytes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import structlog
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.observability.metrics.jobs import staging_orphans_deleted_total
+from app.platform.jobs.models import IngestJob
+from app.platform.storage.provider import StoredObject
+from app.platform.storage.titiler_url import resolve_current_storage_key
+
+log = structlog.get_logger()
+
+# The one prefix this sweep may delete under. Everything below it is written
+# by the upload system and namespaced by the job that wrote it
+# (`staging/{job_id}/…`, plus the `frozen/` snapshot under the same job
+# segment); `manifest_sources.py` explicitly refuses operator keys here for
+# that reason. Nothing outside this prefix is ever listed, so no object the
+# upload system does not own can reach the delete path at all.
+STAGING_PREFIX = "staging/"
+
+# Deletes per pass. The pass holds one transaction open for its advisory lock,
+# and each delete costs a row recheck plus an age re-read, so an unbounded loop
+# over a pathological bucket would keep a session idle-in-transaction for a
+# long time. Leftovers are not urgent — they are already-leaked bytes, and the
+# sweep runs every few minutes.
+_MAX_DELETES_PER_PASS = 200
+
+
+@dataclass(frozen=True)
+class StagingReconcileOutcome:
+    """What one reconciliation pass saw and did."""
+
+    # False when the pass declined to run at all: another process holds the
+    # lock, or multi-tenant mode gave no tenant context to scope the prefix.
+    ran: bool = False
+    objects_listed: int = 0
+    orphans_deleted: int = 0
+    delete_failures: int = 0
+    # Skips, each its own number because they mean different things:
+    #   recent          — younger than the threshold at listing time; the
+    #                     ordinary steady state on a busy instance.
+    #   object_changed  — the pre-delete re-read found it gone or rewritten;
+    #                     race #1 being caught.
+    #   row_appeared    — the pre-delete recheck found a row; race #2.
+    #   unattributable  — something under `staging/` whose owning job cannot
+    #                     be named, which this sweep declines to touch.
+    skipped_recent: int = 0
+    skipped_object_changed: int = 0
+    skipped_row_appeared: int = 0
+    skipped_unattributable: int = 0
+
+    def as_log_fields(self) -> dict[str, int]:
+        """Flatten to structlog kwargs."""
+        return {
+            "objects_listed": self.objects_listed,
+            "orphans_deleted": self.orphans_deleted,
+            "delete_failures": self.delete_failures,
+            "skipped_recent": self.skipped_recent,
+            "skipped_object_changed": self.skipped_object_changed,
+            "skipped_row_appeared": self.skipped_row_appeared,
+            "skipped_unattributable": self.skipped_unattributable,
+        }
+
+
+def _job_id_from_key(logical_key: str) -> uuid.UUID | None:
+    """Extract the owning job id from a `staging/{job_id}/…` key.
+
+    Returns None for anything that is not shaped like a job-owned staging key
+    — including `staging/{job_id}` with no trailing segment, which names no
+    object this sweep put there. An unparseable key is never deleted: this
+    sweep only destroys objects it can positively attribute to an absent row,
+    and "I cannot tell whose this is" is not that.
+    """
+    parts = logical_key.split("/")
+    if len(parts) < 3 or parts[0] != "staging" or not parts[-1]:
+        return None
+    try:
+        return uuid.UUID(parts[1])
+    except ValueError:
+        return None
+
+
+async def _job_row_exists(db: AsyncSession, job_id: uuid.UUID) -> bool:
+    """Is there still an ``ingest_jobs`` row with this id, right now?
+
+    A fresh statement rather than a reuse of the batch query's result on
+    purpose: under READ COMMITTED every statement takes its own snapshot, so
+    this sees rows committed since that query — which is exactly the race it
+    exists to catch. Core select over the id column, never an ORM object load,
+    so the session's identity map cannot answer from a stale instance.
+    """
+    result = await db.execute(select(IngestJob.id).where(IngestJob.id == job_id))
+    return result.first() is not None
+
+
+async def _current_entry(storage, physical_key: str) -> StoredObject | None:
+    """Re-read one object's last-modified time, or None if it is gone.
+
+    ``list_objects`` with a COMPLETE key rather than a directory prefix: the
+    Protocol has no head-with-timestamp call, and a prefix listing of one exact
+    key is the portable way to ask every provider the same question. The result
+    is filtered for an exact match because a prefix listing also returns
+    siblings whose keys merely start with this one.
+    """
+    for entry in await storage.list_objects(physical_key):
+        if entry.key == physical_key:
+            return entry
+    return None
+
+
+async def reconcile_orphaned_staging_objects(
+    db: AsyncSession, *, now: datetime | None = None
+) -> StagingReconcileOutcome:
+    """Delete staging objects that no ``ingest_jobs`` row tracks.
+
+    Read-only against ``db`` — the only mutation is on the object store, and
+    the caller's session is neither committed nor rolled back here. That is
+    deliberate rather than incidental: a rollback expires every instance in
+    the caller's identity map regardless of ``expire_on_commit``, so a sweep
+    that still holds ORM objects would find them unloadable afterwards. The
+    advisory lock therefore lives on a session of this function's own.
+
+    The lock is what makes the counter honest. Every API worker runs its own
+    copy of the sweeper loop, and each would otherwise list the same prefix and
+    count the same delete, reporting N times the truth under
+    ``UVICORN_WORKERS>1`` — the same fabricated-number class #1240 existed to
+    remove. It also keeps the provider LIST to one per interval per tenant
+    rather than one per worker. Transaction-scoped, so a process that dies
+    mid-pass releases it with its connection rather than wedging every future
+    pass.
+
+    Never raises: a provider or database failure mid-pass leaves whatever it
+    has not reached for the next cycle. Nothing downstream depends on this
+    having run, and the sweep it is wired into must survive it.
+    """
+    now = now or datetime.now(timezone.utc)
+    try:
+        return await _reconcile(db, now=now)
+    except Exception as exc:  # broad: best-effort pass, never fails its caller
+        log.warning(
+            "Staging orphan reconciliation failed",
+            error=str(exc),
+            exc_info=True,
+        )
+        return StagingReconcileOutcome(ran=False)
+
+
+async def _reconcile(db: AsyncSession, *, now: datetime) -> StagingReconcileOutcome:
+    """The pass itself. See the wrapper above for the error and lock contract."""
+    from app.core.db import async_session  # late-bound for tests, as #909 does
+    from app.core.db.tenant_session import current_tenant_var
+    from app.core.tenancy import is_multi_tenant
+    from app.platform.storage import get_storage
+
+    if is_multi_tenant() and current_tenant_var.get() is None:
+        # No tenant context, no tenant namespace to scope the listing to.
+        # Declining is the only safe answer: the alternative would sweep the
+        # whole bucket while the session's RLS shows it no rows at all, which
+        # reads every tenant's objects as untracked. Same fail-closed posture
+        # as `_stale_generation_storage_keys` in sweep.py.
+        return StagingReconcileOutcome(ran=False)
+
+    # Resolves the ACTIVE tenant's namespace in multi-tenant mode, so the
+    # listing can never cross a tenant boundary.
+    physical_prefix = resolve_current_storage_key(STAGING_PREFIX)
+
+    # A session that exists only to hold the lock. It touches no table, so RLS
+    # and tenant context are irrelevant to it; every row read below goes
+    # through the caller's already tenant-scoped ``db``. Leaving the context
+    # ends its transaction and releases the lock, and it does so without
+    # committing or rolling back anything the caller owns.
+    async with async_session() as lock_session:
+        locked = await lock_session.execute(
+            text("SELECT pg_try_advisory_xact_lock(hashtextextended(:lock_key, 0))"),
+            {"lock_key": f"staging-orphan-reconcile:{physical_prefix}"},
+        )
+        if not locked.scalar():
+            return StagingReconcileOutcome(ran=False)
+        return await _reconcile_locked(
+            db, now=now, physical_prefix=physical_prefix, storage=get_storage()
+        )
+
+
+async def _reconcile_locked(
+    db: AsyncSession,
+    *,
+    now: datetime,
+    physical_prefix: str,
+    storage,
+) -> StagingReconcileOutcome:
+    """The pass body, entered only with the advisory lock held."""
+    # Clock skew between this process and the object store is immaterial at a
+    # threshold measured in hours, which is one more reason the threshold is
+    # not a tuned estimate of transfer duration.
+    cutoff = now - timedelta(seconds=settings.staging_orphan_min_age_seconds)
+    listed = await storage.list_objects(physical_prefix)
+
+    skipped_recent = 0
+    skipped_unattributable = 0
+    candidates: list[tuple[str, uuid.UUID]] = []
+    for entry in listed:
+        # Defensive: a provider that returned a key outside the prefix it was
+        # asked for must not be trusted to name a deletable object.
+        if not entry.key.startswith(physical_prefix):
+            skipped_unattributable += 1
+            continue
+        logical_key = STAGING_PREFIX + entry.key[len(physical_prefix) :]
+        job_id = _job_id_from_key(logical_key)
+        if job_id is None:
+            skipped_unattributable += 1
+            continue
+        if entry.last_modified >= cutoff:
+            skipped_recent += 1
+            continue
+        candidates.append((entry.key, job_id))
+
+    if not candidates:
+        return StagingReconcileOutcome(
+            ran=True,
+            objects_listed=len(listed),
+            skipped_recent=skipped_recent,
+            skipped_unattributable=skipped_unattributable,
+        )
+
+    # One query for the common case (everything is tracked); the per-object
+    # recheck below is the authority, this only avoids paying for it per object
+    # on a healthy bucket.
+    live_ids = set(
+        (
+            await db.execute(
+                select(IngestJob.id).where(
+                    IngestJob.id.in_({job_id for _key, job_id in candidates})
+                )
+            )
+        ).scalars()
+    )
+
+    deleted = 0
+    failures = 0
+    skipped_object_changed = 0
+    skipped_row_appeared = 0
+    for physical_key, job_id in sorted(candidates):
+        if job_id in live_ids:
+            continue
+        if deleted + failures >= _MAX_DELETES_PER_PASS:
+            break
+        # Deliberately OUTSIDE the try below. A database error here is not a
+        # per-object problem to count and move past — it leaves the
+        # transaction unusable, so every remaining candidate would "fail" on a
+        # recheck that never ran. Let it reach the wrapper and end the pass.
+        if await _job_row_exists(db, job_id):
+            skipped_row_appeared += 1
+            continue
+        try:
+            entry = await _current_entry(storage, physical_key)
+            if entry is None or entry.last_modified >= cutoff:
+                # Gone already, or rewritten since the listing. Either way
+                # this pass has nothing it can honestly delete.
+                skipped_object_changed += 1
+                continue
+            await storage.delete(physical_key)
+        except Exception:  # broad: best-effort per object, the pass continues
+            failures += 1
+            log.warning(
+                "Failed to delete orphaned staging object",
+                storage_key=physical_key,
+                job_id=str(job_id),
+            )
+            continue
+        deleted += 1
+        log.warning(
+            "Deleted orphaned staging object with no ingest job row",
+            storage_key=physical_key,
+            job_id=str(job_id),
+            last_modified=entry.last_modified.isoformat(),
+            age_seconds=int((now - entry.last_modified).total_seconds()),
+        )
+
+    if deleted:
+        # After the deletes returned, never before: the counter records
+        # completed deletions, not intentions.
+        staging_orphans_deleted_total.inc(deleted)
+
+    return StagingReconcileOutcome(
+        ran=True,
+        objects_listed=len(listed),
+        orphans_deleted=deleted,
+        delete_failures=failures,
+        skipped_recent=skipped_recent,
+        skipped_object_changed=skipped_object_changed,
+        skipped_row_appeared=skipped_row_appeared,
+        skipped_unattributable=skipped_unattributable,
+    )

--- a/backend/app/platform/jobs/staging_reconcile.py
+++ b/backend/app/platform/jobs/staging_reconcile.py
@@ -76,12 +76,19 @@ log = structlog.get_logger()
 # upload system does not own can reach the delete path at all.
 STAGING_PREFIX = "staging/"
 
-# Deletes per pass. The pass holds one transaction open for its advisory lock,
-# and each delete costs a row recheck plus an age re-read, so an unbounded loop
-# over a pathological bucket would keep a session idle-in-transaction for a
-# long time. Leftovers are not urgent — they are already-leaked bytes, and the
-# sweep runs every few minutes.
+# Two budgets, both checked between provider pages, because the pass holds a
+# transaction (and its connection) open for its advisory lock the whole time
+# and a `staging/` prefix has no upper bound on an unhealthy deployment
+# (fix(#1249) review r1). Leftovers are not urgent — they are already-leaked
+# bytes, and the sweep runs every few minutes.
+#
+# Deletes: each one costs a row recheck plus an age re-read, so this bounds
+# how long the lock is held once there IS work.
 _MAX_DELETES_PER_PASS = 200
+# Objects examined: bounds the walk when there is NOT. Without it a prefix of
+# a million tracked-and-old objects would be paged through in full every
+# cycle to delete nothing.
+_MAX_OBJECTS_SCANNED_PER_PASS = 20_000
 
 
 @dataclass(frozen=True)
@@ -120,6 +127,39 @@ class StagingReconcileOutcome:
         }
 
 
+@dataclass
+class _Tally:
+    """Mutable accumulator for one pass; frozen into the outcome at the end.
+
+    The pass runs page by page and every helper contributes to the same
+    numbers, so the counters are carried rather than returned and re-summed —
+    which is how a helper's contribution gets dropped without anything failing.
+    """
+
+    objects_listed: int = 0
+    orphans_deleted: int = 0
+    delete_failures: int = 0
+    skipped_recent: int = 0
+    skipped_object_changed: int = 0
+    skipped_row_appeared: int = 0
+    skipped_unattributable: int = 0
+
+    def as_log_fields(self) -> dict[str, int]:
+        return self.freeze().as_log_fields()
+
+    def freeze(self) -> StagingReconcileOutcome:
+        return StagingReconcileOutcome(
+            ran=True,
+            objects_listed=self.objects_listed,
+            orphans_deleted=self.orphans_deleted,
+            delete_failures=self.delete_failures,
+            skipped_recent=self.skipped_recent,
+            skipped_object_changed=self.skipped_object_changed,
+            skipped_row_appeared=self.skipped_row_appeared,
+            skipped_unattributable=self.skipped_unattributable,
+        )
+
+
 def _job_id_from_key(logical_key: str) -> uuid.UUID | None:
     """Extract the owning job id from a `staging/{job_id}/…` key.
 
@@ -154,15 +194,16 @@ async def _job_row_exists(db: AsyncSession, job_id: uuid.UUID) -> bool:
 async def _current_entry(storage, physical_key: str) -> StoredObject | None:
     """Re-read one object's last-modified time, or None if it is gone.
 
-    ``list_objects`` with a COMPLETE key rather than a directory prefix: the
-    Protocol has no head-with-timestamp call, and a prefix listing of one exact
-    key is the portable way to ask every provider the same question. The result
-    is filtered for an exact match because a prefix listing also returns
-    siblings whose keys merely start with this one.
+    ``iter_object_pages`` with a COMPLETE key rather than a directory prefix:
+    the Protocol has no head-with-timestamp call, and a prefix listing of one
+    exact key is the portable way to ask every provider the same question. The
+    entries are filtered for an exact match because a prefix listing also
+    returns siblings whose keys merely start with this one.
     """
-    for entry in await storage.list_objects(physical_key):
-        if entry.key == physical_key:
-            return entry
+    async for page in storage.iter_object_pages(physical_key):
+        for entry in page:
+            if entry.key == physical_key:
+                return entry
     return None
 
 
@@ -246,43 +287,93 @@ async def _reconcile_locked(
     physical_prefix: str,
     storage,
 ) -> StagingReconcileOutcome:
-    """The pass body, entered only with the advisory lock held."""
+    """The pass body, entered only with the advisory lock held.
+
+    Page at a time, and both budgets below are checked between pages, so the
+    pass never holds more than one provider page in memory and never issues
+    another listing round trip once it has enough work (fix(#1249) review r1).
+    """
     # Clock skew between this process and the object store is immaterial at a
     # threshold measured in hours, which is one more reason the threshold is
     # not a tuned estimate of transfer duration.
     cutoff = now - timedelta(seconds=settings.staging_orphan_min_age_seconds)
-    listed = await storage.list_objects(physical_prefix)
+    tally = _Tally()
 
-    skipped_recent = 0
-    skipped_unattributable = 0
+    async for page in storage.iter_object_pages(physical_prefix):
+        tally.objects_listed += len(page)
+        candidates = _page_candidates(
+            page, physical_prefix=physical_prefix, cutoff=cutoff, tally=tally
+        )
+        if candidates:
+            await _delete_page_orphans(
+                db,
+                candidates,
+                now=now,
+                cutoff=cutoff,
+                storage=storage,
+                tally=tally,
+            )
+        if (
+            tally.orphans_deleted + tally.delete_failures >= _MAX_DELETES_PER_PASS
+            or tally.objects_listed >= _MAX_OBJECTS_SCANNED_PER_PASS
+        ):
+            log.info(
+                "Staging orphan reconciliation stopped at its per-pass budget",
+                **tally.as_log_fields(),
+            )
+            break
+
+    if tally.orphans_deleted:
+        # After the deletes returned, never before: the counter records
+        # completed deletions, not intentions.
+        staging_orphans_deleted_total.inc(tally.orphans_deleted)
+
+    return tally.freeze()
+
+
+def _page_candidates(
+    page: list[StoredObject],
+    *,
+    physical_prefix: str,
+    cutoff: datetime,
+    tally: "_Tally",
+) -> list[tuple[str, uuid.UUID]]:
+    """Which entries on one page are old enough and attributable."""
     candidates: list[tuple[str, uuid.UUID]] = []
-    for entry in listed:
+    for entry in page:
         # Defensive: a provider that returned a key outside the prefix it was
         # asked for must not be trusted to name a deletable object.
         if not entry.key.startswith(physical_prefix):
-            skipped_unattributable += 1
+            tally.skipped_unattributable += 1
             continue
         logical_key = STAGING_PREFIX + entry.key[len(physical_prefix) :]
         job_id = _job_id_from_key(logical_key)
         if job_id is None:
-            skipped_unattributable += 1
+            tally.skipped_unattributable += 1
             continue
         if entry.last_modified >= cutoff:
-            skipped_recent += 1
+            tally.skipped_recent += 1
             continue
         candidates.append((entry.key, job_id))
+    return candidates
 
-    if not candidates:
-        return StagingReconcileOutcome(
-            ran=True,
-            objects_listed=len(listed),
-            skipped_recent=skipped_recent,
-            skipped_unattributable=skipped_unattributable,
-        )
 
-    # One query for the common case (everything is tracked); the per-object
-    # recheck below is the authority, this only avoids paying for it per object
-    # on a healthy bucket.
+async def _delete_page_orphans(
+    db: AsyncSession,
+    candidates: list[tuple[str, uuid.UUID]],
+    *,
+    now: datetime,
+    cutoff: datetime,
+    storage,
+    tally: "_Tally",
+) -> None:
+    """Delete the untracked candidates from ONE page."""
+    # One query per page, never per pass: the id set is bounded by the page
+    # size the provider chose (1000 for S3 and Azure), so this expanding IN can
+    # never approach the driver's bind-parameter ceiling no matter how large
+    # the orphan backlog grows (fix(#1249) review r1). The per-object recheck
+    # below is the authority; this only avoids paying for it per object on a
+    # healthy bucket.
     live_ids = set(
         (
             await db.execute(
@@ -293,39 +384,35 @@ async def _reconcile_locked(
         ).scalars()
     )
 
-    deleted = 0
-    failures = 0
-    skipped_object_changed = 0
-    skipped_row_appeared = 0
     for physical_key, job_id in sorted(candidates):
         if job_id in live_ids:
             continue
-        if deleted + failures >= _MAX_DELETES_PER_PASS:
-            break
+        if tally.orphans_deleted + tally.delete_failures >= _MAX_DELETES_PER_PASS:
+            return
         # Deliberately OUTSIDE the try below. A database error here is not a
         # per-object problem to count and move past — it leaves the
         # transaction unusable, so every remaining candidate would "fail" on a
         # recheck that never ran. Let it reach the wrapper and end the pass.
         if await _job_row_exists(db, job_id):
-            skipped_row_appeared += 1
+            tally.skipped_row_appeared += 1
             continue
         try:
             entry = await _current_entry(storage, physical_key)
             if entry is None or entry.last_modified >= cutoff:
                 # Gone already, or rewritten since the listing. Either way
                 # this pass has nothing it can honestly delete.
-                skipped_object_changed += 1
+                tally.skipped_object_changed += 1
                 continue
             await storage.delete(physical_key)
         except Exception:  # broad: best-effort per object, the pass continues
-            failures += 1
+            tally.delete_failures += 1
             log.warning(
                 "Failed to delete orphaned staging object",
                 storage_key=physical_key,
                 job_id=str(job_id),
             )
             continue
-        deleted += 1
+        tally.orphans_deleted += 1
         log.warning(
             "Deleted orphaned staging object with no ingest job row",
             storage_key=physical_key,
@@ -333,19 +420,3 @@ async def _reconcile_locked(
             last_modified=entry.last_modified.isoformat(),
             age_seconds=int((now - entry.last_modified).total_seconds()),
         )
-
-    if deleted:
-        # After the deletes returned, never before: the counter records
-        # completed deletions, not intentions.
-        staging_orphans_deleted_total.inc(deleted)
-
-    return StagingReconcileOutcome(
-        ran=True,
-        objects_listed=len(listed),
-        orphans_deleted=deleted,
-        delete_failures=failures,
-        skipped_recent=skipped_recent,
-        skipped_object_changed=skipped_object_changed,
-        skipped_row_appeared=skipped_row_appeared,
-        skipped_unattributable=skipped_unattributable,
-    )

--- a/backend/app/platform/jobs/staging_reconcile.py
+++ b/backend/app/platform/jobs/staging_reconcile.py
@@ -80,12 +80,16 @@ from app.platform.storage.titiler_url import resolve_current_storage_key
 
 log = structlog.get_logger()
 
-# The one prefix this sweep may delete under. Everything below it is written
-# by the upload system and namespaced by the job that wrote it
+# The one prefix this sweep may delete under. Everything below it in a BUCKET
+# is written by the upload system and namespaced by the job that wrote it
 # (`staging/{job_id}/…`, plus the `frozen/` snapshot under the same job
-# segment); `manifest_sources.py` explicitly refuses operator keys here for
-# that reason. Nothing outside this prefix is ever listed, so no object the
-# upload system does not own can reach the delete path at all.
+# segment); `manifest_sources.py` refuses operator-declared s3:// keys here for
+# exactly that reason. Nothing outside this prefix is ever listed, so no object
+# the upload system does not own can reach the delete path.
+#
+# "In a bucket" is load-bearing — the same prefix on the LOCAL backend is not
+# exclusively ours, which is why the pass runs on S3 storage only. See the
+# provider gate in `_reconcile`.
 STAGING_PREFIX = "staging/"
 
 # Two budgets, both checked between provider pages, because the pass holds a
@@ -397,6 +401,27 @@ async def _reconcile(db: AsyncSession, *, now: datetime) -> StagingReconcileOutc
     from app.core.db.tenant_session import current_tenant_var
     from app.core.tenancy import is_multi_tenant
     from app.platform.storage import get_storage
+
+    if settings.storage_provider != "s3":
+        # fix(#1249 review r8, codex P1): `staging/` is the upload system's
+        # exclusive namespace in a BUCKET, and only in a bucket. On the local
+        # backend the same prefix sits inside `upload_staging_dir`, which is
+        # also where an operator stages manifest seed files — a local manifest
+        # source spelled `staging/{anything}/seed.geojson` resolves to an
+        # absolute path under that directory whenever the directory's basename
+        # is not itself `staging` (see `classify_manifest_source`). Those files
+        # are operator-owned, are legitimately staged BEFORE the manifest that
+        # names them is applied, and are stored as absolute paths that no
+        # logical-key comparison here would ever match. Deleting one is not a
+        # leaked byte, it is someone's input.
+        #
+        # Nothing is lost by declining: presigned uploads refuse anything but
+        # the S3 backend at request time, so the late-PUT orphan this module
+        # exists for cannot occur on local or Azure storage at all. The s3://
+        # manifest branch closes the mirror-image hole by refusing `staging/`
+        # keys outright (`_storage_uri_to_key`), which is what makes the bucket
+        # prefix exclusively ours in the first place.
+        return StagingReconcileOutcome(ran=False)
 
     if is_multi_tenant() and current_tenant_var.get() is None:
         # No tenant context, no tenant namespace to scope the listing to.

--- a/backend/app/platform/jobs/staging_reconcile.py
+++ b/backend/app/platform/jobs/staging_reconcile.py
@@ -61,12 +61,12 @@ from datetime import datetime, timedelta, timezone
 from typing import NamedTuple
 
 import structlog
-from sqlalchemy import or_, select, text
+from sqlalchemy import and_, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.observability.metrics.jobs import staging_orphans_deleted_total
-from app.platform.jobs.models import IngestJob
+from app.platform.jobs.models import STATUSES_NEEDING_STAGED_INPUT, IngestJob
 from app.platform.storage.provider import StoredObject
 from app.platform.storage.titiler_url import resolve_current_storage_key
 
@@ -244,19 +244,39 @@ def _reference_clause(job_id: uuid.UUID | None, logical_keys: set[str]):
     ``IngestJob.id`` alone would look up the purged parent, find nothing, and
     delete the input the child (or its retry) is about to read.
 
-    So the question is "does any row still reference this key", asked of both
-    columns that can hold one: ``file_path`` (the bound input, cloned onto
-    fan-out children) and ``user_metadata->>'s3_key'`` (the client-writable
-    upload key, also cloned wholesale onto children). Those are the only two
-    places in the schema a `staging/` key is ever stored.
+    So the question is "does any row still NEED this key", which is two
+    different questions with two different answers:
 
-    Both comparisons are against the LOGICAL key. The provider reports
-    physical keys, which carry the ``tenants/{id}/`` namespace in multi-tenant
-    mode, while these columns deliberately persist the tenant-agnostic form.
+    - The row whose id the key names owns it outright, at any status. That row
+      is where ``_sweep_expired_presigned_staging``'s markers live and it is
+      the row the retention purge holds back while a PUT URL may still be
+      live, so while it exists the key has a lifecycle and this reconciler is
+      not it.
+    - Any OTHER row only counts while it can still consume the bytes, which is
+      ``STATUSES_NEEDING_STAGED_INPUT`` (fix(#1249) review r4, codex P2).
+      Unconditional was wrong in the direction that never self-corrects: a
+      fan-out child stays ``complete`` forever and is exempt from retention
+      indefinitely as a dataset's latest complete job, so its inherited
+      ``file_path`` would answer "still referenced" on every future pass and
+      the leaked parent object could never be repaired. That is the same rule
+      the retention purge's own survivor query applies, now read from one
+      place so the two cannot drift.
+
+    ``user_metadata->>'s3_key'`` is deliberately NOT consulted. It is cloned
+    onto fan-out children wholesale, and ``owned_presigned_staging_key``
+    already settles that an inherited copy is not ownership; the only row for
+    which it IS ownership is the one whose id the key names, which the first
+    clause covers already.
+
+    Comparisons are against the LOGICAL key. The provider reports physical
+    keys, which carry the ``tenants/{id}/`` namespace in multi-tenant mode,
+    while these columns deliberately persist the tenant-agnostic form.
     """
     clauses = [
-        IngestJob.file_path.in_(logical_keys),
-        IngestJob.user_metadata["s3_key"].astext.in_(logical_keys),
+        and_(
+            IngestJob.file_path.in_(logical_keys),
+            IngestJob.status.in_(STATUSES_NEEDING_STAGED_INPUT),
+        )
     ]
     if job_id is not None:
         clauses.insert(0, IngestJob.id == job_id)
@@ -499,25 +519,22 @@ async def _delete_page_orphans(
     logical_keys = {candidate.logical_key for candidate in candidates}
     referenced_rows = (
         await db.execute(
-            select(
-                IngestJob.id,
-                IngestJob.file_path,
-                IngestJob.user_metadata["s3_key"].astext,
-            ).where(
+            select(IngestJob.id, IngestJob.file_path, IngestJob.status).where(
                 or_(
                     IngestJob.id.in_({c.job_id for c in candidates}),
                     IngestJob.file_path.in_(logical_keys),
-                    IngestJob.user_metadata["s3_key"].astext.in_(logical_keys),
                 )
             )
         )
     ).all()
-    live_ids = {row_id for row_id, _file_path, _s3_key in referenced_rows}
+    live_ids = {row_id for row_id, _file_path, _status in referenced_rows}
+    # A row's file_path only shields the object while that row can still
+    # consume it — see `_reference_clause`, whose per-object recheck applies
+    # the identical rule and is the authority.
     referenced_keys = {
-        key
-        for _row_id, file_path, s3_key in referenced_rows
-        for key in (file_path, s3_key)
-        if key
+        file_path
+        for _row_id, file_path, status in referenced_rows
+        if file_path and status in STATUSES_NEEDING_STAGED_INPUT
     }
 
     processed: str | None = None

--- a/backend/app/platform/jobs/staging_reconcile.py
+++ b/backend/app/platform/jobs/staging_reconcile.py
@@ -109,20 +109,18 @@ _MAX_OBJECTS_SCANNED_PER_PASS = 20_000
 # reached at all.
 #
 # Advanced to the last key examined when a pass stops on a budget, and CLEARED
-# when a walk reaches the end of the prefix — a completed walk has seen
-# everything, so the next one starts at the front again.
+# when a pass gets all the way round — it has seen the whole prefix, so the
+# next one may as well start at the front.
 #
-# Process-local rather than a new persisted row, seeded at a RANDOM point the
-# first time a process walks a given prefix. Both halves of that matter. Per
-# process is enough because every pass is independently correct — the cursor
-# only decides where to look first, never what may be deleted — so the worst a
-# lost cursor costs is re-examining keys that were already cheap to skip. And
-# seeding randomly is what keeps that true under `UVICORN_MAX_REQUESTS`
-# recycling: a worker that restarts more often than a full walk completes would,
-# from a fixed start, never reach the tail — the exact starvation the cursor
-# exists to remove, reintroduced by the restart. From a random start, every
-# region of the prefix is equally likely to be walked first, so coverage does
-# not depend on any process living long enough to earn it.
+# The scan is CIRCULAR (see `_reconcile_locked`), which is what makes this
+# cursor a starting OFFSET rather than a window: an unbudgeted pass covers the
+# whole prefix from wherever it begins. That is why process-local state is
+# enough here, and why it is seeded at a random point rather than at the front
+# (fix(#1249) review r2/r7). Every pass is independently correct — the cursor
+# never decides what may be deleted, only what is looked at first — so the
+# worst a lost cursor costs is re-examining keys that were already cheap to
+# skip, and a worker recycled under `UVICORN_MAX_REQUESTS` before its next pass
+# does not keep restarting its coverage from the same place.
 _scan_cursors: dict[str, str | None] = {}
 
 
@@ -444,6 +442,15 @@ async def _reconcile_locked(
     A pass that stops on a budget leaves a cursor behind so the next one
     resumes where it stopped rather than re-walking the same window forever
     (review r2 — see ``_scan_cursors``).
+
+    The scan is CIRCULAR (review r7, codex P2): it walks from the cursor to the
+    end of the prefix and then, with whatever budget is left, from the front of
+    the prefix back up to the cursor. A one-directional scan from a random
+    start is not a rotation, it is a sample — a worker recycled before its next
+    pass would only ever see suffixes, and an orphan sorting near the front of
+    a large prefix would be reached with probability ~1/(objects+1) per
+    restart. With the wrap, one unbudgeted pass covers the whole prefix and the
+    cursor only decides where it starts.
     """
     # Clock skew between this process and the object store is immaterial at a
     # threshold measured in hours, which is one more reason the threshold is
@@ -453,54 +460,83 @@ async def _reconcile_locked(
     last_examined: str | None = None
     stopped_early = False
 
-    async for page in storage.iter_object_pages(
-        physical_prefix, start_after=_resume_point(physical_prefix)
-    ):
-        tally.objects_listed += len(page)
-        if page:
-            # Pages arrive in ascending key order, so the last entry is the
-            # high-water mark whether or not this page produced any deletes.
-            last_examined = page[-1].key
-        candidates = _page_candidates(
-            page, physical_prefix=physical_prefix, cutoff=cutoff, tally=tally
-        )
-        if candidates:
-            unfinished_at = await _delete_page_orphans(
-                db,
-                candidates,
-                now=now,
-                cutoff=cutoff,
-                storage=storage,
-                tally=tally,
-            )
-            if unfinished_at is not None:
-                # The delete budget ran out partway through this page. Resume
-                # from the last candidate actually PROCESSED, not from the end
-                # of the page, so the ones it never reached are not skipped
-                # until the walk wraps.
-                last_examined = unfinished_at
-        if (
-            tally.orphans_deleted + tally.delete_failures >= _MAX_DELETES_PER_PASS
-            or tally.objects_listed >= _MAX_OBJECTS_SCANNED_PER_PASS
+    resume_point = _resume_point(physical_prefix)
+    # (start_after, stop_at). The second leg is the wrap and is skipped when
+    # the pass already begins at the front, where there is nothing to wrap to.
+    legs: list[tuple[str | None, str | None]] = [(resume_point, None)]
+    if resume_point is not None:
+        legs.append((None, resume_point))
+
+    for start_after, stop_at in legs:
+        async for page in _iter_leg(
+            storage, physical_prefix, start_after=start_after, stop_at=stop_at
         ):
-            stopped_early = True
-            log.info(
-                "Staging orphan reconciliation stopped at its per-pass budget",
-                resume_after=last_examined,
-                **tally.as_log_fields(),
+            tally.objects_listed += len(page)
+            if page:
+                # Pages arrive in ascending key order, so the last entry is the
+                # high-water mark whether or not this page produced any deletes.
+                last_examined = page[-1].key
+            candidates = _page_candidates(
+                page, physical_prefix=physical_prefix, cutoff=cutoff, tally=tally
             )
+            if candidates:
+                unfinished_at = await _delete_page_orphans(
+                    db,
+                    candidates,
+                    now=now,
+                    cutoff=cutoff,
+                    storage=storage,
+                    tally=tally,
+                )
+                if unfinished_at is not None:
+                    # The delete budget ran out partway through this page.
+                    # Resume from the last candidate actually PROCESSED, not
+                    # from the end of the page, so the ones it never reached
+                    # are not skipped until the next lap.
+                    last_examined = unfinished_at
+            if (
+                tally.orphans_deleted + tally.delete_failures >= _MAX_DELETES_PER_PASS
+                or tally.objects_listed >= _MAX_OBJECTS_SCANNED_PER_PASS
+            ):
+                stopped_early = True
+                log.info(
+                    "Staging orphan reconciliation stopped at its per-pass budget",
+                    resume_after=last_examined,
+                    **tally.as_log_fields(),
+                )
+                break
+        if stopped_early:
             break
 
-    # A completed walk has seen everything after its start point, so the next
-    # pass begins at the front. Only a budget stop carries a resume point, and
-    # only when the walk actually got somewhere — a budget stop with no page
-    # yielded would otherwise clear the cursor and undo the pass's progress.
+    # A pass that got all the way round has seen the whole prefix, so the next
+    # one may as well start at the front. Only a budget stop carries a resume
+    # point, and only when the walk actually got somewhere — a budget stop with
+    # no page yielded would otherwise clear the cursor and undo the progress.
     if stopped_early and last_examined is not None:
         _scan_cursors[physical_prefix] = last_examined
     else:
         _scan_cursors[physical_prefix] = None
 
     return tally.freeze()
+
+
+async def _iter_leg(storage, physical_prefix: str, *, start_after, stop_at):
+    """Pages of one leg of the circular scan, bounded above by ``stop_at``.
+
+    The wrap leg must not run past the point the pass started from, or it would
+    re-examine the keys the first leg already covered instead of ending.
+    """
+    async for page in storage.iter_object_pages(
+        physical_prefix, start_after=start_after
+    ):
+        if stop_at is None:
+            yield page
+            continue
+        bounded = [entry for entry in page if entry.key <= stop_at]
+        if bounded:
+            yield bounded
+        if len(bounded) < len(page):
+            return  # this page crossed the boundary, so the leg is done
 
 
 def _page_candidates(

--- a/backend/app/platform/jobs/staging_reconcile.py
+++ b/backend/app/platform/jobs/staging_reconcile.py
@@ -30,8 +30,12 @@ from causes no margin ever addressed: a delete that failed inside a
 best-effort reaper, a row purged while its object delete errored, a worker
 killed between writing an object and committing the row that names it.
 
-"Any row", not "the row whose id is in the key" — see `_reference_clause` for
-why fan-out makes that distinction load-bearing rather than pedantic.
+"Still needs", not "still exists", and the difference took two review rounds
+to get right in both directions: a fan-out child's inherited `file_path`
+(`_can_still_consume`) and the owning row's own finished lifecycle
+(`_owner_still_manages`). Either read as an unconditional shield leaves an
+object nothing will ever clean up, including — in the second case — the very
+late-PUT leak this module exists to close.
 
 ### The two races, handled by construction
 
@@ -66,7 +70,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.observability.metrics.jobs import staging_orphans_deleted_total
-from app.platform.jobs.models import STATUSES_NEEDING_STAGED_INPUT, IngestJob
+from app.platform.jobs.models import (
+    STAGING_REAPED_FINAL_MARKER,
+    STATUSES_NEEDING_STAGED_INPUT,
+    IngestJob,
+)
 from app.platform.storage.provider import StoredObject
 from app.platform.storage.titiler_url import resolve_current_storage_key
 
@@ -245,42 +253,74 @@ def _reference_clause(job_id: uuid.UUID | None, logical_keys: set[str]):
     delete the input the child (or its retry) is about to read.
 
     So the question is "does any row still NEED this key", which is two
-    different questions with two different answers:
+    different questions with two different answers — ``_owner_still_manages``
+    for the row whose id the key names, ``_can_still_consume`` for every other
+    row. Neither is "a row exists", and both took a review round to learn.
 
-    - The row whose id the key names owns it outright, at any status. That row
-      is where ``_sweep_expired_presigned_staging``'s markers live and it is
-      the row the retention purge holds back while a PUT URL may still be
-      live, so while it exists the key has a lifecycle and this reconciler is
-      not it.
-    - Any OTHER row only counts while it can still consume the bytes, which is
-      ``STATUSES_NEEDING_STAGED_INPUT`` (fix(#1249) review r4, codex P2).
-      Unconditional was wrong in the direction that never self-corrects: a
-      fan-out child stays ``complete`` forever and is exempt from retention
-      indefinitely as a dataset's latest complete job, so its inherited
-      ``file_path`` would answer "still referenced" on every future pass and
-      the leaked parent object could never be repaired. That is the same rule
-      the retention purge's own survivor query applies, now read from one
-      place so the two cannot drift.
-
-    ``user_metadata->>'s3_key'`` is deliberately NOT consulted. It is cloned
-    onto fan-out children wholesale, and ``owned_presigned_staging_key``
-    already settles that an inherited copy is not ownership; the only row for
-    which it IS ownership is the one whose id the key names, which the first
-    clause covers already.
+    ``user_metadata->>'s3_key'`` is deliberately NOT consulted as a reference.
+    It is cloned onto fan-out children wholesale, and
+    ``owned_presigned_staging_key`` already settles that an inherited copy is
+    not ownership; the only row for which it IS ownership is the one whose id
+    the key names, which the first branch covers.
 
     Comparisons are against the LOGICAL key. The provider reports physical
     keys, which carry the ``tenants/{id}/`` namespace in multi-tenant mode,
-    while these columns deliberately persist the tenant-agnostic form.
+    while ``file_path`` deliberately persists the tenant-agnostic form.
     """
-    clauses = [
-        and_(
-            IngestJob.file_path.in_(logical_keys),
-            IngestJob.status.in_(STATUSES_NEEDING_STAGED_INPUT),
-        )
-    ]
+    clauses = [and_(IngestJob.file_path.in_(logical_keys), _can_still_consume())]
     if job_id is not None:
-        clauses.insert(0, IngestJob.id == job_id)
+        clauses.insert(0, and_(IngestJob.id == job_id, _owner_still_manages()))
     return or_(*clauses)
+
+
+def _can_still_consume():
+    """Predicate: this row can still read the staged input it points at.
+
+    fix(#1249 review r4, codex P2): a reference is only a reference while the
+    row can act on it. Unconditional was wrong in the direction that never
+    self-corrects — a fan-out child stays ``complete`` forever and is exempt
+    from retention indefinitely as a dataset's latest complete job, so its
+    inherited ``file_path`` would answer "still referenced" on every future
+    pass and the leaked parent object could never be repaired. Same line the
+    retention purge's own survivor query draws, read from one place so the two
+    cannot drift.
+    """
+    return IngestJob.status.in_(STATUSES_NEEDING_STAGED_INPUT)
+
+
+def _owner_still_manages():
+    """Predicate: some mechanism OTHER than this sweep still owns the row's keys.
+
+    The row whose id a staging key names is not a reference to it, it is its
+    lifecycle — so the question for that row is not "does it exist" but "is
+    anything still going to act on this key". Exactly two things do:
+
+    - The task tails and the retention purge, while the row can still consume
+      the bytes (``_can_still_consume``).
+    - ``_sweep_expired_presigned_staging``, while the row carries an ``s3_key``
+      it has not yet finalized.
+
+    fix(#1249 review r6, codex P2): existence alone was a permanent shield, and
+    it shielded the exact leak this whole change exists to close. Once the
+    post-expiry sweep sets ``STAGING_REAPED_FINAL_MARKER`` it never looks at
+    that key again; if the row is also its dataset's latest complete job, the
+    retention purge exempts it indefinitely. A PUT that lands after that final
+    delete recreates an object that every row-driven reaper is now finished
+    with — and, before this predicate, one this reconciler declined forever
+    because the row was still there.
+
+    The ``s3_key IS NOT NULL`` half matters as much as the marker half: a
+    direct upload (or any job that never presigned) has no such key, so the
+    presigned sweep will never set a marker on it, and treating a missing
+    marker as "not yet finalized" would shield those rows forever instead.
+    """
+    return or_(
+        _can_still_consume(),
+        and_(
+            IngestJob.user_metadata["s3_key"].astext.is_not(None),
+            IngestJob.user_metadata[STAGING_REAPED_FINAL_MARKER].astext.is_(None),
+        ),
+    )
 
 
 async def _staging_reference_exists(
@@ -511,31 +551,35 @@ async def _delete_page_orphans(
     # large the orphan backlog grows (fix(#1249) review r1). The per-object
     # recheck below is the authority; this only avoids paying for it per object
     # on a healthy bucket.
+    # Two halves of `_reference_clause`, asked in bulk with the SAME two
+    # predicates rather than a Python re-derivation of them — a pre-filter that
+    # shields more than the recheck would silently skip candidates the recheck
+    # never gets to see, which is how r4 and r6 each hid a permanent leak.
     logical_keys = {candidate.logical_key for candidate in candidates}
-    referenced_rows = (
-        await db.execute(
-            select(IngestJob.id, IngestJob.file_path, IngestJob.status).where(
-                or_(
+    shielding_ids = set(
+        (
+            await db.execute(
+                select(IngestJob.id).where(
                     IngestJob.id.in_({c.job_id for c in candidates}),
-                    IngestJob.file_path.in_(logical_keys),
+                    _owner_still_manages(),
                 )
             )
-        )
-    ).all()
-    live_ids = {row_id for row_id, _file_path, _status in referenced_rows}
-    # A row's file_path only shields the object while that row can still
-    # consume it — see `_reference_clause`, whose per-object recheck applies
-    # the identical rule and is the authority.
-    referenced_keys = {
-        file_path
-        for _row_id, file_path, status in referenced_rows
-        if file_path and status in STATUSES_NEEDING_STAGED_INPUT
-    }
+        ).scalars()
+    )
+    referenced_keys = set(
+        (
+            await db.execute(
+                select(IngestJob.file_path).where(
+                    IngestJob.file_path.in_(logical_keys), _can_still_consume()
+                )
+            )
+        ).scalars()
+    )
 
     processed: str | None = None
     for candidate in sorted(candidates):
         physical_key, logical_key, job_id = candidate
-        if job_id in live_ids or logical_key in referenced_keys:
+        if job_id in shielding_ids or logical_key in referenced_keys:
             continue
         if tally.orphans_deleted + tally.delete_failures >= _MAX_DELETES_PER_PASS:
             return processed

--- a/backend/app/platform/jobs/staging_reconcile.py
+++ b/backend/app/platform/jobs/staging_reconcile.py
@@ -20,7 +20,7 @@ while the delete is in flight.
 
 Reconciliation removes the class instead of shrinking it. It never has to
 decide whether some upload is "probably done"; it asks a question with a
-durable answer — is there a row that owns this key? — and an object whose
+durable answer — does any row still reference this key? — and an object whose
 answer is no is unreachable by any future PUT, because a presigned URL for
 `staging/{job_id}/…` is only ever minted alongside the `ingest_jobs` row with
 that id, and the retention purge deliberately keeps such a row alive until
@@ -29,6 +29,9 @@ past `MAX_PRESIGNED_URL_LIFETIME_SECONDS + _RECHECK_TRANSFER_MARGIN_SECONDS`
 from causes no margin ever addressed: a delete that failed inside a
 best-effort reaper, a row purged while its object delete errored, a worker
 killed between writing an object and committing the row that names it.
+
+"Any row", not "the row whose id is in the key" — see `_reference_clause` for
+why fan-out makes that distinction load-bearing rather than pedantic.
 
 ### The two races, handled by construction
 
@@ -55,9 +58,10 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from typing import NamedTuple
 
 import structlog
-from sqlalchemy import select, text
+from sqlalchemy import or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -160,6 +164,22 @@ class StagingReconcileOutcome:
         }
 
 
+class _Candidate(NamedTuple):
+    """One page entry the pass may act on, in the two forms it needs.
+
+    The provider reports PHYSICAL keys (tenant-namespaced in multi-tenant
+    mode); ``ingest_jobs.file_path`` and ``user_metadata->>'s3_key'``
+    deliberately persist the tenant-agnostic LOGICAL form. Carrying both is
+    what keeps the reference check from comparing one against the other.
+    Ordered by physical key first so ``sorted()`` walks a page in provider
+    order, which is what the resume cursor assumes.
+    """
+
+    physical_key: str
+    logical_key: str
+    job_id: uuid.UUID
+
+
 @dataclass
 class _Tally:
     """Mutable accumulator for one pass; frozen into the outcome at the end.
@@ -211,8 +231,42 @@ def _job_id_from_key(logical_key: str) -> uuid.UUID | None:
         return None
 
 
-async def _job_row_exists(db: AsyncSession, job_id: uuid.UUID) -> bool:
-    """Is there still an ``ingest_jobs`` row with this id, right now?
+def _reference_clause(job_id: uuid.UUID | None, logical_keys: set[str]):
+    """Every way an ``ingest_jobs`` row can still need a staging object.
+
+    fix(#1249 review r3, codex P1): the key's own job segment is NOT the whole
+    ownership story, and the case that proves it is fan-out. ``create_fan_out_
+    jobs`` clones the parent's ``file_path`` onto every child, so a child's
+    only input is the PARENT's ``staging/{parent_id}/frozen/...`` object. The
+    parent row reaches the retention cutoff on its own schedule — the purge's
+    survivor query is what keeps the OBJECT alive for a still-pending,
+    running, or retryable-failed child, not the parent's row. Reconciling on
+    ``IngestJob.id`` alone would look up the purged parent, find nothing, and
+    delete the input the child (or its retry) is about to read.
+
+    So the question is "does any row still reference this key", asked of both
+    columns that can hold one: ``file_path`` (the bound input, cloned onto
+    fan-out children) and ``user_metadata->>'s3_key'`` (the client-writable
+    upload key, also cloned wholesale onto children). Those are the only two
+    places in the schema a `staging/` key is ever stored.
+
+    Both comparisons are against the LOGICAL key. The provider reports
+    physical keys, which carry the ``tenants/{id}/`` namespace in multi-tenant
+    mode, while these columns deliberately persist the tenant-agnostic form.
+    """
+    clauses = [
+        IngestJob.file_path.in_(logical_keys),
+        IngestJob.user_metadata["s3_key"].astext.in_(logical_keys),
+    ]
+    if job_id is not None:
+        clauses.insert(0, IngestJob.id == job_id)
+    return or_(*clauses)
+
+
+async def _staging_reference_exists(
+    db: AsyncSession, job_id: uuid.UUID, logical_key: str
+) -> bool:
+    """Does any ``ingest_jobs`` row still need this staging object, right now?
 
     A fresh statement rather than a reuse of the batch query's result on
     purpose: under READ COMMITTED every statement takes its own snapshot, so
@@ -220,7 +274,9 @@ async def _job_row_exists(db: AsyncSession, job_id: uuid.UUID) -> bool:
     exists to catch. Core select over the id column, never an ORM object load,
     so the session's identity map cannot answer from a stale instance.
     """
-    result = await db.execute(select(IngestJob.id).where(IngestJob.id == job_id))
+    result = await db.execute(
+        select(IngestJob.id).where(_reference_clause(job_id, {logical_key}))
+    )
     return result.first() is not None
 
 
@@ -398,9 +454,9 @@ def _page_candidates(
     physical_prefix: str,
     cutoff: datetime,
     tally: "_Tally",
-) -> list[tuple[str, uuid.UUID]]:
+) -> list["_Candidate"]:
     """Which entries on one page are old enough and attributable."""
-    candidates: list[tuple[str, uuid.UUID]] = []
+    candidates: list[_Candidate] = []
     for entry in page:
         # Defensive: a provider that returned a key outside the prefix it was
         # asked for must not be trusted to name a deletable object.
@@ -415,44 +471,59 @@ def _page_candidates(
         if entry.last_modified >= cutoff:
             tally.skipped_recent += 1
             continue
-        candidates.append((entry.key, job_id))
+        candidates.append(_Candidate(entry.key, logical_key, job_id))
     return candidates
 
 
 async def _delete_page_orphans(
     db: AsyncSession,
-    candidates: list[tuple[str, uuid.UUID]],
+    candidates: list["_Candidate"],
     *,
     now: datetime,
     cutoff: datetime,
     storage,
     tally: "_Tally",
 ) -> str | None:
-    """Delete the untracked candidates from ONE page.
+    """Delete the unreferenced candidates from ONE page.
 
     Returns the last key it PROCESSED if the delete budget stopped it partway,
     so the caller can resume there rather than past the candidates it never
     reached; ``None`` when the whole page was worked through.
     """
-    # One query per page, never per pass: the id set is bounded by the page
-    # size the provider chose (1000 for S3 and Azure), so this expanding IN can
-    # never approach the driver's bind-parameter ceiling no matter how large
-    # the orphan backlog grows (fix(#1249) review r1). The per-object recheck
-    # below is the authority; this only avoids paying for it per object on a
-    # healthy bucket.
-    live_ids = set(
-        (
-            await db.execute(
-                select(IngestJob.id).where(
-                    IngestJob.id.in_({job_id for _key, job_id in candidates})
+    # One query per page, never per pass: the bound id/key sets are the page
+    # the provider chose (1000 entries on S3 and Azure), so these expanding INs
+    # can never approach the driver's bind-parameter ceiling no matter how
+    # large the orphan backlog grows (fix(#1249) review r1). The per-object
+    # recheck below is the authority; this only avoids paying for it per object
+    # on a healthy bucket.
+    logical_keys = {candidate.logical_key for candidate in candidates}
+    referenced_rows = (
+        await db.execute(
+            select(
+                IngestJob.id,
+                IngestJob.file_path,
+                IngestJob.user_metadata["s3_key"].astext,
+            ).where(
+                or_(
+                    IngestJob.id.in_({c.job_id for c in candidates}),
+                    IngestJob.file_path.in_(logical_keys),
+                    IngestJob.user_metadata["s3_key"].astext.in_(logical_keys),
                 )
             )
-        ).scalars()
-    )
+        )
+    ).all()
+    live_ids = {row_id for row_id, _file_path, _s3_key in referenced_rows}
+    referenced_keys = {
+        key
+        for _row_id, file_path, s3_key in referenced_rows
+        for key in (file_path, s3_key)
+        if key
+    }
 
     processed: str | None = None
-    for physical_key, job_id in sorted(candidates):
-        if job_id in live_ids:
+    for candidate in sorted(candidates):
+        physical_key, logical_key, job_id = candidate
+        if job_id in live_ids or logical_key in referenced_keys:
             continue
         if tally.orphans_deleted + tally.delete_failures >= _MAX_DELETES_PER_PASS:
             return processed
@@ -461,7 +532,7 @@ async def _delete_page_orphans(
         # per-object problem to count and move past — it leaves the
         # transaction unusable, so every remaining candidate would "fail" on a
         # recheck that never ran. Let it reach the wrapper and end the pass.
-        if await _job_row_exists(db, job_id):
+        if await _staging_reference_exists(db, job_id, logical_key):
             tally.skipped_row_appeared += 1
             continue
         try:
@@ -482,7 +553,7 @@ async def _delete_page_orphans(
             continue
         tally.orphans_deleted += 1
         log.warning(
-            "Deleted orphaned staging object with no ingest job row",
+            "Deleted orphaned staging object no ingest job row references",
             storage_key=physical_key,
             job_id=str(job_id),
             last_modified=entry.last_modified.isoformat(),

--- a/backend/app/platform/jobs/staging_reconcile.py
+++ b/backend/app/platform/jobs/staging_reconcile.py
@@ -90,6 +90,39 @@ _MAX_DELETES_PER_PASS = 200
 # cycle to delete nothing.
 _MAX_OBJECTS_SCANNED_PER_PASS = 20_000
 
+# Where the next pass resumes, per physical prefix (fix(#1249) review r2). A
+# cap without a cursor is not a bound, it is a blind spot: every pass would
+# re-walk the same lexicographically first window, and an orphan sorting after
+# a window full of tracked, recent, or unattributable keys would never be
+# reached at all.
+#
+# Advanced to the last key examined when a pass stops on a budget, and CLEARED
+# when a walk reaches the end of the prefix — a completed walk has seen
+# everything, so the next one starts at the front again.
+#
+# Process-local rather than a new persisted row, seeded at a RANDOM point the
+# first time a process walks a given prefix. Both halves of that matter. Per
+# process is enough because every pass is independently correct — the cursor
+# only decides where to look first, never what may be deleted — so the worst a
+# lost cursor costs is re-examining keys that were already cheap to skip. And
+# seeding randomly is what keeps that true under `UVICORN_MAX_REQUESTS`
+# recycling: a worker that restarts more often than a full walk completes would,
+# from a fixed start, never reach the tail — the exact starvation the cursor
+# exists to remove, reintroduced by the restart. From a random start, every
+# region of the prefix is equally likely to be walked first, so coverage does
+# not depend on any process living long enough to earn it.
+_scan_cursors: dict[str, str | None] = {}
+
+
+def _resume_point(physical_prefix: str) -> str | None:
+    """Where this pass starts, seeding a random point on first use."""
+    if physical_prefix not in _scan_cursors:
+        # A uuid in the same alphabet as the job segment of every staging key,
+        # so the seed lands uniformly inside the keyspace rather than before
+        # or after all of it.
+        _scan_cursors[physical_prefix] = f"{physical_prefix}{uuid.uuid4()}"
+    return _scan_cursors[physical_prefix]
+
 
 @dataclass(frozen=True)
 class StagingReconcileOutcome:
@@ -292,20 +325,31 @@ async def _reconcile_locked(
     Page at a time, and both budgets below are checked between pages, so the
     pass never holds more than one provider page in memory and never issues
     another listing round trip once it has enough work (fix(#1249) review r1).
+    A pass that stops on a budget leaves a cursor behind so the next one
+    resumes where it stopped rather than re-walking the same window forever
+    (review r2 — see ``_scan_cursors``).
     """
     # Clock skew between this process and the object store is immaterial at a
     # threshold measured in hours, which is one more reason the threshold is
     # not a tuned estimate of transfer duration.
     cutoff = now - timedelta(seconds=settings.staging_orphan_min_age_seconds)
     tally = _Tally()
+    last_examined: str | None = None
+    stopped_early = False
 
-    async for page in storage.iter_object_pages(physical_prefix):
+    async for page in storage.iter_object_pages(
+        physical_prefix, start_after=_resume_point(physical_prefix)
+    ):
         tally.objects_listed += len(page)
+        if page:
+            # Pages arrive in ascending key order, so the last entry is the
+            # high-water mark whether or not this page produced any deletes.
+            last_examined = page[-1].key
         candidates = _page_candidates(
             page, physical_prefix=physical_prefix, cutoff=cutoff, tally=tally
         )
         if candidates:
-            await _delete_page_orphans(
+            unfinished_at = await _delete_page_orphans(
                 db,
                 candidates,
                 now=now,
@@ -313,15 +357,32 @@ async def _reconcile_locked(
                 storage=storage,
                 tally=tally,
             )
+            if unfinished_at is not None:
+                # The delete budget ran out partway through this page. Resume
+                # from the last candidate actually PROCESSED, not from the end
+                # of the page, so the ones it never reached are not skipped
+                # until the walk wraps.
+                last_examined = unfinished_at
         if (
             tally.orphans_deleted + tally.delete_failures >= _MAX_DELETES_PER_PASS
             or tally.objects_listed >= _MAX_OBJECTS_SCANNED_PER_PASS
         ):
+            stopped_early = True
             log.info(
                 "Staging orphan reconciliation stopped at its per-pass budget",
+                resume_after=last_examined,
                 **tally.as_log_fields(),
             )
             break
+
+    # A completed walk has seen everything after its start point, so the next
+    # pass begins at the front. Only a budget stop carries a resume point, and
+    # only when the walk actually got somewhere — a budget stop with no page
+    # yielded would otherwise clear the cursor and undo the pass's progress.
+    if stopped_early and last_examined is not None:
+        _scan_cursors[physical_prefix] = last_examined
+    else:
+        _scan_cursors[physical_prefix] = None
 
     if tally.orphans_deleted:
         # After the deletes returned, never before: the counter records
@@ -366,8 +427,13 @@ async def _delete_page_orphans(
     cutoff: datetime,
     storage,
     tally: "_Tally",
-) -> None:
-    """Delete the untracked candidates from ONE page."""
+) -> str | None:
+    """Delete the untracked candidates from ONE page.
+
+    Returns the last key it PROCESSED if the delete budget stopped it partway,
+    so the caller can resume there rather than past the candidates it never
+    reached; ``None`` when the whole page was worked through.
+    """
     # One query per page, never per pass: the id set is bounded by the page
     # size the provider chose (1000 for S3 and Azure), so this expanding IN can
     # never approach the driver's bind-parameter ceiling no matter how large
@@ -384,11 +450,13 @@ async def _delete_page_orphans(
         ).scalars()
     )
 
+    processed: str | None = None
     for physical_key, job_id in sorted(candidates):
         if job_id in live_ids:
             continue
         if tally.orphans_deleted + tally.delete_failures >= _MAX_DELETES_PER_PASS:
-            return
+            return processed
+        processed = physical_key
         # Deliberately OUTSIDE the try below. A database error here is not a
         # per-object problem to count and move past — it leaves the
         # transaction unusable, so every remaining candidate would "fail" on a
@@ -420,3 +488,4 @@ async def _delete_page_orphans(
             last_modified=entry.last_modified.isoformat(),
             age_seconds=int((now - entry.last_modified).total_seconds()),
         )
+    return None

--- a/backend/app/platform/jobs/staging_reconcile.py
+++ b/backend/app/platform/jobs/staging_reconcile.py
@@ -460,11 +460,6 @@ async def _reconcile_locked(
     else:
         _scan_cursors[physical_prefix] = None
 
-    if tally.orphans_deleted:
-        # After the deletes returned, never before: the counter records
-        # completed deletions, not intentions.
-        staging_orphans_deleted_total.inc(tally.orphans_deleted)
-
     return tally.freeze()
 
 
@@ -569,6 +564,15 @@ async def _delete_page_orphans(
             )
             continue
         tally.orphans_deleted += 1
+        # Published here rather than once at the end of the pass (fix(#1249)
+        # review r5, codex P2). The object is already gone, so a later page
+        # listing or database error that ends the pass must not take this
+        # number with it — nothing can recover the count afterwards, and a
+        # counter that silently under-reports completed cleanup is worse than
+        # one incremented a few statements earlier. The durability rule is
+        # unchanged: this runs strictly after the provider's delete returned,
+        # so it still counts completions rather than intentions.
+        staging_orphans_deleted_total.inc()
         log.warning(
             "Deleted orphaned staging object no ingest job row references",
             storage_key=physical_key,

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
 from app.observability.metrics.refresh import refresh_sweep_reconciled_total
 from app.platform.jobs.models import IngestJob, owned_presigned_staging_key
+from app.platform.jobs.staging_reconcile import reconcile_orphaned_staging_objects
 from app.platform.refresh.service import sweep_abandoned_refresh_runs
 from app.platform.storage.titiler_url import resolve_current_storage_key
 
@@ -1361,6 +1362,14 @@ async def fail_stale_jobs(
         publish_refresh_reconciliation(outcome)
         outcome = await _reap_committed_staged_paths(outcome)
         outcome = await _sweep_expired_presigned_staging(db, outcome, now=now)
+        # fix(#1249): the row-driven reapers above can only clean up objects
+        # some surviving row still names. This one starts from the objects and
+        # asks whether any row still owns them, which is the only direction
+        # that finds one nothing references. Deliberately not folded into
+        # StaleCleanupOutcome — that dataclass is a published API and audit
+        # shape several callers reconstruct field by field, and this pass
+        # answers a different question with its own log line and counter.
+        await reconcile_orphaned_staging_objects(db, now=now)
     if detailed:
         return outcome
     return outcome.pending_failed, outcome.running_failed

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -24,7 +24,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
 from app.observability.metrics.refresh import refresh_sweep_reconciled_total
-from app.platform.jobs.models import IngestJob, owned_presigned_staging_key
+from app.platform.jobs.models import (
+    STATUSES_NEEDING_STAGED_INPUT,
+    IngestJob,
+    owned_presigned_staging_key,
+)
 from app.platform.jobs.staging_reconcile import reconcile_orphaned_staging_objects
 from app.platform.refresh.service import sweep_abandoned_refresh_runs
 from app.platform.storage.titiler_url import resolve_current_storage_key
@@ -1333,7 +1337,7 @@ async def fail_stale_jobs(
             survivors = await db.execute(
                 select(IngestJob.file_path).where(
                     IngestJob.file_path.in_(deleted_paths),
-                    IngestJob.status.in_(("pending", "running", "failed")),
+                    IngestJob.status.in_(STATUSES_NEEDING_STAGED_INPUT),
                 )
             )
             deleted_paths -= set(survivors.scalars())

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import MAX_PRESIGNED_URL_LIFETIME_SECONDS, settings
 from app.observability.metrics.refresh import refresh_sweep_reconciled_total
 from app.platform.jobs.models import (
+    STAGING_REAPED_FINAL_MARKER,
     STATUSES_NEEDING_STAGED_INPUT,
     IngestJob,
     owned_presigned_staging_key,
@@ -278,7 +279,7 @@ _STAGING_REAPED_MARKER = "s3_key_reaped"
 # latest moment any URL for the job, signed under any setting the deployment
 # ever ran, can still be live. Only rows carrying this marker are excluded
 # from every future pass; _STAGING_REAPED_MARKER alone no longer is.
-_STAGING_REAPED_FINAL_MARKER = "s3_key_reaped_final"
+_STAGING_REAPED_FINAL_MARKER = STAGING_REAPED_FINAL_MARKER
 
 # fix(#1236 review, codex P1): SigV4 bounds when a URL may be SIGNED for, not
 # when an already-accepted PUT finishes transferring bytes — S3 validates the

--- a/backend/app/platform/storage/azure.py
+++ b/backend/app/platform/storage/azure.py
@@ -222,13 +222,27 @@ class AzureBlobStorageProvider:
 
         return await asyncio.to_thread(_list)
 
-    async def list_objects(self, prefix: str) -> list[StoredObject]:
-        """List blobs under a prefix with their last-modified timestamps."""
+    async def iter_object_pages(self, prefix: str) -> AsyncIterator[list[StoredObject]]:
+        """Yield blob pages under a prefix, each entry with its last-modified.
 
-        def _list_objects() -> list[StoredObject]:
-            container_client = self._client.get_container_client(self.container)
-            objects: list[StoredObject] = []
-            for blob in container_client.list_blobs(name_starts_with=prefix):
+        ``by_page()`` rather than the flat iterator so a consumer that stops
+        early stops the service round trips with it (fix(#1249) review r1).
+        """
+        container_client = self._client.get_container_client(self.container)
+        pages = container_client.list_blobs(name_starts_with=prefix).by_page()
+
+        def _next_page() -> list | None:
+            try:
+                return list(next(pages))
+            except StopIteration:
+                return None
+
+        while True:
+            blobs = await asyncio.to_thread(_next_page)
+            if blobs is None:
+                return
+            page: list[StoredObject] = []
+            for blob in blobs:
                 last_modified = getattr(blob, "last_modified", None)
                 if last_modified is None:
                     # feat(#1249): a blob the SDK cannot date cannot be aged,
@@ -236,15 +250,13 @@ class AzureBlobStorageProvider:
                     # delete". Dropping it here keeps that decision out of the
                     # caller, which only ever sees datable objects.
                     continue
-                objects.append(
+                page.append(
                     StoredObject(
                         key=blob.name,
                         last_modified=_as_utc(last_modified),
                     )
                 )
-            return objects
-
-        return await asyncio.to_thread(_list_objects)
+            yield page
 
     async def health_check(self) -> None:
         """Verify the Azure container is reachable via get_container_properties."""

--- a/backend/app/platform/storage/azure.py
+++ b/backend/app/platform/storage/azure.py
@@ -222,11 +222,22 @@ class AzureBlobStorageProvider:
 
         return await asyncio.to_thread(_list)
 
-    async def iter_object_pages(self, prefix: str) -> AsyncIterator[list[StoredObject]]:
+    async def iter_object_pages(
+        self, prefix: str, *, start_after: str | None = None
+    ) -> AsyncIterator[list[StoredObject]]:
         """Yield blob pages under a prefix, each entry with its last-modified.
 
         ``by_page()`` rather than the flat iterator so a consumer that stops
         early stops the service round trips with it (fix(#1249) review r1).
+
+        ``start_after`` is filtered client-side: Azure's flat listing takes a
+        name PREFIX, not a start marker, and its own continuation tokens are
+        service-issued handles rather than a key a later pass could reconstruct
+        (fix(#1249) review r2). Blob listings are name-ordered, so the filter
+        yields the same sequence S3's ``StartAfter`` does; only the skipped
+        pages still cross the wire. Nothing this backend serves makes that
+        matter — presigned uploads refuse anything but S3 at request time, so
+        an Azure container holds no `staging/` objects to walk.
         """
         container_client = self._client.get_container_client(self.container)
         pages = container_client.list_blobs(name_starts_with=prefix).by_page()
@@ -243,6 +254,8 @@ class AzureBlobStorageProvider:
                 return
             page: list[StoredObject] = []
             for blob in blobs:
+                if start_after is not None and blob.name <= start_after:
+                    continue
                 last_modified = getattr(blob, "last_modified", None)
                 if last_modified is None:
                     # feat(#1249): a blob the SDK cannot date cannot be aged,

--- a/backend/app/platform/storage/azure.py
+++ b/backend/app/platform/storage/azure.py
@@ -31,11 +31,26 @@ implementation for STOR-01 (Phase 1210).
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator, BinaryIO
 
 from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient
+
+from app.platform.storage.provider import StoredObject
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Normalize a provider timestamp to timezone-aware UTC (feat #1249).
+
+    Azure returns aware datetimes; the normalization is pinned here because
+    the ``StoredObject`` contract — not the SDK's current behaviour — is what
+    the reconciliation's cutoff comparison relies on.
+    """
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 class AzureBlobStorageProvider:
@@ -206,6 +221,30 @@ class AzureBlobStorageProvider:
             ]
 
         return await asyncio.to_thread(_list)
+
+    async def list_objects(self, prefix: str) -> list[StoredObject]:
+        """List blobs under a prefix with their last-modified timestamps."""
+
+        def _list_objects() -> list[StoredObject]:
+            container_client = self._client.get_container_client(self.container)
+            objects: list[StoredObject] = []
+            for blob in container_client.list_blobs(name_starts_with=prefix):
+                last_modified = getattr(blob, "last_modified", None)
+                if last_modified is None:
+                    # feat(#1249): a blob the SDK cannot date cannot be aged,
+                    # and an undatable entry must never read as "old enough to
+                    # delete". Dropping it here keeps that decision out of the
+                    # caller, which only ever sees datable objects.
+                    continue
+                objects.append(
+                    StoredObject(
+                        key=blob.name,
+                        last_modified=_as_utc(last_modified),
+                    )
+                )
+            return objects
+
+        return await asyncio.to_thread(_list_objects)
 
     async def health_check(self) -> None:
         """Verify the Azure container is reachable via get_container_properties."""

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 import os
 import shutil
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator, BinaryIO
 
 from app.core.async_io import run_in_thread_draining
+from app.platform.storage.provider import StoredObject
 
 
 # Chunk size for streaming reads (ING-03 / P2-03). 1 MiB is large enough to
@@ -160,6 +162,21 @@ class LocalStorageProvider:
         path = self._resolve_contained(key)
         return await asyncio.to_thread(lambda: path.stat().st_size)
 
+    def _matching_files(self, prefix: str, resolved_prefix: Path) -> list[Path]:
+        """Every regular file whose key starts with *prefix*. Blocking."""
+        resolved_base = self.base_dir.resolve()
+        if not prefix or prefix.endswith("/") or resolved_prefix == resolved_base:
+            # Directory prefix: list all files recursively under it
+            if not resolved_prefix.exists():
+                return []
+            return [p for p in resolved_prefix.rglob("*") if p.is_file()]
+        # File prefix: glob in the parent directory
+        parent = resolved_prefix.parent
+        if not parent.exists():
+            return []
+        pattern = resolved_prefix.name + "*"
+        return [p for p in parent.glob(pattern) if p.is_file()]
+
     async def list(self, prefix: str) -> list[str]:
         """List keys matching a prefix, relative to base_dir."""
         # SEC-026: resolve the caller-supplied prefix before touching the
@@ -169,28 +186,37 @@ class LocalStorageProvider:
         resolved_base = self.base_dir.resolve()
 
         def _list() -> list[str]:
-            if not prefix or prefix.endswith("/") or resolved_prefix == resolved_base:
-                # Directory prefix: list all files recursively under it
-                search_dir = resolved_prefix
-                if not search_dir.exists():
-                    return []
-                return [
-                    str(p.relative_to(resolved_base))
-                    for p in search_dir.rglob("*")
-                    if p.is_file()
-                ]
-            # File prefix: glob in the parent directory
-            parent = resolved_prefix.parent
-            if not parent.exists():
-                return []
-            pattern = resolved_prefix.name + "*"
             return [
                 str(p.relative_to(resolved_base))
-                for p in parent.glob(pattern)
-                if p.is_file()
+                for p in self._matching_files(prefix, resolved_prefix)
             ]
 
         return await asyncio.to_thread(_list)
+
+    async def list_objects(self, prefix: str) -> list[StoredObject]:
+        """List keys matching a prefix with their mtimes (feat #1249)."""
+        resolved_prefix = self._resolve_contained(prefix)
+        resolved_base = self.base_dir.resolve()
+
+        def _list_objects() -> list[StoredObject]:
+            objects: list[StoredObject] = []
+            for path in self._matching_files(prefix, resolved_prefix):
+                try:
+                    mtime = path.stat().st_mtime
+                except OSError:
+                    # Deleted between the glob and the stat. An entry that
+                    # cannot be dated must not reach the caller, which would
+                    # otherwise have to invent an age for it.
+                    continue
+                objects.append(
+                    StoredObject(
+                        key=str(path.relative_to(resolved_base)),
+                        last_modified=datetime.fromtimestamp(mtime, tz=timezone.utc),
+                    )
+                )
+            return objects
+
+        return await asyncio.to_thread(_list_objects)
 
     async def health_check(self) -> None:
         """Verify the storage directory exists."""

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -193,8 +193,13 @@ class LocalStorageProvider:
 
         return await asyncio.to_thread(_list)
 
-    async def list_objects(self, prefix: str) -> list[StoredObject]:
-        """List keys matching a prefix with their mtimes (feat #1249)."""
+    async def iter_object_pages(self, prefix: str) -> AsyncIterator[list[StoredObject]]:
+        """Yield keys matching a prefix with their mtimes (feat #1249).
+
+        A local walk has no service-side paging to mirror, so this is a single
+        page. The signature matches the Protocol so the caller's bounded-work
+        loop is provider-agnostic.
+        """
         resolved_prefix = self._resolve_contained(prefix)
         resolved_base = self.base_dir.resolve()
 
@@ -216,7 +221,7 @@ class LocalStorageProvider:
                 )
             return objects
 
-        return await asyncio.to_thread(_list_objects)
+        yield await asyncio.to_thread(_list_objects)
 
     async def health_check(self) -> None:
         """Verify the storage directory exists."""

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -16,6 +16,10 @@ from app.platform.storage.provider import StoredObject
 # per concurrent download stays bounded.
 _STREAM_CHUNK_BYTES = 1024 * 1024  # 1 MiB
 
+# Page size for ``iter_object_pages``. Matches the ListObjectsV2 default so a
+# consumer's per-page budget behaves the same on every backend (feat #1249).
+_OBJECT_PAGE_SIZE = 1000
+
 
 class LocalStorageProvider:
     """Storage provider wrapping local filesystem operations under a base directory."""
@@ -193,12 +197,18 @@ class LocalStorageProvider:
 
         return await asyncio.to_thread(_list)
 
-    async def iter_object_pages(self, prefix: str) -> AsyncIterator[list[StoredObject]]:
+    async def iter_object_pages(
+        self, prefix: str, *, start_after: str | None = None
+    ) -> AsyncIterator[list[StoredObject]]:
         """Yield keys matching a prefix with their mtimes (feat #1249).
 
-        A local walk has no service-side paging to mirror, so this is a single
-        page. The signature matches the Protocol so the caller's bounded-work
-        loop is provider-agnostic.
+        Chunked into ``_OBJECT_PAGE_SIZE`` pages even though a local walk has
+        no service-side paging to mirror (fix(#1249) review r2): returning the
+        whole prefix as one page would hand the consumer an unbounded page and
+        defeat the between-pages budget it relies on. Key-sorted so
+        ``start_after`` means the same thing here as the S3 ``StartAfter`` it
+        mirrors, and so successive pages are a stable sequence rather than
+        whatever order ``rglob`` produced.
         """
         resolved_prefix = self._resolve_contained(prefix)
         resolved_base = self.base_dir.resolve()
@@ -206,6 +216,9 @@ class LocalStorageProvider:
         def _list_objects() -> list[StoredObject]:
             objects: list[StoredObject] = []
             for path in self._matching_files(prefix, resolved_prefix):
+                key = str(path.relative_to(resolved_base))
+                if start_after is not None and key <= start_after:
+                    continue
                 try:
                     mtime = path.stat().st_mtime
                 except OSError:
@@ -215,13 +228,16 @@ class LocalStorageProvider:
                     continue
                 objects.append(
                     StoredObject(
-                        key=str(path.relative_to(resolved_base)),
+                        key=key,
                         last_modified=datetime.fromtimestamp(mtime, tz=timezone.utc),
                     )
                 )
+            objects.sort(key=lambda entry: entry.key)
             return objects
 
-        yield await asyncio.to_thread(_list_objects)
+        objects = await asyncio.to_thread(_list_objects)
+        for start in range(0, max(len(objects), 1), _OBJECT_PAGE_SIZE):
+            yield objects[start : start + _OBJECT_PAGE_SIZE]
 
     async def health_check(self) -> None:
         """Verify the storage directory exists."""

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -197,47 +197,122 @@ class LocalStorageProvider:
 
         return await asyncio.to_thread(_list)
 
+    def _walk_in_key_order(
+        self, root: Path, resolved_base: Path, start_after: str | None
+    ):
+        """Lazily yield ``(path, key)`` under *root* in ascending key order.
+
+        Blocking, and a generator on purpose (fix(#1249) review r5): building
+        the whole list first would put an unbounded walk in front of the first
+        page, so a consumer's per-page budget bounded its SQL but neither the
+        filesystem traversal nor the memory it took to hold the result. Only
+        one directory level is materialized at a time, and a subtree entirely
+        below ``start_after`` is skipped without being entered at all.
+
+        Entries sort by ``name + "/"`` for directories so this matches the
+        lexicographic order of the FULL keys, which is what ``start_after``
+        and the S3 ``StartAfter`` it mirrors are defined against — plain name
+        order disagrees whenever a directory and a file share a stem (``/`` is
+        0x2F, so ``frozen/x`` sorts after ``frozen.txt``).
+
+        Symlinks are not followed. A staging tree has none, and for a walk
+        that feeds a deleter, declining to leave the tree through one is the
+        posture to keep.
+        """
+        try:
+            with os.scandir(root) as entries:
+                ordered = sorted(
+                    entries,
+                    key=lambda e: (
+                        e.name + "/" if e.is_dir(follow_symlinks=False) else e.name
+                    ),
+                )
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
+            return
+        for entry in ordered:
+            path = Path(entry.path)
+            key = str(path.relative_to(resolved_base))
+            if entry.is_dir(follow_symlinks=False):
+                child_prefix = key + "/"
+                if (
+                    start_after is not None
+                    and child_prefix <= start_after
+                    and not start_after.startswith(child_prefix)
+                ):
+                    continue  # every key in here sorts at or before the cursor
+                yield from self._walk_in_key_order(path, resolved_base, start_after)
+            elif entry.is_file(follow_symlinks=False):
+                if start_after is not None and key <= start_after:
+                    continue
+                yield path, key
+
+    def _keys_in_order(
+        self,
+        prefix: str,
+        resolved_prefix: Path,
+        resolved_base: Path,
+        start_after: str | None,
+    ):
+        """``(path, key)`` pairs matching *prefix*, ascending, lazily."""
+        if not prefix or prefix.endswith("/") or resolved_prefix == resolved_base:
+            yield from self._walk_in_key_order(
+                resolved_prefix, resolved_base, start_after
+            )
+            return
+        # File prefix: one directory's glob, already bounded by construction.
+        # This is the pre-delete re-read's shape — a complete key.
+        parent = resolved_prefix.parent
+        if not parent.exists():
+            return
+        for path in sorted(parent.glob(resolved_prefix.name + "*")):
+            if not path.is_file():
+                continue
+            key = str(path.relative_to(resolved_base))
+            if start_after is None or key > start_after:
+                yield path, key
+
     async def iter_object_pages(
         self, prefix: str, *, start_after: str | None = None
     ) -> AsyncIterator[list[StoredObject]]:
         """Yield keys matching a prefix with their mtimes (feat #1249).
 
         Chunked into ``_OBJECT_PAGE_SIZE`` pages even though a local walk has
-        no service-side paging to mirror (fix(#1249) review r2): returning the
-        whole prefix as one page would hand the consumer an unbounded page and
-        defeat the between-pages budget it relies on. Key-sorted so
-        ``start_after`` means the same thing here as the S3 ``StartAfter`` it
-        mirrors, and so successive pages are a stable sequence rather than
-        whatever order ``rglob`` produced.
+        no service-side paging to mirror (fix(#1249) review r2): an unbounded
+        page defeats the between-pages budget the consumer relies on. The walk
+        behind it is lazy, so a consumer that stops after one page has not paid
+        for the rest of the tree either (review r5).
         """
         resolved_prefix = self._resolve_contained(prefix)
         resolved_base = self.base_dir.resolve()
+        walker = self._keys_in_order(
+            prefix, resolved_prefix, resolved_base, start_after
+        )
 
-        def _list_objects() -> list[StoredObject]:
-            objects: list[StoredObject] = []
-            for path in self._matching_files(prefix, resolved_prefix):
-                key = str(path.relative_to(resolved_base))
-                if start_after is not None and key <= start_after:
-                    continue
+        def _take_page() -> list[StoredObject]:
+            page: list[StoredObject] = []
+            for path, key in walker:
                 try:
                     mtime = path.stat().st_mtime
                 except OSError:
-                    # Deleted between the glob and the stat. An entry that
+                    # Deleted between the walk and the stat. An entry that
                     # cannot be dated must not reach the caller, which would
                     # otherwise have to invent an age for it.
                     continue
-                objects.append(
+                page.append(
                     StoredObject(
                         key=key,
                         last_modified=datetime.fromtimestamp(mtime, tz=timezone.utc),
                     )
                 )
-            objects.sort(key=lambda entry: entry.key)
-            return objects
+                if len(page) >= _OBJECT_PAGE_SIZE:
+                    break
+            return page
 
-        objects = await asyncio.to_thread(_list_objects)
-        for start in range(0, max(len(objects), 1), _OBJECT_PAGE_SIZE):
-            yield objects[start : start + _OBJECT_PAGE_SIZE]
+        while True:
+            page = await asyncio.to_thread(_take_page)
+            if not page:
+                return
+            yield page
 
     async def health_check(self) -> None:
         """Verify the storage directory exists."""

--- a/backend/app/platform/storage/provider.py
+++ b/backend/app/platform/storage/provider.py
@@ -1,8 +1,25 @@
 from __future__ import annotations
 
 import builtins
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import AsyncIterator, BinaryIO, Protocol
+
+
+@dataclass(frozen=True)
+class StoredObject:
+    """One object as the provider reports it right now.
+
+    feat(#1249): the staging-orphan reconciliation needs "and how old is it"
+    alongside "does it exist". ``last_modified`` is timezone-aware UTC on
+    every provider — a naive value would make the caller's cutoff comparison
+    raise rather than answer, so each implementation normalizes before
+    returning.
+    """
+
+    key: str
+    last_modified: datetime
 
 
 class StorageProvider(Protocol):
@@ -74,6 +91,21 @@ class StorageProvider(Protocol):
 
     async def list(self, prefix: str) -> list[str]:
         """List keys matching a prefix."""
+        ...
+
+    async def list_objects(self, prefix: str) -> "builtins.list[StoredObject]":
+        """List objects under a prefix, each with its last-modified time.
+
+        feat(#1249): ``list`` answers which keys exist; this also answers how
+        old each one is, which is what tells an abandoned staging object from
+        one whose upload landed a second ago.
+
+        A COMPLETE key is a valid ``prefix`` and is how a caller re-reads one
+        object's timestamp immediately before acting on it. Implementations
+        return every entry whose key STARTS WITH ``prefix`` — matching
+        ``list`` — so a caller that means one exact object must filter for
+        ``entry.key == key`` rather than trusting the result length.
+        """
         ...
 
     async def health_check(self) -> None:

--- a/backend/app/platform/storage/provider.py
+++ b/backend/app/platform/storage/provider.py
@@ -93,18 +93,25 @@ class StorageProvider(Protocol):
         """List keys matching a prefix."""
         ...
 
-    async def list_objects(self, prefix: str) -> "builtins.list[StoredObject]":
-        """List objects under a prefix, each with its last-modified time.
+    def iter_object_pages(
+        self, prefix: str
+    ) -> AsyncIterator["builtins.list[StoredObject]"]:
+        """Yield objects under a prefix one provider page at a time.
 
         feat(#1249): ``list`` answers which keys exist; this also answers how
         old each one is, which is what tells an abandoned staging object from
         one whose upload landed a second ago.
 
+        Pages rather than one list, and for the same reason ``get_stream``
+        exists (fix(#1249) review r1): a caller that can act on a bounded
+        amount of work must not have to materialize an unbounded prefix first.
+        A consumer that stops early stops the provider's paging with it.
+
         A COMPLETE key is a valid ``prefix`` and is how a caller re-reads one
         object's timestamp immediately before acting on it. Implementations
-        return every entry whose key STARTS WITH ``prefix`` — matching
-        ``list`` — so a caller that means one exact object must filter for
-        ``entry.key == key`` rather than trusting the result length.
+        yield every entry whose key STARTS WITH ``prefix`` — matching ``list``
+        — so a caller that means one exact object must filter for
+        ``entry.key == key`` rather than trusting the page length.
         """
         ...
 

--- a/backend/app/platform/storage/provider.py
+++ b/backend/app/platform/storage/provider.py
@@ -94,7 +94,7 @@ class StorageProvider(Protocol):
         ...
 
     def iter_object_pages(
-        self, prefix: str
+        self, prefix: str, *, start_after: str | None = None
     ) -> AsyncIterator["builtins.list[StoredObject]"]:
         """Yield objects under a prefix one provider page at a time.
 
@@ -106,6 +106,14 @@ class StorageProvider(Protocol):
         exists (fix(#1249) review r1): a caller that can act on a bounded
         amount of work must not have to materialize an unbounded prefix first.
         A consumer that stops early stops the provider's paging with it.
+
+        ``start_after`` resumes a walk: only keys strictly greater than it are
+        yielded, in ascending key order, so a caller with a per-pass budget can
+        continue where the last one stopped instead of re-reading the front of
+        the prefix forever (fix(#1249) review r2). S3 pushes it down as
+        ``StartAfter``; the other backends filter, which costs them nothing
+        that matters — neither can hold a presigned staging object, since
+        presigned uploads refuse anything but the S3 backend at request time.
 
         A COMPLETE key is a valid ``prefix`` and is how a caller re-reads one
         object's timestamp immediately before acting on it. Implementations

--- a/backend/app/platform/storage/s3.py
+++ b/backend/app/platform/storage/s3.py
@@ -22,12 +22,28 @@ configurable via env vars.
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator, BinaryIO
 
 import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
+
+from app.platform.storage.provider import StoredObject
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Normalize a provider timestamp to timezone-aware UTC.
+
+    feat(#1249): botocore returns aware datetimes today, but the
+    ``StoredObject`` contract is what the reconciliation's cutoff comparison
+    depends on — a naive value would raise there instead of answering, so it
+    is pinned here rather than assumed.
+    """
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 class S3StorageProvider:
@@ -220,6 +236,28 @@ class S3StorageProvider:
             return keys
 
         return await asyncio.to_thread(_list)
+
+    async def list_objects(self, prefix: str) -> list[StoredObject]:
+        """List objects under a prefix with their last-modified timestamps."""
+
+        def _list_objects() -> list[StoredObject]:
+            objects: list[StoredObject] = []
+            params: dict = {"Bucket": self.bucket, "Prefix": prefix}
+            while True:
+                response = self.client.list_objects_v2(**params)
+                objects.extend(
+                    StoredObject(
+                        key=obj["Key"],
+                        last_modified=_as_utc(obj["LastModified"]),
+                    )
+                    for obj in response.get("Contents", [])
+                )
+                if not response.get("IsTruncated"):
+                    break
+                params["ContinuationToken"] = response["NextContinuationToken"]
+            return objects
+
+        return await asyncio.to_thread(_list_objects)
 
     async def health_check(self) -> None:
         """Verify the S3 bucket is reachable via head_bucket."""

--- a/backend/app/platform/storage/s3.py
+++ b/backend/app/platform/storage/s3.py
@@ -237,15 +237,25 @@ class S3StorageProvider:
 
         return await asyncio.to_thread(_list)
 
-    async def iter_object_pages(self, prefix: str) -> AsyncIterator[list[StoredObject]]:
+    async def iter_object_pages(
+        self, prefix: str, *, start_after: str | None = None
+    ) -> AsyncIterator[list[StoredObject]]:
         """Yield ListObjectsV2 pages, each entry with its last-modified time.
 
         One request per page rather than a drain-then-return: a consumer that
         stops after the first page never issues the second, so a caller with a
         bounded work budget pays for a bounded number of round trips against an
         arbitrarily large prefix (fix(#1249) review r1).
+
+        ``start_after`` becomes S3's own ``StartAfter``, so a resumed walk skips
+        the earlier keys server-side rather than fetching and discarding them
+        (fix(#1249) review r2). It applies to the FIRST request only —
+        ListObjectsV2 ignores it once a ``ContinuationToken`` is present, and
+        sending both would only invite a reader to think otherwise.
         """
         params: dict = {"Bucket": self.bucket, "Prefix": prefix}
+        if start_after is not None:
+            params["StartAfter"] = start_after
         while True:
             response = await asyncio.to_thread(self.client.list_objects_v2, **params)
             yield [
@@ -257,6 +267,7 @@ class S3StorageProvider:
             ]
             if not response.get("IsTruncated"):
                 return
+            params.pop("StartAfter", None)
             params["ContinuationToken"] = response["NextContinuationToken"]
 
     async def health_check(self) -> None:

--- a/backend/app/platform/storage/s3.py
+++ b/backend/app/platform/storage/s3.py
@@ -237,27 +237,27 @@ class S3StorageProvider:
 
         return await asyncio.to_thread(_list)
 
-    async def list_objects(self, prefix: str) -> list[StoredObject]:
-        """List objects under a prefix with their last-modified timestamps."""
+    async def iter_object_pages(self, prefix: str) -> AsyncIterator[list[StoredObject]]:
+        """Yield ListObjectsV2 pages, each entry with its last-modified time.
 
-        def _list_objects() -> list[StoredObject]:
-            objects: list[StoredObject] = []
-            params: dict = {"Bucket": self.bucket, "Prefix": prefix}
-            while True:
-                response = self.client.list_objects_v2(**params)
-                objects.extend(
-                    StoredObject(
-                        key=obj["Key"],
-                        last_modified=_as_utc(obj["LastModified"]),
-                    )
-                    for obj in response.get("Contents", [])
+        One request per page rather than a drain-then-return: a consumer that
+        stops after the first page never issues the second, so a caller with a
+        bounded work budget pays for a bounded number of round trips against an
+        arbitrarily large prefix (fix(#1249) review r1).
+        """
+        params: dict = {"Bucket": self.bucket, "Prefix": prefix}
+        while True:
+            response = await asyncio.to_thread(self.client.list_objects_v2, **params)
+            yield [
+                StoredObject(
+                    key=obj["Key"],
+                    last_modified=_as_utc(obj["LastModified"]),
                 )
-                if not response.get("IsTruncated"):
-                    break
-                params["ContinuationToken"] = response["NextContinuationToken"]
-            return objects
-
-        return await asyncio.to_thread(_list_objects)
+                for obj in response.get("Contents", [])
+            ]
+            if not response.get("IsTruncated"):
+                return
+            params["ContinuationToken"] = response["NextContinuationToken"]
 
     async def health_check(self) -> None:
         """Verify the S3 bucket is reachable via head_bucket."""

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2309,7 +2309,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # on this entry (fix #1236, fix #1322 rounds 1-6, ...) is unchanged and
     # readable via `git log` on the pre-split file; sweep.py is entered
     # fresh at its measured size below.
-    "backend/app/platform/jobs/sweep.py": 1366,
+    # fix(#1249): +9 — the object-driven staging reconciliation is wired in
+    # after the two row-driven reapers, with the comment saying why it is not
+    # folded into StaleCleanupOutcome (that dataclass is a published API and
+    # audit shape). The pass itself lives in its own module,
+    # platform/jobs/staging_reconcile.py, which is under the 1000-line
+    # inclusion threshold and needs no entry. Cap 1366 -> 1375, exact.
+    "backend/app/platform/jobs/sweep.py": 1375,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side
@@ -2326,7 +2332,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # against the migrate service's actual database URL login, so managed DB
     # reconciliation can install future-object defaults for the right role.
     # Cap 1056 -> 1091, exact.
-    "backend/app/core/config.py": 1091,
+    # fix(#1249): +13 — `staging_orphan_min_age_seconds`, the age an untracked
+    # staging object must reach before the reconciliation sweep may delete it.
+    # Most of the lines are the comment saying what the number is NOT (an
+    # estimate of how long an upload takes — the tracking-row check is what
+    # decides ownership), so nobody later "tunes" it as if it were a transfer
+    # margin. Cap 1091 -> 1104, exact.
+    "backend/app/core/config.py": 1104,
     # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
     # the inclusion rule's own comment predicted for this file ("watched by
     # nothing until they cross 1000. The threshold catches them then"). The

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2322,7 +2322,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # direction and a deletion of live input in the other. The lines are the
     # multi-name import that replaced the single-name one. Cap 1375 -> 1379,
     # exact.
-    "backend/app/platform/jobs/sweep.py": 1379,
+    # fix(#1249 review r6): +1 — STAGING_REAPED_FINAL_MARKER moved to
+    # jobs/models.py too. Its presence is what tells the reconciliation the
+    # post-expiry sweep is finished with a key, and a copy of the string in
+    # each module is one rename away from a row that shields an object
+    # forever. Cap 1379 -> 1380, exact.
+    "backend/app/platform/jobs/sweep.py": 1380,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2315,7 +2315,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # audit shape). The pass itself lives in its own module,
     # platform/jobs/staging_reconcile.py, which is under the 1000-line
     # inclusion threshold and needs no entry. Cap 1366 -> 1375, exact.
-    "backend/app/platform/jobs/sweep.py": 1375,
+    # fix(#1249 review r4): +4 — the retention purge's survivor query now reads
+    # STATUSES_NEEDING_STAGED_INPUT from jobs/models.py instead of an inline
+    # tuple, because the reconciliation asks the same question and two copies
+    # of "which statuses still need the bytes" drift into a leak in one
+    # direction and a deletion of live input in the other. The lines are the
+    # multi-name import that replaced the single-name one. Cap 1375 -> 1379,
+    # exact.
+    "backend/app/platform/jobs/sweep.py": 1379,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side

--- a/backend/tests/test_staging_orphan_reconcile_1249.py
+++ b/backend/tests/test_staging_orphan_reconcile_1249.py
@@ -1,0 +1,480 @@
+"""fix(#1249): staging objects with no ingest_jobs row are reconciled away.
+
+#1236 review r5 left a residual orphan window that no time-based margin can
+close: S3 validates a presigned signature when a request STARTS, so an
+accepted single-part PUT can still be transferring after every deadline
+derived from its URL has passed, and a sweep that inferred "the transfer must
+be done by now" from elapsed time deleted the key and retired the row before
+the PUT landed. The fix reverses the direction of the question — start from
+the OBJECT, ask whether any row still owns it — so nothing has to be inferred
+from a clock at all.
+
+The decision logic is exercised against a fake storage layer with a REAL
+database session: the row lookups are the whole point, so a mocked session
+would assert nothing about whether they are even valid SQL. The provider
+halves (`list_objects` on local + S3) are pinned separately, and one
+end-to-end case runs the whole pass against a real ``LocalStorageProvider``
+with a backdated mtime — no sleeps anywhere, every wait is a fact the test
+sets up rather than one it hopes for.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.platform.jobs.models import IngestJob
+from app.platform.jobs.staging_reconcile import (
+    STAGING_PREFIX,
+    _job_id_from_key,
+    reconcile_orphaned_staging_objects,
+)
+from app.platform.storage.provider import StoredObject
+
+pytestmark = pytest.mark.anyio
+
+
+NOW = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+
+
+def _old() -> datetime:
+    """A last-modified far past the deletion threshold."""
+    return NOW - timedelta(seconds=settings.staging_orphan_min_age_seconds + 3600)
+
+
+def _young() -> datetime:
+    """A last-modified inside the threshold — an upload that just landed."""
+    return NOW - timedelta(seconds=60)
+
+
+class FakeStorage:
+    """Just enough provider to drive the reconciliation deterministically."""
+
+    def __init__(self, objects: dict[str, datetime]) -> None:
+        self.objects = dict(objects)
+        self.deleted: list[str] = []
+        self.listed_prefixes: list[str] = []
+        self.delete_error: Exception | None = None
+        # Called with the key right before its pre-delete re-read, so a test
+        # can mutate the world exactly at the moment the race would happen.
+        self.on_recheck = None
+
+    async def list_objects(self, prefix: str) -> list[StoredObject]:
+        self.listed_prefixes.append(prefix)
+        if self.on_recheck is not None and prefix != STAGING_PREFIX:
+            await self.on_recheck(prefix)
+        return [
+            StoredObject(key=key, last_modified=modified)
+            for key, modified in sorted(self.objects.items())
+            if key.startswith(prefix)
+        ]
+
+    async def delete(self, key: str) -> None:
+        if self.delete_error is not None:
+            raise self.delete_error
+        self.deleted.append(key)
+        self.objects.pop(key, None)
+
+
+async def _job(session: AsyncSession, *, status: str = "complete") -> uuid.UUID:
+    """Insert a committed ingest_jobs row and return its id."""
+    job = IngestJob(source_filename="orphan-test", status=status)
+    session.add(job)
+    await session.flush()
+    job_id = job.id
+    await session.commit()
+    return job_id
+
+
+async def _run(session: AsyncSession, storage: FakeStorage):
+    with patch("app.platform.storage.get_storage", return_value=storage):
+        return await reconcile_orphaned_staging_objects(session, now=NOW)
+
+
+class TestJobIdFromKey:
+    """Which keys this sweep is willing to reason about at all."""
+
+    def test_a_staging_upload_key_names_its_job(self) -> None:
+        job_id = uuid.uuid4()
+        assert _job_id_from_key(f"staging/{job_id}/roads.geojson") == job_id
+
+    def test_the_frozen_snapshot_names_the_same_job(self) -> None:
+        """`frozen/` sits under the job segment, so it reconciles identically."""
+        job_id = uuid.uuid4()
+        assert _job_id_from_key(f"staging/{job_id}/frozen/roads.geojson") == job_id
+
+    # Literal uuids, not uuid4() calls: a parametrize argument evaluated at
+    # collection time differs per xdist worker, and xdist aborts the whole run
+    # when workers disagree about which tests exist.
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "staging/not-a-uuid/roads.geojson",
+            "staging/roads.geojson",
+            "staging/",
+            "staging/6f1b6b1e-6d3a-4f0a-9f0e-1f2a3b4c5d6e/",
+            "other/6f1b6b1e-6d3a-4f0a-9f0e-1f2a3b4c5d6e/roads.geojson",
+            "",
+        ],
+    )
+    def test_anything_it_cannot_attribute_is_declined(self, key: str) -> None:
+        """ "I cannot tell whose this is" must never become "so delete it"."""
+        assert _job_id_from_key(key) is None
+
+
+class TestReconciliationDecision:
+    """Row present / absent+young / absent+old, plus both races."""
+
+    async def test_an_object_whose_job_row_still_exists_is_kept(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        job_id = await _job(test_db_session)
+        key = f"staging/{job_id}/roads.geojson"
+        storage = FakeStorage({key: _old()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == []
+        assert outcome.ran is True
+        assert outcome.orphans_deleted == 0
+
+    async def test_an_untracked_object_inside_the_threshold_is_kept(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The single-part PUT that just landed after its row was purged.
+
+        This is #1249's own scenario at the moment it happens: the object is
+        real, nothing tracks it, and deleting it now would race a client that
+        may still be finishing. The age threshold is what makes waiting free —
+        the next pass a day later deletes it with no inference required.
+        """
+        key = f"staging/{uuid.uuid4()}/roads.geojson"
+        storage = FakeStorage({key: _young()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == []
+        assert outcome.skipped_recent == 1
+        assert outcome.orphans_deleted == 0
+
+    async def test_an_untracked_object_past_the_threshold_is_deleted(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        key = f"staging/{uuid.uuid4()}/roads.geojson"
+        storage = FakeStorage({key: _old()})
+
+        with patch(
+            "app.platform.jobs.staging_reconcile.staging_orphans_deleted_total"
+        ) as counter:
+            outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == [key]
+        assert outcome.orphans_deleted == 1
+        assert outcome.delete_failures == 0
+        counter.inc.assert_called_once_with(1)
+
+    async def test_a_row_that_appears_before_the_delete_saves_the_object(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Race #2, with the real recheck query rather than a stubbed answer.
+
+        The row is committed after the batch query has already concluded the
+        object is untracked. Under READ COMMITTED the per-object recheck takes
+        its own snapshot, so it sees the new row and declines — which is the
+        entire reason the recheck is a separate statement instead of a reuse of
+        the batch result.
+        """
+        job_id = uuid.uuid4()
+        key = f"staging/{job_id}/roads.geojson"
+        storage = FakeStorage({key: _old()})
+
+        real_exists = None
+
+        async def _insert_then_check(db: AsyncSession, checked_id: uuid.UUID) -> bool:
+            await db.execute(
+                text(
+                    "INSERT INTO catalog.ingest_jobs (id, status, source_filename)"
+                    " VALUES (:id, 'pending', 'raced') ON CONFLICT DO NOTHING"
+                ).bindparams(id=checked_id)
+            )
+            await db.commit()
+            return await real_exists(db, checked_id)
+
+        import app.platform.jobs.staging_reconcile as module
+
+        real_exists = module._job_row_exists
+        with patch.object(module, "_job_row_exists", _insert_then_check):
+            outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == []
+        assert outcome.skipped_row_appeared == 1
+        assert outcome.orphans_deleted == 0
+
+    async def test_an_object_rewritten_before_the_delete_is_left_alone(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Race #1: a listing entry is never authority for destroying anything.
+
+        The object is old in the snapshot and freshly written by the time the
+        pre-delete re-read runs. The re-read is what decides, so it survives.
+        """
+        key = f"staging/{uuid.uuid4()}/roads.geojson"
+        storage = FakeStorage({key: _old()})
+
+        async def _rewrite(prefix: str) -> None:
+            storage.objects[prefix] = _young()
+
+        storage.on_recheck = _rewrite
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == []
+        assert outcome.skipped_object_changed == 1
+        assert outcome.orphans_deleted == 0
+
+    async def test_an_object_that_vanished_before_the_delete_is_not_a_failure(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        key = f"staging/{uuid.uuid4()}/roads.geojson"
+        storage = FakeStorage({key: _old()})
+
+        async def _vanish(prefix: str) -> None:
+            storage.objects.pop(prefix, None)
+
+        storage.on_recheck = _vanish
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == []
+        assert outcome.skipped_object_changed == 1
+        assert outcome.delete_failures == 0
+
+    async def test_an_unattributable_staging_key_is_never_touched(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        storage = FakeStorage(
+            {
+                "staging/not-a-uuid/mystery.gpkg": _old(),
+                "staging/loose-file.gpkg": _old(),
+            }
+        )
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == []
+        assert outcome.skipped_unattributable == 2
+
+    async def test_only_the_staging_prefix_is_ever_listed(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Objects the upload system does not own are out of reach by construction."""
+        outside = f"customer-data/{uuid.uuid4()}/quarterly.gpkg"
+        storage = FakeStorage({outside: _old()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == []
+        assert outcome.objects_listed == 0
+        assert storage.listed_prefixes == [STAGING_PREFIX]
+
+    async def test_a_provider_delete_failure_is_counted_not_raised(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The sweep this runs inside must survive a broken object store."""
+        key = f"staging/{uuid.uuid4()}/roads.geojson"
+        storage = FakeStorage({key: _old()})
+        storage.delete_error = RuntimeError("provider down")
+
+        outcome = await _run(test_db_session, storage)
+
+        assert outcome.delete_failures == 1
+        assert outcome.orphans_deleted == 0
+
+    async def test_a_listing_failure_ends_the_pass_without_raising(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        storage = AsyncMock()
+        storage.list_objects.side_effect = RuntimeError("provider down")
+
+        with patch("app.platform.storage.get_storage", return_value=storage):
+            outcome = await reconcile_orphaned_staging_objects(test_db_session, now=NOW)
+
+        assert outcome.ran is False
+        storage.delete.assert_not_awaited()
+
+    async def test_the_callers_orm_instances_survive_the_pass(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The pass must not commit or roll back the session it is handed.
+
+        A rollback expires every instance in the identity map regardless of
+        ``expire_on_commit``, so a caller still holding ORM objects (which
+        ``fail_stale_jobs`` does) would find them unloadable afterwards. This
+        is why the advisory lock lives on a session of the pass's own.
+        """
+        job = IngestJob(source_filename="held-across-the-pass", status="complete")
+        test_db_session.add(job)
+        await test_db_session.flush()
+        await test_db_session.commit()
+        key = f"staging/{uuid.uuid4()}/roads.geojson"
+
+        outcome = await _run(test_db_session, FakeStorage({key: _old()}))
+
+        assert outcome.orphans_deleted == 1
+        # Reading through the instance, not a fresh query: an expired
+        # attribute would raise here rather than answer.
+        assert job.source_filename == "held-across-the-pass"
+
+    async def test_a_concurrent_pass_declines_rather_than_double_counting(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The advisory lock is what makes the counter honest.
+
+        Every API worker runs its own sweeper loop; without the lock each would
+        list the same prefix and count the same delete, reporting N times the
+        truth under UVICORN_WORKERS>1.
+        """
+        import app.core.db as db_module
+
+        key = f"staging/{uuid.uuid4()}/roads.geojson"
+        storage = FakeStorage({key: _old()})
+
+        async with db_module.async_session() as holder:
+            held = await holder.execute(
+                text(
+                    "SELECT pg_try_advisory_xact_lock(hashtextextended(:lock_key, 0))"
+                ),
+                {"lock_key": f"staging-orphan-reconcile:{STAGING_PREFIX}"},
+            )
+            assert held.scalar() is True, "precondition: the other process has it"
+
+            outcome = await _run(test_db_session, storage)
+
+        assert outcome.ran is False
+        assert storage.deleted == []
+        assert storage.listed_prefixes == []
+
+
+class TestAgainstRealLocalStorage:
+    """One end-to-end pass with a real provider and real mtimes."""
+
+    async def test_the_orphan_is_deleted_and_the_tracked_object_survives(
+        self, test_db_session: AsyncSession, tmp_path, monkeypatch
+    ) -> None:
+        from app.platform.storage.local import LocalStorageProvider
+
+        storage = LocalStorageProvider(str(tmp_path))
+        monkeypatch.setattr(
+            "app.platform.storage.get_storage", lambda: storage, raising=True
+        )
+
+        tracked_id = await _job(test_db_session)
+        orphan_id = uuid.uuid4()
+        tracked_key = f"staging/{tracked_id}/tracked.geojson"
+        orphan_key = f"staging/{orphan_id}/orphan.geojson"
+        await storage.put(tracked_key, b"tracked")
+        await storage.put(orphan_key, b"orphan")
+
+        # Backdate both past the threshold. Deterministic by construction —
+        # the age is a fact the test writes, never one it waits for.
+        backdated = (_old()).timestamp()
+        for key in (tracked_key, orphan_key):
+            os.utime(tmp_path / key, (backdated, backdated))
+
+        outcome = await reconcile_orphaned_staging_objects(test_db_session, now=NOW)
+
+        assert outcome.orphans_deleted == 1
+        assert await storage.exists(tracked_key)
+        assert not await storage.exists(orphan_key)
+
+
+class TestProviderListObjects:
+    """The new provider call, on both backends that can serve staging keys."""
+
+    async def test_local_reports_mtime_as_aware_utc(self, tmp_path) -> None:
+        from app.platform.storage.local import LocalStorageProvider
+
+        storage = LocalStorageProvider(str(tmp_path))
+        await storage.put("staging/a/one.txt", b"1")
+        await storage.put("staging/b/two.txt", b"2")
+        backdated = _old().timestamp()
+        os.utime(tmp_path / "staging/a/one.txt", (backdated, backdated))
+
+        entries = {e.key: e for e in await storage.list_objects("staging/")}
+
+        assert set(entries) == {"staging/a/one.txt", "staging/b/two.txt"}
+        assert entries["staging/a/one.txt"].last_modified.tzinfo is not None
+        assert entries["staging/a/one.txt"].last_modified == datetime.fromtimestamp(
+            backdated, tz=timezone.utc
+        )
+
+    async def test_local_accepts_a_complete_key_as_the_prefix(self, tmp_path) -> None:
+        """The pre-delete re-read passes an exact key, not a directory."""
+        from app.platform.storage.local import LocalStorageProvider
+
+        storage = LocalStorageProvider(str(tmp_path))
+        await storage.put("staging/a/one.txt", b"1")
+        await storage.put("staging/a/one.txt.part", b"partial")
+
+        entries = await storage.list_objects("staging/a/one.txt")
+
+        # A prefix listing also returns siblings sharing the prefix, which is
+        # exactly why the caller filters for an exact key match.
+        assert {e.key for e in entries} == {
+            "staging/a/one.txt",
+            "staging/a/one.txt.part",
+        }
+
+    async def test_s3_reports_aware_timestamps_and_paginates(self) -> None:
+        from app.platform.storage.s3 import S3StorageProvider
+
+        with mock_aws():
+            client = boto3.client("s3", region_name="us-east-1")
+            client.create_bucket(Bucket="orphan-bucket")
+            for index in range(3):
+                client.put_object(
+                    Bucket="orphan-bucket", Key=f"staging/j/{index}.txt", Body=b"x"
+                )
+            client.put_object(Bucket="orphan-bucket", Key="other/keep.txt", Body=b"x")
+            provider = S3StorageProvider(
+                bucket="orphan-bucket",
+                region="us-east-1",
+                access_key_id="testing",
+                secret_access_key="testing",
+            )
+
+            entries = await provider.list_objects("staging/")
+
+        assert {e.key for e in entries} == {
+            "staging/j/0.txt",
+            "staging/j/1.txt",
+            "staging/j/2.txt",
+        }
+        assert all(e.last_modified.tzinfo is not None for e in entries)
+
+
+async def test_the_stale_job_sweep_runs_the_reconciliation(
+    test_db_session: AsyncSession,
+) -> None:
+    """The wiring, not the logic: a sweep pass must actually reach it.
+
+    ``fail_stale_jobs`` is where every scheduled cleanup converges, so a
+    reconciliation nothing calls is a reconciliation that does not exist.
+    """
+    from app.platform.jobs import sweep as sweep_module
+
+    with patch.object(
+        sweep_module, "reconcile_orphaned_staging_objects", new_callable=AsyncMock
+    ) as reconcile:
+        await sweep_module.fail_stale_jobs(test_db_session)
+
+    reconcile.assert_awaited_once()

--- a/backend/tests/test_staging_orphan_reconcile_1249.py
+++ b/backend/tests/test_staging_orphan_reconcile_1249.py
@@ -12,7 +12,7 @@ from a clock at all.
 The decision logic is exercised against a fake storage layer with a REAL
 database session: the row lookups are the whole point, so a mocked session
 would assert nothing about whether they are even valid SQL. The provider
-halves (`list_objects` on local + S3) are pinned separately, and one
+halves (`iter_object_pages` on local + S3) are pinned separately, and one
 end-to-end case runs the whole pass against a real ``LocalStorageProvider``
 with a backdated mtime — no sleeps anywhere, every wait is a fact the test
 sets up rather than one it hopes for.
@@ -59,24 +59,35 @@ def _young() -> datetime:
 class FakeStorage:
     """Just enough provider to drive the reconciliation deterministically."""
 
-    def __init__(self, objects: dict[str, datetime]) -> None:
+    def __init__(self, objects: dict[str, datetime], *, page_size: int = 1000) -> None:
         self.objects = dict(objects)
+        self.page_size = page_size
         self.deleted: list[str] = []
         self.listed_prefixes: list[str] = []
+        # One entry per page of the PREFIX walk actually fetched, so a test can
+        # prove the pass stopped paging rather than merely stopped acting. The
+        # per-object pre-delete re-reads pass a complete key (no trailing "/")
+        # and are excluded — they are not the walk.
+        self.pages_served: list[int] = []
         self.delete_error: Exception | None = None
         # Called with the key right before its pre-delete re-read, so a test
         # can mutate the world exactly at the moment the race would happen.
         self.on_recheck = None
 
-    async def list_objects(self, prefix: str) -> list[StoredObject]:
+    async def iter_object_pages(self, prefix: str):
         self.listed_prefixes.append(prefix)
         if self.on_recheck is not None and prefix != STAGING_PREFIX:
             await self.on_recheck(prefix)
-        return [
+        matching = [
             StoredObject(key=key, last_modified=modified)
             for key, modified in sorted(self.objects.items())
             if key.startswith(prefix)
         ]
+        for start in range(0, max(len(matching), 1), self.page_size):
+            page = matching[start : start + self.page_size]
+            if prefix.endswith("/"):
+                self.pages_served.append(len(page))
+            yield page
 
     async def delete(self, key: str) -> None:
         if self.delete_error is not None:
@@ -303,13 +314,60 @@ class TestReconciliationDecision:
         self, test_db_session: AsyncSession
     ) -> None:
         storage = AsyncMock()
-        storage.list_objects.side_effect = RuntimeError("provider down")
+
+        async def _explode(prefix: str):
+            raise RuntimeError("provider down")
+            yield []  # unreachable; makes this an async generator
+
+        storage.iter_object_pages = _explode
 
         with patch("app.platform.storage.get_storage", return_value=storage):
             outcome = await reconcile_orphaned_staging_objects(test_db_session, now=NOW)
 
         assert outcome.ran is False
         storage.delete.assert_not_awaited()
+
+    async def test_the_pass_stops_paging_once_its_delete_budget_is_spent(
+        self, test_db_session: AsyncSession, monkeypatch
+    ) -> None:
+        """fix(#1249) review r1: a large `staging/` prefix is not materialized.
+
+        The pass holds a transaction (and its connection) open for the advisory
+        lock, so both budgets are checked BETWEEN pages — it must stop asking
+        the provider for more, not merely stop deleting what it was handed.
+        """
+        import app.platform.jobs.staging_reconcile as module
+
+        monkeypatch.setattr(module, "_MAX_DELETES_PER_PASS", 2)
+        orphans = {
+            f"staging/{uuid.uuid4()}/f{index}.geojson": _old() for index in range(9)
+        }
+        storage = FakeStorage(orphans, page_size=3)
+
+        outcome = await _run(test_db_session, storage)
+
+        assert outcome.orphans_deleted == 2
+        # One page fetched, not three: the budget was spent inside the first.
+        assert storage.pages_served == [3]
+        assert outcome.objects_listed == 3
+
+    async def test_the_scan_budget_bounds_a_prefix_with_nothing_to_delete(
+        self, test_db_session: AsyncSession, monkeypatch
+    ) -> None:
+        """The other half of the bound: no orphans is not a licence to walk forever."""
+        import app.platform.jobs.staging_reconcile as module
+
+        monkeypatch.setattr(module, "_MAX_OBJECTS_SCANNED_PER_PASS", 4)
+        young = {
+            f"staging/{uuid.uuid4()}/f{index}.geojson": _young() for index in range(12)
+        }
+        storage = FakeStorage(young, page_size=2)
+
+        outcome = await _run(test_db_session, storage)
+
+        assert outcome.orphans_deleted == 0
+        assert outcome.objects_listed == 4
+        assert storage.pages_served == [2, 2]
 
     async def test_the_callers_orm_instances_survive_the_pass(
         self, test_db_session: AsyncSession
@@ -397,7 +455,11 @@ class TestAgainstRealLocalStorage:
         assert not await storage.exists(orphan_key)
 
 
-class TestProviderListObjects:
+async def _all_entries(storage, prefix: str) -> list[StoredObject]:
+    return [entry async for page in storage.iter_object_pages(prefix) for entry in page]
+
+
+class TestProviderIterObjectPages:
     """The new provider call, on both backends that can serve staging keys."""
 
     async def test_local_reports_mtime_as_aware_utc(self, tmp_path) -> None:
@@ -409,7 +471,7 @@ class TestProviderListObjects:
         backdated = _old().timestamp()
         os.utime(tmp_path / "staging/a/one.txt", (backdated, backdated))
 
-        entries = {e.key: e for e in await storage.list_objects("staging/")}
+        entries = {e.key: e for e in await _all_entries(storage, "staging/")}
 
         assert set(entries) == {"staging/a/one.txt", "staging/b/two.txt"}
         assert entries["staging/a/one.txt"].last_modified.tzinfo is not None
@@ -425,7 +487,7 @@ class TestProviderListObjects:
         await storage.put("staging/a/one.txt", b"1")
         await storage.put("staging/a/one.txt.part", b"partial")
 
-        entries = await storage.list_objects("staging/a/one.txt")
+        entries = await _all_entries(storage, "staging/a/one.txt")
 
         # A prefix listing also returns siblings sharing the prefix, which is
         # exactly why the caller filters for an exact key match.
@@ -434,13 +496,18 @@ class TestProviderListObjects:
             "staging/a/one.txt.part",
         }
 
-    async def test_s3_reports_aware_timestamps_and_paginates(self) -> None:
+    async def test_s3_pages_and_stops_when_the_consumer_does(self) -> None:
+        """Real ListObjectsV2 continuation, and a consumer that breaks early.
+
+        The second assertion is the one review r1 asked for: abandoning the
+        generator must abandon the round trips too, not just the results.
+        """
         from app.platform.storage.s3 import S3StorageProvider
 
         with mock_aws():
             client = boto3.client("s3", region_name="us-east-1")
             client.create_bucket(Bucket="orphan-bucket")
-            for index in range(3):
+            for index in range(5):
                 client.put_object(
                     Bucket="orphan-bucket", Key=f"staging/j/{index}.txt", Body=b"x"
                 )
@@ -452,14 +519,27 @@ class TestProviderListObjects:
                 secret_access_key="testing",
             )
 
-            entries = await provider.list_objects("staging/")
+            entries = await _all_entries(provider, "staging/")
+
+            calls: list[dict] = []
+            unpatched = provider.client.list_objects_v2
+
+            def _counting(**kwargs):
+                calls.append(kwargs)
+                return unpatched(**kwargs, MaxKeys=2)
+
+            provider.client.list_objects_v2 = _counting
+            first_page = None
+            async for page in provider.iter_object_pages("staging/"):
+                first_page = page
+                break
 
         assert {e.key for e in entries} == {
-            "staging/j/0.txt",
-            "staging/j/1.txt",
-            "staging/j/2.txt",
+            f"staging/j/{index}.txt" for index in range(5)
         }
         assert all(e.last_modified.tzinfo is not None for e in entries)
+        assert first_page is not None and len(first_page) == 2
+        assert len(calls) == 1, "breaking out must stop the paging, not just the loop"
 
 
 async def test_the_stale_job_sweep_runs_the_reconciliation(

--- a/backend/tests/test_staging_orphan_reconcile_1249.py
+++ b/backend/tests/test_staging_orphan_reconcile_1249.py
@@ -214,19 +214,62 @@ class TestReconciliationDecision:
         assert storage.deleted == [], "deleted a surviving child's only input"
         assert outcome.orphans_deleted == 0
 
-    async def test_an_inherited_s3_key_also_counts_as_a_reference(
+    async def test_a_failed_child_still_shields_the_input_it_can_retry_from(
         self, test_db_session: AsyncSession
     ) -> None:
-        """The other cloned column. `user_metadata` is copied wholesale too, so
-        a child carries the parent's client-writable upload key as well."""
+        """`/jobs/{id}/retry` is failed-only, so a failed row is not done."""
         purged_parent_id = uuid.uuid4()
-        upload_key = f"staging/{purged_parent_id}/multi.gpkg"
+        shared_input = f"staging/{purged_parent_id}/frozen/multi.gpkg"
+        await _job(test_db_session, status="failed", file_path=shared_input)
+        storage = FakeStorage({shared_input: _old()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == []
+        assert outcome.orphans_deleted == 0
+
+    async def test_a_complete_childs_inherited_reference_does_not_shield_forever(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """fix(#1249 review r4, codex P2): the sibling of the r3 fix.
+
+        A fan-out child stays `complete` forever and is exempt from retention
+        indefinitely as a dataset's latest complete job. Counting its inherited
+        `file_path` as a live reference at any status would answer "still
+        referenced" on every future pass, so an object leaked by a failed
+        parent-side delete could never be repaired — the reconciler would
+        permanently decline the one case it exists for. The retention purge
+        draws the line in exactly the same place.
+        """
+        purged_parent_id = uuid.uuid4()
+        shared_input = f"staging/{purged_parent_id}/frozen/multi.gpkg"
         await _job(
             test_db_session,
-            status="failed",
-            file_path=f"staging/{purged_parent_id}/frozen/multi.gpkg",
-            user_metadata={"s3_key": upload_key},
+            status="complete",
+            file_path=shared_input,
+            # Cloned wholesale by create_fan_out_jobs, and never ownership —
+            # owned_presigned_staging_key rejects an inherited key for the
+            # same reason this must not shield one.
+            user_metadata={"s3_key": f"staging/{purged_parent_id}/multi.gpkg"},
         )
+        storage = FakeStorage({shared_input: _old()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == [shared_input]
+        assert outcome.orphans_deleted == 1
+
+    async def test_the_owning_row_shields_its_key_at_any_status(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The status rule applies to OTHER rows, never to the key's own job.
+
+        That row is where the post-expiry sweep's markers live and the one
+        retention holds back while a PUT URL may still be live, so while it
+        exists the key has a lifecycle and this reconciler is not it.
+        """
+        job_id = await _job(test_db_session, status="complete")
+        upload_key = f"staging/{job_id}/roads.geojson"
         storage = FakeStorage({upload_key: _old()})
 
         outcome = await _run(test_db_session, storage)

--- a/backend/tests/test_staging_orphan_reconcile_1249.py
+++ b/backend/tests/test_staging_orphan_reconcile_1249.py
@@ -151,16 +151,23 @@ async def _job_with_id(
 
 
 @pytest.fixture(autouse=True)
-def _front_of_the_prefix():
-    """Start every test's first pass at the front of the keyspace.
+def _front_of_the_prefix(monkeypatch):
+    """Start every test's first pass at the front of the keyspace, on S3.
 
     The cursor seeds itself at a RANDOM point on first use per process (so a
     restart-prone worker still covers the whole prefix), which would otherwise
     make every assertion here depend on a uuid draw. Tests that care about the
     cursor set it themselves.
+
+    `storage_provider` matters because the pass runs on S3 storage only — the
+    local backend's `staging/` directory is not exclusively the upload
+    system's. The provider DOUBLE stays a fake (or a real
+    LocalStorageProvider, for the end-to-end case); only the setting the gate
+    reads is moved.
     """
     import app.platform.jobs.staging_reconcile as module
 
+    monkeypatch.setattr(settings, "storage_provider", "s3")
     module._scan_cursors.clear()
     module._scan_cursors[STAGING_PREFIX] = None
     yield
@@ -768,6 +775,29 @@ class TestScanCursor:
         # Reading through the instance, not a fresh query: an expired
         # attribute would raise here rather than answer.
         assert job.source_filename == "held-across-the-pass"
+
+    async def test_local_storage_is_declined_outright(
+        self, test_db_session: AsyncSession, monkeypatch
+    ) -> None:
+        """fix(#1249 review r8, codex P1): `staging/` is only ours in a BUCKET.
+
+        On the local backend the same prefix sits inside `upload_staging_dir`,
+        where an operator also stages manifest seed files — legitimately, and
+        legitimately BEFORE the manifest that names them is applied, stored as
+        an absolute path no logical-key comparison here would match. Deleting
+        one is not a leaked byte, it is someone's input. Nothing is lost by
+        declining: presigned uploads refuse anything but S3 at request time,
+        so the orphan class this module exists for cannot occur here.
+        """
+        monkeypatch.setattr(settings, "storage_provider", "local")
+        seed = f"staging/{uuid.uuid4()}/seed.geojson"
+        storage = FakeStorage({seed: _old()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert outcome.ran is False
+        assert storage.deleted == []
+        assert storage.listed_prefixes == [], "it must not even look"
 
     async def test_a_concurrent_pass_declines_rather_than_double_counting(
         self, test_db_session: AsyncSession

--- a/backend/tests/test_staging_orphan_reconcile_1249.py
+++ b/backend/tests/test_staging_orphan_reconcile_1249.py
@@ -69,19 +69,24 @@ class FakeStorage:
         # per-object pre-delete re-reads pass a complete key (no trailing "/")
         # and are excluded — they are not the walk.
         self.pages_served: list[int] = []
+        # The `start_after` each prefix walk was handed, so the cursor's
+        # advance is observable rather than inferred from what got deleted.
+        self.resumed_from: list[str | None] = []
         self.delete_error: Exception | None = None
         # Called with the key right before its pre-delete re-read, so a test
         # can mutate the world exactly at the moment the race would happen.
         self.on_recheck = None
 
-    async def iter_object_pages(self, prefix: str):
+    async def iter_object_pages(self, prefix: str, *, start_after: str | None = None):
         self.listed_prefixes.append(prefix)
+        if prefix.endswith("/"):
+            self.resumed_from.append(start_after)
         if self.on_recheck is not None and prefix != STAGING_PREFIX:
             await self.on_recheck(prefix)
         matching = [
             StoredObject(key=key, last_modified=modified)
             for key, modified in sorted(self.objects.items())
-            if key.startswith(prefix)
+            if key.startswith(prefix) and (start_after is None or key > start_after)
         ]
         for start in range(0, max(len(matching), 1), self.page_size):
             page = matching[start : start + self.page_size]
@@ -104,6 +109,23 @@ async def _job(session: AsyncSession, *, status: str = "complete") -> uuid.UUID:
     job_id = job.id
     await session.commit()
     return job_id
+
+
+@pytest.fixture(autouse=True)
+def _front_of_the_prefix():
+    """Start every test's first pass at the front of the keyspace.
+
+    The cursor seeds itself at a RANDOM point on first use per process (so a
+    restart-prone worker still covers the whole prefix), which would otherwise
+    make every assertion here depend on a uuid draw. Tests that care about the
+    cursor set it themselves.
+    """
+    import app.platform.jobs.staging_reconcile as module
+
+    module._scan_cursors.clear()
+    module._scan_cursors[STAGING_PREFIX] = None
+    yield
+    module._scan_cursors.clear()
 
 
 async def _run(session: AsyncSession, storage: FakeStorage):
@@ -368,6 +390,80 @@ class TestReconciliationDecision:
         assert outcome.orphans_deleted == 0
         assert outcome.objects_listed == 4
         assert storage.pages_served == [2, 2]
+
+
+class TestScanCursor:
+    """fix(#1249) review r2: a capped walk without a cursor is a blind spot.
+
+    Without one, every pass re-walks the same lexicographically first window,
+    and an orphan sorting after a window full of tracked, recent, or
+    unattributable keys is never reached at all.
+    """
+
+    async def test_a_budget_stop_resumes_the_next_pass_where_it_stopped(
+        self, test_db_session: AsyncSession, monkeypatch
+    ) -> None:
+        import app.platform.jobs.staging_reconcile as module
+
+        monkeypatch.setattr(module, "_MAX_OBJECTS_SCANNED_PER_PASS", 2)
+        # Young, so nothing is deleted and only the cursor can explain progress.
+        keys = [f"staging/{uuid.uuid4()}/f.geojson" for _ in range(6)]
+        storage = FakeStorage(dict.fromkeys(keys, _young()), page_size=2)
+
+        first = await _run(test_db_session, storage)
+        second = await _run(test_db_session, storage)
+
+        in_key_order = sorted(keys)
+        assert storage.resumed_from == [None, in_key_order[1]]
+        assert first.objects_listed == 2 and second.objects_listed == 2
+        assert module._scan_cursors[STAGING_PREFIX] == in_key_order[3]
+
+    async def test_a_completed_walk_wraps_to_the_front(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Seeing everything after the start point means starting over next time."""
+        import app.platform.jobs.staging_reconcile as module
+
+        module._scan_cursors[STAGING_PREFIX] = "staging/zzz"
+        storage = FakeStorage({f"staging/{uuid.uuid4()}/f.geojson": _young()})
+
+        await _run(test_db_session, storage)
+
+        assert storage.resumed_from == ["staging/zzz"]
+        assert module._scan_cursors[STAGING_PREFIX] is None
+
+    async def test_a_delete_budget_stop_resumes_at_the_last_candidate_processed(
+        self, test_db_session: AsyncSession, monkeypatch
+    ) -> None:
+        """Not at the end of the page — the rest of it was never worked."""
+        import app.platform.jobs.staging_reconcile as module
+
+        monkeypatch.setattr(module, "_MAX_DELETES_PER_PASS", 1)
+        keys = sorted(f"staging/{uuid.uuid4()}/f.geojson" for _ in range(4))
+        storage = FakeStorage(dict.fromkeys(keys, _old()), page_size=4)
+
+        await _run(test_db_session, storage)
+
+        assert storage.deleted == [keys[0]]
+        assert module._scan_cursors[STAGING_PREFIX] == keys[0], (
+            "resuming past the unprocessed candidates would skip them until the wrap"
+        )
+
+    def test_the_first_pass_of_a_process_starts_somewhere_random(self) -> None:
+        """A worker recycled more often than a full walk completes must not
+        keep restarting at the front — that is the starvation the cursor
+        exists to remove, reintroduced by the restart."""
+        import app.platform.jobs.staging_reconcile as module
+
+        module._scan_cursors.clear()
+        seeds = set()
+        for _ in range(3):
+            module._scan_cursors.clear()
+            seed = module._resume_point("staging/")
+            assert seed is not None and seed.startswith("staging/")
+            seeds.add(seed)
+
+        assert len(seeds) == 3, "a fixed seed would make every process walk alike"
 
     async def test_the_callers_orm_instances_survive_the_pass(
         self, test_db_session: AsyncSession

--- a/backend/tests/test_staging_orphan_reconcile_1249.py
+++ b/backend/tests/test_staging_orphan_reconcile_1249.py
@@ -101,9 +101,20 @@ class FakeStorage:
         self.objects.pop(key, None)
 
 
-async def _job(session: AsyncSession, *, status: str = "complete") -> uuid.UUID:
+async def _job(
+    session: AsyncSession,
+    *,
+    status: str = "complete",
+    file_path: str | None = None,
+    user_metadata: dict | None = None,
+) -> uuid.UUID:
     """Insert a committed ingest_jobs row and return its id."""
-    job = IngestJob(source_filename="orphan-test", status=status)
+    job = IngestJob(
+        source_filename="orphan-test",
+        status=status,
+        file_path=file_path,
+        user_metadata=user_metadata,
+    )
     session.add(job)
     await session.flush()
     job_id = job.id
@@ -180,6 +191,85 @@ class TestReconciliationDecision:
         assert outcome.ran is True
         assert outcome.orphans_deleted == 0
 
+    async def test_a_fan_out_childs_shared_input_survives_its_purged_parent(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """fix(#1249 review r3, codex P1): the key's job segment is not ownership.
+
+        ``create_fan_out_jobs`` clones the parent's ``file_path`` onto every
+        child, so a child's only input is the PARENT's staging object. The
+        parent row hits the retention cutoff on its own schedule — the purge's
+        survivor query keeps the OBJECT alive for a still-pending child, not
+        the parent's row. Reconciling on the id in the key alone would look up
+        the purged parent, find nothing, and delete the input the child is
+        about to read.
+        """
+        purged_parent_id = uuid.uuid4()
+        shared_input = f"staging/{purged_parent_id}/frozen/multi.gpkg"
+        await _job(test_db_session, status="pending", file_path=shared_input)
+        storage = FakeStorage({shared_input: _old()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == [], "deleted a surviving child's only input"
+        assert outcome.orphans_deleted == 0
+
+    async def test_an_inherited_s3_key_also_counts_as_a_reference(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The other cloned column. `user_metadata` is copied wholesale too, so
+        a child carries the parent's client-writable upload key as well."""
+        purged_parent_id = uuid.uuid4()
+        upload_key = f"staging/{purged_parent_id}/multi.gpkg"
+        await _job(
+            test_db_session,
+            status="failed",
+            file_path=f"staging/{purged_parent_id}/frozen/multi.gpkg",
+            user_metadata={"s3_key": upload_key},
+        )
+        storage = FakeStorage({upload_key: _old()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == []
+        assert outcome.orphans_deleted == 0
+
+    async def test_a_reference_that_appears_before_the_delete_saves_the_object(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The per-object recheck covers references, not just the id.
+
+        A batch query that saw no reference must not licence a delete once a
+        fan-out child lands between it and the delete itself.
+        """
+        parent_id = uuid.uuid4()
+        shared_input = f"staging/{parent_id}/frozen/multi.gpkg"
+        storage = FakeStorage({shared_input: _old()})
+
+        import app.platform.jobs.staging_reconcile as module
+
+        real_exists = module._staging_reference_exists
+
+        async def _insert_child_then_check(
+            db: AsyncSession, checked_id: uuid.UUID, logical_key: str
+        ) -> bool:
+            await db.execute(
+                text(
+                    "INSERT INTO catalog.ingest_jobs (status, source_filename,"
+                    " file_path) VALUES ('pending', 'late-child', :fp)"
+                ).bindparams(fp=logical_key)
+            )
+            await db.commit()
+            return await real_exists(db, checked_id, logical_key)
+
+        with patch.object(
+            module, "_staging_reference_exists", _insert_child_then_check
+        ):
+            outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == []
+        assert outcome.skipped_row_appeared == 1
+
     async def test_an_untracked_object_inside_the_threshold_is_kept(
         self, test_db_session: AsyncSession
     ) -> None:
@@ -232,7 +322,9 @@ class TestReconciliationDecision:
 
         real_exists = None
 
-        async def _insert_then_check(db: AsyncSession, checked_id: uuid.UUID) -> bool:
+        async def _insert_then_check(
+            db: AsyncSession, checked_id: uuid.UUID, logical_key: str
+        ) -> bool:
             await db.execute(
                 text(
                     "INSERT INTO catalog.ingest_jobs (id, status, source_filename)"
@@ -240,12 +332,12 @@ class TestReconciliationDecision:
                 ).bindparams(id=checked_id)
             )
             await db.commit()
-            return await real_exists(db, checked_id)
+            return await real_exists(db, checked_id, logical_key)
 
         import app.platform.jobs.staging_reconcile as module
 
-        real_exists = module._job_row_exists
-        with patch.object(module, "_job_row_exists", _insert_then_check):
+        real_exists = module._staging_reference_exists
+        with patch.object(module, "_staging_reference_exists", _insert_then_check):
             outcome = await _run(test_db_session, storage)
 
         assert storage.deleted == []

--- a/backend/tests/test_staging_orphan_reconcile_1249.py
+++ b/backend/tests/test_staging_orphan_reconcile_1249.py
@@ -46,6 +46,11 @@ pytestmark = pytest.mark.anyio
 NOW = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
 
 
+def _uuid_starting(first_hex: str) -> uuid.UUID:
+    """A real uuid4 with its leading hex digit pinned, for ordering tests."""
+    return uuid.UUID(first_hex + str(uuid.uuid4())[1:])
+
+
 def _old() -> datetime:
     """A last-modified far past the deletion threshold."""
     return NOW - timedelta(seconds=settings.staging_orphan_min_age_seconds + 3600)
@@ -660,19 +665,53 @@ class TestScanCursor:
         assert first.objects_listed == 2 and second.objects_listed == 2
         assert module._scan_cursors[STAGING_PREFIX] == in_key_order[3]
 
-    async def test_a_completed_walk_wraps_to_the_front(
+    async def test_a_pass_that_starts_mid_prefix_wraps_to_the_front(
         self, test_db_session: AsyncSession
     ) -> None:
-        """Seeing everything after the start point means starting over next time."""
+        """fix(#1249 review r7, codex P2): a one-directional scan is a sample.
+
+        Starting at a random point and never wrapping means a worker recycled
+        before its next pass only ever sees suffixes, so an orphan near the
+        front of a large prefix is reached with probability ~1/(objects+1) per
+        restart. With the wrap, one unbudgeted pass covers everything and the
+        cursor only decides where it starts.
+        """
         import app.platform.jobs.staging_reconcile as module
 
-        module._scan_cursors[STAGING_PREFIX] = "staging/zzz"
-        storage = FakeStorage({f"staging/{uuid.uuid4()}/f.geojson": _young()})
+        # Real uuids with a pinned leading hex digit, so they straddle the
+        # cursor AND still parse as the job segment of a staging key.
+        low = f"staging/{_uuid_starting('0')}/f.geojson"
+        high = f"staging/{_uuid_starting('f')}/f.geojson"
+        module._scan_cursors[STAGING_PREFIX] = f"staging/8{'0' * 8}"
+        storage = FakeStorage({low: _old(), high: _old()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.resumed_from == [f"staging/8{'0' * 8}", None], (
+            "the pass must walk the tail and then come back for the front"
+        )
+        assert sorted(storage.deleted) == [low, high]
+        assert outcome.orphans_deleted == 2
+        # It got all the way round, so the next pass may start at the front.
+        assert module._scan_cursors[STAGING_PREFIX] is None
+
+    async def test_the_wrap_leg_stops_where_the_pass_started(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Otherwise it re-walks the keys the first leg already covered."""
+        import app.platform.jobs.staging_reconcile as module
+
+        cursor = f"staging/8{'0' * 8}"
+        module._scan_cursors[STAGING_PREFIX] = cursor
+        after_cursor = f"staging/{_uuid_starting('9')}/f.geojson"
+        storage = FakeStorage({after_cursor: _young()})
 
         await _run(test_db_session, storage)
 
-        assert storage.resumed_from == ["staging/zzz"]
-        assert module._scan_cursors[STAGING_PREFIX] is None
+        # The tail leg saw it; the wrap leg is bounded above by the cursor and
+        # so must not report it a second time.
+        assert storage.resumed_from == [cursor, None]
+        assert (await _run(test_db_session, storage)).objects_listed == 1
 
     async def test_a_delete_budget_stop_resumes_at_the_last_candidate_processed(
         self, test_db_session: AsyncSession, monkeypatch

--- a/backend/tests/test_staging_orphan_reconcile_1249.py
+++ b/backend/tests/test_staging_orphan_reconcile_1249.py
@@ -32,7 +32,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.platform.jobs.models import IngestJob
+from app.platform.jobs.models import STAGING_REAPED_FINAL_MARKER, IngestJob
 from app.platform.jobs.staging_reconcile import (
     STAGING_PREFIX,
     _job_id_from_key,
@@ -130,6 +130,21 @@ async def _job(
     return job_id
 
 
+async def _job_with_id(
+    session: AsyncSession, job_id: uuid.UUID, *, status: str, user_metadata: dict
+) -> None:
+    """Insert a committed row at a CHOSEN id, for keys that name their job."""
+    session.add(
+        IngestJob(
+            id=job_id,
+            source_filename="orphan-test",
+            status=status,
+            user_metadata=user_metadata,
+        )
+    )
+    await session.commit()
+
+
 @pytest.fixture(autouse=True)
 def _front_of_the_prefix():
     """Start every test's first pass at the front of the keyspace.
@@ -186,10 +201,10 @@ class TestJobIdFromKey:
 class TestReconciliationDecision:
     """Row present / absent+young / absent+old, plus both races."""
 
-    async def test_an_object_whose_job_row_still_exists_is_kept(
+    async def test_an_object_whose_job_is_still_running_is_kept(
         self, test_db_session: AsyncSession
     ) -> None:
-        job_id = await _job(test_db_session)
+        job_id = await _job(test_db_session, status="running")
         key = f"staging/{job_id}/roads.geojson"
         storage = FakeStorage({key: _old()})
 
@@ -267,23 +282,79 @@ class TestReconciliationDecision:
         assert storage.deleted == [shared_input]
         assert outcome.orphans_deleted == 1
 
-    async def test_the_owning_row_shields_its_key_at_any_status(
+    async def test_the_owning_row_shields_while_the_post_expiry_sweep_owns_the_key(
         self, test_db_session: AsyncSession
     ) -> None:
-        """The status rule applies to OTHER rows, never to the key's own job.
+        """A complete presigned job that has not been finalized yet.
 
-        That row is where the post-expiry sweep's markers live and the one
-        retention holds back while a PUT URL may still be live, so while it
-        exists the key has a lifecycle and this reconciler is not it.
+        `_sweep_expired_presigned_staging` is still going to act on this key,
+        so this reconciler must not race it — the status rule alone would have
+        called a complete row done with the bytes.
         """
-        job_id = await _job(test_db_session, status="complete")
+        # The key names the job it belongs to, so the row is created first and
+        # its metadata written in a second statement.
+        job_id = uuid.uuid4()
         upload_key = f"staging/{job_id}/roads.geojson"
+        await _job_with_id(
+            test_db_session,
+            job_id,
+            status="complete",
+            user_metadata={"s3_key": upload_key},
+        )
         storage = FakeStorage({upload_key: _old()})
 
         outcome = await _run(test_db_session, storage)
 
         assert storage.deleted == []
         assert outcome.orphans_deleted == 0
+
+    async def test_a_finally_reaped_owner_no_longer_shields_a_recreated_upload(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """fix(#1249 review r6, codex P2): #1249's own scenario, end to end.
+
+        A single-part PUT that lands after the post-expiry sweep's FINAL delete
+        recreates the object. That sweep never looks at the key again once its
+        final marker is set, and retention exempts a dataset's latest
+        complete job indefinitely — so "the row still exists" as a shield left
+        the recreated object unreachable by every reaper including this one,
+        which is the exact leak this module was written to close.
+        """
+        job_id = uuid.uuid4()
+        upload_key = f"staging/{job_id}/roads.geojson"
+        await _job_with_id(
+            test_db_session,
+            job_id,
+            status="complete",
+            user_metadata={
+                "s3_key": upload_key,
+                STAGING_REAPED_FINAL_MARKER: True,
+            },
+        )
+        storage = FakeStorage({upload_key: _old()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == [upload_key]
+        assert outcome.orphans_deleted == 1
+
+    async def test_a_complete_direct_uploads_leftover_is_reclaimable(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """A job that never presigned gets no marker, ever.
+
+        Reading a missing marker as "not finalized yet" would shield every
+        direct-upload row forever — the same permanent-shield shape, arrived at
+        from the other side.
+        """
+        job_id = await _job(test_db_session, status="complete")
+        leftover = f"staging/{job_id}/roads.geojson"
+        storage = FakeStorage({leftover: _old()})
+
+        outcome = await _run(test_db_session, storage)
+
+        assert storage.deleted == [leftover]
+        assert outcome.orphans_deleted == 1
 
     async def test_a_reference_that_appears_before_the_delete_saves_the_object(
         self, test_db_session: AsyncSession
@@ -702,7 +773,7 @@ class TestAgainstRealLocalStorage:
             "app.platform.storage.get_storage", lambda: storage, raising=True
         )
 
-        tracked_id = await _job(test_db_session)
+        tracked_id = await _job(test_db_session, status="running")
         orphan_id = uuid.uuid4()
         tracked_key = f"staging/{tracked_id}/tracked.geojson"
         orphan_key = f"staging/{orphan_id}/orphan.geojson"

--- a/backend/tests/test_staging_orphan_reconcile_1249.py
+++ b/backend/tests/test_staging_orphan_reconcile_1249.py
@@ -73,6 +73,9 @@ class FakeStorage:
         # advance is observable rather than inferred from what got deleted.
         self.resumed_from: list[str | None] = []
         self.delete_error: Exception | None = None
+        # Raise from the prefix walk after this many pages, to model a pass
+        # that dies partway through with deletes already committed.
+        self.fail_after_pages: int | None = None
         # Called with the key right before its pre-delete re-read, so a test
         # can mutate the world exactly at the moment the race would happen.
         self.on_recheck = None
@@ -91,6 +94,11 @@ class FakeStorage:
         for start in range(0, max(len(matching), 1), self.page_size):
             page = matching[start : start + self.page_size]
             if prefix.endswith("/"):
+                if (
+                    self.fail_after_pages is not None
+                    and len(self.pages_served) >= self.fail_after_pages
+                ):
+                    raise RuntimeError("provider down mid-walk")
                 self.pages_served.append(len(page))
             yield page
 
@@ -346,7 +354,35 @@ class TestReconciliationDecision:
         assert storage.deleted == [key]
         assert outcome.orphans_deleted == 1
         assert outcome.delete_failures == 0
-        counter.inc.assert_called_once_with(1)
+        # Once per completed delete, not once per pass: a pass that fails
+        # after partial progress must not take the count with it, since the
+        # objects are already gone and nothing can recover it (review r5).
+        counter.inc.assert_called_once_with()
+
+    async def test_deletes_already_done_are_counted_when_the_pass_then_fails(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """fix(#1249 review r5, codex P2): the object is gone either way.
+
+        A pass that dies after partial progress used to discard its tally
+        before the end-of-pass increment ran, so the counter permanently
+        under-reported cleanup that really happened — nothing later can
+        recover a count for an object that no longer exists.
+        """
+        orphans = {
+            f"staging/{uuid.uuid4()}/f{index}.geojson": _old() for index in range(3)
+        }
+        storage = FakeStorage(orphans, page_size=1)
+        storage.fail_after_pages = 1
+
+        with patch(
+            "app.platform.jobs.staging_reconcile.staging_orphans_deleted_total"
+        ) as counter:
+            outcome = await _run(test_db_session, storage)
+
+        assert outcome.ran is False, "precondition: the pass failed"
+        assert len(storage.deleted) == 1, "precondition: one delete got through"
+        assert counter.inc.call_count == 1
 
     async def test_a_row_that_appears_before_the_delete_saves_the_object(
         self, test_db_session: AsyncSession
@@ -726,6 +762,62 @@ class TestProviderIterObjectPages:
             "staging/a/one.txt",
             "staging/a/one.txt.part",
         }
+
+    async def test_local_orders_a_dir_and_file_sharing_a_stem_by_full_key(
+        self, tmp_path
+    ) -> None:
+        """Plain per-name ordering disagrees with full-key ordering here.
+
+        ``/`` is 0x2F and ``.`` is 0x2E, so ``frozen.txt`` sorts BEFORE
+        ``frozen/x.txt`` even though the bare names sort the other way — and
+        `frozen/` is a real segment of every presigned staging layout, next to
+        a filename the uploader chose. Getting this backwards would make
+        `start_after` skip or repeat entries on a resumed walk.
+        """
+        from app.platform.storage.local import LocalStorageProvider
+
+        storage = LocalStorageProvider(str(tmp_path))
+        await storage.put("staging/a/frozen.txt", b"1")
+        await storage.put("staging/a/frozen/x.txt", b"2")
+
+        keys = [e.key for e in await _all_entries(storage, "staging/")]
+
+        assert keys == ["staging/a/frozen.txt", "staging/a/frozen/x.txt"]
+        assert keys == sorted(keys), "the walk must be in full-key order"
+
+    async def test_local_does_not_walk_past_the_page_the_consumer_took(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """fix(#1249 review r5): the walk itself is lazy, not just its slicing.
+
+        Counted in ``scandir`` calls rather than results, because a walk that
+        materializes everything and then hands back one page returns the same
+        results while costing the whole tree.
+        """
+        import app.platform.storage.local as local_module
+        from app.platform.storage.local import LocalStorageProvider
+
+        storage = LocalStorageProvider(str(tmp_path))
+        for name in ("a", "b", "c"):
+            await storage.put(f"staging/{name}/f.txt", b"x")
+        monkeypatch.setattr(local_module, "_OBJECT_PAGE_SIZE", 1)
+
+        scans: list[str] = []
+        real_scandir = local_module.os.scandir
+
+        def _counting_scandir(path):
+            scans.append(str(path))
+            return real_scandir(path)
+
+        monkeypatch.setattr(local_module.os, "scandir", _counting_scandir)
+
+        async for page in storage.iter_object_pages("staging/"):
+            assert [e.key for e in page] == ["staging/a/f.txt"]
+            break
+
+        # staging/ plus staging/a/ only. An eager walk would have entered b/
+        # and c/ as well before returning anything.
+        assert len(scans) == 2, scans
 
     async def test_s3_pages_and_stops_when_the_consumer_does(self) -> None:
         """Real ListObjectsV2 continuation, and a consumer that breaks early.


### PR DESCRIPTION
Closes #1249.

## The residual gap

#1236 review r5 accepted a known hole and this PR is the follow-up it named. Every staging reaper in the tree starts from a job ROW and asks what object it owns — `_reap_committed_staged_paths`, `_sweep_expired_presigned_staging`, the two ingest task tails. An object that no row references at all is invisible to all of them.

The case that produces one: S3 validates a presigned signature when a request **starts**, not when it finishes transferring. An accepted single-part PUT can still be writing after every deadline derived from its URL has passed. The sweep deletes the key, the retention purge retires the row, and then the PUT lands — recreating an object with no tracking row anywhere.

## Why reconciliation and not another margin

`_RECHECK_TRANSFER_MARGIN_SECONDS` already took four rounds to settle, and the issue concedes the direction is structurally defeatable: any margin is a guess at a transfer rate nothing enforces (`generate_presigned_put_url` signs `ContentType`, never a content-length constraint). Widening it makes the guess rarer, not correct.

A HEAD-before-delete has the symmetric problem: it proves the object was absent when the check ran, not that it stays absent while the delete is in flight. It moves the race one step later.

Reconciliation removes the class. It never asks "is this upload probably done" — it asks a question with a durable answer, *is there a row that owns this key*, and an object whose answer is no is unreachable by any future PUT: a presigned URL for `staging/{job_id}/…` is only ever minted alongside the `ingest_jobs` row with that id, and the retention purge deliberately keeps such a row alive past `MAX_PRESIGNED_URL_LIFETIME_SECONDS + _RECHECK_TRANSFER_MARGIN_SECONDS` (`presigned_url_may_still_be_live`). It also catches orphans from causes no margin ever addressed — a best-effort delete that failed, a row purged while its object delete errored, a worker killed between writing an object and committing the row that names it.

Note on #1211/#1237: MinIO's stale-uploads sweep aborts *incomplete multipart sessions*. This is a single-part PUT that **completes**, so no lifecycle rule reaches it. The issue said a bucket-level fix would need a listing sweep that reconciles objects against tracking rows. That is what this is.

## Race analysis

Two races, both handled by construction rather than by ordering (there is no atomic delete-if-still-unreferenced across a database and an object store):

**1. An object uploaded after the listing snapshot.** Only objects whose last-modified is older than `staging_orphan_min_age_seconds` are candidates, and the age is **re-read from the provider immediately before the delete**. A listing entry is never authority for destroying anything — an object created or overwritten since the snapshot fails the re-read and is skipped.

**2. A row that lands after the batch row query.** Row absence is re-checked per object, immediately before that object's delete, in its own statement. Under READ COMMITTED each statement takes a fresh snapshot, so the recheck sees rows committed since the batch query rather than replaying it. It is a Core `select` over the id column, never an ORM load, so the identity map cannot answer from a stale instance.

Both rechecks fail **closed** — gone, rewritten, ambiguous, or unreadable all skip the object and leave it for the next pass. The cost of a missed pass is a day of leaked bytes.

Two further boundaries:

- **S3 storage only** (r8). `staging/` is the upload system's exclusive namespace in a *bucket*, and only in a bucket. On the local backend the same prefix sits inside `upload_staging_dir`, where an operator also stages manifest seed files — a local manifest source spelled `staging/{anything}/seed.geojson` resolves to an absolute path under that directory whenever the directory's basename is not itself `staging`, which no logical-key comparison here would match. Those files are operator-owned and legitimately staged *before* the manifest that names them is applied; deleting one is not a leaked byte, it is someone's input. Nothing is lost by declining — presigned uploads refuse anything but S3 at request time, so the orphan class this addresses cannot occur on local or Azure at all, and the s3:// manifest branch closes the mirror-image hole by refusing `staging/` keys outright.
- **Nothing outside `staging/` is ever listed**, so an object the upload system does not own cannot reach the delete path at all. A key under `staging/` whose owning job cannot be named (not `staging/{uuid}/…`) is counted and left alone: "I cannot tell whose this is" never becomes "so delete it".
- **Multi-tenant**: the prefix is resolved through `resolve_current_storage_key`, so a pass can only list its own tenant's namespace, and a call with no tenant context declines rather than sweeping the bucket while RLS shows it no rows (same fail-closed posture as `_stale_generation_storage_keys`).

## Ownership is "any row that still needs the key" (review r3, r4, r6)

A P1, and the case that found it is fan-out. `create_fan_out_jobs` clones the parent's `file_path` onto every child, so a child's only input is the **parent's** `staging/{parent_id}/frozen/...` object. The parent row reaches the retention cutoff on its own schedule — the purge's survivor query is what keeps the *object* alive for a still-pending, running, or retryable-failed child, not the parent's row. Reconciling on `IngestJob.id` alone looked up the purged parent, found nothing, and would have deleted the input the child was about to read.

The question is now *does any row still need this key*, which turns out to be two questions with two answers (r4 found the second half — the sibling of r4's own fix):

- **The row whose id the key names** is not a *reference* to the key, it is its *lifecycle*, so the question is not "does it exist" but "is anything still going to act on this key". Existence alone was a permanent shield, and r6 found it shielded the exact leak this change exists to close: once `_sweep_expired_presigned_staging` sets its final marker it never looks at that key again, and if the row is its dataset's latest complete job the retention purge exempts it indefinitely — so a PUT landing after that final delete recreated an object every row-driven reaper was finished with, and this reconciler then declined forever. `_owner_still_manages` now asks for a live claim: either the row can still consume the bytes, or it carries an `s3_key` the post-expiry sweep has not yet finalized. The `s3_key IS NOT NULL` half matters as much as the marker half — a direct upload never presigns, so no marker is ever set on it, and reading a missing marker as "not finalized" would shield those rows forever instead.
- **Any other row** counts only while it can still consume the bytes. Unconditional was wrong in the direction that never self-corrects: a fan-out child stays `complete` forever and is exempt from retention indefinitely as a dataset's latest complete job, so its inherited `file_path` would answer "still referenced" on every future pass and an object leaked by a failed parent-side delete could never be repaired — the reconciler would permanently decline the one case it exists for.

That is the same line the retention purge's survivor query already drew, so both now read `STATUSES_NEEDING_STAGED_INPUT` from `jobs/models.py` rather than each holding its own tuple. Two copies of "which statuses still need the bytes" drift into a leak in one direction and a deletion of live input in the other. `STAGING_REAPED_FINAL_MARKER` moved there for the same reason once the reconciliation became its second reader.

The per-page pre-filter is two queries built from the same two predicates the per-object recheck uses, not a Python re-derivation of them: a pre-filter that shields *more* than the recheck silently skips candidates the recheck never sees, which is how both r4 and r6 stayed hidden.

`user_metadata->>'s3_key'` is deliberately **not** consulted: it is cloned onto fan-out children wholesale, `owned_presigned_staging_key` already settles that an inherited copy is not ownership, and the only row for which it *is* ownership is the one whose id the key names. Comparisons are against the **logical** key, since `file_path` persists the tenant-agnostic form while the provider reports physical keys.

## Concurrency and the counter

The pass takes a `pg_try_advisory_xact_lock` before doing anything. Without it every API worker's sweeper loop would list the same prefix and count the same delete, reporting N times the truth under `UVICORN_WORKERS>1` — the fabricated-number class #1240 existed to remove. It also keeps the provider LIST to one per interval per tenant.

The lock lives on a **session of the pass's own**, not the caller's. A rollback expires every instance in the identity map regardless of `expire_on_commit`, and `fail_stale_jobs` still holds ORM objects when it calls this — an earlier draft that released the lock by rolling back the caller's session broke `test_presigned_staging_reap_1202.py`. The caller's session is now neither committed nor rolled back, and a test pins that.

## Bounded work per pass (review r1)

The first revision loaded the whole `staging/` prefix before applying any budget. Two P2s with one root: unbounded memory and lock/connection occupancy to attempt at most 200 deletions, and an expanding `IN` that could exceed the driver's bind-parameter ceiling on a large backlog — a failure the best-effort wrapper then swallowed on every subsequent pass, so the backlog could never drain.

`StorageProvider.list_objects` is now `iter_object_pages`, yielding one provider page at a time (ListObjectsV2 continuation on S3, `by_page()` on Azure, a single page for the local walk). A consumer that stops iterating stops the round trips with it, and a test asserts exactly that against moto rather than only asserting the results.

Both budgets are checked **between pages**, so the pass stops asking for more rather than merely stopping acting:

- `_MAX_DELETES_PER_PASS = 200` bounds the lock hold once there **is** work. On an unhealthy prefix this fires inside the first page.
- `_MAX_OBJECTS_SCANNED_PER_PASS = 20_000` bounds the walk when there is **not**, so a prefix of a million tracked-and-old objects is not paged through in full every cycle to delete nothing.

The live-row query moved inside the page loop: its id set is bounded by the provider's page size, so it can never approach the driver's parameter ceiling no matter how large the backlog grows.

## Scan cursor (review r2)

Two more P2s, both about the bound r1 introduced.

The local provider still returned the whole prefix as one page — an unbounded page rebuilds the same oversized `IN` the paging was meant to prevent. It now sorts by key and yields fixed-size pages, matching the ListObjectsV2 default so a per-page budget behaves identically on every backend.

And a scan cap without a cursor is a blind spot, not a bound: every pass re-walked the same lexicographically first window, so an orphan sorting after a window full of tracked, recent, or unattributable keys was never reached at all. `iter_object_pages` gains `start_after` (S3's own `StartAfter`; filtered client-side on the other two, neither of which can hold a presigned staging object anyway), and the pass records where it stopped:

- A budget stop advances the cursor; a completed walk clears it, so the next pass starts at the front.
- When the **delete** budget is what stopped the pass, the resume point is the last candidate actually *processed*, not the end of the page — otherwise candidates it never reached would be skipped until the wrap.

A follow-up round (r5) found the local walk was still eager behind that slicing — it built and sorted every matching object before yielding the first page, so a budget stop bounded the SQL batches but neither memory, filesystem traversal, nor lock occupancy. It is now a lazy generator: one directory level materialized at a time, any subtree sorting entirely at or before `start_after` skipped without being entered, and `stat` called only for entries a page actually needs. Directory entries sort as `name + "/"` so the sequence matches full-key lexicographic order — plain name order disagrees whenever a directory and a file share a stem, and `frozen/` sits next to a caller-chosen filename in every presigned staging layout.

The scan is **circular** (r7): the pass walks from the cursor to the end of the prefix, then spends whatever budget remains walking the front of the prefix back up to the cursor, bounded there so it ends instead of re-walking the first leg. A one-directional scan from a random start is a sample, not a rotation — a worker recycled before its next pass would only ever see suffixes, and an orphan near the front of a large prefix would be reached with probability ~`1/(objects+1)` per restart. With the wrap, one unbudgeted pass covers the whole prefix from wherever it begins.

That is what makes the cursor a starting **offset** rather than a window, and why process-local state seeded at a random point is enough: every pass is independently correct — the cursor never decides what may be deleted, only what is looked at first — so a lost cursor costs re-examining keys that were already cheap to skip.

## Changes

- `backend/app/platform/jobs/staging_reconcile.py` (new): the pass.
- `backend/app/platform/jobs/sweep.py`: called from `fail_stale_jobs` after the two row-driven reapers. Deliberately not folded into `StaleCleanupOutcome` — that dataclass is a published API and audit shape several callers reconstruct field by field.
- `backend/app/platform/jobs/router.py`: same call on the admin cleanup endpoint's single-tenant branch (the multi-tenant branch goes through `fail_stale_jobs` per tenant already).
- `backend/app/platform/storage/{provider,s3,azure,local}.py`: new `StorageProvider.iter_object_pages` yielding pages of `StoredObject(key, last_modified)`. `list` alone cannot age an object, and there is no head-with-timestamp call; a complete key is a valid prefix, which is how the pre-delete re-read works on every backend. `local.py`'s glob logic is now shared between `list` and the new call rather than duplicated.
- `backend/app/observability/metrics/jobs.py`: `geolens_staging_orphans_deleted_total`, incremented once per delete, strictly after the provider call returns. Per delete rather than once per pass (r5): the objects are already gone when a pass dies partway, and nothing later can recover a count for something that no longer exists.
- `backend/tests/test_layering.py`: `sweep.py` 1366 → 1380, `config.py` 1091 → 1104, both exact with comments. The new module is 340 lines, under the 1000-line inclusion threshold.

## Config surface

`.env.example` gains the matching entry — `scripts/check_env_doc_drift.py` (the Installer Tag Resolution job) requires every operator-facing Settings field to be documented there, and the backend suite does not cover it.

One new setting, `STAGING_ORPHAN_MIN_AGE_SECONDS` (`staging_orphan_min_age_seconds`), default `86400`, floored at `3600`. It is **not** an estimate of how long an upload takes — the row check is what decides ownership; this only has to be far enough past a listing that no object is reported old while its own tracking row is still being written. The floor exists so a misconfiguration cannot turn the sweep into a deleter of objects whose uploads are still landing. No schema change, no migration, no API change.

## Verification

- `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- Full backend suite, `uv run pytest -n 4 -q` — **8396 passed, 92 skipped, 0 failed** (re-run after each review round)
- `uv run pytest tests/test_layering.py -q` — 40 passed
- Targeted: `tests/test_staging_orphan_reconcile_1249.py` (43), `tests/test_presigned_staging_reap_1202.py`, `tests/test_storage.py`, `tests/test_storage_azure.py`, `tests/test_local_storage_containment.py`

Tests are deterministic — no sleeps, no bounded waits. Ages are facts each test writes (`os.utime` for the real-provider case, an injected `now=` everywhere). Negative controls run and reverted, twice: disabling the per-object row recheck and the pre-delete age re-read fails exactly the two race tests and nothing else; narrowing the reference clause back to `IngestJob.id` fails exactly the three fan-out tests; dropping the status restriction fails exactly the terminal-child test; making the owner shield unconditional again fails exactly the finally-reaped and direct-upload tests; dropping the wrap leg fails exactly the two circular-scan tests. Every guard here is load-bearing rather than decorative.
