### PR TITLE
feat(builder): save a chat query preview as a dataset

### DIFF
--- a/backend/app/processing/ai/chat_geojson.py
+++ b/backend/app/processing/ai/chat_geojson.py
@@ -257,10 +257,28 @@ def _detect_geom_column(columns: list[str], rows: list[list]) -> int | None:
     return None
 
 
+# JavaScript numbers are IEEE-754 doubles, so an integer beyond this magnitude
+# cannot round-trip through the browser's JSON.parse.
+_JS_MAX_SAFE_INT = 2**53 - 1
+
+
 def _safe_value(v: object) -> object:
-    """Convert non-JSON-serializable types to str; pass through primitives."""
-    if v is None or isinstance(v, (str, int, float, bool)):
+    """Convert values the client cannot represent to str; pass through the rest.
+
+    fix(#1241 codex r5): an integer outside JavaScript's safe range is
+    JSON-serializable and still lossy — 9007199254740993 arrives in the browser
+    as 9007199254740992, because JSON.parse rounds it to the nearest double.
+    That silently wrong id was always on screen; it becomes permanent now that
+    the map builder can save a chat preview as a dataset, since the snapshot is
+    serialized from the parsed payload. Emitting the exact digits as a string
+    is the only shape that survives the trip. Every smaller integer stays a
+    number, so ordinary ids keep their type.
+    """
+    if v is None or isinstance(v, (str, float, bool)):
         return v
+    if isinstance(v, int):
+        # bool is an int subclass and already returned above.
+        return str(v) if abs(v) > _JS_MAX_SAFE_INT else v
     if isinstance(v, (datetime, date, Decimal, bytes, memoryview, UUID)):
         return str(v)
     return str(v)

--- a/backend/tests/test_ephemeral_geojson.py
+++ b/backend/tests/test_ephemeral_geojson.py
@@ -148,6 +148,19 @@ class TestSafeValue:
     def test_bytes_converted(self):
         assert _safe_value(b"raw") == str(b"raw")
 
+    # fix(#1241 codex r5): the browser's JSON.parse rounds an integer past
+    # 2**53-1 to the nearest double, so the exact digits only survive as a
+    # string. The builder can now save a chat preview as a dataset, which
+    # writes whatever the client parsed straight into it.
+    def test_int_beyond_js_safe_range_converted(self):
+        assert _safe_value(9007199254740993) == "9007199254740993"
+        assert _safe_value(-9007199254740993) == "-9007199254740993"
+
+    def test_int_at_js_safe_boundary_stays_numeric(self):
+        # 2**53-1 is exactly representable — an ordinary id must keep its type.
+        assert _safe_value(9007199254740991) == 9007199254740991
+        assert _safe_value(-9007199254740991) == -9007199254740991
+
 
 class TestExtractGeojson:
     def test_wkb_rows_to_feature_collection(self):

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1739,6 +1739,13 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # chat_*.py glob below, ~142 lines under the 350 default) rather than
         # grown here. Cap 530 → 550 (~14 headroom).
         "backend/app/processing/ai/chat_actions.py": 550,
+        # feat(#1241): +18 over the 350 default — _safe_value now emits
+        # integers outside JavaScript's safe range as strings (constant, the
+        # int branch, and the docstring explaining why), so a bigint id
+        # survives the browser's JSON.parse intact instead of arriving rounded
+        # and being written that way into a saved chat-preview snapshot.
+        # Cap 350 → 370 (~17 headroom).
+        "backend/app/processing/ai/chat_geojson.py": 370,
         # fix(#836): extensions-defaults sub-modules over the 350 default at
         # split time. Caps exact (zero headroom): each class moved verbatim
         # from the 1815-LOC defaults.py, and regrowth toward another god

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -7,6 +7,7 @@ import { sendChatMessage, streamChatMessage } from '@/api/maps';
 import { ApiError } from '@/api/client';
 import { cn } from '@/lib/utils';
 import { truncateGraphemes } from '@/lib/text';
+import { chatOverlayCompleteness, overlayFeatureCount } from '@/lib/chat-result-completeness';
 import { assertNever, normalizeLayerOpacity } from '@/components/builder/builder-action-contract';
 import { validateRawFilter, FilterValidationError } from '@/lib/maplibre-filter-utils';
 import { getLayerType, filterPaintForLayerType, clampPaintBounds } from '@/components/builder/layer-adapters/shared';
@@ -538,10 +539,14 @@ export function ChatPanel({
       // The producer half is #1071: until that lands, collect_run_analysis_action
       // still omits `truncated` whenever the total is absent, so this branch is
       // correct and simply not yet reachable for a clip.
-      const total = typeof action.row_count === 'number' ? action.row_count : undefined;
-      const truncation = action.truncated === true
-        ? { truncated: true, ...(total != null ? { totalCount: total } : {}) }
-        : undefined;
+      //
+      // feat(#1241 codex r1): the pair no longer comes from `truncated` alone.
+      // That flag is the SQL row cap; the overlay is clipped to its own render
+      // budget after it, so a 300-row answer can arrive as 50 features with
+      // truncated=false. chatOverlayCompleteness compares what we hold against
+      // row_count and calls that clipped too — see its docstring.
+      const preview = geojson as GeoJSON.FeatureCollection;
+      const truncation = chatOverlayCompleteness(action, overlayFeatureCount(preview));
       // feat(#675): a run_analysis action carries its reconstruction params so
       // the preview surface can offer "Save as dataset" (prefilled Analysis
       // panel) — fix(#1009): the stack row in this path, the badge in the rail.
@@ -559,7 +564,7 @@ export function ChatPanel({
       // no `analysis` behind it, which #675 could not offer anything for — can
       // be saved as a dataset with its question already suggested as the title.
       onQueryResult?.(
-        geojson as GeoJSON.FeatureCollection,
+        preview,
         [minX, minY, maxX, maxY],
         {
           ...truncation,

--- a/frontend/src/components/builder/ChatPanel.tsx
+++ b/frontend/src/components/builder/ChatPanel.tsx
@@ -325,7 +325,14 @@ interface ChatPanelProps {
   onQueryResult?: (
     geojson: GeoJSON.FeatureCollection,
     bbox: [number, number, number, number],
-    meta?: { truncated?: boolean; totalCount?: number; analysis?: EphemeralAnalysisHandoff },
+    meta?: {
+      truncated?: boolean;
+      totalCount?: number;
+      analysis?: EphemeralAnalysisHandoff;
+      /** feat(#1241): the prompt this result answers, so the builder can
+       *  suggest a title when the preview is saved as a dataset. */
+      prompt?: string;
+    },
   ) => void;
   /** fix(#676): clears the single-slot ephemeral overlay when a turn's winning
    *  result carries no geometry — otherwise a stale overlay from an earlier
@@ -488,7 +495,7 @@ export function ChatPanel({
     return t('chat.errorFriendly');
   }
 
-  function dispatchQueryResult(action: ChatAction) {
+  function dispatchQueryResult(action: ChatAction, prompt = '') {
     const geojson = action.geojson;
     if (!geojson) {
       // fix(#676): the turn's winning result has no geometry (empty analysis,
@@ -548,10 +555,17 @@ export function ChatPanel({
                 : {}),
             }
           : undefined;
+      // feat(#1241): the prompt rides along so a plain chat preview — one with
+      // no `analysis` behind it, which #675 could not offer anything for — can
+      // be saved as a dataset with its question already suggested as the title.
       onQueryResult?.(
         geojson as GeoJSON.FeatureCollection,
         [minX, minY, maxX, maxY],
-        truncation || analysis ? { ...truncation, ...(analysis ? { analysis } : {}) } : undefined,
+        {
+          ...truncation,
+          ...(analysis ? { analysis } : {}),
+          ...(prompt ? { prompt } : {}),
+        },
       );
     }
   }
@@ -709,6 +723,10 @@ export function ChatPanel({
         }
         return false;
       case 'show_query_result':
+        // Unreachable in practice: applyActions dispatches the turn's winning
+        // query result itself (and never routes one here), and staging only
+        // ever accepts destructive actions. Kept for exhaustiveness — with no
+        // turn prompt to hand it, feat(#1241)'s title suggestion falls back.
         dispatchQueryResult(action);
         return false;
       case 'add_layer': {
@@ -770,7 +788,7 @@ export function ChatPanel({
    * start of every turn, so a query-only turn leaves it null and the undo affordance
    * can never outlive the turn that created it.
    */
-  function applyActions(actions: ChatAction[], pendingActions: ChatAction[]) {
+  function applyActions(actions: ChatAction[], pendingActions: ChatAction[], prompt: string) {
     if (actions.length === 0) return;
     const mutatingActions = actions.filter(
       (action) => action.type !== 'show_query_result' && !isDestructiveAction(action),
@@ -793,7 +811,7 @@ export function ChatPanel({
       if (action.type === 'show_query_result') {
         // Record every result in pendingActions (message history keeps the
         // full sequence; the card renderer picks the last).
-        if (action === winningQueryResult) dispatchQueryResult(action);
+        if (action === winningQueryResult) dispatchQueryResult(action, prompt);
         pendingActions.push(action);
         continue;
       }
@@ -870,7 +888,7 @@ export function ChatPanel({
           setToolProgress(null);
           break;
         case 'actions':
-          applyActions(getChatActions(data.actions), pendingActions);
+          applyActions(getChatActions(data.actions), pendingActions, userMsg);
           break;
         case 'done': {
           const finalText = (typeof data.explanation === 'string' ? data.explanation : '') || streamState.text;
@@ -918,7 +936,7 @@ export function ChatPanel({
     try {
       const response = await sendChatMessage(mapId, userMsg, layers, i18n.language, [...history, { role: 'user', content: userMsg }]);
       const responseActions = getChatActions(response.actions);
-      applyActions(responseActions, pendingActions);
+      applyActions(responseActions, pendingActions, userMsg);
       // Phase 1135 AI-03: clear any existing error banner on non-streaming success.
       setErrorBanner(null);
       setMessages((prev) => [

--- a/frontend/src/components/builder/EphemeralBadge.tsx
+++ b/frontend/src/components/builder/EphemeralBadge.tsx
@@ -1,7 +1,12 @@
+import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { ephemeralStatusLabel, useAnnouncedLabel } from '@/components/builder/ephemeral-preview';
+import {
+  ephemeralStatusLabel,
+  useAnnouncedLabel,
+  type PreviewSaveDisabledReason,
+} from '@/components/builder/ephemeral-preview';
 
 // fix(#1009): the builder's full stack panel now surfaces the preview as a row
 // (EphemeralPreviewRow), so this badge no longer renders there. It survives as
@@ -21,15 +26,27 @@ interface EphemeralBadgeProps {
   /** fix(#727): totalCount was computed against the map's viewport. */
   viewportScoped?: boolean;
   /** feat(#675): opens the Analysis panel prefilled with the operation behind
-   *  this preview. Builder-only — the viewer has no Analysis rail, so it
-   *  never passes this. */
+   *  this preview. feat(#1241): or the save-as-dataset dialog for a plain chat
+   *  result. Builder-only — the viewer has neither rail nor upload rights, so
+   *  it never passes this. */
   onSaveAsDataset?: () => void;
+  /** feat(#1241): parity with EphemeralPreviewRow — set instead of
+   *  `onSaveAsDataset` when the save belongs on this preview but cannot be
+   *  honoured, so the narrow layout states the reason instead of quietly
+   *  dropping the affordance. */
+  saveDisabledReason?: PreviewSaveDisabledReason;
   /** Position override — the viewer's bottom-left corner is occupied by its basemap toggle. */
   className?: string;
 }
 
-export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount, viewportScoped, onSaveAsDataset, className }: EphemeralBadgeProps) {
+export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount, viewportScoped, onSaveAsDataset, saveDisabledReason, className }: EphemeralBadgeProps) {
   const { t } = useTranslation('builder');
+  const saveDisabledId = useId();
+  const saveDisabledText = saveDisabledReason
+    ? t('ephemeralBadge.saveTruncatedReason')
+    : null;
+  // Row parity: a stated reason wins over a handler.
+  const onSave = saveDisabledText ? undefined : onSaveAsDataset;
 
   // fix(#1009): the count sentence and the announced-label pattern moved to
   // ephemeral-preview.ts so this badge and the stack row cannot drift apart.
@@ -41,32 +58,43 @@ export function EphemeralBadge({ featureCount, onDismiss, truncated, totalCount,
   // is offset to clear this badge, but a panel taller than that offset overlaps it
   // and the z-index decided — the badge lost.
   return (
-    <div className={cn('absolute bottom-8 start-4 z-20 flex items-center gap-2 rounded-md bg-background/95 backdrop-blur-sm border shadow-sm px-3 py-1.5 text-xs', className)}>
-      <span className="h-2 w-2 rounded-full bg-warning shrink-0" />
-      <span role="status" className="sr-only">{announcedLabel}</span>
-      {/* fix(#784): aria-hidden so browse mode doesn't read the badge text
-          twice — the sr-only status region above carries the same string. */}
-      <span aria-hidden="true" className="text-muted-foreground">
-        {statusLabel}
-      </span>
-      {onSaveAsDataset && (
+    <div className={cn('absolute bottom-8 start-4 z-20 rounded-md bg-background/95 backdrop-blur-sm border shadow-sm px-3 py-1.5 text-xs', className)}>
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full bg-warning shrink-0" />
+        <span role="status" className="sr-only">{announcedLabel}</span>
+        {/* fix(#784): aria-hidden so browse mode doesn't read the badge text
+            twice — the sr-only status region above carries the same string. */}
+        <span aria-hidden="true" className="text-muted-foreground">
+          {statusLabel}
+        </span>
+        {(onSave || saveDisabledText) && (
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={!onSave}
+            aria-describedby={saveDisabledText ? saveDisabledId : undefined}
+            className="cursor-pointer font-medium text-primary hover:underline disabled:cursor-not-allowed disabled:text-muted-foreground disabled:no-underline"
+          >
+            {t('ephemeralBadge.saveAsDataset', { defaultValue: 'Save as dataset…' })}
+          </button>
+        )}
         <button
           type="button"
-          onClick={onSaveAsDataset}
-          className="cursor-pointer font-medium text-primary hover:underline"
+          onClick={onDismiss}
+          className="cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
+          title={t('ephemeralBadge.dismiss')}
+          aria-label={t('ephemeralBadge.dismiss')}
         >
-          {t('ephemeralBadge.saveAsDataset', { defaultValue: 'Save as dataset…' })}
+          <X className="h-3 w-3" />
         </button>
+      </div>
+      {/* feat(#1241): row parity — a disabled save states why. The status line
+          above already carries the "N of M". */}
+      {saveDisabledText && (
+        <p id={saveDisabledId} className="mt-0.5 text-2xs text-muted-foreground">
+          {saveDisabledText}
+        </p>
       )}
-      <button
-        type="button"
-        onClick={onDismiss}
-        className="cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
-        title={t('ephemeralBadge.dismiss')}
-        aria-label={t('ephemeralBadge.dismiss')}
-      >
-        <X className="h-3 w-3" />
-      </button>
     </div>
   );
 }

--- a/frontend/src/components/builder/EphemeralPreviewRow.tsx
+++ b/frontend/src/components/builder/EphemeralPreviewRow.tsx
@@ -11,6 +11,7 @@
 // handleDragEnd resolves those ids back to real layers to write sort_order.
 // UnifiedStackPanel renders this row BEFORE the SortableContext opens, the same
 // way the DragOverlay ghost renders a bare StackRow.
+import { useId } from 'react';
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
@@ -20,14 +21,20 @@ import {
   ephemeralStatusLabel,
   useAnnouncedLabel,
   type EphemeralCountInput,
+  type PreviewSaveDisabledReason,
 } from '@/components/builder/ephemeral-preview';
 
 export interface EphemeralPreviewRowProps extends EphemeralCountInput {
   onDismiss: () => void;
   /** feat(#675): opens the Analysis panel prefilled with the operation behind
-   *  this preview. Absent for previews with no analysis behind them (a plain
-   *  chat query result), which is why the action is conditional. */
+   *  this preview. feat(#1241): or opens the save-as-dataset dialog for a
+   *  plain chat result. Absent when neither is on offer, which is why the
+   *  action is conditional. */
   onSaveAsDataset?: () => void;
+  /** feat(#1241): set instead of `onSaveAsDataset` when the save belongs on
+   *  this preview but cannot be honoured — the affordance renders disabled
+   *  with the reason spelled out rather than silently disappearing. */
+  saveDisabledReason?: PreviewSaveDisabledReason;
 }
 
 export function EphemeralPreviewRow({
@@ -37,12 +44,20 @@ export function EphemeralPreviewRow({
   viewportScoped,
   onDismiss,
   onSaveAsDataset,
+  saveDisabledReason,
 }: EphemeralPreviewRowProps) {
   const { t } = useTranslation('builder');
+  const saveDisabledId = useId();
 
   const counts = { featureCount, truncated, totalCount, viewportScoped };
   const countLabel = ephemeralCountLabel(t, counts);
   const announcedLabel = useAnnouncedLabel(ephemeralStatusLabel(t, counts));
+  const saveDisabledText = saveDisabledReason
+    ? t('ephemeralBadge.saveTruncatedReason')
+    : null;
+  // A stated reason wins over a handler: "disabled" must not depend on the
+  // caller also remembering to withhold the callback.
+  const onSave = saveDisabledText ? undefined : onSaveAsDataset;
 
   return (
     // Visual treatment reuses the vocabulary the badge established rather than
@@ -90,17 +105,28 @@ export function EphemeralPreviewRow({
         <span aria-hidden="true" className="truncate text-muted-foreground">
           {countLabel}
         </span>
-        {onSaveAsDataset && (
+        {(onSave || saveDisabledText) && (
           <button
             type="button"
-            onClick={onSaveAsDataset}
+            onClick={onSave}
+            disabled={!onSave}
+            aria-describedby={saveDisabledText ? saveDisabledId : undefined}
             data-testid="ephemeral-preview-save"
-            className="shrink-0 cursor-pointer rounded-sm font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="shrink-0 cursor-pointer rounded-sm font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:text-muted-foreground disabled:no-underline"
           >
             {t('ephemeralBadge.saveAsDataset', { defaultValue: 'Save as dataset…' })}
           </button>
         )}
       </div>
+      {/* feat(#1241): a disabled control with no stated reason is a dead end.
+          The count line above already carries the "N of M" — this says why
+          that N is what rules the save out. Visible text (not a title
+          tooltip), because a disabled button gets no hover or focus. */}
+      {saveDisabledText && (
+        <p id={saveDisabledId} className="mt-0.5 ps-4 text-2xs text-muted-foreground">
+          {saveDisabledText}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/builder/SaveChatPreviewDialog.tsx
+++ b/frontend/src/components/builder/SaveChatPreviewDialog.tsx
@@ -1,0 +1,124 @@
+// feat(#1241): "Save as dataset…" for a plain chat query preview.
+//
+// The preview's whole FeatureCollection is already on the client (it is what
+// the map overlay draws), so persisting it needs no new endpoint: wrap it in a
+// File and push it through the same upload → preview → commit path the import
+// page uses, reusing that page's metadata form so naming, description, and
+// visibility behave identically wherever a dataset is created.
+//
+// This is a SNAPSHOT — a saved answer, frozen at save time, not a live query.
+// The dialog says so, because the resulting dataset is indistinguishable from
+// any other once it lands.
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { ApiError } from '@/api/client';
+import { commitImport, previewFile, uploadFile } from '@/api/ingest';
+import { ImportMetadataForm } from '@/components/import/ImportMetadataForm';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { truncateGraphemes } from '@/lib/text';
+import type { CommitImportRequest } from '@/types/api';
+
+/** RFC 7946: GeoJSON is WGS 84 by definition, so nothing has to detect it. */
+const GEOJSON_EPSG = 4326;
+
+/** Keeps a suggested name readable; the server's own bound is 500. */
+const MAX_SUGGESTED_TITLE = 80;
+
+/**
+ * The chat prompt, shaped into the name of the file we are about to upload.
+ *
+ * Returns a FILE name, not a title, because that is what `defaultName` means
+ * at every other ImportMetadataForm call site — the form strips the extension
+ * to seed its title field, so a prompt carrying its own dots ("buildings over
+ * 3.5m") survives the round trip intact.
+ */
+export function chatPreviewFileName(prompt: string | undefined, fallbackTitle: string): string {
+  const collapsed = (prompt ?? '')
+    // Path separators have no business in a catalog entry's source filename.
+    // The backend strips them too (`safe_upload_basename`) — doing it here
+    // keeps the name the user is shown identical to the one that gets stored.
+    // Newlines need no special case: the whitespace collapse below folds them.
+    .replace(/[\\/]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const title = truncateGraphemes(collapsed, MAX_SUGGESTED_TITLE, '').trim() || fallbackTitle;
+  return `${title}.geojson`;
+}
+
+interface SaveChatPreviewDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The previewed result, complete — callers must not offer this for a
+   *  server-truncated preview (see `previewSaveMode`). */
+  geojson: GeoJSON.FeatureCollection;
+  /** The prompt that produced the preview, used to suggest a name. */
+  prompt?: string;
+}
+
+export function SaveChatPreviewDialog({
+  open,
+  onOpenChange,
+  geojson,
+  prompt,
+}: SaveChatPreviewDialogProps) {
+  const { t } = useTranslation('builder');
+  const [isCommitting, setIsCommitting] = useState(false);
+
+  const fileName = chatPreviewFileName(prompt, t('savePreview.fallbackTitle'));
+
+  const handleCommit = async (metadata: CommitImportRequest) => {
+    if (isCommitting) return;
+    setIsCommitting(true);
+    try {
+      const file = new File([JSON.stringify(geojson)], fileName, {
+        type: 'application/geo+json',
+      });
+      const { job_id } = await uploadFile(file);
+      // Not skippable: preview is where a payload too large for the ingest
+      // budget, or one the server cannot read, is rejected with an actionable
+      // message — before a job is queued and a half-made dataset exists.
+      await previewFile(job_id);
+      await commitImport(job_id, metadata);
+      toast.success(t('savePreview.started'));
+      onOpenChange(false);
+    } catch (err) {
+      // ApiError messages are already localized at the client boundary
+      // (translateApiErrorDetail); anything else gets the generic sentence.
+      toast.error(err instanceof ApiError ? err.message : t('savePreview.failed'));
+    } finally {
+      setIsCommitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // A commit is one request chain with no cancel — closing under it
+        // would orphan the staged upload with the user believing they stopped.
+        if (isCommitting && !next) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t('savePreview.title')}</DialogTitle>
+          <DialogDescription>{t('savePreview.description')}</DialogDescription>
+        </DialogHeader>
+        <ImportMetadataForm
+          defaultName={fileName}
+          detectedCrs={GEOJSON_EPSG}
+          onCommit={(metadata) => void handleCommit(metadata)}
+          isCommitting={isCommitting}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/builder/SaveChatPreviewDialog.tsx
+++ b/frontend/src/components/builder/SaveChatPreviewDialog.tsx
@@ -22,7 +22,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { truncateGraphemes } from '@/lib/text';
+import { splitGraphemes, truncateGraphemes } from '@/lib/text';
 import type { CommitImportRequest } from '@/types/api';
 
 /** RFC 7946: GeoJSON is WGS 84 by definition, so nothing has to detect it. */
@@ -30,6 +30,21 @@ const GEOJSON_EPSG = 4326;
 
 /** Keeps a suggested name readable; the server's own bound is 500. */
 const MAX_SUGGESTED_TITLE = 80;
+
+const GEOJSON_EXT = '.geojson';
+
+/**
+ * feat(#1241 codex r5): the byte budget for the name the file is UPLOADED
+ * under. Graphemes are the wrong unit for a filesystem: 80 emoji plus the
+ * extension is 328 bytes, and local staging writes
+ * `<job-uuid>_<basename>` into a directory entry Linux caps at 255 bytes, so a
+ * multibyte prompt that passes the grapheme cap fails the upload with
+ * ENAMETOOLONG (a 500). 120 leaves room for the uuid prefix and then some.
+ */
+const MAX_UPLOAD_NAME_BYTES = 120;
+
+/** ASCII, so it always fits, for the case where not one grapheme does. */
+const FALLBACK_UPLOAD_BASE = 'chat-result';
 
 /**
  * The chat prompt, shaped into the name of the file we are about to upload.
@@ -49,7 +64,29 @@ export function chatPreviewFileName(prompt: string | undefined, fallbackTitle: s
     .replace(/\s+/g, ' ')
     .trim();
   const title = truncateGraphemes(collapsed, MAX_SUGGESTED_TITLE, '').trim() || fallbackTitle;
-  return `${title}.geojson`;
+  return `${title}${GEOJSON_EXT}`;
+}
+
+/**
+ * The same name, bounded by UTF-8 BYTES so it can be a filesystem entry.
+ *
+ * Kept separate from the name above deliberately: that one only ever reaches
+ * the metadata form, where it becomes the suggested dataset title and no byte
+ * limit applies. Trimming happens by grapheme, so a multibyte name loses whole
+ * characters rather than splitting one down the middle.
+ */
+export function chatPreviewUploadName(fileName: string): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(fileName).length <= MAX_UPLOAD_NAME_BYTES) return fileName;
+
+  const base = fileName.slice(0, -GEOJSON_EXT.length);
+  let kept = '';
+  for (const grapheme of splitGraphemes(base)) {
+    const next = kept + grapheme;
+    if (encoder.encode(`${next}${GEOJSON_EXT}`).length > MAX_UPLOAD_NAME_BYTES) break;
+    kept = next;
+  }
+  return `${kept.trim() || FALLBACK_UPLOAD_BASE}${GEOJSON_EXT}`;
 }
 
 /**
@@ -114,7 +151,7 @@ export function SaveChatPreviewDialog({
     setIsCommitting(true);
     try {
       if (!stagedRef.current) {
-        const file = new File([JSON.stringify(geojson)], fileName, {
+        const file = new File([JSON.stringify(geojson)], chatPreviewUploadName(fileName), {
           type: 'application/geo+json',
         });
         const { job_id } = await uploadFile(file);

--- a/frontend/src/components/builder/SaveChatPreviewDialog.tsx
+++ b/frontend/src/components/builder/SaveChatPreviewDialog.tsx
@@ -13,7 +13,7 @@ import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { ApiError } from '@/api/client';
-import { commitImport, previewFile, uploadFile } from '@/api/ingest';
+import { commitImport, getJobStatus, previewFile, uploadFile } from '@/api/ingest';
 import { ImportMetadataForm } from '@/components/import/ImportMetadataForm';
 import {
   Dialog,
@@ -50,6 +50,30 @@ export function chatPreviewFileName(prompt: string | undefined, fallbackTitle: s
     .trim();
   const title = truncateGraphemes(collapsed, MAX_SUGGESTED_TITLE, '').trim() || fallbackTitle;
   return `${title}.geojson`;
+}
+
+/**
+ * feat(#1241 codex r3/r4): what became of a job whose commit we already sent.
+ *
+ * The backend refuses a repeat commit with 400 for EVERY non-pending status,
+ * and those statuses do not mean the same thing. A commit that queued the
+ * import leaves the job for the worker to claim (`running`, then `complete`).
+ * A commit whose dispatch failed leaves it `failed` with its staged file
+ * already deleted (`queue_ingest_job`'s orphan guard, which also returns 503),
+ * so nothing on that job can ever succeed. Reading the 400 alone would call
+ * both of them success.
+ */
+async function stagedJobOutcome(jobId: string): Promise<'queued' | 'dead' | 'unknown'> {
+  try {
+    const job = await getJobStatus(jobId);
+    if (job.status === 'running' || job.status === 'complete') return 'queued';
+    if (job.status === 'failed' || job.status === 'cancelled') return 'dead';
+    // `pending` contradicts the 400 that sent us here (a race), and no other
+    // status belongs to this flow. Claim nothing.
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
 }
 
 interface SaveChatPreviewDialogProps {
@@ -113,9 +137,8 @@ export function SaveChatPreviewDialog({
       } catch (err) {
         // feat(#1241 codex r3): a commit whose response was lost still queued
         // the import, and the backend then refuses the repeat with 400 "Job
-        // already processed". That refusal IS the confirmation the import
-        // exists, so swallowing it here is what stops the dialog looping over
-        // a dataset the server already has. Only ever on a RE-commit: a 400 on
+        // already processed" — forever, so the dialog could never close over a
+        // dataset the server already had. Only ever on a RE-commit: a 400 on
         // the first attempt is a real rejection.
         //
         // Sending the second commit at all is safe. The worker claims a job
@@ -125,6 +148,17 @@ export function SaveChatPreviewDialog({
         // the worker picked the job up — the redundant task finds the row
         // claimed and no-ops. One dataset either way.
         if (!isRecommit || !(err instanceof ApiError) || err.status !== 400) throw err;
+        // feat(#1241 codex r4): but that 400 covers every non-pending status,
+        // including the job a failed dispatch marked `failed` (503 on the
+        // first attempt, staged file already deleted). Ask what actually
+        // happened rather than reading success into the refusal.
+        const outcome = await stagedJobOutcome(staged.jobId);
+        if (outcome !== 'queued') {
+          // A dead job can never produce a dataset and its staged file is
+          // gone, so stop resuming it: the next submit starts a fresh upload.
+          if (outcome === 'dead') stagedRef.current = null;
+          throw err;
+        }
       }
       toast.success(t('savePreview.started'));
       onOpenChange(false);

--- a/frontend/src/components/builder/SaveChatPreviewDialog.tsx
+++ b/frontend/src/components/builder/SaveChatPreviewDialog.tsx
@@ -9,7 +9,7 @@
 // This is a SNAPSHOT — a saved answer, frozen at save time, not a live query.
 // The dialog says so, because the resulting dataset is indistinguishable from
 // any other once it lands.
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { ApiError } from '@/api/client';
@@ -70,6 +70,14 @@ export function SaveChatPreviewDialog({
 }: SaveChatPreviewDialogProps) {
   const { t } = useTranslation('builder');
   const [isCommitting, setIsCommitting] = useState(false);
+  // feat(#1241 codex r2): the staged job survives a failed attempt, so a retry
+  // resumes the chain instead of restarting it. Re-uploading would leave the
+  // first job staged with nothing pointing at it, and worse: if a commit was
+  // accepted and only its response was lost, a fresh job would queue a second
+  // dataset from the same answer. Resuming puts that retry back on the job the
+  // server already has, where a repeat commit is refused ("Job already
+  // processed") instead of duplicating.
+  const stagedRef = useRef<{ jobId: string; previewed: boolean } | null>(null);
 
   const fileName = chatPreviewFileName(prompt, t('savePreview.fallbackTitle'));
 
@@ -77,15 +85,24 @@ export function SaveChatPreviewDialog({
     if (isCommitting) return;
     setIsCommitting(true);
     try {
-      const file = new File([JSON.stringify(geojson)], fileName, {
-        type: 'application/geo+json',
-      });
-      const { job_id } = await uploadFile(file);
-      // Not skippable: preview is where a payload too large for the ingest
-      // budget, or one the server cannot read, is rejected with an actionable
-      // message — before a job is queued and a half-made dataset exists.
-      await previewFile(job_id);
-      await commitImport(job_id, metadata);
+      if (!stagedRef.current) {
+        const file = new File([JSON.stringify(geojson)], fileName, {
+          type: 'application/geo+json',
+        });
+        const { job_id } = await uploadFile(file);
+        stagedRef.current = { jobId: job_id, previewed: false };
+      }
+      const staged = stagedRef.current;
+      if (!staged.previewed) {
+        // Not skippable: preview is where a payload too large for the ingest
+        // budget, or one the server cannot read, is rejected with an
+        // actionable message, before a job is queued and a half-made dataset
+        // exists. Recorded so a retry after a commit failure does not re-run
+        // it (the job is already validated).
+        await previewFile(staged.jobId);
+        staged.previewed = true;
+      }
+      await commitImport(staged.jobId, metadata);
       toast.success(t('savePreview.started'));
       onOpenChange(false);
     } catch (err) {

--- a/frontend/src/components/builder/SaveChatPreviewDialog.tsx
+++ b/frontend/src/components/builder/SaveChatPreviewDialog.tsx
@@ -75,9 +75,13 @@ export function SaveChatPreviewDialog({
   // first job staged with nothing pointing at it, and worse: if a commit was
   // accepted and only its response was lost, a fresh job would queue a second
   // dataset from the same answer. Resuming puts that retry back on the job the
-  // server already has, where a repeat commit is refused ("Job already
-  // processed") instead of duplicating.
-  const stagedRef = useRef<{ jobId: string; previewed: boolean } | null>(null);
+  // server already has, where the outcome is one dataset either way.
+  const stagedRef = useRef<{
+    jobId: string;
+    previewed: boolean;
+    /** Whether a commit for this job has already been sent (landed or not). */
+    committed: boolean;
+  } | null>(null);
 
   const fileName = chatPreviewFileName(prompt, t('savePreview.fallbackTitle'));
 
@@ -90,7 +94,7 @@ export function SaveChatPreviewDialog({
           type: 'application/geo+json',
         });
         const { job_id } = await uploadFile(file);
-        stagedRef.current = { jobId: job_id, previewed: false };
+        stagedRef.current = { jobId: job_id, previewed: false, committed: false };
       }
       const staged = stagedRef.current;
       if (!staged.previewed) {
@@ -102,7 +106,26 @@ export function SaveChatPreviewDialog({
         await previewFile(staged.jobId);
         staged.previewed = true;
       }
-      await commitImport(staged.jobId, metadata);
+      const isRecommit = staged.committed;
+      staged.committed = true;
+      try {
+        await commitImport(staged.jobId, metadata);
+      } catch (err) {
+        // feat(#1241 codex r3): a commit whose response was lost still queued
+        // the import, and the backend then refuses the repeat with 400 "Job
+        // already processed". That refusal IS the confirmation the import
+        // exists, so swallowing it here is what stops the dialog looping over
+        // a dataset the server already has. Only ever on a RE-commit: a 400 on
+        // the first attempt is a real rejection.
+        //
+        // Sending the second commit at all is safe. The worker claims a job
+        // with one conditional UPDATE (pending -> running, fenced on
+        // attempt_id, backend/app/platform/jobs/heartbeat.py), so if the
+        // repeat is accepted instead of refused — the response was lost before
+        // the worker picked the job up — the redundant task finds the row
+        // claimed and no-ops. One dataset either way.
+        if (!isRecommit || !(err instanceof ApiError) || err.status !== 400) throw err;
+      }
       toast.success(t('savePreview.started'));
       onOpenChange(false);
     } catch (err) {

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -163,7 +163,12 @@ describe('ChatPanel', () => {
     await typeAndSend(user, 'find features');
 
     await waitFor(() => {
-      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, undefined);
+      // feat(#1241): the meta now always carries the prompt behind the result,
+      // so a plain preview (no truncation, no analysis) can be saved as a
+      // dataset with its question suggested as the name.
+      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
+        prompt: 'find features',
+      });
     });
   });
 
@@ -193,6 +198,7 @@ describe('ChatPanel', () => {
       expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
         truncated: true,
         totalCount: 10651,
+        prompt: 'buffer the earthquakes by 10km',
       });
     });
   });
@@ -223,6 +229,7 @@ describe('ChatPanel', () => {
     await waitFor(() => {
       expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
         truncated: true,
+        prompt: 'clip the buildings to the flood zone',
       });
     });
   });
@@ -248,7 +255,10 @@ describe('ChatPanel', () => {
     await typeAndSend(user, 'clip the buildings to the flood zone');
 
     await waitFor(() => {
-      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, undefined);
+      // No `truncated` key at all — an uncapped result must not disclose one.
+      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
+        prompt: 'clip the buildings to the flood zone',
+      });
     });
   });
 
@@ -309,6 +319,7 @@ describe('ChatPanel', () => {
     await waitFor(() => {
       expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
         analysis: { operation: 'buffer', layerId: 'layer-1', distanceMeters: 500 },
+        prompt: 'buffer the schools by 500m',
       });
     });
   });
@@ -1654,7 +1665,9 @@ describe('ChatPanel — inline data-analysis card (Phase 1135 AI-08)', () => {
     const props = renderPanel();
     await typeAndSend(user, 'find spatial features');
     await waitFor(() => {
-      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, undefined);
+      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
+        prompt: 'find spatial features',
+      });
     });
     // Negative control — no inline card when rows is absent
     expect(screen.queryByRole('region', { name: /query result table/i })).not.toBeInTheDocument();

--- a/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/ChatPanel.test.tsx
@@ -38,6 +38,12 @@ function makeLayer(overrides: Partial<MapLayerResponse> = {}): MapLayerResponse 
   };
 }
 
+/** One overlay feature. feat(#1241 codex r1): overlay completeness is judged
+ *  against row_count, so a fixture's feature COUNT is now load-bearing. */
+function feature() {
+  return { type: 'Feature', geometry: { type: 'Point', coordinates: [-73.9, 40.8] }, properties: {} };
+}
+
 function renderPanel(
   propOverrides: Partial<React.ComponentProps<typeof ChatPanel>> & Partial<LayerActions> = {},
 ) {
@@ -236,15 +242,22 @@ describe('ChatPanel', () => {
 
   // The other direction: an uncapped result must forward nothing, or the
   // preview discloses a truncation that did not happen.
+  //
+  // feat(#1241 codex r1): the fixture holds one feature per matched row. The
+  // overlay is complete only when it carries every row the answer matched, and
+  // the server never emits an empty FeatureCollection (_extract_geojson
+  // returns None when no row is mappable), so a features:[] fixture with
+  // row_count: 12 describes a state that cannot occur — and now reads, as it
+  // should, as a clipped result.
   it('forwards no truncation for an uncapped result', async () => {
-    const geojson = { type: 'FeatureCollection', features: [] };
+    const geojson = { type: 'FeatureCollection', features: [feature()] };
     const bbox = [-74, 40, -73, 41];
 
     mockStreamChat.mockImplementation(async function* () {
       yield {
         event: 'actions',
         data: {
-          actions: [{ type: 'show_query_result', geojson, bbox, row_count: 12 }],
+          actions: [{ type: 'show_query_result', geojson, bbox, row_count: 1 }],
         },
       };
       yield { event: 'done', data: { explanation: 'Clipped' } };
@@ -258,6 +271,41 @@ describe('ChatPanel', () => {
       // No `truncated` key at all — an uncapped result must not disclose one.
       expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
         prompt: 'clip the buildings to the flood zone',
+      });
+    });
+  });
+
+  // feat(#1241 codex r1): `truncated` is the SQL sandbox's row cap. When the
+  // model selects geometry itself the sandbox runs at its 1000-row default and
+  // the server then slices the OVERLAY to its own 50-row budget, so a 300-row
+  // answer arrives as a short FeatureCollection with the flag false. Believing
+  // the flag there labels a clipped preview complete — and would let the #1241
+  // save file it in the catalog as the whole answer.
+  it('discloses an overlay clipped below row_count even with truncated false', async () => {
+    const geojson = { type: 'FeatureCollection', features: [feature(), feature()] };
+    const bbox = [-74, 40, -73, 41];
+
+    mockStreamChat.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            { type: 'show_query_result', geojson, bbox, truncated: false, row_count: 300 },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Found 300' } };
+    });
+
+    const user = userEvent.setup();
+    const props = renderPanel();
+    await typeAndSend(user, 'show me every park');
+
+    await waitFor(() => {
+      expect(props.onQueryResult).toHaveBeenCalledWith(geojson, bbox, {
+        truncated: true,
+        totalCount: 300,
+        prompt: 'show me every park',
       });
     });
   });

--- a/frontend/src/components/builder/__tests__/EphemeralBadge.test.tsx
+++ b/frontend/src/components/builder/__tests__/EphemeralBadge.test.tsx
@@ -113,4 +113,42 @@ describe('EphemeralBadge', () => {
     const { container } = render(<EphemeralBadge featureCount={1} onDismiss={vi.fn()} />);
     expect(container.firstElementChild).toHaveClass('z-20');
   });
+
+  // feat(#1241): the builder's <1100px rail is a preview surface too, so the
+  // truncation guard has to read the same here as on the stack row — a save
+  // silently missing on one layout and offered on the other is the drift
+  // ephemeral-preview.ts exists to prevent.
+  describe('save affordance parity with the stack row', () => {
+    it('offers the save when the builder passes a handler', () => {
+      const onSaveAsDataset = vi.fn();
+      render(
+        <EphemeralBadge featureCount={240} onDismiss={vi.fn()} onSaveAsDataset={onSaveAsDataset} />,
+      );
+      const save = screen.getByRole('button', { name: /save as dataset/i });
+      expect(save).toBeEnabled();
+    });
+
+    it('disables the save on a truncated preview and says why', () => {
+      render(
+        <EphemeralBadge
+          featureCount={500}
+          totalCount={10651}
+          truncated
+          onDismiss={vi.fn()}
+          saveDisabledReason="truncated"
+        />,
+      );
+      const save = screen.getByRole('button', { name: /save as dataset/i });
+      expect(save).toBeDisabled();
+      const reason = screen.getByText(/Capped previews can't be saved/i);
+      expect(save).toHaveAttribute('aria-describedby', reason.getAttribute('id'));
+      // The count sentence the reason refers to is still there.
+      expect(screen.getByText('Result · 500 of 10,651 features')).toBeInTheDocument();
+    });
+
+    it('shows no save affordance at all when neither is passed (the viewer)', () => {
+      render(<EphemeralBadge featureCount={240} onDismiss={vi.fn()} />);
+      expect(screen.queryByRole('button', { name: /save as dataset/i })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/builder/__tests__/SaveChatPreviewDialog.test.tsx
+++ b/frontend/src/components/builder/__tests__/SaveChatPreviewDialog.test.tsx
@@ -6,13 +6,14 @@ import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
 import { SaveChatPreviewDialog, chatPreviewFileName } from '../SaveChatPreviewDialog';
 import { ApiError } from '@/api/client';
 
-const { uploadFile, previewFile, commitImport } = vi.hoisted(() => ({
+const { uploadFile, previewFile, commitImport, getJobStatus } = vi.hoisted(() => ({
   uploadFile: vi.fn(),
   previewFile: vi.fn(),
   commitImport: vi.fn(),
+  getJobStatus: vi.fn(),
 }));
 
-vi.mock('@/api/ingest', () => ({ uploadFile, previewFile, commitImport }));
+vi.mock('@/api/ingest', () => ({ uploadFile, previewFile, commitImport, getJobStatus }));
 
 const { toastSuccess, toastError } = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
@@ -37,6 +38,7 @@ beforeEach(() => {
   uploadFile.mockResolvedValue({ job_id: 'job-1' });
   previewFile.mockResolvedValue({ job_id: 'job-1' });
   commitImport.mockResolvedValue({ job_id: 'job-1', status: 'pending', message: 'Import queued' });
+  getJobStatus.mockResolvedValue({ id: 'job-1', status: 'running' });
 });
 
 function renderDialog(props: Partial<React.ComponentProps<typeof SaveChatPreviewDialog>> = {}) {
@@ -192,6 +194,47 @@ describe('SaveChatPreviewDialog', () => {
     await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(toastError).toHaveBeenCalledTimes(1);
+  });
+
+  // feat(#1241 codex r4): the backend answers a repeat commit with the same
+  // 400 for every non-pending status, and a dispatch failure leaves the job
+  // `failed` with its staged file deleted. Reading the 400 alone reported
+  // success for an import that was never queued.
+  it('does not claim success when the job the commit reached is dead', async () => {
+    commitImport
+      .mockRejectedValueOnce(new ApiError('Queue unavailable', 503))
+      .mockRejectedValueOnce(new ApiError('Job already processed', 400));
+    getJobStatus.mockResolvedValue({ id: 'job-1', status: 'failed' });
+    const { onOpenChange } = renderDialog();
+
+    submit();
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+
+    submit();
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(2));
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    // The dead job is abandoned rather than resumed forever: the next attempt
+    // starts a fresh upload, which is the only thing that can succeed once the
+    // staged file is gone.
+    submit();
+    await waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(2));
+  });
+
+  it('claims nothing when the job status cannot be read', async () => {
+    commitImport
+      .mockRejectedValueOnce(new ApiError('Network unavailable', 0))
+      .mockRejectedValueOnce(new ApiError('Job already processed', 400));
+    getJobStatus.mockRejectedValue(new ApiError('Not found', 404));
+    const { onOpenChange } = renderDialog();
+
+    submit();
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+    submit();
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(2));
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it('does not swallow a 400 on the first commit attempt', async () => {

--- a/frontend/src/components/builder/__tests__/SaveChatPreviewDialog.test.tsx
+++ b/frontend/src/components/builder/__tests__/SaveChatPreviewDialog.test.tsx
@@ -1,0 +1,164 @@
+// feat(#1241): the chat preview → dataset snapshot. What matters here is that
+// the client's FeatureCollection reaches the ORDINARY ingest path — upload,
+// preview, commit — as a .geojson file, so the result is a dataset with
+// nothing special about it downstream.
+import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
+import { SaveChatPreviewDialog, chatPreviewFileName } from '../SaveChatPreviewDialog';
+import { ApiError } from '@/api/client';
+
+const { uploadFile, previewFile, commitImport } = vi.hoisted(() => ({
+  uploadFile: vi.fn(),
+  previewFile: vi.fn(),
+  commitImport: vi.fn(),
+}));
+
+vi.mock('@/api/ingest', () => ({ uploadFile, previewFile, commitImport }));
+
+const { toastSuccess, toastError } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: toastSuccess, error: toastError } }));
+
+const geojson: GeoJSON.FeatureCollection = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [1, 2] },
+      properties: { magnitude: 5.5 },
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uploadFile.mockResolvedValue({ job_id: 'job-1' });
+  previewFile.mockResolvedValue({ job_id: 'job-1' });
+  commitImport.mockResolvedValue({ job_id: 'job-1', status: 'pending', message: 'Import queued' });
+});
+
+function renderDialog(props: Partial<React.ComponentProps<typeof SaveChatPreviewDialog>> = {}) {
+  const onOpenChange = vi.fn();
+  render(
+    <SaveChatPreviewDialog
+      open
+      onOpenChange={onOpenChange}
+      geojson={geojson}
+      prompt="show me the latest earthquake"
+      {...props}
+    />,
+  );
+  return { onOpenChange };
+}
+
+function submit() {
+  fireEvent.click(screen.getByRole('button', { name: /import dataset/i }));
+}
+
+describe('chatPreviewFileName', () => {
+  it('suggests the prompt as the file name', () => {
+    expect(chatPreviewFileName('show me the latest earthquake', 'Fallback')).toBe(
+      'show me the latest earthquake.geojson',
+    );
+  });
+
+  // The form seeds its title field with stripExtension(defaultName), which cuts
+  // at the LAST dot — so a prompt carrying its own dots only survives because
+  // what we hand it is a file name, not a bare title.
+  it('keeps a prompt that contains dots intact through the extension', () => {
+    expect(chatPreviewFileName('buildings over 3.5m', 'Fallback')).toBe(
+      'buildings over 3.5m.geojson',
+    );
+  });
+
+  it('collapses whitespace and drops path separators', () => {
+    expect(chatPreviewFileName('  parks\n/ gardens  ', 'Fallback')).toBe('parks gardens.geojson');
+  });
+
+  it('falls back when there is no prompt to name it after', () => {
+    expect(chatPreviewFileName(undefined, 'Chat query result')).toBe('Chat query result.geojson');
+    expect(chatPreviewFileName('   ', 'Chat query result')).toBe('Chat query result.geojson');
+  });
+
+  it('caps a rambling prompt instead of making a 900-character name', () => {
+    const name = chatPreviewFileName('a'.repeat(400), 'Fallback');
+    expect(name).toBe(`${'a'.repeat(80)}.geojson`);
+  });
+});
+
+describe('SaveChatPreviewDialog', () => {
+  it('prefills the name from the chat prompt', () => {
+    renderDialog();
+    expect(screen.getByLabelText(/name/i)).toHaveValue('show me the latest earthquake');
+  });
+
+  it('says the dataset is a snapshot, not a live query', () => {
+    renderDialog();
+    expect(screen.getByText(/snapshot of this answer, not a live query/i)).toBeInTheDocument();
+  });
+
+  it('pushes the preview through upload → preview → commit', async () => {
+    const { onOpenChange } = renderDialog();
+    submit();
+
+    await waitFor(() => expect(commitImport).toHaveBeenCalled());
+
+    const file = uploadFile.mock.calls[0][0] as File;
+    expect(file.name).toBe('show me the latest earthquake.geojson');
+    await expect(file.text()).resolves.toBe(JSON.stringify(geojson));
+
+    // Preview is not skippable: it is where an unreadable or over-budget
+    // payload is rejected, before a job is queued.
+    expect(previewFile).toHaveBeenCalledWith('job-1');
+    expect(commitImport).toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({ title: 'show me the latest earthquake', visibility: 'private' }),
+    );
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it('commits the edited name, not the suggestion', async () => {
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Quakes today' } });
+    submit();
+
+    await waitFor(() => expect(commitImport).toHaveBeenCalled());
+    expect(commitImport).toHaveBeenCalledWith('job-1', expect.objectContaining({ title: 'Quakes today' }));
+    // The upload still carries the suggested file name — renaming the dataset
+    // is not renaming the file it came from.
+    expect((uploadFile.mock.calls[0][0] as File).name).toBe('show me the latest earthquake.geojson');
+  });
+
+  it('keeps the dialog open and surfaces the reason when the upload fails', async () => {
+    uploadFile.mockRejectedValue(new ApiError('File too large', 413));
+    const { onOpenChange } = renderDialog();
+    submit();
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('File too large'));
+    expect(previewFile).not.toHaveBeenCalled();
+    expect(commitImport).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('never commits a payload the ingest preview rejected', async () => {
+    previewFile.mockRejectedValue(new ApiError('Unable to preview file.', 422));
+    renderDialog();
+    submit();
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(commitImport).not.toHaveBeenCalled();
+  });
+
+  it('uploads once when the submit button is double-clicked', async () => {
+    renderDialog();
+    const button = screen.getByRole('button', { name: /import dataset/i });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => expect(commitImport).toHaveBeenCalled());
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/builder/__tests__/SaveChatPreviewDialog.test.tsx
+++ b/frontend/src/components/builder/__tests__/SaveChatPreviewDialog.test.tsx
@@ -152,6 +152,43 @@ describe('SaveChatPreviewDialog', () => {
     expect(commitImport).not.toHaveBeenCalled();
   });
 
+  // feat(#1241 codex r2): the commit chain has three server steps and the
+  // dialog stays open when one fails. Re-uploading on retry strands the first
+  // staged job, and if a commit was accepted with only its response lost, a
+  // fresh job would queue a SECOND dataset from the same answer. Resuming puts
+  // the retry back on the job the server already has, where a repeat commit is
+  // refused rather than duplicated.
+  it('resumes the staged job on retry instead of uploading again', async () => {
+    commitImport.mockRejectedValueOnce(new ApiError('Service unavailable', 503));
+    renderDialog();
+
+    submit();
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+
+    submit();
+    await waitFor(() => expect(commitImport).toHaveBeenCalledTimes(2));
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+    // The payload was already validated by the first preview; the retry picks
+    // up at the step that failed.
+    expect(previewFile).toHaveBeenCalledTimes(1);
+    expect(commitImport.mock.calls.every(([jobId]) => jobId === 'job-1')).toBe(true);
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it('re-runs only the failed step when the preview is what failed', async () => {
+    previewFile.mockRejectedValueOnce(new ApiError('Unable to preview file.', 422));
+    renderDialog();
+
+    submit();
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(commitImport).not.toHaveBeenCalled();
+
+    submit();
+    await waitFor(() => expect(commitImport).toHaveBeenCalled());
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+    expect(previewFile).toHaveBeenCalledTimes(2);
+  });
+
   it('uploads once when the submit button is double-clicked', async () => {
     renderDialog();
     const button = screen.getByRole('button', { name: /import dataset/i });

--- a/frontend/src/components/builder/__tests__/SaveChatPreviewDialog.test.tsx
+++ b/frontend/src/components/builder/__tests__/SaveChatPreviewDialog.test.tsx
@@ -175,6 +175,35 @@ describe('SaveChatPreviewDialog', () => {
     expect(toastSuccess).toHaveBeenCalled();
   });
 
+  // feat(#1241 codex r3): the ambiguous case. A commit that reached the server
+  // with only its response lost leaves a queued import behind, and the backend
+  // refuses the repeat with 400 "Job already processed" — forever. Without
+  // this the dialog can never close over a dataset that already exists.
+  it('treats "job already processed" on a retry as the success it describes', async () => {
+    commitImport
+      .mockRejectedValueOnce(new ApiError('Network unavailable', 0))
+      .mockRejectedValueOnce(new ApiError('Job already processed', 400));
+    const { onOpenChange } = renderDialog();
+
+    submit();
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+
+    submit();
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not swallow a 400 on the first commit attempt', async () => {
+    commitImport.mockRejectedValue(new ApiError('Job has no file', 400));
+    const { onOpenChange } = renderDialog();
+
+    submit();
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Job has no file'));
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   it('re-runs only the failed step when the preview is what failed', async () => {
     previewFile.mockRejectedValueOnce(new ApiError('Unable to preview file.', 422));
     renderDialog();

--- a/frontend/src/components/builder/__tests__/SaveChatPreviewDialog.test.tsx
+++ b/frontend/src/components/builder/__tests__/SaveChatPreviewDialog.test.tsx
@@ -3,7 +3,11 @@
 // preview, commit — as a .geojson file, so the result is a dataset with
 // nothing special about it downstream.
 import { fireEvent, render, screen, waitFor } from '@/test/test-utils';
-import { SaveChatPreviewDialog, chatPreviewFileName } from '../SaveChatPreviewDialog';
+import {
+  SaveChatPreviewDialog,
+  chatPreviewFileName,
+  chatPreviewUploadName,
+} from '../SaveChatPreviewDialog';
 import { ApiError } from '@/api/client';
 
 const { uploadFile, previewFile, commitImport, getJobStatus } = vi.hoisted(() => ({
@@ -87,6 +91,41 @@ describe('chatPreviewFileName', () => {
   it('caps a rambling prompt instead of making a 900-character name', () => {
     const name = chatPreviewFileName('a'.repeat(400), 'Fallback');
     expect(name).toBe(`${'a'.repeat(80)}.geojson`);
+  });
+});
+
+// feat(#1241 codex r5): graphemes are the wrong unit for a filesystem entry.
+// 80 emoji plus the extension is 328 bytes, and local staging writes
+// `<job-uuid>_<basename>` into a directory entry Linux caps at 255 — the
+// upload then fails with ENAMETOOLONG, which the endpoint returns as a 500.
+describe('chatPreviewUploadName', () => {
+  const bytes = (value: string) => new TextEncoder().encode(value).length;
+
+  it('leaves an ordinary name alone', () => {
+    expect(chatPreviewUploadName('show me the latest earthquake.geojson')).toBe(
+      'show me the latest earthquake.geojson',
+    );
+  });
+
+  it('bounds a multibyte name that passed the grapheme cap', () => {
+    const emoji = chatPreviewFileName('🌍'.repeat(120), 'Fallback');
+    expect(bytes(emoji)).toBeGreaterThan(255);
+
+    const uploaded = chatPreviewUploadName(emoji);
+    expect(bytes(uploaded)).toBeLessThanOrEqual(120);
+    expect(uploaded.endsWith('.geojson')).toBe(true);
+  });
+
+  it('keeps whole characters when it trims', () => {
+    // A split surrogate pair would encode as U+FFFD and corrupt the name.
+    const uploaded = chatPreviewUploadName(chatPreviewFileName('🌍'.repeat(120), 'Fallback'));
+    expect(uploaded).toBe(`${'🌍'.repeat(28)}.geojson`);
+  });
+
+  it('bounds a long non-Latin name without losing the extension', () => {
+    const uploaded = chatPreviewUploadName(chatPreviewFileName('東京'.repeat(40), 'Fallback'));
+    expect(bytes(uploaded)).toBeLessThanOrEqual(120);
+    expect(uploaded.endsWith('.geojson')).toBe(true);
   });
 });
 

--- a/frontend/src/components/builder/__tests__/UnifiedStackPanel.preview-row.test.tsx
+++ b/frontend/src/components/builder/__tests__/UnifiedStackPanel.preview-row.test.tsx
@@ -271,6 +271,63 @@ describe('#1009: the row carries everything the badge offered', () => {
     expect(screen.queryByTestId('ephemeral-preview-save')).not.toBeInTheDocument();
   });
 
+  // feat(#1241): a plain chat preview can now be snapshotted into a dataset,
+  // so "no analysis behind it" no longer means "no save" — but a capped one
+  // still must not be saveable, and must say why rather than go quiet.
+  it('offers the save on a plain chat preview', () => {
+    const onSaveAsDataset = vi.fn();
+    render(
+      <UnifiedStackPanel
+        {...defaultProps({ layers, preview: makePreview({ featureCount: 240, onSaveAsDataset }) })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('ephemeral-preview-save'));
+    expect(onSaveAsDataset).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the save on a truncated preview and says why', () => {
+    render(
+      <UnifiedStackPanel
+        {...defaultProps({
+          layers,
+          preview: makePreview({
+            featureCount: 500,
+            totalCount: 10651,
+            truncated: true,
+            saveDisabledReason: 'truncated',
+          }),
+        })}
+      />,
+    );
+
+    const save = screen.getByTestId('ephemeral-preview-save');
+    expect(save).toBeDisabled();
+    // The "N of M" the disabled state is explained by is still on the row.
+    expect(screen.getByText('500 of 10,651 features')).toBeInTheDocument();
+    const reason = screen.getByText(/Capped previews can't be saved/i);
+    expect(reason).toBeInTheDocument();
+    // Visible text, and wired to the control — a disabled button gets no
+    // hover and no focus, so a title tooltip would reach nobody.
+    expect(save).toHaveAttribute('aria-describedby', reason.getAttribute('id'));
+  });
+
+  it('never fires a save from the disabled affordance', () => {
+    const onSaveAsDataset = vi.fn();
+    render(
+      <UnifiedStackPanel
+        {...defaultProps({
+          layers,
+          // Both props set is not a state the page produces; pinning it here
+          // keeps the row's own contract ("disabled means disabled") true
+          // independently of the caller that decides.
+          preview: makePreview({ truncated: true, saveDisabledReason: 'truncated', onSaveAsDataset }),
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('ephemeral-preview-save'));
+    expect(onSaveAsDataset).not.toHaveBeenCalled();
+  });
+
   it('dismisses the preview from the row', () => {
     const onDismiss = vi.fn();
     render(<UnifiedStackPanel {...defaultProps({ layers, preview: makePreview({ onDismiss }) })} />);

--- a/frontend/src/components/builder/__tests__/ephemeral-preview.save-mode.test.ts
+++ b/frontend/src/components/builder/__tests__/ephemeral-preview.save-mode.test.ts
@@ -46,4 +46,21 @@ describe('previewSaveMode', () => {
   it('offers no snapshot of an empty result', () => {
     expect(previewSaveMode({ featureCount: 0 }, true)).toBe('none');
   });
+
+  // feat(#1241 codex r2): an Analysis-panel preview carries `source` but no
+  // `analysis` (that field marks a CHAT run_analysis handoff), so a mode
+  // decided on `analysis` alone classified it as a chat snapshot and offered
+  // the ingest dialog beside the panel's own Create dataset. Its preview is
+  // bbox-scoped too, so the snapshot would persist whatever the map was
+  // looking at rather than the operation's result.
+  it('leaves an Analysis-panel preview to the panel that drew it', () => {
+    expect(previewSaveMode({ featureCount: 240, source: 'analysis-panel' }, true)).toBe('none');
+    expect(
+      previewSaveMode({ featureCount: 240, source: 'analysis-panel', truncated: true }, true),
+    ).toBe('none');
+  });
+
+  it('excludes any stamped producer, not just the one that exists today', () => {
+    expect(previewSaveMode({ featureCount: 240, source: 'some-future-panel' }, true)).toBe('none');
+  });
 });

--- a/frontend/src/components/builder/__tests__/ephemeral-preview.save-mode.test.ts
+++ b/frontend/src/components/builder/__tests__/ephemeral-preview.save-mode.test.ts
@@ -1,0 +1,49 @@
+// feat(#1241): which save a preview earns. The two guards this encodes —
+// truncation and the upload capability — are the reason the snapshot path
+// exists at all, so they are pinned here rather than only through the UI.
+import { previewSaveMode } from '../ephemeral-preview';
+
+describe('previewSaveMode', () => {
+  it('offers nothing without a preview', () => {
+    expect(previewSaveMode(null, true)).toBe('none');
+    expect(previewSaveMode(undefined, true)).toBe('none');
+  });
+
+  it('snapshots a complete chat preview', () => {
+    expect(previewSaveMode({ featureCount: 240 }, true)).toBe('snapshot');
+  });
+
+  it('refuses to snapshot a server-truncated preview (#674/#1076)', () => {
+    expect(previewSaveMode({ featureCount: 500, truncated: true }, true)).toBe('truncated');
+  });
+
+  // The analysis handoff re-runs the operation server-side and materializes the
+  // complete result — the capped PREVIEW says nothing about what it would save,
+  // so #675's path must survive the guard added for the snapshot path.
+  it('keeps the #675 analysis handoff on a truncated preview', () => {
+    expect(
+      previewSaveMode(
+        { featureCount: 500, truncated: true, analysis: { operation: 'buffer', layerId: 'l1' } },
+        true,
+      ),
+    ).toBe('analysis');
+  });
+
+  it('keeps the analysis handoff for a caller who cannot upload', () => {
+    // Materializing an analysis is a different endpoint with its own gate;
+    // #1241 must not narrow a path it did not add.
+    expect(
+      previewSaveMode({ featureCount: 12, analysis: { operation: 'centroid' } }, false),
+    ).toBe('analysis');
+  });
+
+  it('offers no snapshot without the upload capability', () => {
+    expect(previewSaveMode({ featureCount: 240 }, false)).toBe('none');
+    // Not even the disabled/explained state — the affordance is not theirs.
+    expect(previewSaveMode({ featureCount: 500, truncated: true }, false)).toBe('none');
+  });
+
+  it('offers no snapshot of an empty result', () => {
+    expect(previewSaveMode({ featureCount: 0 }, true)).toBe('none');
+  });
+});

--- a/frontend/src/components/builder/ephemeral-preview.ts
+++ b/frontend/src/components/builder/ephemeral-preview.ts
@@ -46,6 +46,9 @@ export interface PreviewSaveInput {
   truncated?: boolean;
   /** How many features the client actually holds. */
   featureCount: number;
+  /** fix(#793 review): the producer that stamped this preview, when it was not
+   *  the chat (today only 'analysis-panel'). */
+  source?: string;
 }
 
 /**
@@ -60,18 +63,26 @@ export interface PreviewSaveInput {
  * nothing about what it would save; blocking it there would remove a working
  * path for no reason.
  *
- * `canUpload` gates the snapshot path only, for the same reason: it is the one
- * that needs the caller's own `upload` capability (POST /ingest/*).
+ * `canSaveDataset` gates the snapshot path only, for the same reason: it is the
+ * one that turns client-held data into a dataset (POST /ingest/*).
  */
 export function previewSaveMode(
   result: PreviewSaveInput | null | undefined,
-  canUpload: boolean,
+  canSaveDataset: boolean,
 ): PreviewSaveMode {
   if (!result) return 'none';
   if (result.analysis) return 'analysis';
+  // feat(#1241 codex r2): only a preview the CHAT produced is snapshottable.
+  // A stamped source means another surface drew this overlay and owns its own
+  // save (the Analysis panel's Create dataset, which materializes the whole
+  // operation server-side); its preview is also bbox-scoped, so snapshotting
+  // it would persist whatever the map happened to be looking at as the result.
+  // Allowlist rather than blocklist, so a future producer is excluded by
+  // default instead of silently inheriting this path.
+  if (result.source) return 'none';
   // A snapshot of nothing is not a dataset — an empty result offers no save
   // (and would only earn a 422 from the ingest preview if it did).
-  if (!canUpload || result.featureCount < 1) return 'none';
+  if (!canSaveDataset || result.featureCount < 1) return 'none';
   return result.truncated ? 'truncated' : 'snapshot';
 }
 

--- a/frontend/src/components/builder/ephemeral-preview.ts
+++ b/frontend/src/components/builder/ephemeral-preview.ts
@@ -21,6 +21,61 @@ export interface EphemeralCountInput {
 }
 
 /**
+ * feat(#1241): why the preview's "Save as dataset…" affordance is disabled.
+ * A closed union rather than a free string so the copy stays in the component
+ * (and therefore in all four locales) instead of at each call site.
+ */
+export type PreviewSaveDisabledReason = 'truncated';
+
+/** What "Save as dataset…" does for the preview currently on screen. */
+export type PreviewSaveMode =
+  /** feat(#675): hand off to the Analysis panel, which re-runs the operation
+   *  server-side. */
+  | 'analysis'
+  /** feat(#1241): snapshot the client's FeatureCollection through ingest. */
+  | 'snapshot'
+  /** feat(#1241): offered but not actionable — see `previewSaveMode`. */
+  | 'truncated'
+  /** Nothing to offer. */
+  | 'none';
+
+export interface PreviewSaveInput {
+  /** feat(#675): set when an Analysis operation is behind this preview. */
+  analysis?: unknown;
+  /** Whether the server capped the result. */
+  truncated?: boolean;
+  /** How many features the client actually holds. */
+  featureCount: number;
+}
+
+/**
+ * feat(#1241): decide what the preview surfaces offer for "Save as dataset…".
+ *
+ * The truncation guard applies to the SNAPSHOT path only, and deliberately so:
+ * a snapshot persists the client's copy, so saving a capped one would file
+ * "first N of M" in the catalog as if it were the whole answer — the
+ * misrepresentation #674/#1076 closed on the count label, through a door that
+ * outlives the session. The #675 analysis handoff re-runs the operation
+ * server-side and materializes the complete result, so a capped PREVIEW says
+ * nothing about what it would save; blocking it there would remove a working
+ * path for no reason.
+ *
+ * `canUpload` gates the snapshot path only, for the same reason: it is the one
+ * that needs the caller's own `upload` capability (POST /ingest/*).
+ */
+export function previewSaveMode(
+  result: PreviewSaveInput | null | undefined,
+  canUpload: boolean,
+): PreviewSaveMode {
+  if (!result) return 'none';
+  if (result.analysis) return 'analysis';
+  // A snapshot of nothing is not a dataset — an empty result offers no save
+  // (and would only earn a 422 from the ingest preview if it did).
+  if (!canUpload || result.featureCount < 1) return 'none';
+  return result.truncated ? 'truncated' : 'snapshot';
+}
+
+/**
  * The preview's "how many features?" sentence.
  *
  * fix(#1076): three cases, not two. A clip filters rows, so the server cannot

--- a/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
+++ b/frontend/src/components/builder/hooks/use-ephemeral-layers.ts
@@ -41,6 +41,13 @@ export function useEphemeralLayers(
     /** feat(#675): present when the overlay came from a chat run_analysis
      *  preview the builder can hand off to the Analysis panel. */
     analysis?: EphemeralAnalysisHandoff;
+    /** feat(#1241): the chat prompt that produced this preview. The builder
+     *  uses it to suggest a title when the preview is saved as a dataset —
+     *  the same "a handoff lands on the save form with a title already in it"
+     *  pattern AnalysisPanel's prefill uses. Absent for Analysis-panel
+     *  previews (they carry `analysis` instead) and for the cold-load
+     *  handoff, which stashes geometry only. */
+    prompt?: string;
     /** fix(#793 review): stamped by the Analysis panel's own previews so
      *  its stale-restore cleanup can tell them from a chat result sharing
      *  this slot — it must never clear an overlay someone else drew. */
@@ -165,6 +172,7 @@ export function useEphemeralLayers(
       totalCount?: number;
       viewportScoped?: boolean;
       analysis?: EphemeralAnalysisHandoff;
+      prompt?: string;
       source?: 'analysis-panel';
     },
   ) => {

--- a/frontend/src/components/dataset/DatasetChatPanel.tsx
+++ b/frontend/src/components/dataset/DatasetChatPanel.tsx
@@ -10,6 +10,7 @@ import { useCreateMap } from '@/hooks/use-maps';
 import { useAIAvailability } from '@/hooks/use-ai-availability';
 import { QueryResultTable, type QueryResult } from '@/components/viewer/ViewerChatPanel';
 import { stashChatResult, toChatResultHandoff, type ChatResultHandoff } from '@/lib/chat-result-handoff';
+import { chatOverlayCompleteness, overlayFeatureCount } from '@/lib/chat-result-completeness';
 import { cn } from '@/lib/utils';
 import type { ChatAction, ChatHistoryMessage } from '@/types/api';
 
@@ -141,7 +142,19 @@ export function DatasetChatPanel({ datasetId, datasetTitle, showOpenInBuilder, o
                 // same accepted action, so "Open in builder" never carries
                 // geometry from an earlier result than the table shown (#533).
                 queryResult = qr;
-                spatialResult = toChatResultHandoff(action.geojson, action.bbox) ?? undefined;
+                // feat(#1241 codex r1): carry the completeness pair and the
+                // question with the geometry. The builder can now save a
+                // carried result as a dataset, so a handoff that arrives
+                // without them looks like a complete answer to every guard on
+                // the other side.
+                const carried = toChatResultHandoff(action.geojson, action.bbox);
+                spatialResult = carried
+                  ? {
+                      ...carried,
+                      ...chatOverlayCompleteness(action, overlayFeatureCount(carried.geojson)),
+                      prompt: userMsg,
+                    }
+                  : undefined;
               }
             }
           }

--- a/frontend/src/components/dataset/__tests__/DatasetChatPanel.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetChatPanel.test.tsx
@@ -102,7 +102,15 @@ describe('DatasetChatPanel', () => {
 
   it('carries a spatial query result into the builder via sessionStorage', async () => {
     setAvailable(true);
-    const geojson = { type: 'FeatureCollection', features: [] };
+    // feat(#1241 codex r1): one feature for one matched row — the overlay is
+    // complete, so nothing about truncation rides along. The server never
+    // emits an empty FeatureCollection (_extract_geojson returns None when no
+    // row is mappable), so a features:[] fixture would exercise a state that
+    // cannot reach this code and would now read as a clipped result.
+    const geojson = {
+      type: 'FeatureCollection',
+      features: [{ type: 'Feature', geometry: { type: 'Point', coordinates: [-73.9, 40.8] }, properties: {} }],
+    };
     const bbox = [-74.5, 40.4, -73.4, 41.1];
     mockStream.mockImplementation(async function* () {
       yield {
@@ -133,7 +141,62 @@ describe('DatasetChatPanel', () => {
     await userEvent.click(screen.getByRole('button', { name: /Open in builder/i }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/maps/map-9?add_dataset=ds-1&chat_result=1');
-    expect(JSON.parse(sessionStorage.getItem('geolens-chat-result')!)).toEqual({ geojson, bbox });
+    // feat(#1241): the prompt rides along so the builder can suggest a name if
+    // the carried result is saved as a dataset.
+    expect(JSON.parse(sessionStorage.getItem('geolens-chat-result')!)).toEqual({
+      geojson,
+      bbox,
+      prompt: 'largest park',
+    });
+  });
+
+  // feat(#1241 codex r1): the builder can now SAVE a carried result, so the
+  // handoff must say whether it is the whole answer. Geometry alone let a
+  // clipped result arrive looking complete.
+  it('carries the completeness pair when the overlay is clipped', async () => {
+    setAvailable(true);
+    const geojson = {
+      type: 'FeatureCollection',
+      features: [{ type: 'Feature', geometry: { type: 'Point', coordinates: [-73.9, 40.8] }, properties: {} }],
+    };
+    const bbox = [-74.5, 40.4, -73.4, 41.1];
+    mockStream.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            {
+              type: 'show_query_result',
+              rows: [['Central Park', 843]],
+              columns: ['name', 'acres'],
+              // 300 matched rows behind a 1-feature overlay, and `truncated`
+              // absent — the server's overlay budget, not the SQL row cap.
+              row_count: 300,
+              geojson,
+              bbox,
+            },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Found 300 results.' } };
+    });
+    mockMutateAsync.mockResolvedValue({ id: 'map-9' });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'Ask AI' }));
+    await userEvent.type(screen.getByPlaceholderText('Ask about this data...'), 'all parks');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await screen.findByText('Found 300 results.');
+    await userEvent.click(screen.getByRole('button', { name: /Open in builder/i }));
+
+    expect(JSON.parse(sessionStorage.getItem('geolens-chat-result')!)).toEqual({
+      geojson,
+      bbox,
+      truncated: true,
+      totalCount: 300,
+      prompt: 'all parks',
+    });
   });
 
   it('does not carry a stale spatial payload when a later table result has none (#533)', async () => {

--- a/frontend/src/components/viewer/ViewerChatPanel.tsx
+++ b/frontend/src/components/viewer/ViewerChatPanel.tsx
@@ -9,6 +9,7 @@ import { useAIAvailability } from '@/hooks/use-ai-availability';
 import { useEphemeralLayers } from '@/components/builder/hooks/use-ephemeral-layers';
 import { EphemeralBadge } from '@/components/builder/EphemeralBadge';
 import { cn } from '@/lib/utils';
+import { chatOverlayCompleteness, overlayFeatureCount } from '@/lib/chat-result-completeness';
 import type { ChatAction, ChatHistoryMessage, MapLayerResponse } from '@/types/api';
 
 const prefersReducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false;
@@ -176,13 +177,19 @@ export function ViewerChatPanel({ mapId, layers, mapInstanceRef }: ViewerChatPan
         //
         // The producer half is #1071; until it lands this branch is correct and
         // simply not yet reachable for a clip.
-        const total = typeof action.row_count === 'number' ? action.row_count : undefined;
+        //
+        // feat(#1241 codex r1): `truncated` is the SQL row cap, not a statement
+        // about the overlay — the server clips the FeatureCollection to its own
+        // render budget after it, so a 300-row answer arrives as 50 features
+        // with the flag false. chatOverlayCompleteness catches that too. The
+        // builder needs it for the save guard; this surface needs it for the
+        // same reason it needed #674: the badge must not call a clipped
+        // overlay complete.
+        const preview = geojson as GeoJSON.FeatureCollection;
         handleQueryResult(
-          geojson as GeoJSON.FeatureCollection,
+          preview,
           [minX, minY, maxX, maxY],
-          action.truncated === true
-            ? { truncated: true, ...(total != null ? { totalCount: total } : {}) }
-            : undefined,
+          chatOverlayCompleteness(action, overlayFeatureCount(preview)),
         );
       }
     }

--- a/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerChatPanel.test.tsx
@@ -23,6 +23,12 @@ function setAvailable(available: boolean) {
   mockAvailability.mockReturnValue({ isAIAvailable: available } as ReturnType<typeof useAIAvailability>);
 }
 
+/** One overlay feature. feat(#1241 codex r1): overlay completeness is judged
+ *  against row_count, so a fixture's feature COUNT is now load-bearing. */
+function feature() {
+  return { type: 'Feature', geometry: { type: 'Point', coordinates: [-73.9, 40.8] }, properties: {} };
+}
+
 function renderPanel() {
   const mapInstanceRef = { current: null };
   return render(
@@ -100,7 +106,7 @@ describe('ViewerChatPanel', () => {
           actions: [
             {
               type: 'show_query_result',
-              geojson: { type: 'FeatureCollection', features: [] },
+              geojson: { type: 'FeatureCollection', features: [feature()] },
               bbox: [-1, -1, 1, 1],
               rows: [['Alpha', 10]],
               columns: ['name', 'count'],
@@ -119,9 +125,9 @@ describe('ViewerChatPanel', () => {
 
     await screen.findByText('Found 1 result.');
     expect(handleQueryResult).toHaveBeenCalledWith(
-      { type: 'FeatureCollection', features: [] },
+      { type: 'FeatureCollection', features: [feature()] },
       [-1, -1, 1, 1],
-      undefined,
+      {},
     );
     expect(screen.getByText('Alpha')).toBeInTheDocument();
     expect(screen.getByText('1 row')).toBeInTheDocument();
@@ -165,6 +171,10 @@ describe('ViewerChatPanel', () => {
     );
   });
 
+  // feat(#1241 codex r1): one feature per matched row is what "uncapped" means.
+  // The server never emits an empty FeatureCollection (_extract_geojson returns
+  // None when no row is mappable), so features:[] with row_count: 12 described
+  // an impossible state that now reads, correctly, as a clipped overlay.
   it('forwards no truncation for an uncapped result', async () => {
     setAvailable(true);
     mockStream.mockImplementation(async function* () {
@@ -174,9 +184,9 @@ describe('ViewerChatPanel', () => {
           actions: [
             {
               type: 'show_query_result',
-              geojson: { type: 'FeatureCollection', features: [] },
+              geojson: { type: 'FeatureCollection', features: [feature()] },
               bbox: [-1, -1, 1, 1],
-              row_count: 12,
+              row_count: 1,
             },
           ],
         },
@@ -194,9 +204,48 @@ describe('ViewerChatPanel', () => {
 
     await screen.findByText('Clipped.');
     expect(handleQueryResult).toHaveBeenCalledWith(
-      { type: 'FeatureCollection', features: [] },
+      { type: 'FeatureCollection', features: [feature()] },
       [-1, -1, 1, 1],
-      undefined,
+      {},
+    );
+  });
+
+  // The embed/shared-link surface must disclose a clipped overlay even when the
+  // SQL row cap never bit: the server slices the FeatureCollection to its own
+  // render budget afterwards, so `truncated: false` says nothing about it.
+  it('discloses an overlay clipped below row_count even with truncated false', async () => {
+    setAvailable(true);
+    mockStream.mockImplementation(async function* () {
+      yield {
+        event: 'actions',
+        data: {
+          actions: [
+            {
+              type: 'show_query_result',
+              geojson: { type: 'FeatureCollection', features: [feature()] },
+              bbox: [-1, -1, 1, 1],
+              truncated: false,
+              row_count: 300,
+            },
+          ],
+        },
+      };
+      yield { event: 'done', data: { explanation: 'Found 300.' } };
+    });
+
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: 'Ask AI' }));
+    await userEvent.type(
+      screen.getByPlaceholderText('Ask about this map...'),
+      'show me every park',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await screen.findByText('Found 300.');
+    expect(handleQueryResult).toHaveBeenCalledWith(
+      { type: 'FeatureCollection', features: [feature()] },
+      [-1, -1, 1, 1],
+      { truncated: true, totalCount: 300 },
     );
   });
 

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -1088,7 +1088,15 @@
     "featureCountTruncatedScoped_other": "{{count, number}} von {{total, number}} Features im Vorschauausschnitt",
     "featureCountCapped_one": "erstes {{count, number}} Feature",
     "featureCountCapped_other": "erste {{count, number}} Features",
-    "saveAsDataset": "Als Datensatz speichern…"
+    "saveAsDataset": "Als Datensatz speichern…",
+    "saveTruncatedReason": "Gekürzte Vorschauen können nicht gespeichert werden – dies ist ein Teil der Antwort, nicht die ganze."
+  },
+  "savePreview": {
+    "title": "Vorschau als Datensatz speichern",
+    "description": "Speichert die Objekte der Vorschau als neuen Datensatz. Es ist eine Momentaufnahme dieser Antwort, keine Live-Abfrage – sie ändert sich nicht, wenn sich die Quelldaten ändern.",
+    "fallbackTitle": "Chat-Abfrageergebnis",
+    "started": "Import gestartet. Der Datensatz erscheint in Ihrem Katalog, sobald die Verarbeitung abgeschlossen ist.",
+    "failed": "Die Vorschau konnte nicht als Datensatz gespeichert werden."
   },
   "previewRow": {
     "ephemeralTag": "Flüchtig – nicht gespeichert"

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -1088,7 +1088,15 @@
     "featureCountCapped_one": "first {{count, number}} feature",
     "featureCountCapped_other": "first {{count, number}} features",
     "dismiss": "Dismiss result",
-    "saveAsDataset": "Save as dataset…"
+    "saveAsDataset": "Save as dataset…",
+    "saveTruncatedReason": "Capped previews can't be saved — this is part of the answer, not all of it."
+  },
+  "savePreview": {
+    "title": "Save preview as dataset",
+    "description": "Saves the previewed features as a new dataset. It is a snapshot of this answer, not a live query — it will not change when the source data does.",
+    "fallbackTitle": "Chat query result",
+    "started": "Import started. The dataset appears in your catalog once processing finishes.",
+    "failed": "Could not save the preview as a dataset."
   },
   "previewRow": {
     "ephemeralTag": "Ephemeral — not saved"

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -1088,7 +1088,15 @@
     "featureCountTruncatedScoped_other": "{{count, number}} de {{total, number}} entidades en la extensión previsualizada",
     "featureCountCapped_one": "primera {{count, number}} entidad",
     "featureCountCapped_other": "primeras {{count, number}} entidades",
-    "saveAsDataset": "Guardar como conjunto de datos…"
+    "saveAsDataset": "Guardar como conjunto de datos…",
+    "saveTruncatedReason": "Las vistas previas recortadas no se pueden guardar: esto es una parte de la respuesta, no toda."
+  },
+  "savePreview": {
+    "title": "Guardar la vista previa como conjunto de datos",
+    "description": "Guarda las entidades de la vista previa como un nuevo conjunto de datos. Es una instantánea de esta respuesta, no una consulta en vivo: no cambiará cuando cambien los datos de origen.",
+    "fallbackTitle": "Resultado de consulta del chat",
+    "started": "Importación iniciada. El conjunto de datos aparecerá en tu catálogo cuando termine el procesamiento.",
+    "failed": "No se pudo guardar la vista previa como conjunto de datos."
   },
   "previewRow": {
     "ephemeralTag": "Efímero: sin guardar"

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -1088,7 +1088,15 @@
     "featureCountTruncatedScoped_other": "{{count, number}} sur {{total, number}} entités dans l'étendue prévisualisée",
     "featureCountCapped_one": "{{count, number}} première entité",
     "featureCountCapped_other": "{{count, number}} premières entités",
-    "saveAsDataset": "Enregistrer comme jeu de données…"
+    "saveAsDataset": "Enregistrer comme jeu de données…",
+    "saveTruncatedReason": "Les aperçus tronqués ne peuvent pas être enregistrés : ceci est une partie de la réponse, pas la totalité."
+  },
+  "savePreview": {
+    "title": "Enregistrer l'aperçu comme jeu de données",
+    "description": "Enregistre les entités de l'aperçu dans un nouveau jeu de données. C'est un instantané de cette réponse, pas une requête en direct : il ne changera pas lorsque les données source changeront.",
+    "fallbackTitle": "Résultat de requête du chat",
+    "started": "Import lancé. Le jeu de données apparaîtra dans votre catalogue une fois le traitement terminé.",
+    "failed": "Impossible d'enregistrer l'aperçu comme jeu de données."
   },
   "previewRow": {
     "ephemeralTag": "Éphémère — non enregistré"

--- a/frontend/src/lib/__tests__/chat-result-completeness.test.ts
+++ b/frontend/src/lib/__tests__/chat-result-completeness.test.ts
@@ -1,0 +1,71 @@
+// feat(#1241 codex r1): the overlay-completeness rule, in one place.
+//
+// The defect this exists for: `truncated` is the SQL sandbox's row-cap flag.
+// backend/app/processing/ai/chat_actions.py slices the FeatureCollection to a
+// 50-row overlay budget AFTER the sandbox returns (which runs at its 1000-row
+// default when the model selected geometry itself), so a 300-row answer
+// arrives as 50 features with truncated=false. Every consumer that read the
+// flag alone believed that preview was complete.
+import { chatOverlayCompleteness, overlayFeatureCount } from '../chat-result-completeness';
+
+describe('chatOverlayCompleteness', () => {
+  it('says nothing about a complete overlay', () => {
+    expect(chatOverlayCompleteness({ row_count: 12 }, 12)).toEqual({});
+    expect(chatOverlayCompleteness({}, 12)).toEqual({});
+    expect(chatOverlayCompleteness({ truncated: false, row_count: 3 }, 3)).toEqual({});
+  });
+
+  // The case the flag misses: nothing was truncated by the SQL cap, but the
+  // overlay still holds a fraction of the answer.
+  it('reports a clipped overlay the truncated flag never mentions', () => {
+    expect(chatOverlayCompleteness({ truncated: false, row_count: 300 }, 50)).toEqual({
+      truncated: true,
+      totalCount: 300,
+    });
+  });
+
+  it('keeps the server-reported cap and its total', () => {
+    expect(chatOverlayCompleteness({ truncated: true, row_count: 10651 }, 500)).toEqual({
+      truncated: true,
+      totalCount: 10651,
+    });
+  });
+
+  // fix(#1076): a clip filters rows, so no source total is reported. The flag
+  // must survive without one.
+  it('keeps a cap that arrives without a total', () => {
+    expect(chatOverlayCompleteness({ truncated: true }, 500)).toEqual({ truncated: true });
+  });
+
+  it('ignores a non-numeric row_count instead of inventing a total', () => {
+    expect(chatOverlayCompleteness({ row_count: 'lots' }, 50)).toEqual({});
+    expect(chatOverlayCompleteness({ truncated: true, row_count: null }, 50)).toEqual({
+      truncated: true,
+    });
+  });
+
+  // Not a bug: more features than rows cannot mean "incomplete". (A geometry
+  // collection exploded into parts, say.)
+  it('does not call an overlay clipped when it holds more than the row count', () => {
+    expect(chatOverlayCompleteness({ row_count: 3 }, 7)).toEqual({});
+  });
+});
+
+describe('overlayFeatureCount', () => {
+  it('counts the features', () => {
+    expect(
+      overlayFeatureCount({
+        type: 'FeatureCollection',
+        features: [
+          { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} },
+        ],
+      }),
+    ).toBe(1);
+  });
+
+  it('treats a payload with no features array as holding nothing', () => {
+    // Wire data, not a trusted type: a malformed collection must count as
+    // zero rather than throw inside the dispatch path.
+    expect(overlayFeatureCount({ type: 'FeatureCollection' } as GeoJSON.FeatureCollection)).toBe(0);
+  });
+});

--- a/frontend/src/lib/__tests__/chat-result-handoff.test.ts
+++ b/frontend/src/lib/__tests__/chat-result-handoff.test.ts
@@ -45,6 +45,32 @@ describe('stashChatResult / takeChatResult', () => {
     expect(sessionStorage.getItem('geolens-chat-result')).toBeNull();
   });
 
+  // feat(#1241 codex r1): the builder can save a carried result as a dataset,
+  // so the stash has to say whether it is the whole answer. Geometry alone
+  // arrived on the other side looking complete.
+  it('round-trips the completeness pair and the prompt', () => {
+    expect(
+      stashChatResult({ geojson: fc, bbox, truncated: true, totalCount: 300, prompt: 'all parks' }),
+    ).toBe(true);
+    expect(takeChatResult()).toEqual({
+      geojson: fc,
+      bbox,
+      truncated: true,
+      totalCount: 300,
+      prompt: 'all parks',
+    });
+  });
+
+  it('drops fields of the wrong type instead of trusting the stash', () => {
+    sessionStorage.setItem(
+      'geolens-chat-result',
+      JSON.stringify({ geojson: fc, bbox, truncated: 'yes', totalCount: 'lots', prompt: 42 }),
+    );
+    // A truthy-but-not-true `truncated` must not become a disclosure, and a
+    // non-numeric total must not reach a count label as "N of lots".
+    expect(takeChatResult()).toEqual({ geojson: fc, bbox });
+  });
+
   it('returns false when storage write throws (quota/private mode)', () => {
     // jsdom's Storage proxy turns method assignment into a stored item, so
     // spyOn can't replace setItem — stub the whole global instead.

--- a/frontend/src/lib/chat-result-completeness.ts
+++ b/frontend/src/lib/chat-result-completeness.ts
@@ -1,0 +1,43 @@
+/**
+ * feat(#1241 codex r1): whether a chat overlay holds the WHOLE answer.
+ *
+ * `truncated` on a show_query_result action is the SQL sandbox's row-cap flag,
+ * and it is not a statement about the FeatureCollection. When the model selects
+ * geometry itself, `backend/app/processing/ai/chat_actions.py` executes at the
+ * sandbox's default 1000-row limit and then slices the overlay to its own
+ * 50-row render budget, so a 300-row answer arrives as 50 features with
+ * `truncated: false`. Read that flag alone and a clipped preview looks
+ * complete: the count label says "50 features" (the #674/#1076
+ * misrepresentation, reached through a producer those fixes did not cover) and
+ * a snapshot save would file 50 of 300 rows in the catalog as the answer.
+ *
+ * The client can tell without any server change. `row_count` is the matched-row
+ * total the model narrates, so an overlay carrying fewer features than that is
+ * clipped, whoever clipped it. A row whose geometry is null counts as clipped
+ * too, which is deliberate: this errs toward disclosure, and disclosure is the
+ * direction that cannot mislead.
+ */
+
+/** The truncation pair every preview surface consumes (see ephemeral-preview). */
+export interface ChatOverlayCompleteness {
+  truncated?: true;
+  totalCount?: number;
+}
+
+export function chatOverlayCompleteness(
+  action: { truncated?: unknown; row_count?: unknown },
+  featureCount: number,
+): ChatOverlayCompleteness {
+  const total = typeof action.row_count === 'number' ? action.row_count : undefined;
+  const clipped = action.truncated === true || (total != null && featureCount < total);
+  if (!clipped) return {};
+  // fix(#1076): the flag does not wait for the total. A clip filters rows, so
+  // the server reports no source total for it; the surface picks its wording
+  // from whether one arrived.
+  return { truncated: true, ...(total != null ? { totalCount: total } : {}) };
+}
+
+/** Features in a payload the caller has already shaped as a FeatureCollection. */
+export function overlayFeatureCount(geojson: GeoJSON.FeatureCollection): number {
+  return Array.isArray(geojson.features) ? geojson.features.length : 0;
+}

--- a/frontend/src/lib/chat-result-handoff.ts
+++ b/frontend/src/lib/chat-result-handoff.ts
@@ -17,6 +17,15 @@
 export interface ChatResultHandoff {
   geojson: GeoJSON.FeatureCollection;
   bbox: [number, number, number, number];
+  /** feat(#1241 codex r1): whether the overlay holds the whole answer, and of
+   *  how many. Geometry alone was enough while the builder could only draw and
+   *  dismiss a carried result; now it can also be saved as a dataset, and a
+   *  handoff that drops the completeness pair arrives looking complete. */
+  truncated?: true;
+  totalCount?: number;
+  /** feat(#1241): the question this result answers, so the builder can suggest
+   *  a name for it. Absent handoffs fall back to a generic title. */
+  prompt?: string;
 }
 
 const KEY = 'geolens-chat-result';
@@ -25,6 +34,10 @@ const KEY = 'geolens-chat-result';
  * Validate a show_query_result-style geojson/bbox pair. Mirrors
  * ViewerChatPanel's flyover guard: finite, WGS84-bounded, non-inverted bbox
  * (fix(#527 B-054/C-06) — NaN/inverted bounds throw in fitBounds).
+ *
+ * Geometry only: the completeness pair and the prompt are added by the caller
+ * that has them, so this stays the one place that decides whether a payload is
+ * drawable at all.
  */
 export function toChatResultHandoff(geojson: unknown, bbox: unknown): ChatResultHandoff | null {
   if (
@@ -63,8 +76,24 @@ export function takeChatResult(): ChatResultHandoff | null {
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object') return null;
-    const { geojson, bbox } = parsed as { geojson?: unknown; bbox?: unknown };
-    return toChatResultHandoff(geojson, bbox);
+    const { geojson, bbox, truncated, totalCount, prompt } = parsed as {
+      geojson?: unknown;
+      bbox?: unknown;
+      truncated?: unknown;
+      totalCount?: unknown;
+      prompt?: unknown;
+    };
+    const carried = toChatResultHandoff(geojson, bbox);
+    if (!carried) return null;
+    // The stash is same-session and self-written, but it is still parsed
+    // input: type-check each field rather than trust it, so a malformed entry
+    // cannot hand the builder a bogus total (or a truthy non-true `truncated`).
+    return {
+      ...carried,
+      ...(truncated === true ? { truncated: true as const } : {}),
+      ...(typeof totalCount === 'number' && Number.isFinite(totalCount) ? { totalCount } : {}),
+      ...(typeof prompt === 'string' ? { prompt } : {}),
+    };
   } catch {
     return null;
   }

--- a/frontend/src/lib/text.ts
+++ b/frontend/src/lib/text.ts
@@ -7,7 +7,7 @@ type SegmenterConstructor = new (
   options?: { granularity: 'grapheme' },
 ) => GraphemeSegmenter;
 
-function splitGraphemes(value: string): string[] {
+export function splitGraphemes(value: string): string[] {
   const Segmenter = (Intl as typeof Intl & { Segmenter?: SegmenterConstructor }).Segmenter;
   if (!Segmenter) return Array.from(value);
 

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -145,12 +145,21 @@ export function MapBuilderPage() {
 
   const { isAIAvailable: aiAvailable } = useAIAvailability();
   // feat(#1241): saving a chat preview creates a dataset through POST
-  // /ingest/*, which needs the caller's own `upload` capability — the map's
-  // edit rights say nothing about it. can() is false while the query is in
-  // flight, which is the safe way round: the affordance appears once the
-  // capability is known rather than 403ing after the user has named a dataset.
+  // /ingest/*, which needs the caller's own `upload` capability. The map's edit
+  // rights say nothing about it. can() is false while the query is in flight,
+  // which is the safe way round: the affordance appears once the capability is
+  // known rather than 403ing after the user has named a dataset.
+  //
+  // feat(#1241 codex r2): `export` as well. The snapshot hands the caller a
+  // durable, caller-owned copy of source attributes they may only be able to
+  // READ, which is exactly why analysis materialize requires both (fix(#692),
+  // `require_permission("upload", "export")` in
+  // backend/app/modules/catalog/datasets/api/router_analysis.py). The ingest
+  // endpoints ask only for `upload` because their file normally comes from the
+  // caller's own machine; this one's does not, so the client must not offer a
+  // path around that boundary under a customized role matrix.
   const { can } = usePermissions();
-  const canUpload = can('upload');
+  const canSaveDataset = can('upload') && can('export');
   useDocumentTitle(mapData?.name ?? t('common:pageTitle.mapBuilder'));
 
   // Three-column layout: isRail (sidebar→64px at <1100px), isEditorHidden (flyout hidden at <800px)
@@ -992,7 +1001,7 @@ export function MapBuilderPage() {
     const featureCount = result.geojson.features.length;
     // feat(#1241): which save (if any) this preview earns — the truncation
     // guard and the upload-capability gate both live in previewSaveMode.
-    const saveMode = previewSaveMode({ ...result, featureCount }, canUpload);
+    const saveMode = previewSaveMode({ ...result, featureCount }, canSaveDataset);
     return {
       featureCount,
       truncated: result.truncated,
@@ -1007,7 +1016,7 @@ export function MapBuilderPage() {
           : undefined,
       saveDisabledReason: saveMode === 'truncated' ? ('truncated' as const) : undefined,
     };
-  }, [layers.ephemeralResult, layers.handleDismissEphemeral, canUpload, handleSaveAnalysisPreview, handleSaveChatPreview]);
+  }, [layers.ephemeralResult, layers.handleDismissEphemeral, canSaveDataset, handleSaveAnalysisPreview, handleSaveChatPreview]);
 
   // ux(#772): stack-row kebab "Analyze this layer" — the same handoff path the
   // chat preview uses, so the panel opens (or remounts, via the prefill nonce

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -59,6 +59,12 @@ import { clearPersistedFolderGroup, getParentGroupId, resolveDropGroupMembership
 import { SidebarRail } from '@/components/builder/SidebarRail';
 import { LayerEditorPanel, type LayerEditorHandlers } from '@/components/builder/LayerEditorPanel';
 import { EphemeralBadge } from '@/components/builder/EphemeralBadge';
+import { previewSaveMode } from '@/components/builder/ephemeral-preview';
+// feat(#1241): only mounted while the save dialog is open, and it pulls in the
+// import page's metadata form — lazy so the builder's initial chunk is unchanged.
+const SaveChatPreviewDialog = lazy(() =>
+  import('@/components/builder/SaveChatPreviewDialog').then((m) => ({ default: m.SaveChatPreviewDialog }))
+);
 import { MapToolbar } from '@/components/builder/MapToolbar';
 import { MapTitleBar } from '@/components/builder/MapTitleBar';
 import { BuilderRail, type RailPanel } from '@/components/builder/BuilderRail';
@@ -79,6 +85,7 @@ import { MapErrorBoundary, PanelErrorBoundary } from '@/components/error';
 import { LazyLoadErrorBoundary } from '@/components/error/LazyLoadErrorBoundary';
 import { useMap, useAddLayer, useRemoveLayer } from '@/hooks/use-maps';
 import { useAIAvailability } from '@/hooks/use-ai-availability';
+import { usePermissions } from '@/hooks/use-permissions';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 import { useEnabledPlugins } from '@/hooks/use-settings';
 import { useBuilderLayout } from '@/components/builder/hooks/use-builder-layout';
@@ -137,6 +144,13 @@ export function MapBuilderPage() {
   const removeLayer = useRemoveLayer();
 
   const { isAIAvailable: aiAvailable } = useAIAvailability();
+  // feat(#1241): saving a chat preview creates a dataset through POST
+  // /ingest/*, which needs the caller's own `upload` capability — the map's
+  // edit rights say nothing about it. can() is false while the query is in
+  // flight, which is the safe way round: the affordance appears once the
+  // capability is known rather than 403ing after the user has named a dataset.
+  const { can } = usePermissions();
+  const canUpload = can('upload');
   useDocumentTitle(mapData?.name ?? t('common:pageTitle.mapBuilder'));
 
   // Three-column layout: isRail (sidebar→64px at <1100px), isEditorHidden (flyout hidden at <800px)
@@ -944,21 +958,46 @@ export function MapBuilderPage() {
     setRailPanel('analysis');
   }, [ephemeralAnalysis]);
 
+  // feat(#1241): the same affordance for a preview with no analysis behind it —
+  // a plain chat query result, which until now could only be dismissed. The
+  // draft snapshots the FeatureCollection at the moment the dialog opens, so a
+  // new chat turn (or a dismiss) landing mid-dialog can't swap what gets saved
+  // out from under the name the user is typing.
+  const [chatSaveDraft, setChatSaveDraft] = useState<{
+    geojson: GeoJSON.FeatureCollection;
+    prompt?: string;
+  } | null>(null);
+  const ephemeralResult = layers.ephemeralResult;
+  const handleSaveChatPreview = useCallback(() => {
+    if (!ephemeralResult) return;
+    setChatSaveDraft({ geojson: ephemeralResult.geojson, prompt: ephemeralResult.prompt });
+  }, [ephemeralResult]);
+
   // fix(#1009): the preview's stack-row props. Memoized because a fresh object
   // literal on the UnifiedStackPanel prop would defeat its memo() on every
   // render of this (very large) page.
   const previewRowProps = useMemo(() => {
     const result = layers.ephemeralResult;
     if (!result) return null;
+    const featureCount = result.geojson.features.length;
+    // feat(#1241): which save (if any) this preview earns — the truncation
+    // guard and the upload-capability gate both live in previewSaveMode.
+    const saveMode = previewSaveMode({ ...result, featureCount }, canUpload);
     return {
-      featureCount: result.geojson.features.length,
+      featureCount,
       truncated: result.truncated,
       totalCount: result.totalCount,
       viewportScoped: result.viewportScoped,
       onDismiss: layers.handleDismissEphemeral,
-      onSaveAsDataset: ephemeralAnalysis ? handleSaveAnalysisPreview : undefined,
+      onSaveAsDataset:
+        saveMode === 'analysis'
+          ? handleSaveAnalysisPreview
+          : saveMode === 'snapshot'
+          ? handleSaveChatPreview
+          : undefined,
+      saveDisabledReason: saveMode === 'truncated' ? ('truncated' as const) : undefined,
     };
-  }, [layers.ephemeralResult, layers.handleDismissEphemeral, ephemeralAnalysis, handleSaveAnalysisPreview]);
+  }, [layers.ephemeralResult, layers.handleDismissEphemeral, canUpload, handleSaveAnalysisPreview, handleSaveChatPreview]);
 
   // ux(#772): stack-row kebab "Analyze this layer" — the same handoff path the
   // chat preview uses, so the panel opens (or remounts, via the prefill nonce
@@ -2098,6 +2137,7 @@ export function MapBuilderPage() {
               totalCount={previewRowProps.totalCount}
               viewportScoped={previewRowProps.viewportScoped}
               onSaveAsDataset={previewRowProps.onSaveAsDataset}
+              saveDisabledReason={previewRowProps.saveDisabledReason}
             />
           )}
 
@@ -2269,6 +2309,23 @@ export function MapBuilderPage() {
               mapName={layers.localName}
               open={showStyleJson}
               onOpenChange={setShowStyleJson}
+            />
+          </Suspense>
+        </LazyLoadErrorBoundary>
+      )}
+
+      {/* feat(#1241): snapshot a chat query preview into a real dataset.
+          Mounted only while open, for the same reason StyleJsonDialog above is
+          — an always-mounted lazy component resolves its import on first paint
+          and the split buys nothing. */}
+      {chatSaveDraft && (
+        <LazyLoadErrorBoundary>
+          <Suspense fallback={null}>
+            <SaveChatPreviewDialog
+              open
+              onOpenChange={(open) => { if (!open) setChatSaveDraft(null); }}
+              geojson={chatSaveDraft.geojson}
+              prompt={chatSaveDraft.prompt}
             />
           </Suspense>
         </LazyLoadErrorBoundary>

--- a/frontend/src/pages/MapBuilderPage.tsx
+++ b/frontend/src/pages/MapBuilderPage.tsx
@@ -369,7 +369,17 @@ export function MapBuilderPage() {
       return prev;
     }, { replace: true });
     const result = takeChatResult();
-    if (result) handleChatQueryResult(result.geojson, result.bbox);
+    // feat(#1241 codex r1): forward everything the stash carries, not just the
+    // geometry. Without the completeness pair a clipped carried result reads as
+    // a complete one here, and the save this issue adds would persist it as the
+    // whole answer.
+    if (result) {
+      handleChatQueryResult(result.geojson, result.bbox, {
+        ...(result.truncated ? { truncated: true } : {}),
+        ...(result.totalCount != null ? { totalCount: result.totalCount } : {}),
+        ...(result.prompt ? { prompt: result.prompt } : {}),
+      });
+    }
   }, [mapInstance, searchParams, setSearchParams, handleChatQueryResult]);
 
   const pluginCtx = useMemo(


### PR DESCRIPTION
## What changed

Extends the preview row's "Save as dataset…" to plain AI-chat query previews, which previously had no persistence path (the affordance was wired only for analysis-backed previews, #675).

The result's FeatureCollection is already client-side, so this adds no API surface. Clicking the link opens a dialog that reuses the import page's `ImportMetadataForm` (name, description, visibility), and submitting wraps the collection in `new File([JSON.stringify(geojson)], "<name>.geojson")` and runs it through the existing ingest flow in `api/ingest.ts`: `uploadFile()` -> `previewFile()` -> `commitImport()`. The preview step is kept because it is where an unreadable or over-budget payload is rejected with an actionable message, before a job is queued. What lands is an ordinary dataset with no special casing downstream.

The suggested name comes from the chat prompt, which now rides along in the `onQueryResult` meta (`ChatPanel` -> `use-ephemeral-layers`), mirroring how `AnalysisPanel` prefills its save form from a chat handoff. It is handed to the form as a *file* name (`"<prompt>.geojson"`), because the form seeds its title from `stripExtension(defaultName)` and that cuts at the last dot: a prompt like "buildings over 3.5m" only survives intact this way. The file's own name is separately bounded by UTF-8 bytes, since a multibyte prompt within the grapheme cap can still blow the filesystem's 255-byte limit.

### Truncation guard

A truncated preview is not saveable. Saving the client copy would file "first N of M" in the catalog as if it were the complete answer, which is the misrepresentation #674/#1076 closed on the count label, except a dataset outlives the session. Both preview surfaces render the affordance **disabled** with the reason stated and the "N of M" count still visible, rather than dropping it silently.

Review turned up that `truncated` alone does not answer the question. It is the SQL sandbox's row-cap flag, and `chat_actions.py` slices the overlay to its own 50-row render budget *after* the sandbox returns, so a 300-row answer arrives as 50 features with the flag false. `chatOverlayCompleteness` (new, in `lib/`) compares what the client holds against `row_count` and calls anything short of it clipped, whoever clipped it. All three chat producers go through it, so the count label and the save guard cannot disagree. The dataset-chat handoff carried geometry only, so it now carries that pair and the prompt too.

The #675 analysis handoff is deliberately exempt from the guard: it re-runs the operation server-side and materializes the complete result, so a capped *preview* says nothing about what it would save. `previewSaveMode()` in `components/builder/ephemeral-preview.ts` is the single place that decides, and is unit-tested directly. It allowlists rather than blocklists: a preview with a stamped `source` (the Analysis panel's own, today) is never snapshotted, since that surface owns its own save flow and its preview is bbox-scoped.

### Permissions

The snapshot needs `upload` **and** `export`. It hands the caller a durable, caller-owned copy of source attributes they may only be able to read, which is why analysis materialize requires both (fix(#692), `router_analysis.py`); the ingest endpoints ask only for `upload` because their file normally comes from the caller's own machine.

### Retry

The commit chain has three server steps and the dialog stays open when one fails, so the staged job survives and a retry resumes from the failed step instead of re-uploading. A repeat commit is safe (the worker claims a job with one conditional UPDATE, fenced on attempt_id), and a 400 on a re-commit is reconciled against the job's actual status: only a running or complete job counts as evidence the import exists. A dead job (dispatch failure marks it `failed` and deletes its staged file) is abandoned so the next attempt starts fresh.

## Backend change

One producer fix, no new endpoint: `_safe_value` in `processing/ai/chat_geojson.py` now emits integers outside JavaScript's safe range as strings. The browser's `JSON.parse` rounds them (9007199254740993 arrives as ...992), which was always visible in the chat table and becomes permanent once a snapshot is serialized from the parsed payload. The function already stringifies `Decimal`, `UUID`, and `datetime` for the same reason. `chat_geojson.py`'s cap in `_MODULE_LOC_CAPS` is raised 350 -> 370 in the same commit.

## UI impact

- Layer stack preview row: "Save as dataset…" now appears for plain chat previews; on a truncated preview it renders disabled with a muted explanation line beneath, wired to the button via `aria-describedby` (a disabled button gets no hover or focus, so a title tooltip would reach nobody).
- Builder below 1100px (`EphemeralBadge`, the rail's preview surface): same treatment, so the two surfaces cannot drift.
- New dialog: title, snapshot disclaimer, and the import metadata form. Lazy-loaded and mounted only while open.
- Public viewer: unchanged affordances (it never passes a save handler), but its count label now discloses a clipped overlay.

Screenshots not captured from this worktree, since the dev stack serves the main checkout; the orchestrator can capture them.

## i18n

Five new `builder` keys (`savePreview.*`) plus `ephemeralBadge.saveTruncatedReason`, added to all four locales (en/es/fr/de). No plural-suffix keys.

## Verification

```
cd frontend
npm ci
npm run typecheck                     # clean
npm run lint                          # clean
npx vitest run                        # 388 files, 4834 tests passed
npm run test:i18n                     # passed
npm run check:i18n:toast-strings      # passed
npm run check:i18n:api-errors         # passed
npm run check:i18n:changed            # builder.json present in all locales
npm run test:coverage                 # passed

cd backend                            # host run, .env.test sourced
uv run ruff check / ruff format --check   # clean
uv run pytest tests/test_ephemeral_geojson.py tests/test_collect_chat_action.py \
              tests/test_ai_chat_actions_phase1135.py -q   # 102 passed
uv run pytest tests/test_layering.py -q                    # 40 passed
```

No schema, API, or config changes. No Playwright run: this worktree's dev stack serves the main checkout, so an e2e result here would not describe this branch.

Closes #1241
