### PR TITLE
fix(frontend): refetch refresh runs on window focus so external runs are observed

### DIFF
--- a/frontend/src/components/dataset/hooks/__tests__/use-dataset.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-dataset.test.ts
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from '@/test/test-utils';
-import { act } from '@testing-library/react';
+import { act, renderHook as renderHookRTL } from '@testing-library/react';
 import { vi } from 'vitest';
-import { useRef } from 'react';
-import { useQueryClient, type QueryClient } from '@tanstack/react-query';
+import { createElement, useRef, type ReactNode } from 'react';
+import { useQueryClient, QueryClient, QueryClientProvider, focusManager } from '@tanstack/react-query';
 
 vi.mock('@/api/datasets', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/api/datasets')>();
@@ -315,6 +315,59 @@ describe('useDatasetRefreshRuns', () => {
     renderHook(() => useDatasetRefreshRuns(''));
 
     expect(mockGetDatasetRefreshRuns).not.toHaveBeenCalled();
+  });
+
+  /**
+   * fix(#1328): main.tsx sets refetchOnWindowFocus: false as the GLOBAL
+   * default because a refresh dispatched from the CLI or another editor's
+   * session never touches this client's cache — without a per-query
+   * override, this query's cached "idle" state is never re-validated by
+   * returning focus to the tab. The shared test client (test-utils.tsx)
+   * doesn't set that global default, so asserting against it would pass
+   * even without the fix (react-query's own default is already `true`).
+   * Build a client that mirrors main.tsx's global `false` instead, so a
+   * refetch here can only be explained by this query's own override.
+   */
+  it('refetches on window focus once stale, even under a client that disables it globally', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockGetDatasetRefreshRuns.mockResolvedValue({
+        runs: [makeRun({ id: 'run-1', status: 'succeeded' })],
+        total: 1,
+      });
+
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0, refetchOnWindowFocus: false } },
+      });
+      function Wrapper({ children }: { children: ReactNode }) {
+        return createElement(QueryClientProvider, { client: queryClient }, children);
+      }
+
+      const { result } = renderHookRTL(() => useDatasetRefreshRuns('ds-1'), { wrapper: Wrapper });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.isSuccess).toBe(true);
+      expect(mockGetDatasetRefreshRuns).toHaveBeenCalledTimes(1);
+
+      // Past this query's own 15s staleTime — refetchOnWindowFocus: true
+      // only refetches stale data, per TanStack Query's own contract.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_001);
+      });
+      expect(mockGetDatasetRefreshRuns).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        focusManager.setFocused(true);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockGetDatasetRefreshRuns).toHaveBeenCalledTimes(2);
+    } finally {
+      focusManager.setFocused(undefined);
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/frontend/src/components/dataset/hooks/__tests__/use-dataset.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-dataset.test.ts
@@ -327,8 +327,19 @@ describe('useDatasetRefreshRuns', () => {
    * even without the fix (react-query's own default is already `true`).
    * Build a client that mirrors main.tsx's global `false` instead, so a
    * refetch here can only be explained by this query's own override.
+   *
+   * fix(#1328 codex review): the override must be 'always', not `true`.
+   * `true` only refetches when the cached data is already stale, but an
+   * external run can start and this tab can regain focus inside the SAME
+   * 15s staleTime window as this query's last fetch — the exact case a
+   * user "checking after a colleague ran a refresh" is likely to hit, and
+   * the one `true` silently drops (worse, nothing schedules a fetch once
+   * the data merely becomes stale afterward, since refetchInterval is off
+   * in the idle state — the page would wait on a second, unrelated focus
+   * or a remount to notice). Assert the fresh-window case directly rather
+   * than the now-irrelevant "skipped while fresh" behavior.
    */
-  it('refetches on window focus once stale, even under a client that disables it globally', async () => {
+  it('refetches on window focus regardless of staleness, including while data is still fresh', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {
       mockGetDatasetRefreshRuns.mockResolvedValue({
@@ -351,19 +362,31 @@ describe('useDatasetRefreshRuns', () => {
       expect(result.current.isSuccess).toBe(true);
       expect(mockGetDatasetRefreshRuns).toHaveBeenCalledTimes(1);
 
-      // Past this query's own 15s staleTime — refetchOnWindowFocus: true
-      // only refetches stale data, per TanStack Query's own contract.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(15_001);
-      });
-      expect(mockGetDatasetRefreshRuns).toHaveBeenCalledTimes(1);
-
+      // Still well inside the 15s staleTime — an external run could have
+      // started and finished in this window. This is the case
+      // refetchOnWindowFocus: true would have missed.
       await act(async () => {
         focusManager.setFocused(true);
         await vi.advanceTimersByTimeAsync(0);
       });
-
       expect(mockGetDatasetRefreshRuns).toHaveBeenCalledTimes(2);
+
+      // Merely becoming stale, with no focus/mount/reconnect event, still
+      // doesn't schedule a fetch on its own.
+      focusManager.setFocused(false);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_001);
+      });
+      expect(mockGetDatasetRefreshRuns).toHaveBeenCalledTimes(2);
+
+      // A later focus event still refetches once the data is genuinely
+      // stale too — 'always' keeps covering the case `true` covered, it
+      // just no longer depends on it.
+      await act(async () => {
+        focusManager.setFocused(true);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mockGetDatasetRefreshRuns).toHaveBeenCalledTimes(3);
     } finally {
       focusManager.setFocused(undefined);
       vi.useRealTimers();

--- a/frontend/src/components/dataset/hooks/use-dataset.ts
+++ b/frontend/src/components/dataset/hooks/use-dataset.ts
@@ -234,11 +234,19 @@ export function useDatasetRefreshRuns(
     // touches this client's cache — under the global default, this query's
     // cached "idle" state (no active run) is otherwise never re-validated
     // until something else remounts or invalidates it. Overriding the
-    // default here means returning focus to the tab re-fetches runs (once
-    // staleTime has lapsed), so useDatasetRefreshWatch's active->terminal
-    // transition guard gets a chance to observe a run it never dispatched
-    // and never saw start.
-    refetchOnWindowFocus: true,
+    // default here means returning focus to the tab re-fetches runs, so
+    // useDatasetRefreshWatch's active->terminal transition guard gets a
+    // chance to observe a run it never dispatched and never saw start.
+    //
+    // 'always', not `true`: plain `true` only refetches if the cached data
+    // is already stale, so an external run started less than staleTime
+    // (15s) after this query's last fetch would be missed on the very
+    // focus event meant to catch it — and since becoming stale later is
+    // passive (nothing schedules a fetch once refetchInterval is off), the
+    // page could then wait on a second, unrelated focus/remount to notice.
+    // Focus returning to the tab IS the signal to check for an external
+    // run, independent of this query's own freshness clock.
+    refetchOnWindowFocus: 'always',
     // fix(#1285 codex round 2): keepPreviousData shows the LAST successful
     // result as a placeholder for ANY new query invocation, not just a
     // paged re-fetch of the same dataset — so navigating straight from one

--- a/frontend/src/components/dataset/hooks/use-dataset.ts
+++ b/frontend/src/components/dataset/hooks/use-dataset.ts
@@ -228,6 +228,17 @@ export function useDatasetRefreshRuns(
     enabled: !!datasetId,
     placeholderData: keepPreviousData,
     staleTime: 15_000,
+    // fix(#1328): observe externally-started refresh runs on tab refocus.
+    // The app disables refetchOnWindowFocus globally (main.tsx) because a
+    // refresh dispatched from the CLI or another editor's session never
+    // touches this client's cache — under the global default, this query's
+    // cached "idle" state (no active run) is otherwise never re-validated
+    // until something else remounts or invalidates it. Overriding the
+    // default here means returning focus to the tab re-fetches runs (once
+    // staleTime has lapsed), so useDatasetRefreshWatch's active->terminal
+    // transition guard gets a chance to observe a run it never dispatched
+    // and never saw start.
+    refetchOnWindowFocus: true,
     // fix(#1285 codex round 2): keepPreviousData shows the LAST successful
     // result as a placeholder for ANY new query invocation, not just a
     // paged re-fetch of the same dataset — so navigating straight from one


### PR DESCRIPTION
## What

Adds a per-query `refetchOnWindowFocus: 'always'` override to `useDatasetRefreshRuns` (`frontend/src/components/dataset/hooks/use-dataset.ts`), the query behind both the dataset page's refresh-run watcher (`useDatasetRefreshWatch`) and the Source panel's refresh history section. Returning focus to a dataset page tab now refetches its refresh runs every time, regardless of whether the cached data is still within the query's 15s staleTime, instead of only ever refetching on remount or on this client's own dispatch.

## Why

The app disables `refetchOnWindowFocus` globally in `main.tsx`; most queries have no business refetching on every alt-tab. That default means a refresh dispatched from the CLI or another editor's session, after this page has already cached an idle "no active run" state, is never observed. Nothing invalidates or refetches the runs query, so the page can serve stale data indefinitely until the route unmounts and remounts.

This is option (b) from #1328: piggyback on the window-focus signal instead of adding a standing idle poll (option a) or new push infrastructure (option c).

The override has to be `'always'`, not plain `true`. Plain `true` only refetches when the cached data is already stale, but an external run can start and this tab can regain focus inside the same 15s window as this query's last fetch. That fresh-window case is the realistic "user checks back after a colleague ran a refresh" scenario this fix targets, not a rare corner case. Worse, once that window passes, becoming stale is passive: nothing schedules a fetch on its own since `refetchInterval` is off in the idle state, so the page would need a second, unrelated focus event or a remount to notice. `'always'` makes every focus event the trigger, independent of this query's own freshness clock.

## Face 2 coverage

The issue's follow-up comment describes a second face of the same problem. `useDatasetRefreshWatch`'s active-to-terminal transition guard only fires invalidation when a run was actually observed going from active to terminal by the current mount. A run whose entire active phase happens with no observer watching (route navigation unmount and remount, most obviously) surfaces on the next fetch as already terminal, which the guard ignores, so data-derived caches like rows, versions, and attributes fall back to their own staleTime to self-correct.

This change covers most of that in practice, but not all of it. A run that this mount saw as active before the tab lost focus, whether its own dispatch or an external run already active on mount, still gets caught correctly on refocus. `wasActiveRef` is a ref, not component state, so it survives a focus/blur cycle untouched; only a true unmount resets it. Once the refocus refetch reports that run terminal, `wasActive` is still `true` from before the blur, the transition fires, and the full invalidation sweep runs.

What's still missed is a run whose entire lifecycle, dispatch and completion both, happens while the tab is unfocused, with this mount never having observed it active. On refocus the refetch reports it already terminal in one jump. The transition guard has nothing to compare against, so no invalidation fires. The refresh-runs list itself is still correct, since the refetch did happen, so the history section and the busy/disabled gate stay accurate; the rest of the data-derived caches just wait out their own staleTime, same as before this change. Using `'always'` instead of `true` doesn't change this part: it only changes when the refetch happens, not what the transition guard does with the result once it arrives.

Navigating away from the dataset page and back is unaffected either way. A remount's initial fetch is governed by `refetchOnMount` and staleTime, not `refetchOnWindowFocus`, so this change doesn't touch that path. It was already accepted as bounded and self-healing when #1323 deferred this issue, and stays exactly as it was.

Per the issue's own framing, a persisted watermark would close the remaining gap for good, but that's more than this issue asks for.

## Verification

- `cd frontend && npm ci`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/components/dataset/hooks/__tests__/use-dataset.test.ts`
- `npx vitest run src/components/dataset/` (full directory, checked for regressions in SourcePanel/SourceRefreshAction, which share this query)

Closes #1328
