### PR TITLE
feat(ai): offer the layer-filter path after predicate chat queries

### DIFF
--- a/backend/app/processing/ai/chat_service.py
+++ b/backend/app/processing/ai/chat_service.py
@@ -155,6 +155,8 @@ def build_chat_system_prompt(
     When ``can_edit`` is False the caller may view but not edit the map (the AI
     is given read-only tools — see ``select_chat_tools``); a read-only directive
     is injected so the model declines edit requests instead of silently failing.
+    ``can_edit`` also gates the query_data filter-offer note (#1242): only an
+    editor has set_filter available to fulfil it.
     """
     # Cap layers to prevent unbounded prompt growth
     display_layers = layers[:_MAX_SYSTEM_PROMPT_LAYERS]
@@ -241,6 +243,34 @@ def build_chat_system_prompt(
         )
     )
 
+    # feat(#1242): companion to the query_data/set_filter split above, not a
+    # rewrite of it — this fires AFTER query_data has already answered a
+    # QUESTION, so it never decides which tool a request reaches. A persisted
+    # set_filter beats an ephemeral query_data result for the shape it covers
+    # (a plain row predicate), so the model is told to name that option, once,
+    # as an offer the user can decline. It must stay an offer: #549 is the
+    # record of "show me the ..." silently landing on a persistent filter, and
+    # that was reverted specifically because a read-shaped question must never
+    # mutate saved map state on its own. Gated on can_edit — a read-only
+    # caller never has set_filter in its tool set (select_chat_tools), so
+    # promising it here would be a broken offer the readonly_note above
+    # already tells the model to avoid making.
+    filter_offer_note = (
+        (
+            "\n- If the question was a simple row predicate on a layer "
+            "already on the map"
+            ' ("earthquakes above magnitude 5", "parcels zoned commercial" -- '
+            "not a count, aggregate, top-N/ranked list, multi-layer join, or "
+            '"most recent" style question), offer -- after answering -- to '
+            "apply it as a persistent filter on that layer instead: "
+            'something like "Want this as a filter on the layer instead? It '
+            'persists when you save the map." This is an offer, not an '
+            "action -- call set_filter only if the user accepts."
+        )
+        if can_edit
+        else ""
+    )
+
     return f"""\
 You are a map editing assistant. The user has a map with these layers:
 
@@ -323,7 +353,7 @@ When reporting query results back to the user:
 - Keep answers concise (2-4 sentences for simple questions, up to a paragraph for complex ones).
 - If results were truncated, mention it naturally (e.g., "showing the first 50 of 1,200 results").
 - Never show raw SQL, table structures, or row counts as bare numbers -- interpret them meaningfully.
-- If no results were found, tell the user and suggest trying different criteria.
+- If no results were found, tell the user and suggest trying different criteria.{filter_offer_note}
 
 {QUERY_RESULT_SANITY_PROMPT}
 ## Uncertainty

--- a/backend/app/processing/ai/tools.py
+++ b/backend/app/processing/ai/tools.py
@@ -330,6 +330,12 @@ CHAT_TOOLS_ANTHROPIC = [
             # question", "do NOT use this for map styling"), competing with
             # the system prompt's verb classes from a second site without
             # naming any sibling tool.
+            # feat(#1242): stays behavioural for the same reason. Whether a
+            # result is worth OFFERING as a set_filter follow-up is a
+            # response-shaping rule, not tool-selection, and it is decided in
+            # the system prompt's "Query Data Responses" section
+            # (build_chat_system_prompt) -- not restated here as a second
+            # classification site.
             "Query the user's map data using SQL. The server generates the "
             "SQL from a natural language question and executes it safely, so "
             "the result is a table of values plus an optional highlight "

--- a/backend/tests/test_ai_chat_dataset.py
+++ b/backend/tests/test_ai_chat_dataset.py
@@ -207,6 +207,18 @@ def test_dataset_prompt_has_result_sanity_check():
     assert "retry query_data ONCE" in prompt
 
 
+def test_dataset_prompt_has_no_filter_offer():
+    """#1242's "persist this as a filter?" follow-up requires a target layer on
+    a map -- dataset-scoped chat has neither (no map, no set_filter tool; the
+    router always builds this surface with can_edit=False), so the prompt must
+    never carry it, however predicate-shaped the user's question was."""
+    layer = ChatMapLayer(id="x", name="x", dataset_id="x", dataset_table_name="t")
+    prompt = build_dataset_chat_system_prompt(layer)
+    assert "simple row predicate" not in prompt
+    assert "Want this as a filter" not in prompt
+    assert "set_filter" not in prompt
+
+
 @pytest.mark.anyio
 async def test_restrict_tables_blocks_other_visible_tables(
     client: AsyncClient, test_db_session

--- a/backend/tests/test_chat_narrative.py
+++ b/backend/tests/test_chat_narrative.py
@@ -63,6 +63,50 @@ def test_system_prompt_has_result_sanity_check():
     assert "retry query_data ONCE" in prompt
 
 
+# --- Filter-offer follow-up (#1242) ------------------------------------------
+#
+# Complements #1241 (snapshot save): a query_data result that is a simple row
+# predicate has a strictly better durable form than a snapshot -- a persisted
+# set_filter -- so the prompt should name it. This is a response-shaping rule
+# that fires AFTER query_data has already answered a QUESTION; it is not a
+# second verb-classification site and must not compete with the #549 rule
+# pinned in test_ai_chat_verb_routing_549.py.
+
+
+def test_system_prompt_offers_filter_after_predicate_query():
+    """An editor is told to OFFER (not apply) set_filter for a predicate result."""
+    prompt = build_chat_system_prompt([_make_layer()])
+    assert "simple row predicate" in prompt
+    assert "Want this as a filter on the layer instead" in prompt
+    assert "persists when you save the map" in prompt
+    # Never automatic -- #549 is the record of a read-shaped question
+    # silently mutating saved map state, and that was reverted.
+    assert "This is an offer, not an action" in prompt
+    assert "call set_filter only if the user accepts" in prompt
+
+
+def test_system_prompt_filter_offer_excludes_non_predicate_shapes():
+    """The offer names the shapes it does NOT cover, so it can't swallow #1241's."""
+    prompt = build_chat_system_prompt([_make_layer()])
+    offer_block = prompt.split("simple row predicate")[1].split(
+        "## Result Sanity Check"
+    )[0]
+    for shape in ("aggregate", "top-N/ranked list", "multi-layer join", "most recent"):
+        assert shape in offer_block, shape
+
+
+def test_system_prompt_filter_offer_absent_for_read_only_caller():
+    """A read-only viewer never gets set_filter in its tool set (select_chat_tools),
+    so offering to persist a filter here would be a promise the model cannot keep --
+    it would directly contradict the Read-Only Access note below."""
+    prompt = build_chat_system_prompt([_make_layer()], can_edit=False)
+    assert "Want this as a filter on the layer instead" not in prompt
+    assert "simple row predicate" not in prompt
+    # The read-only note itself is still present and still says no filters.
+    assert "Read-Only Access" in prompt
+    assert "cannot change styles, filters, labels" in prompt.lower()
+
+
 # --- Error message mapping ---
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1465,7 +1465,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # outright, reading the request's OBJECT (catalog / layer / data / map
         # appearance) before its verb, so the tool descriptions stop
         # re-litigating which phrasing wins. Cap raised 446 -> 456.
-        "backend/app/processing/ai/chat_service.py": 456,
+        # feat(#1242): +29 LOC — build_chat_system_prompt gains the
+        # can_edit-gated filter_offer_note (offer, never apply, a persistent
+        # set_filter after a query_data result that reads as a simple row
+        # predicate) plus the doc/comment explaining why it is gated and why
+        # it lives here rather than in tools.py. Cap raised 456 -> 485, exact.
+        "backend/app/processing/ai/chat_service.py": 485,
         # fix(#836): defaults.py is the facade over the extensions-defaults
         # split (defaults_*.py sub-modules discovered below). Pure re-exports —
         # a new Default* class costs a few lines here.


### PR DESCRIPTION
## What changed

Extends the builder-chat system prompt (`build_chat_system_prompt` in `backend/app/processing/ai/chat_service.py`) so that after a `query_data` result that reads as a simple row predicate (no aggregate, top-N/ranked list, or multi-layer join), the assistant offers to persist it as a layer filter instead: "Want this as a filter on the layer instead? It persists when you save the map." This is prompt and routing-guidance only. There is no SQL-to-MapLibre-expression compiler: the model decides from the shape of the request it just served.

`backend/app/processing/ai/tools.py` gets a pointer comment only (no description-string change) in the `query_data` #549 area, documenting that the offer is response-shaping and lives in the system prompt, not a second tool-description classification site.

## Behavior impact

- The offer is additive text in the assistant's response, never an automatic tool call. It stays an offer the user must accept, matching the #549 precedent that a read-shaped question (`query_data`) must never silently mutate saved map state (that's what `set_filter` does, and it fires only if the user accepts in a follow-up turn).
- Scoped to builder chat with an editable map: gated on `can_edit`, because a read-only viewer never has `set_filter` in its tool set (`select_chat_tools`), and the readonly note already tells the model it cannot filter. Offering it there would be a promise the model can't keep.
- Dataset-page chat (`build_dataset_chat_system_prompt`) is untouched: no map, no layer to filter.
- Complements #1241 (snapshot save): predicate-shaped queries get the live-filter suggestion; everything else (top-N, aggregates, joins, "latest X") persists via snapshot. Neither path subsumes the other.

## Verification

- `cd backend && uv run ruff check .`
- `cd backend && uv run ruff format --check .`
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_chat_narrative.py tests/test_ai_chat_dataset.py tests/test_ai_chat_verb_routing_549.py tests/test_sql_engine.py -v` (107 passed)
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q` (40 passed; chat_service.py's ratcheted cap raised 456 -> 485 in the same commit)

Closes #1242