### PR TITLE
chore(deps): ignore @tanstack/react-table majors pending hand migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,11 @@ updates:
         patterns: ["react", "react-dom", "@types/react*"]
       tanstack:
         patterns: ["@tanstack/*"]
+    ignore:
+      # fix(#1407): react-table v9 is a hand migration (AttributeTable);
+      # the major gets pulled deliberately, not via bump PR.
+      - dependency-name: "@tanstack/react-table"
+        update-types: ["version-update:semver-major"]
 
   # --- Root E2E (Playwright) — was untracked ---
   - package-ecosystem: "npm"


### PR DESCRIPTION
Adds an ignore rule to the frontend npm block of `.github/dependabot.yml`: no more major-version bump PRs for `@tanstack/react-table`. The backend block already runs this policy for all majors.

Why: v9 reached npm latest on 2026-08-07 and shipped three patches in its first three days. Our one consumer, `AttributeTable.tsx`, needs a hand migration with live re-verification of its sorting and virtualizer behavior; #1407 tracks that work with the full API map. The bump PR (#1338) is being closed by hand because two `@dependabot ignore this major version` comments went unacked today while dependabot was otherwise active in the repo, so the comment channel was not a reliable place to park this decision.

Config impact: dependabot automation only. No app code, no schema, no API surface.

Verification: YAML parse check on the edited file (`ruby -ryaml`).
