### PR TITLE
fix(tiles): fold tile_cache_version into the raster meta cache key

### DIFF
--- a/backend/app/processing/ingest/tasks_raster_swap.py
+++ b/backend/app/processing/ingest/tasks_raster_swap.py
@@ -580,14 +580,18 @@ async def _run_post_swap_followups(
 
     "No reader left" is true of the DATABASE. An API process that served a tile
     in the last minute may still hold this dataset in the tile router's
-    ``_resolve_raster_meta`` cache, whose entries carry the OLD asset_uri for up
-    to ``_RASTER_META_CACHE_TTL`` (60s) — so raster tiles can fail for that
-    window before the entry expires and the new pointer is read. Deliberately
-    not worked around: ``regenerate_vrt`` reaps its superseded generation the
-    same way against the same cache, the window is bounded and self-healing, and
-    closing it needs cross-process invalidation neither path has. The bumped
-    ``tile_cache_version`` already changes the tile URL, so browser and CDN
-    caches roll over immediately.
+    ``_resolve_raster_meta`` cache, whose entries carry the OLD asset_uri.
+    fix(#1329): that cache is now keyed on the request's ``v``, so the
+    ``tile_cache_version`` bump this swap already made in the write transaction
+    IS the invalidation — the first tile request carrying the new version misses
+    in every API process and reads the new pointer, with no separate
+    coordination channel (``regenerate_vrt`` and the STAC moved-asset refresh
+    bump the same counter and get the same effect). What is left is requests
+    still carrying the OLD ``v`` — a tab that has not refetched its tile URL:
+    those keep the pre-swap asset_uri until the entry expires
+    (``_RASTER_META_CACHE_TTL``, 60s), so their tiles can fail for that bounded,
+    self-healing window. The bumped ``tile_cache_version`` also changes the tile
+    URL, so browser and CDN caches roll over immediately.
     """
     from app.core.db import async_session
     from sqlalchemy.orm import joinedload

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -609,19 +609,20 @@ async def refresh_stac(
                 # beside the content change it describes, which is the
                 # contract on the method.
                 #
-                # It does NOT reach `tiles.router._raster_meta_cache` (#1266
-                # review): that is a per-process LRU in the API workers, keyed
-                # on tenant and dataset alone, so an API process that served a
-                # tile in the last minute keeps the pre-refresh href until its
-                # 60s TTL expires — even for requests carrying the new `_v=`.
-                # Left as it is, deliberately and not for the first time:
-                # `reupload_raster` and `regenerate_vrt` have the same window
-                # against the same cache (see the note in
-                # tasks_raster_swap._run_post_swap_followups), and closing it
-                # needs cross-process invalidation none of the three has.
-                # Building that for one of them would leave the other two
-                # stale while implying otherwise; it belongs to the tile
-                # router, once, for all of them.
+                # It reaches `tiles.router._raster_meta_cache` too, which it
+                # once did not (#1266 review, when that per-process LRU was
+                # keyed on tenant and dataset alone and kept the pre-refresh
+                # href for a TTL even for requests carrying the new version).
+                # fix(#1329) keyed it on the request's `v` as well, so this
+                # bump is itself the invalidation: the first request carrying
+                # the new value misses in every API process and re-reads the
+                # href. `reupload_raster` and `regenerate_vrt` bump the same
+                # counter in their own write transactions and get the same
+                # effect (see the note in
+                # tasks_raster_swap._run_post_swap_followups) — the fix that
+                # belonged to the tile router, once, for all three. A request
+                # still carrying the OLD version keeps the pre-refresh href
+                # until that entry expires (60s), bounded and self-healing.
                 dataset.bump_tile_cache_version()
 
             # AFTER the rebind, never before: `set_dataset_origin` clears the

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -655,9 +655,26 @@ def _require_tile_tenant_context() -> str | None:
     return tenant_id
 
 
+def _meta_cache_version_segment(raw: str | None) -> str | None:
+    """Normalize a request's ``v`` into a raster meta cache-key segment (#1329).
+
+    ``tile_cache_version`` is a small monotonic integer, so only a short ASCII
+    digit run is accepted as a key segment. Anything else — absent, empty,
+    non-numeric, absurdly long — returns None, which puts the caller back on the
+    unversioned key and therefore on the pre-#1329 behavior (60s-bounded
+    staleness), never on an error.
+    """
+    if raw is None or not (0 < len(raw) <= 10):
+        return None
+    if not (raw.isascii() and raw.isdigit()):
+        return None
+    return raw
+
+
 async def _resolve_raster_meta(
     db: AsyncSession,
     dataset_id: uuid.UUID,
+    requested_version: str | None = None,
 ) -> _RasterMeta:
     """Look up raster dataset/asset metadata with a short in-memory cache.
 
@@ -672,6 +689,10 @@ async def _resolve_raster_meta(
     filters ``catalog.datasets.tenant_id`` explicitly. An unresolved tenant
     fails before cache lookup or SQL. Single-tenant keys and SQL stay unchanged.
 
+    ``requested_version`` is the request's ``v`` (see the #1329 note at the key
+    derivation); callers that have no request context omit it and keep the
+    pre-#1329 key.
+
     Raises HTTPException(404) when the dataset is missing, is not a raster, or
     has no raster asset.
     """
@@ -679,6 +700,32 @@ async def _resolve_raster_meta(
     cache_key = (
         f"{tenant_id}:{dataset_id}" if tenant_id is not None else str(dataset_id)
     )
+    # fix(#1329): the key carries the REQUEST's `v`, not the row's
+    # `tile_cache_version`. Three paths swap a raster's pointer in place
+    # (reupload #1290, VRT regeneration, STAC moved-asset refresh #1326) and all
+    # three bump the version in the same transaction — but the row's version
+    # reaches this function only through the snapshot below, so it is exactly as
+    # stale as the `asset_uri` it would be guarding and folding it in would buy
+    # nothing. The request's `v` is independent: it comes from the dataset/map
+    # metadata the client fetched, so the first tile request after a swap
+    # carries the new value, misses in EVERY api process, and re-reads the href
+    # and band shape once. Requests still carrying the old `v` keep hitting the
+    # old entry — stale but well-formed, bounded by the TTL and self-healing,
+    # which is the tradeoff #1329 accepts.
+    #
+    # This partitions the per-process cache exactly the way nginx's
+    # `proxy_cache_key` `$arg_v` segment partitions the shared tile cache
+    # (frontend/nginx.conf), so an entry written under `v=N` can only ever be
+    # served to a request carrying `v=N`. The #1372 pre-warm defense is
+    # untouched: cacheability is still decided against the SNAPSHOT's own
+    # version, so priming a future `v` yields a `private, no-store` response and
+    # never populates the shared cache. Memory stays bounded by the LRU, and a
+    # caller varying `v` to evict entries costs at most one extra indexed read
+    # per request — the same order as the uncached miss an unknown dataset id
+    # already produces.
+    version_segment = _meta_cache_version_segment(requested_version)
+    if version_segment is not None:
+        cache_key = f"{cache_key}:v{version_segment}"
     now = time.monotonic()
     with _raster_meta_cache_lock:
         cached_entry = _raster_meta_cache.get(cache_key)
@@ -795,6 +842,7 @@ async def _resolve_raster_access(
     dataset_id: uuid.UUID,
     request: Request,
     user: Identity | None,
+    requested_version: str | None = None,
 ) -> tuple[_RasterMeta, str]:
     """Validate RBAC access to a raster dataset and return row metadata + storage backend.
 
@@ -802,10 +850,13 @@ async def _resolve_raster_access(
     validation, embed-token / user / RBAC checks (3 auth priority branches), and
     returns the _RasterMeta together with the resolved storage_backend string.
 
+    ``requested_version`` is the request's ``v`` and only reaches the metadata
+    cache key (#1329); it is never an input to any auth decision.
+
     Raises HTTPException on any auth or lookup failure.
     """
     # PERF-002: metadata resolved from cache; auth checks always run per-request.
-    meta = await _resolve_raster_meta(db, dataset_id)
+    meta = await _resolve_raster_meta(db, dataset_id, requested_version)
 
     visibility = meta.visibility
     record_status = meta.record_status
@@ -910,7 +961,25 @@ async def raster_auth_check(
         403 if embed token is invalid
         404 if dataset not found, not a raster, or has no raster asset
     """
-    meta, storage_backend = await _resolve_raster_access(db, dataset_id, request, user)
+    # fix(#1372 codex r4): nginx keys on the FIRST occurrence of `v` and matches
+    # the param NAME case-insensitively; `QueryParams.get()` returns the LAST
+    # occurrence of an exact-case name — so `?v=<future>&v=<current>` (or
+    # `?V=<future>`) would pass a naive check while nginx keys on the future
+    # value. Read once here because the same values decide two things: which
+    # metadata cache entry serves this request (#1329) and whether the response
+    # may be stored by the shared cache (below).
+    v_values = [
+        value
+        for name, value in request.query_params.multi_items()
+        if name.lower() == "v"
+    ]
+    meta, storage_backend = await _resolve_raster_access(
+        db,
+        dataset_id,
+        request,
+        user,
+        requested_version=v_values[0] if v_values else None,
+    )
 
     # Resolve COG open-path for Titiler via the single storage seam (STOR-02 / Phase 1210).
     # resolve_open_path handles local/s3/azure dispatch and http(s) pass-through.
@@ -930,23 +999,18 @@ async def raster_auth_check(
     # public URLs and increments predictably, so an unvalidated `v` would let a
     # caller pre-warm the NEXT version's cache key with pre-replace bytes and
     # defeat the invalidation for a full TTL. A mismatched `v` still serves —
-    # a stale tab keeps rendering current bytes — but as `private, no-store`,
-    # so the wrong key is never populated. Compared against the same cached
-    # meta snapshot the bytes come from (`_RASTER_META_CACHE_TTL` note above),
-    # so version and content can never disagree within one response.
+    # a stale tab keeps rendering (its own version's entry for up to the meta
+    # TTL after a swap, then the current bytes, #1329) — but as
+    # `private, no-store`, so the wrong key is never populated. Compared
+    # against the same cached meta snapshot the bytes come from
+    # (`_RASTER_META_CACHE_TTL` note above), so version and content can never
+    # disagree within one response.
     #
     # fix(#1372 codex r4): the match must mirror nginx's `$arg_v` semantics,
-    # not Starlette's. nginx keys on the FIRST occurrence and matches the
-    # param NAME case-insensitively; `QueryParams.get()` returns the LAST
-    # occurrence of an exact-case name — so `?v=<future>&v=<current>` (or
-    # `?V=<future>`) would pass a naive check while nginx keys on the future
-    # value. Cacheable requires exactly one case-insensitive `v`, equal to
-    # the current version; anything else is served no-store.
-    v_values = [
-        value
-        for name, value in request.query_params.multi_items()
-        if name.lower() == "v"
-    ]
+    # not Starlette's (read at the top of this handler, with the parser
+    # disagreement documented there). Cacheable requires exactly one
+    # case-insensitive `v`, equal to the current version; anything else is
+    # served no-store.
     if (
         cache_status == "public"
         and v_values

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -697,35 +697,29 @@ async def _resolve_raster_meta(
     has no raster asset.
     """
     tenant_id = _require_tile_tenant_context()
-    cache_key = (
-        f"{tenant_id}:{dataset_id}" if tenant_id is not None else str(dataset_id)
-    )
-    # fix(#1329): the key carries the REQUEST's `v`, not the row's
+    base_key = f"{tenant_id}:{dataset_id}" if tenant_id is not None else str(dataset_id)
+    # fix(#1329): LOOK UP under the REQUEST's `v`, not the row's
     # `tile_cache_version`. Three paths swap a raster's pointer in place
     # (reupload #1290, VRT regeneration, STAC moved-asset refresh #1326) and all
     # three bump the version in the same transaction — but the row's version
     # reaches this function only through the snapshot below, so it is exactly as
-    # stale as the `asset_uri` it would be guarding and folding it in would buy
-    # nothing. The request's `v` is independent: it comes from the dataset/map
-    # metadata the client fetched, so the first tile request after a swap
-    # carries the new value, misses in EVERY api process, and re-reads the href
-    # and band shape once. Requests still carrying the old `v` keep hitting the
-    # old entry — stale but well-formed, bounded by the TTL and self-healing,
+    # stale as the `asset_uri` it would be guarding and looking up by it would
+    # buy nothing. The request's `v` is independent: it comes from the
+    # dataset/map metadata the client fetched, so the first tile request after a
+    # swap carries the new value, misses in EVERY api process, and re-reads the
+    # href and band shape once. Requests still carrying the old `v` read their
+    # own entry — stale but well-formed, bounded by the TTL and self-healing,
     # which is the tradeoff #1329 accepts.
     #
-    # This partitions the per-process cache exactly the way nginx's
-    # `proxy_cache_key` `$arg_v` segment partitions the shared tile cache
-    # (frontend/nginx.conf), so an entry written under `v=N` can only ever be
-    # served to a request carrying `v=N`. The #1372 pre-warm defense is
-    # untouched: cacheability is still decided against the SNAPSHOT's own
-    # version, so priming a future `v` yields a `private, no-store` response and
-    # never populates the shared cache. Memory stays bounded by the LRU, and a
-    # caller varying `v` to evict entries costs at most one extra indexed read
-    # per request — the same order as the uncached miss an unknown dataset id
-    # already produces.
+    # The lookup is under the request's value, but the STORE is under the row's
+    # (see the write site below) — the request never names the entry it writes.
+    # Memory stays bounded by the LRU, and a caller varying `v` to evict entries
+    # costs at most one extra indexed read per request — the same order as the
+    # uncached miss an unknown dataset id already produces.
     version_segment = _meta_cache_version_segment(requested_version)
-    if version_segment is not None:
-        cache_key = f"{cache_key}:v{version_segment}"
+    cache_key = (
+        f"{base_key}:v{version_segment}" if version_segment is not None else base_key
+    )
     now = time.monotonic()
     with _raster_meta_cache_lock:
         cached_entry = _raster_meta_cache.get(cache_key)
@@ -795,8 +789,27 @@ async def _resolve_raster_meta(
         nodata=row["nodata"],
         tile_cache_version=row["tile_cache_version"] or 1,
     )
+    # fix(#1329 codex P1): entries must be stamped with the version they
+    # correspond to, or a predictable future `v` pre-warms stale metadata past
+    # the swap. Storing under the REQUESTED value let any caller name an entry:
+    # asking for `v=N+1` while the row still reads N stored the CURRENT snapshot
+    # under the next version's key, and the swap that bumps the row to N+1 then
+    # found that key already occupied, so genuine `v=N+1` requests kept the
+    # pre-swap href for a full TTL. Refusing to mark such a response cacheable
+    # (#1372) does not help — that defends nginx, and the poisoned entry is
+    # process-local. Deriving the write key from the snapshot's OWN version
+    # makes it structurally impossible: key and content always agree, a
+    # mismatched request resolves fresh and writes only its dataset's real
+    # version, and the first post-swap request at the new version finds nothing
+    # and reads the new pointer. The cost is that mismatched-`v` requests are
+    # permanent misses, one indexed read each.
+    store_key = (
+        f"{base_key}:v{meta.tile_cache_version}"
+        if version_segment is not None
+        else base_key
+    )
     with _raster_meta_cache_lock:
-        _raster_meta_cache[cache_key] = (now, meta)
+        _raster_meta_cache[store_key] = (now, meta)
     return meta
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2833,8 +2833,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # pre-swap href for a TTL. Most of it is the note recording WHY it is the
     # request's `v` and not the row's: the row's version arrives through the
     # same cached snapshot, so it is exactly as stale as the href it would be
-    # guarding. Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2255,
+    # guarding.
+    # fix(#1329 codex P1): +13 — the lookup key is the request's `v` but the
+    # STORE key is the resolved row's, so no caller can name the entry it
+    # writes and a predictable future `v` can no longer park a pre-swap
+    # snapshot on the key the swap is about to make legitimate.
+    # Ratchet stays exact.
+    "backend/app/processing/tiles/router.py": 2268,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2826,7 +2826,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1372 codex r4): +12 — the check mirrors nginx's $arg_v semantics
     # (first occurrence, case-insensitive name), closing the duplicate-param
     # and name-case parser-disagreement variants of the same pre-warm attack.
-    "backend/app/processing/tiles/router.py": 2191,
+    # fix(#1329): +64 — the raster meta cache key carries the request's `v`, so
+    # the three in-place pointer swaps (reupload, VRT regeneration, STAC
+    # moved-asset refresh) invalidate every api process's snapshot with the
+    # version bump they already do, instead of each process serving the
+    # pre-swap href for a TTL. Most of it is the note recording WHY it is the
+    # request's `v` and not the row's: the row's version arrives through the
+    # same cached snapshot, so it is exactly as stale as the href it would be
+    # guarding. Ratchet stays exact.
+    "backend/app/processing/tiles/router.py": 2255,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_perf002_raster_meta_cache.py
+++ b/backend/tests/test_perf002_raster_meta_cache.py
@@ -6,10 +6,15 @@ Verifies:
   - _raster_meta_cache is populated after the first call.
   - Authorization is still evaluated per request: a caller who is denied access
     does not inherit a cached allow decision from a previous authorized caller.
+  - fix(#1329): the cache key carries the request's `v` (tile_cache_version), so
+    a pointer swap that bumps the version is missed by every api process on the
+    first request that carries the new value — while an absent or malformed `v`
+    keeps the pre-#1329 unversioned key and its 60s-bounded staleness.
 """
 
 import uuid
 
+from sqlalchemy import text
 
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.processing.raster.models import RasterAsset
@@ -197,3 +202,170 @@ class TestRasterMetaCache:
         assert anon_resp.status_code == 401, (
             f"PERF-002 FAIL: cached metadata bypassed auth; got {anon_resp.status_code}"
         )
+
+
+# ---------------------------------------------------------------------------
+# fix(#1329): version-keyed cache entries
+# ---------------------------------------------------------------------------
+
+
+async def _swap_raster_pointer(session, dataset_id: uuid.UUID) -> str:
+    """Swap the asset pointer and bump tile_cache_version in one transaction.
+
+    Mirrors what raster reupload (#1290), VRT regeneration, and the STAC
+    moved-asset refresh (#1326) each already do: the new href and the bumped
+    counter commit together, so a request carrying the new `v` can never read
+    the old pointer back out of the database.
+    """
+    new_uri = f"rasters/{dataset_id}/swapped-{uuid.uuid4().hex[:8]}.cog.tif"
+    await session.execute(
+        text(
+            "UPDATE catalog.raster_assets SET asset_uri = :uri WHERE dataset_id = :id"
+        ),
+        {"uri": new_uri, "id": dataset_id},
+    )
+    await session.execute(
+        text(
+            "UPDATE catalog.datasets "
+            "SET tile_cache_version = tile_cache_version + 1 WHERE id = :id"
+        ),
+        {"id": dataset_id},
+    )
+    await session.commit()
+    return new_uri
+
+
+def _forget(*cache_keys: str) -> None:
+    """Drop cache entries left over from an earlier test."""
+    with _raster_meta_cache_lock:
+        for key in cache_keys:
+            _raster_meta_cache.pop(key, None)
+
+
+class TestRasterMetaCacheVersionKey:
+    """fix(#1329): the request's `v` partitions the per-process meta cache."""
+
+    async def test_cache_key_includes_requested_version(self, test_db_session):
+        """A request carrying `v` is cached under a version-scoped key."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _create_public_raster(test_db_session, created_by=admin_id)
+
+        bare_key = str(dataset.id)
+        versioned_key = f"{dataset.id}:v7"
+        _forget(bare_key, versioned_key)
+
+        meta = await _resolve_raster_meta(test_db_session, dataset.id, "7")
+
+        assert isinstance(meta, _RasterMeta)
+        with _raster_meta_cache_lock:
+            assert versioned_key in _raster_meta_cache
+            # The unversioned key is NOT written, so a request carrying a
+            # different `v` can never be served this entry.
+            assert bare_key not in _raster_meta_cache
+
+    async def test_bumped_version_misses_the_pre_swap_entry(self, test_db_session):
+        """The bump alone invalidates: no TTL expiry, no coordination channel."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _create_public_raster(test_db_session, created_by=admin_id)
+        dataset_id = dataset.id
+
+        _forget(str(dataset_id), f"{dataset_id}:v1", f"{dataset_id}:v2")
+
+        before = await _resolve_raster_meta(test_db_session, dataset_id, "1")
+        assert before.tile_cache_version == 1
+        old_uri = before.asset_uri
+
+        new_uri = await _swap_raster_pointer(test_db_session, dataset_id)
+        assert new_uri != old_uri
+
+        # Requests still carrying the OLD `v` keep their entry: stale but
+        # well-formed, bounded by the TTL and self-healing. That is the window
+        # #1329 accepts, and it is what the shared nginx cache does with the
+        # same `$arg_v` segment.
+        stale = await _resolve_raster_meta(test_db_session, dataset_id, "1")
+        assert stale is before
+        assert stale.asset_uri == old_uri
+
+        # The new `v` misses in this process and re-reads the swapped pointer.
+        fresh = await _resolve_raster_meta(test_db_session, dataset_id, "2")
+        assert fresh.asset_uri == new_uri
+        assert fresh.tile_cache_version == 2
+
+    async def test_absent_version_serves_from_the_unversioned_key(
+        self, test_db_session
+    ):
+        """No `v` at all (copied connect URLs) keeps the pre-#1329 behavior."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _create_public_raster(test_db_session, created_by=admin_id)
+
+        bare_key = str(dataset.id)
+        _forget(bare_key)
+
+        meta1 = await _resolve_raster_meta(test_db_session, dataset.id)
+        meta2 = await _resolve_raster_meta(test_db_session, dataset.id)
+
+        assert meta1 is meta2
+        with _raster_meta_cache_lock:
+            assert bare_key in _raster_meta_cache
+
+    async def test_malformed_version_degrades_to_the_unversioned_key(
+        self, test_db_session
+    ):
+        """A junk `v` degrades to the old key, never to an error."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _create_public_raster(test_db_session, created_by=admin_id)
+
+        bare_key = str(dataset.id)
+        _forget(bare_key)
+
+        # Empty, non-numeric, signed, fractional, non-ASCII digits, and an
+        # absurdly long run: none of them shapes a tile_cache_version.
+        for raw in ("", "abc", "-1", "2.0", "٧", "9" * 11):
+            meta = await _resolve_raster_meta(test_db_session, dataset.id, raw)
+            assert isinstance(meta, _RasterMeta)
+            with _raster_meta_cache_lock:
+                assert bare_key in _raster_meta_cache
+                assert f"{dataset.id}:v{raw}" not in _raster_meta_cache
+
+    async def test_auth_check_reads_the_swapped_pointer_for_the_new_version(
+        self, client, admin_auth_header, test_db_session
+    ):
+        """End to end: the `v` on the tile URL reaches the cache key.
+
+        Primes the entry through the real request path, swaps the pointer, then
+        checks that a request carrying the bumped `v` resolves the NEW open path
+        while one carrying the old `v` still resolves the old one.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _create_public_raster(test_db_session, created_by=admin_id)
+        dataset_id = dataset.id
+        _forget(str(dataset_id), f"{dataset_id}:v1", f"{dataset_id}:v2")
+
+        primed = await client.get(
+            "/tiles/raster-auth-check/",
+            params={"dataset_id": str(dataset_id), "v": "1"},
+            headers=admin_auth_header,
+        )
+        assert primed.status_code == 200, primed.text
+        old_path = primed.headers["X-GeoLens-Asset-OpenPath"]
+
+        new_uri = await _swap_raster_pointer(test_db_session, dataset_id)
+
+        stale = await client.get(
+            "/tiles/raster-auth-check/",
+            params={"dataset_id": str(dataset_id), "v": "1"},
+            headers=admin_auth_header,
+        )
+        assert stale.status_code == 200, stale.text
+        assert stale.headers["X-GeoLens-Asset-OpenPath"] == old_path
+
+        fresh = await client.get(
+            "/tiles/raster-auth-check/",
+            params={"dataset_id": str(dataset_id), "v": "2"},
+            headers=admin_auth_header,
+        )
+        assert fresh.status_code == 200, fresh.text
+        assert new_uri in fresh.headers["X-GeoLens-Asset-OpenPath"]
+        # The #1372 shared-cache guard still passes on the new key: `v` matches
+        # the version of the snapshot the bytes are built from.
+        assert fresh.headers["X-GeoLens-Cache-Status"] == "public"

--- a/backend/tests/test_perf002_raster_meta_cache.py
+++ b/backend/tests/test_perf002_raster_meta_cache.py
@@ -251,10 +251,10 @@ class TestRasterMetaCacheVersionKey:
         dataset = await _create_public_raster(test_db_session, created_by=admin_id)
 
         bare_key = str(dataset.id)
-        versioned_key = f"{dataset.id}:v7"
+        versioned_key = f"{dataset.id}:v1"
         _forget(bare_key, versioned_key)
 
-        meta = await _resolve_raster_meta(test_db_session, dataset.id, "7")
+        meta = await _resolve_raster_meta(test_db_session, dataset.id, "1")
 
         assert isinstance(meta, _RasterMeta)
         with _raster_meta_cache_lock:
@@ -369,3 +369,51 @@ class TestRasterMetaCacheVersionKey:
         # The #1372 shared-cache guard still passes on the new key: `v` matches
         # the version of the snapshot the bytes are built from.
         assert fresh.headers["X-GeoLens-Cache-Status"] == "public"
+
+    async def test_future_version_request_cannot_pre_warm_the_next_key(
+        self, client, test_db_session
+    ):
+        """fix(#1329 codex P1): a predictable future `v` cannot poison a swap.
+
+        The counter is public and increments by one, so an anonymous caller on
+        a public raster can ask for the version the next swap will produce. If
+        the entry were filed under the value the request asked for, that call
+        would park the CURRENT snapshot on the key the swap is about to make
+        legitimate, and the swap would land on an occupied key. Filing it under
+        the snapshot's own version is what makes that impossible.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _create_public_raster(test_db_session, created_by=admin_id)
+        dataset_id = dataset.id
+        _forget(str(dataset_id), f"{dataset_id}:v1", f"{dataset_id}:v2")
+
+        # The row is at version 1; ask anonymously for the NEXT one.
+        primed = await client.get(
+            "/tiles/raster-auth-check/",
+            params={"dataset_id": str(dataset_id), "v": "2"},
+        )
+        assert primed.status_code == 200, primed.text
+        pre_swap_path = primed.headers["X-GeoLens-Asset-OpenPath"]
+        # The mismatched request is still served, and never as shared-cacheable
+        # (#1372) — which defends nginx only, hence the key rule below.
+        assert primed.headers["X-GeoLens-Cache-Status"] == "private"
+
+        # It was filed under the row's own version, so the key the swap is
+        # about to make legitimate is still empty.
+        with _raster_meta_cache_lock:
+            assert f"{dataset_id}:v1" in _raster_meta_cache
+            assert f"{dataset_id}:v2" not in _raster_meta_cache
+
+        new_uri = await _swap_raster_pointer(test_db_session, dataset_id)
+
+        # The first genuine v=2 request resolves fresh rather than inheriting
+        # the pre-swap snapshot.
+        after = await client.get(
+            "/tiles/raster-auth-check/",
+            params={"dataset_id": str(dataset_id), "v": "2"},
+        )
+        assert after.status_code == 200, after.text
+        after_path = after.headers["X-GeoLens-Asset-OpenPath"]
+        assert new_uri in after_path
+        assert after_path != pre_swap_path
+        assert after.headers["X-GeoLens-Cache-Status"] == "public"


### PR DESCRIPTION
Shape 1 of #1329. `tiles/router.py` keeps `_raster_meta_cache`, a per-process LRU with a 60s TTL holding the href, band shape and rescale params the raster proxy builds Titiler requests from. It was keyed on tenant and dataset alone, so when a raster's pointer swapped in place, every API worker that had served a tile in the last minute kept building requests from the pre-swap description until its own entry expired.

## Which lever, and why

The issue conditions shape 1 on the version being readable at cache-lookup time without an extra query per tile. Two candidates, only one of which the code supports.

The dataset row that feeds the raster path does carry `tile_cache_version`: `_resolve_raster_meta` already selects `d.tile_cache_version` and stores it on the `_RasterMeta` snapshot. That value is useless as a key component. It arrives through the very snapshot the key is meant to guard, so it is exactly as stale as the `asset_uri` beside it, and folding it in buys nothing. (The vector `_dataset_cache` near the top of the file is a separate 60s cache keyed on `table_name`, and the raster path never consults it. Its `_DatasetMeta` does not carry the version at all.)

The request does carry it, thanks to #1372. Every raster tile URL the API emits gets `?v=<tile_cache_version>`: the dataset detail payload, map layer payloads, search results, the OGC landing links, and the signed raster template. nginx forwards `$args` when it rewrites `/raster-tiles/...` to `/tiles/raster-proxy/...`, and the Vite dev proxy preserves the query too, so `raster_auth_check` sees the value on the request it is already parsing for the #1372 cacheability check. That is the lever this PR uses. No new query, no new coordination channel.

## What invalidates now

The key gains a `v` segment taken from the request. All three swap paths already bump `tile_cache_version` in the same transaction as the pointer swap (raster reupload #1290, VRT regeneration, STAC moved-asset refresh #1326), so a client that has refetched its metadata requests the new version, misses in every API process, and gets one indexed read of the new href and band shape. Nothing was added to the swap paths themselves; their existing bump is the whole mechanism. The two comments that recorded the window as deliberately open are updated to say what closed it.

The `v` is read once, at the top of `raster_auth_check`, using the same nginx `$arg_v` semantics the #1372 check needed (first occurrence, case-insensitive name), so the key and the cacheability decision can never disagree about which value the request carried.

Lookup and store use different keys, which is what keeps the request from naming the entry it writes (codex P1 on this PR). The lookup key is the request's `v`. The store key is the resolved row's `tile_cache_version`, taken from the snapshot being stored. The first draft used the request's value for both, and that reopened the bug from the other side: the counter is public and increments by one, so an anonymous caller on a public raster could ask for `v=N+1` while the row still read N, park the current snapshot on the key the imminent swap was about to make legitimate, and leave genuine post-swap requests reading the old href for a full TTL. Answering that request with `private, no-store` does not help, because that defends nginx while the poisoned entry is process-local. With the store key derived from the snapshot, key and content always agree: a mismatched request resolves fresh and files under the row's real version, and the first post-swap request at the new version finds nothing and reads the new pointer. Mismatched requests become permanent cache misses, one indexed read each.

The #1372 pre-warm defense is unchanged. Cacheability is still decided against the snapshot's own version, which comes from the database and never from the request, so priming a future `v` gets a `private, no-store` response and never populates the shared cache.

Sibling surfaces on the same axis, so the reviewer can see it is closed: the vector `_dataset_cache` in the same module is keyed on `table_name` with no request-supplied component, and its `_DatasetMeta` does not carry a version at all; the nginx layer already answers a mismatched `v` with `private, no-store`. This meta cache was the only place where a request parameter could name a cache entry, and it no longer can.

## Degradation

An absent `v` (a connect URL copied into desktop GIS, a direct API caller) keeps the unversioned key byte for byte, and with it the old 60s-bounded staleness. So does a malformed one: `_meta_cache_version_segment` accepts a short ASCII digit run and returns None for anything else, which puts the caller back on the old key rather than on an error.

Requests still carrying the old `v` keep hitting their own entry, stale but well formed, until it expires. That is the tradeoff #1329 states it accepts, and it matches what the shared nginx cache does with the same `$arg_v` segment.

Memory stays bounded by the existing `LRUCache(maxsize=256)`. A caller varying `v` to evict entries costs at most one extra indexed read per request, which is the same order as the uncached miss an unknown dataset id already produces on this route.

## Tests

`backend/tests/test_perf002_raster_meta_cache.py` gains a `TestRasterMetaCacheVersionKey` class covering the key derivation, a swap followed by a lookup at the bumped version, the accepted stale read at the old version, an absent `v`, and a junk `v`. Two of them drive the whole thing through `/tiles/raster-auth-check/` so the plumbing from query param to key is exercised, not just the helper.

The poisoning scenario has its own test: an anonymous request for `v=2` while the row reads 1, asserting the entry lands on `:v1` and not `:v2`, then a swap, then a genuine `v=2` request that must resolve the swapped URI. Against the request-keyed store it fails twice over, first on the key and then, with that assertion relaxed to let the test run to the end, on the post-swap request serving the pre-swap pointer. The same fail-first check was run for the three original fix-specific tests. The two degradation tests pass either way, which is the point of them.

`tiles/router.py` grew 77 lines, most of it the notes recording why the lookup uses the request's `v`, why the store does not, so the `_MODULE_LOC_CAPS` entry is raised from 2191 to 2268 with that rationale.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_layering.py -q                                        # 40 passed
uv run pytest tests/test_perf002_raster_meta_cache.py -q                       # 10 passed
uv run pytest tests/test_raster_tile_url_version_1372.py tests/test_raster_tiles.py \
  tests/test_raster_colormap_proxy.py tests/test_tile_signing.py \
  tests/test_vrt_catalog_175.py tests/test_rule1_structural.py \
  tests/test_rule2_structural.py -q                                            # 263 passed
uv run pytest tests/test_tiles.py tests/test_tile_cache.py \
  tests/test_tile_cache_scope_sec009.py tests/test_raster_replace_1221.py \
  tests/test_regenerate_vrt_integration.py tests/test_vector_tile_auth.py \
  tests/test_dp03_cross_tenant_privilege_gate.py \
  tests/test_raster_antimeridian_887.py -q                                     # 327 passed
uv run pytest tests/test_stac_refresh_1266.py tests/test_raster_replace_1221.py -q  # 217 passed
```

No schema, API or config impact. No e2e run: the change is backend-only and the dev stack bind-mounts main, so a Playwright run from this worktree would not have exercised it.

Closes #1329
