### PR TITLE
docs(refresh): document origin_kind as the run's door, not the dataset origin

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -1422,7 +1422,14 @@ class DatasetRefreshRunResponse(BaseModel):
             "row is purged by retention; the run itself survives."
         ),
     )
-    origin_kind: str = Field(description="upload, postgis, service, stac, or raster")
+    origin_kind: str = Field(
+        description=(
+            "The run's execution door, not the dataset's origin: upload, "
+            "postgis, service, stac, or raster. 'raster' is the "
+            "raster-replace door and has no origin counterpart; a raster "
+            "dataset's own origin is 'upload'."
+        )
+    )
     trigger: str = Field(description="manual, api, or cli")
     status: str = Field(description="pending, running, succeeded, failed, or cancelled")
     triggered_by: uuid.UUID | None = None

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -1425,9 +1425,10 @@ class DatasetRefreshRunResponse(BaseModel):
     origin_kind: str = Field(
         description=(
             "The run's execution door, not the dataset's origin: upload, "
-            "postgis, service, stac, or raster. 'raster' is the "
-            "raster-replace door and has no origin counterpart; a raster "
-            "dataset's own origin is 'upload'."
+            "postgis, service, stac, or raster. 'raster' is reserved for a "
+            "future, distinct raster-replace door label; today's "
+            "raster-replace runs are still recorded as 'upload', matching "
+            "the dataset's origin."
         )
     )
     trigger: str = Field(description="manual, api, or cli")

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -1425,10 +1425,12 @@ class DatasetRefreshRunResponse(BaseModel):
     origin_kind: str = Field(
         description=(
             "The run's execution door, not the dataset's origin: upload, "
-            "postgis, service, stac, or raster. 'raster' is reserved for a "
-            "future, distinct raster-replace door label; today's "
-            "raster-replace runs are still recorded as 'upload', matching "
-            "the dataset's origin."
+            "postgis, service, stac, or raster. The two can visibly "
+            "diverge; for example a STAC-imported raster's pending or "
+            "failed replace run is recorded 'upload' while the dataset's "
+            "origin stays 'stac' until the replace succeeds. 'raster' "
+            "itself is reserved for a future, distinct raster-replace door "
+            "label, with today's raster-replace runs recorded 'upload'."
         )
     )
     trigger: str = Field(description="manual, api, or cli")

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -45,6 +45,18 @@ SERVICE_SOURCE_FORMATS: frozenset[str] = frozenset(
 # fetched from anywhere. Both classify as None so the type badge speaks alone.
 _ORIGINLESS_RECORD_TYPES: frozenset[str] = frozenset({"collection", "vrt_dataset"})
 
+# fix(#1325): this is the dataset's ORIGIN — how its data entered the catalog,
+# derived once by classify_origin() from source_format/record_type and never
+# revisited afterward. It is a DIFFERENT vocabulary from
+# DatasetRefreshRun.origin_kind, the CHECK constraint in
+# platform/refresh/models.py: that column is the per-attempt execution DOOR a
+# refresh or reupload ran through, not the dataset's origin, and the two sets
+# diverge on purpose in both directions. 'created' is here but has no ledger
+# counterpart, because a dataset drawn in the app has nothing to refresh from.
+# The ledger's 'raster' has no ORIGIN_KINDS counterpart, because a raster
+# dataset's origin is still 'upload' (the GeoTIFF it arrived as) even when its
+# replace run goes through a distinct door; see the CHECK constraint's comment
+# for what that door does and does not do today.
 ORIGIN_KINDS: frozenset[str] = frozenset(
     {"upload", "postgis", "service", "stac", "created"}
 )

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -48,9 +48,14 @@ _ORIGINLESS_RECORD_TYPES: frozenset[str] = frozenset({"collection", "vrt_dataset
 # fix(#1325): this is the dataset's ORIGIN — how its data entered the
 # catalog. It is DERIVED, not stored: classify_origin() recomputes it from
 # the dataset's CURRENT source_format/record_type every time a response is
-# built (datasets/domain/helpers.py:192), so it moves whenever source_format
-# does. It is a DIFFERENT vocabulary from DatasetRefreshRun.origin_kind, the
-# CHECK constraint in platform/refresh/models.py: that column is the run's
+# built (datasets/domain/helpers.py:192). It changes only when a mutation
+# crosses one of classify_origin()'s category boundaries, e.g. a successful
+# raster replace reclassifying 'stac' to 'upload' by setting
+# source_format='geotiff'; a same-category reupload such as GeoJSON to CSV
+# (both classify to 'upload', per _apply_reupload_swap in tasks_common.py)
+# leaves it unchanged. It is a DIFFERENT vocabulary from
+# DatasetRefreshRun.origin_kind, the CHECK constraint in
+# platform/refresh/models.py: that column is the run's
 # execution DOOR, written once by create_pending_run at commit time and
 # never updated afterward (platform/refresh/service.py has no other writer)
 # — the immutable side of a comparison whose other side, the dataset's

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -53,10 +53,11 @@ _ORIGINLESS_RECORD_TYPES: frozenset[str] = frozenset({"collection", "vrt_dataset
 # refresh or reupload ran through, not the dataset's origin, and the two sets
 # diverge on purpose in both directions. 'created' is here but has no ledger
 # counterpart, because a dataset drawn in the app has nothing to refresh from.
-# The ledger's 'raster' has no ORIGIN_KINDS counterpart, because a raster
-# dataset's origin is still 'upload' (the GeoTIFF it arrived as) even when its
-# replace run goes through a distinct door; see the CHECK constraint's comment
-# for what that door does and does not do today.
+# The ledger's 'raster' has no ORIGIN_KINDS counterpart: it is RESERVED for a
+# distinct raster-replace door label, but a raster dataset's origin is still
+# 'upload' (the GeoTIFF it arrived as) and its replace runs are still
+# recorded 'upload' too, today; see the CHECK constraint's comment for what
+# 'raster' does and does not do.
 ORIGIN_KINDS: frozenset[str] = frozenset(
     {"upload", "postgis", "service", "stac", "created"}
 )

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -49,15 +49,22 @@ _ORIGINLESS_RECORD_TYPES: frozenset[str] = frozenset({"collection", "vrt_dataset
 # derived once by classify_origin() from source_format/record_type and never
 # revisited afterward. It is a DIFFERENT vocabulary from
 # DatasetRefreshRun.origin_kind, the CHECK constraint in
-# platform/refresh/models.py: that column is the per-attempt execution DOOR a
-# refresh or reupload ran through, not the dataset's origin, and the two sets
-# diverge on purpose in both directions. 'created' is here but has no ledger
-# counterpart, because a dataset drawn in the app has nothing to refresh from.
-# The ledger's 'raster' has no ORIGIN_KINDS counterpart: it is RESERVED for a
-# distinct raster-replace door label, but a raster dataset's origin is still
-# 'upload' (the GeoTIFF it arrived as) and its replace runs are still
-# recorded 'upload' too, today; see the CHECK constraint's comment for what
-# 'raster' does and does not do.
+# platform/refresh/models.py: that column is the run's execution DOOR, and
+# the two never mean the same thing even where they share a spelling. Do NOT
+# read the ledger's origin_kind as "this dataset's origin, restated at the
+# run level" — a run's door and its dataset's origin can visibly disagree
+# while work is in flight. Concretely: a STAC-imported raster
+# (dataset.origin == 'stac') that gets replaced has its run row stamped
+# origin_kind='upload' at commit time (router_reupload.py), while the
+# dataset's origin is only rebound to 'upload' inside a SUCCESSFUL swap's
+# field write (tasks_raster_swap.py:_write_swapped_fields). While that run
+# is pending, and permanently if it fails, the run says 'upload' and the
+# dataset still says 'stac'. 'created' is here but has no ledger counterpart,
+# because a dataset drawn in the app has nothing to refresh from. The
+# ledger's 'raster' has no ORIGIN_KINDS counterpart at all: it is RESERVED
+# for a future, distinct raster-replace door label; today every
+# raster-replace run's door is 'upload', independent of the dataset's own
+# origin.
 ORIGIN_KINDS: frozenset[str] = frozenset(
     {"upload", "postgis", "service", "stac", "created"}
 )

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -45,21 +45,26 @@ SERVICE_SOURCE_FORMATS: frozenset[str] = frozenset(
 # fetched from anywhere. Both classify as None so the type badge speaks alone.
 _ORIGINLESS_RECORD_TYPES: frozenset[str] = frozenset({"collection", "vrt_dataset"})
 
-# fix(#1325): this is the dataset's ORIGIN — how its data entered the catalog,
-# derived once by classify_origin() from source_format/record_type and never
-# revisited afterward. It is a DIFFERENT vocabulary from
-# DatasetRefreshRun.origin_kind, the CHECK constraint in
-# platform/refresh/models.py: that column is the run's execution DOOR, and
-# the two never mean the same thing even where they share a spelling. Do NOT
-# read the ledger's origin_kind as "this dataset's origin, restated at the
-# run level" — a run's door and its dataset's origin can visibly disagree
-# while work is in flight. Concretely: a STAC-imported raster
-# (dataset.origin == 'stac') that gets replaced has its run row stamped
-# origin_kind='upload' at commit time (router_reupload.py), while the
-# dataset's origin is only rebound to 'upload' inside a SUCCESSFUL swap's
-# field write (tasks_raster_swap.py:_write_swapped_fields). While that run
-# is pending, and permanently if it fails, the run says 'upload' and the
-# dataset still says 'stac'. 'created' is here but has no ledger counterpart,
+# fix(#1325): this is the dataset's ORIGIN — how its data entered the
+# catalog. It is DERIVED, not stored: classify_origin() recomputes it from
+# the dataset's CURRENT source_format/record_type every time a response is
+# built (datasets/domain/helpers.py:192), so it moves whenever source_format
+# does. It is a DIFFERENT vocabulary from DatasetRefreshRun.origin_kind, the
+# CHECK constraint in platform/refresh/models.py: that column is the run's
+# execution DOOR, written once by create_pending_run at commit time and
+# never updated afterward (platform/refresh/service.py has no other writer)
+# — the immutable side of a comparison whose other side, the dataset's
+# origin, is not. Do NOT read the ledger's origin_kind as "this dataset's
+# origin, restated at the run level": a run's door and its dataset's CURRENT
+# origin can visibly disagree, because the door was fixed once, at commit
+# time, while the origin keeps answering for whatever source_format says
+# right now. Concretely: a STAC-imported raster (dataset.origin == 'stac')
+# that gets replaced has its run row stamped origin_kind='upload' at commit
+# time (router_reupload.py), while the dataset's origin only moves to
+# 'upload' once a SUCCESSFUL swap rebinds source_format to 'geotiff'
+# (tasks_raster_swap.py:_write_swapped_fields). While that run is pending,
+# and permanently if it fails, the run still says 'upload' and the dataset
+# still says 'stac'. 'created' is here but has no ledger counterpart,
 # because a dataset drawn in the app has nothing to refresh from. The
 # ledger's 'raster' has no ORIGIN_KINDS counterpart at all: it is RESERVED
 # for a future, distinct raster-replace door label; today every

--- a/backend/app/platform/refresh/models.py
+++ b/backend/app/platform/refresh/models.py
@@ -59,17 +59,22 @@ class DatasetRefreshRun(Base):
         # fix(#1325): origin_kind here is the run's execution DOOR, not the
         # dataset's origin — see ORIGIN_KINDS in platform/dataset_origin.py, a
         # separate vocabulary derived once from source_format and never
-        # revisited per run. 'upload'/'postgis'/'service'/'stac' share both
-        # spelling and meaning with their ORIGIN_KINDS counterparts because
-        # every door built so far executes the same way its origin formed.
-        # 'raster' does not: it is RESERVED for the raster-replace door
-        # (#1290), which has no ORIGIN_KINDS counterpart (a raster dataset's
-        # origin is 'upload', the file it arrived as). Reserved, not live —
-        # reupload_commit (router_reupload.py) still stamps raster-replace
-        # runs 'upload' today, matching the dataset's origin rather than a
-        # distinct door, so no row has ever actually carried 'raster'.
-        # Decision (a) on #1325 is to document this split, not close it by
-        # renaming a value or migrating a column.
+        # revisited per run. Never read this column as "the dataset's
+        # origin, restated at the run level," even for a value that happens
+        # to spell the same as an ORIGIN_KINDS member: the two can visibly
+        # disagree while a run is in flight. Concretely, a STAC-imported
+        # raster (dataset.origin == 'stac') stamps its replace run 'upload'
+        # at commit time (router_reupload.py), and the dataset's origin is
+        # only rebound to 'upload' inside a SUCCESSFUL swap's field write
+        # (tasks_raster_swap.py:_write_swapped_fields) — so a pending or
+        # failed replace leaves the run at 'upload' against a dataset still
+        # reporting 'stac'. 'raster' is a second, permanent divergence: it is
+        # RESERVED for the raster-replace door (#1290), which has no
+        # ORIGIN_KINDS counterpart at all. Reserved, not live —
+        # reupload_commit (router_reupload.py) stamps every raster-replace
+        # run 'upload' today, never 'raster', so no row has ever actually
+        # carried it. Decision (a) on #1325 is to document this split, not
+        # close it by renaming a value or migrating a column.
         CheckConstraint(
             "origin_kind IN ('upload', 'postgis', 'service', 'stac', 'raster')",
             name="chk_refresh_runs_origin_kind",

--- a/backend/app/platform/refresh/models.py
+++ b/backend/app/platform/refresh/models.py
@@ -56,6 +56,20 @@ class DatasetRefreshRun(Base):
             "trigger IN ('manual', 'api', 'cli')",
             name="chk_refresh_runs_trigger",
         ),
+        # fix(#1325): origin_kind here is the run's execution DOOR, not the
+        # dataset's origin — see ORIGIN_KINDS in platform/dataset_origin.py, a
+        # separate vocabulary derived once from source_format and never
+        # revisited per run. 'upload'/'postgis'/'service'/'stac' share both
+        # spelling and meaning with their ORIGIN_KINDS counterparts because
+        # every door built so far executes the same way its origin formed.
+        # 'raster' does not: it is RESERVED for the raster-replace door
+        # (#1290), which has no ORIGIN_KINDS counterpart (a raster dataset's
+        # origin is 'upload', the file it arrived as). Reserved, not live —
+        # reupload_commit (router_reupload.py) still stamps raster-replace
+        # runs 'upload' today, matching the dataset's origin rather than a
+        # distinct door, so no row has ever actually carried 'raster'.
+        # Decision (a) on #1325 is to document this split, not close it by
+        # renaming a value or migrating a column.
         CheckConstraint(
             "origin_kind IN ('upload', 'postgis', 'service', 'stac', 'raster')",
             name="chk_refresh_runs_origin_kind",

--- a/backend/app/platform/refresh/models.py
+++ b/backend/app/platform/refresh/models.py
@@ -63,7 +63,10 @@ class DatasetRefreshRun(Base):
         # and error fields. It is NOT the dataset's origin — see
         # ORIGIN_KINDS in platform/dataset_origin.py, which classify_origin()
         # recomputes fresh from the dataset's CURRENT source_format on every
-        # response build, so it moves whenever source_format does. The
+        # response build. It changes only when a mutation crosses one of
+        # classify_origin()'s category boundaries (e.g. a successful raster
+        # replace reclassifying 'stac' to 'upload'); a same-category
+        # reupload such as GeoJSON to CSV leaves it 'upload' both times. The
         # ledger row is the immutable side of that comparison; the dataset's
         # origin is not. Never read this column as "the dataset's origin,
         # restated at the run level," even for a value that happens to spell

--- a/backend/app/platform/refresh/models.py
+++ b/backend/app/platform/refresh/models.py
@@ -56,21 +56,28 @@ class DatasetRefreshRun(Base):
             "trigger IN ('manual', 'api', 'cli')",
             name="chk_refresh_runs_trigger",
         ),
-        # fix(#1325): origin_kind here is the run's execution DOOR, not the
-        # dataset's origin — see ORIGIN_KINDS in platform/dataset_origin.py, a
-        # separate vocabulary derived once from source_format and never
-        # revisited per run. Never read this column as "the dataset's
-        # origin, restated at the run level," even for a value that happens
-        # to spell the same as an ORIGIN_KINDS member: the two can visibly
-        # disagree while a run is in flight. Concretely, a STAC-imported
-        # raster (dataset.origin == 'stac') stamps its replace run 'upload'
-        # at commit time (router_reupload.py), and the dataset's origin is
-        # only rebound to 'upload' inside a SUCCESSFUL swap's field write
+        # fix(#1325): origin_kind here is the run's execution DOOR, written
+        # once by create_pending_run at commit time and never updated
+        # afterward: record_refresh_success/failure and the stale-run sweep
+        # (platform/refresh/service.py) only ever touch status, finished_at,
+        # and error fields. It is NOT the dataset's origin — see
+        # ORIGIN_KINDS in platform/dataset_origin.py, which classify_origin()
+        # recomputes fresh from the dataset's CURRENT source_format on every
+        # response build, so it moves whenever source_format does. The
+        # ledger row is the immutable side of that comparison; the dataset's
+        # origin is not. Never read this column as "the dataset's origin,
+        # restated at the run level," even for a value that happens to spell
+        # the same as an ORIGIN_KINDS member: the two can visibly disagree
+        # while a run is in flight, because the door was fixed once and the
+        # origin keeps answering live. Concretely, a STAC-imported raster
+        # (dataset.origin == 'stac') stamps its replace run 'upload' at
+        # commit time (router_reupload.py), and the dataset's origin only
+        # moves to 'upload' once a SUCCESSFUL swap rebinds source_format
         # (tasks_raster_swap.py:_write_swapped_fields) — so a pending or
         # failed replace leaves the run at 'upload' against a dataset still
-        # reporting 'stac'. 'raster' is a second, permanent divergence: it is
-        # RESERVED for the raster-replace door (#1290), which has no
-        # ORIGIN_KINDS counterpart at all. Reserved, not live —
+        # reporting 'stac'. 'raster' is a different kind of gap: it has no
+        # ORIGIN_KINDS counterpart at all, and it is RESERVED for the
+        # raster-replace door (#1290) rather than actively used.
         # reupload_commit (router_reupload.py) stamps every raster-replace
         # run 'upload' today, never 'raster', so no row has ever actually
         # carried it. Decision (a) on #1325 is to document this split, not

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5107,7 +5107,7 @@
             "title": "Ingest Job Id"
           },
           "origin_kind": {
-            "description": "The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is the raster-replace door and has no origin counterpart; a raster dataset's own origin is 'upload'.",
+            "description": "The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is reserved for a future, distinct raster-replace door label; today's raster-replace runs are still recorded as 'upload', matching the dataset's origin.",
             "title": "Origin Kind",
             "type": "string"
           },

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5107,7 +5107,7 @@
             "title": "Ingest Job Id"
           },
           "origin_kind": {
-            "description": "upload, postgis, service, stac, or raster",
+            "description": "The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is the raster-replace door and has no origin counterpart; a raster dataset's own origin is 'upload'.",
             "title": "Origin Kind",
             "type": "string"
           },

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5107,7 +5107,7 @@
             "title": "Ingest Job Id"
           },
           "origin_kind": {
-            "description": "The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is reserved for a future, distinct raster-replace door label; today's raster-replace runs are still recorded as 'upload', matching the dataset's origin.",
+            "description": "The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. The two can visibly diverge; for example a STAC-imported raster's pending or failed replace run is recorded 'upload' while the dataset's origin stays 'stac' until the replace succeeds. 'raster' itself is reserved for a future, distinct raster-replace door label, with today's raster-replace runs recorded 'upload'.",
             "title": "Origin Kind",
             "type": "string"
           },

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2644,7 +2644,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # door has no ORIGIN_KINDS counterpart), matching the CHECK constraint
     # comment in platform/refresh/models.py and the ORIGIN_KINDS docstring in
     # platform/dataset_origin.py. Cap 1458 -> 1465, exact.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1465,
+    # fix(#1325 review): +1 — codex caught the description overclaiming
+    # 'raster' as live behavior ("is the raster-replace door") when
+    # refresh/models.py's own comment on the same constraint says reserved,
+    # not live. Reworded to match: 'raster' is reserved for a future door
+    # label, today's raster-replace runs are still recorded 'upload'. Cap
+    # 1465 -> 1466, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1466,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2650,7 +2650,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # not live. Reworded to match: 'raster' is reserved for a future door
     # label, today's raster-replace runs are still recorded 'upload'. Cap
     # 1465 -> 1466, exact.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1466,
+    # fix(#1325 review round 3): +2 — codex found a second, live divergence
+    # the first reword still implied away: it said raster-replace 'upload'
+    # runs "match the dataset's origin", true only when the dataset's origin
+    # was already 'upload'. A STAC-imported raster's pending or failed
+    # replace run is recorded 'upload' while the dataset's origin stays
+    # 'stac' until the swap succeeds — reworded to drop the equality claim
+    # entirely and name that case. Cap 1466 -> 1468, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1468,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2639,7 +2639,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # claimed it shared ALL of VrtSourceHealth.status's values, which stopped
     # being true when fix(#1221) added VrtSourceHealth's VRT-specific `stale`
     # value without updating this cross-reference. Cap 1454 -> 1458, exact.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1458,
+    # fix(#1325): +7 — DatasetRefreshRunResponse.origin_kind's description now
+    # states the door-vs-origin distinction inline (a raster-replace run's
+    # door has no ORIGIN_KINDS counterpart), matching the CHECK constraint
+    # comment in platform/refresh/models.py and the ORIGIN_KINDS docstring in
+    # platform/dataset_origin.py. Cap 1458 -> 1465, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1465,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch

--- a/frontend/src/components/dataset/SourcePanel.tsx
+++ b/frontend/src/components/dataset/SourcePanel.tsx
@@ -299,10 +299,12 @@ function RefreshRunHistory({ dataset }: { dataset: DatasetResponse }) {
                 <Badge variant="outline" className={refreshRunStatusColors[run.status] ?? ''}>
                   {t(`sourcePanel.refresh.history.status.${run.status}`, { defaultValue: run.status })}
                 </Badge>
-                {/* fix(#1325): run.origin_kind is the run's execution door
-                    (e.g. a raster replace runs through 'raster'), not the
-                    dataset's origin shown by the OriginBadge above — label
-                    and tooltip say so, so the two never read as disagreeing. */}
+                {/* fix(#1325): run.origin_kind is the run's execution door,
+                    not the dataset's origin shown by the OriginBadge above
+                    (a raster-replace run is still recorded 'upload' today,
+                    matching the dataset's origin, since 'raster' is a
+                    reserved value with no live producer yet) — label and
+                    tooltip say so, so the two never read as disagreeing. */}
                 <Badge
                   variant="secondary"
                   title={t('sourcePanel.refresh.history.mechanismTooltip')}

--- a/frontend/src/components/dataset/SourcePanel.tsx
+++ b/frontend/src/components/dataset/SourcePanel.tsx
@@ -299,7 +299,16 @@ function RefreshRunHistory({ dataset }: { dataset: DatasetResponse }) {
                 <Badge variant="outline" className={refreshRunStatusColors[run.status] ?? ''}>
                   {t(`sourcePanel.refresh.history.status.${run.status}`, { defaultValue: run.status })}
                 </Badge>
-                <Badge variant="secondary">{run.origin_kind}</Badge>
+                {/* fix(#1325): run.origin_kind is the run's execution door
+                    (e.g. a raster replace runs through 'raster'), not the
+                    dataset's origin shown by the OriginBadge above — label
+                    and tooltip say so, so the two never read as disagreeing. */}
+                <Badge
+                  variant="secondary"
+                  title={t('sourcePanel.refresh.history.mechanismTooltip')}
+                >
+                  {t('sourcePanel.refresh.history.mechanismLabel', { mechanism: run.origin_kind })}
+                </Badge>
               </div>
               <p className="mt-0.5 text-xs text-muted-foreground">
                 {formatDateTimeSmart(run.started_at)}

--- a/frontend/src/components/dataset/SourcePanel.tsx
+++ b/frontend/src/components/dataset/SourcePanel.tsx
@@ -303,9 +303,10 @@ function RefreshRunHistory({ dataset }: { dataset: DatasetResponse }) {
                     not the dataset's origin shown by the OriginBadge above —
                     the two can visibly disagree while work is in flight (see
                     the CHECK constraint comment in refresh/models.py for a
-                    concrete case). Label and tooltip say "mechanism", never
-                    "origin", so this row never reads as a second, competing
-                    origin claim. */}
+                    concrete case). The label reads "Method: <value>" and the
+                    tooltip spells out that it is not the dataset's origin,
+                    so this row never reads as a second, competing origin
+                    claim. */}
                 <Badge
                   variant="secondary"
                   title={t('sourcePanel.refresh.history.mechanismTooltip')}

--- a/frontend/src/components/dataset/SourcePanel.tsx
+++ b/frontend/src/components/dataset/SourcePanel.tsx
@@ -300,11 +300,12 @@ function RefreshRunHistory({ dataset }: { dataset: DatasetResponse }) {
                   {t(`sourcePanel.refresh.history.status.${run.status}`, { defaultValue: run.status })}
                 </Badge>
                 {/* fix(#1325): run.origin_kind is the run's execution door,
-                    not the dataset's origin shown by the OriginBadge above
-                    (a raster-replace run is still recorded 'upload' today,
-                    matching the dataset's origin, since 'raster' is a
-                    reserved value with no live producer yet) — label and
-                    tooltip say so, so the two never read as disagreeing. */}
+                    not the dataset's origin shown by the OriginBadge above —
+                    the two can visibly disagree while work is in flight (see
+                    the CHECK constraint comment in refresh/models.py for a
+                    concrete case). Label and tooltip say "mechanism", never
+                    "origin", so this row never reads as a second, competing
+                    origin claim. */}
                 <Badge
                   variant="secondary"
                   title={t('sourcePanel.refresh.history.mechanismTooltip')}

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -834,6 +834,8 @@
         "empty": "Noch keine Aktualisierungen.",
         "featureDelta": "{{before}} → {{after}} Features",
         "triggeredBy": "Gestartet von {{username}}",
+        "mechanismLabel": "Methode: {{mechanism}}",
+        "mechanismTooltip": "Wie dieser Lauf ausgeführt wurde, nicht die Herkunft des Datensatzes",
         "status": {
           "pending": "In Warteschlange",
           "running": "Läuft",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -785,6 +785,8 @@
         "empty": "No refresh runs yet.",
         "featureDelta": "{{before}} → {{after}} features",
         "triggeredBy": "Started by {{username}}",
+        "mechanismLabel": "Method: {{mechanism}}",
+        "mechanismTooltip": "How this run executed, not the dataset's origin",
         "status": {
           "pending": "Queued",
           "running": "Running",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -834,6 +834,8 @@
         "empty": "Todavía no hay actualizaciones.",
         "featureDelta": "{{before}} → {{after}} entidades",
         "triggeredBy": "Iniciado por {{username}}",
+        "mechanismLabel": "Método: {{mechanism}}",
+        "mechanismTooltip": "Cómo se ejecutó esta actualización, no el origen del conjunto de datos",
         "status": {
           "pending": "En cola",
           "running": "En curso",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -834,6 +834,8 @@
         "empty": "Aucune actualisation pour le moment.",
         "featureDelta": "{{before}} → {{after}} entités",
         "triggeredBy": "Démarré par {{username}}",
+        "mechanismLabel": "Méthode : {{mechanism}}",
+        "mechanismTooltip": "Comment cette exécution s'est déroulée, et non l'origine du jeu de données",
         "status": {
           "pending": "En file d'attente",
           "running": "En cours",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7382,7 +7382,7 @@ export interface components {
             ingest_job_id?: string | null;
             /**
              * Origin Kind
-             * @description The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is the raster-replace door and has no origin counterpart; a raster dataset's own origin is 'upload'.
+             * @description The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is reserved for a future, distinct raster-replace door label; today's raster-replace runs are still recorded as 'upload', matching the dataset's origin.
              */
             origin_kind: string;
             /**

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7382,7 +7382,7 @@ export interface components {
             ingest_job_id?: string | null;
             /**
              * Origin Kind
-             * @description The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is reserved for a future, distinct raster-replace door label; today's raster-replace runs are still recorded as 'upload', matching the dataset's origin.
+             * @description The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. The two can visibly diverge; for example a STAC-imported raster's pending or failed replace run is recorded 'upload' while the dataset's origin stays 'stac' until the replace succeeds. 'raster' itself is reserved for a future, distinct raster-replace door label, with today's raster-replace runs recorded 'upload'.
              */
             origin_kind: string;
             /**

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7382,7 +7382,7 @@ export interface components {
             ingest_job_id?: string | null;
             /**
              * Origin Kind
-             * @description upload, postgis, service, stac, or raster
+             * @description The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is the raster-replace door and has no origin counterpart; a raster dataset's own origin is 'upload'.
              */
             origin_kind: string;
             /**

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -999,9 +999,11 @@ export interface DatasetRefreshRunResponse {
   dataset_version_id: string | null;
   ingest_job_id: string | null;
   /** fix(#1325): the run's execution door, not the dataset's origin (compare
-   *  DatasetResponse.origin). 'raster' is reserved for a future distinct
-   *  raster-replace door label; today's raster-replace runs are still
-   *  recorded 'upload'. */
+   *  DatasetResponse.origin) — the two can visibly disagree while work is in
+   *  flight; see refresh/models.py's CHECK constraint comment for a
+   *  concrete case. 'raster' is reserved for a future distinct
+   *  raster-replace door label; today's raster-replace runs are recorded
+   *  'upload'. */
   origin_kind: string;
   trigger: string;
   /** "pending" | "running" | "succeeded" | "failed" | "cancelled", kept as a

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -998,6 +998,8 @@ export interface DatasetRefreshRunResponse {
   dataset_id: string;
   dataset_version_id: string | null;
   ingest_job_id: string | null;
+  /** fix(#1325): the run's execution door (e.g. 'raster' for a raster
+   *  replace), not the dataset's origin — compare DatasetResponse.origin. */
   origin_kind: string;
   trigger: string;
   /** "pending" | "running" | "succeeded" | "failed" | "cancelled", kept as a

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -998,8 +998,10 @@ export interface DatasetRefreshRunResponse {
   dataset_id: string;
   dataset_version_id: string | null;
   ingest_job_id: string | null;
-  /** fix(#1325): the run's execution door (e.g. 'raster' for a raster
-   *  replace), not the dataset's origin — compare DatasetResponse.origin. */
+  /** fix(#1325): the run's execution door, not the dataset's origin (compare
+   *  DatasetResponse.origin). 'raster' is reserved for a future distinct
+   *  raster-replace door label; today's raster-replace runs are still
+   *  recorded 'upload'. */
   origin_kind: string;
   trigger: string;
   /** "pending" | "running" | "succeeded" | "failed" | "cancelled", kept as a

--- a/sdks/python/geolens/models/dataset_refresh_run_response.py
+++ b/sdks/python/geolens/models/dataset_refresh_run_response.py
@@ -36,8 +36,9 @@ class DatasetRefreshRunResponse:
             id (UUID):
             dataset_id (UUID):
             origin_kind (str): The run's execution door, not the dataset's origin: upload, postgis, service, stac, or
-                raster. 'raster' is reserved for a future, distinct raster-replace door label; today's raster-replace runs are
-                still recorded as 'upload', matching the dataset's origin.
+                raster. The two can visibly diverge; for example a STAC-imported raster's pending or failed replace run is
+                recorded 'upload' while the dataset's origin stays 'stac' until the replace succeeds. 'raster' itself is
+                reserved for a future, distinct raster-replace door label, with today's raster-replace runs recorded 'upload'.
             trigger (str): manual, api, or cli
             status (str): pending, running, succeeded, failed, or cancelled
             started_at (datetime.datetime): Dispatch time, not claim time — queue wait is visible

--- a/sdks/python/geolens/models/dataset_refresh_run_response.py
+++ b/sdks/python/geolens/models/dataset_refresh_run_response.py
@@ -35,7 +35,9 @@ class DatasetRefreshRunResponse:
         Attributes:
             id (UUID):
             dataset_id (UUID):
-            origin_kind (str): upload, postgis, service, stac, or raster
+            origin_kind (str): The run's execution door, not the dataset's origin: upload, postgis, service, stac, or
+                raster. 'raster' is the raster-replace door and has no origin counterpart; a raster dataset's own origin is
+                'upload'.
             trigger (str): manual, api, or cli
             status (str): pending, running, succeeded, failed, or cancelled
             started_at (datetime.datetime): Dispatch time, not claim time — queue wait is visible

--- a/sdks/python/geolens/models/dataset_refresh_run_response.py
+++ b/sdks/python/geolens/models/dataset_refresh_run_response.py
@@ -36,8 +36,8 @@ class DatasetRefreshRunResponse:
             id (UUID):
             dataset_id (UUID):
             origin_kind (str): The run's execution door, not the dataset's origin: upload, postgis, service, stac, or
-                raster. 'raster' is the raster-replace door and has no origin counterpart; a raster dataset's own origin is
-                'upload'.
+                raster. 'raster' is reserved for a future, distinct raster-replace door label; today's raster-replace runs are
+                still recorded as 'upload', matching the dataset's origin.
             trigger (str): manual, api, or cli
             status (str): pending, running, succeeded, failed, or cancelled
             started_at (datetime.datetime): Dispatch time, not claim time — queue wait is visible

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3054,7 +3054,7 @@ export type DatasetRefreshRunResponse = {
     /**
      * Origin Kind
      *
-     * The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is reserved for a future, distinct raster-replace door label; today's raster-replace runs are still recorded as 'upload', matching the dataset's origin.
+     * The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. The two can visibly diverge; for example a STAC-imported raster's pending or failed replace run is recorded 'upload' while the dataset's origin stays 'stac' until the replace succeeds. 'raster' itself is reserved for a future, distinct raster-replace door label, with today's raster-replace runs recorded 'upload'.
      */
     origin_kind: string;
     /**

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3054,7 +3054,7 @@ export type DatasetRefreshRunResponse = {
     /**
      * Origin Kind
      *
-     * upload, postgis, service, stac, or raster
+     * The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is the raster-replace door and has no origin counterpart; a raster dataset's own origin is 'upload'.
      */
     origin_kind: string;
     /**

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -3054,7 +3054,7 @@ export type DatasetRefreshRunResponse = {
     /**
      * Origin Kind
      *
-     * The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is the raster-replace door and has no origin counterpart; a raster dataset's own origin is 'upload'.
+     * The run's execution door, not the dataset's origin: upload, postgis, service, stac, or raster. 'raster' is reserved for a future, distinct raster-replace door label; today's raster-replace runs are still recorded as 'upload', matching the dataset's origin.
      */
     origin_kind: string;
     /**


### PR DESCRIPTION
## What

Implements option (a) from #1325: document the `origin_kind` name collision instead of renaming anything.

Two vocabularies share the field name `origin_kind`:

- `ORIGIN_KINDS` in `backend/app/platform/dataset_origin.py` (upload, postgis, service, stac, created) is the dataset's origin: how its data entered the catalog, recomputed fresh from the dataset's current `source_format`/`record_type` on every response. It is not stored and not fixed at ingest, but it does not move on every `source_format` write either: `classify_origin()` sorts every format into one of five buckets, and only a mutation that crosses a bucket boundary (a successful raster replace: `stac` to `geotiff`, reclassifying `stac` to `upload`) changes it. A same-bucket reupload, GeoJSON to CSV for example, leaves it `upload` both times.
- The CHECK constraint on `catalog.dataset_refresh_runs.origin_kind` in `backend/app/platform/refresh/models.py` (upload, postgis, service, stac, raster) is a run's execution door: which mechanism this particular refresh or reupload attempt went through.

Four of the five values happen to share a spelling across both vocabularies. That is a coincidence of which doors have been built so far, not a guarantee that a run's door and its dataset's origin ever agree (see the correction below for a case where they don't). The other two values don't even share a spelling: `created` has no ledger counterpart (nothing to refresh from), and `raster` has no origin counterpart (it is reserved for a future raster-replace door label; today's raster-replace runs use `upload`).

Changes:

- `dataset_origin.py`: comment above `ORIGIN_KINDS` states the door-vs-origin split and points at the ledger constraint.
- `refresh/models.py`: comment above the CHECK constraint states the same split from the other side, and what `raster` means.
- `schemas.py`: `DatasetRefreshRunResponse.origin_kind`'s field description now says door, not origin. This is an OpenAPI-visible string, so `backend/openapi.json`, both SDKs (`sdks/python`, `sdks/typescript`), and the frontend's generated type mirror (`frontend/src/types/api.generated.ts`) are regenerated and committed. The hand-maintained `frontend/src/types/api.ts` mirror gets the same note in a doc comment.
- `SourcePanel.tsx`: the run-history row's origin_kind badge gets a label ("Method: x") and a tooltip explaining it's the run's mechanism, not the dataset's origin, so it stops reading as a second, disagreeing origin claim next to the OriginBadge shown above it. Two new keys (`sourcePanel.refresh.history.mechanismLabel`, `mechanismTooltip`) added to all four locales (en/es/fr/de).
- CLI: checked `cli/geolens_cli/` for anywhere it prints `origin_kind`. The only place it does is the refresh-dispatch response (`DatasetRefreshResponse`, a different schema from the run-history one above), and that response only ever carries `postgis`/`service`/`stac`. `upload`, `created`, and `raster` datasets are refused before reaching it, so its `origin=` label was never ambiguous. No CLI change.
- Backend module-size gate: `schemas.py` was already at its exact cap; `_MODULE_LOC_CAPS` in `test_layering.py` moves from 1458 to 1468 across this PR's wording revisions, each bump with its own comment explaining the added lines.

No renames, no migration. `chk_refresh_runs_origin_kind` stays exactly as deployed.

## One correction to the issue's premise

The issue describes the visible symptom as a raster dataset's Source panel showing origin "Upload" while its run-history row says "raster". That specific pairing does not happen today. Tracing the actual code path (`reupload_commit` in `router_reupload.py`, the one place a raster replace creates its ledger row) shows raster-replace runs are stamped `origin_kind="upload"`, never `"raster"`. `test_raster_replace_1221.py`'s `_queue_replace_job` helper, which mirrors what the real commit door writes, asserts the same thing. `raster` has been present in the CHECK constraint since the ledger table's first commit, before raster replace existed, so it reads as a value reserved ahead of an implementation that never actually switched to it, the same pattern as this file's own `blocked` status and `scheduled` trigger comments. That half of the premise, a run row literally showing `"raster"`, is dormant, not live.

But the underlying contradiction the issue is pointing at, a run's `origin_kind` disagreeing with its dataset's own origin, is reachable today, just through a different value. A STAC-imported raster's origin is `"stac"`. Replacing it stamps the run `origin_kind="upload"` immediately, at commit time (`router_reupload.py`), while the dataset's origin is only rebound to `"upload"` inside a successful swap's field write (`tasks_raster_swap.py`, `_write_swapped_fields`). While that replace is pending, and permanently if it fails, the Source panel would show origin "STAC" next to a run row recorded "upload": the same shape of disagreement the issue describes, on a supported path, today.

This PR documents the general rule rather than the specific case the issue named: `origin_kind` on a run is the door it executed through, and it must never be read as, or presented as, the dataset's origin, whether or not the two happen to share a spelling. `dataset_origin.py`, `refresh/models.py`, the OpenAPI field description, and the two frontend comments all say so explicitly now, and the STAC-raster-replace path above is the concrete example each of them points at. This still does not change any stamping behavior; making the two vocabularies agree on every path would be a behavior change outside what option (a) covers.

Closes #1325.

## Notes for reviewers

- Another PR in this wave (#1291) also regenerates `backend/openapi.json`; merge order between the two is being coordinated so neither's regen artifacts get clobbered by the other's rebase.
- Nothing here is a schema/DB change. The CHECK constraint's string is unchanged; only comments, one field description, and frontend display strings moved.

## Verification

- `cd backend && uv run ruff check .` and `uv run ruff format --check .`: clean on touched files
- `uv run pytest tests/test_layering.py -q`: 40 passed
- `uv run pytest tests/test_dataset_refresh_runs.py tests/test_origin_ref_indexes.py tests/test_refresh_gate_1269.py tests/test_raster_replace_1221.py tests/test_stac_refresh_1266.py tests/test_dataset_source_state.py tests/test_service_refresh_1220.py tests/test_source_health_1222.py tests/test_postgis_refresh_1265.py tests/test_reupload.py tests/test_dataset_source_freshness.py -q`: 726 passed
- `make openapi`, `make sdks`, `npm run types:generate`: regenerated and diffed to confirm the only change is the `origin_kind` description
- `cd cli && uv run --extra dev python -m pytest -q`: 308 passed (sanity check against the regenerated Python SDK)
- `cd frontend && npm run typecheck`: clean
- `cd frontend && npm run lint`: clean
- `cd frontend && npx vitest run` on the touched dataset test files: 58 passed
- `cd frontend && npm run test:i18n`: clean
