### PR TITLE
fix(ops): reach tenant-ownership adoption forward-only at the head schema

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -726,8 +726,10 @@ What it does, walking `catalog.tenants` with each tenant in its own transaction:
   act as, a `SECURITY DEFINER` or untrusted-language routine in a tenant schema
   — is reported with the exact statement to run and the role to run it as, and
   that tenant is left for the next run. The automatic membership PostgreSQL
-  gives a role's creator is the one exception it tolerates rather than reports:
-  nobody can revoke it, and it confers nothing on its own.
+  gives a role's creator is tolerated only for the login running adoption. On
+  any other login it is refused — `ADMIN` alone lets that login grant itself a
+  usable edge — and the report names the remedy: `DROP ROLE` the retired
+  login, or revoke the membership as its recorded grantor.
 
 The end state is the one migration 0019 produced. Idempotence is keyed on
 database state rather than on a marker or a timestamp: a tenant already in that

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -643,9 +643,44 @@ writer/sandbox/tile SET-only shapes adoption requires. Adoption refuses a wrong
 shape rather than rewriting somebody else's grant, so leaving one here stops 2d
 before it starts. Re-issuing them is a no-op when they already match.
 
-These are the grants `.env.example` documents alongside
-`GEOLENS_RUNTIME_DB_ROLE`; substitute your own login names, and never give the
-tile login any of the first three:
+First clear every membership row the replay restored, whatever grantor it
+recorded. Re-granting on top does not rewrite a restored row — on PostgreSQL
+16+ it adds a second row under your grantor and the old default-INHERIT/SET
+row survives to make 2d refuse the topology. This block is version-aware and
+safe to run on any supported release:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+DO $$
+DECLARE m RECORD;
+BEGIN
+  FOR m IN SELECT granted.rolname AS granted_name,
+                  member.rolname AS member_name,
+                  grantor.rolname AS grantor_name
+           FROM pg_catalog.pg_auth_members AS am
+           JOIN pg_catalog.pg_roles AS granted ON granted.oid = am.roleid
+           JOIN pg_catalog.pg_roles AS member ON member.oid = am.member
+           LEFT JOIN pg_catalog.pg_roles AS grantor ON grantor.oid = am.grantor
+           WHERE granted.rolname IN ('geolens_tenant_control',
+                                     'geolens_tenant_writer',
+                                     'geolens_tenant_sandbox',
+                                     'geolens_tile_gateway')
+  LOOP
+    IF current_setting('server_version_num')::int >= 160000
+       AND m.grantor_name IS NOT NULL THEN
+      EXECUTE format('REVOKE %I FROM %I GRANTED BY %I',
+                     m.granted_name, m.member_name, m.grantor_name);
+    ELSE
+      EXECUTE format('REVOKE %I FROM %I', m.granted_name, m.member_name);
+    END IF;
+  END LOOP;
+END $$;
+SQL
+```
+
+Then issue the canonical grants — these are the ones `.env.example` documents
+alongside `GEOLENS_RUNTIME_DB_ROLE`; substitute your own login names, and
+never give the tile login any of the first three:
 
 ```bash
 docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -505,12 +505,11 @@ For managed/external Postgres there is no `db` container to exec into: drop the
 `docker compose exec -T db` prefix and pass the provider's `-h`, `-p`, and `-U`
 to `pg_dumpall`/`psql` directly.
 
-If no globals dump exists, create the five fixed NOLOGIN groups by hand. This
-must happen **before** the step 2 commands: the downgrade passes through 0024,
-whose `downgrade()` re-installs the provisioning function with
-`OWNER TO geolens_tenant_provisioner`, so it fails on a cluster where that role
-is missing. The block is idempotent; run it as the migrator (needs CREATEROLE),
-and the attributes match what 0019 creates and validates.
+If no globals dump exists, step 2 creates the five fixed NOLOGIN groups itself,
+so you can skip ahead. The equivalent by hand, for a cluster where you want them
+in place first or where step 2 refused on the existing topology — it is
+idempotent, needs CREATEROLE, and the attributes match what 0019 creates and
+validates:
 
 ```sql
 DO $$
@@ -538,62 +537,15 @@ END
 $$;
 ```
 
-**Step 2 — re-own the restored tenant objects. Last resort; read this first.**
-
-Replaying globals restores role definitions only; the restored tables, views,
-and sequences are all owned by whoever ran `pg_restore`. Migration 0019's
-upgrade is what fixes that, and the only way to reach it is to downgrade below
-0019 and come back up.
-
-> **That downgrade is not a supported recovery path.** It walks back through
-> every migration between head and 0019, and several of them either refuse on
-> data the current schema fully supports or discard state the re-upgrade
-> cannot rebuild. As of 0030 the known list is:
->
-> | Migration | What its `downgrade()` does |
-> |---|---|
-> | 0030 | **Refuses** while any `catalog.records` row holds a MULTIPOLYGON `spatial_extent` — i.e. any antimeridian-crossing footprint, which the current schema exists to store |
-> | 0029 | **Refuses** while any API key carries an expiry or any user's `key_epoch` has been bumped. Dropping `api_keys.expires_at` and both `key_epoch` columns would turn time-limited keys into permanent ones and un-revoke keys a `key_epoch` bump had invalidated; the error message lists the affected keys and the SQL that revokes them |
-> | 0027 | **Refuses** while any dataset uses a `parquet`, `json`, `xlsx`, or `xls` source format — all currently supported |
-> | 0022 | **Discards** `tenant_id` on `catalog.audit_logs` and `catalog.ingest_jobs`. The re-upgrade re-derives it from each row's live parent, so rows whose parent is gone lose tenant attribution permanently |
-> | 0021, 0020 | **Refuse** when two tenants share a collection name, OAuth subject, or `datasets.table_name` — all legal under the current per-tenant scoping |
->
-> The refusals are correct: forcing them would corrupt the restored data.
-> Taken together they mean this path is unusable or lossy for most real
-> multi-database clusters, and there is currently no supported way to re-run
-> 0019's adoption without it (0019 installs its functions with plain
-> `CREATE FUNCTION`, so `alembic stamp 0018 && alembic upgrade 0019` collides
-> with the functions the restored dump already carries).
->
-> **So: do not treat this as routine.** Open a support issue (`SUPPORT.md`)
-> before running it on data you care about.
->
-> Be clear about what the alternatives do and do not buy you. A globals dump
-> and a same-cluster restore both remove the *role* half of the problem —
-> globals replays the role definitions onto a new cluster, and on the same
-> cluster they never left. Neither touches the *ownership* half. The archive
-> carries no owner or ACL metadata, `--clean` drops each schema together with
-> its ACLs and default privileges, and `scripts/restore.sh` restores
-> `--no-owner` and re-grants only the single-tenant `geolens_reader`
-> privileges on schema `data`. Once per-tenant roles are in play, every
-> restore therefore lands tenant relations owned by `$POSTGRES_USER` with no
-> per-tenant grants, and step 2 is the only shipped way to fix that. Removing
-> that dependency is
-> the product gap this section is really describing — keep a globals dump
-> regardless, because it is the half you *can* solve today.
-
-If you have read the above and are proceeding anyway, work through 2a to 2d
-**in that order**. The snapshot in 2b and the restore in 2d bracket the
-downgrade because of 0022, and cover only that one row of the table — the
-other losses above have no equivalent remediation here.
+**Step 2 — restore the dump, then re-own its tenant objects.**
 
 Everything below runs through the Compose containers, because the bundled
 database listens on `127.0.0.1:${DB_PORT}` rather than a host socket and the
 Alembic config lives in `backend/`, not the repo root. Do **not** use
-`scripts/restore.sh` here — it restarts `api` and `worker` on exit, and the
-whole point of this section is that nothing may serve traffic until step 2d.
-Managed/external Postgres: drop the `docker compose exec -T db` prefix and
-pass the provider's `-h`, `-p`, and `-U` instead.
+`scripts/restore.sh` here — it restarts `api` and `worker` on exit, and nothing
+may serve traffic until 2b has finished. Managed/external Postgres: drop the
+`docker compose exec -T db` prefix and pass the provider's `-h`, `-p`, and `-U`
+instead.
 
 Keep `.env` loaded in this shell (`set -a; . ./.env; set +a`, as in step 1) —
 `$POSTGRES_USER` and `$POSTGRES_DB` expand on the host, not in the container.
@@ -607,95 +559,100 @@ docker compose exec -T db pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
   --clean --if-exists --no-owner --no-acl < ./restore/geolens_<timestamp>.dump
 ```
 
-**2b. Snapshot tenant attribution, BEFORE the downgrade.** Skipping this is
-the one irreversible mistake in the recipe: once 2c has run, the rows you
-would have saved no longer carry a `tenant_id` to save.
+**2b. Adopt the restored tenant objects.**
 
-```bash
-docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
-CREATE TABLE public.recover_audit_tenant AS
-  SELECT id, tenant_id FROM catalog.audit_logs WHERE tenant_id IS NOT NULL;
-CREATE TABLE public.recover_job_tenant AS
-  SELECT id, tenant_id FROM catalog.ingest_jobs WHERE tenant_id IS NOT NULL;
-SQL
-```
-
-**2c. Rebuild the topology.** Run these against the **`migrate`** service with
-`--no-deps`, not against `api`. Both parts matter: `api`'s entrypoint runs
-`alembic upgrade heads` of its own accord before it would execute your command
-(`backend/scripts/api-entrypoint.sh`), and `api` declares
-`depends_on: migrate`, so without `--no-deps` Compose starts the `migrate`
-one-shot — with `.env`'s runtime credential rather than your override — and
-upgrades the schema before the downgrade ever runs. The `migrate` service has
-`entrypoint: []` and depends only on a healthy `db`, so it does exactly what
-you ask and nothing else.
+Replaying globals restores role definitions only. The restored tables, views,
+and sequences are all owned by whoever ran `pg_restore`, with no per-tenant
+grants on any of them, and the two SECURITY DEFINER functions that guard tenant
+provisioning come back owned by that same login. One command puts all of it back
+under the provisioning boundary:
 
 ```bash
 docker compose run --rm --no-deps -e DATABASE_URL_OVERRIDE="<migrator-url>" \
-  migrate sh -c "uv run --no-dev alembic downgrade 0016"
-docker compose run --rm --no-deps -e DATABASE_URL_OVERRIDE="<migrator-url>" \
-  migrate sh -c "uv run --no-dev alembic upgrade heads"
+  migrate sh -c "uv run --no-dev python -m app.core.db.tenant_adoption --apply"
 ```
 
-The migrator credential is required: the least-privilege runtime login in
-`.env` is deliberately not allowed to do any of this.
+Run it before `api`, `worker`, or tile traffic starts. Both parts of the command
+shape matter: `api`'s entrypoint runs `alembic upgrade heads` of its own accord
+before it would execute your command
+(`backend/scripts/api-entrypoint.sh`), and `api` declares `depends_on: migrate`,
+so without `--no-deps` Compose starts the `migrate` one-shot with `.env`'s
+runtime credential rather than your override. The `migrate` service has
+`entrypoint: []` and depends only on a healthy `db`, so it does exactly what you
+ask and nothing else. The migrator credential is required: the least-privilege
+runtime login in `.env` is deliberately not allowed to do any of this.
+Managed/external Postgres uses the same command with `DATABASE_URL_OVERRIDE`
+pointed at the provider.
 
-**2d. Put the attribution back.** Scoped to the rows the re-upgrade could not
-derive, which is also what keeps the parent-consistency triggers satisfied.
+Drop `--apply` for a read-only report of what it would change. That form exits
+non-zero while anything is still pending, so it also works as a post-restore
+check.
 
-```bash
-docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
-UPDATE catalog.audit_logs AS a SET tenant_id = r.tenant_id
-  FROM public.recover_audit_tenant AS r
- WHERE r.id = a.id AND a.tenant_id IS NULL;
-UPDATE catalog.ingest_jobs AS j SET tenant_id = r.tenant_id
-  FROM public.recover_job_tenant AS r
- WHERE r.id = j.id AND j.tenant_id IS NULL;
-DROP TABLE public.recover_audit_tenant, public.recover_job_tenant;
-SQL
-```
+What it does, walking `catalog.tenants` with each tenant in its own transaction:
 
-**If 2c refuses, the database it refused in is not salvageable — start over
-from the dump.** A failed downgrade does not roll back the ones that already
-succeeded. Several of these migrations do index work inside Alembic's
-`autocommit_block()` (0020, 0021, 0022 among them), which commits the DDL
-preceding it, so a refusal at 0021 leaves you past 0022's discards with no
-transaction to undo them. Drop and recreate the target database, then
-re-run 2a and 2b against the untouched dump before attempting anything else.
+- Creates the five fixed NOLOGIN cluster roles if they are missing, and refuses
+  on an unsafe existing topology — the same validation 0019 performs.
+- Re-owns `catalog.provision_tenant_data_schema` and
+  `catalog.deprovision_tenant_data_schema` to `geolens_tenant_provisioner`, and
+  takes back the `EXECUTE` that `PUBLIC` holds after a `--no-acl` restore.
+  PostgreSQL's default for a function carrying no ACL is `EXECUTE` to `PUBLIC`,
+  so until this runs both functions are SECURITY DEFINER, owned by the restoring
+  superuser, and callable by every login in the database. It never installs a
+  function body — the migrations own those, and adoption refuses if either
+  function is absent or is not the migration-installed shape.
+- Normalizes each legacy tenant reader role (NOINHERIT, stray memberships,
+  leftover default privileges), transfers the tenant schema to the provisioner,
+  calls the guarded provisioning function to recreate the reader/writer roles and
+  their SET-only gateway memberships, moves every restored relation to the
+  per-tenant writer, and has that writer grant the paired reader `SELECT`.
 
-0029 is the one place where the order works in your favour: walking back from
-head it is reached second, before any of the discarding migrations, so its
-refusal stops the run while the database is still whole. Deal with its
-remediation there rather than discovering the loss after a refusal further
-down (fix(#1016) — it used to drop those columns silently).
-The dump file itself is never modified, so nothing is lost by restarting — but
-continuing in a half-downgraded database is how a recovery turns into a second
-incident.
+The end state is the one migration 0019 produced. Idempotence is keyed on
+database state rather than on a marker or a timestamp: a tenant already in that
+shape issues no DDL at all, so re-running is safe and a run interrupted partway
+is resumed by running it again. A tenant that refuses is named in the report
+while the rest continue, and adopted tenants stay adopted.
 
-Do not force a refusal past its guard. Those migrations are protecting data
-the current schema legitimately holds, and the remediations their error
-messages offer — widening seam extents to `-180..180`, remapping source
-formats — are themselves lossy. The reconstruction logic 2c is trying to reach
-is `_adopt_and_backfill_existing_tenants` in
-`backend/alembic/versions/0019_tenant_provisioning_boundary.py`; making it
-runnable without the downgrade is a product gap, not something to work around
-by hand here.
+**What it does not do.** Reapply the runtime login grants from `.env.example`
+afterwards; those login credentials are deliberately not stored in the database
+dump. Enabling and FORCEing row-level security stays the API's job at boot
+(`apply_tenancy_rls`) — the report lists which boundary tables are not enabled or
+not FORCEd, read from the live insert-stamping triggers rather than from any list
+frozen into a migration, so a table that joined the boundary after 0018 is
+visible here. Object storage is a separate artifact; see step 0 of the full
+restore below.
 
-When 2c does complete, its 0019 re-upgrade is the whole per-tenant
-role-reconstruction step: it recreates the fixed
-provisioner/control/writer/sandbox/tile roles, walks
-`catalog.tenants` to recreate each tenant reader/writer role via
-`provision_tenant_data_schema`, and transfers restored tenant tables and
-sequences to the matching writer. No separate script exists or is needed
-(fix(#950): an earlier revision of this recipe referenced a
-`prepare-tenant-rls.py` script that was never shipped). Reapply the runtime
-login grants from `.env.example` afterward; those login credentials are
-deliberately not stored in the database dump. Verify that the API login can
-`SET ROLE` to one tenant writer/reader, the tile login can set only that tenant
-reader, and neither login owns catalog RLS tables or a `data_t_*` schema — the
-backend re-checks the runtime login at boot
-(`assert_multi_tenant_runtime_role`) and refuses to start on an unsafe role, so
-a misconfigured restore fails loudly rather than serving cross-tenant data.
+Then verify by hand: the API login can `SET ROLE` to one tenant writer/reader,
+the tile login can set only that tenant reader, and neither login owns catalog
+RLS tables or a `data_t_*` schema. The backend re-checks the runtime login at
+boot (`assert_multi_tenant_runtime_role`) and refuses to start on an unsafe
+role, so a misconfigured restore fails loudly rather than serving cross-tenant
+data.
+
+#### Do not reach for `alembic downgrade 0016`
+
+Until this command existed, downgrading below 0019 and coming back up was the
+only way to reach that migration's adoption pass (fix(#998): an earlier revision
+of this section documented that downgrade as the recipe). It is still not a
+supported recovery path, and it is no longer necessary. It walks back through
+every migration between head and 0019, and several of them either refuse on data
+the current schema legitimately holds or discard state the re-upgrade cannot
+rebuild:
+
+| Migration | What its `downgrade()` does |
+|---|---|
+| 0030 | **Refuses** while any `catalog.records` row holds a MULTIPOLYGON `spatial_extent` — i.e. any antimeridian-crossing footprint, which the current schema exists to store |
+| 0029 | **Refuses** while any API key carries an expiry or any user's `key_epoch` has been bumped. Dropping `api_keys.expires_at` and both `key_epoch` columns would turn time-limited keys into permanent ones and un-revoke keys a `key_epoch` bump had invalidated; the error message lists the affected keys and the SQL that revokes them |
+| 0027 | **Refuses** while any dataset uses a `parquet`, `json`, `xlsx`, or `xls` source format — all currently supported |
+| 0022 | **Discards** `tenant_id` on `catalog.audit_logs` and `catalog.ingest_jobs`. The re-upgrade re-derives it from each row's live parent, so rows whose parent is gone lose tenant attribution permanently |
+| 0021, 0020 | **Refuse** when two tenants share a collection name, OAuth subject, or `datasets.table_name` — all legal under the current per-tenant scoping |
+
+The refusals are correct: forcing them would corrupt the restored data. And a
+failed downgrade is not recoverable in place. Several of these migrations do
+index work inside Alembic's `autocommit_block()` (0020, 0021 and 0022 among
+them), which commits the DDL preceding it, so a refusal at 0021 leaves you past
+0022's discards with no transaction to undo them — drop the database and start
+over from the dump. Step 2 above touches none of that: it runs forward, at head,
+and never moves the schema version.
 
 ### Step-by-step: full restore (DB + object storage)
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -453,6 +453,16 @@ mandatory post-restore reconciliation reapplies that boundary.
 **Never** use `psql < <dump>` on a custom-format (`-Fc`) dump file — it is binary,
 not plain SQL, and will fail.
 
+> **If `catalog.tenants` has rows, `restore.sh` is not the whole recipe.** Its
+> step 6 reconciles the single-tenant runtime role and the shared `data` schema;
+> it does not touch per-tenant schemas, per-tenant roles, or the two SECURITY
+> DEFINER provisioning functions, which the restore leaves owned by the restore
+> login with `EXECUTE` granted to `PUBLIC`. Step 7 then restarts `api` and
+> `worker`, so following this section alone puts traffic on a database in
+> exactly that state. Use the stop / restore / adopt sequence in the
+> role-reconstruction section immediately below instead, and run its dry run
+> afterwards as the check that nothing was left behind.
+
 ### Multi-tenant role reconstruction after a fresh-cluster restore
 
 PostgreSQL roles are cluster objects and are not included in a database-only

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -565,9 +565,17 @@ Keep `.env` loaded in this shell (`set -a; . ./.env; set +a`, as in step 1) —
 The dump path is a host path; copy the dump out of the `backup_data` volume
 first, exactly as in "Step-by-step: full restore" below.
 
-**2a. Restore the dump.**
+**2a. Stop the services, then restore the dump.**
+
+`restore.sh` stops `api` and `worker` before it restores and restarts them on
+the way out; this recipe replaces it, so the stop is yours to do. Without it,
+traffic races a `--clean` restore and can reach the restore-owned SECURITY
+DEFINER functions during the window where `PUBLIC` can execute them. Nothing
+starts again until 2f is done.
 
 ```bash
+docker compose stop api worker
+
 docker compose exec -T db pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
   --clean --if-exists --no-owner --no-acl < ./restore/geolens_<timestamp>.dump
 ```
@@ -743,7 +751,13 @@ REVOKE geolens_tenant_provisioner FROM "<migrator-role>";
 SQL
 ```
 
-Then verify by hand: the API login can `SET ROLE` to one tenant writer/reader,
+Then start the services again:
+
+```bash
+docker compose start api worker
+```
+
+And verify by hand: the API login can `SET ROLE` to one tenant writer/reader,
 the tile login can set only that tenant reader, and neither login owns catalog
 RLS tables or a `data_t_*` schema. The backend re-checks the runtime login at
 boot (`assert_multi_tenant_runtime_role`) and refuses to start on an unsafe

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -629,8 +629,8 @@ visible here, and a trigger left DISABLED by a restore is reported rather than
 counted. Object storage is a separate artifact; see step 0 of the full restore
 below.
 
-A dump carries row-security state, so a healthy multi-tenant source cluster
-restores with it already on.
+A dump carries row-security state, so a source cluster that was already
+enforcing it restores with it still on.
 
 Then verify by hand: the API login can `SET ROLE` to one tenant writer/reader,
 the tile login can set only that tenant reader, and neither login owns catalog

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -573,6 +573,9 @@ traffic races a `--clean` restore and can reach the restore-owned SECURITY
 DEFINER functions during the window where `PUBLIC` can execute them. Nothing
 starts again until 2f is done.
 
+The stop applies to managed/external Postgres too: the database is elsewhere,
+but `api` and `worker` are still the things that would write to it.
+
 ```bash
 docker compose stop api worker
 
@@ -697,6 +700,13 @@ and restore paths use lives in the `db` container:
 ```bash
 docker compose exec -T db /usr/local/bin/configure-runtime-db-role
 ```
+
+The script is mounted into the bundled `db` container, so there is nothing to
+exec into on managed/external Postgres. A provider snapshot or PITR restore
+keeps its ACLs, so the grants come back with it and this step does not apply; a
+logical `pg_restore --no-acl` into a managed instance does not, and there the
+equivalent is to replay the grants from `.env.example` by hand — see the
+single-tenant runtime-role section above for exactly which ones.
 
 Then check it took, the way `restore.sh` does — a reader without schema access
 breaks every read-only consumer silently:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -516,13 +516,12 @@ For managed/external Postgres there is no `db` container to exec into: drop the
 to `pg_dumpall`/`psql` directly.
 
 If no globals dump exists, create the five fixed NOLOGIN groups with the block
-below. Step 2c creates them too, but that is too late in one case that matters:
-a dump stamped anywhere in 0019-0023 has to be upgraded first (2b), and 0024's
-upgrade runs `ALTER FUNCTION … OWNER TO geolens_tenant_provisioner`, which fails
-outright when that role does not exist. Skip this only when the dump already
-matches the running release, or when a globals replay has already put the roles
-back. The block is idempotent, needs CREATEROLE, and the attributes match what
-0019 creates and validates:
+below, and do it now rather than later. Adoption creates them too, but that is
+step 2d, and two things ahead of it need them already there: 0024's upgrade in
+2b runs `ALTER FUNCTION … OWNER TO geolens_tenant_provisioner`, and 2c grants
+memberships in all five. Skip this only when a globals replay has already put
+the roles back. The block is idempotent, needs CREATEROLE, and the attributes
+match what 0019 creates and validates:
 
 ```sql
 DO $$

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -674,7 +674,25 @@ below.
 A dump carries row-security state, so a source cluster that was already
 enforcing it restores with it still on.
 
-**2d. Give the temporary privileges back.**
+**2d. Re-apply the runtime grants.**
+
+`--no-acl` drops them and this recipe does not run `scripts/restore.sh`, which
+is what normally re-applies them. The same privileged reconciler the bootstrap
+and restore paths use lives in the `db` container:
+
+```bash
+docker compose exec -T db /usr/local/bin/configure-runtime-db-role
+```
+
+Then check it took, the way `restore.sh` does — a reader without schema access
+breaks every read-only consumer silently:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+  "SELECT has_schema_privilege('geolens_reader', 'data', 'USAGE');"
+```
+
+**2e. Give the temporary privileges back.**
 
 Only if you granted them in 2b. Adoption manages its own borrow when it has to
 take one, and hands that back on its own; these two are yours, and left in place

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -515,11 +515,14 @@ For managed/external Postgres there is no `db` container to exec into: drop the
 `docker compose exec -T db` prefix and pass the provider's `-h`, `-p`, and `-U`
 to `pg_dumpall`/`psql` directly.
 
-If no globals dump exists, step 2 creates the five fixed NOLOGIN groups itself,
-so you can skip ahead. The equivalent by hand, for a cluster where you want them
-in place first or where step 2 refused on the existing topology — it is
-idempotent, needs CREATEROLE, and the attributes match what 0019 creates and
-validates:
+If no globals dump exists, create the five fixed NOLOGIN groups with the block
+below. Step 2c creates them too, but that is too late in one case that matters:
+a dump stamped anywhere in 0019-0023 has to be upgraded first (2b), and 0024's
+upgrade runs `ALTER FUNCTION … OWNER TO geolens_tenant_provisioner`, which fails
+outright when that role does not exist. Skip this only when the dump already
+matches the running release, or when a globals replay has already put the roles
+back. The block is idempotent, needs CREATEROLE, and the attributes match what
+0019 creates and validates:
 
 ```sql
 DO $$

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -595,7 +595,7 @@ privileges first, because 0024's upgrade transfers ownership of the boundary
 functions to `geolens_tenant_provisioner`, and PostgreSQL wants the incoming
 owner to hold `CREATE` on the schema and the caller to hold that owner's
 privileges. A superuser has both implicitly and can skip this. Grant them as the
-same admin identity that ran step 1's role block, and hand them back in 2f:
+same admin identity that ran step 1's role block, and hand them back in 2g:
 
 ```bash
 docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
@@ -618,7 +618,46 @@ docker compose run --rm --no-deps -e DATABASE_URL_OVERRIDE="<migrator-url>" \
 Skip the upgrade only if the dump came from the running release. Running it
 anyway is a no-op on a database already at head.
 
-**2c. Adopt the restored tenant objects.**
+**2c. Normalize the fixed-group memberships.**
+
+Run these whatever step 1 did, and run them before adoption. They are needed
+outright when the roles were rebuilt by hand, and still needed after a globals
+replay from a PostgreSQL 13-15 cluster: those dumps carry plain grants, which
+pick up the target server's defaults rather than the control inherit-only and
+writer/sandbox/tile SET-only shapes adoption requires. Adoption refuses a wrong
+shape rather than rewriting somebody else's grant, so leaving one here stops 2d
+before it starts. Re-issuing them is a no-op when they already match.
+
+These are the grants `.env.example` documents alongside
+`GEOLENS_RUNTIME_DB_ROLE`; substitute your own login names, and never give the
+tile login any of the first three:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+GRANT geolens_tenant_control TO "<runtime-login>" WITH INHERIT TRUE, SET FALSE;
+GRANT geolens_tenant_writer  TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
+GRANT geolens_tenant_sandbox TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
+GRANT geolens_tile_gateway   TO "<tile-login>"    WITH INHERIT FALSE, SET TRUE;
+SQL
+```
+
+That is the PostgreSQL 16+ form. On 13-15 there are no per-membership options,
+so drop every `WITH` clause. Leave the runtime login `INHERIT` there: it calls
+the provisioning functions directly and needs `geolens_tenant_control`'s
+`EXECUTE` to arrive by inheritance. What keeps the per-tenant roles behind a
+`SET ROLE` on those releases is the `NOINHERIT` attribute on the four fixed
+gateway roles, not anything about the login:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+GRANT geolens_tenant_control TO "<runtime-login>";
+GRANT geolens_tenant_writer  TO "<runtime-login>";
+GRANT geolens_tenant_sandbox TO "<runtime-login>";
+GRANT geolens_tile_gateway   TO "<tile-login>";
+SQL
+```
+
+**2d. Adopt the restored tenant objects.**
 
 Replaying globals restores role definitions only. The restored tables, views,
 and sequences are all owned by whoever ran `pg_restore`, with no per-tenant
@@ -691,7 +730,7 @@ below.
 A dump carries row-security state, so a source cluster that was already
 enforcing it restores with it still on.
 
-**2d. Re-apply the runtime grants.**
+**2e. Re-apply the runtime grants.**
 
 `--no-acl` drops them and this recipe does not run `scripts/restore.sh`, which
 is what normally re-applies them. The same privileged reconciler the bootstrap
@@ -716,10 +755,9 @@ docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
   "SELECT has_schema_privilege('geolens_reader', 'data', 'USAGE');"
 ```
 
-**2e. Let the tile login connect, and put the runtime logins back in the fixed
-groups.**
+**2f. Let the tile login connect.**
 
-The `CONNECT` grant is unconditional. 2d's reconciler revokes `PUBLIC CONNECT`
+Unconditional, and after 2e: that reconciler revokes `PUBLIC CONNECT`
 and grants it back to the current, migration and runtime roles only, in every
 path, so the tile login cannot reach the database at all after a restart without
 this — including when a globals replay restored everything else about it:
@@ -731,42 +769,7 @@ GRANT CONNECT ON DATABASE :"db" TO "<tile-login>";
 SQL
 ```
 
-Run the group memberships below whatever step 1 did. They are needed outright
-when the roles were rebuilt by hand, and they are still needed after a globals
-replay from a PostgreSQL 13-15 cluster: those dumps carry plain grants, which
-pick up the target server's defaults rather than the control inherit-only and
-writer/sandbox/tile SET-only shapes that adoption requires — and it refuses on
-the wrong shape rather than rewriting somebody else's grant. Re-issuing them
-explicitly is a no-op when they already match. These are the grants
-`.env.example` documents alongside `GEOLENS_RUNTIME_DB_ROLE`; substitute your own
-login names, and never give the tile login any of the first three:
-
-```bash
-docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
-GRANT geolens_tenant_control TO "<runtime-login>" WITH INHERIT TRUE, SET FALSE;
-GRANT geolens_tenant_writer  TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
-GRANT geolens_tenant_sandbox TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
-GRANT geolens_tile_gateway   TO "<tile-login>"    WITH INHERIT FALSE, SET TRUE;
-SQL
-```
-
-That is the PostgreSQL 16+ form. On 13-15 there are no per-membership options,
-so drop every `WITH` clause. Leave the runtime login `INHERIT` there: it calls
-the provisioning functions directly and needs `geolens_tenant_control`'s
-`EXECUTE` to arrive by inheritance. What keeps the per-tenant roles behind a
-`SET ROLE` on those releases is the `NOINHERIT` attribute on the four fixed
-gateway roles, not anything about the login:
-
-```bash
-docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
-GRANT geolens_tenant_control TO "<runtime-login>";
-GRANT geolens_tenant_writer  TO "<runtime-login>";
-GRANT geolens_tenant_sandbox TO "<runtime-login>";
-GRANT geolens_tile_gateway   TO "<tile-login>";
-SQL
-```
-
-**2f. Give the temporary privileges back.**
+**2g. Give the temporary privileges back.**
 
 Only if you granted them in 2b. Adoption manages its own borrow when it has to
 take one, and hands that back on its own; these two are yours, and left in place

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -579,13 +579,27 @@ works only at head — it refuses on a boundary function that a later migration
 installed. `--no-deps` is what stops the `migrate` one-shot and the API
 entrypoint from doing this for you, so do it here, with the same override:
 
+A non-superuser migrator — a managed provider's admin, for instance — needs two
+privileges first, because 0024's upgrade transfers ownership of the boundary
+functions to `geolens_tenant_provisioner`, and PostgreSQL wants the incoming
+owner to hold `CREATE` on the schema and the caller to hold that owner's
+privileges. A superuser has both implicitly and can skip this. Grant them as the
+same admin identity that ran step 1's role block, and hand them back in 2d:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+GRANT CREATE ON SCHEMA catalog TO geolens_tenant_provisioner;
+GRANT geolens_tenant_provisioner TO "<migrator-role>" WITH ADMIN OPTION;
+SQL
+```
+
 ```bash
 docker compose run --rm --no-deps -e DATABASE_URL_OVERRIDE="<migrator-url>" \
   migrate sh -c "uv run --no-dev alembic upgrade heads"
 ```
 
-Skip it only if the dump came from the running release. Running it anyway is a
-no-op on a database already at head.
+Skip the upgrade only if the dump came from the running release. Running it
+anyway is a no-op on a database already at head.
 
 **2c. Adopt the restored tenant objects.**
 
@@ -659,6 +673,20 @@ below.
 
 A dump carries row-security state, so a source cluster that was already
 enforcing it restores with it still on.
+
+**2d. Give the temporary privileges back.**
+
+Only if you granted them in 2b. Adoption manages its own borrow when it has to
+take one, and hands that back on its own; these two are yours, and left in place
+they are a standing `CREATE` on `catalog` for the provisioner and a membership
+that makes the next recovery refuse under a rotated migrator credential:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+REVOKE CREATE ON SCHEMA catalog FROM geolens_tenant_provisioner;
+REVOKE geolens_tenant_provisioner FROM "<migrator-role>";
+SQL
+```
 
 Then verify by hand: the API login can `SET ROLE` to one tenant writer/reader,
 the tile login can set only that tenant reader, and neither login owns catalog

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -589,9 +589,15 @@ same admin identity that ran step 1's role block, and hand them back in 2d:
 ```bash
 docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
 GRANT CREATE ON SCHEMA catalog TO geolens_tenant_provisioner;
-GRANT geolens_tenant_provisioner TO "<migrator-role>" WITH ADMIN OPTION;
+GRANT geolens_tenant_provisioner TO "<migrator-role>" WITH INHERIT TRUE, SET TRUE;
 SQL
 ```
+
+No `ADMIN OPTION`: if the migrator is the same identity that ran step 1's block,
+PostgreSQL 16+ already gave it ADMIN there and refuses to grant ADMIN back to
+its own grantor. On PostgreSQL 13-15 drop the `WITH` clause — per-membership
+`INHERIT`/`SET` arrived in 16, and before that a membership simply carries the
+member's privileges.
 
 ```bash
 docker compose run --rm --no-deps -e DATABASE_URL_OVERRIDE="<migrator-url>" \
@@ -707,6 +713,19 @@ GRANT geolens_tenant_control TO "<runtime-login>" WITH INHERIT TRUE, SET FALSE;
 GRANT geolens_tenant_writer  TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
 GRANT geolens_tenant_sandbox TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
 GRANT geolens_tile_gateway   TO "<tile-login>"    WITH INHERIT FALSE, SET TRUE;
+SQL
+```
+
+That is the PostgreSQL 16+ form. On 13-15 there are no per-membership options —
+drop every `WITH` clause, and the `NOINHERIT` attribute on the login is what
+makes the membership SET-only:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+GRANT geolens_tenant_control TO "<runtime-login>";
+GRANT geolens_tenant_writer  TO "<runtime-login>";
+GRANT geolens_tenant_sandbox TO "<runtime-login>";
+GRANT geolens_tile_gateway   TO "<tile-login>";
 SQL
 ```
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -716,26 +716,34 @@ docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
   "SELECT has_schema_privilege('geolens_reader', 'data', 'USAGE');"
 ```
 
-**2e. Put the runtime logins back in the fixed groups.**
+**2e. Let the tile login connect, and put the runtime logins back in the fixed
+groups.**
 
-Only when step 1 rebuilt the roles by hand: a globals replay carries these
-memberships, the reconciler in 2d does not, and without them the API cannot call
-the provisioning functions or reach a tenant reader, and the tile login cannot
-either. These are the grants `.env.example` documents alongside
-`GEOLENS_RUNTIME_DB_ROLE`; substitute your own login names, and never give the
-tile login any of the first three:
+The `CONNECT` grant is unconditional. 2d's reconciler revokes `PUBLIC CONNECT`
+and grants it back to the current, migration and runtime roles only, in every
+path, so the tile login cannot reach the database at all after a restart without
+this — including when a globals replay restored everything else about it:
 
 ```bash
 docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
   -v db="$POSTGRES_DB" <<'SQL'
+GRANT CONNECT ON DATABASE :"db" TO "<tile-login>";
+SQL
+```
+
+The group memberships below are needed only when step 1 rebuilt the roles by
+hand: a globals replay carries them, the reconciler does not, and without them
+the API cannot call the provisioning functions or reach a tenant reader, and the
+tile login cannot either. These are the grants `.env.example` documents
+alongside `GEOLENS_RUNTIME_DB_ROLE`; substitute your own login names, and never
+give the tile login any of the first three:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
 GRANT geolens_tenant_control TO "<runtime-login>" WITH INHERIT TRUE, SET FALSE;
 GRANT geolens_tenant_writer  TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
 GRANT geolens_tenant_sandbox TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
 GRANT geolens_tile_gateway   TO "<tile-login>"    WITH INHERIT FALSE, SET TRUE;
--- 2d's reconciler revokes PUBLIC CONNECT and grants it back to the current,
--- migration and runtime roles only, so the tile login needs its own. The
--- heredoc is quoted, so the database name arrives as a psql variable.
-GRANT CONNECT ON DATABASE :"db" TO "<tile-login>";
 SQL
 ```
 
@@ -747,13 +755,11 @@ the provisioning functions directly and needs `geolens_tenant_control`'s
 gateway roles, not anything about the login:
 
 ```bash
-docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
-  -v db="$POSTGRES_DB" <<'SQL'
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
 GRANT geolens_tenant_control TO "<runtime-login>";
 GRANT geolens_tenant_writer  TO "<runtime-login>";
 GRANT geolens_tenant_sandbox TO "<runtime-login>";
 GRANT geolens_tile_gateway   TO "<tile-login>";
-GRANT CONNECT ON DATABASE :"db" TO "<tile-login>";
 SQL
 ```
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -731,12 +731,15 @@ GRANT CONNECT ON DATABASE :"db" TO "<tile-login>";
 SQL
 ```
 
-The group memberships below are needed only when step 1 rebuilt the roles by
-hand: a globals replay carries them, the reconciler does not, and without them
-the API cannot call the provisioning functions or reach a tenant reader, and the
-tile login cannot either. These are the grants `.env.example` documents
-alongside `GEOLENS_RUNTIME_DB_ROLE`; substitute your own login names, and never
-give the tile login any of the first three:
+Run the group memberships below whatever step 1 did. They are needed outright
+when the roles were rebuilt by hand, and they are still needed after a globals
+replay from a PostgreSQL 13-15 cluster: those dumps carry plain grants, which
+pick up the target server's defaults rather than the control inherit-only and
+writer/sandbox/tile SET-only shapes that adoption requires — and it refuses on
+the wrong shape rather than rewriting somebody else's grant. Re-issuing them
+explicitly is a no-op when they already match. These are the grants
+`.env.example` documents alongside `GEOLENS_RUNTIME_DB_ROLE`; substitute your own
+login names, and never give the tile login any of the first three:
 
 ```bash
 docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -731,6 +731,9 @@ GRANT geolens_tenant_control TO "<runtime-login>" WITH INHERIT TRUE, SET FALSE;
 GRANT geolens_tenant_writer  TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
 GRANT geolens_tenant_sandbox TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
 GRANT geolens_tile_gateway   TO "<tile-login>"    WITH INHERIT FALSE, SET TRUE;
+-- 2d's reconciler revokes PUBLIC CONNECT and grants it back to the current,
+-- migration and runtime roles only, so the tile login needs its own.
+GRANT CONNECT ON DATABASE "$POSTGRES_DB" TO "<tile-login>";
 SQL
 ```
 
@@ -744,6 +747,7 @@ GRANT geolens_tenant_control TO "<runtime-login>";
 GRANT geolens_tenant_writer  TO "<runtime-login>";
 GRANT geolens_tenant_sandbox TO "<runtime-login>";
 GRANT geolens_tile_gateway   TO "<tile-login>";
+GRANT CONNECT ON DATABASE "$POSTGRES_DB" TO "<tile-login>";
 SQL
 ```
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -595,7 +595,7 @@ privileges first, because 0024's upgrade transfers ownership of the boundary
 functions to `geolens_tenant_provisioner`, and PostgreSQL wants the incoming
 owner to hold `CREATE` on the schema and the caller to hold that owner's
 privileges. A superuser has both implicitly and can skip this. Grant them as the
-same admin identity that ran step 1's role block, and hand them back in 2d:
+same admin identity that ran step 1's role block, and hand them back in 2f:
 
 ```bash
 docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
@@ -726,14 +726,16 @@ either. These are the grants `.env.example` documents alongside
 tile login any of the first three:
 
 ```bash
-docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -v db="$POSTGRES_DB" <<'SQL'
 GRANT geolens_tenant_control TO "<runtime-login>" WITH INHERIT TRUE, SET FALSE;
 GRANT geolens_tenant_writer  TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
 GRANT geolens_tenant_sandbox TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
 GRANT geolens_tile_gateway   TO "<tile-login>"    WITH INHERIT FALSE, SET TRUE;
 -- 2d's reconciler revokes PUBLIC CONNECT and grants it back to the current,
--- migration and runtime roles only, so the tile login needs its own.
-GRANT CONNECT ON DATABASE "$POSTGRES_DB" TO "<tile-login>";
+-- migration and runtime roles only, so the tile login needs its own. The
+-- heredoc is quoted, so the database name arrives as a psql variable.
+GRANT CONNECT ON DATABASE :"db" TO "<tile-login>";
 SQL
 ```
 
@@ -742,12 +744,13 @@ drop every `WITH` clause, and the `NOINHERIT` attribute on the login is what
 makes the membership SET-only:
 
 ```bash
-docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -v db="$POSTGRES_DB" <<'SQL'
 GRANT geolens_tenant_control TO "<runtime-login>";
 GRANT geolens_tenant_writer  TO "<runtime-login>";
 GRANT geolens_tenant_sandbox TO "<runtime-login>";
 GRANT geolens_tile_gateway   TO "<tile-login>";
-GRANT CONNECT ON DATABASE "$POSTGRES_DB" TO "<tile-login>";
+GRANT CONNECT ON DATABASE :"db" TO "<tile-login>";
 SQL
 ```
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -739,9 +739,12 @@ GRANT CONNECT ON DATABASE :"db" TO "<tile-login>";
 SQL
 ```
 
-That is the PostgreSQL 16+ form. On 13-15 there are no per-membership options —
-drop every `WITH` clause, and the `NOINHERIT` attribute on the login is what
-makes the membership SET-only:
+That is the PostgreSQL 16+ form. On 13-15 there are no per-membership options,
+so drop every `WITH` clause. Leave the runtime login `INHERIT` there: it calls
+the provisioning functions directly and needs `geolens_tenant_control`'s
+`EXECUTE` to arrive by inheritance. What keeps the per-tenant roles behind a
+`SET ROLE` on those releases is the `NOINHERIT` attribute on the four fixed
+gateway roles, not anything about the login:
 
 ```bash
 docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -615,11 +615,18 @@ while the rest continue, and adopted tenants stay adopted.
 **What it does not do.** Reapply the runtime login grants from `.env.example`
 afterwards; those login credentials are deliberately not stored in the database
 dump. Enabling and FORCEing row-level security stays the API's job at boot
-(`apply_tenancy_rls`) — the report lists which boundary tables are not enabled or
-not FORCEd, read from the live insert-stamping triggers rather than from any list
+(`apply_tenancy_rls`), and adoption does not turn it on for you. It does refuse
+to report a clean database while any boundary table on a control plane that has
+tenants is missing it, and while any table has row security enabled without
+`FORCE` — the table owner bypasses a policy that is not FORCEd. Which tables
+those are is read from the live insert-stamping triggers rather than from a list
 frozen into a migration, so a table that joined the boundary after 0018 is
-visible here. Object storage is a separate artifact; see step 0 of the full
-restore below.
+visible here, and a trigger left DISABLED by a restore is reported rather than
+counted. Object storage is a separate artifact; see step 0 of the full restore
+below.
+
+A dump carries row-security state, so a healthy multi-tenant source cluster
+restores with it already on.
 
 Then verify by hand: the API login can `SET ROLE` to one tenant writer/reader,
 the tile login can set only that tenant reader, and neither login owns catalog

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -587,8 +587,13 @@ Then stop the services. That applies to managed/external Postgres too: the
 database is elsewhere, but `api` and `worker` are still the things that would
 write to it.
 
+Stop the backup service with them. A scheduled cycle landing mid-window dumps
+the half-restored database as the newest artifact — one that passes the
+validation above — and advances retention pruning against the copies you still
+need.
+
 ```bash
-docker compose stop api worker
+docker compose stop api worker backup
 
 docker compose exec -T db pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
   --clean --if-exists --no-owner --no-acl < ./restore/geolens_<timestamp>.dump
@@ -713,11 +718,17 @@ What it does, walking `catalog.tenants` with each tenant in its own transaction:
   superuser, and callable by every login in the database. It never installs a
   function body — the migrations own those, and adoption refuses if either
   function is absent or is not the migration-installed shape.
-- Normalizes each legacy tenant reader role (NOINHERIT, stray memberships,
-  leftover default privileges), transfers the tenant schema to the provisioner,
-  calls the guarded provisioning function to recreate the reader/writer roles and
-  their SET-only gateway memberships, moves every restored relation to the
+- Transfers the tenant schema to the provisioner, calls the guarded
+  provisioning function to recreate the reader/writer roles and their SET-only
+  gateway memberships, moves every restored relation, routine and type to the
   per-tenant writer, and has that writer grant the paired reader `SELECT`.
+- Rewrites only the grants it made itself. A pre-existing anomaly — a membership
+  some third party granted, a default-privilege entry owned by a role it cannot
+  act as, a `SECURITY DEFINER` or untrusted-language routine in a tenant schema
+  — is reported with the exact statement to run and the role to run it as, and
+  that tenant is left for the next run. The automatic membership PostgreSQL
+  gives a role's creator is the one exception it tolerates rather than reports:
+  nobody can revoke it, and it confers nothing on its own.
 
 The end state is the one migration 0019 produced. Idempotence is keyed on
 database state rather than on a marker or a timestamp: a tenant already in that
@@ -797,7 +808,7 @@ SQL
 Then start the services again:
 
 ```bash
-docker compose start api worker
+docker compose start api worker backup
 ```
 
 And verify by hand: the API login can `SET ROLE` to one tenant writer/reader,
@@ -1505,6 +1516,13 @@ docker compose up -d --wait --scale backup=0
 #    If the shell that ran step 1 is gone, $DUMP is unset — pick the newest
 #    verified dump explicitly:
 #      ls -t ./backups/pre-upgrade/*.dump | head -1
+# If catalog.tenants has rows, restore.sh is not the whole recipe — it
+# restarts api and worker on a database whose tenant objects are still owned by
+# the restore login. Use §2's stop / restore / adopt sequence instead, and run
+#   docker compose run --rm --no-deps -e DATABASE_URL_OVERRIDE="<migrator-url>" \
+#     migrate sh -c "uv run --no-dev python -m app.core.db.tenant_adoption"
+# afterwards: without --apply it changes nothing and exits non-zero while
+# anything is still pending.
 ./scripts/restore.sh "$DUMP"
 
 # 5. Bring the backup service up now that the cluster holds real data, and

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -565,16 +565,27 @@ Keep `.env` loaded in this shell (`set -a; . ./.env; set +a`, as in step 1) —
 The dump path is a host path; copy the dump out of the `backup_data` volume
 first, exactly as in "Step-by-step: full restore" below.
 
-**2a. Stop the services, then restore the dump.**
+**2a. Check the archive, stop the services, restore the dump.**
 
-`restore.sh` stops `api` and `worker` before it restores and restarts them on
-the way out; this recipe replaces it, so the stop is yours to do. Without it,
-traffic races a `--clean` restore and can reach the restore-owned SECURITY
-DEFINER functions during the window where `PUBLIC` can execute them. Nothing
-starts again until 2f is done.
+`restore.sh` validates the archive, stops `api` and `worker`, restores, and
+restarts them on the way out; this recipe replaces it, so all of that is yours
+to do. Without the stop, traffic races a `--clean` restore and can reach the
+restore-owned SECURITY DEFINER functions during the window where `PUBLIC` can
+execute them. Nothing starts again until 2g is done.
 
-The stop applies to managed/external Postgres too: the database is elsewhere,
-but `api` and `worker` are still the things that would write to it.
+Validate the archive before anything destructive, exactly as `restore.sh` does:
+`--list` only reads the table of contents, which a truncated file still passes,
+so read every data block. A `--clean` restore that discovers the corruption
+halfway through has already dropped the database that was working.
+
+```bash
+docker compose exec -T db pg_restore -f /dev/null \
+  < ./restore/geolens_<timestamp>.dump
+```
+
+Then stop the services. That applies to managed/external Postgres too: the
+database is elsewhere, but `api` and `worker` are still the things that would
+write to it.
 
 ```bash
 docker compose stop api worker

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -582,7 +582,11 @@ runtime credential rather than your override. The `migrate` service has
 ask and nothing else. The migrator credential is required: the least-privilege
 runtime login in `.env` is deliberately not allowed to do any of this.
 Managed/external Postgres uses the same command with `DATABASE_URL_OVERRIDE`
-pointed at the provider.
+pointed at the provider. A non-superuser migrator there needs `CREATEROLE`,
+ownership of the restored objects, and the privileges of
+`geolens_tenant_provisioner`, because PostgreSQL will not hand that role
+ownership of the boundary functions otherwise; the command prints the exact
+`GRANT` if it is missing.
 
 Drop `--apply` for a read-only report of what it would change. That form exits
 non-zero while anything is still pending, so it also works as a post-restore

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -692,7 +692,25 @@ docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
   "SELECT has_schema_privilege('geolens_reader', 'data', 'USAGE');"
 ```
 
-**2e. Give the temporary privileges back.**
+**2e. Put the runtime logins back in the fixed groups.**
+
+Only when step 1 rebuilt the roles by hand: a globals replay carries these
+memberships, the reconciler in 2d does not, and without them the API cannot call
+the provisioning functions or reach a tenant reader, and the tile login cannot
+either. These are the grants `.env.example` documents alongside
+`GEOLENS_RUNTIME_DB_ROLE`; substitute your own login names, and never give the
+tile login any of the first three:
+
+```bash
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+GRANT geolens_tenant_control TO "<runtime-login>" WITH INHERIT TRUE, SET FALSE;
+GRANT geolens_tenant_writer  TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
+GRANT geolens_tenant_sandbox TO "<runtime-login>" WITH INHERIT FALSE, SET TRUE;
+GRANT geolens_tile_gateway   TO "<tile-login>"    WITH INHERIT FALSE, SET TRUE;
+SQL
+```
+
+**2f. Give the temporary privileges back.**
 
 Only if you granted them in 2b. Adoption manages its own borrow when it has to
 take one, and hands that back on its own; these two are yours, and left in place

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -569,7 +569,22 @@ docker compose exec -T db pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
   --clean --if-exists --no-owner --no-acl < ./restore/geolens_<timestamp>.dump
 ```
 
-**2b. Adopt the restored tenant objects.**
+**2b. Bring the restored schema to head.**
+
+A dump older than the running release restores an older schema, and adoption
+works only at head — it refuses on a boundary function that a later migration
+installed. `--no-deps` is what stops the `migrate` one-shot and the API
+entrypoint from doing this for you, so do it here, with the same override:
+
+```bash
+docker compose run --rm --no-deps -e DATABASE_URL_OVERRIDE="<migrator-url>" \
+  migrate sh -c "uv run --no-dev alembic upgrade heads"
+```
+
+Skip it only if the dump came from the running release. Running it anyway is a
+no-op on a database already at head.
+
+**2c. Adopt the restored tenant objects.**
 
 Replaying globals restores role definitions only. The restored tables, views,
 and sequences are all owned by whoever ran `pg_restore`, with no per-tenant

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -148,13 +148,15 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
                    -- policy denies every runtime read, and an altered one can
                    -- return another tenant's rows. Its expression has been
                    -- byte-identical since 0006, so it is compared exactly.
-                   -- ...and the only permissive one. PostgreSQL ORs permissive
-                   -- policies, so a second `USING (true)` beside the canonical
-                   -- rule returns every tenant's rows with RLS fully enabled.
+                   -- ...and the only policy of any kind. PostgreSQL ORs
+                   -- permissive policies, so a second `USING (true)` beside the
+                   -- canonical rule returns every tenant's rows with RLS fully
+                   -- enabled; it ANDs restrictive ones, so an added
+                   -- `USING (false)` denies everything. Neither is what the
+                   -- migrations install and neither is repaired at boot.
                    (
                        SELECT count(*) FROM pg_catalog.pg_policy AS policy
                        WHERE policy.polrelid = relation.oid
-                         AND policy.polpermissive
                    ) = 1
                    AND EXISTS (
                        SELECT 1 FROM pg_catalog.pg_policy AS policy
@@ -466,6 +468,32 @@ def _role_secure_sql(
                           AND NOT membership.admin_option
                           AND {_MEMBER_SET_ONLY}
                     ) = {len(gateways)}
+                    -- Counting the good rows is not enough: PostgreSQL allows a
+                    -- second grant of the same role to the same member from a
+                    -- different grantor, and one carrying INHERIT or ADMIN would
+                    -- sit beside the canonical row undetected. The gateway would
+                    -- then hold the tenant role's privileges outright instead of
+                    -- having to SET ROLE for them.
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM pg_catalog.pg_auth_members AS membership
+                        JOIN pg_catalog.pg_roles AS member_role
+                          ON member_role.oid = membership.member
+                        WHERE membership.roleid = (SELECT oid FROM {role_cte})
+                          AND member_role.rolname IN ({gateway_names})
+                          AND NOT (
+                              NOT membership.admin_option AND {_MEMBER_SET_ONLY}
+                          )
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM pg_catalog.pg_auth_members AS membership
+                        JOIN pg_catalog.pg_roles AS member_role
+                          ON member_role.oid = membership.member
+                        WHERE membership.roleid = (SELECT oid FROM {role_cte})
+                          AND member_role.rolname = '{PROVISIONER}'
+                          AND NOT (membership.admin_option AND {_MEMBER_ADMIN_ONLY})
+                    )
                 )"""
 
 

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -56,6 +56,7 @@ from app.core.db.tenant_adoption_report import (
     BOUNDARY_TRIGGER_FUNCTION,
     BOUNDARY_TRIGGER_TYPE,
     ISOLATION_POLICY_EXPRESSION,
+    STAMPING_FUNCTION_SEARCH_PATH,
     AdoptionReport,
     BoundaryFunctionState,
     BoundaryTableState,
@@ -70,6 +71,7 @@ from app.core.db.tenant_adoption_sql import (
     CONTROL,
     PROVISIONER,
     PROVISIONER_DATABASE_GRANT_SQL,
+    RELEASE_BOOTSTRAP_MEMBERSHIP_SQL,
     SANDBOX,
     SECURE_BOUNDARY_FUNCTIONS_SQL,
     TENANT_GUC,
@@ -263,8 +265,9 @@ async def stamping_function_shape(conn) -> str | None:
             SELECT language.lanname AS language,
                    routine.prosecdef AS security_definer,
                    routine.prorettype = 'trigger'::regtype AS returns_trigger,
-                   COALESCE(routine.proconfig::text LIKE '%search_path=%', false)
-                       AS search_path_pinned,
+                   COALESCE(
+                       :stamping_search_path = ANY(routine.proconfig), false
+                   ) AS search_path_pinned,
                    (
                        {_EXECUTABLE_BODY} LIKE '%app.current_tenant%'
                        AND {_EXECUTABLE_BODY} LIKE '%NEW.tenant_id%'
@@ -279,7 +282,10 @@ async def stamping_function_shape(conn) -> str | None:
               AND routine.pronargs = 0
             """
         ),
-        {"name": BOUNDARY_TRIGGER_FUNCTION},
+        {
+            "name": BOUNDARY_TRIGGER_FUNCTION,
+            "stamping_search_path": STAMPING_FUNCTION_SEARCH_PATH,
+        },
     )
     row = result.one_or_none()
     if row is None:
@@ -299,7 +305,11 @@ async def stamping_function_shape(conn) -> str | None:
             "installs it SECURITY INVOKER, and it fires on every insert"
         )
     if not row.search_path_pinned:
-        return f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() has no pinned search_path"
+        return (
+            f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() does not carry "
+            f"`SET {STAMPING_FUNCTION_SEARCH_PATH}` — an unqualified name in it "
+            "can resolve through a writable schema"
+        )
     if not row.body_markers_present:
         return (
             f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() has a body that no longer "
@@ -558,6 +568,14 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                              (SELECT schema_name FROM names),
                              'USAGE'
                          )
+                     -- The reader is the SET target of the sandbox and tile
+                     -- gateways. CREATE there would let either of them build
+                     -- objects in a schema meant to be read-only.
+                     AND NOT pg_catalog.has_schema_privilege(
+                             (SELECT oid FROM reader),
+                             (SELECT schema_name FROM names),
+                             'CREATE'
+                         )
                      AND pg_catalog.has_schema_privilege(
                              (SELECT oid FROM writer),
                              (SELECT schema_name FROM names),
@@ -622,6 +640,18 @@ async def secure_boundary_functions(conn) -> list[BoundaryFunctionState]:
     return await boundary_function_states(conn)
 
 
+async def release_bootstrap_membership(engine) -> None:
+    """Give back the provisioner membership a fresh-cluster run had to take.
+
+    Leaving it would make the next recovery depend on the same migrator
+    credential, because the cluster guard rejects every direct member of the
+    provisioner except the role running it.  A no-op unless this run created the
+    role and granted itself the edge.
+    """
+    async with engine.begin() as conn:
+        await conn.execute(text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
+
+
 async def adopt_tenant(conn, tenant_id: str) -> None:
     """Move one tenant's schema, roles, and relations under the boundary."""
     normalized = str(uuid.UUID(tenant_id))
@@ -670,6 +700,8 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
             logger.error(
                 "tenant_adoption: tenant failed", tenant_id=tenant_id, exc_info=True
             )
+
+    await release_bootstrap_membership(engine)
 
     topology = await cluster_topology_error(engine)
     async with engine.connect() as conn:

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -860,12 +860,27 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                 -- reader explicitly on each relation, so a default ACL here
                 -- hands out privileges on relations that do not exist yet, to
                 -- whoever it names.
+                -- fix(#998 codex r47): schema-less entries (defaclnamespace 0)
+                -- owned by the tenant pair or the provisioner apply to every
+                -- schema they create in; --apply refuses them, so the dry run
+                -- must count them or call adopted what --apply would stop on.
                 (
                     SELECT count(*)
                     FROM pg_catalog.pg_default_acl AS default_acl
-                    JOIN pg_catalog.pg_namespace AS namespace
+                    LEFT JOIN pg_catalog.pg_namespace AS namespace
                       ON namespace.oid = default_acl.defaclnamespace
                     WHERE namespace.nspname = (SELECT schema_name FROM names)
+                       OR (
+                           default_acl.defaclnamespace = 0
+                           AND default_acl.defaclrole IN (
+                               (SELECT oid FROM reader),
+                               (SELECT oid FROM writer),
+                               (
+                                   SELECT oid FROM pg_catalog.pg_roles
+                                   WHERE rolname = :provisioner
+                               )
+                           )
+                       )
                 ) AS unexpected_default_acls,
                 """
             + _role_secure_sql("reader", (PROVISIONER, SANDBOX, TILE), (SANDBOX, TILE))

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -53,11 +53,15 @@ from sqlalchemy import text
 from app.core.db.rls import RLS_TABLES
 from app.core.db.tenant_adoption_sql import (
     ADOPT_TENANT_SQL,
-    CLUSTER_ROLE_SQL,
+    CLUSTER_ROLE_CREATE_SQL,
+    CLUSTER_ROLE_VALIDATE_SQL,
     CONTROL,
     PROVISIONER,
     PROVISIONER_DATABASE_GRANT_SQL,
+    SANDBOX,
     TENANT_GUC,
+    TILE,
+    WRITER,
 )
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -114,9 +118,19 @@ class TenantOwnershipState:
     relations: int
     relations_not_owned_by_writer: int
     relations_without_reader_select: int
+    reader_role_secure: bool
+    writer_role_secure: bool
+    schema_privileges_secure: bool
 
     @property
     def adopted(self) -> bool:
+        """Every invariant ``--apply`` enforces, not just the visible ones.
+
+        Ownership and effective privileges alone would call a reader carrying
+        ``LOGIN``/``SUPERUSER``/``BYPASSRLS`` adopted — a superuser satisfies the
+        ``SELECT`` check by fiat — and would miss a stray member or a missing
+        gateway edge, both of which ``ADOPT_TENANT_SQL`` refuses or repairs.
+        """
         return (
             self.schema_exists
             and self.schema_owner == PROVISIONER
@@ -124,6 +138,9 @@ class TenantOwnershipState:
             and self.writer_exists
             and self.relations_not_owned_by_writer == 0
             and self.relations_without_reader_select == 0
+            and self.reader_role_secure
+            and self.writer_role_secure
+            and self.schema_privileges_secure
         )
 
 
@@ -243,12 +260,99 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
     return [BoundaryFunctionState(**dict(row._mapping)) for row in result]
 
 
+async def cluster_topology_error(engine) -> str | None:
+    """Would ``--apply`` refuse this cluster's fixed role topology?
+
+    Runs the identical guard ``ensure_cluster_roles`` runs, minus the half that
+    creates anything, rather than a read-only paraphrase of it that could drift.
+    A raise aborts the transaction, so it gets a connection of its own.
+    """
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(CLUSTER_ROLE_VALIDATE_SQL))
+    except Exception as exc:  # broad: any refusal is the answer, whatever its class
+        return str(exc).strip().splitlines()[0]
+    return None
+
+
 async def list_tenants(conn) -> list[str]:
     """Every tenant id in the control plane, in a stable order."""
     result = await conn.execute(
         text("SELECT id::text FROM catalog.tenants ORDER BY id")
     )
     return [row[0] for row in result]
+
+
+#: ``pg_auth_members.inherit_option``/``set_option`` arrived in PostgreSQL 16 and
+#: GeoLens supports 13 and up (README), so naming those columns directly would be
+#: a parse error on an older server.  Reading them back out of the row as jsonb
+#: parses everywhere, and the guard degrades to ``admin_option`` alone before 16 —
+#: which is correct, because that is where NOINHERIT on the fixed gateway roles
+#: carries the same SET-only guarantee.
+_MEMBER_OPTIONS_PRESENT = "jsonb_exists(to_jsonb(membership), 'set_option')"
+_MEMBER_INHERIT = "(to_jsonb(membership) ->> 'inherit_option')::boolean"
+_MEMBER_SET = "(to_jsonb(membership) ->> 'set_option')::boolean"
+_MEMBER_ADMIN_ONLY = (
+    f"(NOT {_MEMBER_OPTIONS_PRESENT} OR NOT ({_MEMBER_INHERIT} OR {_MEMBER_SET}))"
+)
+_MEMBER_SET_ONLY = (
+    f"(NOT {_MEMBER_OPTIONS_PRESENT} OR (NOT {_MEMBER_INHERIT} AND {_MEMBER_SET}))"
+)
+
+
+def _role_secure_sql(
+    role_cte: str, allowed_members: tuple[str, ...], gateways: tuple[str, ...]
+) -> str:
+    """SQL for "this per-tenant role has the shape ``--apply`` enforces".
+
+    Every clause mirrors a refusal in ``ADOPT_TENANT_SQL`` or in
+    ``catalog.provision_tenant_data_schema``, so a dry run cannot call a topology
+    adopted that ``--apply`` would reject or repair.  Role existence and
+    effective privileges are not enough on their own: a reader carrying
+    ``SUPERUSER`` satisfies every ``has_table_privilege`` check by fiat.
+
+    Role names come from the module constants above, never from a caller.
+    """
+    allowed = ", ".join(f"'{name}'" for name in allowed_members)
+    gateway_names = ", ".join(f"'{name}'" for name in gateways)
+    return f"""(
+                    EXISTS (
+                        SELECT 1 FROM {role_cte}
+                        WHERE NOT rolcanlogin AND NOT rolsuper AND NOT rolcreatedb
+                          AND NOT rolcreaterole AND NOT rolinherit
+                          AND NOT rolreplication AND NOT rolbypassrls
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM pg_catalog.pg_auth_members AS membership
+                        JOIN pg_catalog.pg_roles AS member_role
+                          ON member_role.oid = membership.member
+                        WHERE membership.roleid = (SELECT oid FROM {role_cte})
+                          AND member_role.rolname NOT IN ({allowed})
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM pg_catalog.pg_auth_members AS membership
+                        WHERE membership.member = (SELECT oid FROM {role_cte})
+                    )
+                    AND EXISTS (
+                        SELECT 1 FROM pg_catalog.pg_auth_members AS membership
+                        JOIN pg_catalog.pg_roles AS member_role
+                          ON member_role.oid = membership.member
+                        WHERE membership.roleid = (SELECT oid FROM {role_cte})
+                          AND member_role.rolname = '{PROVISIONER}'
+                          AND membership.admin_option
+                          AND {_MEMBER_ADMIN_ONLY}
+                    )
+                    AND (
+                        SELECT count(*)
+                        FROM pg_catalog.pg_auth_members AS membership
+                        JOIN pg_catalog.pg_roles AS member_role
+                          ON member_role.oid = membership.member
+                        WHERE membership.roleid = (SELECT oid FROM {role_cte})
+                          AND member_role.rolname IN ({gateway_names})
+                          AND NOT membership.admin_option
+                          AND {_MEMBER_SET_ONLY}
+                    ) = {len(gateways)}
+                )"""
 
 
 async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
@@ -264,8 +368,12 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                            AS writer_name
             ),
             reader AS (
-                SELECT oid FROM pg_catalog.pg_roles
+                SELECT * FROM pg_catalog.pg_roles
                 WHERE rolname = (SELECT reader_name FROM names)
+            ),
+            writer AS (
+                SELECT * FROM pg_catalog.pg_roles
+                WHERE rolname = (SELECT writer_name FROM names)
             ),
             relations AS (
                 SELECT relation.oid, relation.relkind, owner_role.rolname AS owner
@@ -324,7 +432,36 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                             )
                         )
                     )
-                END AS relations_without_reader_select
+                END AS relations_without_reader_select,
+                """
+            + _role_secure_sql("reader", (PROVISIONER, SANDBOX, TILE), (SANDBOX, TILE))
+            + " AS reader_role_secure, "
+            + _role_secure_sql("writer", (PROVISIONER, WRITER), (WRITER,))
+            + """ AS writer_role_secure,
+                CASE
+                    WHEN NOT EXISTS (
+                        SELECT 1 FROM pg_catalog.pg_namespace
+                        WHERE nspname = (SELECT schema_name FROM names)
+                    ) OR NOT EXISTS (SELECT 1 FROM reader)
+                      OR NOT EXISTS (SELECT 1 FROM writer)
+                    THEN false
+                    ELSE NOT pg_catalog.has_schema_privilege(
+                             'public', (SELECT schema_name FROM names), 'USAGE'
+                         )
+                     AND NOT pg_catalog.has_schema_privilege(
+                             'public', (SELECT schema_name FROM names), 'CREATE'
+                         )
+                     AND pg_catalog.has_schema_privilege(
+                             (SELECT oid FROM reader),
+                             (SELECT schema_name FROM names),
+                             'USAGE'
+                         )
+                     AND pg_catalog.has_schema_privilege(
+                             (SELECT oid FROM writer),
+                             (SELECT schema_name FROM names),
+                             'USAGE, CREATE'
+                         )
+                END AS schema_privileges_secure
             """
         ),
         {"tenant_id": tenant_id},
@@ -340,7 +477,8 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
 
 async def ensure_cluster_roles(conn) -> None:
     """Create the fixed role topology if absent, and refuse an unsafe one."""
-    await conn.execute(text(CLUSTER_ROLE_SQL))
+    await conn.execute(text(CLUSTER_ROLE_CREATE_SQL))
+    await conn.execute(text(CLUSTER_ROLE_VALIDATE_SQL))
     await conn.execute(text(PROVISIONER_DATABASE_GRANT_SQL))
     await conn.execute(text(f"GRANT USAGE ON SCHEMA catalog TO {PROVISIONER}"))
     await conn.execute(text(f"GRANT SELECT ON TABLE catalog.tenants TO {PROVISIONER}"))
@@ -410,6 +548,7 @@ class AdoptionReport:
     before: list[TenantOwnershipState]
     after: list[TenantOwnershipState]
     failures: dict[str, str]
+    cluster_topology: str | None = None
 
     @property
     def missing_functions(self) -> list[str]:
@@ -430,10 +569,10 @@ class AdoptionReport:
         what makes ``--apply``-less invocation usable as a post-restore check.
         Every condition the report surfaces has to be in here, or the check
         passes on a database the report itself calls broken: a missing boundary
-        function, and boundary drift that leaves a stamped table without RLS at
-        boot, both count.
+        function, a fixed-role topology ``--apply`` would refuse, and boundary
+        drift that leaves a stamped table without RLS at boot all count.
         """
-        if self.failures or self.missing_functions:
+        if self.failures or self.missing_functions or self.cluster_topology:
             return False
         if not all(function.secured for function in self.functions):
             return False
@@ -451,6 +590,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
         before = [await tenant_ownership_state(conn, tid) for tid in tenants]
         boundary = await live_tenant_boundary(conn)
         functions = await boundary_function_states(conn)
+    topology = await cluster_topology_error(engine)
 
     if not apply:
         return AdoptionReport(
@@ -460,6 +600,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
             before=before,
             after=before,
             failures={},
+            cluster_topology=topology,
         )
 
     async with engine.begin() as conn:
@@ -480,6 +621,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
     async with engine.connect() as conn:
         after = [await tenant_ownership_state(conn, tid) for tid in tenants]
         boundary = await live_tenant_boundary(conn)
+    topology = await cluster_topology_error(engine)
 
     return AdoptionReport(
         applied=True,
@@ -488,7 +630,20 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
         before=before,
         after=after,
         failures=failures,
+        cluster_topology=topology,
     )
+
+
+def _format_cluster_roles(report: AdoptionReport) -> list[str]:
+    if report.cluster_topology is None:
+        return [
+            f"Fixed cluster roles ({PROVISIONER} and the four gateways): "
+            "present, with safe attributes and memberships."
+        ]
+    return [
+        f"Fixed cluster roles: NEEDS ATTENTION — {report.cluster_topology}",
+        "  --apply creates a missing role; it refuses an unsafe one.",
+    ]
 
 
 def _format_functions(report: AdoptionReport) -> list[str]:
@@ -559,13 +714,23 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
     after_by_id = {state.tenant_id: state for state in report.after}
     for before in report.before:
         after = after_by_id[before.tenant_id]
-        detail = (
-            f"{after.relations} relation(s), "
-            f"{after.relations_not_owned_by_writer} not owned by the writer, "
-            f"{after.relations_without_reader_select} without reader SELECT"
-        )
+        detail = [
+            f"{after.relations} relation(s)",
+            f"{after.relations_not_owned_by_writer} not owned by the writer",
+            f"{after.relations_without_reader_select} without reader SELECT",
+        ]
+        if not after.reader_role_secure:
+            detail.append(
+                "reader role attributes or memberships are not the safe shape"
+            )
+        if not after.writer_role_secure:
+            detail.append(
+                "writer role attributes or memberships are not the safe shape"
+            )
+        if not after.schema_privileges_secure:
+            detail.append("schema privileges are not the safe shape")
         verdict = _tenant_verdict(before, after, report.applied)
-        lines.append(f"  {before.tenant_id}: {verdict} — {detail}")
+        lines.append(f"  {before.tenant_id}: {verdict} — {', '.join(detail)}")
     return lines
 
 
@@ -574,6 +739,7 @@ def format_report(report: AdoptionReport) -> str:
     mode = "APPLIED" if report.applied else "DRY RUN (no changes made)"
     sections = [
         [f"Tenant-ownership adoption — {mode}"],
+        _format_cluster_roles(report),
         _format_functions(report),
         _format_boundary(report.boundary),
         _format_tenants(report),

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -223,6 +223,16 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
                    pg_catalog.has_function_privilege(
                        'public', routine.oid, 'EXECUTE'
                    ) AS public_execute,
+                   -- A direct EXECUTE to a named role survives REVOKE … FROM
+                   -- PUBLIC, and lets that role call provisioner-owned tenant
+                   -- management.
+                   (
+                       SELECT count(DISTINCT grantee_role.rolname)
+                       FROM LATERAL pg_catalog.aclexplode(routine.proacl) AS acl
+                       JOIN pg_catalog.pg_roles AS grantee_role
+                         ON grantee_role.oid = acl.grantee
+                       WHERE grantee_role.rolname NOT IN (:provisioner, :control)
+                   ) AS unexpected_grantees,
                    CASE
                        WHEN EXISTS (
                            SELECT 1 FROM pg_catalog.pg_roles
@@ -245,7 +255,11 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
             ORDER BY routine.proname
             """
         ),
-        {"control": CONTROL, "names": list(BOUNDARY_FUNCTIONS)},
+        {
+            "control": CONTROL,
+            "provisioner": PROVISIONER,
+            "names": list(BOUNDARY_FUNCTIONS),
+        },
     )
     return [BoundaryFunctionState(**dict(row._mapping)) for row in result]
 

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -700,12 +700,18 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                       AND type_row.typowner IS DISTINCT FROM (
                           SELECT oid FROM writer
                       )
-      -- Array types follow their element type, and a table's row type follows
-      -- the table; both move on their own. An extension's types belong to the
+      -- Array types follow their element type, a table's row type follows the
+      -- table, and a range's generated multirange follows the range (14+):
+      -- all move on their own, and ALTER TYPE on the multirange directly is
+      -- refused (fix(#998 codex r46)). An extension's types belong to the
       -- extension.
       AND NOT EXISTS (
           SELECT 1 FROM pg_catalog.pg_type AS element
           WHERE element.typarray = type_row.oid
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_range AS range_type
+          WHERE range_type.rngmultitypid = type_row.oid
       )
       AND (
           type_row.typrelid = 0

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -639,6 +639,20 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                     ELSE (
                         SELECT count(*) FROM relations
                         WHERE EXISTS (
+                            -- Column grants live in pg_attribute, and a
+                            -- table-level REVOKE ALL does not clear them.
+                            SELECT 1
+                            FROM pg_catalog.pg_attribute AS column_row
+                            JOIN LATERAL
+                              pg_catalog.aclexplode(column_row.attacl) AS acl
+                              ON true
+                            WHERE column_row.attrelid = relations.oid
+                              AND NOT column_row.attisdropped
+                              AND acl.grantee IS DISTINCT FROM (
+                                  SELECT oid FROM writer
+                              )
+                        )
+                        OR EXISTS (
                             SELECT 1
                             FROM pg_catalog.pg_class AS relation
                             JOIN LATERAL pg_catalog.aclexplode(relation.relacl)

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -46,12 +46,22 @@ from __future__ import annotations
 import argparse
 import asyncio
 import uuid
-from dataclasses import dataclass, field
 
 import structlog
 from sqlalchemy import text
 
-from app.core.db.rls import RLS_TABLES
+from app.core.db.tenant_adoption_report import (
+    BOUNDARY_FUNCTIONS,
+    BOUNDARY_TRIGGER,
+    BOUNDARY_TRIGGER_FUNCTION,
+    BOUNDARY_TRIGGER_TYPE,
+    AdoptionReport,
+    BoundaryFunctionState,
+    BoundaryTableState,
+    TenantOwnershipState,
+    format_report,
+    unexpected_shape,
+)
 from app.core.db.tenant_adoption_sql import (
     ADOPT_TENANT_SQL,
     CLUSTER_ROLE_CREATE_SQL,
@@ -67,135 +77,6 @@ from app.core.db.tenant_adoption_sql import (
 )
 
 logger = structlog.stdlib.get_logger(__name__)
-
-#: The two migration-owned SECURITY DEFINER entry points.  Adoption verifies and
-#: re-secures them; it never rewrites their bodies.
-BOUNDARY_FUNCTIONS = (
-    "provision_tenant_data_schema",
-    "deprovision_tenant_data_schema",
-)
-
-#: The insert-stamping trigger 0018 installs.  Its presence — not any constant
-#: frozen into a migration — is what marks a table as tenant-scoped.
-BOUNDARY_TRIGGER = "trg_stamp_current_tenant_on_insert"
-
-
-# ---------------------------------------------------------------------------
-# Report types
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class BoundaryFunctionState:
-    """Live state of one migration-owned SECURITY DEFINER entry point."""
-
-    name: str
-    owner: str
-    security_definer: bool
-    search_path_pinned: bool
-    public_execute: bool
-    control_execute: bool
-
-    @property
-    def secured(self) -> bool:
-        return (
-            self.owner == PROVISIONER
-            and self.security_definer
-            and self.search_path_pinned
-            and not self.public_execute
-            and self.control_execute
-        )
-
-
-@dataclass(frozen=True)
-class TenantOwnershipState:
-    """Live ownership state of one tenant's data plane."""
-
-    tenant_id: str
-    schema_name: str
-    schema_exists: bool
-    schema_owner: str | None
-    reader_exists: bool
-    writer_exists: bool
-    relations: int
-    relations_not_owned_by_writer: int
-    relations_without_reader_select: int
-    reader_default_acls: int
-    reader_role_secure: bool
-    writer_role_secure: bool
-    schema_privileges_secure: bool
-
-    @property
-    def adopted(self) -> bool:
-        """Every invariant ``--apply`` enforces, not just the visible ones.
-
-        Ownership and effective privileges alone would call a reader carrying
-        ``LOGIN``/``SUPERUSER``/``BYPASSRLS`` adopted — a superuser satisfies the
-        ``SELECT`` check by fiat — and would miss a stray member or a missing
-        gateway edge, both of which ``ADOPT_TENANT_SQL`` refuses or repairs.
-        """
-        return (
-            self.schema_exists
-            and self.schema_owner == PROVISIONER
-            and self.reader_exists
-            and self.writer_exists
-            and self.relations_not_owned_by_writer == 0
-            and self.relations_without_reader_select == 0
-            and self.reader_default_acls == 0
-            and self.reader_role_secure
-            and self.writer_role_secure
-            and self.schema_privileges_secure
-        )
-
-
-@dataclass(frozen=True)
-class BoundaryTableState:
-    """A ``catalog`` table carrying tenant state, as the database reports it."""
-
-    name: str
-    has_stamping_trigger: bool
-    stamping_trigger_disabled: bool
-    has_tenant_id: bool
-    rls_enabled: bool
-    rls_forced: bool
-
-
-def rls_gaps(boundary: list[BoundaryTableState], *, tenants_present: bool) -> list[str]:
-    """Boundary tables whose row-security posture is not safe to serve.
-
-    ``apply_tenancy_rls`` is mode-gated and a single-tenant install correctly
-    keeps row security off, so a uniformly disabled boundary on a control plane
-    with no tenants is not a finding — and this module cannot read the mode out
-    of the database, only the tenants.  Two states always are findings: a
-    control plane that *has* tenants with row security off, where the isolation
-    boundary simply is not there; and row security enabled without ``FORCE``,
-    where the table owner bypasses every policy.
-    """
-    gaps: list[str] = []
-    for table in boundary:
-        if not table.has_stamping_trigger:
-            continue
-        if tenants_present and not table.rls_enabled:
-            gaps.append(f"{table.name} (row security disabled)")
-        elif table.rls_enabled and not table.rls_forced:
-            gaps.append(f"{table.name} (row security not FORCEd)")
-    return gaps
-
-
-def boundary_drift(boundary: list[BoundaryTableState]) -> tuple[list[str], list[str]]:
-    """Compare the live boundary against the runtime constant that drives RLS.
-
-    ``apply_tenancy_rls`` enables and FORCEs row security from
-    ``app.core.db.rls.RLS_TABLES``.  A table that joined the live boundary
-    without joining that tuple is silently skipped at boot, which is exactly the
-    failure a restored multi-tenant cluster cannot afford.  The other direction
-    is drift too: a table named in the tuple but carrying no stamping trigger
-    accepts an insert with no ``tenant_id`` at all.  Returns
-    ``(live_only, constant_only)``.
-    """
-    live = {state.name for state in boundary if state.has_stamping_trigger}
-    declared = set(RLS_TABLES)
-    return sorted(live - declared), sorted(declared - live)
 
 
 # ---------------------------------------------------------------------------
@@ -229,14 +110,22 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
                          AND trigger_row.tgname = :trigger_name
                          AND NOT trigger_row.tgisinternal
                          AND trigger_row.tgenabled IN ('O', 'A')
+                         AND trigger_row.tgtype = :before_insert_row
+                         AND trigger_row.tgfoid = (
+                             SELECT routine.oid
+                             FROM pg_catalog.pg_proc AS routine
+                             JOIN pg_catalog.pg_namespace AS routine_schema
+                               ON routine_schema.oid = routine.pronamespace
+                             WHERE routine_schema.nspname = 'catalog'
+                               AND routine.proname = :trigger_function
+                         )
                    ) AS has_stamping_trigger,
                    EXISTS (
                        SELECT 1 FROM pg_catalog.pg_trigger AS trigger_row
                        WHERE trigger_row.tgrelid = relation.oid
                          AND trigger_row.tgname = :trigger_name
                          AND NOT trigger_row.tgisinternal
-                         AND trigger_row.tgenabled NOT IN ('O', 'A')
-                   ) AS stamping_trigger_disabled,
+                   ) AS stamping_trigger_present,
                    EXISTS (
                        SELECT 1 FROM pg_catalog.pg_attribute AS attribute
                        WHERE attribute.attrelid = relation.oid
@@ -253,14 +142,18 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
             ORDER BY relation.relname
             """
         ),
-        {"trigger_name": BOUNDARY_TRIGGER},
+        {
+            "trigger_name": BOUNDARY_TRIGGER,
+            "trigger_function": BOUNDARY_TRIGGER_FUNCTION,
+            "before_insert_row": BOUNDARY_TRIGGER_TYPE,
+        },
     )
     states = [BoundaryTableState(**dict(row._mapping)) for row in result]
     return [
         state
         for state in states
         if state.has_stamping_trigger
-        or state.stamping_trigger_disabled
+        or state.stamping_trigger_present
         or state.has_tenant_id
     ]
 
@@ -276,6 +169,13 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
                    COALESCE(
                        'search_path=pg_catalog' = ANY(routine.proconfig), false
                    ) AS search_path_pinned,
+                   language.lanname AS language,
+                   routine.prorettype = 'void'::regtype AS returns_void,
+                   (
+                       routine.prosrc LIKE '%catalog.tenants%'
+                       AND routine.prosrc LIKE '%data_t_%'
+                       AND routine.prosrc LIKE '%pg_advisory_xact_lock%'
+                   ) AS body_markers_present,
                    pg_catalog.has_function_privilege(
                        'public', routine.oid, 'EXECUTE'
                    ) AS public_execute,
@@ -292,6 +192,8 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
             FROM pg_catalog.pg_proc AS routine
             JOIN pg_catalog.pg_namespace AS namespace
               ON namespace.oid = routine.pronamespace
+            JOIN pg_catalog.pg_language AS language
+              ON language.oid = routine.prolang
             WHERE namespace.nspname = 'catalog'
               AND routine.proname = ANY(:names)
               AND routine.pronargs = 1
@@ -606,16 +508,12 @@ async def secure_boundary_functions(conn) -> list[BoundaryFunctionState]:
             "`alembic upgrade heads` against this database first."
         )
     for name, state in states.items():
-        if not state.security_definer:
+        reason = unexpected_shape(state)
+        if reason is not None:
             raise RuntimeError(
-                f"catalog.{name}(uuid) is not SECURITY DEFINER. This is not the "
-                "migration-installed boundary function; refusing to adopt it."
-            )
-        if not state.search_path_pinned:
-            raise RuntimeError(
-                f"catalog.{name}(uuid) has no `SET search_path = pg_catalog`. "
-                "This is not the migration-installed boundary function; "
-                "refusing to adopt it."
+                f"catalog.{name}(uuid) {reason}. This is not the shape the "
+                "migrations install; refusing to give it to "
+                f"{PROVISIONER} or to grant {CONTROL} execution on it."
             )
 
     await conn.execute(text(SECURE_BOUNDARY_FUNCTIONS_SQL))
@@ -630,88 +528,6 @@ async def adopt_tenant(conn, tenant_id: str) -> None:
         {"guc": TENANT_GUC, "tenant_id": normalized},
     )
     await conn.execute(text(ADOPT_TENANT_SQL))
-
-
-# ---------------------------------------------------------------------------
-# Orchestration + CLI
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class AdoptionReport:
-    """What adoption found, and what it changed."""
-
-    applied: bool
-    functions: list[BoundaryFunctionState]
-    boundary: list[BoundaryTableState]
-    before: list[TenantOwnershipState]
-    after: list[TenantOwnershipState]
-    failures: dict[str, str]
-    cluster_topology: str | None = None
-    provisioner_grants_missing: list[str] = field(default_factory=list)
-
-    @property
-    def missing_functions(self) -> list[str]:
-        """Boundary functions the schema does not have.
-
-        ``boundary_function_states`` omits what it cannot find, so an absent
-        function shortens the list rather than marking one unsecured.  Naming
-        the gap keeps ``all(... .secured)`` from passing vacuously.
-        """
-        present = {function.name for function in self.functions}
-        return [name for name in BOUNDARY_FUNCTIONS if name not in present]
-
-    @property
-    def disabled_stamping_triggers(self) -> list[str]:
-        """Boundary tables whose stamping trigger exists but does not fire.
-
-        Its own condition, not a corollary of the drift check: a table that is
-        newly tenant-scoped *and* absent from ``RLS_TABLES`` lands in neither
-        drift direction and has no row-security requirement to miss, so a
-        disabled trigger there would otherwise be printed and then ignored.
-        """
-        return sorted(
-            table.name for table in self.boundary if table.stamping_trigger_disabled
-        )
-
-    @property
-    def rls_gaps(self) -> list[str]:
-        """Boundary tables that cannot enforce tenant isolation as they stand.
-
-        Tenant rows in the control plane are what makes a database
-        multi-tenant, so they are what makes row security mandatory here.
-        """
-        return rls_gaps(self.boundary, tenants_present=bool(self.before))
-
-    @property
-    def ok(self) -> bool:
-        """True when nothing is left to do — the exit code in both modes.
-
-        A dry run that reports pending work therefore exits non-zero, which is
-        what makes ``--apply``-less invocation usable as a post-restore check.
-        Every condition the report surfaces has to be in here, or the check
-        passes on a database the report itself calls broken: a missing boundary
-        function, a fixed-role topology ``--apply`` would refuse, a provisioner
-        grant a restore dropped, boundary drift that leaves a stamped table
-        without RLS at boot, a stamping trigger that does not fire, and a
-        boundary table that cannot enforce isolation as it stands all count.
-        """
-        if (
-            self.failures
-            or self.missing_functions
-            or self.cluster_topology
-            or self.provisioner_grants_missing
-            or self.rls_gaps
-            or self.disabled_stamping_triggers
-        ):
-            return False
-        if not all(function.secured for function in self.functions):
-            return False
-        live_only, constant_only = boundary_drift(self.boundary)
-        if live_only or constant_only:
-            return False
-        states = self.after if self.applied else self.before
-        return all(state.adopted for state in states)
 
 
 async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
@@ -767,154 +583,6 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
         cluster_topology=topology,
         provisioner_grants_missing=grants,
     )
-
-
-def _format_cluster_roles(report: AdoptionReport) -> list[str]:
-    if report.cluster_topology is not None:
-        return [
-            f"Fixed cluster roles: NEEDS ATTENTION — {report.cluster_topology}",
-            "  --apply creates a missing role; it refuses an unsafe one.",
-        ]
-    lines = [
-        f"Fixed cluster roles ({PROVISIONER} and the four gateways): "
-        "present, with safe attributes and memberships."
-    ]
-    if report.provisioner_grants_missing:
-        lines.append(
-            f"  {PROVISIONER} is missing "
-            f"{', '.join(report.provisioner_grants_missing)} — tenant "
-            "provisioning cannot run without them; --apply re-grants them."
-        )
-    return lines
-
-
-def _format_functions(report: AdoptionReport) -> list[str]:
-    lines = ["Boundary functions:"]
-    for function in report.functions:
-        flags = [f"owner={function.owner}"]
-        if function.public_execute:
-            flags.append("EXECUTE granted to PUBLIC")
-        if not function.control_execute:
-            flags.append(f"no EXECUTE for {CONTROL}")
-        verdict = "secured" if function.secured else "NEEDS REPAIR"
-        lines.append(f"  catalog.{function.name}(uuid): {verdict} — {', '.join(flags)}")
-    for name in report.missing_functions:
-        lines.append(
-            f"  catalog.{name}(uuid): MISSING — this database is not at the head "
-            "schema; run `alembic upgrade heads` first"
-        )
-    return lines
-
-
-def _boundary_table_markers(
-    table: BoundaryTableState, *, tenants_present: bool
-) -> list[str]:
-    if table.stamping_trigger_disabled:
-        return [
-            f"{BOUNDARY_TRIGGER} exists but is DISABLED — it stamps nothing, and "
-            "nothing at boot re-enables it"
-        ]
-    if not table.has_stamping_trigger:
-        return ["tenant_id column only, outside the stamped boundary"]
-    if not table.rls_enabled:
-        if tenants_present:
-            return ["RLS not enabled on a control plane that has tenants"]
-        return ["RLS not enabled (correct while the control plane has no tenants)"]
-    if not table.rls_forced:
-        return ["RLS enabled but not FORCEd — the table owner bypasses it"]
-    return []
-
-
-def _format_boundary(report: AdoptionReport) -> list[str]:
-    boundary = report.boundary
-    tenants_present = bool(report.before)
-    lines = [f"Live tenant boundary ({BOUNDARY_TRIGGER}), read from the database:"]
-    for table in boundary:
-        markers = _boundary_table_markers(table, tenants_present=tenants_present)
-        suffix = f" — {'; '.join(markers)}" if markers else ""
-        lines.append(f"  catalog.{table.name}{suffix}")
-
-    live_only, constant_only = boundary_drift(boundary)
-    if live_only:
-        lines.append(
-            "  DRIFT: stamped in the database but absent from "
-            "app.core.db.rls.RLS_TABLES, so boot never enables RLS on them: "
-            f"{', '.join(live_only)}"
-        )
-    if constant_only:
-        lines.append(
-            "  DRIFT: listed in app.core.db.rls.RLS_TABLES but carrying no live "
-            f"stamping trigger here: {', '.join(constant_only)}"
-        )
-    if report.rls_gaps:
-        lines.append(
-            "  NOT SAFE TO SERVE until row security is repaired: "
-            f"{', '.join(report.rls_gaps)}"
-        )
-    return lines
-
-
-def _tenant_verdict(
-    before: TenantOwnershipState, after: TenantOwnershipState, applied: bool
-) -> str:
-    if not applied:
-        return "adopted" if before.adopted else "needs adoption"
-    if not after.adopted:
-        return "STILL INCOMPLETE"
-    return "already adopted (no changes)" if before.adopted else "adopted"
-
-
-def _format_tenants(report: AdoptionReport) -> list[str]:
-    if not report.before:
-        return ["Tenants: none. Nothing to adopt (single-tenant control plane)."]
-
-    lines = [f"Tenants: {len(report.before)}"]
-    after_by_id = {state.tenant_id: state for state in report.after}
-    for before in report.before:
-        after = after_by_id[before.tenant_id]
-        detail = [
-            f"{after.relations} relation(s)",
-            f"{after.relations_not_owned_by_writer} not owned by the writer",
-            f"{after.relations_without_reader_select} without reader SELECT",
-        ]
-        if after.reader_default_acls:
-            detail.append(
-                f"{after.reader_default_acls} legacy default-privilege "
-                "entr(ies) for the reader"
-            )
-        if not after.reader_role_secure:
-            detail.append(
-                "reader role attributes or memberships are not the safe shape"
-            )
-        if not after.writer_role_secure:
-            detail.append(
-                "writer role attributes or memberships are not the safe shape"
-            )
-        if not after.schema_privileges_secure:
-            detail.append("schema privileges are not the safe shape")
-        verdict = _tenant_verdict(before, after, report.applied)
-        lines.append(f"  {before.tenant_id}: {verdict} — {', '.join(detail)}")
-    return lines
-
-
-def format_report(report: AdoptionReport) -> str:
-    """Render the report an operator reads mid-recovery."""
-    mode = "APPLIED" if report.applied else "DRY RUN (no changes made)"
-    sections = [
-        [f"Tenant-ownership adoption — {mode}"],
-        _format_cluster_roles(report),
-        _format_functions(report),
-        _format_boundary(report),
-        _format_tenants(report),
-    ]
-    if report.failures:
-        failures = ["Failures (re-run after fixing; adopted tenants stay adopted):"]
-        failures += [
-            f"  {tenant_id}: {message}"
-            for tenant_id, message in report.failures.items()
-        ]
-        sections.append(failures)
-    return "\n\n".join("\n".join(section) for section in sections)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -612,6 +612,32 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                     WHERE rolname = (SELECT writer_name FROM names)
                 ) AS writer_exists,
                 (SELECT count(*) FROM relations) AS relations,
+                -- Routines live in pg_proc, so none of the relation reads see
+                -- them. A restore brings one back owned by the restore login
+                -- with PUBLIC EXECUTE; a SECURITY DEFINER one is refused
+                -- outright rather than re-owned.
+                CASE
+                    WHEN NOT EXISTS (SELECT 1 FROM reader) THEN 0
+                    ELSE (
+                        SELECT count(*)
+                        FROM pg_catalog.pg_proc AS routine
+                        JOIN pg_catalog.pg_namespace AS namespace
+                          ON namespace.oid = routine.pronamespace
+                        WHERE namespace.nspname = (SELECT schema_name FROM names)
+                          AND (
+                              routine.proowner IS DISTINCT FROM (
+                                  SELECT oid FROM writer
+                              )
+                              OR routine.prosecdef
+                              OR pg_catalog.has_function_privilege(
+                                  'public', routine.oid, 'EXECUTE'
+                              )
+                              OR NOT pg_catalog.has_function_privilege(
+                                  (SELECT oid FROM reader), routine.oid, 'EXECUTE'
+                              )
+                          )
+                    )
+                END AS unsafe_routines,
                 (
                     SELECT count(*) FROM relations
                     WHERE owner <> (SELECT writer_name FROM names)

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -649,15 +649,36 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                               )
                               OR routine.prosecdef
                               OR NOT EXISTS (
+                                  -- prokind 'a' names the `internal`
+                                  -- pseudo-language and says nothing about the
+                                  -- functions that run.
                                   SELECT 1 FROM pg_catalog.pg_language AS language
                                   WHERE language.oid = routine.prolang
-                                    AND language.lanpltrusted
+                                    AND (
+                                        language.lanpltrusted
+                                        OR routine.prokind = 'a'
+                                    )
                               )
                               OR pg_catalog.has_function_privilege(
                                   'public', routine.oid, 'EXECUTE'
                               )
                               OR NOT pg_catalog.has_function_privilege(
                                   (SELECT oid FROM reader), routine.oid, 'EXECUTE'
+                              )
+                              -- The ACL itself, matching what --apply rewrites:
+                              -- a named grantee, or a grantable reader entry.
+                              OR EXISTS (
+                                  SELECT 1
+                                  FROM LATERAL pg_catalog.aclexplode(routine.proacl)
+                                    AS acl
+                                  WHERE acl.grantee NOT IN (
+                                      COALESCE((SELECT oid FROM writer), 0),
+                                      (SELECT oid FROM reader)
+                                  )
+                                  OR (
+                                      acl.grantee = (SELECT oid FROM reader)
+                                      AND acl.is_grantable
+                                  )
                               )
                           )
                     )

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -55,6 +55,7 @@ from app.core.db.tenant_adoption_report import (
     BOUNDARY_TRIGGER,
     BOUNDARY_TRIGGER_FUNCTION,
     BOUNDARY_TRIGGER_TYPE,
+    ISOLATION_POLICY_EXPRESSION,
     AdoptionReport,
     BoundaryFunctionState,
     BoundaryTableState,
@@ -133,7 +134,25 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
                          AND NOT attribute.attisdropped
                    ) AS has_tenant_id,
                    relation.relrowsecurity AS rls_enabled,
-                   relation.relforcerowsecurity AS rls_forced
+                   relation.relforcerowsecurity AS rls_forced,
+                   -- The policy is the isolation rule itself, and boot does not
+                   -- recreate it: a restored table with the flags intact but no
+                   -- policy denies every runtime read, and an altered one can
+                   -- return another tenant's rows. Its expression has been
+                   -- byte-identical since 0006, so it is compared exactly.
+                   EXISTS (
+                       SELECT 1 FROM pg_catalog.pg_policy AS policy
+                       WHERE policy.polrelid = relation.oid
+                         AND policy.polname = 'tenant_isolation_' || relation.relname
+                         AND policy.polcmd = '*'
+                         AND policy.polpermissive
+                         AND pg_catalog.pg_get_expr(
+                             policy.polqual, policy.polrelid
+                         ) = :isolation_expression
+                         AND pg_catalog.pg_get_expr(
+                             policy.polwithcheck, policy.polrelid
+                         ) = :isolation_expression
+                   ) AS isolation_policy_intact
             FROM pg_catalog.pg_class AS relation
             JOIN pg_catalog.pg_namespace AS namespace
               ON namespace.oid = relation.relnamespace
@@ -146,6 +165,7 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
             "trigger_name": BOUNDARY_TRIGGER,
             "trigger_function": BOUNDARY_TRIGGER_FUNCTION,
             "before_insert_row": BOUNDARY_TRIGGER_TYPE,
+            "isolation_expression": ISOLATION_POLICY_EXPRESSION,
         },
     )
     states = [BoundaryTableState(**dict(row._mapping)) for row in result]
@@ -158,11 +178,24 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
     ]
 
 
+#: ``prosrc`` with SQL comments removed.  The markers below say what a body
+#: still *does*, and a substituted body could otherwise carry them in a comment
+#: and satisfy the check while executing something else.  Dead code can still
+#: defeat it — see ``BoundaryFunctionState.migration_shaped`` for why this is a
+#: structural check and not a provenance one, and why the residual exposure only
+#: runs in the safe direction.
+_EXECUTABLE_BODY = (
+    "regexp_replace("
+    "regexp_replace(routine.prosrc, '/\\*.*?\\*/', ' ', 'gs'),"
+    " '--[^\n]*', ' ', 'g')"
+)
+
+
 async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
     """Read owner, SECURITY DEFINER, search_path, and ACL of both functions."""
     result = await conn.execute(
         text(
-            """
+            f"""
             SELECT routine.proname AS name,
                    pg_catalog.pg_get_userbyid(routine.proowner) AS owner,
                    routine.prosecdef AS security_definer,
@@ -172,9 +205,9 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
                    language.lanname AS language,
                    routine.prorettype = 'void'::regtype AS returns_void,
                    (
-                       routine.prosrc LIKE '%catalog.tenants%'
-                       AND routine.prosrc LIKE '%data_t_%'
-                       AND routine.prosrc LIKE '%pg_advisory_xact_lock%'
+                       {_EXECUTABLE_BODY} LIKE '%catalog.tenants%'
+                       AND {_EXECUTABLE_BODY} LIKE '%data_t_%'
+                       AND {_EXECUTABLE_BODY} LIKE '%pg_advisory_xact_lock%'
                    ) AS body_markers_present,
                    pg_catalog.has_function_privilege(
                        'public', routine.oid, 'EXECUTE'
@@ -204,6 +237,58 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
         {"control": CONTROL, "names": list(BOUNDARY_FUNCTIONS)},
     )
     return [BoundaryFunctionState(**dict(row._mapping)) for row in result]
+
+
+async def stamping_function_shape(conn) -> str | None:
+    """Why ``catalog.stamp_current_tenant_on_insert`` is not 0018's, if it is not.
+
+    Checking only that a trigger points at this name proves nothing: replace the
+    body with one that returns ``NEW`` untouched and every insert lands
+    tenantless while every structural check still passes.  Same structural
+    approach, and the same honest limits, as
+    ``BoundaryFunctionState.migration_shaped``.
+    """
+    result = await conn.execute(
+        text(
+            f"""
+            SELECT language.lanname AS language,
+                   routine.prorettype = 'trigger'::regtype AS returns_trigger,
+                   COALESCE(routine.proconfig::text LIKE '%search_path=%', false)
+                       AS search_path_pinned,
+                   (
+                       {_EXECUTABLE_BODY} LIKE '%app.current_tenant%'
+                       AND {_EXECUTABLE_BODY} LIKE '%NEW.tenant_id%'
+                   ) AS body_markers_present
+            FROM pg_catalog.pg_proc AS routine
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = routine.pronamespace
+            JOIN pg_catalog.pg_language AS language
+              ON language.oid = routine.prolang
+            WHERE namespace.nspname = 'catalog'
+              AND routine.proname = :name
+              AND routine.pronargs = 0
+            """
+        ),
+        {"name": BOUNDARY_TRIGGER_FUNCTION},
+    )
+    row = result.one_or_none()
+    if row is None:
+        return f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() is missing"
+    if row.language != "plpgsql":
+        return (
+            f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() is written in "
+            f"{row.language}, not plpgsql"
+        )
+    if not row.returns_trigger:
+        return f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() does not return trigger"
+    if not row.search_path_pinned:
+        return f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() has no pinned search_path"
+    if not row.body_markers_present:
+        return (
+            f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() has a body that no longer "
+            "reads app.current_tenant or writes NEW.tenant_id — it stamps nothing"
+        )
+    return None
 
 
 async def cluster_topology_error(engine) -> str | None:
@@ -539,6 +624,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
         boundary = await live_tenant_boundary(conn)
         functions = await boundary_function_states(conn)
         grants = [] if topology else await missing_provisioner_grants(conn)
+        stamping = await stamping_function_shape(conn)
 
     if not apply:
         return AdoptionReport(
@@ -550,6 +636,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
             failures={},
             cluster_topology=topology,
             provisioner_grants_missing=grants,
+            stamping_function=stamping,
         )
 
     async with engine.begin() as conn:
@@ -572,6 +659,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
         after = [await tenant_ownership_state(conn, tid) for tid in tenants]
         boundary = await live_tenant_boundary(conn)
         grants = [] if topology else await missing_provisioner_grants(conn)
+        stamping = await stamping_function_shape(conn)
 
     return AdoptionReport(
         applied=True,
@@ -582,6 +670,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
         failures=failures,
         cluster_topology=topology,
         provisioner_grants_missing=grants,
+        stamping_function=stamping,
     )
 
 

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -510,8 +510,12 @@ def _role_secure_sql(
                           AND membership.admin_option
                           AND {_MEMBER_ADMIN_ONLY}
                     )
+                    -- DISTINCT on the member: two canonical grants of the same
+                    -- gateway from different grantors are two rows, and a plain
+                    -- count would let them stand in for a gateway that is
+                    -- missing its grant entirely.
                     AND (
-                        SELECT count(*)
+                        SELECT count(DISTINCT member_role.rolname)
                         FROM pg_catalog.pg_auth_members AS membership
                         JOIN pg_catalog.pg_roles AS member_role
                           ON member_role.oid = membership.member

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -243,6 +243,10 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
                        JOIN pg_catalog.pg_roles AS grantee_role
                          ON grantee_role.oid = acl.grantee
                        WHERE grantee_role.rolname NOT IN (:provisioner, :control)
+                          -- A grantable EXECUTE lets a control-role member
+                          -- delegate provisioner-owned tenant management to
+                          -- anyone; the canonical grant is plain.
+                          OR (grantee_role.rolname = :control AND acl.is_grantable)
                    ) AS unexpected_grantees,
                    CASE
                        WHEN EXISTS (
@@ -600,6 +604,13 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                                       COALESCE((SELECT oid FROM writer), 0),
                                       (SELECT oid FROM reader)
                                   )
+                                  -- Grantable SELECT lets a gateway that SET
+                                  -- ROLEs to the reader hand tenant reads to
+                                  -- any role it likes.
+                                  OR (
+                                      acl.grantee = (SELECT oid FROM reader)
+                                      AND acl.is_grantable
+                                  )
                                   OR (
                                       acl.grantee = (SELECT oid FROM reader)
                                       AND acl.privilege_type <> 'SELECT'
@@ -653,15 +664,30 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                              WHERE namespace.nspname = (
                                  SELECT schema_name FROM names
                              )
-                               AND acl.grantee NOT IN (
-                                   COALESCE((SELECT oid FROM reader), 0),
-                                   COALESCE((SELECT oid FROM writer), 0),
-                                   COALESCE(
-                                       (
-                                           SELECT oid FROM pg_catalog.pg_roles
-                                           WHERE rolname = :provisioner
-                                       ),
-                                       0
+                               AND (
+                                   acl.grantee NOT IN (
+                                       COALESCE((SELECT oid FROM reader), 0),
+                                       COALESCE((SELECT oid FROM writer), 0),
+                                       COALESCE(
+                                           (
+                                               SELECT oid FROM pg_catalog.pg_roles
+                                               WHERE rolname = :provisioner
+                                           ),
+                                           0
+                                       )
+                                   )
+                                   -- Same delegation problem one level up: a
+                                   -- grantable USAGE on the schema travels with
+                                   -- a grantable SELECT on the relations.
+                                   OR (
+                                       acl.is_grantable
+                                       AND acl.grantee <> COALESCE(
+                                           (
+                                               SELECT oid FROM pg_catalog.pg_roles
+                                               WHERE rolname = :provisioner
+                                           ),
+                                           0
+                                       )
                                    )
                                )
                          )
@@ -813,19 +839,25 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
         functions = await secure_boundary_functions(conn)
 
     failures: dict[str, str] = {}
-    for tenant_id in tenants:
-        try:
-            async with engine.begin() as conn:
-                await adopt_tenant(conn, tenant_id)
-        except Exception as exc:  # broad: one tenant's refusal must not strand the rest
-            failures[tenant_id] = str(exc).strip().splitlines()[0]
-            logger.error(
-                "tenant_adoption: tenant failed", tenant_id=tenant_id, exc_info=True
-            )
-
-    await release_bootstrap_membership(
-        engine, took_provisioner_edge=took_provisioner_edge
-    )
+    try:
+        for tenant_id in tenants:
+            try:
+                async with engine.begin() as conn:
+                    await adopt_tenant(conn, tenant_id)
+            except (
+                Exception
+            ) as exc:  # broad: one tenant's refusal must not strand the rest
+                failures[tenant_id] = str(exc).strip().splitlines()[0]
+                logger.error(
+                    "tenant_adoption: tenant failed", tenant_id=tenant_id, exc_info=True
+                )
+    finally:
+        # A bare finally, so a Ctrl-C (CancelledError, a BaseException) hands the
+        # edge back too. Only a SIGKILL can leave it now, and the next run's
+        # topology validation is where that would surface.
+        await release_bootstrap_membership(
+            engine, took_provisioner_edge=took_provisioner_edge
+        )
 
     topology = await cluster_topology_error(engine)
     async with engine.connect() as conn:

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -654,6 +654,19 @@ class AdoptionReport:
         return [name for name in BOUNDARY_FUNCTIONS if name not in present]
 
     @property
+    def disabled_stamping_triggers(self) -> list[str]:
+        """Boundary tables whose stamping trigger exists but does not fire.
+
+        Its own condition, not a corollary of the drift check: a table that is
+        newly tenant-scoped *and* absent from ``RLS_TABLES`` lands in neither
+        drift direction and has no row-security requirement to miss, so a
+        disabled trigger there would otherwise be printed and then ignored.
+        """
+        return sorted(
+            table.name for table in self.boundary if table.stamping_trigger_disabled
+        )
+
+    @property
     def rls_gaps(self) -> list[str]:
         """Boundary tables that cannot enforce tenant isolation as they stand.
 
@@ -672,8 +685,8 @@ class AdoptionReport:
         passes on a database the report itself calls broken: a missing boundary
         function, a fixed-role topology ``--apply`` would refuse, a provisioner
         grant a restore dropped, boundary drift that leaves a stamped table
-        without RLS at boot, and a boundary table that cannot enforce isolation
-        as it stands all count.
+        without RLS at boot, a stamping trigger that does not fire, and a
+        boundary table that cannot enforce isolation as it stands all count.
         """
         if (
             self.failures
@@ -681,6 +694,7 @@ class AdoptionReport:
             or self.cluster_topology
             or self.provisioner_grants_missing
             or self.rls_gaps
+            or self.disabled_stamping_triggers
         ):
             return False
         if not all(function.secured for function in self.functions):

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -79,7 +79,6 @@ from app.core.db.tenant_adoption_sql import (
     PROVISIONER,
     PROVISIONER_DATABASE_GRANT_SQL,
     PROVISIONER_DATABASE_REVOKE_OPTION_SQL,
-    RELEASE_GATEWAY_EDGES_SQL,
     RELEASE_PROVISIONER_EDGE_SQL,
     SANDBOX,
     SECURE_BOUNDARY_FUNCTIONS_SQL,
@@ -308,6 +307,20 @@ async def stamping_function_shape(conn) -> str | None:
         text(
             f"""
             SELECT language.lanname AS language,
+                   pg_catalog.pg_get_userbyid(routine.proowner) AS owner,
+                   -- Owned by a role this credential is not, cannot assume, and
+                   -- that is not a superuser: a body firing on every
+                   -- control-plane insert, rewritable by a third party.
+                   (
+                       pg_catalog.pg_has_role(
+                           CURRENT_USER, routine.proowner, 'USAGE'
+                       )
+                       OR EXISTS (
+                           SELECT 1 FROM pg_catalog.pg_roles AS owner_role
+                           WHERE owner_role.oid = routine.proowner
+                             AND owner_role.rolsuper
+                       )
+                   ) AS owner_reachable,
                    routine.prosecdef AS security_definer,
                    routine.prorettype = 'trigger'::regtype AS returns_trigger,
                    COALESCE(
@@ -342,6 +355,12 @@ async def stamping_function_shape(conn) -> str | None:
         )
     if not row.returns_trigger:
         return f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() does not return trigger"
+    if not row.owner_reachable:
+        return (
+            f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() is owned by {row.owner}, a "
+            "role this credential cannot assume — it fires on every "
+            "control-plane insert and its owner can rewrite it"
+        )
     if row.security_definer:
         # 0018 installs it SECURITY INVOKER on purpose: it runs on every insert,
         # and after a --no-owner restore its owner is the restoring superuser.
@@ -374,7 +393,7 @@ async def cluster_topology_error(engine) -> str | None:
         async with engine.begin() as conn:
             await conn.execute(text(CLUSTER_ROLE_VALIDATE_SQL))
     except Exception as exc:  # broad: any refusal is the answer, whatever its class
-        return str(exc).strip().splitlines()[0]
+        return _failure_message(exc)
     return None
 
 
@@ -934,18 +953,26 @@ async def secure_boundary_functions(conn) -> list[BoundaryFunctionState]:
 
 
 async def release_bootstrap_membership(engine, *, took_provisioner_edge: bool) -> None:
-    """Give back what a fresh-cluster run had to take to get going.
+    """Give back the usable membership a fresh-cluster run had to take.
 
-    Leaving any of it would make the next recovery depend on the same migrator
-    credential, because the cluster guard rejects every direct member of these
-    roles except the one running it.  The gateway half runs unconditionally —
-    it targets the automatic creator shape, which nobody sets up to use — while
-    the provisioner edge goes back only when this run is the one that took it.
+    Only that one.  The automatic ADMIN membership PostgreSQL gives a role's
+    creator is tolerated by the guards instead of revoked, because a member
+    cannot revoke it — its grantor is the bootstrap superuser, and on a managed
+    provider no customer role can assume that.
+
+    From PostgreSQL 16 this runs whatever the flag says: the predicate — granted
+    by the current role, carrying no ADMIN — describes the edge adoption takes
+    and nothing an operator would set up by hand, and running it unconditionally
+    is what recovers one a previous run was SIGKILLed before returning.  Before
+    16 there is a single row per pair and no way to tell those apart, so there
+    the flag is the only evidence there is.
     """
     async with engine.begin() as conn:
-        if took_provisioner_edge:
+        modern = await conn.execute(
+            text("SELECT current_setting('server_version_num')::integer >= 160000")
+        )
+        if took_provisioner_edge or modern.scalar_one():
             await conn.execute(text(RELEASE_PROVISIONER_EDGE_SQL))
-        await conn.execute(text(RELEASE_GATEWAY_EDGES_SQL))
 
 
 async def adopt_tenant(conn, tenant_id: str) -> None:
@@ -1019,15 +1046,19 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
                 )
     finally:
         # A bare finally, so a Ctrl-C (CancelledError, a BaseException) hands the
-        # edge back too. Only a SIGKILL can leave it now, and the next run's
-        # topology validation is where that would surface.
+        # edge back too. From PostgreSQL 16 even a SIGKILL is recoverable: the
+        # next run releases the edge whether or not it took one.
         await release_bootstrap_membership(
             engine, took_provisioner_edge=took_provisioner_edge
         )
 
     topology = await cluster_topology_error(engine)
     async with engine.connect() as conn:
-        after = [await tenant_ownership_state(conn, tid) for tid in tenants]
+        # Re-read rather than reuse the pre-apply list: a tenant provisioned
+        # while this ran was never adopted, and reporting only the snapshot
+        # would call the database clean without having looked at it.
+        tenants_after = await list_tenants(conn)
+        after = [await tenant_ownership_state(conn, tid) for tid in tenants_after]
         boundary = await live_tenant_boundary(conn)
         grants = [] if topology else await missing_provisioner_grants(conn)
         stamping = await stamping_function_shape(conn)
@@ -1042,6 +1073,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
         cluster_topology=topology,
         provisioner_grants_missing=grants,
         stamping_function=stamping,
+        tenants_added_during_run=sorted(set(tenants_after) - set(tenants)),
     )
 
 
@@ -1084,7 +1116,7 @@ async def _main(argv: list[str] | None = None) -> int:
         Exception
     ) as exc:  # broad: an operator mid-recovery needs the reason, not a traceback
         logger.error("tenant_adoption: refused", exc_info=True)
-        reason = str(exc).strip().splitlines()[0]
+        reason = _failure_message(exc)
         print(f"Tenant-ownership adoption refused before any tenant: {reason}")
         return 2
     finally:

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -31,8 +31,9 @@ second run over an adopted tenant issues no DDL at all, and a run interrupted
 partway is resumed by running it again — every tenant is adopted in its own
 transaction, so completed tenants stay completed.
 
-Run it with the migrator credential (``CREATEROLE``, plus authority over the
-restored objects), against a database already at head::
+Run it with the migrator credential — ``CREATEROLE``, authority over the
+restored objects, and, on a non-superuser migrator, the privileges of
+``geolens_tenant_provisioner`` — against a database already at head::
 
     docker compose run --rm --no-deps -e DATABASE_URL_OVERRIDE="<migrator-url>" \\
       migrate sh -c "uv run --no-dev python -m app.core.db.tenant_adoption --apply"
@@ -59,6 +60,7 @@ from app.core.db.tenant_adoption_sql import (
     PROVISIONER,
     PROVISIONER_DATABASE_GRANT_SQL,
     SANDBOX,
+    SECURE_BOUNDARY_FUNCTIONS_SQL,
     TENANT_GUC,
     TILE,
     WRITER,
@@ -608,11 +610,7 @@ async def secure_boundary_functions(conn) -> list[BoundaryFunctionState]:
                 "refusing to adopt it."
             )
 
-    for name in BOUNDARY_FUNCTIONS:
-        signature = f"catalog.{name}(uuid)"
-        await conn.execute(text(f"ALTER FUNCTION {signature} OWNER TO {PROVISIONER}"))
-        await conn.execute(text(f"REVOKE ALL ON FUNCTION {signature} FROM PUBLIC"))
-        await conn.execute(text(f"GRANT EXECUTE ON FUNCTION {signature} TO {CONTROL}"))
+    await conn.execute(text(SECURE_BOUNDARY_FUNCTIONS_SQL))
     return await boundary_function_states(conn)
 
 

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -615,20 +615,18 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                 -- The pre-0019 runtime helper left an ALTER DEFAULT PRIVILEGES
                 -- entry behind; ADOPT_TENANT_SQL revokes it, so a tenant still
                 -- carrying one is not adopted however correct the rest looks.
-                CASE
-                    WHEN NOT EXISTS (SELECT 1 FROM reader) THEN 0
-                    ELSE (
-                        SELECT count(DISTINCT default_acl.oid)
-                        FROM pg_catalog.pg_default_acl AS default_acl
-                        JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl)
-                          AS acl ON true
-                        JOIN pg_catalog.pg_namespace AS namespace
-                          ON namespace.oid = default_acl.defaclnamespace
-                        WHERE namespace.nspname = (SELECT schema_name FROM names)
-                          AND default_acl.defaclobjtype = 'r'
-                          AND acl.grantee = (SELECT oid FROM reader)
-                    )
-                END AS reader_default_acls,
+                -- Any of them, for any object kind and any grantee: the
+                -- contract in a tenant schema is that the writer grants the
+                -- reader explicitly on each relation, so a default ACL here
+                -- hands out privileges on relations that do not exist yet, to
+                -- whoever it names.
+                (
+                    SELECT count(*)
+                    FROM pg_catalog.pg_default_acl AS default_acl
+                    JOIN pg_catalog.pg_namespace AS namespace
+                      ON namespace.oid = default_acl.defaclnamespace
+                    WHERE namespace.nspname = (SELECT schema_name FROM names)
+                ) AS unexpected_default_acls,
                 """
             + _role_secure_sql("reader", (PROVISIONER, SANDBOX, TILE), (SANDBOX, TILE))
             + " AS reader_role_secure, "
@@ -644,11 +642,28 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                     -- One privilege per call: a comma-separated list is an
                     -- any-of test, so 'USAGE, CREATE' stays true on a writer
                     -- that has lost one of them.
-                    ELSE NOT pg_catalog.has_schema_privilege(
-                             'public', (SELECT schema_name FROM names), 'USAGE'
-                         )
-                     AND NOT pg_catalog.has_schema_privilege(
-                             'public', (SELECT schema_name FROM names), 'CREATE'
+                    ELSE NOT EXISTS (
+                             -- Nobody outside the three belongs on the schema.
+                             -- A stray USAGE plus a relation grant, or a stray
+                             -- CREATE, is a path around the writer boundary.
+                             SELECT 1
+                             FROM pg_catalog.pg_namespace AS namespace
+                             JOIN LATERAL pg_catalog.aclexplode(namespace.nspacl)
+                               AS acl ON true
+                             WHERE namespace.nspname = (
+                                 SELECT schema_name FROM names
+                             )
+                               AND acl.grantee NOT IN (
+                                   COALESCE((SELECT oid FROM reader), 0),
+                                   COALESCE((SELECT oid FROM writer), 0),
+                                   COALESCE(
+                                       (
+                                           SELECT oid FROM pg_catalog.pg_roles
+                                           WHERE rolname = :provisioner
+                                       ),
+                                       0
+                                   )
+                               )
                          )
                      AND pg_catalog.has_schema_privilege(
                              (SELECT oid FROM reader),
@@ -676,7 +691,7 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                 END AS schema_privileges_secure
             """
         ),
-        {"tenant_id": tenant_id},
+        {"tenant_id": tenant_id, "provisioner": PROVISIONER},
     )
     row = result.one()
     return TenantOwnershipState(tenant_id=tenant_id, **dict(row._mapping))

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -629,6 +629,11 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                                   SELECT oid FROM writer
                               )
                               OR routine.prosecdef
+                              OR NOT EXISTS (
+                                  SELECT 1 FROM pg_catalog.pg_language AS language
+                                  WHERE language.oid = routine.prolang
+                                    AND language.lanpltrusted
+                              )
                               OR pg_catalog.has_function_privilege(
                                   'public', routine.oid, 'EXECUTE'
                               )
@@ -638,6 +643,39 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                           )
                     )
                 END AS unsafe_routines,
+                -- Types a tenant defined live in pg_type, so the relation reads
+                -- miss them, and a writer that cannot alter one cannot replace
+                -- the dataset using it.
+                (
+                    SELECT count(*)
+                    FROM pg_catalog.pg_type AS type_row
+                    JOIN pg_catalog.pg_namespace AS namespace
+                      ON namespace.oid = type_row.typnamespace
+                    WHERE namespace.nspname = (SELECT schema_name FROM names)
+                      AND type_row.typowner IS DISTINCT FROM (
+                          SELECT oid FROM writer
+                      )
+      -- Array types follow their element type, and a table's row type follows
+      -- the table; both move on their own. An extension's types belong to the
+      -- extension.
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_type AS element
+          WHERE element.typarray = type_row.oid
+      )
+      AND (
+          type_row.typrelid = 0
+          OR EXISTS (
+              SELECT 1 FROM pg_catalog.pg_class AS relation
+              WHERE relation.oid = type_row.typrelid AND relation.relkind = 'c'
+          )
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_type'::regclass
+            AND dependency.objid = type_row.oid
+            AND dependency.deptype = 'e'
+      )
+                ) AS unsafe_types,
                 (
                     SELECT count(*) FROM relations
                     WHERE owner <> (SELECT writer_name FROM names)

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -71,7 +71,8 @@ from app.core.db.tenant_adoption_sql import (
     CONTROL,
     PROVISIONER,
     PROVISIONER_DATABASE_GRANT_SQL,
-    RELEASE_BOOTSTRAP_MEMBERSHIP_SQL,
+    RELEASE_GATEWAY_EDGES_SQL,
+    RELEASE_PROVISIONER_EDGE_SQL,
     SANDBOX,
     SECURE_BOUNDARY_FUNCTIONS_SQL,
     TENANT_GUC,
@@ -589,10 +590,16 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                               AS acl ON true
                             WHERE relation.oid = relations.oid
                               AND (
-                                  -- grantee 0 is PUBLIC: the reader holds
-                                  -- whatever PUBLIC holds, and so does everyone
-                                  -- else with USAGE on the schema.
-                                  acl.grantee = 0
+                                  -- Anything but the owning writer and the
+                                  -- reader. Grantee 0 is PUBLIC, which the
+                                  -- reader holds along with everyone else who
+                                  -- can reach the schema; a named role with its
+                                  -- own grant reads tenant data without going
+                                  -- near either tenant role.
+                                  acl.grantee NOT IN (
+                                      COALESCE((SELECT oid FROM writer), 0),
+                                      (SELECT oid FROM reader)
+                                  )
                                   OR (
                                       acl.grantee = (SELECT oid FROM reader)
                                       AND acl.privilege_type <> 'SELECT'
@@ -680,13 +687,30 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
 # ---------------------------------------------------------------------------
 
 
-async def ensure_cluster_roles(conn) -> None:
-    """Create the fixed role topology if absent, and refuse an unsafe one."""
+async def _holds_provisioner_privileges(conn) -> bool:
+    result = await conn.execute(
+        text("SELECT pg_catalog.pg_has_role(CURRENT_USER, :owner, 'USAGE')"),
+        {"owner": PROVISIONER},
+    )
+    return bool(result.scalar_one())
+
+
+async def ensure_cluster_roles(conn) -> bool:
+    """Create the fixed role topology if absent, and refuse an unsafe one.
+
+    Returns whether *this* run had to take a usable membership in the
+    provisioner, which is what decides whether the run gives one back.  An
+    operator may have granted the migrator that role by hand — especially before
+    PostgreSQL 16, where CREATEROLE leaves no automatic membership to compare
+    against — and revoking somebody else's grant is not this tool's business.
+    """
+    held_before = await _holds_provisioner_privileges(conn)
     await conn.execute(text(CLUSTER_ROLE_CREATE_SQL))
     await conn.execute(text(CLUSTER_ROLE_VALIDATE_SQL))
     await conn.execute(text(PROVISIONER_DATABASE_GRANT_SQL))
     await conn.execute(text(f"GRANT USAGE ON SCHEMA catalog TO {PROVISIONER}"))
     await conn.execute(text(f"GRANT SELECT ON TABLE catalog.tenants TO {PROVISIONER}"))
+    return not held_before and await _holds_provisioner_privileges(conn)
 
 
 async def secure_boundary_functions(conn) -> list[BoundaryFunctionState]:
@@ -720,16 +744,19 @@ async def secure_boundary_functions(conn) -> list[BoundaryFunctionState]:
     return await boundary_function_states(conn)
 
 
-async def release_bootstrap_membership(engine) -> None:
-    """Give back the provisioner membership a fresh-cluster run had to take.
+async def release_bootstrap_membership(engine, *, took_provisioner_edge: bool) -> None:
+    """Give back what a fresh-cluster run had to take to get going.
 
-    Leaving it would make the next recovery depend on the same migrator
-    credential, because the cluster guard rejects every direct member of the
-    provisioner except the role running it.  A no-op unless this run created the
-    role and granted itself the edge.
+    Leaving any of it would make the next recovery depend on the same migrator
+    credential, because the cluster guard rejects every direct member of these
+    roles except the one running it.  The gateway half runs unconditionally —
+    it targets the automatic creator shape, which nobody sets up to use — while
+    the provisioner edge goes back only when this run is the one that took it.
     """
     async with engine.begin() as conn:
-        await conn.execute(text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
+        if took_provisioner_edge:
+            await conn.execute(text(RELEASE_PROVISIONER_EDGE_SQL))
+        await conn.execute(text(RELEASE_GATEWAY_EDGES_SQL))
 
 
 async def adopt_tenant(conn, tenant_id: str) -> None:
@@ -767,7 +794,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
         )
 
     async with engine.begin() as conn:
-        await ensure_cluster_roles(conn)
+        took_provisioner_edge = await ensure_cluster_roles(conn)
         functions = await secure_boundary_functions(conn)
 
     failures: dict[str, str] = {}
@@ -781,7 +808,9 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
                 "tenant_adoption: tenant failed", tenant_id=tenant_id, exc_info=True
             )
 
-    await release_bootstrap_membership(engine)
+    await release_bootstrap_membership(
+        engine, took_provisioner_edge=took_provisioner_edge
+    )
 
     topology = await cluster_topology_error(engine)
     async with engine.connect() as conn:

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -341,6 +341,7 @@ async def stamping_function_shape(conn) -> str | None:
             WHERE namespace.nspname = 'catalog'
               AND routine.proname = :name
               AND routine.pronargs = 0
+              AND routine.prokind = 'f'
             """
         ),
         {
@@ -719,6 +720,48 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
             AND dependency.deptype = 'e'
       )
                 ) AS unsafe_types,
+                -- The same four surfaces the apply side refuses on, counted
+                -- here so the dry run cannot call a tenant adopted that
+                -- `--apply` would stop on.
+                (
+                    SELECT count(*)
+                    FROM (
+            SELECT 'schema ' || namespace.nspname AS object_name,
+                   acl.grantor AS grantor_oid
+            FROM pg_catalog.pg_namespace AS namespace
+            JOIN LATERAL pg_catalog.aclexplode(namespace.nspacl) AS acl ON true
+            WHERE namespace.nspname = (SELECT schema_name FROM names)
+              AND acl.grantor <> COALESCE((SELECT oid FROM pg_catalog.pg_roles WHERE rolname = :provisioner), 0)
+            UNION ALL
+            SELECT 'relation ' || relation.relname, acl.grantor
+            FROM pg_catalog.pg_class AS relation
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = relation.relnamespace
+            JOIN LATERAL pg_catalog.aclexplode(relation.relacl) AS acl ON true
+            WHERE namespace.nspname = (SELECT schema_name FROM names)
+              AND acl.grantor <> COALESCE((SELECT oid FROM writer), 0)
+            UNION ALL
+            SELECT 'column ' || relation.relname || '.' || column_row.attname,
+                   acl.grantor
+            FROM pg_catalog.pg_class AS relation
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = relation.relnamespace
+            JOIN pg_catalog.pg_attribute AS column_row
+              ON column_row.attrelid = relation.oid
+            JOIN LATERAL pg_catalog.aclexplode(column_row.attacl) AS acl ON true
+            WHERE namespace.nspname = (SELECT schema_name FROM names)
+              AND NOT column_row.attisdropped
+              AND acl.grantor <> COALESCE((SELECT oid FROM writer), 0)
+            UNION ALL
+            SELECT 'routine ' || routine.proname, acl.grantor
+            FROM pg_catalog.pg_proc AS routine
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = routine.pronamespace
+            JOIN LATERAL pg_catalog.aclexplode(routine.proacl) AS acl ON true
+            WHERE namespace.nspname = (SELECT schema_name FROM names)
+              AND acl.grantor <> COALESCE((SELECT oid FROM writer), 0)
+                    ) AS foreign_grant
+                ) AS foreign_grantors,
                 (
                     SELECT count(*) FROM relations
                     WHERE owner <> (SELECT writer_name FROM names)

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -747,6 +747,66 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                             AND dependency.deptype = 'e'
                       )
                 ) AS unsafe_statistics,
+                -- fix(#998 codex r49): collations, transferred like types and
+                -- statistics; the six rarer owned kinds --apply refuses.
+                (
+                    SELECT count(*)
+                    FROM pg_catalog.pg_collation AS collation_row
+                    JOIN pg_catalog.pg_namespace AS namespace
+                      ON namespace.oid = collation_row.collnamespace
+                    WHERE namespace.nspname = (SELECT schema_name FROM names)
+                      AND collation_row.collowner IS DISTINCT FROM (
+                          SELECT oid FROM writer
+                      )
+                      AND NOT EXISTS (
+                          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+                          WHERE dependency.classid = 'pg_collation'::regclass
+                            AND dependency.objid = collation_row.oid
+                            AND dependency.deptype = 'e'
+                      )
+                ) AS unsafe_collations,
+                (
+                    SELECT count(*)
+                    FROM (
+                        SELECT conversion.oid,
+                               'pg_conversion'::regclass AS classid,
+                               conversion.connamespace AS namespace_oid,
+                               conversion.conowner AS owner_oid
+                        FROM pg_catalog.pg_conversion AS conversion
+                        UNION ALL
+                        SELECT operator.oid, 'pg_operator'::regclass,
+                               operator.oprnamespace, operator.oprowner
+                        FROM pg_catalog.pg_operator AS operator
+                        UNION ALL
+                        SELECT opclass.oid, 'pg_opclass'::regclass,
+                               opclass.opcnamespace, opclass.opcowner
+                        FROM pg_catalog.pg_opclass AS opclass
+                        UNION ALL
+                        SELECT opfamily.oid, 'pg_opfamily'::regclass,
+                               opfamily.opfnamespace, opfamily.opfowner
+                        FROM pg_catalog.pg_opfamily AS opfamily
+                        UNION ALL
+                        SELECT dictionary.oid, 'pg_ts_dict'::regclass,
+                               dictionary.dictnamespace, dictionary.dictowner
+                        FROM pg_catalog.pg_ts_dict AS dictionary
+                        UNION ALL
+                        SELECT config.oid, 'pg_ts_config'::regclass,
+                               config.cfgnamespace, config.cfgowner
+                        FROM pg_catalog.pg_ts_config AS config
+                    ) AS owned_object
+                    JOIN pg_catalog.pg_namespace AS namespace
+                      ON namespace.oid = owned_object.namespace_oid
+                    WHERE namespace.nspname = (SELECT schema_name FROM names)
+                      AND owned_object.owner_oid IS DISTINCT FROM (
+                          SELECT oid FROM writer
+                      )
+                      AND NOT EXISTS (
+                          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+                          WHERE dependency.classid = owned_object.classid
+                            AND dependency.objid = owned_object.oid
+                            AND dependency.deptype = 'e'
+                      )
+                ) AS unowned_other_objects,
                 -- The same four surfaces the apply side refuses on, counted
                 -- here so the dry run cannot call a tenant adopted that
                 -- `--apply` would stop on.

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -282,6 +282,9 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
               AND routine.proname = ANY(:names)
               AND routine.pronargs = 1
               AND routine.proargtypes[0] = 'uuid'::regtype
+              -- A procedure with the same signature is not callable where the
+              -- runtime calls these, so it is not one of them.
+              AND routine.prokind = 'f'
             ORDER BY routine.proname
             """
         ),

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -128,6 +128,11 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
                                ON routine_schema.oid = routine.pronamespace
                              WHERE routine_schema.nspname = 'catalog'
                                AND routine.proname = :trigger_function
+                               -- An overload under the same name would make
+                               -- this scalar subquery return two rows and fail
+                               -- the whole read; the trigger function takes no
+                               -- arguments.
+                               AND routine.pronargs = 0
                          )
                    ) AS has_stamping_trigger,
                    EXISTS (

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -1,0 +1,616 @@
+"""Forward-only tenant-ownership adoption at the current schema head.
+
+Migration ``0019_tenant_provisioning_boundary`` is the only place that has ever
+moved restored tenant schemas, roles, and relations under the least-privilege
+provisioning boundary.  Reaching it again meant ``alembic downgrade 0016``,
+which walks back through migrations that either refuse on data the current
+schema legitimately holds or discard state the re-upgrade cannot rebuild.  On a
+populated cluster that is a data-loss event, not a recovery procedure (#998).
+
+This module reconstructs the same ownership against the **current head schema**,
+so the downgrade is never required.  It is deliberately not a replay of 0019:
+
+- 0019 installs its SECURITY DEFINER functions with plain ``CREATE FUNCTION``,
+  which collides with the functions a restored dump already carries.  Adoption
+  never installs a function body.  The migrations own that body; adoption
+  verifies the two functions are present, ``SECURITY DEFINER``, and
+  ``search_path``-pinned, and repairs only the owner and the ACL that
+  ``pg_restore --no-owner --no-acl`` strips.  That repair matters on its own:
+  PostgreSQL's default function ACL is ``EXECUTE`` to ``PUBLIC``, so a restored
+  ``catalog.provision_tenant_data_schema`` is a SECURITY DEFINER function owned
+  by the restoring superuser and callable by every login in the database.
+- 0019 parked tenant relations on the provisioner so its provisioning function
+  could rewrite their ACLs.  Migration 0024 removed that object-ACL pass, so at
+  head the relations move straight to the per-tenant writer and the reader's
+  per-relation ``SELECT`` is granted by the writer itself — the same contract
+  ingest follows.
+
+Idempotence is keyed on database state, never on a marker or a timestamp: each
+step reads what the cluster currently holds and issues DDL only for the gap.  A
+second run over an adopted tenant issues no DDL at all, and a run interrupted
+partway is resumed by running it again — every tenant is adopted in its own
+transaction, so completed tenants stay completed.
+
+Run it with the migrator credential (``CREATEROLE``, plus authority over the
+restored objects), against a database already at head::
+
+    docker compose run --rm --no-deps -e DATABASE_URL_OVERRIDE="<migrator-url>" \\
+      migrate sh -c "uv run --no-dev python -m app.core.db.tenant_adoption --apply"
+
+Without ``--apply`` the run is a read-only report of what adoption would change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import uuid
+from dataclasses import dataclass
+
+import structlog
+from sqlalchemy import text
+
+from app.core.db.rls import RLS_TABLES
+from app.core.db.tenant_adoption_sql import (
+    ADOPT_TENANT_SQL,
+    CLUSTER_ROLE_SQL,
+    CONTROL,
+    PROVISIONER,
+    PROVISIONER_DATABASE_GRANT_SQL,
+    TENANT_GUC,
+)
+
+logger = structlog.stdlib.get_logger(__name__)
+
+#: The two migration-owned SECURITY DEFINER entry points.  Adoption verifies and
+#: re-secures them; it never rewrites their bodies.
+BOUNDARY_FUNCTIONS = (
+    "provision_tenant_data_schema",
+    "deprovision_tenant_data_schema",
+)
+
+#: The insert-stamping trigger 0018 installs.  Its presence — not any constant
+#: frozen into a migration — is what marks a table as tenant-scoped.
+BOUNDARY_TRIGGER = "trg_stamp_current_tenant_on_insert"
+
+
+# ---------------------------------------------------------------------------
+# Report types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BoundaryFunctionState:
+    """Live state of one migration-owned SECURITY DEFINER entry point."""
+
+    name: str
+    owner: str
+    security_definer: bool
+    search_path_pinned: bool
+    public_execute: bool
+    control_execute: bool
+
+    @property
+    def secured(self) -> bool:
+        return (
+            self.owner == PROVISIONER
+            and self.security_definer
+            and self.search_path_pinned
+            and not self.public_execute
+            and self.control_execute
+        )
+
+
+@dataclass(frozen=True)
+class TenantOwnershipState:
+    """Live ownership state of one tenant's data plane."""
+
+    tenant_id: str
+    schema_name: str
+    schema_exists: bool
+    schema_owner: str | None
+    reader_exists: bool
+    writer_exists: bool
+    relations: int
+    relations_not_owned_by_writer: int
+    relations_without_reader_select: int
+
+    @property
+    def adopted(self) -> bool:
+        return (
+            self.schema_exists
+            and self.schema_owner == PROVISIONER
+            and self.reader_exists
+            and self.writer_exists
+            and self.relations_not_owned_by_writer == 0
+            and self.relations_without_reader_select == 0
+        )
+
+
+@dataclass(frozen=True)
+class BoundaryTableState:
+    """A ``catalog`` table carrying tenant state, as the database reports it."""
+
+    name: str
+    has_stamping_trigger: bool
+    has_tenant_id: bool
+    rls_enabled: bool
+    rls_forced: bool
+
+
+# ---------------------------------------------------------------------------
+# Introspection
+# ---------------------------------------------------------------------------
+
+
+async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
+    """Read the tenant boundary from the database, never from a constant.
+
+    The boundary is whatever currently carries 0018's insert-stamping trigger.
+    Migration 0018 froze a six-table tuple by design and later migrations
+    widened the live set, so any enumeration copied from a migration is stale
+    the moment a table joins.  Tables holding a ``tenant_id`` column *without*
+    the trigger are reported too: 0037's ``dataset_refresh_runs`` is a
+    deliberately dormant column, and an accidental one should look the same
+    here so it can be told apart on purpose rather than by omission.
+    """
+    result = await conn.execute(
+        text(
+            """
+            SELECT relation.relname AS name,
+                   EXISTS (
+                       SELECT 1 FROM pg_catalog.pg_trigger AS trigger_row
+                       WHERE trigger_row.tgrelid = relation.oid
+                         AND trigger_row.tgname = :trigger_name
+                         AND NOT trigger_row.tgisinternal
+                   ) AS has_stamping_trigger,
+                   EXISTS (
+                       SELECT 1 FROM pg_catalog.pg_attribute AS attribute
+                       WHERE attribute.attrelid = relation.oid
+                         AND attribute.attname = 'tenant_id'
+                         AND NOT attribute.attisdropped
+                   ) AS has_tenant_id,
+                   relation.relrowsecurity AS rls_enabled,
+                   relation.relforcerowsecurity AS rls_forced
+            FROM pg_catalog.pg_class AS relation
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = relation.relnamespace
+            WHERE namespace.nspname = 'catalog'
+              AND relation.relkind IN ('r', 'p')
+            ORDER BY relation.relname
+            """
+        ),
+        {"trigger_name": BOUNDARY_TRIGGER},
+    )
+    states = [BoundaryTableState(**dict(row._mapping)) for row in result]
+    return [
+        state for state in states if state.has_stamping_trigger or state.has_tenant_id
+    ]
+
+
+async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
+    """Read owner, SECURITY DEFINER, search_path, and ACL of both functions."""
+    result = await conn.execute(
+        text(
+            """
+            SELECT routine.proname AS name,
+                   pg_catalog.pg_get_userbyid(routine.proowner) AS owner,
+                   routine.prosecdef AS security_definer,
+                   COALESCE(
+                       'search_path=pg_catalog' = ANY(routine.proconfig), false
+                   ) AS search_path_pinned,
+                   pg_catalog.has_function_privilege(
+                       'public', routine.oid, 'EXECUTE'
+                   ) AS public_execute,
+                   CASE
+                       WHEN EXISTS (
+                           SELECT 1 FROM pg_catalog.pg_roles
+                           WHERE rolname = :control
+                       )
+                       THEN pg_catalog.has_function_privilege(
+                           :control, routine.oid, 'EXECUTE'
+                       )
+                       ELSE false
+                   END AS control_execute
+            FROM pg_catalog.pg_proc AS routine
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = routine.pronamespace
+            WHERE namespace.nspname = 'catalog'
+              AND routine.proname = ANY(:names)
+              AND routine.pronargs = 1
+              AND routine.proargtypes[0] = 'uuid'::regtype
+            ORDER BY routine.proname
+            """
+        ),
+        {"control": CONTROL, "names": list(BOUNDARY_FUNCTIONS)},
+    )
+    return [BoundaryFunctionState(**dict(row._mapping)) for row in result]
+
+
+async def list_tenants(conn) -> list[str]:
+    """Every tenant id in the control plane, in a stable order."""
+    result = await conn.execute(
+        text("SELECT id::text FROM catalog.tenants ORDER BY id")
+    )
+    return [row[0] for row in result]
+
+
+async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
+    """Read one tenant's ownership state without changing anything."""
+    result = await conn.execute(
+        text(
+            """
+            WITH names AS (
+                SELECT 'data_t_' || replace(:tenant_id, '-', '_') AS schema_name,
+                       'geolens_reader_t_' || replace(:tenant_id, '-', '_')
+                           AS reader_name,
+                       'geolens_writer_t_' || replace(:tenant_id, '-', '_')
+                           AS writer_name
+            ),
+            reader AS (
+                SELECT oid FROM pg_catalog.pg_roles
+                WHERE rolname = (SELECT reader_name FROM names)
+            ),
+            relations AS (
+                SELECT relation.oid, relation.relkind, owner_role.rolname AS owner
+                FROM pg_catalog.pg_class AS relation
+                JOIN pg_catalog.pg_namespace AS namespace
+                  ON namespace.oid = relation.relnamespace
+                JOIN pg_catalog.pg_roles AS owner_role
+                  ON owner_role.oid = relation.relowner
+                WHERE namespace.nspname = (SELECT schema_name FROM names)
+                  AND relation.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+            )
+            SELECT
+                (SELECT schema_name FROM names) AS schema_name,
+                EXISTS (
+                    SELECT 1 FROM pg_catalog.pg_namespace
+                    WHERE nspname = (SELECT schema_name FROM names)
+                ) AS schema_exists,
+                (
+                    SELECT owner_role.rolname
+                    FROM pg_catalog.pg_namespace AS namespace
+                    JOIN pg_catalog.pg_roles AS owner_role
+                      ON owner_role.oid = namespace.nspowner
+                    WHERE namespace.nspname = (SELECT schema_name FROM names)
+                ) AS schema_owner,
+                EXISTS (
+                    SELECT 1 FROM pg_catalog.pg_roles
+                    WHERE rolname = (SELECT reader_name FROM names)
+                ) AS reader_exists,
+                EXISTS (
+                    SELECT 1 FROM pg_catalog.pg_roles
+                    WHERE rolname = (SELECT writer_name FROM names)
+                ) AS writer_exists,
+                (SELECT count(*) FROM relations) AS relations,
+                (
+                    SELECT count(*) FROM relations
+                    WHERE owner <> (SELECT writer_name FROM names)
+                ) AS relations_not_owned_by_writer,
+                -- CASE, not OR: SQL does not promise to short-circuit an OR, and
+                -- has_table_privilege() errors outright on a role name that the
+                -- restore never brought back.
+                CASE
+                    WHEN NOT EXISTS (SELECT 1 FROM reader)
+                    THEN (SELECT count(*) FROM relations)
+                    ELSE (
+                        SELECT count(*) FROM relations
+                        WHERE (
+                            relations.relkind IN ('r', 'p', 'v', 'm', 'f')
+                            AND NOT pg_catalog.has_table_privilege(
+                                (SELECT oid FROM reader), relations.oid, 'SELECT'
+                            )
+                        )
+                        OR (
+                            relations.relkind = 'S'
+                            AND NOT pg_catalog.has_sequence_privilege(
+                                (SELECT oid FROM reader), relations.oid, 'SELECT'
+                            )
+                        )
+                    )
+                END AS relations_without_reader_select
+            """
+        ),
+        {"tenant_id": tenant_id},
+    )
+    row = result.one()
+    return TenantOwnershipState(tenant_id=tenant_id, **dict(row._mapping))
+
+
+# ---------------------------------------------------------------------------
+# Adoption steps
+# ---------------------------------------------------------------------------
+
+
+async def ensure_cluster_roles(conn) -> None:
+    """Create the fixed role topology if absent, and refuse an unsafe one."""
+    await conn.execute(text(CLUSTER_ROLE_SQL))
+    await conn.execute(text(PROVISIONER_DATABASE_GRANT_SQL))
+    await conn.execute(text(f"GRANT USAGE ON SCHEMA catalog TO {PROVISIONER}"))
+    await conn.execute(text(f"GRANT SELECT ON TABLE catalog.tenants TO {PROVISIONER}"))
+
+
+async def secure_boundary_functions(conn) -> list[BoundaryFunctionState]:
+    """Re-own and re-restrict the two functions a restore left wide open.
+
+    The bodies belong to the migrations and are never rewritten here.  What a
+    ``pg_restore --no-owner --no-acl`` strips is the owner and the ACL, and the
+    PostgreSQL default for a function with no ACL is ``EXECUTE`` to ``PUBLIC``.
+    A SECURITY DEFINER function owned by the restoring superuser and callable by
+    everyone is the state this repairs.
+    """
+    states = {state.name: state for state in await boundary_function_states(conn)}
+    missing = [name for name in BOUNDARY_FUNCTIONS if name not in states]
+    if missing:
+        raise RuntimeError(
+            "Tenant boundary function(s) missing from schema catalog: "
+            f"{', '.join(missing)}. Adoption repairs ownership at the current "
+            "head schema; it does not install function bodies. Run "
+            "`alembic upgrade heads` against this database first."
+        )
+    for name, state in states.items():
+        if not state.security_definer:
+            raise RuntimeError(
+                f"catalog.{name}(uuid) is not SECURITY DEFINER. This is not the "
+                "migration-installed boundary function; refusing to adopt it."
+            )
+        if not state.search_path_pinned:
+            raise RuntimeError(
+                f"catalog.{name}(uuid) has no `SET search_path = pg_catalog`. "
+                "This is not the migration-installed boundary function; "
+                "refusing to adopt it."
+            )
+
+    for name in BOUNDARY_FUNCTIONS:
+        signature = f"catalog.{name}(uuid)"
+        await conn.execute(text(f"ALTER FUNCTION {signature} OWNER TO {PROVISIONER}"))
+        await conn.execute(text(f"REVOKE ALL ON FUNCTION {signature} FROM PUBLIC"))
+        await conn.execute(text(f"GRANT EXECUTE ON FUNCTION {signature} TO {CONTROL}"))
+    return await boundary_function_states(conn)
+
+
+async def adopt_tenant(conn, tenant_id: str) -> None:
+    """Move one tenant's schema, roles, and relations under the boundary."""
+    normalized = str(uuid.UUID(tenant_id))
+    await conn.execute(
+        text("SELECT set_config(:guc, :tenant_id, true)"),
+        {"guc": TENANT_GUC, "tenant_id": normalized},
+    )
+    await conn.execute(text(ADOPT_TENANT_SQL))
+
+
+# ---------------------------------------------------------------------------
+# Orchestration + CLI
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AdoptionReport:
+    """What adoption found, and what it changed."""
+
+    applied: bool
+    functions: list[BoundaryFunctionState]
+    boundary: list[BoundaryTableState]
+    before: list[TenantOwnershipState]
+    after: list[TenantOwnershipState]
+    failures: dict[str, str]
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing is left to do — the exit code in both modes.
+
+        A dry run that reports pending work therefore exits non-zero, which is
+        what makes ``--apply``-less invocation usable as a post-restore check.
+        """
+        if self.failures:
+            return False
+        states = self.after if self.applied else self.before
+        return all(state.adopted for state in states) and all(
+            function.secured for function in self.functions
+        )
+
+
+def boundary_drift(boundary: list[BoundaryTableState]) -> tuple[list[str], list[str]]:
+    """Compare the live boundary against the runtime constant that drives RLS.
+
+    ``apply_tenancy_rls`` enables and FORCEs row security from
+    ``app.core.db.rls.RLS_TABLES``.  A table that joined the live boundary
+    without joining that tuple is silently skipped at boot, which is exactly the
+    failure a restored multi-tenant cluster cannot afford.  Returns
+    ``(live_only, constant_only)``.
+    """
+    live = {state.name for state in boundary if state.has_stamping_trigger}
+    declared = set(RLS_TABLES)
+    return sorted(live - declared), sorted(declared - live)
+
+
+async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
+    """Report the ownership gap and, with ``apply``, close it."""
+    async with engine.connect() as conn:
+        tenants = await list_tenants(conn)
+        before = [await tenant_ownership_state(conn, tid) for tid in tenants]
+        boundary = await live_tenant_boundary(conn)
+        functions = await boundary_function_states(conn)
+
+    if not apply:
+        return AdoptionReport(
+            applied=False,
+            functions=functions,
+            boundary=boundary,
+            before=before,
+            after=before,
+            failures={},
+        )
+
+    async with engine.begin() as conn:
+        await ensure_cluster_roles(conn)
+        functions = await secure_boundary_functions(conn)
+
+    failures: dict[str, str] = {}
+    for tenant_id in tenants:
+        try:
+            async with engine.begin() as conn:
+                await adopt_tenant(conn, tenant_id)
+        except Exception as exc:  # broad: one tenant's refusal must not strand the rest
+            failures[tenant_id] = str(exc).strip().splitlines()[0]
+            logger.error(
+                "tenant_adoption: tenant failed", tenant_id=tenant_id, exc_info=True
+            )
+
+    async with engine.connect() as conn:
+        after = [await tenant_ownership_state(conn, tid) for tid in tenants]
+        boundary = await live_tenant_boundary(conn)
+
+    return AdoptionReport(
+        applied=True,
+        functions=functions,
+        boundary=boundary,
+        before=before,
+        after=after,
+        failures=failures,
+    )
+
+
+def _format_functions(functions: list[BoundaryFunctionState]) -> list[str]:
+    lines = ["Boundary functions:"]
+    for function in functions:
+        flags = [f"owner={function.owner}"]
+        if function.public_execute:
+            flags.append("EXECUTE granted to PUBLIC")
+        if not function.control_execute:
+            flags.append(f"no EXECUTE for {CONTROL}")
+        verdict = "secured" if function.secured else "NEEDS REPAIR"
+        lines.append(f"  catalog.{function.name}(uuid): {verdict} — {', '.join(flags)}")
+    return lines
+
+
+def _boundary_table_markers(table: BoundaryTableState) -> list[str]:
+    if not table.has_stamping_trigger:
+        return ["tenant_id column only, outside the stamped boundary"]
+    if not table.rls_enabled:
+        return ["RLS not enabled (the API enables it at boot in multi_tenant)"]
+    if not table.rls_forced:
+        return ["RLS enabled but not FORCEd — the table owner bypasses it"]
+    return []
+
+
+def _format_boundary(boundary: list[BoundaryTableState]) -> list[str]:
+    lines = [f"Live tenant boundary ({BOUNDARY_TRIGGER}), read from the database:"]
+    for table in boundary:
+        markers = _boundary_table_markers(table)
+        suffix = f" — {'; '.join(markers)}" if markers else ""
+        lines.append(f"  catalog.{table.name}{suffix}")
+
+    live_only, constant_only = boundary_drift(boundary)
+    if live_only:
+        lines.append(
+            "  DRIFT: stamped in the database but absent from "
+            "app.core.db.rls.RLS_TABLES, so boot never enables RLS on them: "
+            f"{', '.join(live_only)}"
+        )
+    if constant_only:
+        lines.append(
+            "  DRIFT: listed in app.core.db.rls.RLS_TABLES but carrying no "
+            f"stamping trigger here: {', '.join(constant_only)}"
+        )
+    return lines
+
+
+def _tenant_verdict(
+    before: TenantOwnershipState, after: TenantOwnershipState, applied: bool
+) -> str:
+    if not applied:
+        return "adopted" if before.adopted else "needs adoption"
+    if not after.adopted:
+        return "STILL INCOMPLETE"
+    return "already adopted (no changes)" if before.adopted else "adopted"
+
+
+def _format_tenants(report: AdoptionReport) -> list[str]:
+    if not report.before:
+        return ["Tenants: none. Nothing to adopt (single-tenant control plane)."]
+
+    lines = [f"Tenants: {len(report.before)}"]
+    after_by_id = {state.tenant_id: state for state in report.after}
+    for before in report.before:
+        after = after_by_id[before.tenant_id]
+        detail = (
+            f"{after.relations} relation(s), "
+            f"{after.relations_not_owned_by_writer} not owned by the writer, "
+            f"{after.relations_without_reader_select} without reader SELECT"
+        )
+        verdict = _tenant_verdict(before, after, report.applied)
+        lines.append(f"  {before.tenant_id}: {verdict} — {detail}")
+    return lines
+
+
+def format_report(report: AdoptionReport) -> str:
+    """Render the report an operator reads mid-recovery."""
+    mode = "APPLIED" if report.applied else "DRY RUN (no changes made)"
+    sections = [
+        [f"Tenant-ownership adoption — {mode}"],
+        _format_functions(report.functions),
+        _format_boundary(report.boundary),
+        _format_tenants(report),
+    ]
+    if report.failures:
+        failures = ["Failures (re-run after fixing; adopted tenants stay adopted):"]
+        failures += [
+            f"  {tenant_id}: {message}"
+            for tenant_id, message in report.failures.items()
+        ]
+        sections.append(failures)
+    return "\n\n".join("\n".join(section) for section in sections)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m app.core.db.tenant_adoption",
+        description=(
+            "Reconstruct tenant schema/role ownership at the current head "
+            "schema, without the destructive downgrade to 0016 (#998)."
+        ),
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Perform the adoption. Without it the run only reports the gap.",
+    )
+    parser.epilog = (
+        "Exit codes: 0 nothing left to do; 1 work is pending or a tenant "
+        "failed; 2 refused before touching any tenant."
+    )
+    return parser
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from sqlalchemy.pool import NullPool
+
+    from app.core.config import settings
+
+    engine = create_async_engine(
+        settings.database_url,
+        poolclass=NullPool,
+        connect_args=settings.database_connect_args,
+    )
+    try:
+        report = await run_adoption(engine, apply=args.apply)
+    except (
+        Exception
+    ) as exc:  # broad: an operator mid-recovery needs the reason, not a traceback
+        logger.error("tenant_adoption: refused", exc_info=True)
+        reason = str(exc).strip().splitlines()[0]
+        print(f"Tenant-ownership adoption refused before any tenant: {reason}")
+        return 2
+    finally:
+        await engine.dispose()
+
+    print(format_report(report))
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -152,9 +152,32 @@ class BoundaryTableState:
 
     name: str
     has_stamping_trigger: bool
+    stamping_trigger_disabled: bool
     has_tenant_id: bool
     rls_enabled: bool
     rls_forced: bool
+
+
+def rls_gaps(boundary: list[BoundaryTableState], *, tenants_present: bool) -> list[str]:
+    """Boundary tables whose row-security posture is not safe to serve.
+
+    ``apply_tenancy_rls`` is mode-gated and a single-tenant install correctly
+    keeps row security off, so a uniformly disabled boundary on a control plane
+    with no tenants is not a finding — and this module cannot read the mode out
+    of the database, only the tenants.  Two states always are findings: a
+    control plane that *has* tenants with row security off, where the isolation
+    boundary simply is not there; and row security enabled without ``FORCE``,
+    where the table owner bypasses every policy.
+    """
+    gaps: list[str] = []
+    for table in boundary:
+        if not table.has_stamping_trigger:
+            continue
+        if tenants_present and not table.rls_enabled:
+            gaps.append(f"{table.name} (row security disabled)")
+        elif table.rls_enabled and not table.rls_forced:
+            gaps.append(f"{table.name} (row security not FORCEd)")
+    return gaps
 
 
 def boundary_drift(boundary: list[BoundaryTableState]) -> tuple[list[str], list[str]]:
@@ -193,12 +216,25 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
         text(
             """
             SELECT relation.relname AS name,
+                   -- tgenabled 'O'/'A' are the only states that fire for an
+                   -- ordinary application session. A restored trigger left
+                   -- 'D' (disabled) or 'R' (replica-only) still exists under
+                   -- this name and stamps nothing, and nothing at boot
+                   -- re-enables it.
                    EXISTS (
                        SELECT 1 FROM pg_catalog.pg_trigger AS trigger_row
                        WHERE trigger_row.tgrelid = relation.oid
                          AND trigger_row.tgname = :trigger_name
                          AND NOT trigger_row.tgisinternal
+                         AND trigger_row.tgenabled IN ('O', 'A')
                    ) AS has_stamping_trigger,
+                   EXISTS (
+                       SELECT 1 FROM pg_catalog.pg_trigger AS trigger_row
+                       WHERE trigger_row.tgrelid = relation.oid
+                         AND trigger_row.tgname = :trigger_name
+                         AND NOT trigger_row.tgisinternal
+                         AND trigger_row.tgenabled NOT IN ('O', 'A')
+                   ) AS stamping_trigger_disabled,
                    EXISTS (
                        SELECT 1 FROM pg_catalog.pg_attribute AS attribute
                        WHERE attribute.attrelid = relation.oid
@@ -219,7 +255,11 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
     )
     states = [BoundaryTableState(**dict(row._mapping)) for row in result]
     return [
-        state for state in states if state.has_stamping_trigger or state.has_tenant_id
+        state
+        for state in states
+        if state.has_stamping_trigger
+        or state.stamping_trigger_disabled
+        or state.has_tenant_id
     ]
 
 
@@ -616,6 +656,15 @@ class AdoptionReport:
         return [name for name in BOUNDARY_FUNCTIONS if name not in present]
 
     @property
+    def rls_gaps(self) -> list[str]:
+        """Boundary tables that cannot enforce tenant isolation as they stand.
+
+        Tenant rows in the control plane are what makes a database
+        multi-tenant, so they are what makes row security mandatory here.
+        """
+        return rls_gaps(self.boundary, tenants_present=bool(self.before))
+
+    @property
     def ok(self) -> bool:
         """True when nothing is left to do — the exit code in both modes.
 
@@ -624,14 +673,16 @@ class AdoptionReport:
         Every condition the report surfaces has to be in here, or the check
         passes on a database the report itself calls broken: a missing boundary
         function, a fixed-role topology ``--apply`` would refuse, a provisioner
-        grant a restore dropped, and boundary drift that leaves a stamped table
-        without RLS at boot all count.
+        grant a restore dropped, boundary drift that leaves a stamped table
+        without RLS at boot, and a boundary table that cannot enforce isolation
+        as it stands all count.
         """
         if (
             self.failures
             or self.missing_functions
             or self.cluster_topology
             or self.provisioner_grants_missing
+            or self.rls_gaps
         ):
             return False
         if not all(function.secured for function in self.functions):
@@ -735,20 +786,31 @@ def _format_functions(report: AdoptionReport) -> list[str]:
     return lines
 
 
-def _boundary_table_markers(table: BoundaryTableState) -> list[str]:
+def _boundary_table_markers(
+    table: BoundaryTableState, *, tenants_present: bool
+) -> list[str]:
+    if table.stamping_trigger_disabled:
+        return [
+            f"{BOUNDARY_TRIGGER} exists but is DISABLED — it stamps nothing, and "
+            "nothing at boot re-enables it"
+        ]
     if not table.has_stamping_trigger:
         return ["tenant_id column only, outside the stamped boundary"]
     if not table.rls_enabled:
-        return ["RLS not enabled (the API enables it at boot in multi_tenant)"]
+        if tenants_present:
+            return ["RLS not enabled on a control plane that has tenants"]
+        return ["RLS not enabled (correct while the control plane has no tenants)"]
     if not table.rls_forced:
         return ["RLS enabled but not FORCEd — the table owner bypasses it"]
     return []
 
 
-def _format_boundary(boundary: list[BoundaryTableState]) -> list[str]:
+def _format_boundary(report: AdoptionReport) -> list[str]:
+    boundary = report.boundary
+    tenants_present = bool(report.before)
     lines = [f"Live tenant boundary ({BOUNDARY_TRIGGER}), read from the database:"]
     for table in boundary:
-        markers = _boundary_table_markers(table)
+        markers = _boundary_table_markers(table, tenants_present=tenants_present)
         suffix = f" — {'; '.join(markers)}" if markers else ""
         lines.append(f"  catalog.{table.name}{suffix}")
 
@@ -761,8 +823,13 @@ def _format_boundary(boundary: list[BoundaryTableState]) -> list[str]:
         )
     if constant_only:
         lines.append(
-            "  DRIFT: listed in app.core.db.rls.RLS_TABLES but carrying no "
+            "  DRIFT: listed in app.core.db.rls.RLS_TABLES but carrying no live "
             f"stamping trigger here: {', '.join(constant_only)}"
+        )
+    if report.rls_gaps:
+        lines.append(
+            "  NOT SAFE TO SERVE until row security is repaired: "
+            f"{', '.join(report.rls_gaps)}"
         )
     return lines
 
@@ -817,7 +884,7 @@ def format_report(report: AdoptionReport) -> str:
         [f"Tenant-ownership adoption — {mode}"],
         _format_cluster_roles(report),
         _format_functions(report),
-        _format_boundary(report.boundary),
+        _format_boundary(report),
         _format_tenants(report),
     ]
     if report.failures:

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -148,7 +148,15 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
                    -- policy denies every runtime read, and an altered one can
                    -- return another tenant's rows. Its expression has been
                    -- byte-identical since 0006, so it is compared exactly.
-                   EXISTS (
+                   -- ...and the only permissive one. PostgreSQL ORs permissive
+                   -- policies, so a second `USING (true)` beside the canonical
+                   -- rule returns every tenant's rows with RLS fully enabled.
+                   (
+                       SELECT count(*) FROM pg_catalog.pg_policy AS policy
+                       WHERE policy.polrelid = relation.oid
+                         AND policy.polpermissive
+                   ) = 1
+                   AND EXISTS (
                        SELECT 1 FROM pg_catalog.pg_policy AS policy
                        WHERE policy.polrelid = relation.oid
                          AND policy.polname = 'tenant_isolation_' || relation.relname
@@ -552,15 +560,23 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                             JOIN LATERAL pg_catalog.aclexplode(relation.relacl)
                               AS acl ON true
                             WHERE relation.oid = relations.oid
-                              AND acl.grantee = (SELECT oid FROM reader)
-                              AND acl.privilege_type <> 'SELECT'
-                              AND NOT (
-                                  relations.relkind = 'S'
-                                  AND acl.privilege_type = 'USAGE'
+                              AND (
+                                  -- grantee 0 is PUBLIC: the reader holds
+                                  -- whatever PUBLIC holds, and so does everyone
+                                  -- else with USAGE on the schema.
+                                  acl.grantee = 0
+                                  OR (
+                                      acl.grantee = (SELECT oid FROM reader)
+                                      AND acl.privilege_type <> 'SELECT'
+                                      AND NOT (
+                                          relations.relkind = 'S'
+                                          AND acl.privilege_type = 'USAGE'
+                                      )
+                                  )
                               )
                         )
                     )
-                END AS relations_with_reader_write,
+                END AS relations_with_unsafe_acl,
                 -- The pre-0019 runtime helper left an ALTER DEFAULT PRIVILEGES
                 -- entry behind; ADOPT_TENANT_SQL revokes it, so a tenant still
                 -- carrying one is not adopted however correct the rest looks.

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -71,6 +71,7 @@ from app.core.db.tenant_adoption_sql import (
     CONTROL,
     PROVISIONER,
     PROVISIONER_DATABASE_GRANT_SQL,
+    PROVISIONER_DATABASE_REVOKE_OPTION_SQL,
     RELEASE_GATEWAY_EDGES_SQL,
     RELEASE_PROVISIONER_EDGE_SQL,
     SANDBOX,
@@ -226,8 +227,11 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
             SELECT routine.proname AS name,
                    pg_catalog.pg_get_userbyid(routine.proowner) AS owner,
                    routine.prosecdef AS security_definer,
+                   -- Exactly that one setting: an extra proconfig entry such
+                   -- as `SET role` changes what a SECURITY DEFINER body runs
+                   -- as, and it would sit beside a correct search_path.
                    COALESCE(
-                       'search_path=pg_catalog' = ANY(routine.proconfig), false
+                       routine.proconfig = ARRAY['search_path=pg_catalog'], false
                    ) AS search_path_pinned,
                    language.lanname AS language,
                    routine.prorettype = 'void'::regtype AS returns_void,
@@ -300,7 +304,7 @@ async def stamping_function_shape(conn) -> str | None:
                    routine.prosecdef AS security_definer,
                    routine.prorettype = 'trigger'::regtype AS returns_trigger,
                    COALESCE(
-                       :stamping_search_path = ANY(routine.proconfig), false
+                       routine.proconfig = ARRAY[:stamping_search_path], false
                    ) AS search_path_pinned,
                    (
                        {_EXECUTABLE_BODY} LIKE '%app.current_tenant%'
@@ -379,6 +383,37 @@ async def missing_provisioner_grants(conn) -> list[str]:
     result = await conn.execute(
         text(
             """
+            WITH owner AS (
+                SELECT oid FROM pg_catalog.pg_roles WHERE rolname = :provisioner
+            ),
+            grantable AS (
+                SELECT 'database_create' AS grant_key
+                FROM pg_catalog.pg_database AS db
+                JOIN LATERAL pg_catalog.aclexplode(db.datacl) AS acl ON true
+                WHERE db.datname = pg_catalog.current_database()
+                  AND acl.grantee = (SELECT oid FROM owner)
+                  AND acl.privilege_type = 'CREATE'
+                  AND acl.is_grantable
+                UNION ALL
+                SELECT 'catalog_usage'
+                FROM pg_catalog.pg_namespace AS namespace
+                JOIN LATERAL pg_catalog.aclexplode(namespace.nspacl) AS acl ON true
+                WHERE namespace.nspname = 'catalog'
+                  AND acl.grantee = (SELECT oid FROM owner)
+                  AND acl.privilege_type = 'USAGE'
+                  AND acl.is_grantable
+                UNION ALL
+                SELECT 'tenants_select'
+                FROM pg_catalog.pg_class AS relation
+                JOIN pg_catalog.pg_namespace AS namespace
+                  ON namespace.oid = relation.relnamespace
+                JOIN LATERAL pg_catalog.aclexplode(relation.relacl) AS acl ON true
+                WHERE namespace.nspname = 'catalog'
+                  AND relation.relname = 'tenants'
+                  AND acl.grantee = (SELECT oid FROM owner)
+                  AND acl.privilege_type = 'SELECT'
+                  AND acl.is_grantable
+            )
             SELECT pg_catalog.has_database_privilege(
                        :provisioner, pg_catalog.current_database(), 'CREATE'
                    ) AS database_create,
@@ -387,7 +422,8 @@ async def missing_provisioner_grants(conn) -> list[str]:
                    ) AS catalog_usage,
                    pg_catalog.has_table_privilege(
                        :provisioner, 'catalog.tenants', 'SELECT'
-                   ) AS tenants_select
+                   ) AS tenants_select,
+                   ARRAY(SELECT grant_key FROM grantable) AS grantable_keys
             """
         ),
         {"provisioner": PROVISIONER},
@@ -398,7 +434,13 @@ async def missing_provisioner_grants(conn) -> list[str]:
         "catalog_usage": "USAGE on schema catalog",
         "tenants_select": "SELECT on catalog.tenants",
     }
-    return [label for key, label in labels.items() if not getattr(row, key)]
+    findings = [label for key, label in labels.items() if not getattr(row, key)]
+    # The provisioner is reachable only through SECURITY DEFINER functions, so a
+    # grantable privilege there is a delegation nothing else would notice.
+    findings += [
+        f"{labels[key]} is grantable" for key in row.grantable_keys if key in labels
+    ]
+    return findings
 
 
 async def list_tenants(conn) -> list[str]:
@@ -756,6 +798,18 @@ async def ensure_cluster_roles(conn) -> bool:
     await conn.execute(text(PROVISIONER_DATABASE_GRANT_SQL))
     await conn.execute(text(f"GRANT USAGE ON SCHEMA catalog TO {PROVISIONER}"))
     await conn.execute(text(f"GRANT SELECT ON TABLE catalog.tenants TO {PROVISIONER}"))
+    # A re-GRANT adds the privilege and leaves an existing GRANT OPTION alone.
+    # These are no-ops on a database that never had one.
+    await conn.execute(
+        text(f"REVOKE GRANT OPTION FOR USAGE ON SCHEMA catalog FROM {PROVISIONER}")
+    )
+    await conn.execute(
+        text(
+            "REVOKE GRANT OPTION FOR SELECT ON TABLE catalog.tenants "
+            f"FROM {PROVISIONER}"
+        )
+    )
+    await conn.execute(text(PROVISIONER_DATABASE_REVOKE_OPTION_SQL))
     return not held_before and await _holds_provisioner_privileges(conn)
 
 

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -727,6 +727,26 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
             AND dependency.deptype = 'e'
       )
                 ) AS unsafe_types,
+                -- fix(#998 codex r48): extended statistics are schema objects
+                -- with an owner of their own; the writer must be able to
+                -- ALTER and DROP them.
+                (
+                    SELECT count(*)
+                    FROM pg_catalog.pg_statistic_ext AS statistics_row
+                    JOIN pg_catalog.pg_namespace AS namespace
+                      ON namespace.oid = statistics_row.stxnamespace
+                    WHERE namespace.nspname = (SELECT schema_name FROM names)
+                      AND statistics_row.stxowner IS DISTINCT FROM (
+                          SELECT oid FROM writer
+                      )
+                      AND NOT EXISTS (
+                          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+                          WHERE dependency.classid
+                                = 'pg_statistic_ext'::regclass
+                            AND dependency.objid = statistics_row.oid
+                            AND dependency.deptype = 'e'
+                      )
+                ) AS unsafe_statistics,
                 -- The same four surfaces the apply side refuses on, counted
                 -- here so the dry run cannot call a tenant adopted that
                 -- `--apply` would stop on.

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -894,6 +894,24 @@ async def adopt_tenant(conn, tenant_id: str) -> None:
     await conn.execute(text(ADOPT_TENANT_SQL))
 
 
+def _failure_message(exc: BaseException) -> str:
+    """One line, plus the remediation PostgreSQL attached to it.
+
+    The refusals this module raises carry the exact statement to run and the
+    role to run it as in the exception's HINT, and the driver leaves that out of
+    ``str(exc)``.  Dropping it would report a tenant as incomplete without
+    saying what to do about it.
+    """
+    message = str(exc).strip().splitlines()[0]
+    cause: BaseException | None = exc
+    while cause is not None:
+        hint = getattr(cause, "hint", None)
+        if hint:
+            return f"{message} — {hint}"
+        cause = cause.__cause__
+    return message
+
+
 async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
     """Report the ownership gap and, with ``apply``, close it."""
     topology = await cluster_topology_error(engine)
@@ -931,7 +949,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
             except (
                 Exception
             ) as exc:  # broad: one tenant's refusal must not strand the rest
-                failures[tenant_id] = str(exc).strip().splitlines()[0]
+                failures[tenant_id] = _failure_message(exc)
                 logger.error(
                     "tenant_adoption: tenant failed", tenant_id=tenant_id, exc_info=True
                 )

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -138,6 +138,22 @@ class BoundaryTableState:
     rls_forced: bool
 
 
+def boundary_drift(boundary: list[BoundaryTableState]) -> tuple[list[str], list[str]]:
+    """Compare the live boundary against the runtime constant that drives RLS.
+
+    ``apply_tenancy_rls`` enables and FORCEs row security from
+    ``app.core.db.rls.RLS_TABLES``.  A table that joined the live boundary
+    without joining that tuple is silently skipped at boot, which is exactly the
+    failure a restored multi-tenant cluster cannot afford.  The other direction
+    is drift too: a table named in the tuple but carrying no stamping trigger
+    accepts an insert with no ``tenant_id`` at all.  Returns
+    ``(live_only, constant_only)``.
+    """
+    live = {state.name for state in boundary if state.has_stamping_trigger}
+    declared = set(RLS_TABLES)
+    return sorted(live - declared), sorted(declared - live)
+
+
 # ---------------------------------------------------------------------------
 # Introspection
 # ---------------------------------------------------------------------------
@@ -396,32 +412,36 @@ class AdoptionReport:
     failures: dict[str, str]
 
     @property
+    def missing_functions(self) -> list[str]:
+        """Boundary functions the schema does not have.
+
+        ``boundary_function_states`` omits what it cannot find, so an absent
+        function shortens the list rather than marking one unsecured.  Naming
+        the gap keeps ``all(... .secured)`` from passing vacuously.
+        """
+        present = {function.name for function in self.functions}
+        return [name for name in BOUNDARY_FUNCTIONS if name not in present]
+
+    @property
     def ok(self) -> bool:
         """True when nothing is left to do — the exit code in both modes.
 
         A dry run that reports pending work therefore exits non-zero, which is
         what makes ``--apply``-less invocation usable as a post-restore check.
+        Every condition the report surfaces has to be in here, or the check
+        passes on a database the report itself calls broken: a missing boundary
+        function, and boundary drift that leaves a stamped table without RLS at
+        boot, both count.
         """
-        if self.failures:
+        if self.failures or self.missing_functions:
+            return False
+        if not all(function.secured for function in self.functions):
+            return False
+        live_only, constant_only = boundary_drift(self.boundary)
+        if live_only or constant_only:
             return False
         states = self.after if self.applied else self.before
-        return all(state.adopted for state in states) and all(
-            function.secured for function in self.functions
-        )
-
-
-def boundary_drift(boundary: list[BoundaryTableState]) -> tuple[list[str], list[str]]:
-    """Compare the live boundary against the runtime constant that drives RLS.
-
-    ``apply_tenancy_rls`` enables and FORCEs row security from
-    ``app.core.db.rls.RLS_TABLES``.  A table that joined the live boundary
-    without joining that tuple is silently skipped at boot, which is exactly the
-    failure a restored multi-tenant cluster cannot afford.  Returns
-    ``(live_only, constant_only)``.
-    """
-    live = {state.name for state in boundary if state.has_stamping_trigger}
-    declared = set(RLS_TABLES)
-    return sorted(live - declared), sorted(declared - live)
+        return all(state.adopted for state in states)
 
 
 async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
@@ -471,9 +491,9 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
     )
 
 
-def _format_functions(functions: list[BoundaryFunctionState]) -> list[str]:
+def _format_functions(report: AdoptionReport) -> list[str]:
     lines = ["Boundary functions:"]
-    for function in functions:
+    for function in report.functions:
         flags = [f"owner={function.owner}"]
         if function.public_execute:
             flags.append("EXECUTE granted to PUBLIC")
@@ -481,6 +501,11 @@ def _format_functions(functions: list[BoundaryFunctionState]) -> list[str]:
             flags.append(f"no EXECUTE for {CONTROL}")
         verdict = "secured" if function.secured else "NEEDS REPAIR"
         lines.append(f"  catalog.{function.name}(uuid): {verdict} — {', '.join(flags)}")
+    for name in report.missing_functions:
+        lines.append(
+            f"  catalog.{name}(uuid): MISSING — this database is not at the head "
+            "schema; run `alembic upgrade heads` first"
+        )
     return lines
 
 
@@ -549,7 +574,7 @@ def format_report(report: AdoptionReport) -> str:
     mode = "APPLIED" if report.applied else "DRY RUN (no changes made)"
     sections = [
         [f"Tenant-ownership adoption — {mode}"],
-        _format_functions(report.functions),
+        _format_functions(report),
         _format_boundary(report.boundary),
         _format_tenants(report),
     ]

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -525,6 +525,28 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                         )
                     )
                 END AS relations_without_reader_select,
+                -- Beyond SELECT is a write path: the sandbox and tile gateways
+                -- SET ROLE to this reader. Read out of the ACL rather than
+                -- named privilege by privilege, which grows by release.
+                CASE
+                    WHEN NOT EXISTS (SELECT 1 FROM reader) THEN 0
+                    ELSE (
+                        SELECT count(*) FROM relations
+                        WHERE EXISTS (
+                            SELECT 1
+                            FROM pg_catalog.pg_class AS relation
+                            JOIN LATERAL pg_catalog.aclexplode(relation.relacl)
+                              AS acl ON true
+                            WHERE relation.oid = relations.oid
+                              AND acl.grantee = (SELECT oid FROM reader)
+                              AND acl.privilege_type <> 'SELECT'
+                              AND NOT (
+                                  relations.relkind = 'S'
+                                  AND acl.privilege_type = 'USAGE'
+                              )
+                        )
+                    )
+                END AS relations_with_reader_write,
                 -- The pre-0019 runtime helper left an ALTER DEFAULT PRIVILEGES
                 -- entry behind; ADOPT_TENANT_SQL revokes it, so a tenant still
                 -- carrying one is not adopted however correct the rest looks.

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -31,6 +31,13 @@ second run over an adopted tenant issues no DDL at all, and a run interrupted
 partway is resumed by running it again — every tenant is adopted in its own
 transaction, so completed tenants stay completed.
 
+Adoption rewrites only the grants it is itself the grantor of.  A pre-existing
+anomaly — a membership some third party granted, a duplicate row behind a
+canonical one, a default-privilege entry owned by a role this credential cannot
+assume — is reported with the exact statement to run and the role to run it as,
+and the tenant is left for the next run.  See the repair boundary in
+:mod:`app.core.db.tenant_adoption_sql`.
+
 Run it with the migrator credential — ``CREATEROLE``, authority over the
 restored objects, and, on a non-superuser migrator, the privileges of
 ``geolens_tenant_provisioner`` — against a database already at head::

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -112,6 +112,12 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
                          AND NOT trigger_row.tgisinternal
                          AND trigger_row.tgenabled IN ('O', 'A')
                          AND trigger_row.tgtype = :before_insert_row
+                         -- 0018 installs it unconditional and argument-free. A
+                         -- WHEN clause that is false for some rows leaves those
+                         -- inserts unstamped while everything else still checks
+                         -- out.
+                         AND trigger_row.tgqual IS NULL
+                         AND trigger_row.tgnargs = 0
                          AND trigger_row.tgfoid = (
                              SELECT routine.oid
                              FROM pg_catalog.pg_proc AS routine
@@ -146,6 +152,9 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
                          AND policy.polname = 'tenant_isolation_' || relation.relname
                          AND policy.polcmd = '*'
                          AND policy.polpermissive
+                         -- polroles {0} is TO PUBLIC. Narrowed to a named list,
+                         -- every role outside it takes the implicit deny.
+                         AND policy.polroles = '{0}'::oid[]
                          AND pg_catalog.pg_get_expr(
                              policy.polqual, policy.polrelid
                          ) = :isolation_expression
@@ -252,6 +261,7 @@ async def stamping_function_shape(conn) -> str | None:
         text(
             f"""
             SELECT language.lanname AS language,
+                   routine.prosecdef AS security_definer,
                    routine.prorettype = 'trigger'::regtype AS returns_trigger,
                    COALESCE(routine.proconfig::text LIKE '%search_path=%', false)
                        AS search_path_pinned,
@@ -281,6 +291,13 @@ async def stamping_function_shape(conn) -> str | None:
         )
     if not row.returns_trigger:
         return f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() does not return trigger"
+    if row.security_definer:
+        # 0018 installs it SECURITY INVOKER on purpose: it runs on every insert,
+        # and after a --no-owner restore its owner is the restoring superuser.
+        return (
+            f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() is SECURITY DEFINER — 0018 "
+            "installs it SECURITY INVOKER, and it fires on every insert"
+        )
     if not row.search_path_pinned:
         return f"catalog.{BOUNDARY_TRIGGER_FUNCTION}() has no pinned search_path"
     if not row.body_markers_present:

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -79,6 +79,7 @@ from app.core.db.tenant_adoption_sql import (
     PROVISIONER,
     PROVISIONER_DATABASE_GRANT_SQL,
     PROVISIONER_DATABASE_REVOKE_OPTION_SQL,
+    PROVISIONER_GRANT_OPTION_GUARD_SQL,
     RELEASE_PROVISIONER_EDGE_SQL,
     SANDBOX,
     SECURE_BOUNDARY_FUNCTIONS_SQL,
@@ -973,6 +974,10 @@ async def ensure_cluster_roles(conn) -> bool:
     await conn.execute(text(PROVISIONER_DATABASE_GRANT_SQL))
     await conn.execute(text(f"GRANT USAGE ON SCHEMA catalog TO {PROVISIONER}"))
     await conn.execute(text(f"GRANT SELECT ON TABLE catalog.tenants TO {PROVISIONER}"))
+    # fix(#998 codex r45): a grantable entry some third role issued survives
+    # the plain revokes below; refuse it with the grantor named before
+    # pretending to rewrite it.
+    await conn.execute(text(PROVISIONER_GRANT_OPTION_GUARD_SQL))
     # A re-GRANT adds the privilege and leaves an existing GRANT OPTION alone.
     # These are no-ops on a database that never had one.
     await conn.execute(

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -540,6 +540,9 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                     ) OR NOT EXISTS (SELECT 1 FROM reader)
                       OR NOT EXISTS (SELECT 1 FROM writer)
                     THEN false
+                    -- One privilege per call: a comma-separated list is an
+                    -- any-of test, so 'USAGE, CREATE' stays true on a writer
+                    -- that has lost one of them.
                     ELSE NOT pg_catalog.has_schema_privilege(
                              'public', (SELECT schema_name FROM names), 'USAGE'
                          )
@@ -554,7 +557,12 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                      AND pg_catalog.has_schema_privilege(
                              (SELECT oid FROM writer),
                              (SELECT schema_name FROM names),
-                             'USAGE, CREATE'
+                             'USAGE'
+                         )
+                     AND pg_catalog.has_schema_privilege(
+                             (SELECT oid FROM writer),
+                             (SELECT schema_name FROM names),
+                             'CREATE'
                          )
                 END AS schema_privileges_secure
             """

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import structlog
 from sqlalchemy import text
@@ -118,6 +118,7 @@ class TenantOwnershipState:
     relations: int
     relations_not_owned_by_writer: int
     relations_without_reader_select: int
+    reader_default_acls: int
     reader_role_secure: bool
     writer_role_secure: bool
     schema_privileges_secure: bool
@@ -138,6 +139,7 @@ class TenantOwnershipState:
             and self.writer_exists
             and self.relations_not_owned_by_writer == 0
             and self.relations_without_reader_select == 0
+            and self.reader_default_acls == 0
             and self.reader_role_secure
             and self.writer_role_secure
             and self.schema_privileges_secure
@@ -273,6 +275,40 @@ async def cluster_topology_error(engine) -> str | None:
     except Exception as exc:  # broad: any refusal is the answer, whatever its class
         return str(exc).strip().splitlines()[0]
     return None
+
+
+async def missing_provisioner_grants(conn) -> list[str]:
+    """Object privileges ``ensure_cluster_roles`` grants and a restore drops.
+
+    Replaying globals brings the role back; it brings none of these with it, and
+    without them ``catalog.provision_tenant_data_schema`` cannot see
+    ``catalog.tenants`` or create a tenant schema.  Call only once
+    :func:`cluster_topology_error` has confirmed the role exists — the
+    ``has_*_privilege`` family errors on a role name that is not there.
+    """
+    result = await conn.execute(
+        text(
+            """
+            SELECT pg_catalog.has_database_privilege(
+                       :provisioner, pg_catalog.current_database(), 'CREATE'
+                   ) AS database_create,
+                   pg_catalog.has_schema_privilege(
+                       :provisioner, 'catalog', 'USAGE'
+                   ) AS catalog_usage,
+                   pg_catalog.has_table_privilege(
+                       :provisioner, 'catalog.tenants', 'SELECT'
+                   ) AS tenants_select
+            """
+        ),
+        {"provisioner": PROVISIONER},
+    )
+    row = result.one()
+    labels = {
+        "database_create": "CREATE on the database",
+        "catalog_usage": "USAGE on schema catalog",
+        "tenants_select": "SELECT on catalog.tenants",
+    }
+    return [label for key, label in labels.items() if not getattr(row, key)]
 
 
 async def list_tenants(conn) -> list[str]:
@@ -433,6 +469,23 @@ async def tenant_ownership_state(conn, tenant_id: str) -> TenantOwnershipState:
                         )
                     )
                 END AS relations_without_reader_select,
+                -- The pre-0019 runtime helper left an ALTER DEFAULT PRIVILEGES
+                -- entry behind; ADOPT_TENANT_SQL revokes it, so a tenant still
+                -- carrying one is not adopted however correct the rest looks.
+                CASE
+                    WHEN NOT EXISTS (SELECT 1 FROM reader) THEN 0
+                    ELSE (
+                        SELECT count(DISTINCT default_acl.oid)
+                        FROM pg_catalog.pg_default_acl AS default_acl
+                        JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl)
+                          AS acl ON true
+                        JOIN pg_catalog.pg_namespace AS namespace
+                          ON namespace.oid = default_acl.defaclnamespace
+                        WHERE namespace.nspname = (SELECT schema_name FROM names)
+                          AND default_acl.defaclobjtype = 'r'
+                          AND acl.grantee = (SELECT oid FROM reader)
+                    )
+                END AS reader_default_acls,
                 """
             + _role_secure_sql("reader", (PROVISIONER, SANDBOX, TILE), (SANDBOX, TILE))
             + " AS reader_role_secure, "
@@ -549,6 +602,7 @@ class AdoptionReport:
     after: list[TenantOwnershipState]
     failures: dict[str, str]
     cluster_topology: str | None = None
+    provisioner_grants_missing: list[str] = field(default_factory=list)
 
     @property
     def missing_functions(self) -> list[str]:
@@ -569,10 +623,16 @@ class AdoptionReport:
         what makes ``--apply``-less invocation usable as a post-restore check.
         Every condition the report surfaces has to be in here, or the check
         passes on a database the report itself calls broken: a missing boundary
-        function, a fixed-role topology ``--apply`` would refuse, and boundary
-        drift that leaves a stamped table without RLS at boot all count.
+        function, a fixed-role topology ``--apply`` would refuse, a provisioner
+        grant a restore dropped, and boundary drift that leaves a stamped table
+        without RLS at boot all count.
         """
-        if self.failures or self.missing_functions or self.cluster_topology:
+        if (
+            self.failures
+            or self.missing_functions
+            or self.cluster_topology
+            or self.provisioner_grants_missing
+        ):
             return False
         if not all(function.secured for function in self.functions):
             return False
@@ -585,12 +645,13 @@ class AdoptionReport:
 
 async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
     """Report the ownership gap and, with ``apply``, close it."""
+    topology = await cluster_topology_error(engine)
     async with engine.connect() as conn:
         tenants = await list_tenants(conn)
         before = [await tenant_ownership_state(conn, tid) for tid in tenants]
         boundary = await live_tenant_boundary(conn)
         functions = await boundary_function_states(conn)
-    topology = await cluster_topology_error(engine)
+        grants = [] if topology else await missing_provisioner_grants(conn)
 
     if not apply:
         return AdoptionReport(
@@ -601,6 +662,7 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
             after=before,
             failures={},
             cluster_topology=topology,
+            provisioner_grants_missing=grants,
         )
 
     async with engine.begin() as conn:
@@ -618,10 +680,11 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
                 "tenant_adoption: tenant failed", tenant_id=tenant_id, exc_info=True
             )
 
+    topology = await cluster_topology_error(engine)
     async with engine.connect() as conn:
         after = [await tenant_ownership_state(conn, tid) for tid in tenants]
         boundary = await live_tenant_boundary(conn)
-    topology = await cluster_topology_error(engine)
+        grants = [] if topology else await missing_provisioner_grants(conn)
 
     return AdoptionReport(
         applied=True,
@@ -631,19 +694,27 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
         after=after,
         failures=failures,
         cluster_topology=topology,
+        provisioner_grants_missing=grants,
     )
 
 
 def _format_cluster_roles(report: AdoptionReport) -> list[str]:
-    if report.cluster_topology is None:
+    if report.cluster_topology is not None:
         return [
-            f"Fixed cluster roles ({PROVISIONER} and the four gateways): "
-            "present, with safe attributes and memberships."
+            f"Fixed cluster roles: NEEDS ATTENTION — {report.cluster_topology}",
+            "  --apply creates a missing role; it refuses an unsafe one.",
         ]
-    return [
-        f"Fixed cluster roles: NEEDS ATTENTION — {report.cluster_topology}",
-        "  --apply creates a missing role; it refuses an unsafe one.",
+    lines = [
+        f"Fixed cluster roles ({PROVISIONER} and the four gateways): "
+        "present, with safe attributes and memberships."
     ]
+    if report.provisioner_grants_missing:
+        lines.append(
+            f"  {PROVISIONER} is missing "
+            f"{', '.join(report.provisioner_grants_missing)} — tenant "
+            "provisioning cannot run without them; --apply re-grants them."
+        )
+    return lines
 
 
 def _format_functions(report: AdoptionReport) -> list[str]:
@@ -719,6 +790,11 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
             f"{after.relations_not_owned_by_writer} not owned by the writer",
             f"{after.relations_without_reader_select} without reader SELECT",
         ]
+        if after.reader_default_acls:
+            detail.append(
+                f"{after.reader_default_acls} legacy default-privilege "
+                "entr(ies) for the reader"
+            )
         if not after.reader_role_secure:
             detail.append(
                 "reader role attributes or memberships are not the safe shape"

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -149,7 +149,7 @@ class TenantOwnershipState:
     relations_not_owned_by_writer: int
     relations_without_reader_select: int
     relations_with_unsafe_acl: int
-    reader_default_acls: int
+    unexpected_default_acls: int
     reader_role_secure: bool
     writer_role_secure: bool
     schema_privileges_secure: bool
@@ -171,7 +171,7 @@ class TenantOwnershipState:
             and self.relations_not_owned_by_writer == 0
             and self.relations_without_reader_select == 0
             and self.relations_with_unsafe_acl == 0
-            and self.reader_default_acls == 0
+            and self.unexpected_default_acls == 0
             and self.reader_role_secure
             and self.writer_role_secure
             and self.schema_privileges_secure
@@ -451,10 +451,10 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
             f"{after.relations_without_reader_select} without reader SELECT",
             f"{after.relations_with_unsafe_acl} with an ACL beyond reader SELECT",
         ]
-        if after.reader_default_acls:
+        if after.unexpected_default_acls:
             detail.append(
-                f"{after.reader_default_acls} legacy default-privilege "
-                "entr(ies) for the reader"
+                f"{after.unexpected_default_acls} default-privilege entr(ies) "
+                "in the schema"
             )
         if not after.reader_role_secure:
             detail.append(

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -37,6 +37,11 @@ BOUNDARY_TRIGGER = "trg_stamp_current_tenant_on_insert"
 #: recreated under the boundary name but pointed at a different function, or
 #: fired on a different event, stamps nothing.
 BOUNDARY_TRIGGER_FUNCTION = "stamp_current_tenant_on_insert"
+
+#: The search path 0018 pins on that function.  Compared exactly, like the
+#: isolation expression: an unqualified name resolved through a writable
+#: schema is the classic SECURITY-adjacent function hijack.
+STAMPING_FUNCTION_SEARCH_PATH = "search_path=pg_catalog, catalog"
 BOUNDARY_TRIGGER_TYPE = 7
 
 #: The isolation rule 0006 installs, as PostgreSQL canonicalizes it.  Pinned

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -148,6 +148,7 @@ class TenantOwnershipState:
     relations: int
     unsafe_routines: int
     unsafe_types: int
+    foreign_grantors: int
     relations_not_owned_by_writer: int
     relations_without_reader_select: int
     relations_with_unsafe_acl: int
@@ -172,6 +173,7 @@ class TenantOwnershipState:
             and self.writer_exists
             and self.unsafe_routines == 0
             and self.unsafe_types == 0
+            and self.foreign_grantors == 0
             and self.relations_not_owned_by_writer == 0
             and self.relations_without_reader_select == 0
             and self.relations_with_unsafe_acl == 0
@@ -466,6 +468,7 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
             f"{after.relations} relation(s)",
             f"{after.unsafe_routines} routine(s) out of shape",
             f"{after.unsafe_types} type(s) not owned by the writer",
+            f"{after.foreign_grantors} privilege(s) granted by a third party",
             f"{after.relations_not_owned_by_writer} not owned by the writer",
             f"{after.relations_without_reader_select} without reader SELECT",
             f"{after.relations_with_unsafe_acl} with an ACL beyond reader SELECT",

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -146,6 +146,7 @@ class TenantOwnershipState:
     relations: int
     relations_not_owned_by_writer: int
     relations_without_reader_select: int
+    relations_with_reader_write: int
     reader_default_acls: int
     reader_role_secure: bool
     writer_role_secure: bool
@@ -167,6 +168,7 @@ class TenantOwnershipState:
             and self.writer_exists
             and self.relations_not_owned_by_writer == 0
             and self.relations_without_reader_select == 0
+            and self.relations_with_reader_write == 0
             and self.reader_default_acls == 0
             and self.reader_role_secure
             and self.writer_role_secure
@@ -440,6 +442,7 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
             f"{after.relations} relation(s)",
             f"{after.relations_not_owned_by_writer} not owned by the writer",
             f"{after.relations_without_reader_select} without reader SELECT",
+            f"{after.relations_with_reader_write} the reader can write",
         ]
         if after.reader_default_acls:
             detail.append(

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -146,6 +146,7 @@ class TenantOwnershipState:
     reader_exists: bool
     writer_exists: bool
     relations: int
+    unsafe_routines: int
     relations_not_owned_by_writer: int
     relations_without_reader_select: int
     relations_with_unsafe_acl: int
@@ -168,6 +169,7 @@ class TenantOwnershipState:
             and self.schema_owner == PROVISIONER
             and self.reader_exists
             and self.writer_exists
+            and self.unsafe_routines == 0
             and self.relations_not_owned_by_writer == 0
             and self.relations_without_reader_select == 0
             and self.relations_with_unsafe_acl == 0
@@ -447,6 +449,7 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
         after = after_by_id[before.tenant_id]
         detail = [
             f"{after.relations} relation(s)",
+            f"{after.unsafe_routines} routine(s) out of shape",
             f"{after.relations_not_owned_by_writer} not owned by the writer",
             f"{after.relations_without_reader_select} without reader SELECT",
             f"{after.relations_with_unsafe_acl} with an ACL beyond reader SELECT",

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -1,0 +1,453 @@
+"""Report types and verdicts for :mod:`app.core.db.tenant_adoption`.
+
+Split out at the point the tool crossed the repository's 1000-line module
+ceiling.  The boundary is the one the code already had: this module is what
+adoption *found* — the live state of the boundary functions, the fixed cluster
+roles, each tenant's ownership, and the row-security posture — plus the single
+predicate that decides whether anything is left to do, and the text an operator
+reads.  :mod:`app.core.db.tenant_adoption` is what adoption *does*: the queries
+that fill these in, the DDL that closes the gap, and the CLI.
+
+Keeping ``AdoptionReport.ok`` next to the things it consults is the point.  It
+is the process exit code, so every condition the report can print has to reach
+it; several rounds of review on #1405 were findings of exactly the shape "the
+report says this is broken and the check still exits 0".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.core.db.rls import RLS_TABLES
+from app.core.db.tenant_adoption_sql import CONTROL, PROVISIONER
+
+#: The two migration-owned SECURITY DEFINER entry points.  Adoption verifies and
+#: re-secures them; it never rewrites their bodies.
+BOUNDARY_FUNCTIONS = (
+    "provision_tenant_data_schema",
+    "deprovision_tenant_data_schema",
+)
+
+#: The insert-stamping trigger 0018 installs.  Its presence — not any constant
+#: frozen into a migration — is what marks a table as tenant-scoped.
+BOUNDARY_TRIGGER = "trg_stamp_current_tenant_on_insert"
+
+#: The function 0018 wires that trigger to, and the ``tgtype`` bitmask for
+#: ``BEFORE INSERT … FOR EACH ROW`` (ROW 1 | BEFORE 2 | INSERT 4).  A trigger
+#: recreated under the boundary name but pointed at a different function, or
+#: fired on a different event, stamps nothing.
+BOUNDARY_TRIGGER_FUNCTION = "stamp_current_tenant_on_insert"
+BOUNDARY_TRIGGER_TYPE = 7
+
+
+# ---------------------------------------------------------------------------
+# Report types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BoundaryFunctionState:
+    """Live state of one migration-owned SECURITY DEFINER entry point."""
+
+    name: str
+    owner: str
+    security_definer: bool
+    search_path_pinned: bool
+    language: str
+    returns_void: bool
+    body_markers_present: bool
+    public_execute: bool
+    control_execute: bool
+
+    @property
+    def migration_shaped(self) -> bool:
+        """Structural agreement with what the migrations install.
+
+        Not a proof of provenance — that would need the migration's exact text
+        pinned in app code, which goes stale the next time a migration edits the
+        body, in a module whose whole job is to still work years after the
+        restore.  What it does rule out is a wholesale substitution: a different
+        language, a different return type, or a body that no longer mentions the
+        tenant table, the tenant schema prefix, or the advisory lock the
+        boundary is built on.
+
+        The residual exposure is bounded in the direction that matters.  A
+        ``--no-owner --no-acl`` restore leaves these functions owned by the
+        restoring login — normally the superuser — with ``EXECUTE`` to
+        ``PUBLIC``.  Adoption only ever moves them to a ``NOLOGIN`` role and
+        narrows execution to the control group, so it cannot raise the privilege
+        of a body that was already tampered with; it can only fail to notice.
+        """
+        return (
+            self.security_definer
+            and self.search_path_pinned
+            and self.language == "plpgsql"
+            and self.returns_void
+            and self.body_markers_present
+        )
+
+    @property
+    def secured(self) -> bool:
+        return (
+            self.owner == PROVISIONER
+            and self.migration_shaped
+            and not self.public_execute
+            and self.control_execute
+        )
+
+
+def unexpected_shape(state: BoundaryFunctionState) -> str | None:
+    """Why this function is not the one the migrations install, if it is not.
+
+    The refusal message adoption prints before it would hand a body to
+    :data:`PROVISIONER` and grant :data:`CONTROL` execution on it.
+    """
+    if not state.security_definer:
+        return "is not SECURITY DEFINER"
+    if not state.search_path_pinned:
+        return "has no `SET search_path = pg_catalog`"
+    if state.language != "plpgsql":
+        return f"is written in {state.language}, not plpgsql"
+    if not state.returns_void:
+        return "does not return void"
+    if not state.body_markers_present:
+        return (
+            "has a body that no longer references catalog.tenants, the "
+            "data_t_ schema prefix, and the tenant advisory lock"
+        )
+    return None
+
+
+@dataclass(frozen=True)
+class TenantOwnershipState:
+    """Live ownership state of one tenant's data plane."""
+
+    tenant_id: str
+    schema_name: str
+    schema_exists: bool
+    schema_owner: str | None
+    reader_exists: bool
+    writer_exists: bool
+    relations: int
+    relations_not_owned_by_writer: int
+    relations_without_reader_select: int
+    reader_default_acls: int
+    reader_role_secure: bool
+    writer_role_secure: bool
+    schema_privileges_secure: bool
+
+    @property
+    def adopted(self) -> bool:
+        """Every invariant ``--apply`` enforces, not just the visible ones.
+
+        Ownership and effective privileges alone would call a reader carrying
+        ``LOGIN``/``SUPERUSER``/``BYPASSRLS`` adopted — a superuser satisfies the
+        ``SELECT`` check by fiat — and would miss a stray member or a missing
+        gateway edge, both of which ``ADOPT_TENANT_SQL`` refuses or repairs.
+        """
+        return (
+            self.schema_exists
+            and self.schema_owner == PROVISIONER
+            and self.reader_exists
+            and self.writer_exists
+            and self.relations_not_owned_by_writer == 0
+            and self.relations_without_reader_select == 0
+            and self.reader_default_acls == 0
+            and self.reader_role_secure
+            and self.writer_role_secure
+            and self.schema_privileges_secure
+        )
+
+
+@dataclass(frozen=True)
+class BoundaryTableState:
+    """A ``catalog`` table carrying tenant state, as the database reports it."""
+
+    name: str
+    #: A trigger by the boundary name exists AND fires on an ordinary insert:
+    #: enabled, ``BEFORE INSERT … FOR EACH ROW``, calling the migration's
+    #: stamping function.
+    has_stamping_trigger: bool
+    #: The name exists but does not satisfy the above.
+    stamping_trigger_present: bool
+    has_tenant_id: bool
+    rls_enabled: bool
+    rls_forced: bool
+
+    @property
+    def stamping_trigger_inert(self) -> bool:
+        """The boundary name is taken by a trigger that stamps nothing.
+
+        Disabled, wired to the wrong event or timing, or calling some other
+        function — all the same to a row being inserted, and none of them
+        something boot repairs.
+        """
+        return self.stamping_trigger_present and not self.has_stamping_trigger
+
+
+def rls_gaps(boundary: list[BoundaryTableState], *, tenants_present: bool) -> list[str]:
+    """Boundary tables whose row-security posture is not safe to serve.
+
+    ``apply_tenancy_rls`` is mode-gated and a single-tenant install correctly
+    keeps row security off, so a uniformly disabled boundary on a control plane
+    with no tenants is not a finding — and this module cannot read the mode out
+    of the database, only the tenants.  Two states always are findings: a
+    control plane that *has* tenants with row security off, where the isolation
+    boundary simply is not there; and row security enabled without ``FORCE``,
+    where the table owner bypasses every policy.
+    """
+    gaps: list[str] = []
+    for table in boundary:
+        if not table.has_stamping_trigger:
+            continue
+        if tenants_present and not table.rls_enabled:
+            gaps.append(f"{table.name} (row security disabled)")
+        elif table.rls_enabled and not table.rls_forced:
+            gaps.append(f"{table.name} (row security not FORCEd)")
+    return gaps
+
+
+def boundary_drift(boundary: list[BoundaryTableState]) -> tuple[list[str], list[str]]:
+    """Compare the live boundary against the runtime constant that drives RLS.
+
+    ``apply_tenancy_rls`` enables and FORCEs row security from
+    ``app.core.db.rls.RLS_TABLES``.  A table that joined the live boundary
+    without joining that tuple is silently skipped at boot, which is exactly the
+    failure a restored multi-tenant cluster cannot afford.  The other direction
+    is drift too: a table named in the tuple but carrying no stamping trigger
+    accepts an insert with no ``tenant_id`` at all.  Returns
+    ``(live_only, constant_only)``.
+    """
+    live = {state.name for state in boundary if state.has_stamping_trigger}
+    declared = set(RLS_TABLES)
+    return sorted(live - declared), sorted(declared - live)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration + CLI
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AdoptionReport:
+    """What adoption found, and what it changed."""
+
+    applied: bool
+    functions: list[BoundaryFunctionState]
+    boundary: list[BoundaryTableState]
+    before: list[TenantOwnershipState]
+    after: list[TenantOwnershipState]
+    failures: dict[str, str]
+    cluster_topology: str | None = None
+    provisioner_grants_missing: list[str] = field(default_factory=list)
+
+    @property
+    def missing_functions(self) -> list[str]:
+        """Boundary functions the schema does not have.
+
+        ``boundary_function_states`` omits what it cannot find, so an absent
+        function shortens the list rather than marking one unsecured.  Naming
+        the gap keeps ``all(... .secured)`` from passing vacuously.
+        """
+        present = {function.name for function in self.functions}
+        return [name for name in BOUNDARY_FUNCTIONS if name not in present]
+
+    @property
+    def inert_stamping_triggers(self) -> list[str]:
+        """Boundary tables whose stamping trigger exists but does not fire.
+
+        Its own condition, not a corollary of the drift check: a table that is
+        newly tenant-scoped *and* absent from ``RLS_TABLES`` lands in neither
+        drift direction and has no row-security requirement to miss, so a
+        disabled trigger there would otherwise be printed and then ignored.
+        """
+        return sorted(
+            table.name for table in self.boundary if table.stamping_trigger_inert
+        )
+
+    @property
+    def rls_gaps(self) -> list[str]:
+        """Boundary tables that cannot enforce tenant isolation as they stand.
+
+        Tenant rows in the control plane are what makes a database
+        multi-tenant, so they are what makes row security mandatory here.
+        """
+        return rls_gaps(self.boundary, tenants_present=bool(self.before))
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing is left to do — the exit code in both modes.
+
+        A dry run that reports pending work therefore exits non-zero, which is
+        what makes ``--apply``-less invocation usable as a post-restore check.
+        Every condition the report surfaces has to be in here, or the check
+        passes on a database the report itself calls broken: a missing boundary
+        function, a fixed-role topology ``--apply`` would refuse, a provisioner
+        grant a restore dropped, boundary drift that leaves a stamped table
+        without RLS at boot, a stamping trigger that does not fire, and a
+        boundary table that cannot enforce isolation as it stands all count.
+        """
+        if (
+            self.failures
+            or self.missing_functions
+            or self.cluster_topology
+            or self.provisioner_grants_missing
+            or self.rls_gaps
+            or self.inert_stamping_triggers
+        ):
+            return False
+        if not all(function.secured for function in self.functions):
+            return False
+        live_only, constant_only = boundary_drift(self.boundary)
+        if live_only or constant_only:
+            return False
+        states = self.after if self.applied else self.before
+        return all(state.adopted for state in states)
+
+
+def _format_cluster_roles(report: AdoptionReport) -> list[str]:
+    if report.cluster_topology is not None:
+        return [
+            f"Fixed cluster roles: NEEDS ATTENTION — {report.cluster_topology}",
+            "  --apply creates a missing role; it refuses an unsafe one.",
+        ]
+    lines = [
+        f"Fixed cluster roles ({PROVISIONER} and the four gateways): "
+        "present, with safe attributes and memberships."
+    ]
+    if report.provisioner_grants_missing:
+        lines.append(
+            f"  {PROVISIONER} is missing "
+            f"{', '.join(report.provisioner_grants_missing)} — tenant "
+            "provisioning cannot run without them; --apply re-grants them."
+        )
+    return lines
+
+
+def _format_functions(report: AdoptionReport) -> list[str]:
+    lines = ["Boundary functions:"]
+    for function in report.functions:
+        flags = [f"owner={function.owner}"]
+        if function.public_execute:
+            flags.append("EXECUTE granted to PUBLIC")
+        if not function.control_execute:
+            flags.append(f"no EXECUTE for {CONTROL}")
+        verdict = "secured" if function.secured else "NEEDS REPAIR"
+        lines.append(f"  catalog.{function.name}(uuid): {verdict} — {', '.join(flags)}")
+    for name in report.missing_functions:
+        lines.append(
+            f"  catalog.{name}(uuid): MISSING — this database is not at the head "
+            "schema; run `alembic upgrade heads` first"
+        )
+    return lines
+
+
+def _boundary_table_markers(
+    table: BoundaryTableState, *, tenants_present: bool
+) -> list[str]:
+    if table.stamping_trigger_inert:
+        return [
+            f"{BOUNDARY_TRIGGER} exists but does not stamp — DISABLED, or wired "
+            "to another event or function; nothing at boot repairs that"
+        ]
+    if not table.has_stamping_trigger:
+        return ["tenant_id column only, outside the stamped boundary"]
+    if not table.rls_enabled:
+        if tenants_present:
+            return ["RLS not enabled on a control plane that has tenants"]
+        return ["RLS not enabled (correct while the control plane has no tenants)"]
+    if not table.rls_forced:
+        return ["RLS enabled but not FORCEd — the table owner bypasses it"]
+    return []
+
+
+def _format_boundary(report: AdoptionReport) -> list[str]:
+    boundary = report.boundary
+    tenants_present = bool(report.before)
+    lines = [f"Live tenant boundary ({BOUNDARY_TRIGGER}), read from the database:"]
+    for table in boundary:
+        markers = _boundary_table_markers(table, tenants_present=tenants_present)
+        suffix = f" — {'; '.join(markers)}" if markers else ""
+        lines.append(f"  catalog.{table.name}{suffix}")
+
+    live_only, constant_only = boundary_drift(boundary)
+    if live_only:
+        lines.append(
+            "  DRIFT: stamped in the database but absent from "
+            "app.core.db.rls.RLS_TABLES, so boot never enables RLS on them: "
+            f"{', '.join(live_only)}"
+        )
+    if constant_only:
+        lines.append(
+            "  DRIFT: listed in app.core.db.rls.RLS_TABLES but carrying no live "
+            f"stamping trigger here: {', '.join(constant_only)}"
+        )
+    if report.rls_gaps:
+        lines.append(
+            "  NOT SAFE TO SERVE until row security is repaired: "
+            f"{', '.join(report.rls_gaps)}"
+        )
+    return lines
+
+
+def _tenant_verdict(
+    before: TenantOwnershipState, after: TenantOwnershipState, applied: bool
+) -> str:
+    if not applied:
+        return "adopted" if before.adopted else "needs adoption"
+    if not after.adopted:
+        return "STILL INCOMPLETE"
+    return "already adopted (no changes)" if before.adopted else "adopted"
+
+
+def _format_tenants(report: AdoptionReport) -> list[str]:
+    if not report.before:
+        return ["Tenants: none. Nothing to adopt (single-tenant control plane)."]
+
+    lines = [f"Tenants: {len(report.before)}"]
+    after_by_id = {state.tenant_id: state for state in report.after}
+    for before in report.before:
+        after = after_by_id[before.tenant_id]
+        detail = [
+            f"{after.relations} relation(s)",
+            f"{after.relations_not_owned_by_writer} not owned by the writer",
+            f"{after.relations_without_reader_select} without reader SELECT",
+        ]
+        if after.reader_default_acls:
+            detail.append(
+                f"{after.reader_default_acls} legacy default-privilege "
+                "entr(ies) for the reader"
+            )
+        if not after.reader_role_secure:
+            detail.append(
+                "reader role attributes or memberships are not the safe shape"
+            )
+        if not after.writer_role_secure:
+            detail.append(
+                "writer role attributes or memberships are not the safe shape"
+            )
+        if not after.schema_privileges_secure:
+            detail.append("schema privileges are not the safe shape")
+        verdict = _tenant_verdict(before, after, report.applied)
+        lines.append(f"  {before.tenant_id}: {verdict} — {', '.join(detail)}")
+    return lines
+
+
+def format_report(report: AdoptionReport) -> str:
+    """Render the report an operator reads mid-recovery."""
+    mode = "APPLIED" if report.applied else "DRY RUN (no changes made)"
+    sections = [
+        [f"Tenant-ownership adoption — {mode}"],
+        _format_cluster_roles(report),
+        _format_functions(report),
+        _format_boundary(report),
+        _format_tenants(report),
+    ]
+    if report.failures:
+        failures = ["Failures (re-run after fixing; adopted tenants stay adopted):"]
+        failures += [
+            f"  {tenant_id}: {message}"
+            for tenant_id, message in report.failures.items()
+        ]
+        sections.append(failures)
+    return "\n\n".join("\n".join(section) for section in sections)

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -149,6 +149,8 @@ class TenantOwnershipState:
     unsafe_routines: int
     unsafe_types: int
     unsafe_statistics: int
+    unsafe_collations: int
+    unowned_other_objects: int
     foreign_grantors: int
     relations_not_owned_by_writer: int
     relations_without_reader_select: int
@@ -175,6 +177,8 @@ class TenantOwnershipState:
             and self.unsafe_routines == 0
             and self.unsafe_types == 0
             and self.unsafe_statistics == 0
+            and self.unsafe_collations == 0
+            and self.unowned_other_objects == 0
             and self.foreign_grantors == 0
             and self.relations_not_owned_by_writer == 0
             and self.relations_without_reader_select == 0

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -148,7 +148,7 @@ class TenantOwnershipState:
     relations: int
     relations_not_owned_by_writer: int
     relations_without_reader_select: int
-    relations_with_reader_write: int
+    relations_with_unsafe_acl: int
     reader_default_acls: int
     reader_role_secure: bool
     writer_role_secure: bool
@@ -170,7 +170,7 @@ class TenantOwnershipState:
             and self.writer_exists
             and self.relations_not_owned_by_writer == 0
             and self.relations_without_reader_select == 0
-            and self.relations_with_reader_write == 0
+            and self.relations_with_unsafe_acl == 0
             and self.reader_default_acls == 0
             and self.reader_role_secure
             and self.writer_role_secure
@@ -449,7 +449,7 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
             f"{after.relations} relation(s)",
             f"{after.relations_not_owned_by_writer} not owned by the writer",
             f"{after.relations_without_reader_select} without reader SELECT",
-            f"{after.relations_with_reader_write} the reader can write",
+            f"{after.relations_with_unsafe_acl} with an ACL beyond reader SELECT",
         ]
         if after.reader_default_acls:
             detail.append(

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -73,6 +73,7 @@ class BoundaryFunctionState:
     body_markers_present: bool
     public_execute: bool
     control_execute: bool
+    unexpected_grantees: int
 
     @property
     def migration_shaped(self) -> bool:
@@ -108,6 +109,7 @@ class BoundaryFunctionState:
             and self.migration_shaped
             and not self.public_execute
             and self.control_execute
+            and self.unexpected_grantees == 0
         )
 
 
@@ -355,6 +357,11 @@ def _format_functions(report: AdoptionReport) -> list[str]:
             flags.append("EXECUTE granted to PUBLIC")
         if not function.control_execute:
             flags.append(f"no EXECUTE for {CONTROL}")
+        if function.unexpected_grantees:
+            flags.append(
+                f"{function.unexpected_grantees} role(s) outside "
+                f"{PROVISIONER}/{CONTROL} hold EXECUTE"
+            )
         verdict = "secured" if function.secured else "NEEDS REPAIR"
         lines.append(f"  catalog.{function.name}(uuid): {verdict} — {', '.join(flags)}")
     for name in report.missing_functions:

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -447,6 +447,15 @@ def _tenant_verdict(
 
 def _format_tenants(report: AdoptionReport) -> list[str]:
     if not report.before:
+        # fix(#998 codex r46): a tenant provisioned after the empty snapshot
+        # makes report.ok false; saying "nothing to adopt" while exiting 1
+        # would hide the one condition the operator has to act on.
+        if report.tenants_added_during_run:
+            return [
+                "Tenants: none at the start of the run.",
+                "  provisioned while this ran and therefore never adopted: "
+                + ", ".join(report.tenants_added_during_run),
+            ]
         return ["Tenants: none. Nothing to adopt (single-tenant control plane)."]
 
     lines = [f"Tenants: {len(report.before)}"]

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -455,7 +455,13 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
         )
     after_by_id = {state.tenant_id: state for state in report.after}
     for before in report.before:
-        after = after_by_id[before.tenant_id]
+        # A tenant deleted while this ran has no post-state; its transaction
+        # either completed or did not, and either way the row it describes is
+        # gone. The counterpart to the concurrent-addition case below.
+        after = after_by_id.get(before.tenant_id)
+        if after is None:
+            lines.append(f"  {before.tenant_id}: deleted while this ran")
+            continue
         detail = [
             f"{after.relations} relation(s)",
             f"{after.unsafe_routines} routine(s) out of shape",

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -148,6 +148,7 @@ class TenantOwnershipState:
     relations: int
     unsafe_routines: int
     unsafe_types: int
+    unsafe_statistics: int
     foreign_grantors: int
     relations_not_owned_by_writer: int
     relations_without_reader_select: int
@@ -173,6 +174,7 @@ class TenantOwnershipState:
             and self.writer_exists
             and self.unsafe_routines == 0
             and self.unsafe_types == 0
+            and self.unsafe_statistics == 0
             and self.foreign_grantors == 0
             and self.relations_not_owned_by_writer == 0
             and self.relations_without_reader_select == 0
@@ -477,6 +479,7 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
             f"{after.relations} relation(s)",
             f"{after.unsafe_routines} routine(s) out of shape",
             f"{after.unsafe_types} type(s) not owned by the writer",
+            f"{after.unsafe_statistics} statistics object(s) not owned by the writer",
             f"{after.foreign_grantors} privilege(s) granted by a third party",
             f"{after.relations_not_owned_by_writer} not owned by the writer",
             f"{after.relations_without_reader_select} without reader SELECT",

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -39,6 +39,16 @@ BOUNDARY_TRIGGER = "trg_stamp_current_tenant_on_insert"
 BOUNDARY_TRIGGER_FUNCTION = "stamp_current_tenant_on_insert"
 BOUNDARY_TRIGGER_TYPE = 7
 
+#: The isolation rule 0006 installs, as PostgreSQL canonicalizes it.  Pinned
+#: exactly, unlike the function bodies: it is one expression that has not
+#: changed since 0006, and it *is* the cross-tenant visibility boundary — a
+#: tool that certifies a database as safe to serve should know which rule it is
+#: certifying.  A migration that changes it has to change this line too, which
+#: is the intended amount of friction.
+ISOLATION_POLICY_EXPRESSION = (
+    "(tenant_id = (current_setting('app.current_tenant'::text))::uuid)"
+)
+
 
 # ---------------------------------------------------------------------------
 # Report types
@@ -173,6 +183,7 @@ class BoundaryTableState:
     has_tenant_id: bool
     rls_enabled: bool
     rls_forced: bool
+    isolation_policy_intact: bool
 
     @property
     def stamping_trigger_inert(self) -> bool:
@@ -200,7 +211,9 @@ def rls_gaps(boundary: list[BoundaryTableState], *, tenants_present: bool) -> li
     for table in boundary:
         if not table.has_stamping_trigger:
             continue
-        if tenants_present and not table.rls_enabled:
+        if not table.isolation_policy_intact:
+            gaps.append(f"{table.name} (tenant_isolation policy missing or altered)")
+        elif tenants_present and not table.rls_enabled:
             gaps.append(f"{table.name} (row security disabled)")
         elif table.rls_enabled and not table.rls_forced:
             gaps.append(f"{table.name} (row security not FORCEd)")
@@ -239,6 +252,7 @@ class AdoptionReport:
     after: list[TenantOwnershipState]
     failures: dict[str, str]
     cluster_topology: str | None = None
+    stamping_function: str | None = None
     provisioner_grants_missing: list[str] = field(default_factory=list)
 
     @property
@@ -284,14 +298,16 @@ class AdoptionReport:
         passes on a database the report itself calls broken: a missing boundary
         function, a fixed-role topology ``--apply`` would refuse, a provisioner
         grant a restore dropped, boundary drift that leaves a stamped table
-        without RLS at boot, a stamping trigger that does not fire, and a
-        boundary table that cannot enforce isolation as it stands all count.
+        without RLS at boot, a stamping trigger or stamping function that does
+        not stamp, and a boundary table that cannot enforce isolation as it
+        stands all count.
         """
         if (
             self.failures
             or self.missing_functions
             or self.cluster_topology
             or self.provisioner_grants_missing
+            or self.stamping_function
             or self.rls_gaps
             or self.inert_stamping_triggers
         ):
@@ -352,6 +368,11 @@ def _boundary_table_markers(
         ]
     if not table.has_stamping_trigger:
         return ["tenant_id column only, outside the stamped boundary"]
+    if not table.isolation_policy_intact:
+        return [
+            "the tenant_isolation policy is missing or no longer the rule the "
+            "migrations install; nothing at boot recreates it"
+        ]
     if not table.rls_enabled:
         if tenants_present:
             return ["RLS not enabled on a control plane that has tenants"]
@@ -365,6 +386,8 @@ def _format_boundary(report: AdoptionReport) -> list[str]:
     boundary = report.boundary
     tenants_present = bool(report.before)
     lines = [f"Live tenant boundary ({BOUNDARY_TRIGGER}), read from the database:"]
+    if report.stamping_function is not None:
+        lines.append(f"  NOT SAFE TO SERVE: {report.stamping_function}")
     for table in boundary:
         markers = _boundary_table_markers(table, tenants_present=tenants_present)
         suffix = f" — {'; '.join(markers)}" if markers else ""

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -267,6 +267,7 @@ class AdoptionReport:
     cluster_topology: str | None = None
     stamping_function: str | None = None
     provisioner_grants_missing: list[str] = field(default_factory=list)
+    tenants_added_during_run: list[str] = field(default_factory=list)
 
     @property
     def missing_functions(self) -> list[str]:
@@ -323,6 +324,7 @@ class AdoptionReport:
             or self.stamping_function
             or self.rls_gaps
             or self.inert_stamping_triggers
+            or self.tenants_added_during_run
         ):
             return False
         if not all(function.secured for function in self.functions):
@@ -446,6 +448,11 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
         return ["Tenants: none. Nothing to adopt (single-tenant control plane)."]
 
     lines = [f"Tenants: {len(report.before)}"]
+    if report.tenants_added_during_run:
+        lines.append(
+            "  provisioned while this ran and therefore never adopted: "
+            + ", ".join(report.tenants_added_during_run)
+        )
     after_by_id = {state.tenant_id: state for state in report.after}
     for before in report.before:
         after = after_by_id[before.tenant_id]

--- a/backend/app/core/db/tenant_adoption_report.py
+++ b/backend/app/core/db/tenant_adoption_report.py
@@ -147,6 +147,7 @@ class TenantOwnershipState:
     writer_exists: bool
     relations: int
     unsafe_routines: int
+    unsafe_types: int
     relations_not_owned_by_writer: int
     relations_without_reader_select: int
     relations_with_unsafe_acl: int
@@ -170,6 +171,7 @@ class TenantOwnershipState:
             and self.reader_exists
             and self.writer_exists
             and self.unsafe_routines == 0
+            and self.unsafe_types == 0
             and self.relations_not_owned_by_writer == 0
             and self.relations_without_reader_select == 0
             and self.relations_with_unsafe_acl == 0
@@ -450,6 +452,7 @@ def _format_tenants(report: AdoptionReport) -> list[str]:
         detail = [
             f"{after.relations} relation(s)",
             f"{after.unsafe_routines} routine(s) out of shape",
+            f"{after.unsafe_types} type(s) not owned by the writer",
             f"{after.relations_not_owned_by_writer} not owned by the writer",
             f"{after.relations_without_reader_select} without reader SELECT",
             f"{after.relations_with_unsafe_acl} with an ACL beyond reader SELECT",

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -1517,7 +1517,18 @@ BEGIN
         FROM pg_catalog.pg_class AS relation
         JOIN pg_catalog.pg_namespace AS namespace
           ON namespace.oid = relation.relnamespace
-        JOIN LATERAL pg_catalog.aclexplode(relation.relacl) AS acl ON true
+        JOIN LATERAL (
+            SELECT acl.grantor
+            FROM pg_catalog.aclexplode(relation.relacl) AS acl
+            UNION ALL
+            -- Column grants have their own grantor, and the writer's REVOKE
+            -- cannot reach a foreign one any more than it can at table level.
+            SELECT acl.grantor
+            FROM pg_catalog.pg_attribute AS column_row
+            JOIN LATERAL pg_catalog.aclexplode(column_row.attacl) AS acl ON true
+            WHERE column_row.attrelid = relation.oid
+              AND NOT column_row.attisdropped
+        ) AS acl ON true
         JOIN pg_catalog.pg_roles AS grantor_role ON grantor_role.oid = acl.grantor
         WHERE namespace.nspname = schema_name
           AND grantor_role.rolname <> writer_name

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -727,6 +727,86 @@ END
 $$
 """
 
+#: fix(#998 codex r45): the plain ``REVOKE GRANT OPTION`` statements in
+#: ``ensure_cluster_roles`` reach only entries attributable to the executing
+#: role (or the object owner, for a superuser).  A grantable privilege some
+#: third role handed the provisioner survives them, and the final
+#: ``missing_provisioner_grants`` read then reports it as grantable after
+#: every ``--apply`` with nothing naming the grantor.  Refuse it up front,
+#: on the same terms as every other foreign grant: the role that can revoke
+#: it is named in the remedy.
+PROVISIONER_GRANT_OPTION_GUARD_SQL = f"""
+DO $$
+DECLARE
+    foreign_option_row RECORD;
+BEGIN
+    FOR foreign_option_row IN
+        SELECT 'SCHEMA catalog' AS target,
+               acl.privilege_type AS privilege,
+               grantor_role.rolname AS grantor_name
+        FROM pg_catalog.pg_namespace AS namespace
+        JOIN LATERAL pg_catalog.aclexplode(namespace.nspacl) AS acl ON true
+        JOIN pg_catalog.pg_roles AS grantee_role
+          ON grantee_role.oid = acl.grantee
+        JOIN pg_catalog.pg_roles AS grantor_role
+          ON grantor_role.oid = acl.grantor
+        WHERE namespace.nspname = 'catalog'
+          AND grantee_role.rolname = '{PROVISIONER}'
+          AND acl.is_grantable
+          AND grantor_role.oid <> namespace.nspowner
+          AND grantor_role.rolname <> CURRENT_USER
+        UNION ALL
+        SELECT 'TABLE catalog.tenants',
+               acl.privilege_type,
+               grantor_role.rolname
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        JOIN LATERAL pg_catalog.aclexplode(relation.relacl) AS acl ON true
+        JOIN pg_catalog.pg_roles AS grantee_role
+          ON grantee_role.oid = acl.grantee
+        JOIN pg_catalog.pg_roles AS grantor_role
+          ON grantor_role.oid = acl.grantor
+        WHERE namespace.nspname = 'catalog'
+          AND relation.relname = 'tenants'
+          AND grantee_role.rolname = '{PROVISIONER}'
+          AND acl.is_grantable
+          AND grantor_role.oid <> relation.relowner
+          AND grantor_role.rolname <> CURRENT_USER
+        UNION ALL
+        SELECT 'DATABASE ' || pg_catalog.quote_ident(db.datname),
+               acl.privilege_type,
+               grantor_role.rolname
+        FROM pg_catalog.pg_database AS db
+        JOIN LATERAL pg_catalog.aclexplode(db.datacl) AS acl ON true
+        JOIN pg_catalog.pg_roles AS grantee_role
+          ON grantee_role.oid = acl.grantee
+        JOIN pg_catalog.pg_roles AS grantor_role
+          ON grantor_role.oid = acl.grantor
+        WHERE db.datname = pg_catalog.current_database()
+          AND grantee_role.rolname = '{PROVISIONER}'
+          AND acl.is_grantable
+          AND grantor_role.oid <> db.datdba
+          AND grantor_role.rolname <> CURRENT_USER
+    LOOP
+        RAISE EXCEPTION
+            '{PROVISIONER} holds a grantable % on %, granted by %, which '
+            'this run cannot revoke',
+            foreign_option_row.privilege,
+            foreign_option_row.target,
+            foreign_option_row.grantor_name
+            USING HINT =
+                'as ' ||
+                pg_catalog.quote_ident(foreign_option_row.grantor_name) ||
+                ' (or a role that can assume it) run: REVOKE GRANT OPTION '
+                'FOR ' || foreign_option_row.privilege || ' ON ' ||
+                foreign_option_row.target ||
+                ' FROM {PROVISIONER}; then re-run adoption';
+    END LOOP;
+END
+$$
+"""
+
 
 # ---------------------------------------------------------------------------
 # Per-tenant adoption (port of 0019 ``_adopt_and_backfill_existing_tenants``)
@@ -752,6 +832,7 @@ DECLARE
     default_acl_gap bigint;
     routine_gap bigint;
     type_gap bigint;
+    foreign_grantor_gap bigint;
     reader_oid oid;
     writer_oid oid;
     grantee_name text;
@@ -1211,11 +1292,58 @@ BEGIN
             AND dependency.deptype = 'e'
       );
 
+    -- fix(#998 codex r45): an otherwise-canonical tenant can still carry an
+    -- allowed privilege issued by a third-party grantor.  The five counters
+    -- above are all zero then, and returning here would skip the refusal
+    -- sweep at the end — leaving --apply to exit incomplete forever without
+    -- ever naming the grantor.  Count them with the sweep's own shape; when
+    -- the other counters are zero every owner already matches, so the shapes
+    -- agree exactly.
+    SELECT pg_catalog.count(*) INTO foreign_grantor_gap
+    FROM (
+        SELECT acl.grantor AS grantor_oid
+        FROM pg_catalog.pg_namespace AS namespace
+        JOIN LATERAL pg_catalog.aclexplode(namespace.nspacl) AS acl ON true
+        WHERE namespace.nspname = schema_name
+          AND acl.grantor <> (
+              SELECT oid FROM pg_catalog.pg_roles
+              WHERE rolname = '{PROVISIONER}'
+          )
+        UNION ALL
+        SELECT acl.grantor
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        JOIN LATERAL pg_catalog.aclexplode(relation.relacl) AS acl ON true
+        WHERE namespace.nspname = schema_name
+          AND acl.grantor <> writer_oid
+        UNION ALL
+        SELECT acl.grantor
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        JOIN pg_catalog.pg_attribute AS column_row
+          ON column_row.attrelid = relation.oid
+        JOIN LATERAL pg_catalog.aclexplode(column_row.attacl) AS acl ON true
+        WHERE namespace.nspname = schema_name
+          AND NOT column_row.attisdropped
+          AND acl.grantor <> writer_oid
+        UNION ALL
+        SELECT acl.grantor
+        FROM pg_catalog.pg_proc AS routine
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = routine.pronamespace
+        JOIN LATERAL pg_catalog.aclexplode(routine.proacl) AS acl ON true
+        WHERE namespace.nspname = schema_name
+          AND acl.grantor <> writer_oid
+    ) AS foreign_grant;
+
     IF pending_owner_transfer = 0
        AND reader_privilege_gap = 0
        AND default_acl_gap = 0
        AND routine_gap = 0
-       AND type_gap = 0 THEN
+       AND type_gap = 0
+       AND foreign_grantor_gap = 0 THEN
         RETURN;
     END IF;
 
@@ -1309,38 +1437,52 @@ BEGIN
     -- tenant schema is that the writer grants the reader explicitly on each
     -- relation, so an entry here hands out privileges on relations that do not
     -- exist yet.
+    -- fix(#998 codex r45): one statement per object kind — PostgreSQL accepts
+    -- a single kind per ALTER DEFAULT PRIVILEGES, so aggregating kinds (or
+    -- crossing grantees between kinds) rendered a remedy that fails to parse.
     FOR default_acl_row IN
-        SELECT owner_role.rolname AS owner_name,
+        SELECT per_kind.owner_name,
                pg_catalog.string_agg(
-                   DISTINCT CASE default_acl.defaclobjtype
+                   'ALTER DEFAULT PRIVILEGES FOR ROLE ' ||
+                   pg_catalog.quote_ident(per_kind.owner_name) ||
+                   ' IN SCHEMA ' || pg_catalog.quote_ident(schema_name) ||
+                   ' REVOKE ALL ON ' || per_kind.object_kind || ' FROM ' ||
+                   per_kind.grantees,
+                   '; '
+               ) AS statements
+        FROM (
+            SELECT owner_role.rolname AS owner_name,
+                   CASE default_acl.defaclobjtype
                        WHEN 'r' THEN 'TABLES'
                        WHEN 'S' THEN 'SEQUENCES'
                        WHEN 'f' THEN 'FUNCTIONS'
                        WHEN 'T' THEN 'TYPES'
                        ELSE 'SCHEMAS'
-                   END, ', '
-               ) AS object_kinds,
-               pg_catalog.string_agg(
-                   DISTINCT CASE
-                       WHEN acl.grantee = 0 THEN 'PUBLIC'
-                       ELSE pg_catalog.quote_ident(grantee_role.rolname)
-                   END, ', '
-               ) AS grantees
-        FROM pg_catalog.pg_default_acl AS default_acl
-        JOIN pg_catalog.pg_roles AS owner_role
-          ON owner_role.oid = default_acl.defaclrole
-        JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS acl ON true
-        LEFT JOIN pg_catalog.pg_roles AS grantee_role
-          ON grantee_role.oid = acl.grantee
-        JOIN pg_catalog.pg_namespace AS namespace
-          ON namespace.oid = default_acl.defaclnamespace
-        WHERE namespace.nspname = schema_name
-          AND owner_role.rolname NOT IN (CURRENT_USER, writer_name)
-          AND acl.grantee IS DISTINCT FROM default_acl.defaclrole
-          AND NOT (
-              acl.grantee = 0 AND default_acl.defaclobjtype IN ('f', 'T')
-          )
-        GROUP BY owner_role.rolname
+                   END AS object_kind,
+                   pg_catalog.string_agg(
+                       DISTINCT CASE
+                           WHEN acl.grantee = 0 THEN 'PUBLIC'
+                           ELSE pg_catalog.quote_ident(grantee_role.rolname)
+                       END, ', '
+                   ) AS grantees
+            FROM pg_catalog.pg_default_acl AS default_acl
+            JOIN pg_catalog.pg_roles AS owner_role
+              ON owner_role.oid = default_acl.defaclrole
+            JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS acl
+              ON true
+            LEFT JOIN pg_catalog.pg_roles AS grantee_role
+              ON grantee_role.oid = acl.grantee
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = default_acl.defaclnamespace
+            WHERE namespace.nspname = schema_name
+              AND owner_role.rolname NOT IN (CURRENT_USER, writer_name)
+              AND acl.grantee IS DISTINCT FROM default_acl.defaclrole
+              AND NOT (
+                  acl.grantee = 0 AND default_acl.defaclobjtype IN ('f', 'T')
+              )
+            GROUP BY owner_role.rolname, default_acl.defaclobjtype
+        ) AS per_kind
+        GROUP BY per_kind.owner_name
     LOOP
         RAISE EXCEPTION
             'schema % carries default privileges owned by %, which this role '
@@ -1349,10 +1491,8 @@ BEGIN
             default_acl_row.owner_name
             USING HINT =
                 'as ' || pg_catalog.quote_ident(default_acl_row.owner_name) ||
-                ' run: ALTER DEFAULT PRIVILEGES IN SCHEMA ' ||
-                pg_catalog.quote_ident(schema_name) || ' REVOKE ALL ON ' ||
-                default_acl_row.object_kinds || ' FROM ' ||
-                default_acl_row.grantees || '; then re-run adoption';
+                ' run: ' || default_acl_row.statements ||
+                '; then re-run adoption';
     END LOOP;
 
     FOR default_acl_row IN

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -1102,8 +1102,12 @@ BEGIN
           owner_role.rolname <> writer_name
           OR routine.prosecdef
           OR NOT EXISTS (
+              -- prokind 'a' names the `internal` pseudo-language and says
+              -- nothing about the functions that run; same exemption as the
+              -- refusal above, or every aggregate keeps this gap open forever.
               SELECT 1 FROM pg_catalog.pg_language AS language
-              WHERE language.oid = routine.prolang AND language.lanpltrusted
+              WHERE language.oid = routine.prolang
+                AND (language.lanpltrusted OR routine.prokind = 'a')
           )
           OR pg_catalog.has_function_privilege('public', routine.oid, 'EXECUTE')
           OR NOT pg_catalog.has_function_privilege(

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -702,6 +702,7 @@ DECLARE
     schema_owner text;
     pending_owner_transfer bigint;
     reader_privilege_gap bigint;
+    default_acl_gap bigint;
     reader_oid oid;
     writer_oid oid;
     grantee_name text;
@@ -740,43 +741,6 @@ BEGIN
     -- flag, an automatic creator membership, and an ALTER DEFAULT PRIVILEGES
     -- entry.  Normalize that known legacy shape before the strict provision
     -- function validates the role.
-    -- Every default-privilege entry in the schema, for any object kind and any
-    -- grantee — not just the reader's, which is only the shape the pre-0019
-    -- runtime helper happened to leave. The contract inside a tenant schema is
-    -- that the writer grants the reader explicitly on each relation, so an
-    -- entry here hands out privileges on relations that do not exist yet.
-    FOR default_acl_row IN
-        SELECT owner_role.rolname AS owner_name,
-               default_acl.defaclobjtype AS object_type,
-               CASE
-                   WHEN acl.grantee = 0 THEN 'PUBLIC'
-                   ELSE pg_catalog.quote_ident(grantee_role.rolname)
-               END AS grantee_name
-        FROM pg_catalog.pg_default_acl AS default_acl
-        JOIN pg_catalog.pg_roles AS owner_role
-          ON owner_role.oid = default_acl.defaclrole
-        JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS acl ON true
-        LEFT JOIN pg_catalog.pg_roles AS grantee_role
-          ON grantee_role.oid = acl.grantee
-        JOIN pg_catalog.pg_namespace AS namespace
-          ON namespace.oid = default_acl.defaclnamespace
-        WHERE namespace.nspname = schema_name
-    LOOP
-        EXECUTE pg_catalog.format(
-            'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I REVOKE ALL ON %s FROM %s',
-            default_acl_row.owner_name,
-            schema_name,
-            CASE default_acl_row.object_type
-                WHEN 'r' THEN 'TABLES'
-                WHEN 'S' THEN 'SEQUENCES'
-                WHEN 'f' THEN 'FUNCTIONS'
-                WHEN 'T' THEN 'TYPES'
-                ELSE 'SCHEMAS'
-            END,
-            default_acl_row.grantee_name
-        );
-    END LOOP;
-
     SELECT * INTO writer_row
     FROM pg_catalog.pg_roles
     WHERE rolname = writer_name;
@@ -1018,9 +982,17 @@ BEGIN
           )
       );
 
+    SELECT pg_catalog.count(*) INTO default_acl_gap
+    FROM pg_catalog.pg_default_acl AS default_acl
+    JOIN pg_catalog.pg_namespace AS namespace
+      ON namespace.oid = default_acl.defaclnamespace
+    WHERE namespace.nspname = schema_name;
+
     -- Nothing to move and nothing to grant: an already-adopted tenant issues
     -- zero DDL here, which is what makes a re-run a genuine no-op.
-    IF pending_owner_transfer = 0 AND reader_privilege_gap = 0 THEN
+    IF pending_owner_transfer = 0
+       AND reader_privilege_gap = 0
+       AND default_acl_gap = 0 THEN
         RETURN;
     END IF;
 
@@ -1092,6 +1064,56 @@ BEGIN
             'tenant schema % contains relation not owned by %',
             schema_name, writer_name;
     END IF;
+
+    -- Every default-privilege entry in the schema, for any object kind and any
+    -- grantee — not just the reader's, which is only the shape the pre-0019
+    -- runtime helper happened to leave. The contract inside a tenant schema is
+    -- that the writer grants the reader explicitly on each relation, so an
+    -- entry here hands out privileges on relations that do not exist yet.
+    FOR default_acl_row IN
+        SELECT owner_role.rolname AS owner_name,
+               default_acl.defaclobjtype AS object_type,
+               CASE
+                   WHEN acl.grantee = 0 THEN 'PUBLIC'
+                   ELSE pg_catalog.quote_ident(grantee_role.rolname)
+               END AS grantee_name
+        FROM pg_catalog.pg_default_acl AS default_acl
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = default_acl.defaclrole
+        JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS acl ON true
+        LEFT JOIN pg_catalog.pg_roles AS grantee_role
+          ON grantee_role.oid = acl.grantee
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = default_acl.defaclnamespace
+        WHERE namespace.nspname = schema_name
+    LOOP
+        -- ALTER DEFAULT PRIVILEGES FOR ROLE needs the caller to be able to
+        -- assume that role. The migrator can for its own entries and, inside
+        -- this window, for the writer's; anything else it cannot reach is left
+        -- for the report to keep flagging rather than failing the tenant.
+        BEGIN
+            IF default_acl_row.owner_name <> CURRENT_USER THEN
+                EXECUTE pg_catalog.format('SET ROLE %I', default_acl_row.owner_name);
+            END IF;
+            EXECUTE pg_catalog.format(
+                'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I REVOKE ALL ON %s FROM %s',
+                default_acl_row.owner_name,
+                schema_name,
+                CASE default_acl_row.object_type
+                    WHEN 'r' THEN 'TABLES'
+                    WHEN 'S' THEN 'SEQUENCES'
+                    WHEN 'f' THEN 'FUNCTIONS'
+                    WHEN 'T' THEN 'TYPES'
+                    ELSE 'SCHEMAS'
+                END,
+                default_acl_row.grantee_name
+            );
+            RESET ROLE;
+        EXCEPTION
+            WHEN insufficient_privilege THEN
+                RESET ROLE;
+        END;
+    END LOOP;
 
     EXECUTE pg_catalog.format('SET ROLE %I', writer_name);
     -- Revoke first, then grant back exactly the read privileges: ALTER TABLE …

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -398,6 +398,7 @@ SECURE_BOUNDARY_FUNCTIONS_SQL = f"""
 DO $$
 DECLARE
     routine_name text;
+    grantee_name text;
     temporary_schema_create boolean := false;
     repair_pending boolean;
 BEGIN
@@ -417,6 +418,13 @@ BEGIN
               OR pg_catalog.has_function_privilege('public', routine.oid, 'EXECUTE')
               OR NOT pg_catalog.has_function_privilege(
                   '{CONTROL}', routine.oid, 'EXECUTE'
+              )
+              OR EXISTS (
+                  SELECT 1
+                  FROM LATERAL pg_catalog.aclexplode(routine.proacl) AS acl
+                  JOIN pg_catalog.pg_roles AS grantee_role
+                    ON grantee_role.oid = acl.grantee
+                  WHERE grantee_role.rolname NOT IN ('{PROVISIONER}', '{CONTROL}')
               )
           )
     ) INTO repair_pending;
@@ -452,6 +460,30 @@ BEGIN
         EXECUTE pg_catalog.format(
             'GRANT EXECUTE ON FUNCTION catalog.%I(uuid) TO {CONTROL}', routine_name
         );
+
+        -- REVOKE … FROM PUBLIC does not touch a direct grant to a named role,
+        -- and a restore or an old deployment can leave one. Anything outside
+        -- the canonical pair can call provisioner-owned tenant management.
+        FOR grantee_name IN
+            SELECT DISTINCT grantee_role.rolname
+            FROM pg_catalog.pg_proc AS routine
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = routine.pronamespace
+            JOIN LATERAL pg_catalog.aclexplode(routine.proacl) AS acl ON true
+            JOIN pg_catalog.pg_roles AS grantee_role
+              ON grantee_role.oid = acl.grantee
+            WHERE namespace.nspname = 'catalog'
+              AND routine.proname = routine_name
+              AND routine.pronargs = 1
+              AND routine.proargtypes[0] = 'uuid'::regtype
+              AND grantee_role.rolname NOT IN ('{PROVISIONER}', '{CONTROL}')
+        LOOP
+            EXECUTE pg_catalog.format(
+                'REVOKE ALL ON FUNCTION catalog.%I(uuid) FROM %I',
+                routine_name,
+                grantee_name
+            );
+        END LOOP;
     END LOOP;
 
     IF temporary_schema_create THEN
@@ -505,24 +537,33 @@ BEGIN
     -- in this tool ever needs it: the provisioning function grants tenant roles
     -- TO the gateways using ADMIN on the *tenant* role, not on the gateway.
     -- Left behind, each one is a landmine for the next recovery.
-    FOREACH group_name IN ARRAY ARRAY[
-        '{CONTROL}', '{WRITER}', '{SANDBOX}', '{TILE}'
-    ] LOOP
-        IF EXISTS (
-            SELECT 1
-            FROM pg_catalog.pg_auth_members AS membership
-            JOIN pg_catalog.pg_roles AS granted_role
-              ON granted_role.oid = membership.roleid
-            JOIN pg_catalog.pg_roles AS member_role
-              ON member_role.oid = membership.member
-            WHERE granted_role.rolname = group_name
-              AND member_role.rolname = CURRENT_USER
-        ) THEN
-            EXECUTE pg_catalog.format(
-                'REVOKE %I FROM %I', group_name, CURRENT_USER
-            );
-        END IF;
-    END LOOP;
+    --
+    -- Only edges with the automatic creator's exact shape — ADMIN, and neither
+    -- INHERIT nor SET — and only on 16+, which is the only place that shape is
+    -- created. Before 16 there is no automatic membership at all, so any edge
+    -- there is somebody's decision and stays. An operator who wants the
+    -- migrator to *use* a gateway grants it usably, which this leaves alone.
+    IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+        FOREACH group_name IN ARRAY ARRAY[
+            '{CONTROL}', '{WRITER}', '{SANDBOX}', '{TILE}'
+        ] LOOP
+            IF EXISTS (
+                SELECT 1
+                FROM pg_catalog.pg_auth_members AS membership
+                JOIN pg_catalog.pg_roles AS granted_role
+                  ON granted_role.oid = membership.roleid
+                JOIN pg_catalog.pg_roles AS member_role
+                  ON member_role.oid = membership.member
+                WHERE granted_role.rolname = group_name
+                  AND member_role.rolname = CURRENT_USER
+                  AND {_MEMBERSHIP_ADMIN_ONLY}
+            ) THEN
+                EXECUTE pg_catalog.format(
+                    'REVOKE %I FROM %I', group_name, CURRENT_USER
+                );
+            END IF;
+        END LOOP;
+    END IF;
 END
 $$
 """

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -803,6 +803,28 @@ BEGIN
                 foreign_option_row.target ||
                 ' FROM {PROVISIONER}; then re-run adoption';
     END LOOP;
+
+    -- fix(#998 codex r47): a schema-less default privilege owned by the
+    -- provisioner lands on every future data_t_* schema the provisioning
+    -- function creates.  The per-tenant pass also refuses it, but with zero
+    -- tenants that pass never runs — this is the one place that executes on
+    -- every run regardless.
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_default_acl AS default_acl
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = default_acl.defaclrole
+        WHERE default_acl.defaclnamespace = 0
+          AND owner_role.rolname = '{PROVISIONER}'
+    ) THEN
+        RAISE EXCEPTION
+            '{PROVISIONER} carries schema-less default privileges, which '
+            'apply to every tenant schema it creates'
+            USING HINT =
+                'as {PROVISIONER} run: ALTER DEFAULT PRIVILEGES REVOKE ALL '
+                'ON TABLES FROM PUBLIC (and the same for the other object '
+                'kinds and grantees shown by \\ddp); then re-run adoption';
+    END IF;
 END
 $$
 """
@@ -833,6 +855,7 @@ DECLARE
     routine_gap bigint;
     type_gap bigint;
     foreign_grantor_gap bigint;
+    global_default_acl_gap bigint;
     reader_oid oid;
     writer_oid oid;
     grantee_name text;
@@ -1344,12 +1367,24 @@ BEGIN
           AND acl.grantor <> writer_oid
     ) AS foreign_grant;
 
+    -- fix(#998 codex r47): schema-less default privileges are not in
+    -- default_acl_gap (it joins on the tenant schema), so without this an
+    -- otherwise-canonical tenant returned here and the schema-less refusal
+    -- later in the block was unreachable.
+    SELECT pg_catalog.count(*) INTO global_default_acl_gap
+    FROM pg_catalog.pg_default_acl AS default_acl
+    JOIN pg_catalog.pg_roles AS owner_role
+      ON owner_role.oid = default_acl.defaclrole
+    WHERE default_acl.defaclnamespace = 0
+      AND owner_role.rolname IN (reader_name, writer_name, '{PROVISIONER}');
+
     IF pending_owner_transfer = 0
        AND reader_privilege_gap = 0
        AND default_acl_gap = 0
        AND routine_gap = 0
        AND type_gap = 0
-       AND foreign_grantor_gap = 0 THEN
+       AND foreign_grantor_gap = 0
+       AND global_default_acl_gap = 0 THEN
         RETURN;
     END IF;
 

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -536,9 +536,20 @@ BEGIN
           AND grantor_role.rolname = CURRENT_USER
           AND NOT membership.admin_option
     ) THEN
-        EXECUTE pg_catalog.format(
-            'REVOKE {PROVISIONER} FROM %I GRANTED BY %I', CURRENT_USER, CURRENT_USER
-        );
+        IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+            EXECUTE pg_catalog.format(
+                'REVOKE {PROVISIONER} FROM %I GRANTED BY %I',
+                CURRENT_USER,
+                CURRENT_USER
+            );
+        ELSE
+            -- GRANTED BY on REVOKE ROLE arrived in 16. Before that a role can
+            -- hold only one membership in another, and this branch runs only
+            -- when the run granted it, so the plain form removes exactly it.
+            EXECUTE pg_catalog.format(
+                'REVOKE {PROVISIONER} FROM %I', CURRENT_USER
+            );
+        END IF;
     END IF;
 END
 $$

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -822,8 +822,16 @@ BEGIN
         END IF;
     END IF;
 
-    -- Both tenant roles' member lists, normalized together and here rather than
-    -- earlier: PostgreSQL 16+ grants the creating role an automatic ADMIN
+    -- Both tenant roles' member lists. Unlike the five fixed roles, the
+    -- creator shape is NOT tolerated here: catalog.provision_tenant_data_schema
+    -- is migration-owned, unchanged, and refuses any reader member outside
+    -- provisioner/sandbox/tile — so tolerating one only moves the failure to a
+    -- hintless refusal a few lines down. The remedy is in the message, and for
+    -- a creator edge it is the DROP ROLE branch: its grantor is the bootstrap
+    -- superuser, so nobody else can revoke it, while the tenant role owns
+    -- nothing at this point and provisioning recreates it.
+    --
+    -- Here rather than earlier: PostgreSQL 16+ grants the creating role an automatic ADMIN
     -- membership, so a non-superuser migrator that replayed the globals dump is
     -- a direct member of every restored reader and writer, which the
     -- provisioning function refuses outright.
@@ -850,10 +858,6 @@ BEGIN
         LEFT JOIN pg_catalog.pg_roles AS grantor_role
           ON grantor_role.oid = membership.grantor
         WHERE granted_role.rolname = reader_name
-          -- The automatic creator membership is tolerated here for the same
-          -- reason the cluster guard tolerates it: nobody can revoke it, and it
-          -- confers nothing.
-          AND NOT {_MEMBERSHIP_CREATOR_SHAPE}
           AND (
               member_role.rolname NOT IN ('{PROVISIONER}', '{SANDBOX}', '{TILE}')
               OR (
@@ -897,10 +901,6 @@ BEGIN
         LEFT JOIN pg_catalog.pg_roles AS grantor_role
           ON grantor_role.oid = membership.grantor
         WHERE granted_role.rolname = writer_name
-          -- The automatic creator membership is tolerated here for the same
-          -- reason the cluster guard tolerates it: nobody can revoke it, and it
-          -- confers nothing.
-          AND NOT {_MEMBERSHIP_CREATOR_SHAPE}
           AND (
               member_role.rolname NOT IN ('{PROVISIONER}', '{WRITER}')
               OR (

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -135,25 +135,38 @@ BEGIN
     -- No ADMIN in the grant: PostgreSQL refuses "ADMIN option cannot be granted
     -- back to your own grantor", and the automatic membership already carries
     -- it.
-    IF NOT pg_catalog.pg_has_role(CURRENT_USER, '{PROVISIONER}', 'USAGE')
-       AND EXISTS (
-           SELECT 1
-           FROM pg_catalog.pg_auth_members AS membership
-           JOIN pg_catalog.pg_roles AS granted_role
-             ON granted_role.oid = membership.roleid
-           JOIN pg_catalog.pg_roles AS member_role
-             ON member_role.oid = membership.member
-           WHERE granted_role.rolname = '{PROVISIONER}'
-             AND member_role.rolname = CURRENT_USER
-             AND membership.admin_option
-       ) THEN
+    IF NOT pg_catalog.pg_has_role(CURRENT_USER, '{PROVISIONER}', 'USAGE') THEN
         IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
-            EXECUTE pg_catalog.format(
-                'GRANT {PROVISIONER} TO %I WITH INHERIT TRUE, SET TRUE',
-                CURRENT_USER
-            );
+            -- 16+ requires an ADMIN edge to grant the role, and the creator
+            -- automatically has one. Without it the caller cannot grant itself
+            -- anything, so fall through to the refusal below.
+            IF EXISTS (
+                SELECT 1
+                FROM pg_catalog.pg_auth_members AS membership
+                JOIN pg_catalog.pg_roles AS granted_role
+                  ON granted_role.oid = membership.roleid
+                JOIN pg_catalog.pg_roles AS member_role
+                  ON member_role.oid = membership.member
+                WHERE granted_role.rolname = '{PROVISIONER}'
+                  AND member_role.rolname = CURRENT_USER
+                  AND membership.admin_option
+            ) THEN
+                EXECUTE pg_catalog.format(
+                    'GRANT {PROVISIONER} TO %I WITH INHERIT TRUE, SET TRUE',
+                    CURRENT_USER
+                );
+            END IF;
         ELSE
-            EXECUTE pg_catalog.format('GRANT {PROVISIONER} TO %I', CURRENT_USER);
+            -- Before 16 there is no creator membership to look for: CREATEROLE
+            -- carries admin rights over every non-superuser role, so the grant
+            -- is simply attempted. A caller without that authority is told what
+            -- to run by SECURE_BOUNDARY_FUNCTIONS_SQL rather than by a raw
+            -- permission error.
+            BEGIN
+                EXECUTE pg_catalog.format('GRANT {PROVISIONER} TO %I', CURRENT_USER);
+            EXCEPTION
+                WHEN insufficient_privilege THEN NULL;
+            END;
         END IF;
     END IF;
 END
@@ -547,6 +560,7 @@ DECLARE
     schema_owner text;
     pending_owner_transfer bigint;
     reader_privilege_gap bigint;
+    reader_oid oid;
     temporary_writer_membership boolean := false;
 BEGIN
     schema_name := 'data_t_' || pg_catalog.replace(tenant_id::text, '-', '_');
@@ -724,6 +738,8 @@ BEGIN
     -- are issued by the writer instead of by this function.
     PERFORM catalog.provision_tenant_data_schema(tenant_id);
 
+    SELECT oid INTO reader_oid FROM pg_catalog.pg_roles WHERE rolname = reader_name;
+
     -- The provisioning function grants the reader USAGE; it never takes CREATE
     -- away, and a restored schema can arrive carrying it.  The sandbox and tile
     -- gateways SET ROLE to this reader, so CREATE there is a write path into a
@@ -761,6 +777,17 @@ BEGIN
               AND NOT pg_catalog.has_sequence_privilege(
                   reader_name, relation.oid, 'SELECT'
               )
+          )
+          -- Missing SELECT is only half of it: the reader is the SET target of
+          -- the sandbox and tile gateways, so any privilege beyond reading is a
+          -- write path into tenant data. Read out of the ACL rather than named
+          -- one by one, because the set of privilege types grows by release.
+          OR EXISTS (
+              SELECT 1
+              FROM LATERAL pg_catalog.aclexplode(relation.relacl) AS acl
+              WHERE acl.grantee = reader_oid
+                AND acl.privilege_type <> 'SELECT'
+                AND NOT (relation.relkind = 'S' AND acl.privilege_type = 'USAGE')
           )
       );
 
@@ -837,6 +864,15 @@ BEGIN
     END IF;
 
     EXECUTE pg_catalog.format('SET ROLE %I', writer_name);
+    -- Revoke first, then grant back exactly the read privileges: ALTER TABLE …
+    -- OWNER TO re-attributes the restored grants to the writer, so the writer
+    -- can take away an INSERT or DELETE the old owner had handed the reader.
+    EXECUTE pg_catalog.format(
+        'REVOKE ALL ON ALL TABLES IN SCHEMA %I FROM %I', schema_name, reader_name
+    );
+    EXECUTE pg_catalog.format(
+        'REVOKE ALL ON ALL SEQUENCES IN SCHEMA %I FROM %I', schema_name, reader_name
+    );
     EXECUTE pg_catalog.format(
         'GRANT SELECT ON ALL TABLES IN SCHEMA %I TO %I', schema_name, reader_name
     );

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -104,6 +104,31 @@ BEGIN
         CREATE ROLE {PROVISIONER}
             NOLOGIN NOSUPERUSER NOCREATEDB CREATEROLE NOINHERIT
             NOREPLICATION NOBYPASSRLS;
+
+        -- PostgreSQL 16+ makes a non-superuser creator an ADMIN member of the
+        -- role it just created, but with INHERIT FALSE and SET FALSE — measured
+        -- on 18 — so the creator does not hold the new role's privileges.  The
+        -- boundary-function repair later in this run needs exactly those, and
+        -- would otherwise raise and roll back the five roles it just created,
+        -- leaving the runbook's no-globals recovery unable to finish.  A
+        -- superuser already holds them and takes this branch to no effect.
+        --
+        -- Only the branch that created the role touches the edge, so an
+        -- operator-managed membership is never rewritten.  No ADMIN here:
+        -- PostgreSQL refuses "ADMIN option cannot be granted back to your own
+        -- grantor", and the automatic membership already carries it.
+        IF NOT pg_catalog.pg_has_role(CURRENT_USER, '{PROVISIONER}', 'USAGE') THEN
+            IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+                EXECUTE pg_catalog.format(
+                    'GRANT {PROVISIONER} TO %I WITH INHERIT TRUE, SET TRUE',
+                    CURRENT_USER
+                );
+            ELSE
+                EXECUTE pg_catalog.format(
+                    'GRANT {PROVISIONER} TO %I', CURRENT_USER
+                );
+            END IF;
+        END IF;
     END IF;
 
     FOREACH group_name IN ARRAY ARRAY[

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -607,6 +607,18 @@ END
 $$
 """
 
+#: The grant-option counterpart, because a re-GRANT leaves one in place.
+PROVISIONER_DATABASE_REVOKE_OPTION_SQL = f"""
+DO $$
+BEGIN
+    EXECUTE pg_catalog.format(
+        'REVOKE GRANT OPTION FOR CREATE ON DATABASE %I FROM {PROVISIONER}',
+        pg_catalog.current_database()
+    );
+END
+$$
+"""
+
 PROVISIONER_DATABASE_GRANT_SQL = f"""
 DO $$
 BEGIN

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -19,6 +19,18 @@ moved (#998):
 - Every step is gated on the gap it closes, so an already-adopted tenant
   issues no DDL at all.  0019 ran once, inside a migration; this runs whenever
   an operator needs it.
+
+Repair boundary
+---------------
+Adoption rewrites only grants it is itself the grantor of, plus ACLs on objects
+it owns or can own for the duration.  A pre-existing anomaly — a membership
+granted by a third party, a duplicate row hiding behind a canonical one, a
+default-privilege entry belonging to a role this credential cannot assume — is
+detected and refused with the exact statement to run and the role to run it as,
+not repaired.  Removing somebody else's grant means naming its grantor and being
+able to assume it, and PostgreSQL answers that differently for every combination
+of server version, grantor and dependent grant; the operator has authority this
+process does not, and a refusal that names the remedy costs one re-run.
 - The reserved-role membership guard aggregates with ``bool_or`` instead of
   reading one row.  PostgreSQL keeps one membership row per grantor, so a member
   can hold two grants of the same role and 0019's scalar read picks one
@@ -385,13 +397,12 @@ BEGIN
            OR membership_row.rolinherit
            OR membership_row.rolreplication
            OR membership_row.rolbypassrls
-           -- The edge's options, not only the roles at its ends — but only for
-           -- an orphan: a role carrying the per-tenant naming pattern with no
-           -- row in catalog.tenants is never reached by the per-tenant checks
-           -- or their repairs, so an INHERIT edge there would hand the gateway
-           -- that role's privileges outright and nothing would ever notice. A
-           -- live tenant's roles are normalized per tenant, which is where a
-           -- legacy `WITH ADMIN OPTION` grant gets rewritten.
+           -- An orphan: a role carrying the per-tenant naming pattern with no
+           -- row in catalog.tenants. Nothing per-tenant reaches it — adoption
+           -- iterates catalog.tenants — so whatever objects it still owns are
+           -- outside the boundary entirely, and any edge from a gateway is a
+           -- live path to them. Refused whatever its options are; a live
+           -- tenant's roles are checked per tenant instead.
            OR (
                NOT EXISTS (
                    SELECT 1 FROM catalog.tenants
@@ -402,22 +413,6 @@ BEGIN
                        '_',
                        '-'
                    )
-               )
-               -- "no unsafe row", not "some safe row": PostgreSQL keeps one
-               -- row per grantor, and a canonical SET-only grant sitting beside
-               -- an INHERIT one would otherwise answer for both.
-               AND EXISTS (
-                   SELECT 1
-                   FROM pg_catalog.pg_auth_members AS membership
-                   JOIN pg_catalog.pg_roles AS member_role
-                     ON member_role.oid = membership.member
-                   WHERE membership.roleid = membership_row.oid
-                     AND member_role.rolname = membership_row.member_name
-                     AND NOT CASE
-                         WHEN membership_row.member_name = '{PROVISIONER}'
-                         THEN {_MEMBERSHIP_ADMIN_ONLY}
-                         ELSE {_MEMBERSHIP_SET_ONLY}
-                     END
                )
            )
            OR EXISTS (
@@ -826,6 +821,13 @@ BEGIN
     -- has, which is why the revokes wait until after the provisioner has its own
     -- ADMIN above. Afterwards the caller reaches both roles through the
     -- provisioner, whose privileges it must hold to have got this far.
+    -- Detect, do not rewrite.  Every row here predates this run: a restore, a
+    -- globals replay, or an operator granted it, which makes some other role
+    -- its grantor.  Removing it means naming that grantor and being able to
+    -- assume it, and PostgreSQL has a different answer for every combination of
+    -- server version, grantor and dependent grant.  Adoption repairs only the
+    -- grants it made itself; anything else is one exact statement for the
+    -- operator and a re-run.
     FOR legacy_member_row IN
         SELECT member_role.rolname AS member_name,
                grantor_role.rolname AS grantor_name
@@ -839,49 +841,32 @@ BEGIN
         WHERE granted_role.rolname = reader_name
           AND (
               member_role.rolname NOT IN ('{PROVISIONER}', '{SANDBOX}', '{TILE}')
-              -- ...or an allowed gateway holding an unsafe duplicate. Nothing
-              -- else removes that row, so leaving it makes the tenant
-              -- permanently unadoptable.
               OR (
                   member_role.rolname IN ('{SANDBOX}', '{TILE}')
                   AND NOT {_MEMBERSHIP_SET_ONLY}
               )
           )
     LOOP
-        -- GRANTED BY targets the specific row: a plain REVOKE only removes the
-        -- grant this role made, and PostgreSQL keeps one row per grantor. It
-        -- needs a path to that grantor, so a row from a role this credential
-        -- cannot assume is a refusal with the command to run, not a silent skip.
-        BEGIN
-            IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
-                EXECUTE pg_catalog.format(
-                    'REVOKE %I FROM %I GRANTED BY %I CASCADE',
-                    reader_name,
-                    legacy_member_row.member_name,
-                    legacy_member_row.grantor_name
-                );
-            ELSE
-                EXECUTE pg_catalog.format(
-                    'REVOKE %I FROM %I CASCADE',
-                    reader_name,
-                    legacy_member_row.member_name
-                );
-            END IF;
-        EXCEPTION
-            WHEN insufficient_privilege THEN
-                RAISE EXCEPTION
-                    'cannot revoke % from % : the grant was made by %, which '
-                    'this role cannot assume',
-                    reader_name,
-                    legacy_member_row.member_name,
-                    legacy_member_row.grantor_name
-                    USING HINT =
-                        'run REVOKE ' || reader_name || ' FROM ' ||
-                        legacy_member_row.member_name || ' GRANTED BY ' ||
-                        legacy_member_row.grantor_name || ' CASCADE as a role that can';
-        END;
+        RAISE EXCEPTION
+            'tenant role % carries a membership adoption will not rewrite: '
+            'member %, granted by %',
+            reader_name,
+            legacy_member_row.member_name,
+            legacy_member_row.grantor_name
+            USING HINT =
+                'as ' || legacy_member_row.grantor_name ||
+                ' (or a role that can assume it) run: REVOKE ' || reader_name ||
+                ' FROM ' || legacy_member_row.member_name ||
+                ' CASCADE; then re-run adoption';
     END LOOP;
 
+    -- Detect, do not rewrite.  Every row here predates this run: a restore, a
+    -- globals replay, or an operator granted it, which makes some other role
+    -- its grantor.  Removing it means naming that grantor and being able to
+    -- assume it, and PostgreSQL has a different answer for every combination of
+    -- server version, grantor and dependent grant.  Adoption repairs only the
+    -- grants it made itself; anything else is one exact statement for the
+    -- operator and a re-run.
     FOR legacy_member_row IN
         SELECT member_role.rolname AS member_name,
                grantor_role.rolname AS grantor_name
@@ -895,90 +880,53 @@ BEGIN
         WHERE granted_role.rolname = writer_name
           AND (
               member_role.rolname NOT IN ('{PROVISIONER}', '{WRITER}')
-              -- ...or an allowed gateway holding an unsafe duplicate. Nothing
-              -- else removes that row, so leaving it makes the tenant
-              -- permanently unadoptable.
               OR (
                   member_role.rolname IN ('{WRITER}')
                   AND NOT {_MEMBERSHIP_SET_ONLY}
               )
           )
     LOOP
-        -- GRANTED BY targets the specific row: a plain REVOKE only removes the
-        -- grant this role made, and PostgreSQL keeps one row per grantor. It
-        -- needs a path to that grantor, so a row from a role this credential
-        -- cannot assume is a refusal with the command to run, not a silent skip.
-        BEGIN
-            IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
-                EXECUTE pg_catalog.format(
-                    'REVOKE %I FROM %I GRANTED BY %I CASCADE',
-                    writer_name,
-                    legacy_member_row.member_name,
-                    legacy_member_row.grantor_name
-                );
-            ELSE
-                EXECUTE pg_catalog.format(
-                    'REVOKE %I FROM %I CASCADE',
-                    writer_name,
-                    legacy_member_row.member_name
-                );
-            END IF;
-        EXCEPTION
-            WHEN insufficient_privilege THEN
-                RAISE EXCEPTION
-                    'cannot revoke % from % : the grant was made by %, which '
-                    'this role cannot assume',
-                    writer_name,
-                    legacy_member_row.member_name,
-                    legacy_member_row.grantor_name
-                    USING HINT =
-                        'run REVOKE ' || writer_name || ' FROM ' ||
-                        legacy_member_row.member_name || ' GRANTED BY ' ||
-                        legacy_member_row.grantor_name || ' CASCADE as a role that can';
-        END;
+        RAISE EXCEPTION
+            'tenant role % carries a membership adoption will not rewrite: '
+            'member %, granted by %',
+            writer_name,
+            legacy_member_row.member_name,
+            legacy_member_row.grantor_name
+            USING HINT =
+                'as ' || legacy_member_row.grantor_name ||
+                ' (or a role that can assume it) run: REVOKE ' || writer_name ||
+                ' FROM ' || legacy_member_row.member_name ||
+                ' CASCADE; then re-run adoption';
     END LOOP;
 
-    -- The provisioner's own duplicates, which the loops above deliberately do
-    -- not touch: revoking its membership outright would remove the ADMIN path
-    -- this transaction reaches the tenant roles through. Only the foreign
-    -- grantor's row goes, by name, leaving the canonical one that the guarded
-    -- GRANT above has just made sure exists. Before PostgreSQL 16 there is one
-    -- row per pair and no GRANTED BY to aim with, so there is nothing to do.
-    IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
-        FOR legacy_member_row IN
-            SELECT granted_role.rolname AS granted_name,
-                   grantor_role.rolname AS member_name
-            FROM pg_catalog.pg_auth_members AS membership
-            JOIN pg_catalog.pg_roles AS granted_role
-              ON granted_role.oid = membership.roleid
-            JOIN pg_catalog.pg_roles AS member_role
-              ON member_role.oid = membership.member
-            JOIN pg_catalog.pg_roles AS grantor_role
-              ON grantor_role.oid = membership.grantor
-            WHERE granted_role.rolname IN (reader_name, writer_name)
-              AND member_role.rolname = '{PROVISIONER}'
-              AND NOT {_MEMBERSHIP_ADMIN_ONLY}
-        LOOP
-            BEGIN
-                EXECUTE pg_catalog.format(
-                    'REVOKE %I FROM {PROVISIONER} GRANTED BY %I CASCADE',
-                    legacy_member_row.granted_name,
-                    legacy_member_row.member_name
-                );
-            EXCEPTION
-                WHEN insufficient_privilege THEN
-                    RAISE EXCEPTION
-                        'cannot revoke % from {PROVISIONER}: the grant was made '
-                        'by %, which this role cannot assume',
-                        legacy_member_row.granted_name,
-                        legacy_member_row.member_name
-                        USING HINT =
-                            'run REVOKE ' || legacy_member_row.granted_name ||
-                            ' FROM {PROVISIONER} GRANTED BY ' ||
-                            legacy_member_row.member_name || ' CASCADE as a role that can';
-            END;
-        END LOOP;
-    END IF;
+    -- The provisioner's own duplicates, detected for the same reason and on
+    -- the same terms: the canonical row hides them, and only the grantor can
+    -- take one away.
+    FOR legacy_member_row IN
+        SELECT granted_role.rolname AS granted_name,
+               grantor_role.rolname AS grantor_name
+        FROM pg_catalog.pg_auth_members AS membership
+        JOIN pg_catalog.pg_roles AS granted_role
+          ON granted_role.oid = membership.roleid
+        JOIN pg_catalog.pg_roles AS member_role
+          ON member_role.oid = membership.member
+        JOIN pg_catalog.pg_roles AS grantor_role
+          ON grantor_role.oid = membership.grantor
+        WHERE granted_role.rolname IN (reader_name, writer_name)
+          AND member_role.rolname = '{PROVISIONER}'
+          AND NOT {_MEMBERSHIP_ADMIN_ONLY}
+    LOOP
+        RAISE EXCEPTION
+            'tenant role % carries a {PROVISIONER} membership that is not '
+            'ADMIN-only, granted by %',
+            legacy_member_row.granted_name,
+            legacy_member_row.grantor_name
+            USING HINT =
+                'as ' || legacy_member_row.grantor_name ||
+                ' (or a role that can assume it) run: REVOKE ' ||
+                legacy_member_row.granted_name || ' FROM {PROVISIONER} CASCADE; '
+                'then re-run adoption';
+    END LOOP;
 
     -- The guarded boundary owns schema creation, role creation, gateway
     -- memberships, and schema-level privileges.  Since 0024 it deliberately
@@ -1189,11 +1137,35 @@ BEGIN
             schema_name, writer_name;
     END IF;
 
-    -- Every default-privilege entry in the schema, for any object kind and any
-    -- grantee — not just the reader's, which is only the shape the pre-0019
-    -- runtime helper happened to leave. The contract inside a tenant schema is
-    -- that the writer grants the reader explicitly on each relation, so an
-    -- entry here hands out privileges on relations that do not exist yet.
+    -- Default-privilege entries: cleared when this run can act as the role
+    -- that owns them — itself, or the tenant writer whose SET edge it holds
+    -- inside this window — and refused otherwise, on the same terms as the
+    -- memberships above. Every object kind and every grantee: the contract in a
+    -- tenant schema is that the writer grants the reader explicitly on each
+    -- relation, so an entry here hands out privileges on relations that do not
+    -- exist yet.
+    FOR default_acl_row IN
+        SELECT DISTINCT owner_role.rolname AS owner_name
+        FROM pg_catalog.pg_default_acl AS default_acl
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = default_acl.defaclrole
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = default_acl.defaclnamespace
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname NOT IN (CURRENT_USER, writer_name)
+    LOOP
+        RAISE EXCEPTION
+            'schema % carries default privileges owned by %, which this role '
+            'cannot act as',
+            schema_name,
+            default_acl_row.owner_name
+            USING HINT =
+                'as ' || default_acl_row.owner_name ||
+                ' run: ALTER DEFAULT PRIVILEGES IN SCHEMA ' || schema_name ||
+                ' REVOKE ALL ON TABLES FROM PUBLIC (and the same for SEQUENCES, '
+                'FUNCTIONS, TYPES and SCHEMAS as applicable); then re-run adoption';
+    END LOOP;
+
     FOR default_acl_row IN
         SELECT owner_role.rolname AS owner_name,
                default_acl.defaclobjtype AS object_type,
@@ -1211,33 +1183,46 @@ BEGIN
           ON namespace.oid = default_acl.defaclnamespace
         WHERE namespace.nspname = schema_name
     LOOP
-        -- ALTER DEFAULT PRIVILEGES FOR ROLE needs the caller to be able to
-        -- assume that role. The migrator can for its own entries and, inside
-        -- this window, for the writer's; anything else it cannot reach is left
-        -- for the report to keep flagging rather than failing the tenant.
-        BEGIN
-            IF default_acl_row.owner_name <> CURRENT_USER THEN
-                EXECUTE pg_catalog.format('SET ROLE %I', default_acl_row.owner_name);
-            END IF;
-            EXECUTE pg_catalog.format(
-                'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I REVOKE ALL ON %s FROM %s',
-                default_acl_row.owner_name,
-                schema_name,
-                CASE default_acl_row.object_type
-                    WHEN 'r' THEN 'TABLES'
-                    WHEN 'S' THEN 'SEQUENCES'
-                    WHEN 'f' THEN 'FUNCTIONS'
-                    WHEN 'T' THEN 'TYPES'
-                    ELSE 'SCHEMAS'
-                END,
-                default_acl_row.grantee_name
-            );
-            RESET ROLE;
-        EXCEPTION
-            WHEN insufficient_privilege THEN
-                RESET ROLE;
-        END;
+        IF default_acl_row.owner_name <> CURRENT_USER THEN
+            EXECUTE pg_catalog.format('SET ROLE %I', default_acl_row.owner_name);
+        END IF;
+        EXECUTE pg_catalog.format(
+            'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I REVOKE ALL ON %s FROM %s',
+            default_acl_row.owner_name,
+            schema_name,
+            CASE default_acl_row.object_type
+                WHEN 'r' THEN 'TABLES'
+                WHEN 'S' THEN 'SEQUENCES'
+                WHEN 'f' THEN 'FUNCTIONS'
+                WHEN 'T' THEN 'TYPES'
+                ELSE 'SCHEMAS'
+            END,
+            default_acl_row.grantee_name
+        );
+        RESET ROLE;
     END LOOP;
+
+    -- A subtractive entry — ALTER DEFAULT PRIVILEGES ... REVOKE ... FROM PUBLIC
+    -- — leaves a pg_default_acl row that aclexplode has nothing to show for, so
+    -- the loop above cannot reach it. Restoring the built-in default means
+    -- re-granting what was taken, which only the owner can decide.
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_default_acl AS default_acl
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = default_acl.defaclnamespace
+        WHERE namespace.nspname = schema_name
+    ) THEN
+        RAISE EXCEPTION
+            'schema % still carries a default-privilege entry after clearing '
+            'every grant in it — a subtractive entry, which only its owner can '
+            'reset',
+            schema_name
+            USING HINT =
+                'inspect pg_default_acl for this schema and, as the defaclrole, '
+                'ALTER DEFAULT PRIVILEGES ... GRANT the privilege back to '
+                'restore the built-in default; then re-run adoption';
+    END IF;
 
     EXECUTE pg_catalog.format('SET ROLE %I', writer_name);
     -- Revoke first, then grant back exactly the read privileges: ALTER TABLE …

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -873,6 +873,35 @@ BEGIN
         );
     END LOOP;
 
+    -- The provisioner's own duplicates, which the loops above deliberately do
+    -- not touch: revoking its membership outright would remove the ADMIN path
+    -- this transaction reaches the tenant roles through. Only the foreign
+    -- grantor's row goes, by name, leaving the canonical one that the guarded
+    -- GRANT above has just made sure exists. Before PostgreSQL 16 there is one
+    -- row per pair and no GRANTED BY to aim with, so there is nothing to do.
+    IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+        FOR legacy_member_row IN
+            SELECT granted_role.rolname AS granted_name,
+                   grantor_role.rolname AS member_name
+            FROM pg_catalog.pg_auth_members AS membership
+            JOIN pg_catalog.pg_roles AS granted_role
+              ON granted_role.oid = membership.roleid
+            JOIN pg_catalog.pg_roles AS member_role
+              ON member_role.oid = membership.member
+            JOIN pg_catalog.pg_roles AS grantor_role
+              ON grantor_role.oid = membership.grantor
+            WHERE granted_role.rolname IN (reader_name, writer_name)
+              AND member_role.rolname = '{PROVISIONER}'
+              AND NOT {_MEMBERSHIP_ADMIN_ONLY}
+        LOOP
+            EXECUTE pg_catalog.format(
+                'REVOKE %I FROM {PROVISIONER} GRANTED BY %I',
+                legacy_member_row.granted_name,
+                legacy_member_row.member_name
+            );
+        END LOOP;
+    END IF;
+
     -- The guarded boundary owns schema creation, role creation, gateway
     -- memberships, and schema-level privileges.  Since 0024 it deliberately
     -- does NOT touch per-relation ACLs, which is why the reader grants below

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -665,23 +665,40 @@ BEGIN
         );
     END LOOP;
 
+    -- Every default-privilege entry in the schema, for any object kind and any
+    -- grantee — not just the reader's, which is only the shape the pre-0019
+    -- runtime helper happened to leave. The contract inside a tenant schema is
+    -- that the writer grants the reader explicitly on each relation, so an
+    -- entry here hands out privileges on relations that do not exist yet.
     FOR default_acl_row IN
-        SELECT DISTINCT owner_role.rolname AS owner_name
+        SELECT owner_role.rolname AS owner_name,
+               default_acl.defaclobjtype AS object_type,
+               CASE
+                   WHEN acl.grantee = 0 THEN 'PUBLIC'
+                   ELSE pg_catalog.quote_ident(grantee_role.rolname)
+               END AS grantee_name
         FROM pg_catalog.pg_default_acl AS default_acl
         JOIN pg_catalog.pg_roles AS owner_role
           ON owner_role.oid = default_acl.defaclrole
         JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS acl ON true
-        JOIN pg_catalog.pg_roles AS grantee_role ON grantee_role.oid = acl.grantee
+        LEFT JOIN pg_catalog.pg_roles AS grantee_role
+          ON grantee_role.oid = acl.grantee
         JOIN pg_catalog.pg_namespace AS namespace
           ON namespace.oid = default_acl.defaclnamespace
         WHERE namespace.nspname = schema_name
-          AND default_acl.defaclobjtype = 'r'
-          AND grantee_role.rolname = reader_name
     LOOP
         EXECUTE pg_catalog.format(
-            'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I '
-            'REVOKE ALL ON TABLES FROM %I',
-            default_acl_row.owner_name, schema_name, reader_name
+            'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I REVOKE ALL ON %s FROM %s',
+            default_acl_row.owner_name,
+            schema_name,
+            CASE default_acl_row.object_type
+                WHEN 'r' THEN 'TABLES'
+                WHEN 'S' THEN 'SEQUENCES'
+                WHEN 'f' THEN 'FUNCTIONS'
+                WHEN 'T' THEN 'TYPES'
+                ELSE 'SCHEMAS'
+            END,
+            default_acl_row.grantee_name
         );
     END LOOP;
 
@@ -804,6 +821,30 @@ BEGIN
             'REVOKE CREATE ON SCHEMA %I FROM %I', schema_name, reader_name
         );
     END IF;
+
+    -- And anyone else the restore left on the schema. The provisioning function
+    -- revokes PUBLIC and grants the two tenant roles; a named grantee with
+    -- USAGE, or worse CREATE, is a path around the writer boundary that nothing
+    -- else here would take away.
+    FOR grantee_name IN
+        SELECT DISTINCT
+            CASE
+                WHEN acl.grantee = 0 THEN 'PUBLIC'
+                ELSE pg_catalog.quote_ident(grantee_role.rolname)
+            END
+        FROM pg_catalog.pg_namespace AS namespace
+        JOIN LATERAL pg_catalog.aclexplode(namespace.nspacl) AS acl ON true
+        LEFT JOIN pg_catalog.pg_roles AS grantee_role
+          ON grantee_role.oid = acl.grantee
+        WHERE namespace.nspname = schema_name
+          AND COALESCE(grantee_role.rolname, '') NOT IN (
+              '{PROVISIONER}', reader_name, writer_name
+          )
+    LOOP
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON SCHEMA %I FROM %s', schema_name, grantee_name
+        );
+    END LOOP;
 
     SELECT pg_catalog.count(*) INTO pending_owner_transfer
     FROM pg_catalog.pg_class AS relation

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -302,6 +302,92 @@ END
 $$
 """
 
+#: Re-own and re-restrict the two migration-owned SECURITY DEFINER functions
+#: after a ``pg_restore --no-owner --no-acl``.  Bodies are never touched.
+#:
+#: ``ALTER FUNCTION … OWNER TO`` wants two things PostgreSQL does not spell out
+#: in the error message: the incoming owner must hold ``CREATE`` on the
+#: containing schema, and the caller must hold the *privileges* of that owner,
+#: not merely ``ADMIN`` on it.  A superuser migrator has both implicitly.  The
+#: migrator this module documents — ``CREATEROLE`` plus authority over the
+#: restored objects, which is what a managed provider hands out — has neither by
+#: default, and would otherwise stop here with the restored functions still
+#: owned by the restore login and still executable by ``PUBLIC``.
+#:
+#: The schema privilege is borrowed for the repair and given back before commit,
+#: the same shape the per-tenant writer edge uses below; a database already in
+#: the right state borrows nothing.  The role edge is *not* borrowed: rewriting
+#: the operator's own membership in the provisioner would mean guessing what to
+#: restore it to, so a caller without those privileges gets the exact ``GRANT``
+#: to run instead.
+
+SECURE_BOUNDARY_FUNCTIONS_SQL = f"""
+DO $$
+DECLARE
+    routine_name text;
+    temporary_schema_create boolean := false;
+    repair_pending boolean;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_proc AS routine
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = routine.pronamespace
+        WHERE namespace.nspname = 'catalog'
+          AND routine.proname IN (
+              'provision_tenant_data_schema', 'deprovision_tenant_data_schema'
+          )
+          AND routine.pronargs = 1
+          AND routine.proargtypes[0] = 'uuid'::regtype
+          AND (
+              pg_catalog.pg_get_userbyid(routine.proowner) <> '{PROVISIONER}'
+              OR pg_catalog.has_function_privilege('public', routine.oid, 'EXECUTE')
+              OR NOT pg_catalog.has_function_privilege(
+                  '{CONTROL}', routine.oid, 'EXECUTE'
+              )
+          )
+    ) INTO repair_pending;
+
+    IF NOT repair_pending THEN
+        RETURN;
+    END IF;
+
+    IF NOT pg_catalog.pg_has_role(CURRENT_USER, '{PROVISIONER}', 'USAGE') THEN
+        RAISE EXCEPTION
+            'current role % does not hold the privileges of {PROVISIONER}, '
+            'which PostgreSQL requires to give it ownership of the tenant '
+            'boundary functions', CURRENT_USER
+            USING HINT =
+                'run GRANT {PROVISIONER} TO "' || CURRENT_USER ||
+                '" WITH INHERIT TRUE, or adopt with a superuser migrator';
+    END IF;
+
+    IF NOT pg_catalog.has_schema_privilege('{PROVISIONER}', 'catalog', 'CREATE') THEN
+        temporary_schema_create := true;
+        GRANT CREATE ON SCHEMA catalog TO {PROVISIONER};
+    END IF;
+
+    FOREACH routine_name IN ARRAY ARRAY[
+        'provision_tenant_data_schema', 'deprovision_tenant_data_schema'
+    ] LOOP
+        EXECUTE pg_catalog.format(
+            'ALTER FUNCTION catalog.%I(uuid) OWNER TO {PROVISIONER}', routine_name
+        );
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON FUNCTION catalog.%I(uuid) FROM PUBLIC', routine_name
+        );
+        EXECUTE pg_catalog.format(
+            'GRANT EXECUTE ON FUNCTION catalog.%I(uuid) TO {CONTROL}', routine_name
+        );
+    END LOOP;
+
+    IF temporary_schema_create THEN
+        REVOKE CREATE ON SCHEMA catalog FROM {PROVISIONER};
+    END IF;
+END
+$$
+"""
+
 PROVISIONER_DATABASE_GRANT_SQL = f"""
 DO $$
 BEGIN

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -68,6 +68,22 @@ _RELATION_KINDS = "'r', 'p', 'v', 'm', 'f', 'S'"
 #: The options are read out of the row as jsonb because those columns arrived in
 #: 16 and GeoLens supports 13 and up (README); naming them directly would be a
 #: parse error on an older server, where ``admin_option`` is the whole story.
+#: The membership PostgreSQL 16+ hands a non-superuser role creator, and the
+#: reason none of this file tries to revoke one: its grantor is the bootstrap
+#: superuser, a member's plain ``REVOKE`` of it is a warning-level no-op, and
+#: ``GRANTED BY`` that grantor is permission denied for every customer role on a
+#: managed provider — measured, on 18.  It confers nothing on its own (ADMIN
+#: without INHERIT or SET), so it is tolerated wherever it appears instead.
+#:
+#: Before 16 there is no automatic membership at all, so the pre-16 arm of the
+#: jsonb read never matches and nothing is tolerated by accident.
+_MEMBERSHIP_CREATOR_SHAPE = """(
+              membership.admin_option
+              AND jsonb_exists(to_jsonb(membership), 'set_option')
+              AND NOT (to_jsonb(membership) ->> 'inherit_option')::boolean
+              AND NOT (to_jsonb(membership) ->> 'set_option')::boolean
+          )"""
+
 _MEMBERSHIP_ADMIN_ONLY = """(
               membership.admin_option
               AND (
@@ -281,6 +297,25 @@ BEGIN
             CONTINUE;
         END IF;
 
+        -- The automatic creator membership, whoever holds it. Tolerated rather
+        -- than refused: it grants nothing by itself, and the credential that
+        -- created the role may be retired and unassumable, which would make
+        -- every later recovery refuse before touching a tenant.
+        IF EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_auth_members AS membership
+            WHERE membership.roleid = membership_row.granted_oid
+              AND membership.member = membership_row.member_oid
+        ) AND NOT EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_auth_members AS membership
+            WHERE membership.roleid = membership_row.granted_oid
+              AND membership.member = membership_row.member_oid
+              AND NOT {_MEMBERSHIP_CREATOR_SHAPE}
+        ) THEN
+            CONTINUE;
+        END IF;
+
         direct_membership_unsafe := membership_row.membership_admin;
         IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
             -- bool_or, not a bare SELECT INTO: PostgreSQL keeps one row per
@@ -361,6 +396,14 @@ BEGIN
     -- A reserved role being a member OF another role creates an escalation
     -- path.  Only the three SET-only/maintenance roles may be upstream members
     -- of strictly named per-tenant roles.
+    --
+    -- The edge's *options* are deliberately not judged here, and neither is
+    -- whether catalog.tenants still has the tenant. Roles are cluster objects
+    -- and this table is not: in a cluster hosting more than one GeoLens
+    -- database — which the downgrade note below assumes — every other
+    -- database's live tenant roles look orphaned from here, and refusing them
+    -- would make each database unadoptable from the others' existence. The
+    -- per-tenant checks own that judgement for the tenants of this database.
     FOR membership_row IN
         SELECT member_role.rolname AS member_name,
                upstream_role.rolname AS upstream_name,
@@ -397,24 +440,6 @@ BEGIN
            OR membership_row.rolinherit
            OR membership_row.rolreplication
            OR membership_row.rolbypassrls
-           -- An orphan: a role carrying the per-tenant naming pattern with no
-           -- row in catalog.tenants. Nothing per-tenant reaches it — adoption
-           -- iterates catalog.tenants — so whatever objects it still owns are
-           -- outside the boundary entirely, and any edge from a gateway is a
-           -- live path to them. Refused whatever its options are; a live
-           -- tenant's roles are checked per tenant instead.
-           OR (
-               NOT EXISTS (
-                   SELECT 1 FROM catalog.tenants
-                   WHERE id::text = pg_catalog.replace(
-                       pg_catalog.substring(
-                           membership_row.upstream_name, '_t_(.*)$'
-                       ),
-                       '_',
-                       '-'
-                   )
-               )
-           )
            OR EXISTS (
                SELECT 1
                FROM pg_catalog.pg_auth_members AS chained
@@ -495,8 +520,18 @@ BEGIN
             'which PostgreSQL requires to give it ownership of the tenant '
             'boundary functions', CURRENT_USER
             USING HINT =
-                'run GRANT {PROVISIONER} TO "' || CURRENT_USER ||
-                '" WITH INHERIT TRUE, or adopt with a superuser migrator';
+                CASE
+                    WHEN pg_catalog.current_setting('server_version_num')::integer
+                         >= 160000
+                    THEN 'run GRANT {PROVISIONER} TO ' ||
+                         pg_catalog.quote_ident(CURRENT_USER) ||
+                         ' WITH INHERIT TRUE'
+                    ELSE 'run GRANT {PROVISIONER} TO ' ||
+                         pg_catalog.quote_ident(CURRENT_USER) ||
+                         ' (before PostgreSQL 16 there are no per-membership '
+                         'options; if that role is NOINHERIT, ALTER ROLE ' ||
+                         pg_catalog.quote_ident(CURRENT_USER) || ' INHERIT too)'
+                END || ', or adopt with a superuser migrator';
     END IF;
 
     IF NOT pg_catalog.has_schema_privilege('{PROVISIONER}', 'catalog', 'CREATE') THEN
@@ -584,7 +619,7 @@ BEGIN
           ON granted_role.oid = membership.roleid
         JOIN pg_catalog.pg_roles AS member_role
           ON member_role.oid = membership.member
-        JOIN pg_catalog.pg_roles AS grantor_role
+        LEFT JOIN pg_catalog.pg_roles AS grantor_role
           ON grantor_role.oid = membership.grantor
         WHERE granted_role.rolname = '{PROVISIONER}'
           AND member_role.rolname = CURRENT_USER
@@ -610,49 +645,6 @@ END
 $$
 """
 
-#: The gateway half, which needs no such flag: it targets the automatic creator
-#: shape only, and that shape is never something an operator sets up to use.
-RELEASE_GATEWAY_EDGES_SQL = f"""
-DO $$
-DECLARE
-    group_name text;
-BEGIN
-    -- The four gateways get the same automatic creator membership, and nothing
-    -- in this tool ever needs it: the provisioning function grants tenant roles
-    -- TO the gateways using ADMIN on the *tenant* role, not on the gateway.
-    -- Left behind, each one is a landmine for the next recovery.
-    --
-    -- Only edges with the automatic creator's exact shape — ADMIN, and neither
-    -- INHERIT nor SET — and only on 16+, which is the only place that shape is
-    -- created. Before 16 there is no automatic membership at all, so any edge
-    -- there is somebody's decision and stays. An operator who wants the
-    -- migrator to *use* a gateway grants it usably, which this leaves alone.
-    IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
-        FOREACH group_name IN ARRAY ARRAY[
-            '{CONTROL}', '{WRITER}', '{SANDBOX}', '{TILE}'
-        ] LOOP
-            IF EXISTS (
-                SELECT 1
-                FROM pg_catalog.pg_auth_members AS membership
-                JOIN pg_catalog.pg_roles AS granted_role
-                  ON granted_role.oid = membership.roleid
-                JOIN pg_catalog.pg_roles AS member_role
-                  ON member_role.oid = membership.member
-                WHERE granted_role.rolname = group_name
-                  AND member_role.rolname = CURRENT_USER
-                  AND {_MEMBERSHIP_ADMIN_ONLY}
-            ) THEN
-                EXECUTE pg_catalog.format(
-                    'REVOKE %I FROM %I', group_name, CURRENT_USER
-                );
-            END IF;
-        END LOOP;
-    END IF;
-END
-$$
-"""
-
-#: The grant-option counterpart, because a re-GRANT leaves one in place.
 PROVISIONER_DATABASE_REVOKE_OPTION_SQL = f"""
 DO $$
 BEGIN
@@ -709,6 +701,23 @@ BEGIN
     reader_name := 'geolens_reader_t_' || pg_catalog.replace(tenant_id::text, '-', '_');
     writer_name := 'geolens_writer_t_' || pg_catalog.replace(tenant_id::text, '-', '_');
 
+    -- Every ownership transfer below takes ACCESS EXCLUSIVE, and one
+    -- forgotten session — a tile login, a stray psql, provider maintenance —
+    -- would otherwise queue this transaction and everything behind it for as
+    -- long as it holds on. Failing fast makes it one retryable tenant instead.
+    SET LOCAL lock_timeout = '15s';
+    SET LOCAL statement_timeout = '30min';
+
+    -- The same lock 0019's provisioning and deprovisioning functions take as
+    -- their first act. Taken here too, because everything this block decides is
+    -- read before that function is called, and an unlocked read can race a live
+    -- provisioning of the same tenant.
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+        pg_catalog.hashtextextended(
+            'geolens:tenant-data-plane:' || tenant_id::text, 0
+        )
+    );
+
     PERFORM 1 FROM catalog.tenants WHERE id = tenant_id;
     IF NOT FOUND THEN
         RAISE EXCEPTION 'tenant % does not exist', tenant_id
@@ -735,9 +744,9 @@ BEGIN
     END IF;
 
     -- The pre-0019 runtime helper created readers with the default INHERIT
-    -- flag, an automatic creator membership, and an ALTER DEFAULT PRIVILEGES
-    -- entry.  Normalize that known legacy shape before the strict provision
-    -- function validates the role.
+    -- flag.  That one is normalized; the other two shapes it left — an
+    -- automatic creator membership and an ALTER DEFAULT PRIVILEGES entry — are
+    -- somebody else's grants, so they are refused further down instead.
     SELECT * INTO writer_row
     FROM pg_catalog.pg_roles
     WHERE rolname = writer_name;
@@ -832,15 +841,19 @@ BEGIN
     -- operator and a re-run.
     FOR legacy_member_row IN
         SELECT member_role.rolname AS member_name,
-               grantor_role.rolname AS grantor_name
+               COALESCE(grantor_role.rolname, 'a dropped role') AS grantor_name
         FROM pg_catalog.pg_auth_members AS membership
         JOIN pg_catalog.pg_roles AS granted_role
           ON granted_role.oid = membership.roleid
         JOIN pg_catalog.pg_roles AS member_role
           ON member_role.oid = membership.member
-        JOIN pg_catalog.pg_roles AS grantor_role
+        LEFT JOIN pg_catalog.pg_roles AS grantor_role
           ON grantor_role.oid = membership.grantor
         WHERE granted_role.rolname = reader_name
+          -- The automatic creator membership is tolerated here for the same
+          -- reason the cluster guard tolerates it: nobody can revoke it, and it
+          -- confers nothing.
+          AND NOT {_MEMBERSHIP_CREATOR_SHAPE}
           AND (
               member_role.rolname NOT IN ('{PROVISIONER}', '{SANDBOX}', '{TILE}')
               OR (
@@ -856,10 +869,14 @@ BEGIN
             legacy_member_row.member_name,
             legacy_member_row.grantor_name
             USING HINT =
-                'as ' || legacy_member_row.grantor_name ||
-                ' (or a role that can assume it) run: REVOKE ' || reader_name ||
-                ' FROM ' || legacy_member_row.member_name ||
-                ' CASCADE; then re-run adoption';
+                'as ' || pg_catalog.quote_ident(legacy_member_row.grantor_name) ||
+                ' run: REVOKE ' || pg_catalog.quote_ident(reader_name) ||
+                ' FROM ' || pg_catalog.quote_ident(legacy_member_row.member_name) ||
+                ' CASCADE. If that role is gone or cannot be assumed — a '
+                'retired managed credential, say — DROP ROLE ' ||
+                pg_catalog.quote_ident(reader_name) ||
+                ' instead: after the ownership transfer it owns nothing, and '
+                'provisioning recreates it. Then re-run adoption';
     END LOOP;
 
     -- Detect, do not rewrite.  Every row here predates this run: a restore, a
@@ -871,15 +888,19 @@ BEGIN
     -- operator and a re-run.
     FOR legacy_member_row IN
         SELECT member_role.rolname AS member_name,
-               grantor_role.rolname AS grantor_name
+               COALESCE(grantor_role.rolname, 'a dropped role') AS grantor_name
         FROM pg_catalog.pg_auth_members AS membership
         JOIN pg_catalog.pg_roles AS granted_role
           ON granted_role.oid = membership.roleid
         JOIN pg_catalog.pg_roles AS member_role
           ON member_role.oid = membership.member
-        JOIN pg_catalog.pg_roles AS grantor_role
+        LEFT JOIN pg_catalog.pg_roles AS grantor_role
           ON grantor_role.oid = membership.grantor
         WHERE granted_role.rolname = writer_name
+          -- The automatic creator membership is tolerated here for the same
+          -- reason the cluster guard tolerates it: nobody can revoke it, and it
+          -- confers nothing.
+          AND NOT {_MEMBERSHIP_CREATOR_SHAPE}
           AND (
               member_role.rolname NOT IN ('{PROVISIONER}', '{WRITER}')
               OR (
@@ -895,10 +916,14 @@ BEGIN
             legacy_member_row.member_name,
             legacy_member_row.grantor_name
             USING HINT =
-                'as ' || legacy_member_row.grantor_name ||
-                ' (or a role that can assume it) run: REVOKE ' || writer_name ||
-                ' FROM ' || legacy_member_row.member_name ||
-                ' CASCADE; then re-run adoption';
+                'as ' || pg_catalog.quote_ident(legacy_member_row.grantor_name) ||
+                ' run: REVOKE ' || pg_catalog.quote_ident(writer_name) ||
+                ' FROM ' || pg_catalog.quote_ident(legacy_member_row.member_name) ||
+                ' CASCADE. If that role is gone or cannot be assumed — a '
+                'retired managed credential, say — DROP ROLE ' ||
+                pg_catalog.quote_ident(writer_name) ||
+                ' instead: after the ownership transfer it owns nothing, and '
+                'provisioning recreates it. Then re-run adoption';
     END LOOP;
 
     -- The provisioner's own duplicates, detected for the same reason and on
@@ -906,13 +931,13 @@ BEGIN
     -- take one away.
     FOR legacy_member_row IN
         SELECT granted_role.rolname AS granted_name,
-               grantor_role.rolname AS grantor_name
+               COALESCE(grantor_role.rolname, 'a dropped role') AS grantor_name
         FROM pg_catalog.pg_auth_members AS membership
         JOIN pg_catalog.pg_roles AS granted_role
           ON granted_role.oid = membership.roleid
         JOIN pg_catalog.pg_roles AS member_role
           ON member_role.oid = membership.member
-        JOIN pg_catalog.pg_roles AS grantor_role
+        LEFT JOIN pg_catalog.pg_roles AS grantor_role
           ON grantor_role.oid = membership.grantor
         WHERE granted_role.rolname IN (reader_name, writer_name)
           AND member_role.rolname = '{PROVISIONER}'
@@ -924,10 +949,13 @@ BEGIN
             legacy_member_row.granted_name,
             legacy_member_row.grantor_name
             USING HINT =
-                'as ' || legacy_member_row.grantor_name ||
-                ' (or a role that can assume it) run: REVOKE ' ||
-                legacy_member_row.granted_name || ' FROM {PROVISIONER} CASCADE; '
-                'then re-run adoption';
+                'as ' || pg_catalog.quote_ident(legacy_member_row.grantor_name) ||
+                ' run: REVOKE ' ||
+                pg_catalog.quote_ident(legacy_member_row.granted_name) ||
+                ' FROM {PROVISIONER} CASCADE. If that role is gone or cannot be '
+                'assumed, DROP ROLE ' ||
+                pg_catalog.quote_ident(legacy_member_row.granted_name) ||
+                ' instead and let provisioning recreate it. Then re-run adoption';
     END LOOP;
 
     -- The guarded boundary owns schema creation, role creation, gateway
@@ -1081,6 +1109,14 @@ BEGIN
           OR NOT pg_catalog.has_function_privilege(
               reader_name, routine.oid, 'EXECUTE'
           )
+          -- The ACL itself, not just the two effective checks above: a named
+          -- grantee or a grantable reader entry is invisible to both.
+          OR EXISTS (
+              SELECT 1
+              FROM LATERAL pg_catalog.aclexplode(routine.proacl) AS acl
+              WHERE acl.grantee NOT IN (writer_oid, reader_oid)
+                 OR (acl.grantee = reader_oid AND acl.is_grantable)
+          )
       );
 
     SELECT pg_catalog.count(*) INTO type_gap
@@ -1173,8 +1209,9 @@ BEGIN
         END IF;
     END LOOP;
 
-    IF EXISTS (
-        SELECT 1
+    FOR object_row IN
+        SELECT relation.relname AS relname,
+               owner_role.rolname AS grantee_name
         FROM pg_catalog.pg_class AS relation
         JOIN pg_catalog.pg_namespace AS namespace
           ON namespace.oid = relation.relnamespace
@@ -1182,11 +1219,24 @@ BEGIN
         WHERE namespace.nspname = schema_name
           AND relation.relkind IN ({_RELATION_KINDS})
           AND owner_role.rolname <> writer_name
-    ) THEN
+          -- Same exclusion as the transfer: a column-owned sequence follows its
+          -- table, and one owned by a column in another schema is not something
+          -- this loop can move.
+          AND NOT {_COLUMN_OWNED_SEQUENCE}
+    LOOP
         RAISE EXCEPTION
-            'tenant schema % contains relation not owned by %',
-            schema_name, writer_name;
-    END IF;
+            'tenant schema % still contains %, owned by % rather than %',
+            schema_name,
+            object_row.relname,
+            object_row.grantee_name,
+            writer_name
+            USING HINT =
+                'as ' || pg_catalog.quote_ident(object_row.grantee_name) ||
+                ' run: ALTER TABLE ' || pg_catalog.quote_ident(schema_name) ||
+                '.' || pg_catalog.quote_ident(object_row.relname) ||
+                ' OWNER TO ' || pg_catalog.quote_ident(writer_name) ||
+                '; then re-run adoption';
+    END LOOP;
 
     -- Default-privilege entries: cleared when this run can act as the role
     -- that owns them — itself, or the tenant writer whose SET edge it holds
@@ -1196,14 +1246,37 @@ BEGIN
     -- relation, so an entry here hands out privileges on relations that do not
     -- exist yet.
     FOR default_acl_row IN
-        SELECT DISTINCT owner_role.rolname AS owner_name
+        SELECT owner_role.rolname AS owner_name,
+               pg_catalog.string_agg(
+                   DISTINCT CASE default_acl.defaclobjtype
+                       WHEN 'r' THEN 'TABLES'
+                       WHEN 'S' THEN 'SEQUENCES'
+                       WHEN 'f' THEN 'FUNCTIONS'
+                       WHEN 'T' THEN 'TYPES'
+                       ELSE 'SCHEMAS'
+                   END, ', '
+               ) AS object_kinds,
+               pg_catalog.string_agg(
+                   DISTINCT CASE
+                       WHEN acl.grantee = 0 THEN 'PUBLIC'
+                       ELSE pg_catalog.quote_ident(grantee_role.rolname)
+                   END, ', '
+               ) AS grantees
         FROM pg_catalog.pg_default_acl AS default_acl
         JOIN pg_catalog.pg_roles AS owner_role
           ON owner_role.oid = default_acl.defaclrole
+        JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS acl ON true
+        LEFT JOIN pg_catalog.pg_roles AS grantee_role
+          ON grantee_role.oid = acl.grantee
         JOIN pg_catalog.pg_namespace AS namespace
           ON namespace.oid = default_acl.defaclnamespace
         WHERE namespace.nspname = schema_name
           AND owner_role.rolname NOT IN (CURRENT_USER, writer_name)
+          AND acl.grantee IS DISTINCT FROM default_acl.defaclrole
+          AND NOT (
+              acl.grantee = 0 AND default_acl.defaclobjtype IN ('f', 'T')
+          )
+        GROUP BY owner_role.rolname
     LOOP
         RAISE EXCEPTION
             'schema % carries default privileges owned by %, which this role '
@@ -1211,10 +1284,11 @@ BEGIN
             schema_name,
             default_acl_row.owner_name
             USING HINT =
-                'as ' || default_acl_row.owner_name ||
-                ' run: ALTER DEFAULT PRIVILEGES IN SCHEMA ' || schema_name ||
-                ' REVOKE ALL ON TABLES FROM PUBLIC (and the same for SEQUENCES, '
-                'FUNCTIONS, TYPES and SCHEMAS as applicable); then re-run adoption';
+                'as ' || pg_catalog.quote_ident(default_acl_row.owner_name) ||
+                ' run: ALTER DEFAULT PRIVILEGES IN SCHEMA ' ||
+                pg_catalog.quote_ident(schema_name) || ' REVOKE ALL ON ' ||
+                default_acl_row.object_kinds || ' FROM ' ||
+                default_acl_row.grantees || '; then re-run adoption';
     END LOOP;
 
     FOR default_acl_row IN
@@ -1264,6 +1338,28 @@ BEGIN
         RESET ROLE;
     END LOOP;
 
+    -- Default privileges with no schema at all apply to every schema the owner
+    -- creates in, so a tenant role carrying one seeds a stray grant on the next
+    -- table the writer makes. They belong to whoever set them.
+    FOR default_acl_row IN
+        SELECT owner_role.rolname AS owner_name
+        FROM pg_catalog.pg_default_acl AS default_acl
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = default_acl.defaclrole
+        WHERE default_acl.defaclnamespace = 0
+          AND owner_role.rolname IN (reader_name, writer_name)
+    LOOP
+        RAISE EXCEPTION
+            'role % carries schema-less default privileges, which apply to '
+            'every schema it creates in',
+            default_acl_row.owner_name
+            USING HINT =
+                'as ' || pg_catalog.quote_ident(default_acl_row.owner_name) ||
+                ' run: ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM PUBLIC '
+                '(and the same for the other object kinds and grantees shown by '
+                '\\ddp); then re-run adoption';
+    END LOOP;
+
     -- A subtractive entry — ALTER DEFAULT PRIVILEGES ... REVOKE ... FROM PUBLIC
     -- — leaves a pg_default_acl row that aclexplode has nothing to show for, so
     -- the loop above cannot reach it. Restoring the built-in default means
@@ -1307,7 +1403,14 @@ BEGIN
           -- SECURITY DEFINER is one way to run as somebody else; an untrusted
           -- language is the other, and it needs no privilege escalation to do
           -- native work inside the server. Neither is re-owned.
-          AND (routine.prosecdef OR NOT language.lanpltrusted)
+          --
+          -- prokind 'a' is an aggregate: its pg_proc row names the `internal`
+          -- pseudo-language, which is untrusted by definition and says nothing
+          -- about the transition and final functions that actually run.
+          AND (
+              routine.prosecdef
+              OR (NOT language.lanpltrusted AND routine.prokind <> 'a')
+          )
     LOOP
         RAISE EXCEPTION
             'tenant schema % contains a SECURITY DEFINER or untrusted-language '
@@ -1316,10 +1419,11 @@ BEGIN
             object_row.relname,
             object_row.relkind
             USING HINT =
-                'inspect it, then either ALTER FUNCTION ' || schema_name || '.' ||
+                'inspect it, then either ALTER ROUTINE ' || schema_name || '.' ||
                 pg_catalog.quote_ident(object_row.relname) || '(' ||
                 object_row.relkind || ') SECURITY INVOKER (if that is all that '
-                'is wrong) or DROP it; then re-run adoption';
+                'is wrong) or DROP it; then re-run adoption. ALTER ROUTINE '
+                'covers functions and procedures alike';
     END LOOP;
 
     FOR object_row IN
@@ -1399,6 +1503,35 @@ BEGIN
     EXECUTE pg_catalog.format(
         'REVOKE ALL ON ALL SEQUENCES IN SCHEMA %I FROM PUBLIC', schema_name
     );
+    -- A grant whose grantor is neither the relation's owner nor the writer
+    -- survives ALTER TABLE ... OWNER TO, which only re-attributes the old
+    -- owner's own entries — so the writer's REVOKE below would either fail on
+    -- the dependency or quietly do nothing.
+    FOR object_row IN
+        SELECT relation.relname AS relname,
+               grantor_role.rolname AS grantee_name
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        JOIN LATERAL pg_catalog.aclexplode(relation.relacl) AS acl ON true
+        JOIN pg_catalog.pg_roles AS grantor_role ON grantor_role.oid = acl.grantor
+        WHERE namespace.nspname = schema_name
+          AND grantor_role.rolname <> writer_name
+    LOOP
+        RAISE EXCEPTION
+            'relation %.% carries a grant made by %, which the writer cannot '
+            'revoke',
+            schema_name,
+            object_row.relname,
+            object_row.grantee_name
+            USING HINT =
+                'as ' || pg_catalog.quote_ident(object_row.grantee_name) ||
+                ' run: REVOKE ALL ON ' || schema_name || '.' ||
+                pg_catalog.quote_ident(object_row.relname) ||
+                ' FROM ALL CASCADE-equivalent grantees (see \\dp); '
+                'then re-run adoption';
+    END LOOP;
+
     -- Column-level grants, which the table-level REVOKE ALL above leaves in
     -- place. Emitted per column and grantee because PostgreSQL has no
     -- schema-wide form for them.
@@ -1462,6 +1595,32 @@ BEGIN
     EXECUTE pg_catalog.format(
         'REVOKE ALL ON ALL ROUTINES IN SCHEMA %I FROM PUBLIC', schema_name
     );
+    EXECUTE pg_catalog.format(
+        'REVOKE ALL ON ALL ROUTINES IN SCHEMA %I FROM %I', schema_name, reader_name
+    );
+    -- Symmetric with the relation sweep: only the writer, as owner, and the
+    -- reader belong on a tenant routine.
+    FOR grantee_name IN
+        SELECT DISTINCT
+            CASE
+                WHEN acl.grantee = 0 THEN 'PUBLIC'
+                ELSE pg_catalog.quote_ident(grantee_role.rolname)
+            END
+        FROM pg_catalog.pg_proc AS routine
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = routine.pronamespace
+        JOIN LATERAL pg_catalog.aclexplode(routine.proacl) AS acl ON true
+        LEFT JOIN pg_catalog.pg_roles AS grantee_role
+          ON grantee_role.oid = acl.grantee
+        WHERE namespace.nspname = schema_name
+          AND COALESCE(grantee_role.rolname, '') NOT IN (writer_name, reader_name)
+    LOOP
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON ALL ROUTINES IN SCHEMA %I FROM %s',
+            schema_name,
+            grantee_name
+        );
+    END LOOP;
     EXECUTE pg_catalog.format(
         'GRANT EXECUTE ON ALL ROUTINES IN SCHEMA %I TO %I', schema_name, reader_name
     );

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -403,14 +403,17 @@ BEGIN
                        '-'
                    )
                )
-               AND NOT EXISTS (
+               -- "no unsafe row", not "some safe row": PostgreSQL keeps one
+               -- row per grantor, and a canonical SET-only grant sitting beside
+               -- an INHERIT one would otherwise answer for both.
+               AND EXISTS (
                    SELECT 1
                    FROM pg_catalog.pg_auth_members AS membership
                    JOIN pg_catalog.pg_roles AS member_role
                      ON member_role.oid = membership.member
                    WHERE membership.roleid = membership_row.oid
                      AND member_role.rolname = membership_row.member_name
-                     AND CASE
+                     AND NOT CASE
                          WHEN membership_row.member_name = '{PROVISIONER}'
                          THEN {_MEMBERSHIP_ADMIN_ONLY}
                          ELSE {_MEMBERSHIP_SET_ONLY}

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -699,6 +699,7 @@ DECLARE
     reader_privilege_gap bigint;
     default_acl_gap bigint;
     routine_gap bigint;
+    type_gap bigint;
     reader_oid oid;
     writer_oid oid;
     grantee_name text;
@@ -1072,16 +1073,49 @@ BEGIN
       AND (
           owner_role.rolname <> writer_name
           OR routine.prosecdef
+          OR NOT EXISTS (
+              SELECT 1 FROM pg_catalog.pg_language AS language
+              WHERE language.oid = routine.prolang AND language.lanpltrusted
+          )
           OR pg_catalog.has_function_privilege('public', routine.oid, 'EXECUTE')
           OR NOT pg_catalog.has_function_privilege(
               reader_name, routine.oid, 'EXECUTE'
           )
       );
 
+    SELECT pg_catalog.count(*) INTO type_gap
+    FROM pg_catalog.pg_type AS type_row
+    JOIN pg_catalog.pg_namespace AS namespace
+      ON namespace.oid = type_row.typnamespace
+    JOIN pg_catalog.pg_roles AS owner_role ON owner_role.oid = type_row.typowner
+    WHERE namespace.nspname = schema_name
+      AND owner_role.rolname <> writer_name
+      -- Array types follow their element type, and a table's row type follows
+      -- the table; both move on their own. An extension's types belong to the
+      -- extension.
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_type AS element
+          WHERE element.typarray = type_row.oid
+      )
+      AND (
+          type_row.typrelid = 0
+          OR EXISTS (
+              SELECT 1 FROM pg_catalog.pg_class AS relation
+              WHERE relation.oid = type_row.typrelid AND relation.relkind = 'c'
+          )
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_type'::regclass
+            AND dependency.objid = type_row.oid
+            AND dependency.deptype = 'e'
+      );
+
     IF pending_owner_transfer = 0
        AND reader_privilege_gap = 0
        AND default_acl_gap = 0
-       AND routine_gap = 0 THEN
+       AND routine_gap = 0
+       AND type_gap = 0 THEN
         RETURN;
     END IF;
 
@@ -1268,20 +1302,24 @@ BEGIN
         FROM pg_catalog.pg_proc AS routine
         JOIN pg_catalog.pg_namespace AS namespace
           ON namespace.oid = routine.pronamespace
+        JOIN pg_catalog.pg_language AS language ON language.oid = routine.prolang
         WHERE namespace.nspname = schema_name
-          AND routine.prosecdef
+          -- SECURITY DEFINER is one way to run as somebody else; an untrusted
+          -- language is the other, and it needs no privilege escalation to do
+          -- native work inside the server. Neither is re-owned.
+          AND (routine.prosecdef OR NOT language.lanpltrusted)
     LOOP
         RAISE EXCEPTION
-            'tenant schema % contains a SECURITY DEFINER routine adoption will '
-            'not re-own: %(%)',
+            'tenant schema % contains a SECURITY DEFINER or untrusted-language '
+            'routine adoption will not re-own: %(%)',
             schema_name,
             object_row.relname,
             object_row.relkind
             USING HINT =
                 'inspect it, then either ALTER FUNCTION ' || schema_name || '.' ||
                 pg_catalog.quote_ident(object_row.relname) || '(' ||
-                object_row.relkind || ') SECURITY INVOKER or DROP it; '
-                'then re-run adoption';
+                object_row.relkind || ') SECURITY INVOKER (if that is all that '
+                'is wrong) or DROP it; then re-run adoption';
     END LOOP;
 
     FOR object_row IN
@@ -1299,6 +1337,46 @@ BEGIN
             schema_name,
             object_row.relname,
             object_row.relkind,
+            writer_name
+        );
+    END LOOP;
+
+    -- Types a tenant defined: enums, domains, ranges, standalone composites.
+    -- They are in pg_type, so the relation pass never saw them, and a writer
+    -- that cannot alter or drop one cannot replace the dataset that uses it.
+    FOR object_row IN
+        SELECT type_row.typname AS relname
+        FROM pg_catalog.pg_type AS type_row
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = type_row.typnamespace
+        JOIN pg_catalog.pg_roles AS owner_role ON owner_role.oid = type_row.typowner
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname <> writer_name
+      -- Array types follow their element type, and a table's row type follows
+      -- the table; both move on their own. An extension's types belong to the
+      -- extension.
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_type AS element
+          WHERE element.typarray = type_row.oid
+      )
+      AND (
+          type_row.typrelid = 0
+          OR EXISTS (
+              SELECT 1 FROM pg_catalog.pg_class AS relation
+              WHERE relation.oid = type_row.typrelid AND relation.relkind = 'c'
+          )
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_type'::regclass
+            AND dependency.objid = type_row.oid
+            AND dependency.deptype = 'e'
+      )
+    LOOP
+        EXECUTE pg_catalog.format(
+            'ALTER TYPE %I.%I OWNER TO %I',
+            schema_name,
+            object_row.relname,
             writer_name
         );
     END LOOP;

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -1182,6 +1182,11 @@ BEGIN
         JOIN pg_catalog.pg_namespace AS namespace
           ON namespace.oid = default_acl.defaclnamespace
         WHERE namespace.nspname = schema_name
+          -- aclexplode also returns the owner's own baseline entry. Revoking
+          -- that turns an ordinary additive default into a subtractive one,
+          -- which is a worse state than the one being cleared and which only
+          -- the owner could then reset.
+          AND acl.grantee IS DISTINCT FROM default_acl.defaclrole
     LOOP
         IF default_acl_row.owner_name <> CURRENT_USER THEN
             EXECUTE pg_catalog.format('SET ROLE %I', default_acl_row.owner_name);

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -436,6 +436,46 @@ END
 $$
 """
 
+#: Hand back the membership ``CLUSTER_ROLE_CREATE_SQL`` took when it created the
+#: provisioner on a fresh cluster.
+#:
+#: It cannot be left behind.  ``CLUSTER_ROLE_VALIDATE_SQL`` rejects *any* direct
+#: member of the provisioner except the role running it, so a later recovery
+#: with a rotated migrator credential would refuse the topology before adopting
+#: a single tenant — future recovery would depend on retaining the original
+#: credential.  A run that ends here has already used the edge for everything it
+#: needed it for; the next run either creates the role again or is told the
+#: exact ``GRANT`` to run.
+#:
+#: Only the edge this run granted: grantor ``CURRENT_USER`` and no ``ADMIN``.
+#: The automatic creator membership PostgreSQL adds has a different grantor and
+#: carries ADMIN, and an operator-established edge has a different grantor too.
+RELEASE_BOOTSTRAP_MEMBERSHIP_SQL = f"""
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_auth_members AS membership
+        JOIN pg_catalog.pg_roles AS granted_role
+          ON granted_role.oid = membership.roleid
+        JOIN pg_catalog.pg_roles AS member_role
+          ON member_role.oid = membership.member
+        JOIN pg_catalog.pg_roles AS grantor_role
+          ON grantor_role.oid = membership.grantor
+        WHERE granted_role.rolname = '{PROVISIONER}'
+          AND member_role.rolname = CURRENT_USER
+          AND grantor_role.rolname = CURRENT_USER
+          AND NOT membership.admin_option
+    ) THEN
+        EXECUTE pg_catalog.format(
+            'REVOKE {PROVISIONER} FROM %I GRANTED BY %I',
+            CURRENT_USER, CURRENT_USER
+        );
+    END IF;
+END
+$$
+"""
+
 PROVISIONER_DATABASE_GRANT_SQL = f"""
 DO $$
 BEGIN
@@ -645,6 +685,16 @@ BEGIN
     -- does NOT touch per-relation ACLs, which is why the reader grants below
     -- are issued by the writer instead of by this function.
     PERFORM catalog.provision_tenant_data_schema(tenant_id);
+
+    -- The provisioning function grants the reader USAGE; it never takes CREATE
+    -- away, and a restored schema can arrive carrying it.  The sandbox and tile
+    -- gateways SET ROLE to this reader, so CREATE there is a write path into a
+    -- schema that is supposed to be read-only.
+    IF pg_catalog.has_schema_privilege(reader_name, schema_name, 'CREATE') THEN
+        EXECUTE pg_catalog.format(
+            'REVOKE CREATE ON SCHEMA %I FROM %I', schema_name, reader_name
+        );
+    END IF;
 
     SELECT pg_catalog.count(*) INTO pending_owner_transfer
     FROM pg_catalog.pg_class AS relation

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -40,6 +40,29 @@ TENANT_GUC = "geolens.adoption_tenant_id"
 #: views, materialized views, foreign tables, sequences.
 _RELATION_KINDS = "'r', 'p', 'v', 'm', 'f', 'S'"
 
+#: The ADMIN-only membership shape the provisioning function demands: ``ADMIN``,
+#: and on PostgreSQL 16+ neither ``INHERIT`` nor ``SET``.
+#:
+#: ``admin_option`` alone is not enough to test.  A globals dump written by
+#: PostgreSQL 13-15 carries ``GRANT … WITH ADMIN OPTION``, and replaying that on
+#: 16+ lands ``SET TRUE`` — measured, not assumed — which
+#: ``provision_tenant_data_schema`` rejects as "not ADMIN-only".  Re-issuing the
+#: explicit three-option grant rewrites it in place.
+#:
+#: The options are read out of the row as jsonb because those columns arrived in
+#: 16 and GeoLens supports 13 and up (README); naming them directly would be a
+#: parse error on an older server, where ``admin_option`` is the whole story.
+_MEMBERSHIP_ADMIN_ONLY = """(
+              membership.admin_option
+              AND (
+                  NOT jsonb_exists(to_jsonb(membership), 'set_option')
+                  OR NOT (
+                      (to_jsonb(membership) ->> 'inherit_option')::boolean
+                      OR (to_jsonb(membership) ->> 'set_option')::boolean
+                  )
+              )
+          )"""
+
 #: True for a sequence a column owns — ``serial`` (dependency ``a``) or an
 #: identity column (dependency ``i``).  PostgreSQL refuses ``ALTER SEQUENCE …
 #: OWNER TO`` on those ("cannot change owner of sequence") and instead moves
@@ -527,7 +550,7 @@ BEGIN
           ON member_role.oid = membership.member
         WHERE granted_role.rolname = reader_name
           AND member_role.rolname = '{PROVISIONER}'
-          AND membership.admin_option
+          AND {_MEMBERSHIP_ADMIN_ONLY}
     ) THEN
         IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
             EXECUTE pg_catalog.format(
@@ -551,7 +574,7 @@ BEGIN
           ON member_role.oid = membership.member
         WHERE granted_role.rolname = writer_name
           AND member_role.rolname = '{PROVISIONER}'
-          AND membership.admin_option
+          AND {_MEMBERSHIP_ADMIN_ONLY}
     ) THEN
         IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
             EXECUTE pg_catalog.format(

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -1271,12 +1271,18 @@ BEGIN
     JOIN pg_catalog.pg_roles AS owner_role ON owner_role.oid = type_row.typowner
     WHERE namespace.nspname = schema_name
       AND owner_role.rolname <> writer_name
-      -- Array types follow their element type, and a table's row type follows
-      -- the table; both move on their own. An extension's types belong to the
+      -- Array types follow their element type, a table's row type follows the
+      -- table, and a range's generated multirange follows the range (14+):
+      -- all move on their own, and ALTER TYPE on the multirange directly is
+      -- refused (fix(#998 codex r46)). An extension's types belong to the
       -- extension.
       AND NOT EXISTS (
           SELECT 1 FROM pg_catalog.pg_type AS element
           WHERE element.typarray = type_row.oid
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_range AS range_type
+          WHERE range_type.rngmultitypid = type_row.oid
       )
       AND (
           type_row.typrelid = 0
@@ -1663,12 +1669,18 @@ BEGIN
         JOIN pg_catalog.pg_roles AS owner_role ON owner_role.oid = type_row.typowner
         WHERE namespace.nspname = schema_name
           AND owner_role.rolname <> writer_name
-      -- Array types follow their element type, and a table's row type follows
-      -- the table; both move on their own. An extension's types belong to the
+      -- Array types follow their element type, a table's row type follows the
+      -- table, and a range's generated multirange follows the range (14+):
+      -- all move on their own, and ALTER TYPE on the multirange directly is
+      -- refused (fix(#998 codex r46)). An extension's types belong to the
       -- extension.
       AND NOT EXISTS (
           SELECT 1 FROM pg_catalog.pg_type AS element
           WHERE element.typarray = type_row.oid
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_range AS range_type
+          WHERE range_type.rngmultitypid = type_row.oid
       )
       AND (
           type_row.typrelid = 0

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -823,12 +823,19 @@ BEGIN
           -- the sandbox and tile gateways, so any privilege beyond reading is a
           -- write path into tenant data. Read out of the ACL rather than named
           -- one by one, because the set of privilege types grows by release.
+          -- Grantee 0 is PUBLIC, which the reader holds too — along with every
+          -- other role that can reach the schema.
           OR EXISTS (
               SELECT 1
               FROM LATERAL pg_catalog.aclexplode(relation.relacl) AS acl
-              WHERE acl.grantee = reader_oid
-                AND acl.privilege_type <> 'SELECT'
-                AND NOT (relation.relkind = 'S' AND acl.privilege_type = 'USAGE')
+              WHERE acl.grantee = 0
+                 OR (
+                     acl.grantee = reader_oid
+                     AND acl.privilege_type <> 'SELECT'
+                     AND NOT (
+                         relation.relkind = 'S' AND acl.privilege_type = 'USAGE'
+                     )
+                 )
           )
       );
 
@@ -913,6 +920,14 @@ BEGIN
     );
     EXECUTE pg_catalog.format(
         'REVOKE ALL ON ALL SEQUENCES IN SCHEMA %I FROM %I', schema_name, reader_name
+    );
+    -- Tenant data is never PUBLIC, in either direction: a PUBLIC SELECT is a
+    -- cross-tenant read and a PUBLIC INSERT is a cross-tenant write.
+    EXECUTE pg_catalog.format(
+        'REVOKE ALL ON ALL TABLES IN SCHEMA %I FROM PUBLIC', schema_name
+    );
+    EXECUTE pg_catalog.format(
+        'REVOKE ALL ON ALL SEQUENCES IN SCHEMA %I FROM PUBLIC', schema_name
     );
     EXECUTE pg_catalog.format(
         'GRANT SELECT ON ALL TABLES IN SCHEMA %I TO %I', schema_name, reader_name

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -566,6 +566,32 @@ BEGIN
         END IF;
     END IF;
 
+    -- The writer's counterpart to the reader normalization above, and the same
+    -- cause: PostgreSQL 16+ grants the creating role an automatic ADMIN
+    -- membership, so a non-superuser CREATEROLE migrator that replayed the
+    -- globals dump is a direct member of every restored writer, which the
+    -- provisioning function refuses outright.
+    --
+    -- It sits *here*, after the provisioner's ADMIN grants rather than beside
+    -- the reader's loop, because that creator membership can be the only ADMIN
+    -- path this transaction has: revoking it any earlier would strand the grant
+    -- above. Afterwards the caller reaches the writer through the provisioner,
+    -- whose privileges it must hold to have got this far.
+    FOR legacy_member_row IN
+        SELECT member_role.rolname AS member_name
+        FROM pg_catalog.pg_auth_members AS membership
+        JOIN pg_catalog.pg_roles AS granted_role
+          ON granted_role.oid = membership.roleid
+        JOIN pg_catalog.pg_roles AS member_role
+          ON member_role.oid = membership.member
+        WHERE granted_role.rolname = writer_name
+          AND member_role.rolname NOT IN ('{PROVISIONER}', '{WRITER}')
+    LOOP
+        EXECUTE pg_catalog.format(
+            'REVOKE %I FROM %I', writer_name, legacy_member_row.member_name
+        );
+    END LOOP;
+
     -- The guarded boundary owns schema creation, role creation, gateway
     -- memberships, and schema-level privileges.  Since 0024 it deliberately
     -- does NOT touch per-relation ACLs, which is why the reader grants below

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -1,0 +1,585 @@
+"""DDL ported from migration 0019, runnable at the current head schema.
+
+Split out of :mod:`app.core.db.tenant_adoption` so the tool and the ported DDL
+stay separately readable — these blocks are a faithful port of
+``_create_and_validate_cluster_roles`` and
+``_adopt_and_backfill_existing_tenants`` in
+``backend/alembic/versions/0019_tenant_provisioning_boundary.py``, and they are
+reviewed against that file rather than against the surrounding Python.
+
+Historical migrations must stay self-contained, so this is a port, not an
+import.  Two deliberate divergences from 0019, both because the head schema
+moved (#998):
+
+- 0019 parked every tenant relation on the provisioner so its provisioning
+  function could rewrite their ACLs.  Migration 0024 removed that object-ACL
+  pass, so relations move straight to the per-tenant writer and the reader's
+  per-relation ``SELECT`` is granted by the writer, which is the contract
+  ingest already follows.
+- Every step is gated on the gap it closes, so an already-adopted tenant
+  issues no DDL at all.  0019 ran once, inside a migration; this runs whenever
+  an operator needs it.
+"""
+
+from __future__ import annotations
+
+#: The fixed cluster role topology installed by 0019.  Cluster roles are not
+#: carried by a database dump; on a fresh cluster they arrive from a globals
+#: dump, or from :func:`app.core.db.tenant_adoption.ensure_cluster_roles`.
+PROVISIONER = "geolens_tenant_provisioner"
+CONTROL = "geolens_tenant_control"
+WRITER = "geolens_tenant_writer"
+SANDBOX = "geolens_tenant_sandbox"
+TILE = "geolens_tile_gateway"
+
+#: Transaction-local GUC carrying the tenant id into the adoption block, so no
+#: identifier or value is ever interpolated into SQL.
+TENANT_GUC = "geolens.adoption_tenant_id"
+
+#: Relation kinds a tenant data schema can hold: tables, partitioned tables,
+#: views, materialized views, foreign tables, sequences.
+_RELATION_KINDS = "'r', 'p', 'v', 'm', 'f', 'S'"
+
+#: True for a sequence a column owns — ``serial`` (dependency ``a``) or an
+#: identity column (dependency ``i``).  PostgreSQL refuses ``ALTER SEQUENCE …
+#: OWNER TO`` on those ("cannot change owner of sequence") and instead moves
+#: them with their table, so the transfer must skip them and let the ``ALTER
+#: TABLE`` carry them.  0019 did not exclude them, which is why the ordinary
+#: ``ogr2ogr`` output of a vector ingest — every ``ogc_fid`` serial — would
+#: have stopped its adoption loop dead.
+_COLUMN_OWNED_SEQUENCE = """(
+          relation.relkind = 'S'
+          AND EXISTS (
+              SELECT 1 FROM pg_catalog.pg_depend AS dependency
+              WHERE dependency.classid = 'pg_class'::regclass
+                AND dependency.objid = relation.oid
+                AND dependency.refclassid = 'pg_class'::regclass
+                AND dependency.deptype IN ('a', 'i')
+          )
+      )"""
+
+
+# ---------------------------------------------------------------------------
+# Cluster role topology (port of 0019 ``_create_and_validate_cluster_roles``)
+# ---------------------------------------------------------------------------
+
+CLUSTER_ROLE_SQL = f"""
+DO $$
+DECLARE
+    role_row record;
+    group_name text;
+    membership_row record;
+    direct_membership_unsafe boolean;
+BEGIN
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+        pg_catalog.hashtextextended('geolens:tenant-role-bootstrap', 0)
+    );
+
+    SELECT * INTO role_row
+    FROM pg_catalog.pg_roles
+    WHERE rolname = '{PROVISIONER}';
+
+    IF NOT FOUND THEN
+        CREATE ROLE {PROVISIONER}
+            NOLOGIN NOSUPERUSER NOCREATEDB CREATEROLE NOINHERIT
+            NOREPLICATION NOBYPASSRLS;
+    ELSIF role_row.rolcanlogin
+       OR role_row.rolsuper
+       OR role_row.rolcreatedb
+       OR NOT role_row.rolcreaterole
+       OR role_row.rolinherit
+       OR role_row.rolreplication
+       OR role_row.rolbypassrls THEN
+        RAISE EXCEPTION 'existing role {PROVISIONER} has unsafe attributes';
+    END IF;
+
+    FOREACH group_name IN ARRAY ARRAY[
+        '{CONTROL}', '{WRITER}', '{SANDBOX}', '{TILE}'
+    ] LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = group_name
+        ) THEN
+            EXECUTE pg_catalog.format(
+                'CREATE ROLE %I NOLOGIN NOSUPERUSER NOCREATEDB '
+                'NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS',
+                group_name
+            );
+        END IF;
+    END LOOP;
+
+    FOR role_row IN
+        SELECT * FROM pg_catalog.pg_roles
+        WHERE rolname IN ('{CONTROL}', '{WRITER}', '{SANDBOX}', '{TILE}')
+    LOOP
+        IF role_row.rolcanlogin
+           OR role_row.rolsuper
+           OR role_row.rolcreatedb
+           OR role_row.rolcreaterole
+           OR role_row.rolinherit
+           OR role_row.rolreplication
+           OR role_row.rolbypassrls THEN
+            RAISE EXCEPTION
+                'existing role % has unsafe attributes', role_row.rolname;
+        END IF;
+    END LOOP;
+
+    IF (
+        SELECT pg_catalog.count(*)
+        FROM pg_catalog.pg_roles
+        WHERE rolname IN ('{CONTROL}', '{WRITER}', '{SANDBOX}', '{TILE}')
+    ) <> 4 THEN
+        RAISE EXCEPTION 'tenant role topology is incomplete';
+    END IF;
+
+    -- Reserved role names must not arrive with hidden privilege paths.  The
+    -- adopting role may hold the automatic ADMIN membership PostgreSQL grants
+    -- to a role creator.  Safe LOGIN members of the fixed gateways are retained
+    -- so a globals replay that restored operator-managed credentials is not
+    -- undone here.
+    FOR membership_row IN
+        SELECT granted_role.rolname AS granted_name,
+               member_role.rolname AS member_name,
+               membership.roleid AS granted_oid,
+               membership.member AS member_oid,
+               membership.admin_option AS membership_admin,
+               member_role.*
+        FROM pg_catalog.pg_auth_members AS membership
+        JOIN pg_catalog.pg_roles AS granted_role
+          ON granted_role.oid = membership.roleid
+        JOIN pg_catalog.pg_roles AS member_role
+          ON member_role.oid = membership.member
+        WHERE granted_role.rolname IN (
+            '{PROVISIONER}', '{CONTROL}', '{WRITER}', '{SANDBOX}', '{TILE}'
+        )
+    LOOP
+        IF membership_row.member_name = CURRENT_USER THEN
+            CONTINUE;
+        END IF;
+
+        direct_membership_unsafe := membership_row.membership_admin;
+        IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+            EXECUTE
+                'SELECT membership.admin_option OR CASE WHEN $3 = $4 '
+                'THEN NOT membership.inherit_option OR membership.set_option '
+                'ELSE membership.inherit_option OR NOT membership.set_option '
+                'END '
+                'FROM pg_catalog.pg_auth_members AS membership '
+                'WHERE membership.roleid = $1 AND membership.member = $2'
+                INTO direct_membership_unsafe
+                USING membership_row.granted_oid,
+                      membership_row.member_oid,
+                      membership_row.granted_name,
+                      '{CONTROL}';
+        END IF;
+
+        IF direct_membership_unsafe
+           OR membership_row.granted_name = '{PROVISIONER}'
+           OR NOT membership_row.rolcanlogin
+           OR membership_row.rolsuper
+           OR membership_row.rolcreatedb
+           OR membership_row.rolcreaterole
+           OR membership_row.rolreplication
+           OR membership_row.rolbypassrls
+           OR EXISTS (
+               SELECT 1
+               FROM pg_catalog.pg_roles AS powerful_role
+               WHERE (
+                   powerful_role.rolsuper
+                   OR powerful_role.rolcreatedb
+                   OR powerful_role.rolcreaterole
+                   OR powerful_role.rolreplication
+                   OR powerful_role.rolbypassrls
+               )
+                 AND pg_catalog.pg_has_role(
+                     membership_row.member_name, powerful_role.oid, 'MEMBER'
+                 )
+           )
+           OR (
+               membership_row.granted_name = '{TILE}'
+               AND EXISTS (
+                   SELECT 1
+                   FROM pg_catalog.pg_roles AS application_gateway
+                   WHERE application_gateway.rolname IN (
+                       '{CONTROL}', '{WRITER}', '{SANDBOX}'
+                   )
+                     AND pg_catalog.pg_has_role(
+                         membership_row.member_name,
+                         application_gateway.oid,
+                         'MEMBER'
+                     )
+               )
+           )
+           OR (
+               membership_row.granted_name IN ('{CONTROL}', '{WRITER}', '{SANDBOX}')
+               AND EXISTS (
+                   SELECT 1
+                   FROM pg_catalog.pg_roles AS tile_gateway
+                   WHERE tile_gateway.rolname = '{TILE}'
+                     AND pg_catalog.pg_has_role(
+                         membership_row.member_name, tile_gateway.oid, 'MEMBER'
+                     )
+               )
+           ) THEN
+            RAISE EXCEPTION
+                'reserved role % has unsafe direct member %',
+                membership_row.granted_name,
+                membership_row.member_name;
+        END IF;
+    END LOOP;
+
+    -- A reserved role being a member OF another role creates an escalation
+    -- path.  Only the three SET-only/maintenance roles may be upstream members
+    -- of strictly named per-tenant roles.
+    FOR membership_row IN
+        SELECT member_role.rolname AS member_name,
+               upstream_role.rolname AS upstream_name,
+               upstream_role.*
+        FROM pg_catalog.pg_auth_members AS membership
+        JOIN pg_catalog.pg_roles AS member_role
+          ON member_role.oid = membership.member
+        JOIN pg_catalog.pg_roles AS upstream_role
+          ON upstream_role.oid = membership.roleid
+        WHERE member_role.rolname IN (
+            '{PROVISIONER}', '{CONTROL}', '{WRITER}', '{SANDBOX}', '{TILE}'
+        )
+    LOOP
+        IF membership_row.member_name IN ('{CONTROL}')
+           OR (
+               membership_row.member_name IN ('{SANDBOX}', '{TILE}')
+               AND membership_row.upstream_name !~
+                   '^geolens_reader_t_[0-9a-f]{{8}}_[0-9a-f]{{4}}_[0-9a-f]{{4}}_[0-9a-f]{{4}}_[0-9a-f]{{12}}$'
+           )
+           OR (
+               membership_row.member_name = '{WRITER}'
+               AND membership_row.upstream_name !~
+                   '^geolens_writer_t_[0-9a-f]{{8}}_[0-9a-f]{{4}}_[0-9a-f]{{4}}_[0-9a-f]{{4}}_[0-9a-f]{{12}}$'
+           )
+           OR (
+               membership_row.member_name = '{PROVISIONER}'
+               AND membership_row.upstream_name !~
+                   '^geolens_(reader|writer)_t_[0-9a-f]{{8}}_[0-9a-f]{{4}}_[0-9a-f]{{4}}_[0-9a-f]{{4}}_[0-9a-f]{{12}}$'
+           )
+           OR membership_row.rolcanlogin
+           OR membership_row.rolsuper
+           OR membership_row.rolcreatedb
+           OR membership_row.rolcreaterole
+           OR membership_row.rolinherit
+           OR membership_row.rolreplication
+           OR membership_row.rolbypassrls
+           OR EXISTS (
+               SELECT 1
+               FROM pg_catalog.pg_auth_members AS chained
+               WHERE chained.member = membership_row.oid
+           ) THEN
+            RAISE EXCEPTION
+                'reserved role % has unsafe upstream membership in %',
+                membership_row.member_name,
+                membership_row.upstream_name;
+        END IF;
+    END LOOP;
+END
+$$
+"""
+
+PROVISIONER_DATABASE_GRANT_SQL = f"""
+DO $$
+BEGIN
+    EXECUTE pg_catalog.format(
+        'GRANT CREATE ON DATABASE %I TO {PROVISIONER}',
+        pg_catalog.current_database()
+    );
+END
+$$
+"""
+
+
+# ---------------------------------------------------------------------------
+# Per-tenant adoption (port of 0019 ``_adopt_and_backfill_existing_tenants``)
+# ---------------------------------------------------------------------------
+
+ADOPT_TENANT_SQL = f"""
+DO $$
+DECLARE
+    tenant_id uuid := pg_catalog.current_setting('{TENANT_GUC}')::uuid;
+    object_row record;
+    legacy_member_row record;
+    default_acl_row record;
+    schema_name text;
+    reader_name text;
+    writer_name text;
+    reader_row record;
+    reader_exists boolean;
+    writer_row record;
+    writer_exists boolean;
+    schema_owner text;
+    pending_owner_transfer bigint;
+    reader_privilege_gap bigint;
+    temporary_writer_membership boolean := false;
+BEGIN
+    schema_name := 'data_t_' || pg_catalog.replace(tenant_id::text, '-', '_');
+    reader_name := 'geolens_reader_t_' || pg_catalog.replace(tenant_id::text, '-', '_');
+    writer_name := 'geolens_writer_t_' || pg_catalog.replace(tenant_id::text, '-', '_');
+
+    PERFORM 1 FROM catalog.tenants WHERE id = tenant_id;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'tenant % does not exist', tenant_id
+            USING ERRCODE = '23503';
+    END IF;
+
+    SELECT * INTO reader_row
+    FROM pg_catalog.pg_roles
+    WHERE rolname = reader_name;
+    reader_exists := FOUND;
+    IF reader_exists AND (
+        reader_row.rolcanlogin
+        OR reader_row.rolsuper
+        OR reader_row.rolcreatedb
+        OR reader_row.rolcreaterole
+        OR reader_row.rolreplication
+        OR reader_row.rolbypassrls
+    ) THEN
+        RAISE EXCEPTION
+            'existing tenant reader role % has unsafe attributes', reader_name;
+    END IF;
+    IF reader_exists AND reader_row.rolinherit THEN
+        EXECUTE pg_catalog.format('ALTER ROLE %I NOINHERIT', reader_name);
+    END IF;
+
+    -- The pre-0019 runtime helper created readers with the default INHERIT
+    -- flag, an automatic creator membership, and an ALTER DEFAULT PRIVILEGES
+    -- entry.  Normalize that known legacy shape before the strict provision
+    -- function validates the role.
+    FOR legacy_member_row IN
+        SELECT member_role.rolname AS member_name
+        FROM pg_catalog.pg_auth_members AS membership
+        JOIN pg_catalog.pg_roles AS granted_role
+          ON granted_role.oid = membership.roleid
+        JOIN pg_catalog.pg_roles AS member_role
+          ON member_role.oid = membership.member
+        WHERE granted_role.rolname = reader_name
+          AND member_role.rolname NOT IN ('{PROVISIONER}', '{SANDBOX}', '{TILE}')
+    LOOP
+        EXECUTE pg_catalog.format(
+            'REVOKE %I FROM %I', reader_name, legacy_member_row.member_name
+        );
+    END LOOP;
+
+    FOR default_acl_row IN
+        SELECT DISTINCT owner_role.rolname AS owner_name
+        FROM pg_catalog.pg_default_acl AS default_acl
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = default_acl.defaclrole
+        JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS acl ON true
+        JOIN pg_catalog.pg_roles AS grantee_role ON grantee_role.oid = acl.grantee
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = default_acl.defaclnamespace
+        WHERE namespace.nspname = schema_name
+          AND default_acl.defaclobjtype = 'r'
+          AND grantee_role.rolname = reader_name
+    LOOP
+        EXECUTE pg_catalog.format(
+            'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I '
+            'REVOKE ALL ON TABLES FROM %I',
+            default_acl_row.owner_name, schema_name, reader_name
+        );
+    END LOOP;
+
+    SELECT * INTO writer_row
+    FROM pg_catalog.pg_roles
+    WHERE rolname = writer_name;
+    writer_exists := FOUND;
+    IF writer_exists AND (
+        writer_row.rolcanlogin
+        OR writer_row.rolsuper
+        OR writer_row.rolcreatedb
+        OR writer_row.rolcreaterole
+        OR writer_row.rolinherit
+        OR writer_row.rolreplication
+        OR writer_row.rolbypassrls
+    ) THEN
+        RAISE EXCEPTION
+            'existing tenant writer role % has unsafe attributes', writer_name;
+    END IF;
+
+    SELECT owner_role.rolname INTO schema_owner
+    FROM pg_catalog.pg_namespace AS namespace
+    JOIN pg_catalog.pg_roles AS owner_role ON owner_role.oid = namespace.nspowner
+    WHERE namespace.nspname = schema_name;
+    IF schema_owner IS NOT NULL AND schema_owner <> '{PROVISIONER}' THEN
+        EXECUTE pg_catalog.format(
+            'ALTER SCHEMA %I OWNER TO {PROVISIONER}', schema_name
+        );
+    END IF;
+
+    IF reader_exists AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_auth_members AS membership
+        JOIN pg_catalog.pg_roles AS granted_role
+          ON granted_role.oid = membership.roleid
+        JOIN pg_catalog.pg_roles AS member_role
+          ON member_role.oid = membership.member
+        WHERE granted_role.rolname = reader_name
+          AND member_role.rolname = '{PROVISIONER}'
+          AND membership.admin_option
+    ) THEN
+        IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+            EXECUTE pg_catalog.format(
+                'GRANT %I TO {PROVISIONER} '
+                'WITH ADMIN TRUE, INHERIT FALSE, SET FALSE',
+                reader_name
+            );
+        ELSE
+            EXECUTE pg_catalog.format(
+                'GRANT %I TO {PROVISIONER} WITH ADMIN OPTION', reader_name
+            );
+        END IF;
+    END IF;
+
+    IF writer_exists AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_auth_members AS membership
+        JOIN pg_catalog.pg_roles AS granted_role
+          ON granted_role.oid = membership.roleid
+        JOIN pg_catalog.pg_roles AS member_role
+          ON member_role.oid = membership.member
+        WHERE granted_role.rolname = writer_name
+          AND member_role.rolname = '{PROVISIONER}'
+          AND membership.admin_option
+    ) THEN
+        IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+            EXECUTE pg_catalog.format(
+                'GRANT %I TO {PROVISIONER} '
+                'WITH ADMIN TRUE, INHERIT FALSE, SET FALSE',
+                writer_name
+            );
+        ELSE
+            EXECUTE pg_catalog.format(
+                'GRANT %I TO {PROVISIONER} WITH ADMIN OPTION', writer_name
+            );
+        END IF;
+    END IF;
+
+    -- The guarded boundary owns schema creation, role creation, gateway
+    -- memberships, and schema-level privileges.  Since 0024 it deliberately
+    -- does NOT touch per-relation ACLs, which is why the reader grants below
+    -- are issued by the writer instead of by this function.
+    PERFORM catalog.provision_tenant_data_schema(tenant_id);
+
+    SELECT pg_catalog.count(*) INTO pending_owner_transfer
+    FROM pg_catalog.pg_class AS relation
+    JOIN pg_catalog.pg_namespace AS namespace
+      ON namespace.oid = relation.relnamespace
+    JOIN pg_catalog.pg_roles AS owner_role ON owner_role.oid = relation.relowner
+    WHERE namespace.nspname = schema_name
+      AND relation.relkind IN ({_RELATION_KINDS})
+      AND owner_role.rolname <> writer_name
+      AND NOT {_COLUMN_OWNED_SEQUENCE};
+
+    SELECT pg_catalog.count(*) INTO reader_privilege_gap
+    FROM pg_catalog.pg_class AS relation
+    JOIN pg_catalog.pg_namespace AS namespace
+      ON namespace.oid = relation.relnamespace
+    WHERE namespace.nspname = schema_name
+      AND (
+          (
+              relation.relkind IN ('r', 'p', 'v', 'm', 'f')
+              AND NOT pg_catalog.has_table_privilege(
+                  reader_name, relation.oid, 'SELECT'
+              )
+          )
+          OR (
+              relation.relkind = 'S'
+              AND NOT pg_catalog.has_sequence_privilege(
+                  reader_name, relation.oid, 'SELECT'
+              )
+          )
+      );
+
+    -- Nothing to move and nothing to grant: an already-adopted tenant issues
+    -- zero DDL here, which is what makes a re-run a genuine no-op.
+    IF pending_owner_transfer = 0 AND reader_privilege_gap = 0 THEN
+        RETURN;
+    END IF;
+
+    -- Restored tenant relations are owned by whoever ran pg_restore.  A GRANT
+    -- is not enough: owner-only ALTER/DROP has to follow the per-tenant writer,
+    -- and the reader's SELECT has to be granted by that same owner.  The
+    -- adopting login takes a transaction-scoped SET edge for exactly that, and
+    -- gives it back before commit.
+    temporary_writer_membership := NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_auth_members AS membership
+        JOIN pg_catalog.pg_roles AS granted_role
+          ON granted_role.oid = membership.roleid
+        JOIN pg_catalog.pg_roles AS member_role
+          ON member_role.oid = membership.member
+        WHERE granted_role.rolname = writer_name
+          AND member_role.rolname = CURRENT_USER
+    );
+    IF temporary_writer_membership THEN
+        IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+            EXECUTE pg_catalog.format(
+                'GRANT %I TO %I WITH INHERIT FALSE, SET TRUE',
+                writer_name, CURRENT_USER
+            );
+        ELSE
+            EXECUTE pg_catalog.format('GRANT %I TO %I', writer_name, CURRENT_USER);
+        END IF;
+    END IF;
+
+    FOR object_row IN
+        SELECT relation.relname, relation.relkind
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        JOIN pg_catalog.pg_roles AS owner_role ON owner_role.oid = relation.relowner
+        WHERE namespace.nspname = schema_name
+          AND relation.relkind IN ({_RELATION_KINDS})
+          AND owner_role.rolname <> writer_name
+          AND NOT {_COLUMN_OWNED_SEQUENCE}
+        ORDER BY relation.relkind, relation.relname
+    LOOP
+        IF object_row.relkind = 'S' THEN
+            EXECUTE pg_catalog.format(
+                'ALTER SEQUENCE %I.%I OWNER TO %I',
+                schema_name, object_row.relname, writer_name
+            );
+        ELSE
+            EXECUTE pg_catalog.format(
+                'ALTER TABLE %I.%I OWNER TO %I',
+                schema_name, object_row.relname, writer_name
+            );
+        END IF;
+    END LOOP;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        JOIN pg_catalog.pg_roles AS owner_role ON owner_role.oid = relation.relowner
+        WHERE namespace.nspname = schema_name
+          AND relation.relkind IN ({_RELATION_KINDS})
+          AND owner_role.rolname <> writer_name
+    ) THEN
+        RAISE EXCEPTION
+            'tenant schema % contains relation not owned by %',
+            schema_name, writer_name;
+    END IF;
+
+    EXECUTE pg_catalog.format('SET ROLE %I', writer_name);
+    EXECUTE pg_catalog.format(
+        'GRANT SELECT ON ALL TABLES IN SCHEMA %I TO %I', schema_name, reader_name
+    );
+    EXECUTE pg_catalog.format(
+        'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO %I',
+        schema_name, reader_name
+    );
+    RESET ROLE;
+
+    IF temporary_writer_membership THEN
+        EXECUTE pg_catalog.format('REVOKE %I FROM %I', writer_name, CURRENT_USER);
+    END IF;
+END
+$$
+"""

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -854,6 +854,7 @@ DECLARE
     default_acl_gap bigint;
     routine_gap bigint;
     type_gap bigint;
+    statistics_gap bigint;
     foreign_grantor_gap bigint;
     global_default_acl_gap bigint;
     reader_oid oid;
@@ -1043,8 +1044,11 @@ BEGIN
                 ' CASCADE. If that role is gone or cannot be assumed — a '
                 'retired managed credential, say — DROP ROLE ' ||
                 pg_catalog.quote_ident(reader_name) ||
-                ' instead: after the ownership transfer it owns nothing, and '
-                'provisioning recreates it. Then re-run adoption';
+                ' instead — first REASSIGN OWNED BY it TO CURRENT_USER and '
+                'DROP OWNED BY it (an adopted tenant''s roles hold objects '
+                'and privileges that block a bare DROP ROLE; adoption takes '
+                'them back), then DROP ROLE: provisioning recreates it. Then '
+                're-run adoption';
     END LOOP;
 
     -- Detect, do not rewrite.  Every row here predates this run: a restore, a
@@ -1086,8 +1090,11 @@ BEGIN
                 ' CASCADE. If that role is gone or cannot be assumed — a '
                 'retired managed credential, say — DROP ROLE ' ||
                 pg_catalog.quote_ident(writer_name) ||
-                ' instead: after the ownership transfer it owns nothing, and '
-                'provisioning recreates it. Then re-run adoption';
+                ' instead — first REASSIGN OWNED BY it TO CURRENT_USER and '
+                'DROP OWNED BY it (an adopted tenant''s roles hold objects '
+                'and privileges that block a bare DROP ROLE; adoption takes '
+                'them back), then DROP ROLE: provisioning recreates it. Then '
+                're-run adoption';
     END LOOP;
 
     -- The provisioner's own duplicates, detected for the same reason and on
@@ -1287,6 +1294,24 @@ BEGIN
           )
       );
 
+    -- fix(#998 codex r48): extended statistics are schema objects with an
+    -- owner of their own; a restore leaves them under the restore login and
+    -- the writer can neither ALTER nor DROP them.
+    SELECT pg_catalog.count(*) INTO statistics_gap
+    FROM pg_catalog.pg_statistic_ext AS statistics_row
+    JOIN pg_catalog.pg_namespace AS namespace
+      ON namespace.oid = statistics_row.stxnamespace
+    JOIN pg_catalog.pg_roles AS owner_role
+      ON owner_role.oid = statistics_row.stxowner
+    WHERE namespace.nspname = schema_name
+      AND owner_role.rolname <> writer_name
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_statistic_ext'::regclass
+            AND dependency.objid = statistics_row.oid
+            AND dependency.deptype = 'e'
+      );
+
     SELECT pg_catalog.count(*) INTO type_gap
     FROM pg_catalog.pg_type AS type_row
     JOIN pg_catalog.pg_namespace AS namespace
@@ -1383,6 +1408,7 @@ BEGIN
        AND default_acl_gap = 0
        AND routine_gap = 0
        AND type_gap = 0
+       AND statistics_gap = 0
        AND foreign_grantor_gap = 0
        AND global_default_acl_gap = 0 THEN
         RETURN;
@@ -1733,6 +1759,32 @@ BEGIN
     LOOP
         EXECUTE pg_catalog.format(
             'ALTER TYPE %I.%I OWNER TO %I',
+            schema_name,
+            object_row.relname,
+            writer_name
+        );
+    END LOOP;
+
+    -- fix(#998 codex r48): extended statistics, same terms as the types
+    -- above — restore-owned, and the writer cannot ALTER or DROP them.
+    FOR object_row IN
+        SELECT statistics_row.stxname AS relname
+        FROM pg_catalog.pg_statistic_ext AS statistics_row
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = statistics_row.stxnamespace
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = statistics_row.stxowner
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname <> writer_name
+          AND NOT EXISTS (
+              SELECT 1 FROM pg_catalog.pg_depend AS dependency
+              WHERE dependency.classid = 'pg_statistic_ext'::regclass
+                AND dependency.objid = statistics_row.oid
+                AND dependency.deptype = 'e'
+          )
+    LOOP
+        EXECUTE pg_catalog.format(
+            'ALTER STATISTICS %I.%I OWNER TO %I',
             schema_name,
             object_row.relname,
             writer_name

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -989,6 +989,17 @@ BEGIN
           -- other role that can reach the schema. And a named role with its own
           -- grant plus USAGE on the schema reads or writes tenant data without
           -- going near either tenant role.
+          -- Column grants live in pg_attribute, not pg_class, and a table-level
+          -- REVOKE ALL does not clear them. UPDATE(col) on the reader is a
+          -- write path through the gateways that SET ROLE to it.
+          OR EXISTS (
+              SELECT 1
+              FROM pg_catalog.pg_attribute AS column_row
+              JOIN LATERAL pg_catalog.aclexplode(column_row.attacl) AS acl ON true
+              WHERE column_row.attrelid = relation.oid
+                AND NOT column_row.attisdropped
+                AND acl.grantee <> writer_oid
+          )
           OR EXISTS (
               SELECT 1
               FROM LATERAL pg_catalog.aclexplode(relation.relacl) AS acl
@@ -1097,6 +1108,37 @@ BEGIN
     EXECUTE pg_catalog.format(
         'REVOKE ALL ON ALL SEQUENCES IN SCHEMA %I FROM PUBLIC', schema_name
     );
+    -- Column-level grants, which the table-level REVOKE ALL above leaves in
+    -- place. Emitted per column and grantee because PostgreSQL has no
+    -- schema-wide form for them.
+    FOR object_row IN
+        SELECT relation.relname AS relname,
+               column_row.attname AS attname,
+               CASE
+                   WHEN acl.grantee = 0 THEN 'PUBLIC'
+                   ELSE pg_catalog.quote_ident(grantee_role.rolname)
+               END AS grantee_name
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        JOIN pg_catalog.pg_attribute AS column_row
+          ON column_row.attrelid = relation.oid
+        JOIN LATERAL pg_catalog.aclexplode(column_row.attacl) AS acl ON true
+        LEFT JOIN pg_catalog.pg_roles AS grantee_role
+          ON grantee_role.oid = acl.grantee
+        WHERE namespace.nspname = schema_name
+          AND NOT column_row.attisdropped
+          AND COALESCE(grantee_role.rolname, '') <> writer_name
+    LOOP
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL (%I) ON %I.%I FROM %s',
+            object_row.attname,
+            schema_name,
+            object_row.relname,
+            object_row.grantee_name
+        );
+    END LOOP;
+
     -- And every other grantee the restore carried in. Only the writer (as
     -- owner) and the reader belong on a tenant relation.
     FOR grantee_name IN

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -1182,11 +1182,17 @@ BEGIN
         JOIN pg_catalog.pg_namespace AS namespace
           ON namespace.oid = default_acl.defaclnamespace
         WHERE namespace.nspname = schema_name
-          -- aclexplode also returns the owner's own baseline entry. Revoking
-          -- that turns an ordinary additive default into a subtractive one,
-          -- which is a worse state than the one being cleared and which only
-          -- the owner could then reset.
+          -- aclexplode also returns the entries PostgreSQL puts there itself:
+          -- the owner's own privileges on every object kind, and PUBLIC's
+          -- EXECUTE on functions and USAGE on types. Revoking one of those
+          -- turns an ordinary additive default into a subtractive one, which is
+          -- a worse state than the one being cleared and which only the owner
+          -- could then reset. Functions and types have no other privilege to
+          -- carry, so skipping PUBLIC entirely for them is exact.
           AND acl.grantee IS DISTINCT FROM default_acl.defaclrole
+          AND NOT (
+              acl.grantee = 0 AND default_acl.defaclobjtype IN ('f', 'T')
+          )
     LOOP
         IF default_acl_row.owner_name <> CURRENT_USER THEN
             EXECUTE pg_catalog.format('SET ROLE %I', default_acl_row.owner_name);

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -737,21 +737,6 @@ BEGIN
     -- flag, an automatic creator membership, and an ALTER DEFAULT PRIVILEGES
     -- entry.  Normalize that known legacy shape before the strict provision
     -- function validates the role.
-    FOR legacy_member_row IN
-        SELECT member_role.rolname AS member_name
-        FROM pg_catalog.pg_auth_members AS membership
-        JOIN pg_catalog.pg_roles AS granted_role
-          ON granted_role.oid = membership.roleid
-        JOIN pg_catalog.pg_roles AS member_role
-          ON member_role.oid = membership.member
-        WHERE granted_role.rolname = reader_name
-          AND member_role.rolname NOT IN ('{PROVISIONER}', '{SANDBOX}', '{TILE}')
-    LOOP
-        EXECUTE pg_catalog.format(
-            'REVOKE %I FROM %I', reader_name, legacy_member_row.member_name
-        );
-    END LOOP;
-
     -- Every default-privilege entry in the schema, for any object kind and any
     -- grantee — not just the reader's, which is only the shape the pre-0019
     -- runtime helper happened to leave. The contract inside a tenant schema is
@@ -864,17 +849,31 @@ BEGIN
         END IF;
     END IF;
 
-    -- The writer's counterpart to the reader normalization above, and the same
-    -- cause: PostgreSQL 16+ grants the creating role an automatic ADMIN
-    -- membership, so a non-superuser CREATEROLE migrator that replayed the
-    -- globals dump is a direct member of every restored writer, which the
+    -- Both tenant roles' member lists, normalized together and here rather than
+    -- earlier: PostgreSQL 16+ grants the creating role an automatic ADMIN
+    -- membership, so a non-superuser migrator that replayed the globals dump is
+    -- a direct member of every restored reader and writer, which the
     -- provisioning function refuses outright.
     --
-    -- It sits *here*, after the provisioner's ADMIN grants rather than beside
-    -- the reader's loop, because that creator membership can be the only ADMIN
-    -- path this transaction has: revoking it any earlier would strand the grant
-    -- above. Afterwards the caller reaches the writer through the provisioner,
-    -- whose privileges it must hold to have got this far.
+    -- That creator membership can also be the only ADMIN path this transaction
+    -- has, which is why the revokes wait until after the provisioner has its own
+    -- ADMIN above. Afterwards the caller reaches both roles through the
+    -- provisioner, whose privileges it must hold to have got this far.
+    FOR legacy_member_row IN
+        SELECT member_role.rolname AS member_name
+        FROM pg_catalog.pg_auth_members AS membership
+        JOIN pg_catalog.pg_roles AS granted_role
+          ON granted_role.oid = membership.roleid
+        JOIN pg_catalog.pg_roles AS member_role
+          ON member_role.oid = membership.member
+        WHERE granted_role.rolname = reader_name
+          AND member_role.rolname NOT IN ('{PROVISIONER}', '{SANDBOX}', '{TILE}')
+    LOOP
+        EXECUTE pg_catalog.format(
+            'REVOKE %I FROM %I', reader_name, legacy_member_row.member_name
+        );
+    END LOOP;
+
     FOR legacy_member_row IN
         SELECT member_role.rolname AS member_name
         FROM pg_catalog.pg_auth_members AS membership

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -493,8 +493,11 @@ END
 $$
 """
 
-#: Hand back every membership in the five fixed roles that a fresh-cluster run
-#: leaves on the migrator, keeping only the one it needs to come back.
+#: Hand back the usable provisioner edge this run took, if it took one.
+#:
+#: Gated by the caller on whether the run actually acquired it: an operator on
+#: PostgreSQL 13-15 may have granted the migrator this same shape by hand before
+#: recovery, and revoking somebody else's grant is not this tool's business.
 #:
 #: ``CLUSTER_ROLE_VALIDATE_SQL`` rejects *any* direct member of these roles
 #: except the role running it, so anything left here makes the next recovery
@@ -509,10 +512,8 @@ $$
 #: re-grant by hand after every recovery.  What goes is the usable edge this run
 #: granted (grantor ``CURRENT_USER``, no ``ADMIN``) and the gateway memberships,
 #: which nothing in this tool ever reads.
-RELEASE_BOOTSTRAP_MEMBERSHIP_SQL = f"""
+RELEASE_PROVISIONER_EDGE_SQL = f"""
 DO $$
-DECLARE
-    group_name text;
 BEGIN
     IF EXISTS (
         SELECT 1
@@ -532,7 +533,17 @@ BEGIN
             'REVOKE {PROVISIONER} FROM %I GRANTED BY %I', CURRENT_USER, CURRENT_USER
         );
     END IF;
+END
+$$
+"""
 
+#: The gateway half, which needs no such flag: it targets the automatic creator
+#: shape only, and that shape is never something an operator sets up to use.
+RELEASE_GATEWAY_EDGES_SQL = f"""
+DO $$
+DECLARE
+    group_name text;
+BEGIN
     -- The four gateways get the same automatic creator membership, and nothing
     -- in this tool ever needs it: the provisioning function grants tenant roles
     -- TO the gateways using ADMIN on the *tenant* role, not on the gateway.
@@ -602,6 +613,8 @@ DECLARE
     pending_owner_transfer bigint;
     reader_privilege_gap bigint;
     reader_oid oid;
+    writer_oid oid;
+    grantee_name text;
     temporary_writer_membership boolean := false;
 BEGIN
     schema_name := 'data_t_' || pg_catalog.replace(tenant_id::text, '-', '_');
@@ -780,6 +793,7 @@ BEGIN
     PERFORM catalog.provision_tenant_data_schema(tenant_id);
 
     SELECT oid INTO reader_oid FROM pg_catalog.pg_roles WHERE rolname = reader_name;
+    SELECT oid INTO writer_oid FROM pg_catalog.pg_roles WHERE rolname = writer_name;
 
     -- The provisioning function grants the reader USAGE; it never takes CREATE
     -- away, and a restored schema can arrive carrying it.  The sandbox and tile
@@ -824,11 +838,13 @@ BEGIN
           -- write path into tenant data. Read out of the ACL rather than named
           -- one by one, because the set of privilege types grows by release.
           -- Grantee 0 is PUBLIC, which the reader holds too — along with every
-          -- other role that can reach the schema.
+          -- other role that can reach the schema. And a named role with its own
+          -- grant plus USAGE on the schema reads or writes tenant data without
+          -- going near either tenant role.
           OR EXISTS (
               SELECT 1
               FROM LATERAL pg_catalog.aclexplode(relation.relacl) AS acl
-              WHERE acl.grantee = 0
+              WHERE acl.grantee NOT IN (writer_oid, reader_oid)
                  OR (
                      acl.grantee = reader_oid
                      AND acl.privilege_type <> 'SELECT'
@@ -889,6 +905,9 @@ BEGIN
                 schema_name, object_row.relname, writer_name
             );
         ELSE
+            -- ALTER TABLE ... OWNER TO is the right statement for every other
+            -- kind here, views and materialized views included: PostgreSQL
+            -- accepts it for relkind v/m/f as well as r/p (measured on 18).
             EXECUTE pg_catalog.format(
                 'ALTER TABLE %I.%I OWNER TO %I',
                 schema_name, object_row.relname, writer_name
@@ -929,6 +948,28 @@ BEGIN
     EXECUTE pg_catalog.format(
         'REVOKE ALL ON ALL SEQUENCES IN SCHEMA %I FROM PUBLIC', schema_name
     );
+    -- And every other grantee the restore carried in. Only the writer (as
+    -- owner) and the reader belong on a tenant relation.
+    FOR grantee_name IN
+        SELECT DISTINCT grantee_role.rolname
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        JOIN LATERAL pg_catalog.aclexplode(relation.relacl) AS acl ON true
+        JOIN pg_catalog.pg_roles AS grantee_role ON grantee_role.oid = acl.grantee
+        WHERE namespace.nspname = schema_name
+          AND relation.relkind IN ({_RELATION_KINDS})
+          AND grantee_role.rolname NOT IN (writer_name, reader_name)
+    LOOP
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON ALL TABLES IN SCHEMA %I FROM %I', schema_name, grantee_name
+        );
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON ALL SEQUENCES IN SCHEMA %I FROM %I',
+            schema_name,
+            grantee_name
+        );
+    END LOOP;
     EXECUTE pg_catalog.format(
         'GRANT SELECT ON ALL TABLES IN SCHEMA %I TO %I', schema_name, reader_name
     );

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -67,6 +67,21 @@ _MEMBERSHIP_ADMIN_ONLY = """(
               )
           )"""
 
+#: The SET-only membership shape the fixed gateways must hold in a per-tenant
+#: role: no ADMIN, no INHERIT, SET.  Same jsonb read and the same pre-16
+#: degradation as :data:`_MEMBERSHIP_ADMIN_ONLY`, where ``NOINHERIT`` on the
+#: gateway carries the guarantee instead.
+_MEMBERSHIP_SET_ONLY = """(
+              NOT membership.admin_option
+              AND (
+                  NOT jsonb_exists(to_jsonb(membership), 'set_option')
+                  OR (
+                      NOT (to_jsonb(membership) ->> 'inherit_option')::boolean
+                      AND (to_jsonb(membership) ->> 'set_option')::boolean
+                  )
+              )
+          )"""
+
 #: True for a sequence a column owns — ``serial`` (dependency ``a``) or an
 #: identity column (dependency ``i``).  PostgreSQL refuses ``ALTER SEQUENCE …
 #: OWNER TO`` on those ("cannot change owner of sequence") and instead moves
@@ -370,6 +385,38 @@ BEGIN
            OR membership_row.rolinherit
            OR membership_row.rolreplication
            OR membership_row.rolbypassrls
+           -- The edge's options, not only the roles at its ends — but only for
+           -- an orphan: a role carrying the per-tenant naming pattern with no
+           -- row in catalog.tenants is never reached by the per-tenant checks
+           -- or their repairs, so an INHERIT edge there would hand the gateway
+           -- that role's privileges outright and nothing would ever notice. A
+           -- live tenant's roles are normalized per tenant, which is where a
+           -- legacy `WITH ADMIN OPTION` grant gets rewritten.
+           OR (
+               NOT EXISTS (
+                   SELECT 1 FROM catalog.tenants
+                   WHERE id::text = pg_catalog.replace(
+                       pg_catalog.substring(
+                           membership_row.upstream_name, '_t_(.*)$'
+                       ),
+                       '_',
+                       '-'
+                   )
+               )
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM pg_catalog.pg_auth_members AS membership
+                   JOIN pg_catalog.pg_roles AS member_role
+                     ON member_role.oid = membership.member
+                   WHERE membership.roleid = membership_row.oid
+                     AND member_role.rolname = membership_row.member_name
+                     AND CASE
+                         WHEN membership_row.member_name = '{PROVISIONER}'
+                         THEN {_MEMBERSHIP_ADMIN_ONLY}
+                         ELSE {_MEMBERSHIP_SET_ONLY}
+                     END
+               )
+           )
            OR EXISTS (
                SELECT 1
                FROM pg_catalog.pg_auth_members AS chained

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -855,6 +855,8 @@ DECLARE
     routine_gap bigint;
     type_gap bigint;
     statistics_gap bigint;
+    collation_gap bigint;
+    other_object_gap bigint;
     foreign_grantor_gap bigint;
     global_default_acl_gap bigint;
     reader_oid oid;
@@ -1312,6 +1314,92 @@ BEGIN
             AND dependency.deptype = 'e'
       );
 
+    -- fix(#998 codex r49): collations are the last owned object kind adoption
+    -- transfers; everything rarer is refused below, so no owned object kind in
+    -- a tenant schema is unhandled.
+    SELECT pg_catalog.count(*) INTO collation_gap
+    FROM pg_catalog.pg_collation AS collation_row
+    JOIN pg_catalog.pg_namespace AS namespace
+      ON namespace.oid = collation_row.collnamespace
+    JOIN pg_catalog.pg_roles AS owner_role
+      ON owner_role.oid = collation_row.collowner
+    WHERE namespace.nspname = schema_name
+      AND owner_role.rolname <> writer_name
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_collation'::regclass
+            AND dependency.objid = collation_row.oid
+            AND dependency.deptype = 'e'
+      );
+
+    -- Owned object kinds a tenant schema has no business containing but a
+    -- hand-crafted restore can: conversions, operators, operator classes and
+    -- families, text search dictionaries and configurations.  Detected and
+    -- refused rather than transferred — each has its own ALTER quirks, and an
+    -- operator who created one can move it.
+    SELECT pg_catalog.count(*) INTO other_object_gap
+    FROM (
+        SELECT conversion.oid, 'pg_conversion'::regclass AS classid
+        FROM pg_catalog.pg_conversion AS conversion
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = conversion.connamespace
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = conversion.conowner
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname <> writer_name
+        UNION ALL
+        SELECT operator.oid, 'pg_operator'::regclass
+        FROM pg_catalog.pg_operator AS operator
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = operator.oprnamespace
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = operator.oprowner
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname <> writer_name
+        UNION ALL
+        SELECT opclass.oid, 'pg_opclass'::regclass
+        FROM pg_catalog.pg_opclass AS opclass
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = opclass.opcnamespace
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = opclass.opcowner
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname <> writer_name
+        UNION ALL
+        SELECT opfamily.oid, 'pg_opfamily'::regclass
+        FROM pg_catalog.pg_opfamily AS opfamily
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = opfamily.opfnamespace
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = opfamily.opfowner
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname <> writer_name
+        UNION ALL
+        SELECT dictionary.oid, 'pg_ts_dict'::regclass
+        FROM pg_catalog.pg_ts_dict AS dictionary
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = dictionary.dictnamespace
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = dictionary.dictowner
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname <> writer_name
+        UNION ALL
+        SELECT config.oid, 'pg_ts_config'::regclass
+        FROM pg_catalog.pg_ts_config AS config
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = config.cfgnamespace
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = config.cfgowner
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname <> writer_name
+    ) AS owned_object
+    WHERE NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_depend AS dependency
+        WHERE dependency.classid = owned_object.classid
+          AND dependency.objid = owned_object.oid
+          AND dependency.deptype = 'e'
+    );
+
     SELECT pg_catalog.count(*) INTO type_gap
     FROM pg_catalog.pg_type AS type_row
     JOIN pg_catalog.pg_namespace AS namespace
@@ -1409,9 +1497,27 @@ BEGIN
        AND routine_gap = 0
        AND type_gap = 0
        AND statistics_gap = 0
+       AND collation_gap = 0
+       AND other_object_gap = 0
        AND foreign_grantor_gap = 0
        AND global_default_acl_gap = 0 THEN
         RETURN;
+    END IF;
+
+    -- The refusal for the exotic kinds counted above, before any DDL: the
+    -- operator who created one can move it; this run does not guess at
+    -- per-kind ALTER syntax.
+    IF other_object_gap > 0 THEN
+        RAISE EXCEPTION
+            'tenant schema % contains % owned object(s) of a kind adoption '
+            'does not transfer (conversion, operator, operator class or '
+            'family, text search dictionary or configuration) not owned by %',
+            schema_name, other_object_gap, writer_name
+            USING HINT =
+                'as their owner run the matching ALTER ... OWNER TO ' ||
+                pg_catalog.quote_ident(writer_name) ||
+                ' (\\dc, \\do, \\dAc, \\dAf, \\dFd and \\dF list them); then '
+                're-run adoption';
     END IF;
 
     -- Restored tenant relations are owned by whoever ran pg_restore.  A GRANT
@@ -1785,6 +1891,31 @@ BEGIN
     LOOP
         EXECUTE pg_catalog.format(
             'ALTER STATISTICS %I.%I OWNER TO %I',
+            schema_name,
+            object_row.relname,
+            writer_name
+        );
+    END LOOP;
+
+    -- fix(#998 codex r49): collations, same terms again.
+    FOR object_row IN
+        SELECT collation_row.collname AS relname
+        FROM pg_catalog.pg_collation AS collation_row
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = collation_row.collnamespace
+        JOIN pg_catalog.pg_roles AS owner_role
+          ON owner_role.oid = collation_row.collowner
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname <> writer_name
+          AND NOT EXISTS (
+              SELECT 1 FROM pg_catalog.pg_depend AS dependency
+              WHERE dependency.classid = 'pg_collation'::regclass
+                AND dependency.objid = collation_row.oid
+                AND dependency.deptype = 'e'
+          )
+    LOOP
+        EXECUTE pg_catalog.format(
+            'ALTER COLLATION %I.%I OWNER TO %I',
             schema_name,
             object_row.relname,
             writer_name

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -104,31 +104,6 @@ BEGIN
         CREATE ROLE {PROVISIONER}
             NOLOGIN NOSUPERUSER NOCREATEDB CREATEROLE NOINHERIT
             NOREPLICATION NOBYPASSRLS;
-
-        -- PostgreSQL 16+ makes a non-superuser creator an ADMIN member of the
-        -- role it just created, but with INHERIT FALSE and SET FALSE — measured
-        -- on 18 — so the creator does not hold the new role's privileges.  The
-        -- boundary-function repair later in this run needs exactly those, and
-        -- would otherwise raise and roll back the five roles it just created,
-        -- leaving the runbook's no-globals recovery unable to finish.  A
-        -- superuser already holds them and takes this branch to no effect.
-        --
-        -- Only the branch that created the role touches the edge, so an
-        -- operator-managed membership is never rewritten.  No ADMIN here:
-        -- PostgreSQL refuses "ADMIN option cannot be granted back to your own
-        -- grantor", and the automatic membership already carries it.
-        IF NOT pg_catalog.pg_has_role(CURRENT_USER, '{PROVISIONER}', 'USAGE') THEN
-            IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
-                EXECUTE pg_catalog.format(
-                    'GRANT {PROVISIONER} TO %I WITH INHERIT TRUE, SET TRUE',
-                    CURRENT_USER
-                );
-            ELSE
-                EXECUTE pg_catalog.format(
-                    'GRANT {PROVISIONER} TO %I', CURRENT_USER
-                );
-            END IF;
-        END IF;
     END IF;
 
     FOREACH group_name IN ARRAY ARRAY[
@@ -144,6 +119,43 @@ BEGIN
             );
         END IF;
     END LOOP;
+
+    -- PostgreSQL 16+ makes a non-superuser creator an ADMIN member of the role
+    -- it just created, but with INHERIT FALSE and SET FALSE — measured on 18 —
+    -- so the creator does not hold the new role's privileges.  Everything after
+    -- this point needs them: the boundary-function repair, and every tenant's
+    -- ADMIN path to its own roles.
+    --
+    -- Taken on every apply run, not only the one that creates the role, because
+    -- the run hands it back at the end.  A superuser already holds the
+    -- privileges and does nothing here.  A caller with no ADMIN cannot grant
+    -- itself anything either, so it falls through to the refusal in
+    -- SECURE_BOUNDARY_FUNCTIONS_SQL, which prints the GRANT to run.
+    --
+    -- No ADMIN in the grant: PostgreSQL refuses "ADMIN option cannot be granted
+    -- back to your own grantor", and the automatic membership already carries
+    -- it.
+    IF NOT pg_catalog.pg_has_role(CURRENT_USER, '{PROVISIONER}', 'USAGE')
+       AND EXISTS (
+           SELECT 1
+           FROM pg_catalog.pg_auth_members AS membership
+           JOIN pg_catalog.pg_roles AS granted_role
+             ON granted_role.oid = membership.roleid
+           JOIN pg_catalog.pg_roles AS member_role
+             ON member_role.oid = membership.member
+           WHERE granted_role.rolname = '{PROVISIONER}'
+             AND member_role.rolname = CURRENT_USER
+             AND membership.admin_option
+       ) THEN
+        IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+            EXECUTE pg_catalog.format(
+                'GRANT {PROVISIONER} TO %I WITH INHERIT TRUE, SET TRUE',
+                CURRENT_USER
+            );
+        ELSE
+            EXECUTE pg_catalog.format('GRANT {PROVISIONER} TO %I', CURRENT_USER);
+        END IF;
+    END IF;
 END
 $$
 """
@@ -436,22 +448,26 @@ END
 $$
 """
 
-#: Hand back the membership ``CLUSTER_ROLE_CREATE_SQL`` took when it created the
-#: provisioner on a fresh cluster.
+#: Hand back every membership in the five fixed roles that a fresh-cluster run
+#: leaves on the migrator, keeping only the one it needs to come back.
 #:
-#: It cannot be left behind.  ``CLUSTER_ROLE_VALIDATE_SQL`` rejects *any* direct
-#: member of the provisioner except the role running it, so a later recovery
-#: with a rotated migrator credential would refuse the topology before adopting
-#: a single tenant — future recovery would depend on retaining the original
-#: credential.  A run that ends here has already used the edge for everything it
-#: needed it for; the next run either creates the role again or is told the
-#: exact ``GRANT`` to run.
+#: ``CLUSTER_ROLE_VALIDATE_SQL`` rejects *any* direct member of these roles
+#: except the role running it, so anything left here makes the next recovery
+#: depend on reusing the same migrator credential.  Two sources: the usable
+#: provisioner edge ``CLUSTER_ROLE_CREATE_SQL`` takes for the run, and the
+#: automatic ADMIN membership PostgreSQL 16+ gives a non-superuser creator on
+#: every role it creates.
 #:
-#: Only the edge this run granted: grantor ``CURRENT_USER`` and no ``ADMIN``.
-#: The automatic creator membership PostgreSQL adds has a different grantor and
-#: carries ADMIN, and an operator-established edge has a different grantor too.
+#: The provisioner's automatic ADMIN edge is deliberately kept.  It grants no
+#: privileges by itself — measured — and it is what lets the same credential
+#: re-take a usable edge on the next run; without it the operator would have to
+#: re-grant by hand after every recovery.  What goes is the usable edge this run
+#: granted (grantor ``CURRENT_USER``, no ``ADMIN``) and the gateway memberships,
+#: which nothing in this tool ever reads.
 RELEASE_BOOTSTRAP_MEMBERSHIP_SQL = f"""
 DO $$
+DECLARE
+    group_name text;
 BEGIN
     IF EXISTS (
         SELECT 1
@@ -468,10 +484,32 @@ BEGIN
           AND NOT membership.admin_option
     ) THEN
         EXECUTE pg_catalog.format(
-            'REVOKE {PROVISIONER} FROM %I GRANTED BY %I',
-            CURRENT_USER, CURRENT_USER
+            'REVOKE {PROVISIONER} FROM %I GRANTED BY %I', CURRENT_USER, CURRENT_USER
         );
     END IF;
+
+    -- The four gateways get the same automatic creator membership, and nothing
+    -- in this tool ever needs it: the provisioning function grants tenant roles
+    -- TO the gateways using ADMIN on the *tenant* role, not on the gateway.
+    -- Left behind, each one is a landmine for the next recovery.
+    FOREACH group_name IN ARRAY ARRAY[
+        '{CONTROL}', '{WRITER}', '{SANDBOX}', '{TILE}'
+    ] LOOP
+        IF EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_auth_members AS membership
+            JOIN pg_catalog.pg_roles AS granted_role
+              ON granted_role.oid = membership.roleid
+            JOIN pg_catalog.pg_roles AS member_role
+              ON member_role.oid = membership.member
+            WHERE granted_role.rolname = group_name
+              AND member_role.rolname = CURRENT_USER
+        ) THEN
+            EXECUTE pg_catalog.format(
+                'REVOKE %I FROM %I', group_name, CURRENT_USER
+            );
+        END IF;
+    END LOOP;
 END
 $$
 """

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -19,6 +19,10 @@ moved (#998):
 - Every step is gated on the gap it closes, so an already-adopted tenant
   issues no DDL at all.  0019 ran once, inside a migration; this runs whenever
   an operator needs it.
+- The reserved-role membership guard aggregates with ``bool_or`` instead of
+  reading one row.  PostgreSQL keeps one membership row per grantor, so a member
+  can hold two grants of the same role and 0019's scalar read picks one
+  arbitrarily — a canonical row can hide an unsafe one.
 """
 
 from __future__ import annotations
@@ -252,11 +256,17 @@ BEGIN
 
         direct_membership_unsafe := membership_row.membership_admin;
         IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+            -- bool_or, not a bare SELECT INTO: PostgreSQL keeps one row per
+            -- grantor, so a member can hold two grants of the same reserved
+            -- role and a scalar read would pick one arbitrarily — letting a
+            -- canonical row mask an unsafe one. 0019 has the same shape; this
+            -- is the one place the port is deliberately stricter than it.
             EXECUTE
-                'SELECT membership.admin_option OR CASE WHEN $3 = $4 '
+                'SELECT pg_catalog.bool_or('
+                'membership.admin_option OR CASE WHEN $3 = $4 '
                 'THEN NOT membership.inherit_option OR membership.set_option '
                 'ELSE membership.inherit_option OR NOT membership.set_option '
-                'END '
+                'END) '
                 'FROM pg_catalog.pg_auth_members AS membership '
                 'WHERE membership.roleid = $1 AND membership.member = $2'
                 INTO direct_membership_unsafe

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -1351,7 +1351,10 @@ BEGIN
         JOIN pg_catalog.pg_roles AS owner_role
           ON owner_role.oid = default_acl.defaclrole
         WHERE default_acl.defaclnamespace = 0
-          AND owner_role.rolname IN (reader_name, writer_name)
+          -- The provisioner as well as the tenant pair: the provisioning
+          -- function runs as it and creates every future data_t_* schema, so a
+          -- default of its own lands on tenants that do not exist yet.
+          AND owner_role.rolname IN (reader_name, writer_name, '{PROVISIONER}')
     LOOP
         RAISE EXCEPTION
             'role % carries schema-less default privileges, which apply to '
@@ -1507,44 +1510,64 @@ BEGIN
     EXECUTE pg_catalog.format(
         'REVOKE ALL ON ALL SEQUENCES IN SCHEMA %I FROM PUBLIC', schema_name
     );
-    -- A grant whose grantor is neither the relation's owner nor the writer
-    -- survives ALTER TABLE ... OWNER TO, which only re-attributes the old
-    -- owner's own entries — so the writer's REVOKE below would either fail on
-    -- the dependency or quietly do nothing.
+    -- Ownership only re-attributes the old owner's own grants, so a grant made
+    -- by anyone else survives it — and the writer's REVOKE below reaches only
+    -- what the writer granted. One sweep for all four surfaces a tenant schema
+    -- exposes, because the answer is the same on each: this run cannot remove
+    -- it, and the role that can is named in the remedy.
     FOR object_row IN
-        SELECT relation.relname AS relname,
-               grantor_role.rolname AS grantee_name
+        SELECT foreign_grant.object_name AS relname,
+               COALESCE(grantor_role.rolname, 'a dropped role') AS grantee_name
+        FROM (
+        SELECT 'schema ' || namespace.nspname AS object_name,
+               acl.grantor AS grantor_oid
+        FROM pg_catalog.pg_namespace AS namespace
+        JOIN LATERAL pg_catalog.aclexplode(namespace.nspacl) AS acl ON true
+        WHERE namespace.nspname = schema_name
+          AND acl.grantor <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = '{PROVISIONER}')
+        UNION ALL
+        SELECT 'relation ' || relation.relname, acl.grantor
         FROM pg_catalog.pg_class AS relation
         JOIN pg_catalog.pg_namespace AS namespace
           ON namespace.oid = relation.relnamespace
-        JOIN LATERAL (
-            SELECT acl.grantor
-            FROM pg_catalog.aclexplode(relation.relacl) AS acl
-            UNION ALL
-            -- Column grants have their own grantor, and the writer's REVOKE
-            -- cannot reach a foreign one any more than it can at table level.
-            SELECT acl.grantor
-            FROM pg_catalog.pg_attribute AS column_row
-            JOIN LATERAL pg_catalog.aclexplode(column_row.attacl) AS acl ON true
-            WHERE column_row.attrelid = relation.oid
-              AND NOT column_row.attisdropped
-        ) AS acl ON true
-        JOIN pg_catalog.pg_roles AS grantor_role ON grantor_role.oid = acl.grantor
+        JOIN LATERAL pg_catalog.aclexplode(relation.relacl) AS acl ON true
         WHERE namespace.nspname = schema_name
-          AND grantor_role.rolname <> writer_name
+          AND acl.grantor <> writer_oid
+        UNION ALL
+        SELECT 'column ' || relation.relname || '.' || column_row.attname,
+               acl.grantor
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        JOIN pg_catalog.pg_attribute AS column_row
+          ON column_row.attrelid = relation.oid
+        JOIN LATERAL pg_catalog.aclexplode(column_row.attacl) AS acl ON true
+        WHERE namespace.nspname = schema_name
+          AND NOT column_row.attisdropped
+          AND acl.grantor <> writer_oid
+        UNION ALL
+        SELECT 'routine ' || routine.proname, acl.grantor
+        FROM pg_catalog.pg_proc AS routine
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = routine.pronamespace
+        JOIN LATERAL pg_catalog.aclexplode(routine.proacl) AS acl ON true
+        WHERE namespace.nspname = schema_name
+          AND acl.grantor <> writer_oid
+        ) AS foreign_grant
+        LEFT JOIN pg_catalog.pg_roles AS grantor_role
+          ON grantor_role.oid = foreign_grant.grantor_oid
     LOOP
         RAISE EXCEPTION
-            'relation %.% carries a grant made by %, which the writer cannot '
-            'revoke',
+            'tenant schema % carries a privilege on % granted by %, which this '
+            'run cannot revoke',
             schema_name,
             object_row.relname,
             object_row.grantee_name
             USING HINT =
                 'as ' || pg_catalog.quote_ident(object_row.grantee_name) ||
-                ' run: REVOKE ALL ON ' || schema_name || '.' ||
-                pg_catalog.quote_ident(object_row.relname) ||
-                ' FROM ALL CASCADE-equivalent grantees (see \\dp); '
-                'then re-run adoption';
+                ' revoke it (\\dp and \\ddp in schema ' ||
+                pg_catalog.quote_ident(schema_name) || ' show which), or drop '
+                'that role; then re-run adoption';
     END LOOP;
 
     -- Column-level grants, which the table-level REVOKE ALL above leaves in

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -425,6 +425,7 @@ BEGIN
                   JOIN pg_catalog.pg_roles AS grantee_role
                     ON grantee_role.oid = acl.grantee
                   WHERE grantee_role.rolname NOT IN ('{PROVISIONER}', '{CONTROL}')
+                     OR (grantee_role.rolname = '{CONTROL}' AND acl.is_grantable)
               )
           )
     ) INTO repair_pending;
@@ -456,6 +457,12 @@ BEGIN
         );
         EXECUTE pg_catalog.format(
             'REVOKE ALL ON FUNCTION catalog.%I(uuid) FROM PUBLIC', routine_name
+        );
+        -- Revoke before granting: a re-GRANT does not clear an existing GRANT
+        -- OPTION, and a grantable EXECUTE lets a control-role member delegate
+        -- provisioner-owned tenant management to anyone.
+        EXECUTE pg_catalog.format(
+            'REVOKE ALL ON FUNCTION catalog.%I(uuid) FROM {CONTROL}', routine_name
         );
         EXECUTE pg_catalog.format(
             'GRANT EXECUTE ON FUNCTION catalog.%I(uuid) TO {CONTROL}', routine_name
@@ -822,6 +829,27 @@ BEGIN
         );
     END IF;
 
+    -- A grantable schema privilege survives the provisioning function's GRANT,
+    -- which adds privileges rather than replacing them. REVOKE GRANT OPTION FOR
+    -- takes the delegation away and leaves the privilege.
+    FOREACH grantee_name IN ARRAY ARRAY[reader_name, writer_name] LOOP
+        IF EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_namespace AS namespace
+            JOIN LATERAL pg_catalog.aclexplode(namespace.nspacl) AS acl ON true
+            JOIN pg_catalog.pg_roles AS grantee_role ON grantee_role.oid = acl.grantee
+            WHERE namespace.nspname = schema_name
+              AND grantee_role.rolname = grantee_name
+              AND acl.is_grantable
+        ) THEN
+            EXECUTE pg_catalog.format(
+                'REVOKE GRANT OPTION FOR ALL ON SCHEMA %I FROM %I',
+                schema_name,
+                grantee_name
+            );
+        END IF;
+    END LOOP;
+
     -- And anyone else the restore left on the schema. The provisioning function
     -- revokes PUBLIC and grants the two tenant roles; a named grantee with
     -- USAGE, or worse CREATE, is a path around the writer boundary that nothing
@@ -886,6 +914,7 @@ BEGIN
               SELECT 1
               FROM LATERAL pg_catalog.aclexplode(relation.relacl) AS acl
               WHERE acl.grantee NOT IN (writer_oid, reader_oid)
+                 OR (acl.grantee = reader_oid AND acl.is_grantable)
                  OR (
                      acl.grantee = reader_oid
                      AND acl.privilege_type <> 'SELECT'

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -698,6 +698,7 @@ DECLARE
     pending_owner_transfer bigint;
     reader_privilege_gap bigint;
     default_acl_gap bigint;
+    routine_gap bigint;
     reader_oid oid;
     writer_oid oid;
     grantee_name text;
@@ -1062,9 +1063,25 @@ BEGIN
 
     -- Nothing to move and nothing to grant: an already-adopted tenant issues
     -- zero DDL here, which is what makes a re-run a genuine no-op.
+    SELECT pg_catalog.count(*) INTO routine_gap
+    FROM pg_catalog.pg_proc AS routine
+    JOIN pg_catalog.pg_namespace AS namespace
+      ON namespace.oid = routine.pronamespace
+    JOIN pg_catalog.pg_roles AS owner_role ON owner_role.oid = routine.proowner
+    WHERE namespace.nspname = schema_name
+      AND (
+          owner_role.rolname <> writer_name
+          OR routine.prosecdef
+          OR pg_catalog.has_function_privilege('public', routine.oid, 'EXECUTE')
+          OR NOT pg_catalog.has_function_privilege(
+              reader_name, routine.oid, 'EXECUTE'
+          )
+      );
+
     IF pending_owner_transfer = 0
        AND reader_privilege_gap = 0
-       AND default_acl_gap = 0 THEN
+       AND default_acl_gap = 0
+       AND routine_gap = 0 THEN
         RETURN;
     END IF;
 
@@ -1235,6 +1252,57 @@ BEGIN
                 'restore the built-in default; then re-run adoption';
     END IF;
 
+    -- Routines in a tenant schema. They live in pg_proc, so none of the
+    -- relation sweeps above sees them, and a restore brings one back owned by
+    -- the restore login — normally the superuser — with the default PUBLIC
+    -- EXECUTE. The shared `data` schema has the same rule and the same reason
+    -- (see scripts/lib/configure-runtime-db-role.sh): the runtime owns what it
+    -- can create, and PUBLIC never executes it.
+    --
+    -- SECURITY DEFINER is the exception, and a refusal. Re-owning one is
+    -- blessing a body adoption cannot vouch for — there is no migration behind
+    -- it, unlike the two boundary functions — and leaving it is worse.
+    FOR object_row IN
+        SELECT routine.proname AS relname,
+               pg_catalog.pg_get_function_identity_arguments(routine.oid) AS relkind
+        FROM pg_catalog.pg_proc AS routine
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = routine.pronamespace
+        WHERE namespace.nspname = schema_name
+          AND routine.prosecdef
+    LOOP
+        RAISE EXCEPTION
+            'tenant schema % contains a SECURITY DEFINER routine adoption will '
+            'not re-own: %(%)',
+            schema_name,
+            object_row.relname,
+            object_row.relkind
+            USING HINT =
+                'inspect it, then either ALTER FUNCTION ' || schema_name || '.' ||
+                pg_catalog.quote_ident(object_row.relname) || '(' ||
+                object_row.relkind || ') SECURITY INVOKER or DROP it; '
+                'then re-run adoption';
+    END LOOP;
+
+    FOR object_row IN
+        SELECT routine.proname AS relname,
+               pg_catalog.pg_get_function_identity_arguments(routine.oid) AS relkind
+        FROM pg_catalog.pg_proc AS routine
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = routine.pronamespace
+        JOIN pg_catalog.pg_roles AS owner_role ON owner_role.oid = routine.proowner
+        WHERE namespace.nspname = schema_name
+          AND owner_role.rolname <> writer_name
+    LOOP
+        EXECUTE pg_catalog.format(
+            'ALTER ROUTINE %I.%I(%s) OWNER TO %I',
+            schema_name,
+            object_row.relname,
+            object_row.relkind,
+            writer_name
+        );
+    END LOOP;
+
     EXECUTE pg_catalog.format('SET ROLE %I', writer_name);
     -- Revoke first, then grant back exactly the read privileges: ALTER TABLE …
     -- OWNER TO re-attributes the restored grants to the writer, so the writer
@@ -1312,6 +1380,12 @@ BEGIN
     EXECUTE pg_catalog.format(
         'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO %I',
         schema_name, reader_name
+    );
+    EXECUTE pg_catalog.format(
+        'REVOKE ALL ON ALL ROUTINES IN SCHEMA %I FROM PUBLIC', schema_name
+    );
+    EXECUTE pg_catalog.format(
+        'GRANT EXECUTE ON ALL ROUTINES IN SCHEMA %I TO %I', schema_name, reader_name
     );
     RESET ROLE;
 

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -297,10 +297,14 @@ BEGIN
             CONTINUE;
         END IF;
 
-        -- The automatic creator membership, whoever holds it. Tolerated rather
-        -- than refused: it grants nothing by itself, and the credential that
-        -- created the role may be retired and unassumable, which would make
-        -- every later recovery refuse before touching a tenant.
+        -- fix(#998 codex r44): the automatic creator membership was tolerated
+        -- here for any login, but ADMIN alone lets its holder grant itself a
+        -- usable edge — the bootstrap takes its own edge exactly that way — so
+        -- on any login other than the one running adoption (exempted above) it
+        -- is a live escalation path, not a harmless leftover.  Refuse it with
+        -- the remedy that works on managed platforms, where the recorded
+        -- grantor is the unassumable bootstrap superuser: drop the retired
+        -- login.
         IF EXISTS (
             SELECT 1
             FROM pg_catalog.pg_auth_members AS membership
@@ -313,7 +317,17 @@ BEGIN
               AND membership.member = membership_row.member_oid
               AND NOT {_MEMBERSHIP_CREATOR_SHAPE}
         ) THEN
-            CONTINUE;
+            RAISE EXCEPTION
+                'reserved role % keeps the creator membership of %, which '
+                'ADMIN alone can turn back into a usable edge',
+                membership_row.granted_name, membership_row.member_name
+                USING HINT =
+                    'if that login is retired, run DROP ROLE ' ||
+                    pg_catalog.quote_ident(membership_row.member_name) ||
+                    ' (REASSIGN OWNED BY it first if PostgreSQL refuses); to '
+                    'keep the login, revoke that membership as its recorded '
+                    'grantor (REVOKE ... GRANTED BY, PostgreSQL 16+); then '
+                    're-run adoption';
         END IF;
 
         direct_membership_unsafe := membership_row.membership_admin;
@@ -479,6 +493,7 @@ DO $$
 DECLARE
     routine_name text;
     grantee_name text;
+    foreign_acl_row RECORD;
     temporary_schema_create boolean := false;
     repair_pending boolean;
 BEGIN
@@ -542,6 +557,51 @@ BEGIN
     FOREACH routine_name IN ARRAY ARRAY[
         'provision_tenant_data_schema', 'deprovision_tenant_data_schema'
     ] LOOP
+        -- fix(#998 codex r44): transferring the owner re-attributes only the
+        -- owner's own ACL entries.  An entry some third role granted keeps its
+        -- grantor, the plain REVOKEs below cannot remove it (a non-grantor's
+        -- REVOKE is a warning-level no-op), so every --apply would repeat an
+        -- ineffective repair while the grantee kept EXECUTE on provisioner-
+        -- owned SECURITY DEFINER tenant management.  Refuse before touching
+        -- the function.  Entries granted by the current owner re-attribute on
+        -- transfer and the sweep below clears them; the provisioner's own
+        -- entries are already inside the canonical authority.
+        FOR foreign_acl_row IN
+            SELECT grantor_role.rolname AS grantor_name,
+                   grantee_role.rolname AS grantee_name
+            FROM pg_catalog.pg_proc AS routine
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = routine.pronamespace
+            JOIN LATERAL pg_catalog.aclexplode(routine.proacl) AS acl ON true
+            JOIN pg_catalog.pg_roles AS grantor_role
+              ON grantor_role.oid = acl.grantor
+            LEFT JOIN pg_catalog.pg_roles AS grantee_role
+              ON grantee_role.oid = acl.grantee
+            WHERE namespace.nspname = 'catalog'
+              AND routine.proname = routine_name
+              AND routine.pronargs = 1
+              AND routine.proargtypes[0] = 'uuid'::regtype
+              AND grantor_role.oid <> routine.proowner
+              AND grantor_role.rolname <> '{PROVISIONER}'
+        LOOP
+            RAISE EXCEPTION
+                'boundary function catalog.%(uuid) carries an EXECUTE entry '
+                'granted by %, which adoption cannot revoke',
+                routine_name, foreign_acl_row.grantor_name
+                USING HINT =
+                    'as ' ||
+                    pg_catalog.quote_ident(foreign_acl_row.grantor_name) ||
+                    ' (or a role that can assume it) run: REVOKE ALL ON '
+                    'FUNCTION catalog.' ||
+                    pg_catalog.quote_ident(routine_name) || '(uuid) FROM ' ||
+                    CASE
+                        WHEN foreign_acl_row.grantee_name IS NULL THEN 'PUBLIC'
+                        ELSE pg_catalog.quote_ident(
+                            foreign_acl_row.grantee_name
+                        )
+                    END || '; then re-run adoption';
+        END LOOP;
+
         EXECUTE pg_catalog.format(
             'ALTER FUNCTION catalog.%I(uuid) OWNER TO {PROVISIONER}', routine_name
         );

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -63,34 +63,24 @@ _COLUMN_OWNED_SEQUENCE = """(
 # Cluster role topology (port of 0019 ``_create_and_validate_cluster_roles``)
 # ---------------------------------------------------------------------------
 
-CLUSTER_ROLE_SQL = f"""
+#: Creates whatever is absent and nothing else.  Split from the validation half
+#: (below) so the dry run can answer "would ``--apply`` refuse this cluster?"
+#: by running the identical guard, read-only, instead of a second copy of it.
+CLUSTER_ROLE_CREATE_SQL = f"""
 DO $$
 DECLARE
-    role_row record;
     group_name text;
-    membership_row record;
-    direct_membership_unsafe boolean;
 BEGIN
     PERFORM pg_catalog.pg_advisory_xact_lock(
         pg_catalog.hashtextextended('geolens:tenant-role-bootstrap', 0)
     );
 
-    SELECT * INTO role_row
-    FROM pg_catalog.pg_roles
-    WHERE rolname = '{PROVISIONER}';
-
-    IF NOT FOUND THEN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = '{PROVISIONER}'
+    ) THEN
         CREATE ROLE {PROVISIONER}
             NOLOGIN NOSUPERUSER NOCREATEDB CREATEROLE NOINHERIT
             NOREPLICATION NOBYPASSRLS;
-    ELSIF role_row.rolcanlogin
-       OR role_row.rolsuper
-       OR role_row.rolcreatedb
-       OR NOT role_row.rolcreaterole
-       OR role_row.rolinherit
-       OR role_row.rolreplication
-       OR role_row.rolbypassrls THEN
-        RAISE EXCEPTION 'existing role {PROVISIONER} has unsafe attributes';
     END IF;
 
     FOREACH group_name IN ARRAY ARRAY[
@@ -106,6 +96,37 @@ BEGIN
             );
         END IF;
     END LOOP;
+END
+$$
+"""
+
+#: Pure validation: reads the catalogs and raises, issuing no DDL of any kind.
+CLUSTER_ROLE_VALIDATE_SQL = f"""
+DO $$
+DECLARE
+    role_row record;
+    membership_row record;
+    direct_membership_unsafe boolean;
+BEGIN
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+        pg_catalog.hashtextextended('geolens:tenant-role-bootstrap', 0)
+    );
+
+    SELECT * INTO role_row
+    FROM pg_catalog.pg_roles
+    WHERE rolname = '{PROVISIONER}';
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'role {PROVISIONER} is missing';
+    ELSIF role_row.rolcanlogin
+       OR role_row.rolsuper
+       OR role_row.rolcreatedb
+       OR NOT role_row.rolcreaterole
+       OR role_row.rolinherit
+       OR role_row.rolreplication
+       OR role_row.rolbypassrls THEN
+        RAISE EXCEPTION 'existing role {PROVISIONER} has unsafe attributes';
+    END IF;
 
     FOR role_row IN
         SELECT * FROM pg_catalog.pg_roles

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -834,7 +834,18 @@ BEGIN
         JOIN pg_catalog.pg_roles AS member_role
           ON member_role.oid = membership.member
         WHERE granted_role.rolname = reader_name
-          AND member_role.rolname NOT IN ('{PROVISIONER}', '{SANDBOX}', '{TILE}')
+          AND (
+              member_role.rolname NOT IN ('{PROVISIONER}', '{SANDBOX}', '{TILE}')
+              -- ...or an allowed gateway holding an unsafe duplicate from
+              -- another grantor. A plain REVOKE drops every row for the pair
+              -- and the provisioning function below re-adds the canonical
+              -- SET-only one; leaving it makes the tenant permanently
+              -- unadoptable, since nothing else removes it.
+              OR (
+                  member_role.rolname IN ('{SANDBOX}', '{TILE}')
+                  AND NOT {_MEMBERSHIP_SET_ONLY}
+              )
+          )
     LOOP
         EXECUTE pg_catalog.format(
             'REVOKE %I FROM %I', reader_name, legacy_member_row.member_name
@@ -849,7 +860,13 @@ BEGIN
         JOIN pg_catalog.pg_roles AS member_role
           ON member_role.oid = membership.member
         WHERE granted_role.rolname = writer_name
-          AND member_role.rolname NOT IN ('{PROVISIONER}', '{WRITER}')
+          AND (
+              member_role.rolname NOT IN ('{PROVISIONER}', '{WRITER}')
+              OR (
+                  member_role.rolname = '{WRITER}'
+                  AND NOT {_MEMBERSHIP_SET_ONLY}
+              )
+          )
     LOOP
         EXECUTE pg_catalog.format(
             'REVOKE %I FROM %I', writer_name, legacy_member_row.member_name

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -827,50 +827,115 @@ BEGIN
     -- ADMIN above. Afterwards the caller reaches both roles through the
     -- provisioner, whose privileges it must hold to have got this far.
     FOR legacy_member_row IN
-        SELECT member_role.rolname AS member_name
+        SELECT member_role.rolname AS member_name,
+               grantor_role.rolname AS grantor_name
         FROM pg_catalog.pg_auth_members AS membership
         JOIN pg_catalog.pg_roles AS granted_role
           ON granted_role.oid = membership.roleid
         JOIN pg_catalog.pg_roles AS member_role
           ON member_role.oid = membership.member
+        JOIN pg_catalog.pg_roles AS grantor_role
+          ON grantor_role.oid = membership.grantor
         WHERE granted_role.rolname = reader_name
           AND (
               member_role.rolname NOT IN ('{PROVISIONER}', '{SANDBOX}', '{TILE}')
-              -- ...or an allowed gateway holding an unsafe duplicate from
-              -- another grantor. A plain REVOKE drops every row for the pair
-              -- and the provisioning function below re-adds the canonical
-              -- SET-only one; leaving it makes the tenant permanently
-              -- unadoptable, since nothing else removes it.
+              -- ...or an allowed gateway holding an unsafe duplicate. Nothing
+              -- else removes that row, so leaving it makes the tenant
+              -- permanently unadoptable.
               OR (
                   member_role.rolname IN ('{SANDBOX}', '{TILE}')
                   AND NOT {_MEMBERSHIP_SET_ONLY}
               )
           )
     LOOP
-        EXECUTE pg_catalog.format(
-            'REVOKE %I FROM %I', reader_name, legacy_member_row.member_name
-        );
+        -- GRANTED BY targets the specific row: a plain REVOKE only removes the
+        -- grant this role made, and PostgreSQL keeps one row per grantor. It
+        -- needs a path to that grantor, so a row from a role this credential
+        -- cannot assume is a refusal with the command to run, not a silent skip.
+        BEGIN
+            IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+                EXECUTE pg_catalog.format(
+                    'REVOKE %I FROM %I GRANTED BY %I CASCADE',
+                    reader_name,
+                    legacy_member_row.member_name,
+                    legacy_member_row.grantor_name
+                );
+            ELSE
+                EXECUTE pg_catalog.format(
+                    'REVOKE %I FROM %I CASCADE',
+                    reader_name,
+                    legacy_member_row.member_name
+                );
+            END IF;
+        EXCEPTION
+            WHEN insufficient_privilege THEN
+                RAISE EXCEPTION
+                    'cannot revoke % from % : the grant was made by %, which '
+                    'this role cannot assume',
+                    reader_name,
+                    legacy_member_row.member_name,
+                    legacy_member_row.grantor_name
+                    USING HINT =
+                        'run REVOKE ' || reader_name || ' FROM ' ||
+                        legacy_member_row.member_name || ' GRANTED BY ' ||
+                        legacy_member_row.grantor_name || ' CASCADE as a role that can';
+        END;
     END LOOP;
 
     FOR legacy_member_row IN
-        SELECT member_role.rolname AS member_name
+        SELECT member_role.rolname AS member_name,
+               grantor_role.rolname AS grantor_name
         FROM pg_catalog.pg_auth_members AS membership
         JOIN pg_catalog.pg_roles AS granted_role
           ON granted_role.oid = membership.roleid
         JOIN pg_catalog.pg_roles AS member_role
           ON member_role.oid = membership.member
+        JOIN pg_catalog.pg_roles AS grantor_role
+          ON grantor_role.oid = membership.grantor
         WHERE granted_role.rolname = writer_name
           AND (
               member_role.rolname NOT IN ('{PROVISIONER}', '{WRITER}')
+              -- ...or an allowed gateway holding an unsafe duplicate. Nothing
+              -- else removes that row, so leaving it makes the tenant
+              -- permanently unadoptable.
               OR (
-                  member_role.rolname = '{WRITER}'
+                  member_role.rolname IN ('{WRITER}')
                   AND NOT {_MEMBERSHIP_SET_ONLY}
               )
           )
     LOOP
-        EXECUTE pg_catalog.format(
-            'REVOKE %I FROM %I', writer_name, legacy_member_row.member_name
-        );
+        -- GRANTED BY targets the specific row: a plain REVOKE only removes the
+        -- grant this role made, and PostgreSQL keeps one row per grantor. It
+        -- needs a path to that grantor, so a row from a role this credential
+        -- cannot assume is a refusal with the command to run, not a silent skip.
+        BEGIN
+            IF pg_catalog.current_setting('server_version_num')::integer >= 160000 THEN
+                EXECUTE pg_catalog.format(
+                    'REVOKE %I FROM %I GRANTED BY %I CASCADE',
+                    writer_name,
+                    legacy_member_row.member_name,
+                    legacy_member_row.grantor_name
+                );
+            ELSE
+                EXECUTE pg_catalog.format(
+                    'REVOKE %I FROM %I CASCADE',
+                    writer_name,
+                    legacy_member_row.member_name
+                );
+            END IF;
+        EXCEPTION
+            WHEN insufficient_privilege THEN
+                RAISE EXCEPTION
+                    'cannot revoke % from % : the grant was made by %, which '
+                    'this role cannot assume',
+                    writer_name,
+                    legacy_member_row.member_name,
+                    legacy_member_row.grantor_name
+                    USING HINT =
+                        'run REVOKE ' || writer_name || ' FROM ' ||
+                        legacy_member_row.member_name || ' GRANTED BY ' ||
+                        legacy_member_row.grantor_name || ' CASCADE as a role that can';
+        END;
     END LOOP;
 
     -- The provisioner's own duplicates, which the loops above deliberately do
@@ -894,11 +959,24 @@ BEGIN
               AND member_role.rolname = '{PROVISIONER}'
               AND NOT {_MEMBERSHIP_ADMIN_ONLY}
         LOOP
-            EXECUTE pg_catalog.format(
-                'REVOKE %I FROM {PROVISIONER} GRANTED BY %I',
-                legacy_member_row.granted_name,
-                legacy_member_row.member_name
-            );
+            BEGIN
+                EXECUTE pg_catalog.format(
+                    'REVOKE %I FROM {PROVISIONER} GRANTED BY %I CASCADE',
+                    legacy_member_row.granted_name,
+                    legacy_member_row.member_name
+                );
+            EXCEPTION
+                WHEN insufficient_privilege THEN
+                    RAISE EXCEPTION
+                        'cannot revoke % from {PROVISIONER}: the grant was made '
+                        'by %, which this role cannot assume',
+                        legacy_member_row.granted_name,
+                        legacy_member_row.member_name
+                        USING HINT =
+                            'run REVOKE ' || legacy_member_row.granted_name ||
+                            ' FROM {PROVISIONER} GRANTED BY ' ||
+                            legacy_member_row.member_name || ' CASCADE as a role that can';
+            END;
         END LOOP;
     END IF;
 

--- a/backend/tests/test_dp_single_tenant_byte_identical.py
+++ b/backend/tests/test_dp_single_tenant_byte_identical.py
@@ -259,9 +259,19 @@ class TestNoPerTenantSchemaExistsFromSingleTenantBoot:
             async with engine.connect() as conn:
                 rows = (
                     await conn.execute(
+                        # Roles are cluster objects and this suite shares its
+                        # cluster with every other xdist worker's database, so
+                        # scope the assertion to roles whose schema is in THIS
+                        # database. Without that, a peer worker's tenant
+                        # fixtures fail this test (fix(#998)).
                         sa.text(
-                            "SELECT rolname FROM pg_roles "
-                            "WHERE rolname LIKE 'geolens\\_reader\\_t\\_%'"
+                            "SELECT rolname FROM pg_roles AS role "
+                            "WHERE rolname LIKE 'geolens\\_reader\\_t\\_%' "
+                            "AND EXISTS ("
+                            "  SELECT 1 FROM pg_namespace AS namespace "
+                            "  WHERE namespace.nspname = "
+                            "    'data_t_' || substring(role.rolname from 18)"
+                            ")"
                         )
                     )
                 ).fetchall()

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1672,
+    # fix(#998 codex r44): +60 — refuse creator-shaped memberships retained by
+    # other logins (an ADMIN-only edge can re-arm itself) and refuse boundary-
+    # function ACL entries a foreign grantor issued (unrevokable by the repair,
+    # which would otherwise silently no-op every run).
+    "backend/app/core/db/tenant_adoption_sql.py": 1732,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1220,
+    "backend/app/core/db/tenant_adoption_sql.py": 1249,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1090,
+    "backend/app/core/db/tenant_adoption_sql.py": 1137,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1136,
+    "backend/app/core/db/tenant_adoption_sql.py": 1178,
+    # fix(#998): the tool the DDL above serves — the catalog reads that decide
+    # whether anything is left to do, the steps that close the gap, and the
+    # operator CLI. Already decomposed three ways (report types and the success
+    # predicate in tenant_adoption_report.py, the ported DDL in
+    # tenant_adoption_sql.py); the remainder is one read per object the adoption
+    # boundary covers, and each is a single SQL statement that has to see the
+    # whole object at once.
+    "backend/app/core/db/tenant_adoption.py": 1009,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1178,
+    "backend/app/core/db/tenant_adoption_sql.py": 1181,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1078,
+    "backend/app/core/db/tenant_adoption_sql.py": 1090,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1649,
+    "backend/app/core/db/tenant_adoption_sql.py": 1672,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1953,7 +1953,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    "backend/app/core/db/tenant_adoption.py": 1154,
+    "backend/app/core/db/tenant_adoption.py": 1197,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1327,
+    "backend/app/core/db/tenant_adoption_sql.py": 1312,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1953,7 +1953,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    "backend/app/core/db/tenant_adoption.py": 1009,
+    "backend/app/core/db/tenant_adoption.py": 1016,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1475,
+    "backend/app/core/db/tenant_adoption_sql.py": 1634,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1953,7 +1953,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    "backend/app/core/db/tenant_adoption.py": 1098,
+    "backend/app/core/db/tenant_adoption.py": 1130,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1634,
+    "backend/app/core/db/tenant_adoption_sql.py": 1638,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1953,7 +1953,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    "backend/app/core/db/tenant_adoption.py": 1130,
+    "backend/app/core/db/tenant_adoption.py": 1151,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1203,
+    "backend/app/core/db/tenant_adoption_sql.py": 1220,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1952,11 +1952,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # silently no-op every run), count foreign grantors in the early-return
     # guard so canonical-but-foreign tenants reach the refusal, and render
     # the default-privilege remedy one statement per object kind.
-    # fix(#998 codex r46-r48): +99 (incl. extended-statistics ownership) — generated multiranges excluded on all
+    # fix(#998 codex r46-r49): +268 — extended statistics and collations transferred, the six rarer owned kinds refused, so no owned object kind in a tenant schema is unhandled — generated multiranges excluded on all
     # three type surfaces; schema-less default privileges counted in the
     # fast-path guard and refused cluster-wide for the provisioner (the
     # per-tenant pass never runs with zero tenants).
-    "backend/app/core/db/tenant_adoption_sql.py": 1971,
+    "backend/app/core/db/tenant_adoption_sql.py": 2102,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1964,11 +1964,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    # fix(#998 codex r45-r48): +46 — run the provisioner grant-option guard
+    # fix(#998 codex r45-r49): +130 — read side mirrors every apply-side ownership surface — run the provisioner grant-option guard
     # before the plain revokes it protects; mirror the multirange and
     # schema-less default-privilege refusals on the read side so the dry run
     # cannot call adopted what --apply stops on.
-    "backend/app/core/db/tenant_adoption.py": 1243,
+    "backend/app/core/db/tenant_adoption.py": 1303,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1249,
+    "backend/app/core/db/tenant_adoption_sql.py": 1327,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1638,
+    "backend/app/core/db/tenant_adoption_sql.py": 1649,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1953,7 +1953,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    "backend/app/core/db/tenant_adoption.py": 1151,
+    "backend/app/core/db/tenant_adoption.py": 1154,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1181,
+    "backend/app/core/db/tenant_adoption_sql.py": 1203,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1317,
+    "backend/app/core/db/tenant_adoption_sql.py": 1323,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1137,
+    "backend/app/core/db/tenant_adoption_sql.py": 1136,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1397,
+    "backend/app/core/db/tenant_adoption_sql.py": 1475,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1953,7 +1953,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    "backend/app/core/db/tenant_adoption.py": 1060,
+    "backend/app/core/db/tenant_adoption.py": 1098,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,11 +1945,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    # fix(#998 codex r44): +60 — refuse creator-shaped memberships retained by
-    # other logins (an ADMIN-only edge can re-arm itself) and refuse boundary-
-    # function ACL entries a foreign grantor issued (unrevokable by the repair,
-    # which would otherwise silently no-op every run).
-    "backend/app/core/db/tenant_adoption_sql.py": 1732,
+    # fix(#998 codex r44/r45): +200 — refuse creator-shaped memberships
+    # retained by other logins (an ADMIN-only edge can re-arm itself), refuse
+    # boundary-function and provisioner grant-option ACL entries a foreign
+    # grantor issued (unrevokable by the repair, which would otherwise
+    # silently no-op every run), count foreign grantors in the early-return
+    # guard so canonical-but-foreign tenants reach the refusal, and render
+    # the default-privilege remedy one statement per object kind.
+    "backend/app/core/db/tenant_adoption_sql.py": 1872,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1957,7 +1960,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    "backend/app/core/db/tenant_adoption.py": 1197,
+    # fix(#998 codex r45): +5 — run the provisioner grant-option guard before
+    # the plain revokes it protects.
+    "backend/app/core/db/tenant_adoption.py": 1202,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1028,
+    "backend/app/core/db/tenant_adoption_sql.py": 1057,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1312,
+    "backend/app/core/db/tenant_adoption_sql.py": 1317,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1953,7 +1953,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    "backend/app/core/db/tenant_adoption.py": 1016,
+    "backend/app/core/db/tenant_adoption.py": 1034,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1068,
+    "backend/app/core/db/tenant_adoption_sql.py": 1078,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1938,6 +1938,14 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     this module by the overlay's 1214-05 static AST proof, so the tile_seams.py split
 #     must update the overlay in lockstep.
 _MODULE_LOC_CAPS: dict[str, int] = {
+    # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
+    # is reachable forward-only at head. Almost all of it is SQL text, and it is
+    # one artifact on purpose — the module is reviewed line-by-line against
+    # 0019_tenant_provisioning_boundary.py, which splitting the blocks across
+    # files would make harder, not easier. The Python that drives it and the
+    # report types already live in tenant_adoption.py and
+    # tenant_adoption_report.py.
+    "backend/app/core/db/tenant_adoption_sql.py": 1028,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1057,
+    "backend/app/core/db/tenant_adoption_sql.py": 1068,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1952,9 +1952,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # silently no-op every run), count foreign grantors in the early-return
     # guard so canonical-but-foreign tenants reach the refusal, and render
     # the default-privilege remedy one statement per object kind.
-    # fix(#998 codex r46): +12 — generated multiranges follow their range and
-    # refuse direct ALTER TYPE; excluded on all three type surfaces.
-    "backend/app/core/db/tenant_adoption_sql.py": 1884,
+    # fix(#998 codex r46/r47): +47 — generated multiranges excluded on all
+    # three type surfaces; schema-less default privileges counted in the
+    # fast-path guard and refused cluster-wide for the provisioner (the
+    # per-tenant pass never runs with zero tenants).
+    "backend/app/core/db/tenant_adoption_sql.py": 1919,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1962,10 +1964,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    # fix(#998 codex r45/r46): +11 — run the provisioner grant-option guard
-    # before the plain revokes it protects; exclude generated multiranges on
-    # the read side too.
-    "backend/app/core/db/tenant_adoption.py": 1208,
+    # fix(#998 codex r45-r47): +26 — run the provisioner grant-option guard
+    # before the plain revokes it protects; mirror the multirange and
+    # schema-less default-privilege refusals on the read side so the dry run
+    # cannot call adopted what --apply stops on.
+    "backend/app/core/db/tenant_adoption.py": 1223,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1945,7 +1945,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # files would make harder, not easier. The Python that drives it and the
     # report types already live in tenant_adoption.py and
     # tenant_adoption_report.py.
-    "backend/app/core/db/tenant_adoption_sql.py": 1323,
+    "backend/app/core/db/tenant_adoption_sql.py": 1397,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1953,7 +1953,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    "backend/app/core/db/tenant_adoption.py": 1034,
+    "backend/app/core/db/tenant_adoption.py": 1060,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1952,7 +1952,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # silently no-op every run), count foreign grantors in the early-return
     # guard so canonical-but-foreign tenants reach the refusal, and render
     # the default-privilege remedy one statement per object kind.
-    "backend/app/core/db/tenant_adoption_sql.py": 1872,
+    # fix(#998 codex r46): +12 — generated multiranges follow their range and
+    # refuse direct ALTER TYPE; excluded on all three type surfaces.
+    "backend/app/core/db/tenant_adoption_sql.py": 1884,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1960,9 +1962,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    # fix(#998 codex r45): +5 — run the provisioner grant-option guard before
-    # the plain revokes it protects.
-    "backend/app/core/db/tenant_adoption.py": 1202,
+    # fix(#998 codex r45/r46): +11 — run the provisioner grant-option guard
+    # before the plain revokes it protects; exclude generated multiranges on
+    # the read side too.
+    "backend/app/core/db/tenant_adoption.py": 1208,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1952,11 +1952,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # silently no-op every run), count foreign grantors in the early-return
     # guard so canonical-but-foreign tenants reach the refusal, and render
     # the default-privilege remedy one statement per object kind.
-    # fix(#998 codex r46/r47): +47 — generated multiranges excluded on all
+    # fix(#998 codex r46-r48): +99 (incl. extended-statistics ownership) — generated multiranges excluded on all
     # three type surfaces; schema-less default privileges counted in the
     # fast-path guard and refused cluster-wide for the provisioner (the
     # per-tenant pass never runs with zero tenants).
-    "backend/app/core/db/tenant_adoption_sql.py": 1919,
+    "backend/app/core/db/tenant_adoption_sql.py": 1971,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success
@@ -1964,11 +1964,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    # fix(#998 codex r45-r47): +26 — run the provisioner grant-option guard
+    # fix(#998 codex r45-r48): +46 — run the provisioner grant-option guard
     # before the plain revokes it protects; mirror the multirange and
     # schema-less default-privilege refusals on the read side so the dry run
     # cannot call adopted what --apply stops on.
-    "backend/app/core/db/tenant_adoption.py": 1223,
+    "backend/app/core/db/tenant_adoption.py": 1243,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -1079,6 +1079,66 @@ class TestReportedStateMatchesWhatApplyEnforces:
                 )
             await engine.dispose()
 
+    async def test_a_grantable_provisioner_privilege_is_reported_and_cleared(self):
+        """The provisioner is reachable only through SECURITY DEFINER code.
+
+        A grantable privilege there is a delegation nothing else in the report
+        would show.
+        """
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                assert await missing_provisioner_grants(conn) == []
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"GRANT USAGE ON SCHEMA catalog TO {PROVISIONER} "
+                        "WITH GRANT OPTION"
+                    )
+                )
+
+            async with engine.connect() as conn:
+                assert await missing_provisioner_grants(conn) == [
+                    "USAGE on schema catalog is grantable"
+                ]
+
+            applied = await run_adoption(engine, apply=True)
+            assert applied.provisioner_grants_missing == []
+            assert applied.ok
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        "REVOKE GRANT OPTION FOR USAGE ON SCHEMA catalog "
+                        f"FROM {PROVISIONER}"
+                    )
+                )
+                await conn.execute(
+                    sa.text(f"GRANT USAGE ON SCHEMA catalog TO {PROVISIONER}")
+                )
+            await engine.dispose()
+
+    async def test_extra_proconfig_on_a_boundary_function_is_refused(self):
+        """`SET role` beside a correct search_path changes what the body runs as."""
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            "ALTER FUNCTION catalog.provision_tenant_data_schema(uuid) "
+                            "SET statement_timeout = '1s'"
+                        )
+                    )
+                    with pytest.raises(RuntimeError, match="search_path"):
+                        await secure_boundary_functions(conn)
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
     async def test_healthy_cluster_topology_reports_no_error(self):
         engine = _make_engine()
         try:

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -487,7 +487,7 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
-    async def test_a_third_party_gateway_grant_is_revoked(
+    async def test_a_third_party_gateway_grant_is_refused(
         self, multi_tenant_row_security
     ):
         """The unsafe row belongs to another grantor, not to the adopter.
@@ -518,9 +518,10 @@ class TestReportedStateMatchesWhatApplyEnforces:
                 state = await tenant_ownership_state(conn, tenant_id)
             assert not state.reader_role_secure
 
-            repaired = await run_adoption(engine, apply=True)
-            assert repaired.failures == {}, repaired.failures
-            assert repaired.ok
+            refused = await run_adoption(engine, apply=True)
+            assert tenant_id in refused.failures
+            assert "will not rewrite" in refused.failures[tenant_id]
+            assert not refused.ok
         finally:
             async with engine.begin() as conn:
                 await conn.execute(sa.text(f"DROP OWNED BY {grantor}"))
@@ -528,14 +529,13 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
-    async def test_a_duplicate_provisioner_edge_is_normalized(
+    async def test_the_provisioners_own_edge_is_repaired_in_place(
         self, multi_tenant_row_security
     ):
-        """The canonical row hides it and nothing else would take it away.
+        """The row adoption granted, so adoption is its grantor and can rewrite it.
 
-        Only the foreign grantor's row goes: revoking the provisioner's
-        membership outright would remove the ADMIN path the transaction reaches
-        the tenant roles through.
+        The other side of the boundary: a second row from a third-party grantor
+        is refused instead — see the gateway test above.
         """
         tenant_id, schema, reader, _writer = _new_tenant()
         engine = _make_engine()
@@ -608,14 +608,15 @@ class TestReportedStateMatchesWhatApplyEnforces:
 
             # And a re-run repairs it: nothing else removes the extra row, so
             # leaving it would make the tenant permanently unadoptable.
-            repaired = await run_adoption(engine, apply=True)
-            assert repaired.failures == {}, repaired.failures
-            assert repaired.ok
+            refused = await run_adoption(engine, apply=True)
+            assert tenant_id in refused.failures
+            assert "will not rewrite" in refused.failures[tenant_id]
+            assert not refused.ok
         finally:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
-    async def test_stray_reader_member_is_not_adopted_and_is_repaired(
+    async def test_stray_reader_member_is_refused_with_a_remedy(
         self, multi_tenant_row_security
     ):
         tenant_id, schema, reader, _writer = _new_tenant()
@@ -639,16 +640,17 @@ class TestReportedStateMatchesWhatApplyEnforces:
             assert not state.reader_role_secure
             assert not state.adopted
 
-            repaired = await run_adoption(engine, apply=True)
-            assert repaired.failures == {}, repaired.failures
-            assert repaired.ok
+            refused = await run_adoption(engine, apply=True)
+            assert tenant_id in refused.failures
+            assert "will not rewrite" in refused.failures[tenant_id]
+            assert not refused.ok
         finally:
             async with engine.begin() as conn:
                 await conn.execute(sa.text(f"DROP ROLE IF EXISTS {stray}"))
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
-    async def test_creator_membership_on_the_writer_is_normalized(
+    async def test_creator_membership_on_the_writer_is_refused(
         self, multi_tenant_row_security
     ):
         """PostgreSQL 16+ makes the role creator a direct member of the writer.
@@ -677,23 +679,9 @@ class TestReportedStateMatchesWhatApplyEnforces:
                 )
 
             report = await run_adoption(engine, apply=True)
-            assert report.failures == {}, report.failures
-            assert report.ok
-
-            async with engine.connect() as conn:
-                members = [
-                    row[0]
-                    for row in await conn.execute(
-                        sa.text(
-                            "SELECT member.rolname FROM pg_auth_members AS membership "
-                            "JOIN pg_roles AS granted ON granted.oid = membership.roleid "
-                            "JOIN pg_roles AS member ON member.oid = membership.member "
-                            "WHERE granted.rolname = :writer ORDER BY member.rolname"
-                        ),
-                        {"writer": writer},
-                    )
-                ]
-            assert members == [PROVISIONER, WRITER_GATEWAY]
+            assert tenant_id in report.failures
+            assert "will not rewrite" in report.failures[tenant_id]
+            assert not report.ok
         finally:
             async with engine.begin() as conn:
                 await conn.execute(sa.text(f"DROP ROLE IF EXISTS {creator}"))

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -27,6 +27,7 @@ Run:
 from __future__ import annotations
 
 import uuid
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
@@ -48,6 +49,7 @@ from app.core.db.tenant_adoption import (
     format_report,
     live_tenant_boundary,
     missing_provisioner_grants,
+    TenantOwnershipState,
     run_adoption,
     tenant_ownership_state,
 )
@@ -78,6 +80,54 @@ def _make_engine():
     from app.core.config import settings
 
     return create_async_engine(settings.test_database_url, poolclass=NullPool)
+
+
+@asynccontextmanager
+async def _row_security_enabled(engine):
+    """Give the worker's database the multi-tenant row-security posture.
+
+    Tenant rows in ``catalog.tenants`` are what make a control plane
+    multi-tenant, so they are what makes row security mandatory to
+    ``AdoptionReport.ok``. The suite's shared database is single-tenant with RLS
+    off, so a test that inserts a tenant has to supply the posture and hand it
+    back. The connecting login is a superuser, which is never subject to RLS
+    even under FORCE, so nothing but the catalog flags changes here.
+    """
+    async with engine.begin() as conn:
+        for table in RLS_TABLES:
+            await conn.execute(
+                sa.text(f"ALTER TABLE catalog.{table} ENABLE ROW LEVEL SECURITY")
+            )
+            await conn.execute(
+                sa.text(f"ALTER TABLE catalog.{table} FORCE ROW LEVEL SECURITY")
+            )
+    try:
+        yield
+    finally:
+        async with engine.begin() as conn:
+            for table in RLS_TABLES:
+                await conn.execute(
+                    sa.text(f"ALTER TABLE catalog.{table} NO FORCE ROW LEVEL SECURITY")
+                )
+                await conn.execute(
+                    sa.text(f"ALTER TABLE catalog.{table} DISABLE ROW LEVEL SECURITY")
+                )
+
+
+@pytest.fixture
+async def multi_tenant_row_security():
+    """For any test that puts a tenant row in the control plane.
+
+    Tenants present is what makes row security mandatory to
+    ``AdoptionReport.ok``, so a test that seeds one has to supply the posture a
+    real multi-tenant database would already have.
+    """
+    engine = _make_engine()
+    try:
+        async with _row_security_enabled(engine):
+            yield
+    finally:
+        await engine.dispose()
 
 
 async def _seed_restored_tenant(engine, tenant_id: str, schema: str) -> None:
@@ -241,7 +291,7 @@ async def _restore_boundary_functions(engine) -> None:
 class TestAdoptionReconstructsOwnership:
     """A: the 0019 end state, reached forward-only at head."""
 
-    async def test_restored_tenant_is_adopted(self):
+    async def test_restored_tenant_is_adopted(self, multi_tenant_row_security):
         tenant_id, schema, reader, writer = _new_tenant()
         engine = _make_engine()
         try:
@@ -338,7 +388,9 @@ class TestAdoptionReconstructsOwnership:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
-    async def test_column_owned_sequence_follows_its_table(self):
+    async def test_column_owned_sequence_follows_its_table(
+        self, multi_tenant_row_security
+    ):
         """``bigserial``/identity sequences cannot be re-owned directly.
 
         0019's loop issued ``ALTER SEQUENCE … OWNER TO`` unconditionally, which
@@ -390,7 +442,9 @@ class TestReportedStateMatchesWhatApplyEnforces:
     and a superuser one satisfies `has_table_privilege` by fiat.
     """
 
-    async def test_unsafe_reader_attributes_are_not_adopted(self):
+    async def test_unsafe_reader_attributes_are_not_adopted(
+        self, multi_tenant_row_security
+    ):
         """A LOGIN reader is refused, and the dry run says so before `--apply`.
 
         The role is left un-adopted (no provisioner membership) on purpose:
@@ -419,7 +473,9 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
-    async def test_stray_reader_member_is_not_adopted_and_is_repaired(self):
+    async def test_stray_reader_member_is_not_adopted_and_is_repaired(
+        self, multi_tenant_row_security
+    ):
         tenant_id, schema, reader, _writer = _new_tenant()
         stray = f"w998_stray_{tenant_id.replace('-', '_')}"
         engine = _make_engine()
@@ -450,7 +506,9 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
-    async def test_legacy_reader_default_privileges_are_not_adopted(self):
+    async def test_legacy_reader_default_privileges_are_not_adopted(
+        self, multi_tenant_row_security
+    ):
         """The pre-0019 helper's ALTER DEFAULT PRIVILEGES entry is a live grant.
 
         Nothing else in the report sees it: ownership and per-relation
@@ -538,7 +596,9 @@ class TestReportedStateMatchesWhatApplyEnforces:
 class TestAdoptionIsIdempotent:
     """B: re-running changes nothing, and says so."""
 
-    async def test_second_run_leaves_the_catalog_byte_identical(self):
+    async def test_second_run_leaves_the_catalog_byte_identical(
+        self, multi_tenant_row_security
+    ):
         tenant_id, schema, _reader, _writer = _new_tenant()
         engine = _make_engine()
         try:
@@ -562,7 +622,7 @@ class TestAdoptionIsIdempotent:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
-    async def test_dry_run_makes_no_changes(self):
+    async def test_dry_run_makes_no_changes(self, multi_tenant_row_security):
         tenant_id, schema, _reader, _writer = _new_tenant()
         engine = _make_engine()
         try:
@@ -589,7 +649,9 @@ class TestAdoptionIsIdempotent:
 class TestAdoptionWithRestoredBoundaryFunctions:
     """C: no CREATE FUNCTION collision, and the PUBLIC grant goes away."""
 
-    async def test_restored_functions_are_re_owned_and_re_restricted(self):
+    async def test_restored_functions_are_re_owned_and_re_restricted(
+        self, multi_tenant_row_security
+    ):
         tenant_id, schema, _reader, _writer = _new_tenant()
         engine = _make_engine()
         try:
@@ -674,6 +736,45 @@ class TestLiveTenantBoundary:
         # ago. Anything reading that constant would under-report by three.
         assert len(stamped) > 6
 
+    async def test_a_disabled_stamping_trigger_is_not_a_live_boundary(self):
+        """`tgenabled = 'D'` keeps the name and stamps nothing.
+
+        Nothing at boot re-enables it, so an insert on that table lands with no
+        `tenant_id` on any path that reaches it.
+        """
+        engine = _make_engine()
+        table = "embed_tokens"
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"ALTER TABLE catalog.{table} "
+                        "DISABLE TRIGGER trg_stamp_current_tenant_on_insert"
+                    )
+                )
+
+            async with engine.connect() as conn:
+                boundary = await live_tenant_boundary(conn)
+            state = next(entry for entry in boundary if entry.name == table)
+            assert not state.has_stamping_trigger
+            assert state.stamping_trigger_disabled
+
+            # It is in RLS_TABLES but no longer stamped, so it reads as drift.
+            assert boundary_drift(boundary) == ([], [table])
+
+            report = await run_adoption(engine, apply=False)
+            assert not report.ok
+            assert "DISABLED" in format_report(report)
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"ALTER TABLE catalog.{table} "
+                        "ENABLE TRIGGER trg_stamp_current_tenant_on_insert"
+                    )
+                )
+            await engine.dispose()
+
     async def test_dormant_tenant_id_columns_are_reported_outside_the_boundary(self):
         """0037's ``dataset_refresh_runs.tenant_id`` is deliberately dormant.
 
@@ -744,12 +845,31 @@ def _clean_boundary() -> list[BoundaryTableState]:
         BoundaryTableState(
             name=name,
             has_stamping_trigger=True,
+            stamping_trigger_disabled=False,
             has_tenant_id=True,
             rls_enabled=True,
             rls_forced=True,
         )
         for name in RLS_TABLES
     ]
+
+
+def _adopted_tenant_state() -> TenantOwnershipState:
+    return TenantOwnershipState(
+        tenant_id="00000000-0000-0000-0000-000000000998",
+        schema_name="data_t_00000000_0000_0000_0000_000000000998",
+        schema_exists=True,
+        schema_owner=PROVISIONER,
+        reader_exists=True,
+        writer_exists=True,
+        relations=1,
+        relations_not_owned_by_writer=0,
+        relations_without_reader_select=0,
+        reader_default_acls=0,
+        reader_role_secure=True,
+        writer_role_secure=True,
+        schema_privileges_secure=True,
+    )
 
 
 def _report(**overrides) -> AdoptionReport:
@@ -764,6 +884,10 @@ def _report(**overrides) -> AdoptionReport:
         "provisioner_grants_missing": [],
     }
     fields.update(overrides)
+    # The report renders `after` against `before`, so a caller that overrides
+    # only one of them still gets a coherent report.
+    if "before" in overrides and "after" not in overrides:
+        fields["after"] = fields["before"]
     return AdoptionReport(**fields)
 
 
@@ -799,13 +923,66 @@ class TestSuccessPredicate:
             BoundaryTableState(
                 name="w998_late_arrival",
                 has_stamping_trigger=True,
+                stamping_trigger_disabled=False,
                 has_tenant_id=True,
-                rls_enabled=False,
-                rls_forced=False,
+                rls_enabled=True,
+                rls_forced=True,
             )
         ]
         report = _report(boundary=boundary)
         assert boundary_drift(boundary) == (["w998_late_arrival"], [])
+        assert not report.ok
+
+    def test_row_security_off_with_tenants_present_is_not_ok(self) -> None:
+        """A tenant-carrying control plane with RLS off has no isolation."""
+        boundary = [
+            BoundaryTableState(
+                name=table.name,
+                has_stamping_trigger=True,
+                stamping_trigger_disabled=False,
+                has_tenant_id=True,
+                rls_enabled=False,
+                rls_forced=False,
+            )
+            for table in _clean_boundary()
+        ]
+        report = _report(boundary=boundary, before=[_adopted_tenant_state()])
+        assert report.rls_gaps
+        assert not report.ok
+        assert "NOT SAFE TO SERVE" in format_report(report)
+
+    def test_row_security_off_with_no_tenants_is_ok(self) -> None:
+        """Single-tenant is the default posture; RLS is correctly off there."""
+        boundary = [
+            BoundaryTableState(
+                name=table.name,
+                has_stamping_trigger=True,
+                stamping_trigger_disabled=False,
+                has_tenant_id=True,
+                rls_enabled=False,
+                rls_forced=False,
+            )
+            for table in _clean_boundary()
+        ]
+        report = _report(boundary=boundary)
+        assert report.rls_gaps == []
+        assert report.ok
+
+    def test_row_security_without_force_is_not_ok(self) -> None:
+        """The table owner bypasses a non-FORCEd policy in any mode."""
+        boundary = [
+            BoundaryTableState(
+                name=table.name,
+                has_stamping_trigger=True,
+                stamping_trigger_disabled=False,
+                has_tenant_id=True,
+                rls_enabled=True,
+                rls_forced=False,
+            )
+            for table in _clean_boundary()
+        ]
+        report = _report(boundary=boundary)
+        assert report.rls_gaps
         assert not report.ok
 
     def test_declared_table_without_a_stamping_trigger_is_not_ok(self) -> None:

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -44,6 +44,7 @@ from app.core.db.tenant_adoption import (
     BoundaryTableState,
     boundary_drift,
     boundary_function_states,
+    cluster_topology_error,
     format_report,
     live_tenant_boundary,
     run_adoption,
@@ -380,6 +381,82 @@ class TestAdoptionReconstructsOwnership:
             await engine.dispose()
 
 
+class TestReportedStateMatchesWhatApplyEnforces:
+    """The dry-run verdict cannot be softer than `--apply`'s refusals.
+
+    Ownership plus effective privileges is not enough on its own: a reader that
+    can log in still holds every relation privilege the ownership check reads,
+    and a superuser one satisfies `has_table_privilege` by fiat.
+    """
+
+    async def test_unsafe_reader_attributes_are_not_adopted(self):
+        """A LOGIN reader is refused, and the dry run says so before `--apply`.
+
+        The role is left un-adopted (no provisioner membership) on purpose:
+        once a reserved role holds an edge to it, an unsafe attribute becomes a
+        *cluster*-topology refusal, and cluster roles are shared with every
+        other xdist worker's database.
+        """
+        tenant_id, schema, reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"CREATE ROLE {reader} LOGIN"))
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert state.reader_exists
+            assert not state.reader_role_secure
+            assert not state.adopted
+
+            report = await run_adoption(engine, apply=True)
+            assert tenant_id in report.failures
+            assert "unsafe attributes" in report.failures[tenant_id]
+            assert not report.ok
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_stray_reader_member_is_not_adopted_and_is_repaired(self):
+        tenant_id, schema, reader, _writer = _new_tenant()
+        stray = f"w998_stray_{tenant_id.replace('-', '_')}"
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            # A member outside {provisioner, sandbox, tile} is a read path into
+            # the tenant that nothing else in the report would show: ownership
+            # and per-relation privileges are all still correct.
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"CREATE ROLE {stray} NOLOGIN NOINHERIT"))
+                await conn.execute(sa.text(f"GRANT {reader} TO {stray}"))
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert state.relations_not_owned_by_writer == 0
+            assert state.relations_without_reader_select == 0
+            assert not state.reader_role_secure
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"DROP ROLE IF EXISTS {stray}"))
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_healthy_cluster_topology_reports_no_error(self):
+        engine = _make_engine()
+        try:
+            assert await cluster_topology_error(engine) is None
+        finally:
+            await engine.dispose()
+
+
 # ---------------------------------------------------------------------------
 # B: a second run is a no-op
 # ---------------------------------------------------------------------------
@@ -610,6 +687,7 @@ def _report(**overrides) -> AdoptionReport:
         "before": [],
         "after": [],
         "failures": {},
+        "cluster_topology": None,
     }
     fields.update(overrides)
     return AdoptionReport(**fields)
@@ -630,6 +708,11 @@ class TestSuccessPredicate:
 
     def test_no_boundary_functions_at_all_is_not_ok(self) -> None:
         assert not _report(functions=[]).ok
+
+    def test_refused_cluster_topology_is_not_ok(self) -> None:
+        report = _report(cluster_topology="role geolens_tile_gateway is missing")
+        assert not report.ok
+        assert "NEEDS ATTENTION" in format_report(report)
 
     def test_stamped_table_missing_from_rls_tables_is_not_ok(self) -> None:
         """Boot never enables RLS on it, so the post-restore check must fail."""

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -707,6 +707,52 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_reader_write_privileges_on_relations_are_revoked(
+        self, multi_tenant_row_security
+    ):
+        """SELECT present is not the same as SELECT only.
+
+        The sandbox and tile gateways SET ROLE to the reader, so an INSERT the
+        restore carried over is a write path into tenant data that the
+        SELECT-presence check reported as fine.
+        """
+        tenant_id, schema, reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(f"GRANT INSERT, DELETE ON {schema}.parcels TO {reader}")
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert state.relations_without_reader_select == 0
+            assert state.relations_with_reader_write == 1
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+
+            async with engine.connect() as conn:
+                privileges = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT has_table_privilege(:role, :table, 'SELECT'), "
+                            "has_table_privilege(:role, :table, 'INSERT'), "
+                            "has_table_privilege(:role, :table, 'DELETE')"
+                        ),
+                        {"role": reader, "table": f"{schema}.parcels"},
+                    )
+                ).one()
+            assert tuple(privileges) == (True, False, False)
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_legacy_reader_default_privileges_are_not_adopted(
         self, multi_tenant_row_security
     ):
@@ -1530,6 +1576,7 @@ def _adopted_tenant_state() -> TenantOwnershipState:
         relations=1,
         relations_not_owned_by_writer=0,
         relations_without_reader_select=0,
+        relations_with_reader_write=0,
         reader_default_acls=0,
         reader_role_secure=True,
         writer_role_secure=True,

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -1186,6 +1186,80 @@ class TestLiveTenantBoundary:
         finally:
             await engine.dispose()
 
+    async def test_a_conditional_stamping_trigger_is_not_a_live_boundary(self):
+        """A WHEN clause leaves the rows it excludes unstamped."""
+        engine = _make_engine()
+        table = "embed_tokens"
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            "DROP TRIGGER trg_stamp_current_tenant_on_insert "
+                            f"ON catalog.{table}"
+                        )
+                    )
+                    await conn.execute(
+                        sa.text(
+                            "CREATE TRIGGER trg_stamp_current_tenant_on_insert "
+                            f"BEFORE INSERT ON catalog.{table} FOR EACH ROW "
+                            "WHEN (NEW.tenant_id IS NOT NULL) "
+                            "EXECUTE FUNCTION catalog.stamp_current_tenant_on_insert()"
+                        )
+                    )
+                    boundary = await live_tenant_boundary(conn)
+                    state = next(entry for entry in boundary if entry.name == table)
+                    assert not state.has_stamping_trigger
+                    assert state.stamping_trigger_inert
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_a_security_definer_stamping_function_is_reported(self):
+        """0018 installs it SECURITY INVOKER; it fires on every insert."""
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            "ALTER FUNCTION catalog.stamp_current_tenant_on_insert() "
+                            "SECURITY DEFINER"
+                        )
+                    )
+                    reason = await stamping_function_shape(conn)
+                    assert reason is not None
+                    assert "SECURITY DEFINER" in reason
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_an_isolation_policy_narrowed_off_public_is_reported(self):
+        """Every role outside a named list takes the implicit RLS deny."""
+        engine = _make_engine()
+        table = "embed_tokens"
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            f"ALTER POLICY tenant_isolation_{table} "
+                            f"ON catalog.{table} TO geolens_reader"
+                        )
+                    )
+                    boundary = await live_tenant_boundary(conn)
+                    state = next(entry for entry in boundary if entry.name == table)
+                    assert not state.isolation_policy_intact
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
     async def test_a_missing_isolation_policy_is_reported(self):
         """Boot enables RLS; nothing recreates the rule RLS enforces."""
         engine = _make_engine()

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -2285,6 +2285,7 @@ def _adopted_tenant_state() -> TenantOwnershipState:
         relations=1,
         unsafe_routines=0,
         unsafe_types=0,
+        foreign_grantors=0,
         relations_not_owned_by_writer=0,
         relations_without_reader_select=0,
         relations_with_unsafe_acl=0,

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -906,6 +906,61 @@ class TestAdoptionWithRestoredBoundaryFunctions:
         finally:
             await engine.dispose()
 
+    async def test_role_creation_leaves_the_creator_able_to_use_the_role(self):
+        """What CLUSTER_ROLE_CREATE_SQL compensates for, pinned to the server.
+
+        On a fresh cluster with no globals dump, the non-superuser CREATEROLE
+        migrator creates the provisioner itself. PostgreSQL 16+ makes it an
+        ADMIN member of the new role with INHERIT FALSE and SET FALSE, which is
+        not the same as holding that role's privileges — and the boundary
+        function repair needs the privileges. The real provisioner cannot be
+        dropped and recreated on a shared cluster, so this pins the server
+        behaviour and the compensating grant on a stand-in, in a transaction
+        that is rolled back.
+        """
+        creator = f"w998_creator_{uuid.uuid4().hex[:12]}"
+        created = f"w998_created_{uuid.uuid4().hex[:12]}"
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(f"CREATE ROLE {creator} NOLOGIN NOSUPERUSER CREATEROLE")
+                    )
+                    await conn.execute(sa.text(f"SET LOCAL ROLE {creator}"))
+                    await conn.execute(sa.text(f"CREATE ROLE {created} NOLOGIN"))
+
+                    async def creator_holds_privileges() -> bool:
+                        return (
+                            await conn.execute(
+                                sa.text(
+                                    "SELECT pg_has_role(:creator, :created, 'USAGE')"
+                                ),
+                                {"creator": creator, "created": created},
+                            )
+                        ).scalar_one()
+
+                    assert not await creator_holds_privileges(), (
+                        "the automatic creator membership is expected to be "
+                        "ADMIN-only; if PostgreSQL changed this, the "
+                        "compensating grant in CLUSTER_ROLE_CREATE_SQL is dead code"
+                    )
+
+                    # No ADMIN in the compensating grant: PostgreSQL refuses
+                    # "ADMIN option cannot be granted back to your own grantor",
+                    # and the automatic membership already carries it.
+                    await conn.execute(
+                        sa.text(
+                            f"GRANT {created} TO {creator} WITH INHERIT TRUE, SET TRUE"
+                        )
+                    )
+                    assert await creator_holds_privileges()
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
     async def test_a_migrator_without_provisioner_privileges_is_told_what_to_run(self):
         migrator = f"w998_mig_{uuid.uuid4().hex[:12]}"
         engine = _make_engine()

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -521,6 +521,10 @@ class TestReportedStateMatchesWhatApplyEnforces:
             refused = await run_adoption(engine, apply=True)
             assert tenant_id in refused.failures
             assert "will not rewrite" in refused.failures[tenant_id]
+            # The remediation PostgreSQL attached to the refusal survives
+            # into the report; without it the operator is told a tenant is
+            # incomplete and not what to run.
+            assert "REVOKE" in refused.failures[tenant_id]
             assert not refused.ok
         finally:
             async with engine.begin() as conn:

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -561,6 +561,74 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_legacy_admin_option_membership_is_rewritten(
+        self, multi_tenant_row_security
+    ):
+        """A globals dump from PostgreSQL 13-15 replays as `WITH ADMIN OPTION`.
+
+        On 16+ that lands SET TRUE, which `provision_tenant_data_schema` rejects
+        as not ADMIN-only — so every restored tenant whose roles came back from
+        an older cluster would fail adoption. Checking `admin_option` alone was
+        not enough to notice.
+        """
+        tenant_id, schema, reader, writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            async with engine.begin() as conn:
+                for role in (reader, writer):
+                    await conn.execute(
+                        sa.text(
+                            f"CREATE ROLE {role} NOLOGIN NOSUPERUSER NOCREATEDB "
+                            "NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS"
+                        )
+                    )
+                    await conn.execute(
+                        sa.text(f"GRANT {role} TO {PROVISIONER} WITH ADMIN OPTION")
+                    )
+
+            async with engine.connect() as conn:
+                options = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT membership.set_option FROM pg_auth_members "
+                            "AS membership "
+                            "JOIN pg_roles AS granted ON granted.oid = membership.roleid "
+                            "JOIN pg_roles AS member ON member.oid = membership.member "
+                            "WHERE granted.rolname = :reader AND member.rolname = :owner"
+                        ),
+                        {"reader": reader, "owner": PROVISIONER},
+                    )
+                ).scalar_one()
+            assert options is True, "fixture must reproduce the legacy grant shape"
+
+            report = await run_adoption(engine, apply=True)
+            assert report.failures == {}, report.failures
+            assert report.ok
+
+            async with engine.connect() as conn:
+                for role in (reader, writer):
+                    membership = (
+                        await conn.execute(
+                            sa.text(
+                                "SELECT membership.admin_option, "
+                                "membership.inherit_option, membership.set_option "
+                                "FROM pg_auth_members AS membership "
+                                "JOIN pg_roles AS granted "
+                                "  ON granted.oid = membership.roleid "
+                                "JOIN pg_roles AS member "
+                                "  ON member.oid = membership.member "
+                                "WHERE granted.rolname = :role "
+                                "AND member.rolname = :owner"
+                            ),
+                            {"role": role, "owner": PROVISIONER},
+                        )
+                    ).one()
+                    assert tuple(membership) == (True, False, False), role
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_writer_missing_one_schema_privilege_is_not_adopted(
         self, multi_tenant_row_security
     ):

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -487,6 +487,47 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_a_third_party_gateway_grant_is_revoked(
+        self, multi_tenant_row_security
+    ):
+        """The unsafe row belongs to another grantor, not to the adopter.
+
+        A plain REVOKE removes only the caller's own grant, so this is the case
+        that separates targeting the row from targeting the grantor the adopter
+        happens to be.
+        """
+        tenant_id, schema, reader, _writer = _new_tenant()
+        grantor = f"w998_grantor_{tenant_id.replace('-', '_')}"
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"CREATE ROLE {grantor} NOLOGIN CREATEROLE"))
+                await conn.execute(
+                    sa.text(f"GRANT {reader} TO {grantor} WITH ADMIN OPTION")
+                )
+                await conn.execute(sa.text(f"SET LOCAL ROLE {grantor}"))
+                await conn.execute(
+                    sa.text(f"GRANT {reader} TO {TILE} WITH INHERIT TRUE, SET TRUE")
+                )
+                await conn.execute(sa.text("RESET ROLE"))
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert not state.reader_role_secure
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"DROP OWNED BY {grantor}"))
+                await conn.execute(sa.text(f"DROP ROLE IF EXISTS {grantor}"))
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_a_duplicate_provisioner_edge_is_normalized(
         self, multi_tenant_row_security
     ):

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -43,14 +44,15 @@ from app.core.db.tenant_adoption import (
     AdoptionReport,
     BoundaryFunctionState,
     BoundaryTableState,
+    TenantOwnershipState,
     boundary_drift,
     boundary_function_states,
     cluster_topology_error,
     format_report,
     live_tenant_boundary,
     missing_provisioner_grants,
-    TenantOwnershipState,
     run_adoption,
+    secure_boundary_functions,
     tenant_ownership_state,
 )
 
@@ -679,6 +681,115 @@ class TestAdoptionWithRestoredBoundaryFunctions:
         finally:
             await _restore_boundary_functions(engine)
             await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_a_non_superuser_migrator_can_transfer_ownership(self):
+        """The documented CREATEROLE migrator, not just a bundled superuser.
+
+        `ALTER FUNCTION ... OWNER TO` needs the incoming owner to hold CREATE on
+        the containing schema, which the provisioner deliberately does not have.
+        A superuser is exempt from neither requirement but satisfies both by
+        fiat, so this path only shows up on a managed provider.
+
+        Everything here runs in one transaction that is rolled back: the role
+        and its membership in the provisioner are cluster objects that every
+        other xdist worker's database shares, and an uncommitted grant is
+        invisible to them.
+        """
+        migrator = f"w998_mig_{uuid.uuid4().hex[:12]}"
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(f"CREATE ROLE {migrator} NOSUPERUSER CREATEROLE")
+                    )
+                    await conn.execute(
+                        sa.text(
+                            f"GRANT CREATE, USAGE ON SCHEMA catalog TO {migrator} "
+                            "WITH GRANT OPTION"
+                        )
+                    )
+                    await conn.execute(
+                        sa.text(f"GRANT {PROVISIONER} TO {migrator} WITH INHERIT TRUE")
+                    )
+                    # What pg_restore --no-owner leaves behind.
+                    for name in BOUNDARY_FUNCTIONS:
+                        await conn.execute(
+                            sa.text(
+                                f"ALTER FUNCTION catalog.{name}(uuid) "
+                                f"OWNER TO {migrator}"
+                            )
+                        )
+                        await conn.execute(
+                            sa.text(
+                                f"GRANT EXECUTE ON FUNCTION catalog.{name}(uuid) "
+                                "TO PUBLIC"
+                            )
+                        )
+
+                    await conn.execute(sa.text(f"SET LOCAL ROLE {migrator}"))
+                    assert not (
+                        await conn.execute(
+                            sa.text(
+                                "SELECT has_schema_privilege("
+                                ":provisioner, 'catalog', 'CREATE')"
+                            ),
+                            {"provisioner": PROVISIONER},
+                        )
+                    ).scalar_one()
+
+                    repaired = await secure_boundary_functions(conn)
+                    assert all(state.secured for state in repaired), repaired
+
+                    # The borrowed schema privilege is given back, not kept.
+                    assert not (
+                        await conn.execute(
+                            sa.text(
+                                "SELECT has_schema_privilege("
+                                ":provisioner, 'catalog', 'CREATE')"
+                            ),
+                            {"provisioner": PROVISIONER},
+                        )
+                    ).scalar_one()
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_a_migrator_without_provisioner_privileges_is_told_what_to_run(self):
+        migrator = f"w998_mig_{uuid.uuid4().hex[:12]}"
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(f"CREATE ROLE {migrator} NOSUPERUSER CREATEROLE")
+                    )
+                    await conn.execute(
+                        sa.text(
+                            f"GRANT CREATE, USAGE ON SCHEMA catalog TO {migrator} "
+                            "WITH GRANT OPTION"
+                        )
+                    )
+                    for name in BOUNDARY_FUNCTIONS:
+                        await conn.execute(
+                            sa.text(
+                                f"ALTER FUNCTION catalog.{name}(uuid) "
+                                f"OWNER TO {migrator}"
+                            )
+                        )
+                    await conn.execute(sa.text(f"SET LOCAL ROLE {migrator}"))
+
+                    with pytest.raises(
+                        DBAPIError, match="does not hold the privileges"
+                    ):
+                        await secure_boundary_functions(conn)
+                finally:
+                    await transaction.rollback()
+        finally:
             await engine.dispose()
 
     async def test_missing_function_refuses_instead_of_installing_one(self):

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -487,6 +487,60 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_a_duplicate_provisioner_edge_is_normalized(
+        self, multi_tenant_row_security
+    ):
+        """The canonical row hides it and nothing else would take it away.
+
+        Only the foreign grantor's row goes: revoking the provisioner's
+        membership outright would remove the ADMIN path the transaction reaches
+        the tenant roles through.
+        """
+        tenant_id, schema, reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"GRANT {reader} TO {PROVISIONER} "
+                        "WITH ADMIN TRUE, INHERIT TRUE, SET TRUE"
+                    )
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert not state.reader_role_secure
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+
+            async with engine.connect() as conn:
+                rows = [
+                    tuple(row)
+                    for row in await conn.execute(
+                        sa.text(
+                            "SELECT membership.admin_option, "
+                            "membership.inherit_option, membership.set_option "
+                            "FROM pg_auth_members AS membership "
+                            "JOIN pg_roles AS granted "
+                            "  ON granted.oid = membership.roleid "
+                            "JOIN pg_roles AS member "
+                            "  ON member.oid = membership.member "
+                            "WHERE granted.rolname = :reader AND member.rolname = :owner"
+                        ),
+                        {"reader": reader, "owner": PROVISIONER},
+                    )
+                ]
+            assert rows == [(True, False, False)]
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_a_second_inheriting_gateway_edge_is_not_adopted(
         self, multi_tenant_row_security
     ):

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -60,7 +60,8 @@ from app.core.db.tenant_adoption_report import (
     rls_gaps,
 )
 from app.core.db.tenant_adoption_sql import (
-    RELEASE_BOOTSTRAP_MEMBERSHIP_SQL,
+    RELEASE_GATEWAY_EDGES_SQL,
+    RELEASE_PROVISIONER_EDGE_SQL,
     SANDBOX,
     TILE,
 )
@@ -780,6 +781,47 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_a_stray_grantee_on_a_tenant_relation_is_revoked(
+        self, multi_tenant_row_security
+    ):
+        """A named role with its own grant needs neither tenant role."""
+        tenant_id, schema, _reader, _writer = _new_tenant()
+        stray = f"w998_stray_{tenant_id.replace('-', '_')}"
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"CREATE ROLE {stray} NOLOGIN"))
+                await conn.execute(
+                    sa.text(f"GRANT SELECT ON {schema}.parcels TO {stray}")
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert state.relations_with_unsafe_acl == 1
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+
+            async with engine.connect() as conn:
+                stray_select = (
+                    await conn.execute(
+                        sa.text("SELECT has_table_privilege(:role, :table, 'SELECT')"),
+                        {"role": stray, "table": f"{schema}.parcels"},
+                    )
+                ).scalar_one()
+            assert stray_select is False
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"DROP OWNED BY {stray}"))
+                await conn.execute(sa.text(f"DROP ROLE IF EXISTS {stray}"))
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_public_grants_on_tenant_relations_are_revoked(
         self, multi_tenant_row_security
     ):
@@ -1170,7 +1212,7 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                     )
                     assert len(await edges()) == 1
 
-                    await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
+                    await conn.execute(sa.text(RELEASE_PROVISIONER_EDGE_SQL))
                     assert await edges() == []
 
                     # The provisioner's ADMIN edge is what lets the same
@@ -1180,7 +1222,7 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                             f"GRANT {PROVISIONER} TO current_user WITH ADMIN OPTION"
                         )
                     )
-                    await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
+                    await conn.execute(sa.text(RELEASE_GATEWAY_EDGES_SQL))
                     assert [admin for _grantor, admin in await edges()] == [True]
 
                     # The four gateways get the same automatic creator edge —
@@ -1213,7 +1255,7 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                             )
                         )
                     assert await gateway_edges() == 4
-                    await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
+                    await conn.execute(sa.text(RELEASE_GATEWAY_EDGES_SQL))
                     assert await gateway_edges() == 0
 
                     # A usable edge is somebody's decision, not this run's
@@ -1224,7 +1266,7 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                             "WITH ADMIN TRUE, INHERIT TRUE, SET TRUE"
                         )
                     )
-                    await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
+                    await conn.execute(sa.text(RELEASE_GATEWAY_EDGES_SQL))
                     assert await gateway_edges() == 1
                 finally:
                     await transaction.rollback()

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -1042,10 +1042,19 @@ class TestReportedStateMatchesWhatApplyEnforces:
                     )
                 )
                 await conn.execute(sa.text("RESET ROLE"))
+                # Functions carry a built-in PUBLIC EXECUTE that aclexplode
+                # reports alongside the added grantee; revoking it would leave a
+                # subtractive entry nothing here could reset.
+                await conn.execute(
+                    sa.text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA {schema} "
+                        f"GRANT EXECUTE ON FUNCTIONS TO {_reader}"
+                    )
+                )
 
             async with engine.connect() as conn:
                 state = await tenant_ownership_state(conn, tenant_id)
-            assert state.unexpected_default_acls == 3
+            assert state.unexpected_default_acls == 4
             assert not state.adopted
 
             repaired = await run_adoption(engine, apply=True)

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -47,6 +47,7 @@ from app.core.db.tenant_adoption import (
     cluster_topology_error,
     format_report,
     live_tenant_boundary,
+    missing_provisioner_grants,
     run_adoption,
     tenant_ownership_state,
 )
@@ -449,6 +450,78 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_legacy_reader_default_privileges_are_not_adopted(self):
+        """The pre-0019 helper's ALTER DEFAULT PRIVILEGES entry is a live grant.
+
+        Nothing else in the report sees it: ownership and per-relation
+        privileges are all correct, and it still hands the reader access to
+        every table the writer creates next.
+        """
+        tenant_id, schema, reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA {schema} "
+                        f"GRANT SELECT ON TABLES TO {reader}"
+                    )
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert state.reader_default_acls == 1
+            assert state.relations_not_owned_by_writer == 0
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+            async with engine.connect() as conn:
+                assert (
+                    await tenant_ownership_state(conn, tenant_id)
+                ).reader_default_acls == 0
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_missing_provisioner_grant_is_reported_and_re_granted(self):
+        """Globals replay restores the role; it restores none of its grants."""
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                assert await missing_provisioner_grants(conn) == []
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(f"REVOKE USAGE ON SCHEMA catalog FROM {PROVISIONER}")
+                )
+
+            async with engine.connect() as conn:
+                assert await missing_provisioner_grants(conn) == [
+                    "USAGE on schema catalog"
+                ]
+
+            dry_run = await run_adoption(engine, apply=False)
+            assert dry_run.provisioner_grants_missing == ["USAGE on schema catalog"]
+            assert not dry_run.ok
+            assert "is missing USAGE on schema catalog" in format_report(dry_run)
+
+            applied = await run_adoption(engine, apply=True)
+            assert applied.provisioner_grants_missing == []
+            assert applied.ok
+        finally:
+            # Self-healing above, but a failed assertion must not leave the
+            # worker's database unable to provision a tenant.
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(f"GRANT USAGE ON SCHEMA catalog TO {PROVISIONER}")
+                )
+            await engine.dispose()
+
     async def test_healthy_cluster_topology_reports_no_error(self):
         engine = _make_engine()
         try:
@@ -688,6 +761,7 @@ def _report(**overrides) -> AdoptionReport:
         "after": [],
         "failures": {},
         "cluster_topology": None,
+        "provisioner_grants_missing": [],
     }
     fields.update(overrides)
     return AdoptionReport(**fields)
@@ -713,6 +787,11 @@ class TestSuccessPredicate:
         report = _report(cluster_topology="role geolens_tile_gateway is missing")
         assert not report.ok
         assert "NEEDS ATTENTION" in format_report(report)
+
+    def test_missing_provisioner_grant_is_not_ok(self) -> None:
+        report = _report(provisioner_grants_missing=["SELECT on catalog.tenants"])
+        assert not report.ok
+        assert "SELECT on catalog.tenants" in format_report(report)
 
     def test_stamped_table_missing_from_rls_tables_is_not_ok(self) -> None:
         """Boot never enables RLS on it, so the post-restore check must fail."""

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -2333,6 +2333,7 @@ def _adopted_tenant_state() -> TenantOwnershipState:
         relations=1,
         unsafe_routines=0,
         unsafe_types=0,
+        unsafe_statistics=0,
         foreign_grantors=0,
         relations_not_owned_by_writer=0,
         relations_without_reader_select=0,

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -485,6 +485,33 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_a_second_inheriting_gateway_edge_is_not_adopted(
+        self, multi_tenant_row_security
+    ):
+        """A duplicate grant from another grantor sits beside the canonical row.
+
+        PostgreSQL keeps both, and one carrying INHERIT hands the gateway the
+        tenant role's privileges outright instead of making it SET ROLE.
+        """
+        tenant_id, schema, reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(f"GRANT {reader} TO {TILE} WITH INHERIT TRUE, SET TRUE")
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert not state.reader_role_secure
+            assert not state.adopted
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_stray_reader_member_is_not_adopted_and_is_repaired(
         self, multi_tenant_row_security
     ):
@@ -1564,6 +1591,28 @@ class TestLiveTenantBoundary:
                         sa.text(
                             f"ALTER POLICY tenant_isolation_{table} "
                             f"ON catalog.{table} USING (true)"
+                        )
+                    )
+                    boundary = await live_tenant_boundary(conn)
+                    state = next(entry for entry in boundary if entry.name == table)
+                    assert not state.isolation_policy_intact
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_an_extra_restrictive_policy_is_reported(self):
+        """Restrictive policies AND: one `USING (false)` denies everything."""
+        engine = _make_engine()
+        table = "embed_tokens"
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            f"CREATE POLICY w998_restrictive ON catalog.{table} "
+                            "AS RESTRICTIVE USING (false)"
                         )
                     )
                     boundary = await live_tenant_boundary(conn)

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -2334,6 +2334,8 @@ def _adopted_tenant_state() -> TenantOwnershipState:
         unsafe_routines=0,
         unsafe_types=0,
         unsafe_statistics=0,
+        unsafe_collations=0,
+        unowned_other_objects=0,
         foreign_grantors=0,
         relations_not_owned_by_writer=0,
         relations_without_reader_select=0,

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -39,8 +39,12 @@ from app.core.db.tenant_adoption import (
     BOUNDARY_FUNCTIONS,
     CONTROL,
     PROVISIONER,
+    AdoptionReport,
+    BoundaryFunctionState,
+    BoundaryTableState,
     boundary_drift,
     boundary_function_states,
+    format_report,
     live_tenant_boundary,
     run_adoption,
     tenant_ownership_state,
@@ -567,3 +571,84 @@ def test_module_is_runnable_as_documented() -> None:
     parser = module._build_parser()
     assert parser.parse_args([]).apply is False
     assert parser.parse_args(["--apply"]).apply is True
+
+
+# ---------------------------------------------------------------------------
+# The success predicate covers everything the report surfaces
+# ---------------------------------------------------------------------------
+
+
+def _secured_function(name: str) -> BoundaryFunctionState:
+    return BoundaryFunctionState(
+        name=name,
+        owner=PROVISIONER,
+        security_definer=True,
+        search_path_pinned=True,
+        public_execute=False,
+        control_execute=True,
+    )
+
+
+def _clean_boundary() -> list[BoundaryTableState]:
+    return [
+        BoundaryTableState(
+            name=name,
+            has_stamping_trigger=True,
+            has_tenant_id=True,
+            rls_enabled=True,
+            rls_forced=True,
+        )
+        for name in RLS_TABLES
+    ]
+
+
+def _report(**overrides) -> AdoptionReport:
+    fields: dict = {
+        "applied": False,
+        "functions": [_secured_function(name) for name in BOUNDARY_FUNCTIONS],
+        "boundary": _clean_boundary(),
+        "before": [],
+        "after": [],
+        "failures": {},
+    }
+    fields.update(overrides)
+    return AdoptionReport(**fields)
+
+
+class TestSuccessPredicate:
+    """`ok` is the documented exit code, so it has to see every finding."""
+
+    def test_clean_report_is_ok(self) -> None:
+        assert _report().ok
+
+    def test_missing_boundary_function_is_not_ok(self) -> None:
+        """An absent function shortens the list; `all(...)` alone passes it."""
+        report = _report(functions=[_secured_function(BOUNDARY_FUNCTIONS[0])])
+        assert report.missing_functions == [BOUNDARY_FUNCTIONS[1]]
+        assert not report.ok
+        assert "MISSING" in format_report(report)
+
+    def test_no_boundary_functions_at_all_is_not_ok(self) -> None:
+        assert not _report(functions=[]).ok
+
+    def test_stamped_table_missing_from_rls_tables_is_not_ok(self) -> None:
+        """Boot never enables RLS on it, so the post-restore check must fail."""
+        boundary = _clean_boundary() + [
+            BoundaryTableState(
+                name="w998_late_arrival",
+                has_stamping_trigger=True,
+                has_tenant_id=True,
+                rls_enabled=False,
+                rls_forced=False,
+            )
+        ]
+        report = _report(boundary=boundary)
+        assert boundary_drift(boundary) == (["w998_late_arrival"], [])
+        assert not report.ok
+
+    def test_declared_table_without_a_stamping_trigger_is_not_ok(self) -> None:
+        """The other direction: inserts land with no tenant_id at all."""
+        boundary = [table for table in _clean_boundary() if table.name != RLS_TABLES[0]]
+        report = _report(boundary=boundary)
+        assert boundary_drift(boundary) == ([], [RLS_TABLES[0]])
+        assert not report.ok

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -730,7 +730,7 @@ class TestReportedStateMatchesWhatApplyEnforces:
             async with engine.connect() as conn:
                 state = await tenant_ownership_state(conn, tenant_id)
             assert state.relations_without_reader_select == 0
-            assert state.relations_with_reader_write == 1
+            assert state.relations_with_unsafe_acl == 1
             assert not state.adopted
 
             repaired = await run_adoption(engine, apply=True)
@@ -749,6 +749,51 @@ class TestReportedStateMatchesWhatApplyEnforces:
                     )
                 ).one()
             assert tuple(privileges) == (True, False, False)
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_public_grants_on_tenant_relations_are_revoked(
+        self, multi_tenant_row_security
+    ):
+        """PUBLIC reaches the reader, and everyone else with schema USAGE."""
+        tenant_id, schema, reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(f"GRANT SELECT, INSERT ON {schema}.parcels TO PUBLIC")
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert state.relations_with_unsafe_acl == 1
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+
+            async with engine.connect() as conn:
+                public_select = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT has_table_privilege('public', :table, 'SELECT')"
+                        ),
+                        {"table": f"{schema}.parcels"},
+                    )
+                ).scalar_one()
+                reader_select = (
+                    await conn.execute(
+                        sa.text("SELECT has_table_privilege(:role, :table, 'SELECT')"),
+                        {"role": reader, "table": f"{schema}.parcels"},
+                    )
+                ).scalar_one()
+            assert public_select is False
+            assert reader_select is True
         finally:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
@@ -1529,6 +1574,27 @@ class TestLiveTenantBoundary:
         finally:
             await engine.dispose()
 
+    async def test_an_extra_permissive_policy_is_reported(self):
+        """Permissive policies OR: one `USING (true)` beside the rule undoes it."""
+        engine = _make_engine()
+        table = "embed_tokens"
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            f"CREATE POLICY w998_extra ON catalog.{table} USING (true)"
+                        )
+                    )
+                    boundary = await live_tenant_boundary(conn)
+                    state = next(entry for entry in boundary if entry.name == table)
+                    assert not state.isolation_policy_intact
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
     async def test_dormant_tenant_id_columns_are_reported_outside_the_boundary(self):
         """0037's ``dataset_refresh_runs.tenant_id`` is deliberately dormant.
 
@@ -1624,7 +1690,7 @@ def _adopted_tenant_state() -> TenantOwnershipState:
         relations=1,
         relations_not_owned_by_writer=0,
         relations_without_reader_select=0,
-        relations_with_reader_write=0,
+        relations_with_unsafe_acl=0,
         reader_default_acls=0,
         reader_role_secure=True,
         writer_role_secure=True,

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -45,6 +45,7 @@ from app.core.db.tenant_adoption import (
     live_tenant_boundary,
     missing_provisioner_grants,
     run_adoption,
+    stamping_function_shape,
     secure_boundary_functions,
     tenant_ownership_state,
 )
@@ -56,6 +57,7 @@ from app.core.db.tenant_adoption_report import (
     TenantOwnershipState,
     boundary_drift,
     format_report,
+    rls_gaps,
 )
 from app.core.db.tenant_adoption_sql import WRITER as WRITER_GATEWAY
 
@@ -1155,6 +1157,81 @@ class TestLiveTenantBoundary:
         finally:
             await engine.dispose()
 
+    async def test_a_stubbed_stamping_function_is_reported(self):
+        """The trigger can be perfect and still stamp nothing.
+
+        Every table keeps its BEFORE INSERT trigger on the right function; the
+        function just stops writing NEW.tenant_id. Rolled back.
+        """
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    assert await stamping_function_shape(conn) is None
+                    await conn.execute(
+                        sa.text(
+                            "CREATE OR REPLACE FUNCTION "
+                            "catalog.stamp_current_tenant_on_insert() "
+                            "RETURNS trigger LANGUAGE plpgsql "
+                            "SET search_path = pg_catalog, catalog "
+                            "AS $$ BEGIN RETURN NEW; END $$"
+                        )
+                    )
+                    reason = await stamping_function_shape(conn)
+                    assert reason is not None
+                    assert "stamps nothing" in reason
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_a_missing_isolation_policy_is_reported(self):
+        """Boot enables RLS; nothing recreates the rule RLS enforces."""
+        engine = _make_engine()
+        table = "embed_tokens"
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            f"DROP POLICY tenant_isolation_{table} ON catalog.{table}"
+                        )
+                    )
+                    boundary = await live_tenant_boundary(conn)
+                    state = next(entry for entry in boundary if entry.name == table)
+                    assert not state.isolation_policy_intact
+                    assert rls_gaps(boundary, tenants_present=False) == [
+                        f"{table} (tenant_isolation policy missing or altered)"
+                    ]
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_an_altered_isolation_policy_is_reported(self):
+        """A permissive rewrite returns every tenant's rows and looks intact."""
+        engine = _make_engine()
+        table = "embed_tokens"
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            f"ALTER POLICY tenant_isolation_{table} "
+                            f"ON catalog.{table} USING (true)"
+                        )
+                    )
+                    boundary = await live_tenant_boundary(conn)
+                    state = next(entry for entry in boundary if entry.name == table)
+                    assert not state.isolation_policy_intact
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
     async def test_dormant_tenant_id_columns_are_reported_outside_the_boundary(self):
         """0037's ``dataset_refresh_runs.tenant_id`` is deliberately dormant.
 
@@ -1232,6 +1309,7 @@ def _clean_boundary() -> list[BoundaryTableState]:
             has_tenant_id=True,
             rls_enabled=True,
             rls_forced=True,
+            isolation_policy_intact=True,
         )
         for name in RLS_TABLES
     ]
@@ -1264,6 +1342,7 @@ def _report(**overrides) -> AdoptionReport:
         "after": [],
         "failures": {},
         "cluster_topology": None,
+        "stamping_function": None,
         "provisioner_grants_missing": [],
     }
     fields.update(overrides)
@@ -1310,6 +1389,7 @@ class TestSuccessPredicate:
                 has_tenant_id=True,
                 rls_enabled=True,
                 rls_forced=True,
+                isolation_policy_intact=True,
             )
         ]
         report = _report(boundary=boundary)
@@ -1326,6 +1406,7 @@ class TestSuccessPredicate:
                 has_tenant_id=True,
                 rls_enabled=False,
                 rls_forced=False,
+                isolation_policy_intact=True,
             )
             for table in _clean_boundary()
         ]
@@ -1344,6 +1425,7 @@ class TestSuccessPredicate:
                 has_tenant_id=True,
                 rls_enabled=False,
                 rls_forced=False,
+                isolation_policy_intact=True,
             )
             for table in _clean_boundary()
         ]
@@ -1361,6 +1443,7 @@ class TestSuccessPredicate:
                 has_tenant_id=True,
                 rls_enabled=True,
                 rls_forced=False,
+                isolation_policy_intact=True,
             )
             for table in _clean_boundary()
         ]
@@ -1384,6 +1467,7 @@ class TestSuccessPredicate:
                 has_tenant_id=True,
                 rls_enabled=False,
                 rls_forced=False,
+                isolation_policy_intact=True,
             )
         ]
         report = _report(boundary=boundary)

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -37,25 +37,27 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import NullPool
 
 from app.core.db.rls import RLS_TABLES
-from app.core.db.tenant_adoption_sql import WRITER as WRITER_GATEWAY
 from app.core.db.tenant_adoption import (
-    BOUNDARY_FUNCTIONS,
     CONTROL,
     PROVISIONER,
-    AdoptionReport,
-    BoundaryFunctionState,
-    BoundaryTableState,
-    TenantOwnershipState,
-    boundary_drift,
     boundary_function_states,
     cluster_topology_error,
-    format_report,
     live_tenant_boundary,
     missing_provisioner_grants,
     run_adoption,
     secure_boundary_functions,
     tenant_ownership_state,
 )
+from app.core.db.tenant_adoption_report import (
+    BOUNDARY_FUNCTIONS,
+    AdoptionReport,
+    BoundaryFunctionState,
+    BoundaryTableState,
+    TenantOwnershipState,
+    boundary_drift,
+    format_report,
+)
+from app.core.db.tenant_adoption_sql import WRITER as WRITER_GATEWAY
 
 pytestmark = pytest.mark.anyio
 
@@ -995,6 +997,33 @@ class TestAdoptionWithRestoredBoundaryFunctions:
         finally:
             await engine.dispose()
 
+    async def test_a_substituted_function_body_is_refused(self):
+        """A `(uuid)` SECURITY DEFINER function is not automatically the one.
+
+        Adoption gives the boundary functions to the provisioner and grants the
+        control role execution, so it refuses anything that is not structurally
+        what the migrations install. Rolled back either way.
+        """
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            "CREATE OR REPLACE FUNCTION "
+                            "catalog.provision_tenant_data_schema(p_tenant_id uuid) "
+                            "RETURNS void LANGUAGE sql SECURITY DEFINER "
+                            "SET search_path = pg_catalog AS $$ SELECT NULL::void $$"
+                        )
+                    )
+                    with pytest.raises(RuntimeError, match="not plpgsql"):
+                        await secure_boundary_functions(conn)
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
     async def test_missing_function_refuses_instead_of_installing_one(self):
         """Bodies belong to the migrations; adoption never writes one."""
         from app.core.db.tenant_adoption import secure_boundary_functions
@@ -1071,14 +1100,14 @@ class TestLiveTenantBoundary:
                 boundary = await live_tenant_boundary(conn)
             state = next(entry for entry in boundary if entry.name == table)
             assert not state.has_stamping_trigger
-            assert state.stamping_trigger_disabled
+            assert state.stamping_trigger_inert
 
             # It is in RLS_TABLES but no longer stamped, so it reads as drift.
             assert boundary_drift(boundary) == ([], [table])
 
             report = await run_adoption(engine, apply=False)
             assert not report.ok
-            assert "DISABLED" in format_report(report)
+            assert "does not stamp" in format_report(report)
         finally:
             async with engine.begin() as conn:
                 await conn.execute(
@@ -1087,6 +1116,43 @@ class TestLiveTenantBoundary:
                         "ENABLE TRIGGER trg_stamp_current_tenant_on_insert"
                     )
                 )
+            await engine.dispose()
+
+    async def test_a_trigger_on_the_wrong_event_is_not_a_live_boundary(self):
+        """The name alone proves nothing about what fires.
+
+        A trigger recreated under the boundary name but wired to the wrong
+        timing stamps no ordinary insert, and nothing at boot notices. Rolled
+        back, so the worker's schema is unchanged either way.
+        """
+        engine = _make_engine()
+        table = "embed_tokens"
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            f"DROP TRIGGER trg_stamp_current_tenant_on_insert "
+                            f"ON catalog.{table}"
+                        )
+                    )
+                    await conn.execute(
+                        sa.text(
+                            "CREATE TRIGGER trg_stamp_current_tenant_on_insert "
+                            f"AFTER INSERT ON catalog.{table} FOR EACH ROW "
+                            "EXECUTE FUNCTION catalog.stamp_current_tenant_on_insert()"
+                        )
+                    )
+
+                    boundary = await live_tenant_boundary(conn)
+                    state = next(entry for entry in boundary if entry.name == table)
+                    assert not state.has_stamping_trigger
+                    assert state.stamping_trigger_inert
+                    assert boundary_drift(boundary) == ([], [table])
+                finally:
+                    await transaction.rollback()
+        finally:
             await engine.dispose()
 
     async def test_dormant_tenant_id_columns_are_reported_outside_the_boundary(self):
@@ -1149,6 +1215,9 @@ def _secured_function(name: str) -> BoundaryFunctionState:
         owner=PROVISIONER,
         security_definer=True,
         search_path_pinned=True,
+        language="plpgsql",
+        returns_void=True,
+        body_markers_present=True,
         public_execute=False,
         control_execute=True,
     )
@@ -1159,7 +1228,7 @@ def _clean_boundary() -> list[BoundaryTableState]:
         BoundaryTableState(
             name=name,
             has_stamping_trigger=True,
-            stamping_trigger_disabled=False,
+            stamping_trigger_present=True,
             has_tenant_id=True,
             rls_enabled=True,
             rls_forced=True,
@@ -1237,7 +1306,7 @@ class TestSuccessPredicate:
             BoundaryTableState(
                 name="w998_late_arrival",
                 has_stamping_trigger=True,
-                stamping_trigger_disabled=False,
+                stamping_trigger_present=True,
                 has_tenant_id=True,
                 rls_enabled=True,
                 rls_forced=True,
@@ -1253,7 +1322,7 @@ class TestSuccessPredicate:
             BoundaryTableState(
                 name=table.name,
                 has_stamping_trigger=True,
-                stamping_trigger_disabled=False,
+                stamping_trigger_present=True,
                 has_tenant_id=True,
                 rls_enabled=False,
                 rls_forced=False,
@@ -1271,7 +1340,7 @@ class TestSuccessPredicate:
             BoundaryTableState(
                 name=table.name,
                 has_stamping_trigger=True,
-                stamping_trigger_disabled=False,
+                stamping_trigger_present=True,
                 has_tenant_id=True,
                 rls_enabled=False,
                 rls_forced=False,
@@ -1288,7 +1357,7 @@ class TestSuccessPredicate:
             BoundaryTableState(
                 name=table.name,
                 has_stamping_trigger=True,
-                stamping_trigger_disabled=False,
+                stamping_trigger_present=True,
                 has_tenant_id=True,
                 rls_enabled=True,
                 rls_forced=False,
@@ -1299,7 +1368,7 @@ class TestSuccessPredicate:
         assert report.rls_gaps
         assert not report.ok
 
-    def test_disabled_trigger_on_an_undeclared_table_is_not_ok(self) -> None:
+    def test_inert_trigger_on_an_undeclared_table_is_not_ok(self) -> None:
         """The one combination neither drift direction can see.
 
         A newly tenant-scoped table absent from ``RLS_TABLES`` with its stamping
@@ -1311,7 +1380,7 @@ class TestSuccessPredicate:
             BoundaryTableState(
                 name="w998_new_and_undeclared",
                 has_stamping_trigger=False,
-                stamping_trigger_disabled=True,
+                stamping_trigger_present=True,
                 has_tenant_id=True,
                 rls_enabled=False,
                 rls_forced=False,
@@ -1320,9 +1389,9 @@ class TestSuccessPredicate:
         report = _report(boundary=boundary)
         assert boundary_drift(boundary) == ([], [])
         assert report.rls_gaps == []
-        assert report.disabled_stamping_triggers == ["w998_new_and_undeclared"]
+        assert report.inert_stamping_triggers == ["w998_new_and_undeclared"]
         assert not report.ok
-        assert "DISABLED" in format_report(report)
+        assert "does not stamp" in format_report(report)
 
     def test_declared_table_without_a_stamping_trigger_is_not_ok(self) -> None:
         """The other direction: inserts land with no tenant_id at all."""

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -1005,9 +1005,50 @@ class TestReportedStateMatchesWhatApplyEnforces:
 
             refused = await run_adoption(engine, apply=True)
             assert tenant_id in refused.failures
-            assert "SECURITY DEFINER routine" in refused.failures[tenant_id]
+            assert "SECURITY DEFINER" in refused.failures[tenant_id]
             assert "SECURITY INVOKER" in refused.failures[tenant_id]
             assert not refused.ok
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_a_tenant_defined_type_is_re_owned(self, multi_tenant_row_security):
+        """Types are in pg_type, so the relation pass never sees them."""
+        tenant_id, schema, _reader, writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(f"CREATE TYPE {schema}.parcel_kind AS ENUM ('a', 'b')")
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert state.unsafe_types == 1
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+
+            async with engine.connect() as conn:
+                owner = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT pg_get_userbyid(type_row.typowner) "
+                            "FROM pg_type AS type_row "
+                            "JOIN pg_namespace AS namespace "
+                            "  ON namespace.oid = type_row.typnamespace "
+                            "WHERE namespace.nspname = :schema "
+                            "AND type_row.typname = 'parcel_kind'"
+                        ),
+                        {"schema": schema},
+                    )
+                ).scalar_one()
+            assert owner == writer
         finally:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
@@ -2265,6 +2306,7 @@ def _adopted_tenant_state() -> TenantOwnershipState:
         writer_exists=True,
         relations=1,
         unsafe_routines=0,
+        unsafe_types=0,
         relations_not_owned_by_writer=0,
         relations_without_reader_select=0,
         relations_with_unsafe_acl=0,

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -1111,31 +1111,49 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                     await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
                     assert [admin for _grantor, admin in await edges()] == [True]
 
-                    # The four gateways get the same automatic creator edge and
-                    # nothing in the tool reads it, so all four go.
+                    # The four gateways get the same automatic creator edge —
+                    # ADMIN, no INHERIT, no SET — and nothing in the tool reads
+                    # it, so all four go.
                     gateways = [CONTROL, WRITER_GATEWAY, SANDBOX, TILE]
+
+                    async def gateway_edges() -> int:
+                        return (
+                            await conn.execute(
+                                sa.text(
+                                    "SELECT count(*) FROM pg_auth_members "
+                                    "AS membership "
+                                    "JOIN pg_roles AS granted "
+                                    "  ON granted.oid = membership.roleid "
+                                    "JOIN pg_roles AS member "
+                                    "  ON member.oid = membership.member "
+                                    "WHERE granted.rolname = ANY(:gateways) "
+                                    "AND member.rolname = current_user"
+                                ),
+                                {"gateways": gateways},
+                            )
+                        ).scalar_one()
+
                     for gateway in gateways:
                         await conn.execute(
                             sa.text(
-                                f"GRANT {gateway} TO current_user WITH ADMIN OPTION"
+                                f"GRANT {gateway} TO current_user "
+                                "WITH ADMIN TRUE, INHERIT FALSE, SET FALSE"
                             )
                         )
+                    assert await gateway_edges() == 4
                     await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
-                    remaining = (
-                        await conn.execute(
-                            sa.text(
-                                "SELECT count(*) FROM pg_auth_members AS membership "
-                                "JOIN pg_roles AS granted "
-                                "  ON granted.oid = membership.roleid "
-                                "JOIN pg_roles AS member "
-                                "  ON member.oid = membership.member "
-                                "WHERE granted.rolname = ANY(:gateways) "
-                                "AND member.rolname = current_user"
-                            ),
-                            {"gateways": gateways},
+                    assert await gateway_edges() == 0
+
+                    # A usable edge is somebody's decision, not this run's
+                    # leftover, and survives.
+                    await conn.execute(
+                        sa.text(
+                            f"GRANT {CONTROL} TO current_user "
+                            "WITH ADMIN TRUE, INHERIT TRUE, SET TRUE"
                         )
-                    ).scalar_one()
-                    assert remaining == 0
+                    )
+                    await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
+                    assert await gateway_edges() == 1
                 finally:
                     await transaction.rollback()
         finally:
@@ -1197,6 +1215,35 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                     )
                     with pytest.raises(RuntimeError, match="not plpgsql"):
                         await secure_boundary_functions(conn)
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_a_direct_execute_grant_outside_the_pair_is_revoked(self):
+        """REVOKE … FROM PUBLIC does not touch a grant to a named role."""
+        stray = f"w998_stray_{uuid.uuid4().hex[:12]}"
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(sa.text(f"CREATE ROLE {stray} NOLOGIN"))
+                    for name in BOUNDARY_FUNCTIONS:
+                        await conn.execute(
+                            sa.text(
+                                f"GRANT EXECUTE ON FUNCTION catalog.{name}(uuid) "
+                                f"TO {stray}"
+                            )
+                        )
+
+                    before = await boundary_function_states(conn)
+                    assert all(state.unexpected_grantees == 1 for state in before)
+                    assert not any(state.secured for state in before)
+
+                    repaired = await secure_boundary_functions(conn)
+                    assert all(state.unexpected_grantees == 0 for state in repaired)
+                    assert all(state.secured for state in repaired)
                 finally:
                     await transaction.rollback()
         finally:
@@ -1547,6 +1594,7 @@ def _secured_function(name: str) -> BoundaryFunctionState:
         body_markers_present=True,
         public_execute=False,
         control_execute=True,
+        unexpected_grantees=0,
     )
 
 

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -932,6 +932,86 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_a_restored_routine_is_re_owned_and_taken_off_public(
+        self, multi_tenant_row_security
+    ):
+        """Routines live in pg_proc, so no relation sweep sees them."""
+        tenant_id, schema, reader, writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            # What pg_restore --no-owner --no-acl leaves: owned by the restore
+            # login, executable by PUBLIC.
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"CREATE FUNCTION {schema}.parcel_count() RETURNS bigint "
+                        "LANGUAGE sql AS $$ SELECT count(*) FROM "
+                        f"{schema}.parcels $$"
+                    )
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert state.unsafe_routines == 1
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+
+            async with engine.connect() as conn:
+                owner, public_execute, reader_execute = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT pg_get_userbyid(routine.proowner), "
+                            "has_function_privilege('public', routine.oid, 'EXECUTE'), "
+                            "has_function_privilege(:reader, routine.oid, 'EXECUTE') "
+                            "FROM pg_proc AS routine "
+                            "JOIN pg_namespace AS namespace "
+                            "  ON namespace.oid = routine.pronamespace "
+                            "WHERE namespace.nspname = :schema "
+                            "AND routine.proname = 'parcel_count'"
+                        ),
+                        {"reader": reader, "schema": schema},
+                    )
+                ).one()
+            assert owner == writer
+            assert public_execute is False
+            assert reader_execute is True
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_a_security_definer_routine_in_a_tenant_schema_is_refused(
+        self, multi_tenant_row_security
+    ):
+        """Re-owning one would bless a body with no migration behind it."""
+        tenant_id, schema, _reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"CREATE FUNCTION {schema}.planted() RETURNS void "
+                        "LANGUAGE sql SECURITY DEFINER AS $$ SELECT NULL::void $$"
+                    )
+                )
+
+            refused = await run_adoption(engine, apply=True)
+            assert tenant_id in refused.failures
+            assert "SECURITY DEFINER routine" in refused.failures[tenant_id]
+            assert "SECURITY INVOKER" in refused.failures[tenant_id]
+            assert not refused.ok
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_column_level_grants_are_revoked(self, multi_tenant_row_security):
         """Column grants live in pg_attribute; a table REVOKE ALL misses them."""
         tenant_id, schema, reader, _writer = _new_tenant()
@@ -2184,6 +2264,7 @@ def _adopted_tenant_state() -> TenantOwnershipState:
         reader_exists=True,
         writer_exists=True,
         relations=1,
+        unsafe_routines=0,
         relations_not_owned_by_writer=0,
         relations_without_reader_select=0,
         relations_with_unsafe_acl=0,

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -658,10 +658,11 @@ class TestReportedStateMatchesWhatApplyEnforces:
         """PostgreSQL 16+ makes the role creator a direct member of the writer.
 
         A non-superuser CREATEROLE migrator replaying the fresh-cluster globals
-        dump therefore holds that edge on every restored writer, and
+        dump holds that edge on every restored writer, and the migration-owned
         `provision_tenant_data_schema` refuses an unexpected direct member
-        outright — so every tenant would fail adoption on exactly the managed
-        deployment the runbook points at.
+        outright. Adoption refuses first, with the remedy: its grantor is the
+        bootstrap superuser so nobody else can revoke it, and at this point the
+        tenant role owns nothing, so DROP ROLE and let provisioning recreate it.
         """
         tenant_id, schema, _reader, writer = _new_tenant()
         creator = f"w998_creator_{tenant_id.replace('-', '_')}"
@@ -683,6 +684,7 @@ class TestReportedStateMatchesWhatApplyEnforces:
             report = await run_adoption(engine, apply=True)
             assert tenant_id in report.failures
             assert "will not rewrite" in report.failures[tenant_id]
+            assert "DROP ROLE" in report.failures[tenant_id]
             assert not report.ok
         finally:
             async with engine.begin() as conn:

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -510,6 +510,12 @@ class TestReportedStateMatchesWhatApplyEnforces:
                 state = await tenant_ownership_state(conn, tenant_id)
             assert not state.reader_role_secure
             assert not state.adopted
+
+            # And a re-run repairs it: nothing else removes the extra row, so
+            # leaving it would make the tenant permanently unadoptable.
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
         finally:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -781,6 +781,87 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_a_stray_grantee_on_the_tenant_schema_is_revoked(
+        self, multi_tenant_row_security
+    ):
+        """USAGE on the schema is half of a path around the writer boundary."""
+        tenant_id, schema, _reader, _writer = _new_tenant()
+        stray = f"w998_nsp_{tenant_id.replace('-', '_')}"
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"CREATE ROLE {stray} NOLOGIN"))
+                await conn.execute(
+                    sa.text(f"GRANT USAGE, CREATE ON SCHEMA {schema} TO {stray}")
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert not state.schema_privileges_secure
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+
+            async with engine.connect() as conn:
+                usage = (
+                    await conn.execute(
+                        sa.text("SELECT has_schema_privilege(:role, :schema, 'USAGE')"),
+                        {"role": stray, "schema": schema},
+                    )
+                ).scalar_one()
+            assert usage is False
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"DROP OWNED BY {stray}"))
+                await conn.execute(sa.text(f"DROP ROLE IF EXISTS {stray}"))
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_default_privileges_for_any_grantee_are_cleared(
+        self, multi_tenant_row_security
+    ):
+        """A default ACL hands out privileges on relations that do not exist yet."""
+        tenant_id, schema, _reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA {schema} "
+                        "GRANT SELECT ON TABLES TO PUBLIC"
+                    )
+                )
+                await conn.execute(
+                    sa.text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA {schema} "
+                        "GRANT USAGE ON SEQUENCES TO PUBLIC"
+                    )
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert state.unexpected_default_acls == 2
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+            async with engine.connect() as conn:
+                assert (
+                    await tenant_ownership_state(conn, tenant_id)
+                ).unexpected_default_acls == 0
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_a_stray_grantee_on_a_tenant_relation_is_revoked(
         self, multi_tenant_row_security
     ):
@@ -892,7 +973,7 @@ class TestReportedStateMatchesWhatApplyEnforces:
 
             async with engine.connect() as conn:
                 state = await tenant_ownership_state(conn, tenant_id)
-            assert state.reader_default_acls == 1
+            assert state.unexpected_default_acls == 1
             assert state.relations_not_owned_by_writer == 0
             assert not state.adopted
 
@@ -902,7 +983,7 @@ class TestReportedStateMatchesWhatApplyEnforces:
             async with engine.connect() as conn:
                 assert (
                     await tenant_ownership_state(conn, tenant_id)
-                ).reader_default_acls == 0
+                ).unexpected_default_acls == 0
         finally:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
@@ -1782,7 +1863,7 @@ def _adopted_tenant_state() -> TenantOwnershipState:
         relations_not_owned_by_writer=0,
         relations_without_reader_select=0,
         relations_with_unsafe_acl=0,
-        reader_default_acls=0,
+        unexpected_default_acls=0,
         reader_role_secure=True,
         writer_role_secure=True,
         schema_privileges_secure=True,

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -839,6 +839,42 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_column_level_grants_are_revoked(self, multi_tenant_row_security):
+        """Column grants live in pg_attribute; a table REVOKE ALL misses them."""
+        tenant_id, schema, reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(f"GRANT UPDATE (name) ON {schema}.parcels TO {reader}")
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert state.relations_with_unsafe_acl == 1
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+
+            async with engine.connect() as conn:
+                can_update = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT has_column_privilege(:role, :table, 'name', 'UPDATE')"
+                        ),
+                        {"role": reader, "table": f"{schema}.parcels"},
+                    )
+                ).scalar_one()
+            assert can_update is False
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_a_stray_grantee_on_the_tenant_schema_is_revoked(
         self, multi_tenant_row_security
     ):

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -61,9 +61,7 @@ from app.core.db.tenant_adoption_report import (
 )
 from app.core.db.tenant_adoption_sql import (
     CLUSTER_ROLE_VALIDATE_SQL,
-    RELEASE_GATEWAY_EDGES_SQL,
     RELEASE_PROVISIONER_EDGE_SQL,
-    SANDBOX,
     TILE,
 )
 from app.core.db.tenant_adoption_sql import WRITER as WRITER_GATEWAY
@@ -1409,14 +1407,16 @@ class TestReportedStateMatchesWhatApplyEnforces:
         finally:
             await engine.dispose()
 
-    async def test_an_orphan_tenant_role_with_an_inherit_edge_is_refused(self):
-        """A role with the naming pattern and no tenant row is never repaired.
+    async def test_another_databases_tenant_roles_do_not_fail_validation(self):
+        """Roles are cluster objects; catalog.tenants is not.
 
-        Nothing per-tenant reaches it, so an INHERIT edge to a gateway would
-        hand that gateway the role's privileges outright. Rolled back — the
-        role and the edge are cluster objects.
+        A cluster hosting a second GeoLens database has its tenant roles and
+        gateway edges visible from here with no matching row in this database's
+        catalog.tenants. Judging those would make each database unadoptable
+        because the other exists — which is exactly what the whole suite hits
+        under xdist, every worker being another database. Rolled back.
         """
-        orphan = f"geolens_writer_t_{uuid.uuid4().hex[:8]}_0000_0000_0000_000000000000"
+        foreign = f"geolens_writer_t_{uuid.uuid4().hex[:8]}_0000_0000_0000_000000000000"
         engine = _make_engine()
         try:
             async with engine.connect() as conn:
@@ -1424,18 +1424,17 @@ class TestReportedStateMatchesWhatApplyEnforces:
                 try:
                     await conn.execute(
                         sa.text(
-                            f"CREATE ROLE {orphan} NOLOGIN NOSUPERUSER NOCREATEDB "
+                            f"CREATE ROLE {foreign} NOLOGIN NOSUPERUSER NOCREATEDB "
                             "NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS"
                         )
                     )
                     await conn.execute(
                         sa.text(
-                            f"GRANT {orphan} TO {WRITER_GATEWAY} "
-                            "WITH INHERIT TRUE, SET TRUE"
+                            f"GRANT {foreign} TO {WRITER_GATEWAY} "
+                            "WITH INHERIT FALSE, SET TRUE"
                         )
                     )
-                    with pytest.raises(DBAPIError, match="unsafe upstream membership"):
-                        await conn.execute(sa.text(CLUSTER_ROLE_VALIDATE_SQL))
+                    await conn.execute(sa.text(CLUSTER_ROLE_VALIDATE_SQL))
                 finally:
                     await transaction.rollback()
         finally:
@@ -1673,12 +1672,12 @@ class TestAdoptionWithRestoredBoundaryFunctions:
             await engine.dispose()
 
     async def test_the_bootstrap_membership_is_handed_back(self):
-        """A fresh-cluster run must not leave the credential that made it special.
+        """Only the usable edge this run granted, and only that one.
 
-        The cluster guard rejects every direct member of the provisioner except
-        the role running it, so an edge left behind makes the next recovery
-        depend on reusing the same migrator credential. Only the edge this run
-        granted goes: grantor CURRENT_USER, no ADMIN. Rolled back.
+        The automatic creator membership is left alone on purpose: its grantor
+        is the bootstrap superuser, a member's plain REVOKE of it is a no-op,
+        and on a managed provider no customer role can assume that grantor. The
+        guards tolerate its exact shape instead. Rolled back.
         """
         engine = _make_engine()
         try:
@@ -1715,59 +1714,36 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                     await conn.execute(sa.text(RELEASE_PROVISIONER_EDGE_SQL))
                     assert await edges() == []
 
-                    # The provisioner's ADMIN edge is what lets the same
-                    # credential re-take a usable one next run, so it stays.
+                    # An ADMIN edge is the creator's, or somebody's decision.
+                    # Either way it stays.
                     await conn.execute(
                         sa.text(
                             f"GRANT {PROVISIONER} TO current_user WITH ADMIN OPTION"
                         )
                     )
-                    await conn.execute(sa.text(RELEASE_GATEWAY_EDGES_SQL))
+                    await conn.execute(sa.text(RELEASE_PROVISIONER_EDGE_SQL))
                     assert [admin for _grantor, admin in await edges()] == [True]
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
 
-                    # The four gateways get the same automatic creator edge —
-                    # ADMIN, no INHERIT, no SET — and nothing in the tool reads
-                    # it, so all four go.
-                    gateways = [CONTROL, WRITER_GATEWAY, SANDBOX, TILE]
-
-                    async def gateway_edges() -> int:
-                        return (
-                            await conn.execute(
-                                sa.text(
-                                    "SELECT count(*) FROM pg_auth_members "
-                                    "AS membership "
-                                    "JOIN pg_roles AS granted "
-                                    "  ON granted.oid = membership.roleid "
-                                    "JOIN pg_roles AS member "
-                                    "  ON member.oid = membership.member "
-                                    "WHERE granted.rolname = ANY(:gateways) "
-                                    "AND member.rolname = current_user"
-                                ),
-                                {"gateways": gateways},
-                            )
-                        ).scalar_one()
-
-                    for gateway in gateways:
-                        await conn.execute(
-                            sa.text(
-                                f"GRANT {gateway} TO current_user "
-                                "WITH ADMIN TRUE, INHERIT FALSE, SET FALSE"
-                            )
-                        )
-                    assert await gateway_edges() == 4
-                    await conn.execute(sa.text(RELEASE_GATEWAY_EDGES_SQL))
-                    assert await gateway_edges() == 0
-
-                    # A usable edge is somebody's decision, not this run's
-                    # leftover, and survives.
+    async def test_a_creator_shaped_edge_on_a_gateway_is_tolerated(self):
+        """Nobody can revoke it, so refusing it would strand every recovery."""
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
                     await conn.execute(
                         sa.text(
-                            f"GRANT {CONTROL} TO current_user "
-                            "WITH ADMIN TRUE, INHERIT TRUE, SET TRUE"
+                            f"GRANT {TILE} TO current_user "
+                            "WITH ADMIN TRUE, INHERIT FALSE, SET FALSE"
                         )
                     )
-                    await conn.execute(sa.text(RELEASE_GATEWAY_EDGES_SQL))
-                    assert await gateway_edges() == 1
+                    # CURRENT_USER is exempt anyway; the point is the shape, so
+                    # check it through a role that is not the caller.
+                    await conn.execute(sa.text(CLUSTER_ROLE_VALIDATE_SQL))
                 finally:
                     await transaction.rollback()
         finally:

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -59,6 +59,7 @@ from app.core.db.tenant_adoption_report import (
     format_report,
     rls_gaps,
 )
+from app.core.db.tenant_adoption_sql import RELEASE_BOOTSTRAP_MEMBERSHIP_SQL
 from app.core.db.tenant_adoption_sql import WRITER as WRITER_GATEWAY
 
 pytestmark = pytest.mark.anyio
@@ -660,6 +661,48 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_reader_create_on_the_tenant_schema_is_revoked(
+        self, multi_tenant_row_security
+    ):
+        """CREATE on a read-only schema is a write path through two gateways.
+
+        The sandbox and tile gateways SET ROLE to the reader, and the
+        provisioning function grants USAGE without ever taking CREATE away.
+        """
+        tenant_id, schema, reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(f"GRANT CREATE ON SCHEMA {schema} TO {reader}")
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert not state.schema_privileges_secure
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+
+            async with engine.connect() as conn:
+                can_create = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT has_schema_privilege(:role, :schema, 'CREATE')"
+                        ),
+                        {"role": reader, "schema": schema},
+                    )
+                ).scalar_one()
+            assert can_create is False
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_legacy_reader_default_privileges_are_not_adopted(
         self, multi_tenant_row_security
     ):
@@ -960,6 +1003,62 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                         )
                     )
                     assert await creator_holds_privileges()
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_the_bootstrap_membership_is_handed_back(self):
+        """A fresh-cluster run must not leave the credential that made it special.
+
+        The cluster guard rejects every direct member of the provisioner except
+        the role running it, so an edge left behind makes the next recovery
+        depend on reusing the same migrator credential. Only the edge this run
+        granted goes: grantor CURRENT_USER, no ADMIN. Rolled back.
+        """
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+
+                    async def edges() -> list[tuple]:
+                        rows = await conn.execute(
+                            sa.text(
+                                "SELECT pg_get_userbyid(membership.grantor), "
+                                "membership.admin_option "
+                                "FROM pg_auth_members AS membership "
+                                "JOIN pg_roles AS granted "
+                                "  ON granted.oid = membership.roleid "
+                                "JOIN pg_roles AS member "
+                                "  ON member.oid = membership.member "
+                                "WHERE granted.rolname = :owner "
+                                "AND member.rolname = current_user"
+                            ),
+                            {"owner": PROVISIONER},
+                        )
+                        return [tuple(row) for row in rows]
+
+                    assert await edges() == []
+                    await conn.execute(
+                        sa.text(
+                            f"GRANT {PROVISIONER} TO current_user "
+                            "WITH INHERIT TRUE, SET TRUE"
+                        )
+                    )
+                    assert len(await edges()) == 1
+
+                    await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
+                    assert await edges() == []
+
+                    # An ADMIN-carrying edge is somebody else's decision.
+                    await conn.execute(
+                        sa.text(
+                            f"GRANT {PROVISIONER} TO current_user WITH ADMIN OPTION"
+                        )
+                    )
+                    await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
+                    assert [admin for _grantor, admin in await edges()] == [True]
                 finally:
                     await transaction.rollback()
         finally:

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -59,7 +59,11 @@ from app.core.db.tenant_adoption_report import (
     format_report,
     rls_gaps,
 )
-from app.core.db.tenant_adoption_sql import RELEASE_BOOTSTRAP_MEMBERSHIP_SQL
+from app.core.db.tenant_adoption_sql import (
+    RELEASE_BOOTSTRAP_MEMBERSHIP_SQL,
+    SANDBOX,
+    TILE,
+)
 from app.core.db.tenant_adoption_sql import WRITER as WRITER_GATEWAY
 
 pytestmark = pytest.mark.anyio
@@ -1051,7 +1055,8 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                     await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
                     assert await edges() == []
 
-                    # An ADMIN-carrying edge is somebody else's decision.
+                    # The provisioner's ADMIN edge is what lets the same
+                    # credential re-take a usable one next run, so it stays.
                     await conn.execute(
                         sa.text(
                             f"GRANT {PROVISIONER} TO current_user WITH ADMIN OPTION"
@@ -1059,6 +1064,32 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                     )
                     await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
                     assert [admin for _grantor, admin in await edges()] == [True]
+
+                    # The four gateways get the same automatic creator edge and
+                    # nothing in the tool reads it, so all four go.
+                    gateways = [CONTROL, WRITER_GATEWAY, SANDBOX, TILE]
+                    for gateway in gateways:
+                        await conn.execute(
+                            sa.text(
+                                f"GRANT {gateway} TO current_user WITH ADMIN OPTION"
+                            )
+                        )
+                    await conn.execute(sa.text(RELEASE_BOOTSTRAP_MEMBERSHIP_SQL))
+                    remaining = (
+                        await conn.execute(
+                            sa.text(
+                                "SELECT count(*) FROM pg_auth_members AS membership "
+                                "JOIN pg_roles AS granted "
+                                "  ON granted.oid = membership.roleid "
+                                "JOIN pg_roles AS member "
+                                "  ON member.oid = membership.member "
+                                "WHERE granted.rolname = ANY(:gateways) "
+                                "AND member.rolname = current_user"
+                            ),
+                            {"gateways": gateways},
+                        )
+                    ).scalar_one()
+                    assert remaining == 0
                 finally:
                     await transaction.rollback()
         finally:

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -781,6 +781,63 @@ class TestReportedStateMatchesWhatApplyEnforces:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 
+    async def test_grant_options_on_reader_privileges_are_cleared(
+        self, multi_tenant_row_security
+    ):
+        """A grantable privilege is a delegation the gateways can use.
+
+        The sandbox and tile logins SET ROLE to the reader; with GRANT OPTION on
+        the schema and the relation, either can hand tenant reads to any role.
+        """
+        tenant_id, schema, reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"GRANT USAGE ON SCHEMA {schema} TO {reader} WITH GRANT OPTION"
+                    )
+                )
+                await conn.execute(
+                    sa.text(
+                        f"GRANT SELECT ON {schema}.parcels TO {reader} "
+                        "WITH GRANT OPTION"
+                    )
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert not state.schema_privileges_secure
+            assert state.relations_with_unsafe_acl == 1
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+
+            async with engine.connect() as conn:
+                grantable = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT count(*) FROM pg_namespace AS namespace "
+                            "JOIN LATERAL aclexplode(namespace.nspacl) AS acl "
+                            "  ON true "
+                            "JOIN pg_roles AS grantee "
+                            "  ON grantee.oid = acl.grantee "
+                            "WHERE namespace.nspname = :schema "
+                            "AND grantee.rolname = :reader AND acl.is_grantable"
+                        ),
+                        {"schema": schema, "reader": reader},
+                    )
+                ).scalar_one()
+            assert grantable == 0
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
     async def test_a_stray_grantee_on_the_tenant_schema_is_revoked(
         self, multi_tenant_row_security
     ):
@@ -1439,6 +1496,32 @@ class TestAdoptionWithRestoredBoundaryFunctions:
                     repaired = await secure_boundary_functions(conn)
                     assert all(state.unexpected_grantees == 0 for state in repaired)
                     assert all(state.secured for state in repaired)
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_a_grantable_execute_for_the_control_role_is_downgraded(self):
+        """A re-GRANT does not clear an existing GRANT OPTION."""
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    for name in BOUNDARY_FUNCTIONS:
+                        await conn.execute(
+                            sa.text(
+                                f"GRANT EXECUTE ON FUNCTION catalog.{name}(uuid) "
+                                f"TO {CONTROL} WITH GRANT OPTION"
+                            )
+                        )
+                    before = await boundary_function_states(conn)
+                    assert all(state.unexpected_grantees == 1 for state in before)
+                    assert not any(state.secured for state in before)
+
+                    repaired = await secure_boundary_functions(conn)
+                    assert all(state.secured for state in repaired)
+                    assert all(state.control_execute for state in repaired)
                 finally:
                     await transaction.rollback()
         finally:

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -1730,24 +1730,72 @@ class TestAdoptionWithRestoredBoundaryFunctions:
         finally:
             await engine.dispose()
 
-    async def test_a_creator_shaped_edge_on_a_gateway_is_tolerated(self):
-        """Nobody can revoke it, so refusing it would strand every recovery."""
+    async def test_a_creator_shaped_edge_on_another_login_is_refused(self):
+        """fix(#998 codex r44): ADMIN alone can re-arm itself into a usable
+        edge, so the creator shape is only safe on the login running adoption.
+        The refusal names DROP ROLE, the one remedy a managed platform allows.
+        """
+        retired = f"w998_retired_{uuid.uuid4().hex[:12]}"
         engine = _make_engine()
         try:
             async with engine.connect() as conn:
                 transaction = await conn.begin()
                 try:
+                    await conn.execute(sa.text(f"CREATE ROLE {retired} LOGIN"))
                     await conn.execute(
                         sa.text(
-                            f"GRANT {TILE} TO current_user "
+                            f"GRANT {TILE} TO {retired} "
                             "WITH ADMIN TRUE, INHERIT FALSE, SET FALSE"
                         )
                     )
-                    # CURRENT_USER is exempt anyway; the point is the shape, so
-                    # check it through a role that is not the caller.
-                    await conn.execute(sa.text(CLUSTER_ROLE_VALIDATE_SQL))
+                    with pytest.raises(
+                        DBAPIError, match="keeps the creator membership"
+                    ):
+                        await conn.execute(sa.text(CLUSTER_ROLE_VALIDATE_SQL))
                 finally:
                     await transaction.rollback()
+                await conn.execute(sa.text(f"DROP ROLE IF EXISTS {retired}"))
+        finally:
+            await engine.dispose()
+
+    async def test_a_foreign_granted_boundary_acl_is_refused(self):
+        """fix(#998 codex r44): an EXECUTE entry granted by a third role does
+        not re-attribute on owner transfer and a non-grantor's REVOKE is a
+        no-op, so repairing over it would silently leave the grant standing.
+        """
+        grantor = f"w998_grantor_{uuid.uuid4().hex[:12]}"
+        grantee = f"w998_grantee_{uuid.uuid4().hex[:12]}"
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(sa.text(f"CREATE ROLE {grantor} NOLOGIN"))
+                    await conn.execute(sa.text(f"CREATE ROLE {grantee} NOLOGIN"))
+                    name = BOUNDARY_FUNCTIONS[0]
+                    await conn.execute(
+                        sa.text(f"GRANT USAGE ON SCHEMA catalog TO {grantor}")
+                    )
+                    await conn.execute(
+                        sa.text(
+                            f"GRANT EXECUTE ON FUNCTION catalog.{name}(uuid) "
+                            f"TO {grantor} WITH GRANT OPTION"
+                        )
+                    )
+                    await conn.execute(sa.text(f"SET LOCAL ROLE {grantor}"))
+                    await conn.execute(
+                        sa.text(
+                            f"GRANT EXECUTE ON FUNCTION catalog.{name}(uuid) "
+                            f"TO {grantee}"
+                        )
+                    )
+                    await conn.execute(sa.text("RESET ROLE"))
+                    with pytest.raises(DBAPIError, match="granted by"):
+                        await secure_boundary_functions(conn)
+                finally:
+                    await transaction.rollback()
+                await conn.execute(sa.text(f"DROP ROLE IF EXISTS {grantee}"))
+                await conn.execute(sa.text(f"DROP ROLE IF EXISTS {grantor}"))
         finally:
             await engine.dispose()
 

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -939,10 +939,20 @@ class TestReportedStateMatchesWhatApplyEnforces:
                         "GRANT USAGE ON SEQUENCES TO PUBLIC"
                     )
                 )
+                # One owned by the tenant writer, which the migrator can only
+                # assume inside the adoption window.
+                await conn.execute(sa.text(f"SET LOCAL ROLE {_writer}"))
+                await conn.execute(
+                    sa.text(
+                        f"ALTER DEFAULT PRIVILEGES IN SCHEMA {schema} "
+                        "GRANT SELECT ON TABLES TO PUBLIC"
+                    )
+                )
+                await conn.execute(sa.text("RESET ROLE"))
 
             async with engine.connect() as conn:
                 state = await tenant_ownership_state(conn, tenant_id)
-            assert state.unexpected_default_acls == 2
+            assert state.unexpected_default_acls == 3
             assert not state.adopted
 
             repaired = await run_adoption(engine, apply=True)

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -1096,6 +1096,31 @@ class TestSuccessPredicate:
         assert report.rls_gaps
         assert not report.ok
 
+    def test_disabled_trigger_on_an_undeclared_table_is_not_ok(self) -> None:
+        """The one combination neither drift direction can see.
+
+        A newly tenant-scoped table absent from ``RLS_TABLES`` with its stamping
+        trigger disabled is in neither ``live_only`` (the trigger does not fire)
+        nor ``constant_only`` (the constant never named it), and has no row
+        security to be missing. The disabled trigger has to be its own finding.
+        """
+        boundary = _clean_boundary() + [
+            BoundaryTableState(
+                name="w998_new_and_undeclared",
+                has_stamping_trigger=False,
+                stamping_trigger_disabled=True,
+                has_tenant_id=True,
+                rls_enabled=False,
+                rls_forced=False,
+            )
+        ]
+        report = _report(boundary=boundary)
+        assert boundary_drift(boundary) == ([], [])
+        assert report.rls_gaps == []
+        assert report.disabled_stamping_triggers == ["w998_new_and_undeclared"]
+        assert not report.ok
+        assert "DISABLED" in format_report(report)
+
     def test_declared_table_without_a_stamping_trigger_is_not_ok(self) -> None:
         """The other direction: inserts land with no tenant_id at all."""
         boundary = [table for table in _clean_boundary() if table.name != RLS_TABLES[0]]

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -1,0 +1,569 @@
+"""Forward-only tenant-ownership adoption at the head schema (#998).
+
+The only path that ever reconstructed tenant ownership was
+``alembic downgrade 0016`` followed by a re-upgrade through 0019 — a data-loss
+event on a populated cluster.  ``app.core.db.tenant_adoption`` does the same
+reconstruction at head; these tests hold it to the state 0019 produced.
+
+Coverage
+--------
+A: a head-schema database carrying tenant data with no ownership rows — schema,
+   relations, and roles all sitting where ``pg_restore --no-owner --no-acl``
+   leaves them — is adopted into the 0019 end state.
+B: a second run changes nothing.  Asserted by diffing a full catalog snapshot
+   (owners, ACLs, role attributes, memberships), not by trusting the report.
+C: the dump-restore case — the SECURITY DEFINER boundary functions are already
+   present, owned by the restoring login, with the PostgreSQL default ACL that
+   grants EXECUTE to PUBLIC.  Adoption must not collide with them and must take
+   that grant away.
+D: the tenant boundary is read from the database, never from a constant frozen
+   into a migration.
+
+Run:
+    cd backend && set -a && source ../.env.test && set +a
+    uv run pytest tests/test_tenant_ownership_adoption.py -x -q
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.core.db.rls import RLS_TABLES
+from app.core.db.tenant_adoption import (
+    BOUNDARY_FUNCTIONS,
+    CONTROL,
+    PROVISIONER,
+    boundary_drift,
+    boundary_function_states,
+    live_tenant_boundary,
+    run_adoption,
+    tenant_ownership_state,
+)
+
+pytestmark = pytest.mark.anyio
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _new_tenant() -> tuple[str, str, str, str]:
+    """A tenant id whose cluster-wide role names cannot collide with a peer.
+
+    Per-tenant roles are cluster objects shared by every xdist worker's test
+    database, so a fixed fixture id would have two workers adopting and dropping
+    the same roles.
+    """
+    tenant_id = str(uuid.uuid4())
+    suffix = tenant_id.replace("-", "_")
+    return (
+        tenant_id,
+        f"data_t_{suffix}",
+        f"geolens_reader_t_{suffix}",
+        f"geolens_writer_t_{suffix}",
+    )
+
+
+def _make_engine():
+    from app.core.config import settings
+
+    return create_async_engine(settings.test_database_url, poolclass=NullPool)
+
+
+async def _seed_restored_tenant(engine, tenant_id: str, schema: str) -> None:
+    """Recreate what a ``pg_restore --no-owner --no-acl`` hands the operator.
+
+    Every relation is owned by the restoring login, no ACLs survive, and the
+    per-tenant reader/writer roles do not exist at all — the fresh-cluster case
+    where no globals dump was replayed.
+    """
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa.text(
+                "INSERT INTO catalog.tenants (id, slug, name) "
+                "VALUES (CAST(:id AS uuid), :slug, :name)"
+            ),
+            {"id": tenant_id, "slug": f"w998-{tenant_id[:8]}", "name": "adoption"},
+        )
+        await conn.execute(sa.text(f"CREATE SCHEMA {schema}"))
+        # bigserial gives us a column-owned sequence: PostgreSQL refuses
+        # ALTER SEQUENCE ... OWNER TO on those, and every ogr2ogr vector ingest
+        # produces one as ogc_fid.
+        await conn.execute(
+            sa.text(
+                f"CREATE TABLE {schema}.parcels "
+                "(id bigserial PRIMARY KEY, name text NOT NULL)"
+            )
+        )
+        await conn.execute(
+            sa.text(f"INSERT INTO {schema}.parcels (name) VALUES ('restored row')")
+        )
+        await conn.execute(
+            sa.text(
+                f"CREATE VIEW {schema}.parcel_names AS SELECT name FROM {schema}.parcels"
+            )
+        )
+
+
+async def _drop_tenant(engine, tenant_id: str) -> None:
+    """Remove the tenant whatever state the test left it in.
+
+    Not through ``deprovision_tenant_data_schema``: that refuses on a schema the
+    provisioner does not own, which is exactly the state the dry-run and
+    failure-path tests leave behind. Per-tenant roles are cluster objects, so
+    teardown has to drop them or every run leaks two roles into the cluster the
+    other xdist workers share.
+    """
+    suffix = tenant_id.replace("-", "_")
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa.text("DELETE FROM catalog.tenants WHERE id = CAST(:id AS uuid)"),
+            {"id": tenant_id},
+        )
+        await conn.execute(sa.text(f"DROP SCHEMA IF EXISTS data_t_{suffix} CASCADE"))
+        for role in (f"geolens_reader_t_{suffix}", f"geolens_writer_t_{suffix}"):
+            await conn.execute(
+                sa.text(
+                    "DO $$ BEGIN "
+                    f"IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN "
+                    f"EXECUTE 'DROP OWNED BY {role}'; "
+                    f"EXECUTE 'DROP ROLE {role}'; "
+                    "END IF; END $$"
+                )
+            )
+
+
+async def _catalog_snapshot(engine, tenant_id: str) -> list[tuple]:
+    """Owners, ACLs, role attributes, and memberships for one tenant."""
+    suffix = tenant_id.replace("-", "_")
+    async with engine.connect() as conn:
+        rows: list[tuple] = []
+        rows += list(
+            await conn.execute(
+                sa.text(
+                    "SELECT 'schema', nspname, pg_get_userbyid(nspowner), "
+                    "COALESCE(nspacl::text, '') FROM pg_namespace "
+                    "WHERE nspname = :schema"
+                ),
+                {"schema": f"data_t_{suffix}"},
+            )
+        )
+        rows += list(
+            await conn.execute(
+                sa.text(
+                    "SELECT 'relation', relation.relname, "
+                    "pg_get_userbyid(relation.relowner), "
+                    "COALESCE(relation.relacl::text, '') "
+                    "FROM pg_class AS relation "
+                    "JOIN pg_namespace AS namespace "
+                    "  ON namespace.oid = relation.relnamespace "
+                    "WHERE namespace.nspname = :schema "
+                    "ORDER BY relation.relname"
+                ),
+                {"schema": f"data_t_{suffix}"},
+            )
+        )
+        rows += list(
+            await conn.execute(
+                sa.text(
+                    "SELECT 'role', rolname, rolcanlogin::text || rolinherit::text "
+                    "|| rolsuper::text || rolcreaterole::text || rolbypassrls::text, '' "
+                    "FROM pg_roles WHERE rolname LIKE :pattern ORDER BY rolname"
+                ),
+                {"pattern": f"%{suffix}"},
+            )
+        )
+        rows += list(
+            await conn.execute(
+                sa.text(
+                    "SELECT 'member', granted.rolname, member.rolname, "
+                    "membership.admin_option::text || membership.inherit_option::text "
+                    "|| membership.set_option::text "
+                    "FROM pg_auth_members AS membership "
+                    "JOIN pg_roles AS granted ON granted.oid = membership.roleid "
+                    "JOIN pg_roles AS member ON member.oid = membership.member "
+                    "WHERE granted.rolname LIKE :pattern OR member.rolname LIKE :pattern "
+                    "ORDER BY granted.rolname, member.rolname"
+                ),
+                {"pattern": f"%{suffix}"},
+            )
+        )
+        return [tuple(row) for row in rows]
+
+
+async def _break_boundary_functions(engine) -> None:
+    """Leave the functions exactly as a --no-owner --no-acl restore leaves them."""
+    async with engine.begin() as conn:
+        current_user = (await conn.execute(sa.text("SELECT current_user"))).scalar_one()
+        for name in BOUNDARY_FUNCTIONS:
+            signature = f"catalog.{name}(uuid)"
+            await conn.execute(
+                sa.text(f"ALTER FUNCTION {signature} OWNER TO {current_user}")
+            )
+            await conn.execute(
+                sa.text(f"REVOKE ALL ON FUNCTION {signature} FROM {CONTROL}")
+            )
+            await conn.execute(
+                sa.text(f"GRANT EXECUTE ON FUNCTION {signature} TO PUBLIC")
+            )
+
+
+async def _restore_boundary_functions(engine) -> None:
+    async with engine.begin() as conn:
+        for name in BOUNDARY_FUNCTIONS:
+            signature = f"catalog.{name}(uuid)"
+            await conn.execute(
+                sa.text(f"ALTER FUNCTION {signature} OWNER TO {PROVISIONER}")
+            )
+            await conn.execute(
+                sa.text(f"REVOKE ALL ON FUNCTION {signature} FROM PUBLIC")
+            )
+            await conn.execute(
+                sa.text(f"GRANT EXECUTE ON FUNCTION {signature} TO {CONTROL}")
+            )
+
+
+# ---------------------------------------------------------------------------
+# A: reconstruct ownership on a head-schema database
+# ---------------------------------------------------------------------------
+
+
+class TestAdoptionReconstructsOwnership:
+    """A: the 0019 end state, reached forward-only at head."""
+
+    async def test_restored_tenant_is_adopted(self):
+        tenant_id, schema, reader, writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+
+            async with engine.connect() as conn:
+                before = await tenant_ownership_state(conn, tenant_id)
+            assert not before.adopted
+            assert not before.reader_exists
+            assert not before.writer_exists
+            assert before.relations_not_owned_by_writer == before.relations > 0
+
+            report = await run_adoption(engine, apply=True)
+            assert report.failures == {}, report.failures
+            assert report.ok
+
+            async with engine.connect() as conn:
+                after = await tenant_ownership_state(conn, tenant_id)
+                assert after.adopted
+                assert after.schema_owner == PROVISIONER
+                assert after.relations_not_owned_by_writer == 0
+                assert after.relations_without_reader_select == 0
+
+                # The reader reads and cannot write; the data itself survives.
+                privileges = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT has_table_privilege(:reader, :table, 'SELECT'), "
+                            "has_table_privilege(:reader, :table, 'INSERT'), "
+                            "has_schema_privilege(:reader, :schema, 'USAGE'), "
+                            "has_schema_privilege(:writer, :schema, 'CREATE')"
+                        ),
+                        {
+                            "reader": reader,
+                            "writer": writer,
+                            "schema": schema,
+                            "table": f"{schema}.parcels",
+                        },
+                    )
+                ).one()
+                assert tuple(privileges) == (True, False, True, True)
+
+                rows = (
+                    await conn.execute(
+                        sa.text(f"SELECT count(*) FROM {schema}.parcels")
+                    )
+                ).scalar_one()
+                assert rows == 1
+
+                # Per-tenant roles are NOLOGIN/NOINHERIT, and the provisioner
+                # holds ADMIN only — no inherit, no SET.
+                attributes = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT rolcanlogin, rolinherit, rolsuper, rolbypassrls "
+                            "FROM pg_roles WHERE rolname = :role"
+                        ),
+                        {"role": reader},
+                    )
+                ).one()
+                assert tuple(attributes) == (False, False, False, False)
+
+                membership = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT membership.admin_option, membership.inherit_option, "
+                            "membership.set_option "
+                            "FROM pg_auth_members AS membership "
+                            "JOIN pg_roles AS granted ON granted.oid = membership.roleid "
+                            "JOIN pg_roles AS member ON member.oid = membership.member "
+                            "WHERE granted.rolname = :writer AND member.rolname = :owner"
+                        ),
+                        {"writer": writer, "owner": PROVISIONER},
+                    )
+                ).one()
+                assert tuple(membership) == (True, False, False)
+
+                # The transaction-scoped SET edge the transfer needs is handed
+                # back before commit.
+                leftover = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT count(*) FROM pg_auth_members AS membership "
+                            "JOIN pg_roles AS granted ON granted.oid = membership.roleid "
+                            "JOIN pg_roles AS member ON member.oid = membership.member "
+                            "WHERE granted.rolname = :writer "
+                            "AND member.rolname = current_user"
+                        ),
+                        {"writer": writer},
+                    )
+                ).scalar_one()
+                assert leftover == 0
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_column_owned_sequence_follows_its_table(self):
+        """``bigserial``/identity sequences cannot be re-owned directly.
+
+        0019's loop issued ``ALTER SEQUENCE … OWNER TO`` unconditionally, which
+        PostgreSQL rejects for a column-owned sequence.  Adoption skips them and
+        lets the ``ALTER TABLE`` carry them across.
+        """
+        tenant_id, schema, reader, writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            report = await run_adoption(engine, apply=True)
+            assert report.failures == {}, report.failures
+
+            async with engine.connect() as conn:
+                owner = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT pg_get_userbyid(relation.relowner) "
+                            "FROM pg_class AS relation "
+                            "JOIN pg_namespace AS namespace "
+                            "  ON namespace.oid = relation.relnamespace "
+                            "WHERE namespace.nspname = :schema "
+                            "AND relation.relname = 'parcels_id_seq'"
+                        ),
+                        {"schema": schema},
+                    )
+                ).scalar_one()
+                assert owner == writer
+
+                reader_usage = (
+                    await conn.execute(
+                        sa.text(
+                            "SELECT has_sequence_privilege(:reader, :sequence, 'SELECT')"
+                        ),
+                        {"reader": reader, "sequence": f"{schema}.parcels_id_seq"},
+                    )
+                ).scalar_one()
+                assert reader_usage is True
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# B: a second run is a no-op
+# ---------------------------------------------------------------------------
+
+
+class TestAdoptionIsIdempotent:
+    """B: re-running changes nothing, and says so."""
+
+    async def test_second_run_leaves_the_catalog_byte_identical(self):
+        tenant_id, schema, _reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            first = await run_adoption(engine, apply=True)
+            assert first.failures == {}, first.failures
+            snapshot_after_first = await _catalog_snapshot(engine, tenant_id)
+
+            second = await run_adoption(engine, apply=True)
+            assert second.failures == {}, second.failures
+            assert second.ok
+            snapshot_after_second = await _catalog_snapshot(engine, tenant_id)
+
+            assert snapshot_after_second == snapshot_after_first
+
+            # The report distinguishes "already adopted" from "just adopted",
+            # which is what tells an operator a re-run did nothing.
+            before_states = {state.tenant_id: state for state in second.before}
+            assert before_states[tenant_id].adopted
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_dry_run_makes_no_changes(self):
+        tenant_id, schema, _reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            snapshot_before = await _catalog_snapshot(engine, tenant_id)
+
+            report = await run_adoption(engine, apply=False)
+            assert not report.applied
+            # A dry run over an unadopted tenant reports pending work, which is
+            # the non-zero exit an operator can script against.
+            assert not report.ok
+
+            assert await _catalog_snapshot(engine, tenant_id) == snapshot_before
+        finally:
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# C: the dump-restore case — functions already present, wide open
+# ---------------------------------------------------------------------------
+
+
+class TestAdoptionWithRestoredBoundaryFunctions:
+    """C: no CREATE FUNCTION collision, and the PUBLIC grant goes away."""
+
+    async def test_restored_functions_are_re_owned_and_re_restricted(self):
+        tenant_id, schema, _reader, _writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            await _break_boundary_functions(engine)
+
+            async with engine.connect() as conn:
+                broken = await boundary_function_states(conn)
+            assert len(broken) == len(BOUNDARY_FUNCTIONS)
+            assert all(state.public_execute for state in broken)
+            assert all(state.owner != PROVISIONER for state in broken)
+            assert not any(state.secured for state in broken)
+
+            report = await run_adoption(engine, apply=True)
+            assert report.failures == {}, report.failures
+            assert report.ok
+
+            async with engine.connect() as conn:
+                repaired = await boundary_function_states(conn)
+                after = await tenant_ownership_state(conn, tenant_id)
+            assert all(state.secured for state in repaired)
+            assert all(state.owner == PROVISIONER for state in repaired)
+            assert not any(state.public_execute for state in repaired)
+            assert after.adopted
+        finally:
+            await _restore_boundary_functions(engine)
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_missing_function_refuses_instead_of_installing_one(self):
+        """Bodies belong to the migrations; adoption never writes one."""
+        from app.core.db.tenant_adoption import secure_boundary_functions
+
+        engine = _make_engine()
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        "ALTER FUNCTION catalog.deprovision_tenant_data_schema(uuid) "
+                        "RENAME TO w998_absent_boundary_function"
+                    )
+                )
+                with pytest.raises(RuntimeError, match="alembic upgrade heads"):
+                    await secure_boundary_functions(conn)
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        "ALTER FUNCTION catalog.w998_absent_boundary_function(uuid) "
+                        "RENAME TO deprovision_tenant_data_schema"
+                    )
+                )
+            await _restore_boundary_functions(engine)
+            await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# D: the boundary is read from the database
+# ---------------------------------------------------------------------------
+
+
+class TestLiveTenantBoundary:
+    """D: introspected, never enumerated from a frozen migration constant."""
+
+    async def test_boundary_matches_the_constant_that_drives_rls(self):
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                boundary = await live_tenant_boundary(conn)
+        finally:
+            await engine.dispose()
+
+        stamped = {table.name for table in boundary if table.has_stamping_trigger}
+        assert stamped == set(RLS_TABLES), (
+            "The live insert-stamping boundary and app.core.db.rls.RLS_TABLES "
+            "have diverged. A table stamped in the database but missing from "
+            "RLS_TABLES never gets RLS enabled at boot."
+        )
+        assert boundary_drift(boundary) == ([], [])
+
+        # 0018's frozen tuple is six tables; the live boundary outgrew it long
+        # ago. Anything reading that constant would under-report by three.
+        assert len(stamped) > 6
+
+    async def test_dormant_tenant_id_columns_are_reported_outside_the_boundary(self):
+        """0037's ``dataset_refresh_runs.tenant_id`` is deliberately dormant.
+
+        Reporting it as "tenant_id column only" is what lets an accidental
+        omission be told apart from this intentional one.
+        """
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                boundary = await live_tenant_boundary(conn)
+        finally:
+            await engine.dispose()
+
+        dormant = {
+            table.name
+            for table in boundary
+            if table.has_tenant_id and not table.has_stamping_trigger
+        }
+        assert "dataset_refresh_runs" in dormant
+        assert dormant.isdisjoint(set(RLS_TABLES))
+
+
+# ---------------------------------------------------------------------------
+# The runbook recipe and the module it invokes
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_documents_the_forward_only_recipe() -> None:
+    """A rename that orphans the DR recipe must fail here, not mid-recovery."""
+    runbook = (ROOT / "RUNBOOK.md").read_text(encoding="utf-8")
+
+    assert "python -m app.core.db.tenant_adoption --apply" in runbook
+    # The destructive downgrade is documented as the thing NOT to reach for,
+    # not as the recipe (#998).
+    assert "#### Do not reach for `alembic downgrade 0016`" in runbook
+    assert "uv run --no-dev alembic downgrade 0016" not in runbook
+
+
+def test_module_is_runnable_as_documented() -> None:
+    import importlib
+
+    module = importlib.import_module("app.core.db.tenant_adoption")
+
+    assert callable(module._main)
+    parser = module._build_parser()
+    assert parser.parse_args([]).apply is False
+    assert parser.parse_args(["--apply"]).apply is True

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -37,6 +37,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import NullPool
 
 from app.core.db.rls import RLS_TABLES
+from app.core.db.tenant_adoption_sql import WRITER as WRITER_GATEWAY
 from app.core.db.tenant_adoption import (
     BOUNDARY_FUNCTIONS,
     CONTROL,
@@ -505,6 +506,85 @@ class TestReportedStateMatchesWhatApplyEnforces:
         finally:
             async with engine.begin() as conn:
                 await conn.execute(sa.text(f"DROP ROLE IF EXISTS {stray}"))
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_creator_membership_on_the_writer_is_normalized(
+        self, multi_tenant_row_security
+    ):
+        """PostgreSQL 16+ makes the role creator a direct member of the writer.
+
+        A non-superuser CREATEROLE migrator replaying the fresh-cluster globals
+        dump therefore holds that edge on every restored writer, and
+        `provision_tenant_data_schema` refuses an unexpected direct member
+        outright — so every tenant would fail adoption on exactly the managed
+        deployment the runbook points at.
+        """
+        tenant_id, schema, _reader, writer = _new_tenant()
+        creator = f"w998_creator_{tenant_id.replace('-', '_')}"
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"CREATE ROLE {creator} NOLOGIN CREATEROLE"))
+                await conn.execute(
+                    sa.text(
+                        f"CREATE ROLE {writer} NOLOGIN NOSUPERUSER NOCREATEDB "
+                        "NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS"
+                    )
+                )
+                await conn.execute(
+                    sa.text(f"GRANT {writer} TO {creator} WITH ADMIN OPTION")
+                )
+
+            report = await run_adoption(engine, apply=True)
+            assert report.failures == {}, report.failures
+            assert report.ok
+
+            async with engine.connect() as conn:
+                members = [
+                    row[0]
+                    for row in await conn.execute(
+                        sa.text(
+                            "SELECT member.rolname FROM pg_auth_members AS membership "
+                            "JOIN pg_roles AS granted ON granted.oid = membership.roleid "
+                            "JOIN pg_roles AS member ON member.oid = membership.member "
+                            "WHERE granted.rolname = :writer ORDER BY member.rolname"
+                        ),
+                        {"writer": writer},
+                    )
+                ]
+            assert members == [PROVISIONER, WRITER_GATEWAY]
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(sa.text(f"DROP ROLE IF EXISTS {creator}"))
+            await _drop_tenant(engine, tenant_id)
+            await engine.dispose()
+
+    async def test_writer_missing_one_schema_privilege_is_not_adopted(
+        self, multi_tenant_row_security
+    ):
+        """`has_schema_privilege(role, schema, 'USAGE, CREATE')` is any-of."""
+        tenant_id, schema, _reader, writer = _new_tenant()
+        engine = _make_engine()
+        try:
+            await _seed_restored_tenant(engine, tenant_id, schema)
+            assert (await run_adoption(engine, apply=True)).ok
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(f"REVOKE CREATE ON SCHEMA {schema} FROM {writer}")
+                )
+
+            async with engine.connect() as conn:
+                state = await tenant_ownership_state(conn, tenant_id)
+            assert not state.schema_privileges_secure
+            assert not state.adopted
+
+            repaired = await run_adoption(engine, apply=True)
+            assert repaired.failures == {}, repaired.failures
+            assert repaired.ok
+        finally:
             await _drop_tenant(engine, tenant_id)
             await engine.dispose()
 

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -60,6 +60,7 @@ from app.core.db.tenant_adoption_report import (
     rls_gaps,
 )
 from app.core.db.tenant_adoption_sql import (
+    CLUSTER_ROLE_VALIDATE_SQL,
     RELEASE_GATEWAY_EDGES_SQL,
     RELEASE_PROVISIONER_EDGE_SQL,
     SANDBOX,
@@ -1134,6 +1135,38 @@ class TestReportedStateMatchesWhatApplyEnforces:
                     )
                     with pytest.raises(RuntimeError, match="search_path"):
                         await secure_boundary_functions(conn)
+                finally:
+                    await transaction.rollback()
+        finally:
+            await engine.dispose()
+
+    async def test_an_orphan_tenant_role_with_an_inherit_edge_is_refused(self):
+        """A role with the naming pattern and no tenant row is never repaired.
+
+        Nothing per-tenant reaches it, so an INHERIT edge to a gateway would
+        hand that gateway the role's privileges outright. Rolled back — the
+        role and the edge are cluster objects.
+        """
+        orphan = f"geolens_writer_t_{uuid.uuid4().hex[:8]}_0000_0000_0000_000000000000"
+        engine = _make_engine()
+        try:
+            async with engine.connect() as conn:
+                transaction = await conn.begin()
+                try:
+                    await conn.execute(
+                        sa.text(
+                            f"CREATE ROLE {orphan} NOLOGIN NOSUPERUSER NOCREATEDB "
+                            "NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS"
+                        )
+                    )
+                    await conn.execute(
+                        sa.text(
+                            f"GRANT {orphan} TO {WRITER_GATEWAY} "
+                            "WITH INHERIT TRUE, SET TRUE"
+                        )
+                    )
+                    with pytest.raises(DBAPIError, match="unsafe upstream membership"):
+                        await conn.execute(sa.text(CLUSTER_ROLE_VALIDATE_SQL))
                 finally:
                     await transaction.rollback()
         finally:


### PR DESCRIPTION
## What changed

`backend/app/core/db/tenant_adoption.py` (plus `tenant_adoption_sql.py`, which
holds the DDL ported from migration 0019) reconstructs tenant schema/role
ownership **at the current head schema**, so the destructive
`alembic downgrade 0016` is never required.

```bash
docker compose run --rm --no-deps -e DATABASE_URL_OVERRIDE="<migrator-url>" \
  migrate sh -c "uv run --no-dev python -m app.core.db.tenant_adoption --apply"
```

Without `--apply` it is a read-only report and exits non-zero while work is
pending, so it doubles as a post-restore check.

It is deliberately not a replay of 0019:

- **No function body is ever installed.** That is what made replaying 0019
  impossible on a restored dump — 0019 uses plain `CREATE FUNCTION` and collides
  with the functions the dump already carries. Adoption verifies both boundary
  functions are present, `SECURITY DEFINER`, and `search_path`-pinned, then
  repairs only what `pg_restore --no-owner --no-acl` strips. Bodies stay owned
  by the migrations; a missing or unexpected-shape function is a refusal.
- **Relations go straight to the per-tenant writer.** 0019 parked them on the
  provisioner so its provisioning function could rewrite their ACLs; 0024
  removed that pass, so at head the writer owns them and grants the paired
  reader `SELECT` itself — the contract ingest already follows.
- **Column-owned sequences are skipped in the transfer.** PostgreSQL rejects
  `ALTER SEQUENCE … OWNER TO` on a `serial`/identity sequence and moves it with
  its table instead. 0019's unconditional loop would have stopped dead on the
  `ogc_fid` serial that every `ogr2ogr` vector ingest produces; verified against
  a `bigserial` fixture.

Idempotence is keyed on database state, not on a marker or a timestamp: each
step reads what the cluster holds and issues DDL only for the gap, so an
already-adopted tenant issues none at all. Every tenant runs in its own
transaction, so an interrupted run resumes by re-running it, and a tenant that
refuses is named in the report while the rest continue.

## Security impact

A `--no-owner --no-acl` restore leaves both SECURITY DEFINER boundary functions
owned by the restoring login (typically the superuser) **with the PostgreSQL
default function ACL, which grants `EXECUTE` to `PUBLIC`**. Confirmed on a real
`pg_dump`/`pg_restore` roundtrip at PostgreSQL 18:

```
provision_tenant_data_schema | geolens | secdef=t | proacl=NULL | has_function_privilege('public',…)=t
```

Until adoption runs, every login in a restored database can call
`catalog.provision_tenant_data_schema` as the definer. Adoption re-owns both
functions to `geolens_tenant_provisioner`, revokes `PUBLIC`, and re-grants
`EXECUTE` to `geolens_tenant_control` only.

## The tenant boundary is introspected, not enumerated

The report reads the boundary from the live `trg_stamp_current_tenant_on_insert`
triggers, and cross-checks it against `app.core.db.rls.RLS_TABLES` — a table
stamped in the database but missing from that tuple never gets RLS enabled at
boot. Measured on a fresh head-schema database:

- **9 stamped tables** (the live boundary): `audit_logs`, `collections`,
  `datasets`, `embed_tokens`, `ingest_jobs`, `maps`, `oauth_accounts`,
  `records`, `users`. Migration 0018's frozen `_TABLES` tuple names six.
- `dataset_refresh_runs` carries a `tenant_id` column with no trigger and no
  policy — 0037's deliberately dormant column. It is reported as
  "tenant_id column only, outside the stamped boundary" so an accidental
  omission cannot hide behind an intentional one.

## Operational impact — DR procedure change

`RUNBOOK.md` § "Multi-tenant role reconstruction after a fresh-cluster restore":

- Step 2 is now restore-the-dump + run the adoption command. The old 2c
  (`alembic downgrade 0016 && alembic upgrade heads`) is gone.
- The tenant-attribution snapshot and restore that used to bracket that
  downgrade (old 2b/2d, there because 0022's `downgrade()` discards `tenant_id`
  on `audit_logs`/`ingest_jobs`) are gone with it. Nothing on this path
  discards `tenant_id`.
- Step 1's manual role-creation block is now a fallback: adoption creates the
  five fixed NOLOGIN cluster roles itself, with 0019's validation.
- The downgrade table is kept under a new "Do not reach for
  `alembic downgrade 0016`" heading, reframed as the thing not to do rather than
  the recipe. Honest limits are unchanged and a "What it does not do" paragraph
  was added: runtime login grants, RLS enablement (still the API's job at boot),
  and object storage are all still separate.

No schema, API, or config changes. `alembic check` reports no drift.

## Verification

```bash
# new tests (10) — DB-backed, host Postgres at localhost:5434
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_tenant_ownership_adoption.py -q          # 10 passed

# gates
uv run ruff check . && uv run ruff format --check .               # clean, 968 files
uv run pytest tests/test_layering.py -q                           # 40 passed
uv run pytest tests/test_rule1_structural.py tests/test_rule2_structural.py -q
uv run pytest -n 4 -k "tenant or rls or runtime_db or migration or docs or alembic" -q
#                                                                 # 714 passed, 1 skipped

# schema drift, on a host DB migrated to head
uv run alembic check                                              # No new upgrade operations detected
```

Also exercised end to end by hand against a head-schema database:
`pg_dump -Fc --no-owner --no-acl` → `pg_restore --no-owner --no-acl` into a
second database → `--apply`. The tenant schema, table, view, and `bigserial`
sequence came back owned by the restoring login with no ACLs; after adoption the
schema is owned by `geolens_tenant_provisioner`, every relation by
`geolens_writer_t_<uuid>`, the reader holds `SELECT` (and `SELECT, USAGE` on the
sequence), the provisioner holds ADMIN-only non-SET membership in both
per-tenant roles, and the transaction-scoped writer edge the transfer needs is
handed back before commit. A second run left a full catalog snapshot
byte-identical.

Closes #998
