### PR TITLE
fix(raster): srid_override assigns the CRS instead of reprojecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Changed
+
+- **A raster CRS override now assigns the CRS instead of reprojecting to
+  it.** Supplying an EPSG code at import or replace time relabels the raster
+  in place: pixel values, the pixel grid and the corner coordinates all come
+  through the conversion untouched, and only the CRS they are read under
+  changes. That is what both documented uses of the field want — a file with
+  no CRS has nothing to reproject from, and a file whose declared CRS is
+  wrong reprojects from a wrong starting point and lands somewhere wrong.
+  Two consequences: a dataset ingested with an override now sits where those
+  coordinates put it in the CRS you named, and because the conversion no
+  longer resamples, the uploaded file is deleted after a successful lossless
+  ingest rather than kept as a second permanent copy. Deliberate
+  reproject-at-ingest is not offered; rasters are reprojected at serve time
+  and at export time (#1291).
+
 ## [1.11.1] - 2026-08-10
 
 ### Added

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1993,8 +1993,8 @@ Decision 7).
 
 ### When the conversion is lossy, the upload is kept
 
-Two things about a conversion can make the COG an unfaithful copy, and either
-one causes the upload to be kept.
+One thing about a conversion can make the COG an unfaithful copy, and it causes
+the upload to be kept.
 
 **Compression.** The import form lets the uploader choose. Four options are
 lossless — **DEFLATE** (the default), **LZW**, **ZSTD**, **LERC** — and two
@@ -2006,12 +2006,21 @@ be tuned to throw away precision, but that is the GDAL creation option
 it. So a LERC upload keeps its exact sample values and is treated like any other
 lossless conversion.
 
-**Reprojection.** Supplying a CRS override reprojects the raster, which
-resamples every pixel onto a new grid. The output is a faithful *rendering* but
-not the original measurements, so this counts as lossy even under DEFLATE.
+Under a lossy codec the uploaded file is the only copy of the original samples
+that will ever exist, so GeoLens keeps it.
 
-In either case the uploaded file is the only copy of the original samples that
-will ever exist, so GeoLens keeps it.
+**A CRS override is not lossy** (behavior change, issue #1291).
+Supplying an EPSG code at import time *assigns* that CRS: it relabels the raster
+where it already sits and leaves every pixel value and every corner coordinate
+alone. Only the meaning of those coordinates changes, which is the point — you
+reach for the override when the file's own CRS is missing or wrong. So an
+override under a lossless codec still deletes the upload, and it is safe to:
+the COG holds your samples exactly, and a mistaken override is corrected by
+assigning a different code over the same untouched pixels.
+
+Earlier versions reprojected instead, which resampled every pixel onto a new
+grid, and therefore kept the upload. If you are looking for a retained original
+from one of those ingests, it is still where it always was.
 
 ### Where the kept original lives, and for how long
 
@@ -2124,7 +2133,7 @@ that does and does not recover depends on which case put the file there.
 | Failed upload, still inside the retention window | Yes |
 | **Vector original, local storage** | **Yes** — archived under `originals/` in that volume |
 | Vector original, object-storage install | No — in your bucket under `originals/` |
-| **Retained original from a lossy or reprojected ingest, local storage** | **Yes** — it lives under `originals/` inside that same volume |
+| **Retained original from a lossy ingest, local storage** | **Yes** — it lives under `originals/` inside that same volume |
 | Retained original, object-storage install | No — it is in your bucket under `originals/`, covered by whatever backs up the bucket, not by this tar |
 | Successfully ingested original from a **lossless** conversion | No — deleted before the backup ran |
 

--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -141,7 +141,7 @@ class VectorCommitRequest(BaseCommitRequest):
         default=None,
         ge=1,
         le=998999,
-        description="EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.",
+        description="EPSG code to use when the source CRS is missing or incorrect. Assigns (relabels) the CRS the source coordinates are read under; ingest then reprojects to EPSG:4326 as it does for every vector source.",
     )
     layer_name: str | None = Field(
         default=None,
@@ -168,7 +168,7 @@ class RasterCommitRequest(BaseCommitRequest):
         default=None,
         ge=1,
         le=998999,
-        description="EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.",
+        description="EPSG code to use when the source CRS is missing or incorrect. Assigns (relabels) the CRS without resampling; pixel values are unchanged.",
     )
     compression: str | None = Field(
         default=None,
@@ -239,7 +239,7 @@ class CommitRequest(BaseModel):
         default=None,
         ge=1,
         le=998999,
-        description="EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.",
+        description="EPSG code to use when the source CRS is missing or incorrect. Assigns (relabels) the CRS the source is read under rather than reprojecting from it: raster pixel values are unchanged, and vector geometries are reprojected to EPSG:4326 from the assigned CRS as usual.",
     )
     token: str | None = Field(
         default=None,

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -332,17 +332,29 @@ async def ingest_raster(
         # above can reach this line without converting at all, and a verified
         # COG loses nothing whatever codec it carries. Read in the terminal
         # `finally` to decide whether the uploaded file is still needed.
-        source_preserved_in_cog = cog_preserves_source(
-            cog_status, user_compression, reprojected=assign_crs is not None
-        )
+        # fix(#1291): no `reprojected=`. `assign_crs` now applies through
+        # `gdal_translate -a_srs`, which relabels and resamples nothing, so an
+        # override no longer makes the COG a lossy copy of the upload and no
+        # longer forces a second permanent original. The codec is the only
+        # sample-altering axis this pipeline still has; `cog_preserves_source`
+        # keeps the parameter for a future reprojecting field to set.
+        source_preserved_in_cog = cog_preserves_source(cog_status, user_compression)
 
         # fix(#1290 review): read the artifact that will actually serve. The
-        # round-1 CRS fix made first ingest warp declared-CRS sources, so
-        # persisting the pre-conversion read described a file this dataset does
-        # not have — the same defect the replace tail fixed one round earlier,
-        # left behind because that dispatch was scoped to replace only. The
-        # source read keeps exactly two jobs: the CRS decision above, and
-        # `original_srid` below.
+        # pre-conversion read describes a different file: the codec differs on
+        # every conversion, and under an override the CRS differs too — with it
+        # the footprint, because the same corner coordinates land somewhere
+        # else on earth once they are read in the assigned CRS. Same defect the
+        # replace tail fixed one round earlier, left behind because that
+        # dispatch was scoped to replace only. The source read keeps exactly
+        # two jobs: the CRS decision above, and `original_srid` below.
+        #
+        # fix(#1291): with assignment the pixel grid and the corner NUMBERS
+        # survive the conversion unchanged — only the label on them changes —
+        # so `extract_raster_metadata` reading the COG interprets those numbers
+        # in the assigned CRS, which is exactly the reading the caller asked
+        # for. Reading the source would interpret them in the CRS the caller
+        # just called wrong.
         cog_meta = await asyncio.to_thread(extract_raster_metadata, local_cog_path)
 
         # 7. Hash COG

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -112,6 +112,15 @@ async def _read_published_cog(cog_path: str) -> dict:
     second seam that can drift from the first and no question about which read
     is authoritative.
 
+    fix(#1291): the footprint is still on that list after ``srid_override``
+    became an assignment, and for a sharper reason. The conversion no longer
+    moves the corner coordinates at all — it changes what they MEAN. The same
+    numbers read in the assigned CRS land somewhere else on earth than they do
+    in the CRS the caller just told us was wrong, so the source read would
+    place the dataset at the wrong spot on the map with no field visibly
+    disagreeing. ``extract_raster_metadata`` here reads them off the COG,
+    under the CRS that COG now declares.
+
     Goes through ``extract_raster_metadata`` — already the reader every other
     raster path uses, so this adds no new GDAL seam for Rule 2 to police.
     """
@@ -425,11 +434,13 @@ async def reupload_raster(
         )
         # fix(#1290 review): resolved state, not the request field. Decided here
         # rather than in the tail because this is where the conversion that
-        # actually ran is known — including whether a warp ran, which a
-        # lossless codec does not tell you and which resamples every pixel.
-        source_preserved_in_cog = cog_preserves_source(
-            cog_status, user_compression, reprojected=assign_crs is not None
-        )
+        # actually ran is known — a `verified` COG loses nothing whatever codec
+        # it carries, and the request field cannot tell you which happened.
+        # fix(#1291): the second axis is gone with the warp. `assign_crs` now
+        # reaches `gdal_translate -a_srs`, which writes a tag and passes every
+        # band through, so an override no longer costs this dataset a second
+        # permanent copy of the upload. See `cog_preserves_source`.
+        source_preserved_in_cog = cog_preserves_source(cog_status, user_compression)
 
         asset_sha256 = await asyncio.to_thread(sha256_file, local_cog_path)
         cog_size = os.path.getsize(local_cog_path)
@@ -501,6 +512,12 @@ async def reupload_raster(
             # converted replace, `nodata` wrong under an override, and the CRS
             # and footprint wrong under `srid_override`, which is exactly the
             # case a caller reaches for when the source's CRS is the problem.
+            # fix(#1291): the footprint stays wrong from the source read now
+            # that the override assigns rather than warps — the corner numbers
+            # are identical either side of the conversion, so the ONLY thing
+            # that decides where this dataset lands on the map is which CRS
+            # they are read under. `original_srid` is the one field still taken
+            # from `source_meta`, and it wants the upload's answer by design.
             new_version = _write_swapped_fields(
                 raster_asset,
                 dataset,

--- a/backend/app/processing/raster/cog.py
+++ b/backend/app/processing/raster/cog.py
@@ -76,13 +76,18 @@ def cog_preserves_source(
       does not, at the zero error bound this pipeline leaves in place; the
       condition that keeps that true is spelled out on
       ``LOSSLESS_COG_COMPRESSIONS``.
-    - **assign_crs** — runs ``gdalwarp -t_srs``, which resamples the raster
-      onto a new grid. Every output pixel is interpolated from neighbours, so
-      the source's samples are gone even under DEFLATE. Sample-altering, and
-      the case round 2 missed by looking only at the codec.
-    - **resampling** — feeds ``gdaladdo`` (overviews are additional data, the
-      base band is untouched) and ``gdalwarp -r``. It only alters samples
-      through the warp, which ``reprojected`` already covers.
+    - **assign_crs** — fix(#1291): ``gdal_translate -a_srs``, which writes a
+      CRS tag and nothing else. Exactly like ``-a_nodata`` below: the bands
+      pass through the translate untouched, so under a lossless codec the
+      output carries the uploaded samples bit for bit. Measured on the
+      deployed GDAL: a 32x32 source relabelled 4326 -> 3857 comes back 32x32,
+      same bounds numbers, array-equal to the input. NOT sample-altering.
+      Until #1291 this ran ``gdalwarp -t_srs``, which resampled onto a new
+      grid (the same 32x32 source came back 42x42 with different values) —
+      hence ``reprojected``, and hence this bullet's earlier reading.
+    - **resampling** — feeds ``gdaladdo`` only now (overviews are additional
+      data, the base band is untouched). It used to also feed ``gdalwarp -r``;
+      with the warp gone, no ``resampling`` value can reach the base samples.
     - **nodata** — ``gdal_translate -a_nodata`` writes a metadata tag. Pixel
       values are byte-identical, so this is not sample-altering; it changes how
       the samples are interpreted, not what they are.
@@ -92,12 +97,27 @@ def cog_preserves_source(
     So the predicate is "no lossy codec AND no warp". Anything not proven
     sample-preserving must return False: the cost of a wrong True is the
     permanent loss of the only faithful copy, and the cost of a wrong False is
-    some retained bytes.
+    some retained bytes. That asymmetry is why #1291 argues the assign_crs move
+    rather than just making it: a relabel is the one conversion step that is
+    REVERSIBLE from the stored artifact. If the caller assigns the wrong EPSG,
+    every sample is still there and another ``-a_srs`` corrects it; the
+    catalog also keeps what the upload declared, in ``Dataset.original_srid``.
+    A warp is not reversible, which is what made the retained upload the only
+    faithful copy while one ran.
+
+    ``reprojected`` stays as the switch for that second axis even though no
+    pipeline path sets it today: a deliberate reproject-at-ingest field
+    (``target_srid``, if demand ever appears — #1291) has to pass it, and a
+    parameter that is already here and already tested is one fewer thing for
+    that change to forget. ``convert_to_cog`` running no ``gdalwarp`` is what
+    licenses the callers passing nothing, and that is pinned by
+    ``test_cog_subprocess_env.py``.
 
     ``cog_status == "verified"`` short-circuits because nothing ran at all —
     the bytes written to storage ARE the uploaded bytes, whatever codec they
-    already carried. A warp cannot coexist with it: ``check_and_prepare_cog``
-    treats any ``assign_crs`` as a custom option and always converts.
+    already carried. A conversion cannot coexist with it:
+    ``check_and_prepare_cog`` treats any ``assign_crs`` as a custom option and
+    always converts.
     """
     if cog_status == "verified":
         return True
@@ -110,6 +130,12 @@ def resolve_crs_assignment(
     *, crs_wkt: str | None, srid_override: int | None
 ) -> int | None:
     """The EPSG code the conversion must apply, or None to keep the source's.
+
+    Which code, only. What "apply" DOES belongs to ``convert_to_cog``, and
+    since fix(#1291) it is assignment: the returned code is written onto the
+    output as a label (``-a_srs``) and no sample is touched. This function did
+    not change with that — it never knew whether the code would be warped to
+    or stamped on — but its callers' comments did.
 
     fix(#1290 review): an override applies whenever the caller supplies one,
     not only when the source declares nothing. ``RasterCommitRequest``
@@ -522,45 +548,21 @@ def convert_to_cog(
     """Convert input file to GeoLens COG profile using gdal_translate.
 
     Adds overviews first via gdaladdo, then translates with COPY_SRC_OVERVIEWS.
-    Optionally reprojects via gdalwarp if assign_crs is provided.
+
+    ``assign_crs`` ASSIGNS an EPSG code to the output (``-a_srs``) — it
+    relabels the raster where it already sits and reprojects nothing
+    (fix(#1291); see the decision on that issue). ``resampling`` therefore
+    reaches ``gdaladdo`` and nothing else: it decides how overviews are
+    built, never what the base band contains.
+
     Raises RuntimeError on failure.
     """
-    actual_input = input_path
-
-    # If CRS assignment requested, prepend a gdalwarp step
-    warp_tmp: str | None = None
-    if assign_crs is not None:
-        warp_tmp_file = tempfile.NamedTemporaryFile(
-            suffix=".tif", delete=False, dir=_scratch_dir()
-        )
-        warp_tmp_file.close()
-        warp_tmp = warp_tmp_file.name
-        warp_cmd = [
-            "gdalwarp",
-            "-t_srs",
-            f"EPSG:{assign_crs}",
-        ]
-        if resampling:
-            warp_cmd.extend(["-r", resampling])
-        warp_cmd.extend([input_path, warp_tmp])
-        # KNOWN-03 (Phase 1071): apply the raster-pipeline GDAL safety clamps
-        # (was env=None before — inherited unclamped os.environ).
-        # fix(#430 codex r15): run_gdal raises on timeout (BA-29) — same
-        # sibling leak as prepare_with_overviews; clean warp_tmp on ANY
-        # failure, not just non-zero exit.
-        try:
-            warp_result = run_gdal(
-                warp_cmd, env=gdal_safe_env(), tool="gdalwarp"
-            )  # fix(#430 BA-29)
-            if warp_result.returncode != 0:
-                raise RuntimeError(f"gdalwarp failed: {warp_result.stderr}")
-        except Exception:  # broad: cleanup-and-reraise — warp temp must not survive ANY failure (run_gdal timeout included)
-            Path(warp_tmp).unlink(missing_ok=True)
-            raise
-        actual_input = warp_tmp
-
+    # fix(#1291): overviews are built from the SOURCE grid, which is also the
+    # output grid — a `-a_srs` relabel moves no pixel, so `COPY_SRC_OVERVIEWS`
+    # below carries them across intact. When a gdalwarp step ran first, this
+    # had to consume the warped intermediate instead.
     tmp_path = prepare_with_overviews(
-        actual_input, dtype, resampling=resampling, compression=compression
+        input_path, dtype, resampling=resampling, compression=compression
     )
     try:
         predictor = _predictor_for_dtype(dtype, compression)
@@ -590,14 +592,21 @@ def convert_to_cog(
         )
         if nodata is not None:
             cmd.extend(["-a_nodata", str(nodata)])
+        if assign_crs is not None:
+            # fix(#1291): -a_srs, not a gdalwarp -t_srs prepend. Both cases the
+            # field documents want the samples relabelled where they are: a
+            # source with no CRS has nothing to reproject FROM, and a source
+            # whose declared CRS is wrong reprojects from a lie — the output
+            # coordinates are wrong by construction, so nobody was served by
+            # that. It sits beside -a_nodata deliberately; the two are the same
+            # kind of flag, writing a tag while every band passes through.
+            cmd.extend(["-a_srs", f"EPSG:{assign_crs}"])
         cmd.extend([tmp_path, output_path])
         result = run_gdal(cmd, env=env, tool="gdal_translate")  # fix(#430 BA-29)
         if result.returncode != 0:
             raise RuntimeError(f"gdal_translate failed: {result.stderr}")
     finally:
         Path(tmp_path).unlink(missing_ok=True)
-        if warp_tmp:
-            Path(warp_tmp).unlink(missing_ok=True)
 
 
 def check_and_prepare_cog(
@@ -613,7 +622,13 @@ def check_and_prepare_cog(
 
     Returns (path_to_use, cog_status) where cog_status is 'verified' or 'converted'.
     """
-    # If user specified non-default options, always convert
+    # If user specified non-default options, always convert.
+    # fix(#1291): `assign_crs` stays on this list. Assignment is metadata-only
+    # in what it does to the SAMPLES, but the tag still has to be written, and
+    # `-a_srs` is an argument to the translate run — there is no path that
+    # relabels an already-compliant COG in place. A `verified` return here
+    # would publish the source untouched, still carrying the CRS the caller
+    # asked us to replace, which is the #1186 failure with a different cause.
     has_custom_opts = (
         compression != "DEFLATE"
         or resampling is not None

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3704,7 +3704,7 @@
                 "type": "null"
               }
             ],
-            "description": "EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.",
+            "description": "EPSG code to use when the source CRS is missing or incorrect. Assigns (relabels) the CRS the source is read under rather than reprojecting from it: raster pixel values are unchanged, and vector geometries are reprojected to EPSG:4326 from the assigned CRS as usual.",
             "title": "Srid Override"
           },
           "token": {

--- a/backend/tests/test_cog_subprocess_env.py
+++ b/backend/tests/test_cog_subprocess_env.py
@@ -149,25 +149,22 @@ class TestPrepareWithOverviewsSafeEnv:
 
 
 # ---------------------------------------------------------------------------
-# convert_to_cog (gdalwarp branch)
+# convert_to_cog (assign_crs branch)
 # ---------------------------------------------------------------------------
 
 
-class TestConvertToCogGdalwarpSafeEnv:
-    def test_gdalwarp_subprocess_inherits_clamps(self, tmp_path, monkeypatch):
-        """``convert_to_cog(assign_crs=...)`` invokes ``gdalwarp`` with the clamps.
+class TestConvertToCogCrsAssignment:
+    """fix(#1291): ``assign_crs`` ASSIGNS the CRS and does not reproject.
 
-        Before KNOWN-03, the gdalwarp call passed no ``env=`` at all and
-        inherited an unclamped ``os.environ``.
-        """
-        from app.processing.raster import cog as cog_module
+    This class used to pin the KNOWN-03 clamps on a ``gdalwarp`` subprocess,
+    because ``convert_to_cog`` prepended one whenever an EPSG code was
+    supplied. The decision on #1291 removed that step: the code now rides on
+    the existing ``gdal_translate`` as ``-a_srs``, which relabels the raster
+    and touches no sample. The clamp assertion survives, on the process that
+    now carries the flag.
+    """
 
-        src = tmp_path / "src.tif"
-        src.write_bytes(b"\x00" * 8)
-        dst = tmp_path / "out.tif"
-
-        # Also stub the downstream prepare_with_overviews → rasterio.open
-        # path because convert_to_cog falls through to it after gdalwarp.
+    def _stub_rasterio(self, monkeypatch):
         fake_dataset = mock.MagicMock()
         fake_dataset.count = 1
         fake_dataset.overviews.return_value = []
@@ -179,21 +176,85 @@ class TestConvertToCogGdalwarpSafeEnv:
 
         monkeypatch.setattr(rasterio, "open", lambda *_a, **_k: fake_ctx)
 
-        with _capture_subprocess_runs(monkeypatch) as captured:
-            cog_module.convert_to_cog(str(src), str(dst), "uint8", assign_crs=4326)
+    def test_assign_crs_lands_on_the_translate_and_spawns_no_warp(
+        self, tmp_path, monkeypatch
+    ):
+        """The whole of the #1291 behavior change, in one argv assertion.
 
-        gdalwarp_calls = [
-            (cmd, env) for cmd, env in captured if cmd and cmd[0] == "gdalwarp"
+        ``-a_srs`` writes a CRS tag while every band passes through, so the
+        output carries the uploaded samples. ``gdalwarp -t_srs`` resampled them
+        onto a new grid. The absence of the warp is asserted, not implied: it
+        is what licenses both raster tails calling ``cog_preserves_source``
+        without ``reprojected=``, i.e. what licenses deleting the upload.
+        """
+        from app.processing.raster import cog as cog_module
+
+        src = tmp_path / "src.tif"
+        src.write_bytes(b"\x00" * 8)
+        dst = tmp_path / "out.tif"
+        self._stub_rasterio(monkeypatch)
+
+        with _capture_subprocess_runs(monkeypatch) as captured:
+            cog_module.convert_to_cog(str(src), str(dst), "uint8", assign_crs=3857)
+
+        tools = [cmd[0] for cmd, _ in captured if cmd]
+        assert "gdalwarp" not in tools, (
+            f"a CRS assignment must not reproject (#1291); ran {tools}"
+        )
+
+        translate_calls = [
+            (cmd, env) for cmd, env in captured if cmd and cmd[0] == "gdal_translate"
         ]
-        assert gdalwarp_calls, (
-            f"gdalwarp was not invoked; captured: {[c[0] for c in captured]}"
+        assert translate_calls, f"gdal_translate was not invoked; ran {tools}"
+        cmd, env = translate_calls[0]
+        assert "-a_srs" in cmd, f"-a_srs missing from the translate argv: {cmd}"
+        assert cmd[cmd.index("-a_srs") + 1] == "EPSG:3857"
+        assert "-t_srs" not in cmd, (
+            "-t_srs on gdal_translate reprojects; the assignment flag is -a_srs"
         )
-        _, env = gdalwarp_calls[0]
-        # Pre-KNOWN-03 this branch passed env=None — assert it's no longer None.
-        assert env is not None, (
-            "gdalwarp subprocess passed env=None (KNOWN-03 regression)"
-        )
+        # The flag must precede the positional input/output pair, or GDAL reads
+        # it as a file name.
+        assert cmd.index("-a_srs") < cmd.index(str(dst))
+        # KNOWN-03: the clamps ride on whichever process carries the work.
         _assert_clamps(env)
+
+    def test_no_assign_crs_leaves_the_argv_alone(self, tmp_path, monkeypatch):
+        """The flag is conditional — an ordinary conversion must not stamp a CRS
+        the source never declared."""
+        from app.processing.raster import cog as cog_module
+
+        src = tmp_path / "src.tif"
+        src.write_bytes(b"\x00" * 8)
+        dst = tmp_path / "out.tif"
+        self._stub_rasterio(monkeypatch)
+
+        with _capture_subprocess_runs(monkeypatch) as captured:
+            cog_module.convert_to_cog(str(src), str(dst), "uint8")
+
+        for cmd, _ in captured:
+            assert "-a_srs" not in cmd, f"unrequested CRS assignment in {cmd}"
+
+    def test_resampling_reaches_overviews_only(self, tmp_path, monkeypatch):
+        """``resampling`` fed ``gdalwarp -r`` as well as ``gdaladdo -r`` before
+        #1291. With the warp gone it can only shape overviews, which is what
+        makes it irrelevant to whether the base samples survived."""
+        from app.processing.raster import cog as cog_module
+
+        src = tmp_path / "src.tif"
+        src.write_bytes(b"\x00" * 8)
+        dst = tmp_path / "out.tif"
+        self._stub_rasterio(monkeypatch)
+
+        with _capture_subprocess_runs(monkeypatch) as captured:
+            cog_module.convert_to_cog(
+                str(src), str(dst), "uint8", assign_crs=3857, resampling="cubic"
+            )
+
+        carriers = sorted({cmd[0] for cmd, _ in captured if "cubic" in cmd})
+        assert carriers == ["gdaladdo"], (
+            f"'cubic' reached {carriers}; after #1291 only overview generation "
+            "may see a resampling method"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -324,9 +385,15 @@ class TestGdalFailureTempCleanup:
             "temp raster copy leaked after run_gdal raised"
         )
 
-    def test_convert_to_cog_cleans_warp_tmp_on_run_gdal_raise(
+    def test_convert_to_cog_with_assign_crs_leaves_no_temp_behind(
         self, tmp_path, monkeypatch
     ):
+        """fix(#1291): the assignment path used to stage a second temp file for
+        the ``gdalwarp`` output, and that one leaked on a timeout. It no longer
+        exists — ``-a_srs`` rides the translate — so what this asserts now is
+        that the path adds no temp of its own: the only scratch file is the
+        overview copy, and its owner still removes it on any raise.
+        """
         import tempfile
 
         import pytest
@@ -339,9 +406,10 @@ class TestGdalFailureTempCleanup:
         src = src_dir / "src.tif"
         src.write_bytes(b"\x00" * 8)
         monkeypatch.setattr(tempfile, "tempdir", str(work_dir))
+        self._stub_rasterio_no_overviews(monkeypatch)
 
         def _raise(*_a, **_k):
-            raise RuntimeError("gdalwarp timed out after 900s")
+            raise RuntimeError("gdaladdo timed out after 900s")
 
         monkeypatch.setattr(cog_module, "run_gdal", _raise)
 
@@ -354,5 +422,5 @@ class TestGdalFailureTempCleanup:
             )
 
         assert list(work_dir.iterdir()) == [], (
-            "gdalwarp temp file leaked after run_gdal raised"
+            "a temp file leaked from the CRS-assignment path after run_gdal raised"
         )

--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -1323,6 +1323,12 @@ class TestLossyConversionRetainsSource:
         """The codec is one of two independent ways to lose the source, and
         this change touches only the codec. A warp resamples every pixel
         whatever it is then compressed with.
+
+        fix(#1291) removed the pipeline's only warp, so nothing sets
+        ``reprojected`` today — the axis is kept, and kept tested, because a
+        deliberate reproject-at-ingest field would have to set it, and a
+        predicate whose second input has quietly rotted is how the upload gets
+        deleted on the day that field lands.
         """
         from app.processing.raster.cog import cog_preserves_source
 
@@ -2161,7 +2167,14 @@ class TestLocalStorageHonoursTheRetentionPromise:
 class TestReprojectionCountsAsSampleAltering:
     """FINDING 1. `gdalwarp -t_srs` resamples every pixel onto a new grid, so a
     reprojection under DEFLATE alters samples exactly as JPEG does. Looking
-    only at the codec answered the wrong question."""
+    only at the codec answered the wrong question.
+
+    fix(#1291) then removed the only warp this pipeline ran: `srid_override`
+    assigns a CRS (`gdal_translate -a_srs`) instead of reprojecting to it. The
+    finding's REASONING is untouched and still pinned below — a warp is
+    sample-altering whatever the codec — but nothing reaches it any more, so
+    the end-to-end case moved to `TestCrsAssignmentPreservesTheSamples`.
+    """
 
     def test_a_warp_under_a_lossless_codec_still_alters_samples(self) -> None:
         from app.processing.raster.cog import cog_preserves_source
@@ -2175,57 +2188,12 @@ class TestReprojectionCountsAsSampleAltering:
         assert cog_preserves_source("converted", "JPEG", reprojected=False) is False
 
     def test_verified_still_short_circuits(self) -> None:
-        """Nothing ran, so neither axis applies. A warp cannot co-occur:
+        """Nothing ran, so neither axis applies. A conversion cannot co-occur:
         `check_and_prepare_cog` treats any assign_crs as a custom option and
         always converts."""
         from app.processing.raster.cog import cog_preserves_source
 
         assert cog_preserves_source("verified", "JPEG") is True
-
-    async def test_replace_with_srid_override_keeps_the_original(
-        self, test_db_session, raster_storage, tmp_path
-    ) -> None:
-        """End to end: default DEFLATE plus an override. Lossless codec, warped
-        pixels — the upload is the only copy of the original samples."""
-        admin_id = (
-            await test_db_session.execute(
-                select(User.id).where(User.username == "admin")
-            )
-        ).scalar_one()
-        live = await _make_live_raster(
-            test_db_session, raster_storage, created_by=admin_id
-        )
-        dataset_id = live.dataset.id
-        record_id = live.dataset.record_id
-
-        source = tmp_path / "reprojected.tif"
-        source.write_bytes(_geotiff_bytes(seed=91))
-        job = await _queue_replace_job(
-            test_db_session,
-            dataset_id=dataset_id,
-            user_id=admin_id,
-            file_path=str(source),
-        )
-        job.user_metadata = {**(job.user_metadata or {}), "srid_override": 3857}
-        await test_db_session.commit()
-        job_id = job.id
-
-        try:
-            await reupload_raster.func(
-                job_id=str(job_id),
-                dataset_id=str(dataset_id),
-                file_path=str(source),
-                user_id=str(admin_id),
-                attempt_id=str(job.attempt_id),
-            )
-            assert await _archived_names(test_db_session, dataset_id) == [
-                "reprojected.tif"
-            ], (
-                "a reprojected replace deleted its only un-resampled copy — "
-                "DEFLATE says nothing about a warp (#1290 round-3 finding 1)"
-            )
-        finally:
-            await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
 
 
 class TestRetainedOriginalLivesOutsideThePurgesDomain:
@@ -5157,6 +5125,277 @@ class TestLocalFailurePathsKeepWhatIsDurable:
                 f"a completed-but-cancelled archive write survived unowned: "
                 f"{leftovers} — no quota row references it and nothing will "
                 "ever reap it (#1290 round-14 finding 2)"
+            )
+        finally:
+            await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
+
+
+# ---------------------------------------------------------------------------
+# 17. srid_override becomes a CRS assignment (#1291)
+# ---------------------------------------------------------------------------
+
+
+class TestCrsAssignmentPreservesTheSamples:
+    """fix(#1291). `srid_override` relabels; it does not resample.
+
+    Inverting a "keep the original" into a "delete it" is the direction that
+    costs something when it is wrong, so it is argued rather than asserted:
+    `-a_srs` writes a CRS tag while every band passes through the translate, so
+    the COG holds the uploaded samples exactly and the upload adds nothing. And
+    unlike a warp, the step is reversible from the stored artifact — a caller
+    who assigns the wrong EPSG can assign another one over the same untouched
+    pixels, with `Dataset.original_srid` still recording what the upload
+    declared. The measured half of that claim is
+    `test_the_cog_carries_the_uploaded_samples_and_grid` below.
+    """
+
+    async def test_replace_with_srid_override_supersedes_the_original(
+        self, test_db_session, raster_storage, tmp_path
+    ) -> None:
+        """End to end: default DEFLATE plus an override. Lossless codec,
+        untouched pixels — there is no second copy left to justify."""
+        admin_id = (
+            await test_db_session.execute(
+                select(User.id).where(User.username == "admin")
+            )
+        ).scalar_one()
+        live = await _make_live_raster(
+            test_db_session, raster_storage, created_by=admin_id
+        )
+        dataset_id = live.dataset.id
+        record_id = live.dataset.record_id
+
+        source = tmp_path / "relabelled.tif"
+        source.write_bytes(_geotiff_bytes(seed=91))
+        job = await _queue_replace_job(
+            test_db_session,
+            dataset_id=dataset_id,
+            user_id=admin_id,
+            file_path=str(source),
+        )
+        job.user_metadata = {**(job.user_metadata or {}), "srid_override": 3857}
+        await test_db_session.commit()
+        job_id = job.id
+
+        try:
+            await reupload_raster.func(
+                job_id=str(job_id),
+                dataset_id=str(dataset_id),
+                file_path=str(source),
+                user_id=str(admin_id),
+                attempt_id=str(job.attempt_id),
+            )
+            assert await _archived_names(test_db_session, dataset_id) == [], (
+                "an override archived a second permanent copy of an upload the "
+                "COG reproduces byte for byte — assignment resamples nothing "
+                "(#1291)"
+            )
+        finally:
+            await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
+
+    async def test_the_cog_carries_the_uploaded_samples_and_grid(
+        self, test_db_session, raster_storage, tmp_path
+    ) -> None:
+        """The fact the retention decision above rests on, read off the object
+        that was actually published: same shape, same pixels, new CRS label,
+        and the same corner coordinates — a warp changes all four."""
+        admin_id = (
+            await test_db_session.execute(
+                select(User.id).where(User.username == "admin")
+            )
+        ).scalar_one()
+        live = await _make_live_raster(
+            test_db_session, raster_storage, created_by=admin_id
+        )
+        dataset_id = live.dataset.id
+        record_id = live.dataset.record_id
+
+        # Held in memory because the successful replace deletes the upload —
+        # which is the retention change this test underwrites.
+        source_bytes = _geotiff_bytes(seed=93)
+        source = tmp_path / "relabelled.tif"
+        source.write_bytes(source_bytes)
+        job = await _queue_replace_job(
+            test_db_session,
+            dataset_id=dataset_id,
+            user_id=admin_id,
+            file_path=str(source),
+        )
+        job.user_metadata = {**(job.user_metadata or {}), "srid_override": 3857}
+        await test_db_session.commit()
+        job_id = job.id
+
+        try:
+            await reupload_raster.func(
+                job_id=str(job_id),
+                dataset_id=str(dataset_id),
+                file_path=str(source),
+                user_id=str(admin_id),
+                attempt_id=str(job.attempt_id),
+            )
+
+            test_db_session.expire_all()
+            asset = (
+                await test_db_session.execute(
+                    select(RasterAsset).where(RasterAsset.dataset_id == dataset_id)
+                )
+            ).scalar_one()
+            published = await raster_storage.get(asset.asset_uri)
+
+            with MemoryFile(published) as mem, mem.open() as cog:
+                cog_bounds = tuple(cog.bounds)
+                cog_pixels = cog.read(1)
+                cog_epsg = cog.crs.to_epsg()
+            with MemoryFile(source_bytes) as mem, mem.open() as src:
+                src_bounds = tuple(src.bounds)
+                src_pixels = src.read(1)
+
+            assert cog_epsg == 3857
+            assert cog_pixels.shape == src_pixels.shape, (
+                "the pixel grid was resampled; an assignment must not touch it"
+            )
+            assert np.array_equal(cog_pixels, src_pixels), (
+                "the samples changed under a lossless codec — the conversion "
+                "reprojected instead of relabelling (#1291)"
+            )
+            assert cog_bounds == pytest.approx(src_bounds), (
+                f"the corner coordinates moved ({src_bounds} -> {cog_bounds}); "
+                "assignment changes what they mean, not what they are"
+            )
+        finally:
+            await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
+
+    def test_neither_tail_asks_for_the_reprojected_verdict(self) -> None:
+        """The first-ingest tail's half of the same change.
+
+        Structural for the reason #1290 gave when it pinned its sibling this
+        way: driving a whole successful first ingest — quota, notifications,
+        billing, embeddings — to observe one bit is not worth the runtime, and
+        what would actually regress is the keyword coming back with the warp
+        long gone, quietly charging every override a second permanent copy.
+        """
+        import ast
+        import inspect
+
+        from app.processing.ingest import tasks_raster, tasks_raster_replace
+
+        for module in (tasks_raster, tasks_raster_replace):
+            tree = ast.parse(inspect.getsource(module))
+            calls = [
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and getattr(node.func, "id", None) == "cog_preserves_source"
+            ]
+            assert calls, f"{module.__name__} does not consult the predicate"
+            for call in calls:
+                assert "reprojected" not in {kw.arg for kw in call.keywords}, (
+                    f"{module.__name__} still reports a reprojection to "
+                    "cog_preserves_source; nothing in this pipeline reprojects "
+                    "since #1291"
+                )
+
+    def test_both_tails_persist_the_footprint_of_the_file_they_labelled(
+        self,
+    ) -> None:
+        """Where the footprint comes from, in both tails.
+
+        Under assignment the source and the COG hold the SAME corner numbers,
+        so the two reads no longer disagree about any number — only about which
+        CRS to read them under. That makes the source read a silently wrong
+        answer rather than an obviously wrong one, which is the version of this
+        bug that survives review.
+        """
+        import ast
+        import inspect
+
+        from app.processing.ingest import tasks_raster, tasks_raster_replace
+
+        for module, callee, kwarg in (
+            (tasks_raster, "create_raster_dataset", "meta"),
+            (tasks_raster_replace, "_write_swapped_fields", "cog_meta"),
+        ):
+            tree = ast.parse(inspect.getsource(module))
+            calls = [
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and getattr(node.func, "id", None) == callee
+            ]
+            assert calls, f"{module.__name__} never calls {callee}"
+            for call in calls:
+                passed = {kw.arg: kw.value for kw in call.keywords if kw.arg == kwarg}
+                assert passed, f"{module.__name__}: {callee} got no {kwarg}="
+                assert getattr(passed[kwarg], "id", None) == "cog_meta", (
+                    f"{module.__name__}: {callee} was handed "
+                    f"{ast.dump(passed[kwarg])} — the catalog's extent must "
+                    "come from the converted COG, whose CRS is the assigned one"
+                )
+
+    async def test_the_footprint_is_read_in_the_assigned_crs(
+        self, test_db_session, raster_storage, tmp_path
+    ) -> None:
+        """The subtle half, and a real bug class here before (#1290).
+
+        The source spans the whole world in EPSG:4326. Assigned 3857, those
+        same numbers describe a 360 m by 180 m patch at the origin, so the
+        published extent is sub-degree. Three wrong answers are all excluded by
+        one assertion: reading the source's metadata (or a source-CRS reading
+        of the COG) gives the whole world, and a warp to 3857 would give the
+        whole world back too after the inverse transform.
+        """
+        admin_id = (
+            await test_db_session.execute(
+                select(User.id).where(User.username == "admin")
+            )
+        ).scalar_one()
+        live = await _make_live_raster(
+            test_db_session, raster_storage, created_by=admin_id
+        )
+        dataset_id = live.dataset.id
+        record_id = live.dataset.record_id
+
+        source = tmp_path / "relabelled.tif"
+        source.write_bytes(_geotiff_bytes(seed=97))
+        job = await _queue_replace_job(
+            test_db_session,
+            dataset_id=dataset_id,
+            user_id=admin_id,
+            file_path=str(source),
+        )
+        job.user_metadata = {**(job.user_metadata or {}), "srid_override": 3857}
+        await test_db_session.commit()
+        job_id = job.id
+
+        try:
+            await reupload_raster.func(
+                job_id=str(job_id),
+                dataset_id=str(dataset_id),
+                file_path=str(source),
+                user_id=str(admin_id),
+                attempt_id=str(job.attempt_id),
+            )
+
+            west, south, east, north = (
+                await test_db_session.execute(
+                    text(
+                        "SELECT ST_XMin(spatial_extent), ST_YMin(spatial_extent), "
+                        "ST_XMax(spatial_extent), ST_YMax(spatial_extent) "
+                        "FROM catalog.records WHERE id = :id"
+                    ),
+                    {"id": record_id},
+                )
+            ).one()
+
+            # -180..180 read as metres is ~0.0016 degrees of longitude.
+            assert east - west < 0.01 and north - south < 0.01, (
+                f"the published extent spans {east - west} x {north - south} "
+                "degrees: the corner numbers were read under the CRS the "
+                "caller replaced, not the one they assigned (#1291)"
+            )
+            assert abs(west) < 0.01 and abs(south) < 0.01, (
+                f"the footprint sits at ({west}, {south}); metres near zero "
+                "belong at the origin in WGS84"
             )
         finally:
             await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)

--- a/backend/tests/test_rule2_structural.py
+++ b/backend/tests/test_rule2_structural.py
@@ -4814,12 +4814,14 @@ def test_guard_env_that_goes_nowhere_does_not_credit():
 
 def test_guard_real_tree_credit_shapes_are_all_allowlisted():
     """The practicality check, pinned as a test rather than left to the
-    measurement in #1077's PR body: the exact shapes the four credited argv
-    sites in ``app/`` use. ``prepare_with_overviews`` assigns the env inside a
-    ``try``; ``convert_to_cog`` passes it inline from inside an ``if``;
-    ``_build_vrt`` builds the argv in the straight-line body and passes the
-    env inline from inside a ``try``. Narrowing the allowlist until any of
-    these reports means breaking the tree, and this is where that shows up."""
+    measurement in #1077's PR body: the exact shapes the credited argv sites in
+    ``app/`` use. ``prepare_with_overviews`` assigns the env inside a ``try``;
+    ``convert_to_cog`` builds its argv across conditional ``extend`` calls and
+    passes an env variable (fix(#1291) removed its second, gdalwarp site, whose
+    shape was an env passed inline from inside an ``if``); ``_build_vrt``
+    builds the argv in the straight-line body and passes the env inline from
+    inside a ``try``. Narrowing the allowlist until any of these reports means
+    breaking the tree, and this is where that shows up."""
     violations, total = _collect_gdal_cli_violations(
         _mod(
             "from app.processing.raster.vrt import gdal_safe_env, run_gdal\n"
@@ -4830,13 +4832,18 @@ def test_guard_real_tree_credit_shapes_are_all_allowlisted():
             "        return run_gdal(cmd, env=env, tool='gdaladdo')\n"
             "    except Exception:\n"
             "        raise\n"
-            "def convert(path, out, assign_crs):\n"
-            "    if assign_crs is not None:\n"
-            "        warp_cmd = ['gdalwarp', '-t_srs', f'EPSG:{assign_crs}', path, out]\n"
-            "        try:\n"
-            "            run_gdal(warp_cmd, env=gdal_safe_env(), tool='gdalwarp')\n"
-            "        except Exception:\n"
-            "            raise\n"
+            "def convert(path, out, assign_crs, nodata):\n"
+            "    try:\n"
+            "        env = gdal_safe_env(extras={'GDAL_CACHEMAX': '200'})\n"
+            "        cmd = ['gdal_translate', '-of', 'GTiff']\n"
+            "        if nodata is not None:\n"
+            "            cmd.extend(['-a_nodata', str(nodata)])\n"
+            "        if assign_crs is not None:\n"
+            "            cmd.extend(['-a_srs', f'EPSG:{assign_crs}'])\n"
+            "        cmd.extend([path, out])\n"
+            "        return run_gdal(cmd, env=env, tool='gdal_translate')\n"
+            "    finally:\n"
+            "        pass\n"
             "def build_vrt(sources, out):\n"
             "    cmd = ['gdalbuildvrt', out, *sources]\n"
             "    try:\n"

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -305,7 +305,7 @@
     "compressionLabel": "Komprimierung",
     "compressionHelp": "COG-Ausgabekomprimierung. DEFLATE ist Standard. ZSTD für Geschwindigkeit, JPEG/WEBP für Bilder.",
     "resamplingLabel": "Resampling",
-    "resamplingHelp": "Methode für Übersichtsgenerierung und Reprojektion. Auto wählt basierend auf Datentyp.",
+    "resamplingHelp": "Methode für Übersichtsgenerierung. Auto wählt basierend auf Datentyp.",
     "nodataLabel": "NoData-Wert",
     "nodataHelp": "NoData-Wert für diesen Raster überschreiben oder zuweisen.",
     "geometryColumns": "Geometriespalten",

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -350,7 +350,7 @@
     "compressionLabel": "Compression",
     "compressionHelp": "COG output compression. DEFLATE is default. ZSTD for speed, JPEG/WEBP for imagery.",
     "resamplingLabel": "Resampling",
-    "resamplingHelp": "Method for overview generation and reprojection. Auto selects based on data type.",
+    "resamplingHelp": "Method for overview generation. Auto selects based on data type.",
     "nodataLabel": "NoData Value",
     "nodataHelp": "Override or assign a nodata value for this raster.",
     "geometryColumns": "Geometry Columns",

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -305,7 +305,7 @@
     "compressionLabel": "Compresión",
     "compressionHelp": "Compresión de salida COG. DEFLATE es el valor predeterminado. ZSTD para velocidad, JPEG/WEBP para imágenes.",
     "resamplingLabel": "Remuestreo",
-    "resamplingHelp": "Método para generación de vistas generales y reproyección. Auto selecciona según el tipo de datos.",
+    "resamplingHelp": "Método para generación de vistas generales. Auto selecciona según el tipo de datos.",
     "nodataLabel": "Valor NoData",
     "nodataHelp": "Sobrescribir o asignar un valor NoData para este ráster.",
     "geometryColumns": "Columnas de geometria",

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -305,7 +305,7 @@
     "compressionLabel": "Compression",
     "compressionHelp": "Compression de sortie COG. DEFLATE par défaut. ZSTD pour la vitesse, JPEG/WEBP pour les images.",
     "resamplingLabel": "Rééchantillonnage",
-    "resamplingHelp": "Méthode pour la génération des aperçus et la reprojection. Auto sélectionne selon le type de données.",
+    "resamplingHelp": "Méthode pour la génération des aperçus. Auto sélectionne selon le type de données.",
     "nodataLabel": "Valeur NoData",
     "nodataHelp": "Remplacer ou attribuer une valeur NoData pour ce raster.",
     "geometryColumns": "Colonnes de geometrie",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -6730,7 +6730,7 @@ export interface components {
             visibility: "private" | "restricted" | "internal" | "public";
             /**
              * Srid Override
-             * @description EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.
+             * @description EPSG code to use when the source CRS is missing or incorrect. Assigns (relabels) the CRS the source is read under rather than reprojecting from it: raster pixel values are unchanged, and vector geometries are reprojected to EPSG:4326 from the assigned CRS as usual.
              */
             srid_override?: number | null;
             /**

--- a/sdks/python/geolens/models/commit_request.py
+++ b/sdks/python/geolens/models/commit_request.py
@@ -42,8 +42,9 @@ class CommitRequest:
             summary (None | str | Unset): Optional dataset description shown in the catalog.
             visibility (CommitRequestVisibility | Unset): Dataset visibility level: 'private' (owner-only), 'restricted'
                 (RBAC-controlled), 'internal' (all users), 'public' (anonymous access). Default: 'private'.
-            srid_override (int | None | Unset): EPSG code to use when source CRS is missing or incorrect. Forces
-                reprojection during ingestion.
+            srid_override (int | None | Unset): EPSG code to use when the source CRS is missing or incorrect. Assigns
+                (relabels) the CRS the source is read under rather than reprojecting from it: raster pixel values are unchanged,
+                and vector geometries are reprojected to EPSG:4326 from the assigned CRS as usual.
             token (None | str | Unset): Optional confirmation token returned by the preview step. Required for some
                 workflows.
             temporal_start (datetime.datetime | None | Unset): ISO 8601 start of the dataset's temporal extent.

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -2189,7 +2189,7 @@ export type CommitRequest = {
     /**
      * Srid Override
      *
-     * EPSG code to use when source CRS is missing or incorrect. Forces reprojection during ingestion.
+     * EPSG code to use when the source CRS is missing or incorrect. Assigns (relabels) the CRS the source is read under rather than reprojecting from it: raster pixel values are unchanged, and vector geometries are reprojected to EPSG:4326 from the assigned CRS as usual.
      */
     srid_override?: number | null;
     /**


### PR DESCRIPTION
Implements the decision recorded on #1291: https://github.com/geolens-io/geolens/issues/1291#issuecomment-5260372477

## What changes

`srid_override` reached `convert_to_cog` as a `gdalwarp -t_srs` prepend, which resamples every pixel onto a new grid. It now rides the existing `gdal_translate` as `-a_srs`, which writes a CRS tag while every band passes through.

Measured on the deployed GDAL, with a 32x32 EPSG:4326 source relabelled to 3857:

| | grid | bounds | pixels |
| --- | --- | --- | --- |
| `gdal_translate -a_srs` | 32x32 | unchanged | array-equal to the input |
| `gdalwarp -t_srs` | 42x42 | rewritten in metres | different values |

## Why this is a bug fix for the documented contract

The field's own description names two cases, and neither wanted a warp. A source with no CRS has nothing to reproject *from* — GDAL's own fallback there was to treat the source SRS as the target, so that case was already an assignment in everything but its retention accounting. A source whose declared CRS is *wrong* reprojects from a wrong starting point, so the output coordinates are wrong by construction; nobody can have been using that successfully.

The only use that changes is the off-label one — correct CRS, reprojection wanted at ingest — which the description never promised. Deliberate reprojection is not being added: Titiler reprojects at serve time and export reprojects at export time, and if real demand appears it gets an honestly named `target_srid` rather than a repurposed field.

## `cog_preserves_source`

The audit bullet claiming `assign_crs` is sample-altering is rewritten. `-a_srs` is the same kind of flag as `-a_nodata` sitting next to it: a tag, not a resample. So under a lossless codec the COG carries the uploaded samples and the pre-conversion upload is redundant, and both raster tails now call the predicate without `reprojected=`.

That inverts a "keep the original" into a "delete it", and the docstring notes the asymmetry that makes it worth arguing rather than just doing: a wrong `True` here permanently deletes the only faithful copy. Three things carry the conclusion.

1. The samples are provably intact — measured above, and asserted end to end against the published object in `test_the_cog_carries_the_uploaded_samples_and_grid`.
2. A relabel is the one conversion step that is **reversible from the stored artifact**. A caller who assigns the wrong EPSG assigns another one over the same untouched pixels; a warp could never be undone, which is exactly what made the retained upload irreplaceable while one ran.
3. The upload's own CRS declaration is not lost with the file — `Dataset.original_srid` records it, by the split #1290 introduced.

No caller was left unproven, so nothing needed a conservative carve-out. The `reprojected` parameter itself stays (with its tests): nothing sets it today, and a future reprojecting field must.

`check_and_prepare_cog` still treats any `assign_crs` as a custom option and always converts — verified and kept. The tag is an argument to the translate run, so there is no path that relabels an already-compliant COG in place, and a `verified` return would publish the source still carrying the CRS the caller asked us to replace.

## Footprint under an override

This is the subtlest part, and it was a real bug class here before (#1290). With assignment the pixel grid and the corner **numbers** survive the conversion unchanged; only what they mean changes. So the footprint is decided entirely by which CRS those numbers are read under, and reading the source would read them under the CRS the caller just called wrong — placing the dataset somewhere else on earth with no field visibly disagreeing.

Both tails already read their catalog metadata off the converted COG, so the math needed no change; the in-code comments that justified it in terms of a warp did. The existing tests were moved to assignment semantics rather than deleted: the replace tail now asserts the published extent lands where the assigned CRS puts it (a whole-world 4326 source assigned 3857 must record a sub-degree footprint at the origin, which excludes the source read, a source-CRS read of the COG, and a warp in one assertion), and the first-ingest tail's half is pinned structurally, the way #1290 pinned its sibling for the same runtime reason.

## API surface

Description text only — no field, type, or validation change:

> EPSG code to use when the source CRS is missing or incorrect. Assigns (relabels) the CRS the source is read under rather than reprojecting from it: raster pixel values are unchanged, and vector geometries are reprojected to EPSG:4326 from the assigned CRS as usual.

The vector subclass gets its own wording, because for vector the override has always been an assignment followed by the standard reprojection to 4326 that every vector source gets. Regenerated: `backend/openapi.json`, both SDKs, and `frontend/src/types/api.generated.ts`. Each is a one-line diff.

**Merge order:** #1325 in this wave also regenerates `openapi.json`. Whichever lands second needs a regen on top; the orchestrator is sequencing it.

Also updated because they documented the old behavior: `RUNBOOK.md` section 9 (a CRS override was listed as a reason the upload is kept), a `CHANGELOG.md` entry under Unreleased, and the import form's resampling help text in all four locales — with the warp gone, `resampling` only shapes overviews.

## Verification

```
backend: ruff check . / ruff format --check .            pass
backend: pytest tests/test_layering.py                    40 passed
backend: pytest tests/test_raster_replace_1221.py         112 passed
backend: pytest tests/test_cog_subprocess_env.py          11 passed
backend: pytest tests/test_rule2_structural.py            98 passed
backend: pytest tests/test_raster_ingest.py tests/test_raster_validation.py
         tests/test_raster_schema.py tests/test_cog_band_unit_capture.py
         tests/test_cog_info.py tests/test_raster_antimeridian_887.py
         tests/test_raster_ingest_orphan_cleanup_gap017.py
         tests/test_perf002_raster_meta_cache.py          241 passed
backend: pytest tests/test_ingest.py tests/test_ingest_metadata.py
         tests/test_manifest_apply_service.py tests/test_manifest_apply_roundtrip.py
         tests/test_dp01_ingest_write_path.py
         tests/test_presigned_staging_reap_1202.py        141 passed
backend: pytest tests/test_presigned_raster_stamp_1186.py
         tests/test_strict_cog_enforcement.py
         tests/test_commit_request_schemas.py             58 passed
python scripts/dump_openapi.py --check                    exit 0
make sdks                                                 clean regen, committed
```

Rule 2: the removed `gdalwarp` argv site is one fewer GDAL subprocess; the surviving `gdal_translate` argv keeps `gdal_safe_env()`, and the structural guard still sees 10 argv sites against its floor of 6. Playwright was not run — this is backend and generated-type work, and a worktree e2e run would have exercised `main`.

Closes #1291
