### PR TITLE
fix(vrt): stage source-link mutations on the generation and apply them at swap commit

### DIFF
--- a/backend/alembic/versions/0043_vrt_generations_staged_source_ids.py
+++ b/backend/alembic/versions/0043_vrt_generations_staged_source_ids.py
@@ -1,0 +1,48 @@
+"""Stage a VRT generation's intended member set on the generation row.
+
+fix(#1327). ``add_vrt_source``/``remove_vrt_source`` committed their
+``vrt_source_links`` mutation in the same transaction that flipped the asset to
+``'regenerating'`` — before the regeneration that would make the served artifact
+match. The two steps were separate, non-compensable transactions, so a worker
+death between them left the catalog's declared composition permanently ahead of
+the served bytes; #1322's sweep could detect that drift and refuse to hide it,
+but not repair it.
+
+``staged_source_ids`` holds the FULL intended post-mutation member set as an
+ordered array of source dataset ids. The link table is left alone at request
+time and the staged set is applied to it in the same transaction that swaps the
+artifact and writes ``built_from`` (the #1290 commit-time pattern). Death before
+that swap now leaves the links untouched, so catalog and artifact agree with no
+compensation to run.
+
+Nullable with no backfill, deliberately. NULL means the generation changes no
+membership — a plain regenerate, or anything queued before this column existed —
+and the task builds from the live links and applies nothing for it.
+
+Revision ID: 0043_vrt_generations_staged_source_ids
+Revises: 0042_record_distribution_single_primary
+Create Date: 2026-08-11
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0043_vrt_generations_staged_source_ids"
+down_revision: Union[str, None] = "0042_record_distribution_single_primary"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "vrt_generations",
+        sa.Column("staged_source_ids", postgresql.JSONB(), nullable=True),
+        schema="catalog",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("vrt_generations", "staged_source_ids", schema="catalog")

--- a/backend/app/core/catalog_port.py
+++ b/backend/app/core/catalog_port.py
@@ -269,6 +269,11 @@ class CatalogPort(Protocol):
         self, session: AsyncSession, dataset_ids: list[uuid.UUID]
     ) -> dict[str, dict[str, Any]]: ...
 
+    # How many members ONE generation is assembling. fix(#1327): that is the
+    # attempt's intended set, which for a source add/remove is not what the VRT
+    # is serving until the attempt publishes — so this is a fact about the
+    # generation and must not be projected as a dataset's `source_count`. Count
+    # `catalog.vrt_source_links` for that, as every catalog surface now does.
     async def get_vrt_generation_source_count(
         self, session: AsyncSession, generation_id: uuid.UUID
     ) -> int | None: ...

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -87,7 +87,29 @@ async def delete_dataset(
         from app.platform.storage.provider import get_storage
 
         if record_type == "raster_dataset":
-            # Guard: prevent deletion if any VRT still references this COG
+            # Guard: prevent deletion if any VRT still references this COG.
+            #
+            # fix(#1327): a reference is now either committed or in flight. An
+            # add staged by add_vrt_source has no vrt_source_links row until
+            # its regeneration publishes the artifact, so the link half of this
+            # guard alone would let a source be deleted out from under an
+            # in-flight attempt — a hole staging would otherwise open in a
+            # guarantee this repo already made. The second branch closes it by
+            # asking the same question of the not-yet-applied set. The
+            # regeneration task independently refuses to publish a set whose
+            # members it cannot load, so a delete that slips past this guard
+            # (deleted between this check and the build) fails the attempt
+            # instead of half-applying it.
+            #
+            # Membership is asked with `@>` rather than by expanding the array
+            # with jsonb_array_elements_text. Containment is TOTAL over jsonb:
+            # a column holding the JSON scalar `null` (which is what SQLAlchemy
+            # writes for an explicitly-assigned None — #1322's lesson) answers
+            # false instead of raising, and SQL NULL drops the row. An
+            # expansion would need a jsonb_typeof guard beside it in the same
+            # AND, and nothing obliges the planner to evaluate that guard
+            # first. Only 'pending'/'running' generations count — a terminal
+            # one will never apply its set.
             refs_result = await session.execute(
                 text(
                     """
@@ -96,8 +118,15 @@ async def delete_dataset(
                     JOIN catalog.datasets d ON d.id = vsl.vrt_dataset_id
                     JOIN catalog.records r ON r.id = d.record_id
                     WHERE vsl.source_dataset_id = :dataset_id
+                    UNION
+                    SELECT d.id, r.title
+                    FROM catalog.vrt_generations g
+                    JOIN catalog.datasets d ON d.id = g.vrt_dataset_id
+                    JOIN catalog.records r ON r.id = d.record_id
+                    WHERE g.status IN ('pending', 'running')
+                      AND g.staged_source_ids @> to_jsonb(CAST(:dataset_id_text AS text))
                     """
-                ).bindparams(dataset_id=dataset_id)
+                ).bindparams(dataset_id=dataset_id, dataset_id_text=str(dataset_id))
             )
             refs = refs_result.all()
             if refs:

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -125,24 +125,37 @@ async def _build_raster_assets(
     """Fetch raster metadata for a single dataset (column list lives in
     app/processing/raster/queries.py — KISS-6).
 
-    For VRT datasets, also looks up source_count from VrtGeneration.
+    For VRT datasets, also counts the source rasters the served VRT is made of.
     """
+    from sqlalchemy import text
+
     meta = await get_catalog_port().fetch_raster_meta_one(db, dataset_id)
     if meta is None:
         return None
 
-    # Fetch source_count for VRT datasets (only this site needs it)
-    if (
-        meta.get("vrt_type") is not None
-        and meta.get("current_generation_id") is not None
-    ):
-        source_count = await get_catalog_port().get_vrt_generation_source_count(
-            db, meta["current_generation_id"]
+    # fix(#1327): count the LIVE member links, the same source the dataset
+    # detail and list surfaces count (datasets/domain/service_query.py). This
+    # used to read the in-flight VrtGeneration's source_count instead, which
+    # was the post-mutation number a source add/remove had already written into
+    # the link table. Now that the link write happens at the artifact swap, the
+    # generation's count describes a composition that is not being served yet,
+    # so projecting it here would leave this one surface claiming a member set
+    # the VRT does not have — the exact drift #1327 removes. The generation's
+    # own count still belongs to the generation, and is reported per attempt by
+    # the VRT generations endpoint.
+    if meta.get("vrt_type") is not None:
+        count_result = await db.execute(
+            text(
+                "SELECT COUNT(*) FROM catalog.vrt_source_links "
+                "WHERE vrt_dataset_id = :id"
+            ),
+            {"id": str(dataset_id)},
         )
-        if source_count is not None:
-            meta["source_count"] = source_count
+        meta["source_count"] = count_result.scalar() or 0
 
-    # Drop the internal generation_id from the public response (kept only for the join above).
+    # Drop the internal generation_id from the public response. fix(#1327): no
+    # longer read here at all — the raster-meta query still selects it, and it
+    # still must not reach a caller.
     meta.pop("current_generation_id", None)
     return meta
 

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -625,6 +625,20 @@ async def _reap_stale_generation_storage(keys: tuple[str, ...]) -> None:
 # fragment, not a full statement, so it can be embedded as-is in one UPDATE's
 # WHERE and wrapped in NOT(...) for its mirror — see sweep_stale_vrt_assets.
 #
+# fix(#1327): this check is now near-unreachable in the FALSE direction, and
+# that is the point. add_vrt_source/remove_vrt_source no longer mutate
+# vrt_source_links at request time — they stage the intended member set on the
+# VrtGeneration row, and regenerate_vrt applies it in the same transaction that
+# publishes the artifact and writes built_from. A composition-changing attempt
+# that dies before that swap now leaves the links exactly as built_from
+# describes them, so it takes the honest restore branch like any other dead
+# attempt. The check stays because it is the guard, not the mechanism: rows
+# written before #1327, a generation staged by future code that forgets to
+# apply it, or any path that mutates the link table outside a publish
+# transaction all still produce real drift, and the sweep must keep refusing to
+# call that 'ready'. A check whose FALSE branch has become rare is the outcome
+# of fixing the cause; deleting it would only make the next cause invisible.
+#
 # Count-match + one-directional subset (every built_from key has a live
 # link) proves full set equality: a JSONB object cannot repeat a key, and
 # uq_vsl_vrt_source forbids vrt_source_links from repeating a
@@ -814,15 +828,19 @@ async def sweep_stale_vrt_assets(
     reasons:
 
     1. Nothing about the dataset's declared MEMBERSHIP may have changed
-       underneath the attempt. ``add_vrt_source``/``remove_vrt_source``
-       commit their ``vrt_source_links`` mutation in the same transaction
-       that flips the asset to ``'regenerating'``, BEFORE the regeneration
-       itself ever runs, so a dead attempt of THAT kind leaves the
-       catalog's stated composition already ahead of the served bytes.
-       Restoring ``'ready'`` there would erase the only visible signal of
-       that drift — the status endpoint reads the link set, not the served
-       VRT, and would report a reduced (or expanded) source list as fully
-       healthy while stale composition keeps being served.
+       underneath the attempt. Restoring ``'ready'`` over such a change
+       would erase the only visible signal of it — the status endpoint
+       reads the link set, not the served VRT, and would report a reduced
+       (or expanded) source list as fully healthy while stale composition
+       keeps being served. fix(#1327) removed the path that used to
+       produce this state routinely: ``add_vrt_source``/``remove_vrt_
+       source`` stage their intended member set on the ``VrtGeneration``
+       row and ``regenerate_vrt`` applies it in the same transaction as
+       the artifact swap, so a dead composition-changing attempt now
+       leaves the links untouched and takes the restore branch. The check
+       remains as the guard for what it cannot see: rows written before
+       #1327, and any future path that mutates the link table outside a
+       publish transaction.
     2. The asset must have actually BEEN ``'ready'`` — not ``'failed'`` —
        the instant this attempt was allowed to start. ``regenerate_vrt_
        endpoint``'s guard rejects only ``'regenerating'``, so a caller may
@@ -967,15 +985,20 @@ async def sweep_stale_vrt_assets(
     # tasks_vrt.regenerate_vrt.
     #
     # fix(#1322 review round 3): 'ready' is only honest for a COMPOSITION-
-    # PRESERVING attempt. add_vrt_source / remove_vrt_source commit their
-    # vrt_source_links mutation in the SAME transaction that flips the asset
-    # to 'regenerating' — BEFORE the regeneration itself ever runs. If that
-    # attempt then dies, the catalog's link set already reflects the NEW
-    # composition while the published asset_uri (untouched by the dead
-    # attempt) still serves the OLD one. Restoring 'ready' would erase the
-    # only visible signal of that drift: the status endpoint reads the link
-    # set, not the served bytes, and would report the new (reduced) source
-    # list as fully healthy while stale data keeps being served.
+    # PRESERVING attempt. If the catalog's link set reflects a NEW composition
+    # while the published asset_uri (untouched by the dead attempt) still
+    # serves the OLD one, restoring 'ready' would erase the only visible signal
+    # of that drift: the status endpoint reads the link set, not the served
+    # bytes, and would report the new (reduced) source list as fully healthy
+    # while stale data keeps being served.
+    #
+    # fix(#1327): the routine producer of that drift is gone — add_vrt_source /
+    # remove_vrt_source stage their member set on the generation and
+    # regenerate_vrt applies it in the publish transaction, so a dead
+    # composition-changing attempt leaves the links matching built_from and
+    # lands in the restore branch below. What remains for this check is what it
+    # was always the guard against rather than the mechanism for: pre-#1327
+    # rows and any unforeseen writer of the link table.
     #
     # There is no stored "attempt type" to key off — VrtGeneration.
     # triggered_by holds a user id on every call site, not a kind, and

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -97,7 +97,7 @@ from app.processing.ingest.presigned import (
     should_assemble_multipart,
     sign_url_with_deadline,
 )
-from app.processing.ingest.tasks import regenerate_vrt
+from app.processing.ingest.tasks import regenerate_vrt_staged
 from app.processing.ingest.validation import validate_file_content
 from app.platform.jobs.defer_guard import defer_with_orphan_guard
 from app.core.persistent_config import (
@@ -1340,8 +1340,13 @@ async def add_vrt_source(
     await db.commit()
 
     async def _defer() -> None:
+        # fix(#1327 codex P1): the STAGED task name, not the legacy one. A
+        # pre-#1327 worker does not have this task registered and fails the job
+        # loudly (procrastinate TaskNotFound) instead of rebuilding from the
+        # live links and reporting success, which would drop this add on the
+        # floor during a rolling upgrade. See tasks_vrt.regenerate_vrt_staged.
         await defer_async_with_tenant(
-            regenerate_vrt,
+            regenerate_vrt_staged,
             job_id=str(job.id),
             attempt_id=str(job.attempt_id),
             vrt_dataset_id=str(dataset_id),
@@ -1504,8 +1509,11 @@ async def remove_vrt_source(
     await db.commit()
 
     async def _defer() -> None:
+        # fix(#1327 codex P1): staged task name, same reasoning as the add
+        # endpoint — a pre-#1327 worker must refuse this delivery rather than
+        # rebuild the composition it cannot see.
         await defer_async_with_tenant(
-            regenerate_vrt,
+            regenerate_vrt_staged,
             job_id=str(job.id),
             attempt_id=str(job.attempt_id),
             vrt_dataset_id=str(dataset_id),

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -1170,6 +1170,12 @@ async def add_vrt_source(
     Returns 409 if the VRT is currently regenerating (SRC-05) or source already linked.
     Returns 422 if the source is incompatible with existing sources.
     """
+    # fix(#1327): the resulting member set is STAGED on the VrtGeneration row;
+    # vrt_source_links is written by the regeneration task in the same
+    # transaction that publishes the artifact containing it. Deliberately a
+    # comment and not a docstring line: FastAPI publishes the docstring as this
+    # operation's OpenAPI description, so editing it would churn
+    # backend/openapi.json and every generated SDK for an internal note.
     from app.platform.extensions import get_processing_port
     from app.processing.raster.models import RasterAsset, VrtGeneration
     from sqlalchemy import text
@@ -1285,34 +1291,25 @@ async def add_vrt_source(
             detail=[e.model_dump() for e in errors],
         )
 
-    # 6. Get max position for new link. COALESCE(..., -1) guarantees non-null
-    # in SQL but mypy sees Any|None — default to -1 so the arithmetic is safe.
-    max_pos_result = await db.execute(
-        text(
-            "SELECT COALESCE(MAX(position), -1) FROM catalog.vrt_source_links "
-            "WHERE vrt_dataset_id = :vrt_id"
-        ),
-        {"vrt_id": dataset_id},
-    )
-    max_position = max_pos_result.scalar()
-    if max_position is None:
-        max_position = -1
+    # 6. fix(#1327): STAGE the intended post-mutation member set on the
+    # generation instead of writing it into vrt_source_links here. The link
+    # table is the catalog's statement about what the served VRT contains, and
+    # this request has not produced that artifact yet — regenerate_vrt applies
+    # the staged set in the same transaction that swaps the artifact and writes
+    # built_from, so a death anywhere before that swap leaves the links exactly
+    # where the served bytes are. The full set is staged (not "add this id"),
+    # so applying it is a replace: idempotent, and independent of whatever the
+    # links happen to hold when it lands.
+    #
+    # Order IS the position: existing links were read ORDER BY position above,
+    # and the new source appends, which is what the MAX(position)+1 insert this
+    # replaces computed. Applying the set renumbers positions 0..n-1, closing
+    # any gaps a previous removal left behind.
+    staged_source_ids = [str(sid) for sid in existing_source_ids] + [
+        str(request.source_dataset_id)
+    ]
 
-    # 7. Insert new source link
-    new_link_position = max_position + 1
-    await db.execute(
-        text(
-            "INSERT INTO catalog.vrt_source_links(vrt_dataset_id, source_dataset_id, position) "
-            "VALUES (:vrt_id, :src_id, :pos)"
-        ),
-        {
-            "vrt_id": dataset_id,
-            "src_id": request.source_dataset_id,
-            "pos": new_link_position,
-        },
-    )
-
-    # 8. Set VRT status to regenerating — capture pre-mutation values so
+    # 7. Set VRT status to regenerating — capture pre-mutation values so
     # the orphan-guard rollback (Theme H) can restore them if Procrastinate
     # is unreachable.
     previous_status = vrt_asset.status
@@ -1321,7 +1318,8 @@ async def add_vrt_source(
         vrt_dataset_id=dataset_id,
         status="pending",
         started_at=datetime.now(timezone.utc),
-        source_count=len(existing_source_ids) + 1,
+        source_count=len(staged_source_ids),
+        staged_source_ids=staged_source_ids,
         triggered_by=str(user.id),
     )
     db.add(generation)
@@ -1329,20 +1327,17 @@ async def add_vrt_source(
     vrt_asset.status = "regenerating"
     vrt_asset.current_generation_id = generation.id
 
-    # 9. Create IngestJob
+    # 8. Create IngestJob
     job = await create_ingest_job(db, "vrt_regenerate", "", user.id)
     job.dataset_id = dataset_id
 
-    # 10. Commit + dispatch.
-    # Unlike IngestJob orphans (rescued by 60-minute stale-cleanup), there
-    # is NO sweep for VRT assets stuck in ``status="regenerating"``. If
-    # Procrastinate is unreachable, the rollback below reverts the VRT
-    # asset state, deletes the inserted source link, and marks the job
-    # failed before re-raising as HTTP 503 — otherwise the VRT would be
-    # permanently stuck until an operator manually intervenes.
+    # 9. Commit + dispatch.
+    # If Procrastinate is unreachable the rollback below reverts the VRT
+    # asset state and marks the job failed before re-raising as HTTP 503 —
+    # otherwise the VRT would sit in ``status="regenerating"`` until
+    # ``sweep_stale_vrt_assets`` (GAP-002 / feat(#1267)) reconciled it a
+    # timeout later, 409-ing every mutation in between.
     await db.commit()
-
-    inserted_source_id = request.source_dataset_id
 
     async def _defer() -> None:
         await defer_async_with_tenant(
@@ -1355,21 +1350,19 @@ async def add_vrt_source(
         )
 
     async def _rollback(defer_exc: BaseException) -> None:
-        # Revert VRT asset state to what it was before step 8.
+        # Revert VRT asset state to what it was before step 7.
         vrt_asset.status = previous_status
         vrt_asset.current_generation_id = previous_generation_id
         generation.status = "failed"
         generation.completed_at = datetime.now(timezone.utc)
         generation.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
-        # Delete the source link we just inserted so the VRT matches
-        # its pre-mutation source set.
-        await db.execute(
-            text(
-                "DELETE FROM catalog.vrt_source_links "
-                "WHERE vrt_dataset_id = :vrt_id AND source_dataset_id = :src_id"
-            ),
-            {"vrt_id": dataset_id, "src_id": inserted_source_id},
-        )
+        # fix(#1327): no link surgery here any more. This used to DELETE the
+        # row it had just inserted; with the member set staged on the
+        # generation, an undispatched request never touched vrt_source_links,
+        # so there is nothing to put back. The staged set stays on the failed
+        # generation row as the record of what was asked for — it can only be
+        # applied by a task that still owns the asset pointer, which this
+        # rollback has just handed back.
         # Mark the IngestJob failed so /jobs listings reflect reality.
         job.status = "failed"
         job.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
@@ -1377,8 +1370,11 @@ async def add_vrt_source(
 
     await defer_with_orphan_guard(_defer, rollback=_rollback, db=db)
 
+    # fix(#1327): "queued", not "added". The catalog's source list still
+    # describes the VRT being served; the addition becomes part of it when the
+    # regeneration publishes the artifact that contains it.
     return VrtMutationResponse(
-        job_id=job.id, message="Source added, VRT regeneration started"
+        job_id=job.id, message="Source add queued, VRT regeneration started"
     )
 
 
@@ -1400,6 +1396,10 @@ async def remove_vrt_source(
     Returns 422 if removing would leave fewer than 2 sources.
     Returns 404 if the source is not linked to the VRT.
     """
+    # fix(#1327): the post-removal member set is STAGED on the VrtGeneration
+    # row; vrt_source_links is written by the regeneration task in the same
+    # transaction that publishes the artifact without the removed member. Kept
+    # out of the docstring — see the note on add_vrt_source.
     from app.platform.extensions import get_processing_port
     from app.processing.raster.models import RasterAsset, VrtGeneration
     from sqlalchemy import text
@@ -1437,47 +1437,44 @@ async def remove_vrt_source(
             detail="VRT is currently regenerating. Try again after the current operation completes.",
         )
 
-    # 3. Check minimum source count guard. COUNT(*) is non-null but mypy
-    # sees Any|None from scalar() — default to 0 so the comparison is safe.
-    count_result = await db.execute(
+    # 3. Read the current member set ONCE, in order. fix(#1327): the count
+    # guard, the "is it linked" guard and the staged post-removal set are three
+    # questions about one set — a single ordered read answers all three and
+    # leaves them unable to disagree (this replaced a COUNT(*) and a separate
+    # per-link position lookup).
+    links_result = await db.execute(
         text(
-            "SELECT COUNT(*) FROM catalog.vrt_source_links WHERE vrt_dataset_id = :vrt_id"
+            "SELECT source_dataset_id FROM catalog.vrt_source_links "
+            "WHERE vrt_dataset_id = :vrt_id ORDER BY position ASC"
         ),
         {"vrt_id": dataset_id},
     )
-    source_count = count_result.scalar() or 0
-    if source_count <= 2:
+    existing_source_ids = [row.source_dataset_id for row in links_result.fetchall()]
+
+    # Minimum source count guard, evaluated before membership so an
+    # under-populated VRT reports the real reason it cannot shrink further.
+    if len(existing_source_ids) <= 2:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Removing this source would leave fewer than 2 sources. A VRT requires at least 2 sources.",
         )
 
-    # 4. Check source link exists — also capture its position so the
-    # orphan-guard rollback (Theme H) can re-insert it with the original
-    # ordering if the defer fails.
-    link_result = await db.execute(
-        text(
-            "SELECT position FROM catalog.vrt_source_links "
-            "WHERE vrt_dataset_id = :vrt_id AND source_dataset_id = :src_id"
-        ),
-        {"vrt_id": dataset_id, "src_id": source_dataset_id},
-    )
-    link_row = link_result.fetchone()
-    if link_row is None:
+    # 4. Check the source is actually linked.
+    if source_dataset_id not in existing_source_ids:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Source not linked to this VRT",
         )
-    deleted_link_position = link_row.position
 
-    # 5. Delete the source link
-    await db.execute(
-        text(
-            "DELETE FROM catalog.vrt_source_links "
-            "WHERE vrt_dataset_id = :vrt_id AND source_dataset_id = :src_id"
-        ),
-        {"vrt_id": dataset_id, "src_id": source_dataset_id},
-    )
+    # 5. fix(#1327): STAGE the post-removal member set on the generation rather
+    # than deleting the link row now. The link table keeps describing the VRT
+    # that is actually being served until regenerate_vrt publishes the artifact
+    # this set describes, and applies the set in that same transaction. The
+    # surviving order is preserved; applying renumbers positions 0..n-1 so the
+    # removal leaves no gap.
+    staged_source_ids = [
+        str(sid) for sid in existing_source_ids if sid != source_dataset_id
+    ]
 
     # 6. Set VRT status to regenerating — capture pre-mutation values.
     previous_status = vrt_asset.status
@@ -1486,7 +1483,8 @@ async def remove_vrt_source(
         vrt_dataset_id=dataset_id,
         status="pending",
         started_at=datetime.now(timezone.utc),
-        source_count=source_count - 1,
+        source_count=len(staged_source_ids),
+        staged_source_ids=staged_source_ids,
         triggered_by=str(user.id),
     )
     db.add(generation)
@@ -1499,11 +1497,10 @@ async def remove_vrt_source(
     job.dataset_id = dataset_id
 
     # 8. Commit + dispatch with orphan guard (Theme H).
-    # No stale-cleanup sweep exists for VRT ``status="regenerating"``, so
-    # a Procrastinate outage would leave the VRT permanently stuck and
-    # the deleted source link gone until manual operator intervention.
-    # The rollback below re-inserts the link with its original position,
-    # reverts the VRT asset state, and marks the job failed.
+    # A Procrastinate outage would otherwise leave the VRT in
+    # ``status="regenerating"`` until ``sweep_stale_vrt_assets`` reconciled
+    # it a timeout later, 409-ing every mutation in between. The rollback
+    # below reverts the VRT asset state and marks the job failed.
     await db.commit()
 
     async def _defer() -> None:
@@ -1517,19 +1514,10 @@ async def remove_vrt_source(
         )
 
     async def _rollback(defer_exc: BaseException) -> None:
-        # Re-insert the deleted source link with its original position.
-        await db.execute(
-            text(
-                "INSERT INTO catalog.vrt_source_links("
-                "vrt_dataset_id, source_dataset_id, position) "
-                "VALUES (:vrt_id, :src_id, :pos)"
-            ),
-            {
-                "vrt_id": dataset_id,
-                "src_id": source_dataset_id,
-                "pos": deleted_link_position,
-            },
-        )
+        # fix(#1327): nothing to re-insert. The link row was never deleted —
+        # the post-removal set is staged on the generation and only applied at
+        # the artifact swap, so an undispatched request leaves the catalog's
+        # member set untouched.
         # Revert VRT asset state.
         vrt_asset.status = previous_status
         vrt_asset.current_generation_id = previous_generation_id
@@ -1543,6 +1531,7 @@ async def remove_vrt_source(
 
     await defer_with_orphan_guard(_defer, rollback=_rollback, db=db)
 
+    # fix(#1327): "queued", not "removed" — see the add endpoint's tail.
     return VrtMutationResponse(
-        job_id=job.id, message="Source removed, VRT regeneration started"
+        job_id=job.id, message="Source removal queued, VRT regeneration started"
     )

--- a/backend/app/processing/ingest/tasks.py
+++ b/backend/app/processing/ingest/tasks.py
@@ -52,6 +52,7 @@ from app.processing.ingest.tasks_vrt import (  # noqa: F401
     create_vrt_dataset,
     ingest_vrt,
     regenerate_vrt,
+    regenerate_vrt_staged,
 )
 
 # -- File and service re-upload tasks --

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -110,6 +110,90 @@ def built_from_map(ordered_assets) -> dict:
     return {str(a.dataset_id): a.asset_uri for a in ordered_assets}
 
 
+def staged_source_ids_or_none(generation) -> list[uuid.UUID] | None:
+    """The generation's staged member set as UUIDs, or None when it stages none.
+
+    fix(#1327). NULL means "this generation changes no membership" — a plain
+    regenerate, or any generation queued before ``staged_source_ids`` existed.
+    Both build from the live link rows and apply nothing, so the caller gets one
+    fallback with two producers rather than a version check.
+
+    A JSONB column also reads back Python ``None`` when it holds the JSON scalar
+    ``null`` (SQLAlchemy's plain JSONB serializes an assigned ``None`` that way
+    rather than as SQL NULL — the same trap #1322 hit in SQL), and a non-list
+    value cannot be a member set either. Both fall to the same None answer as a
+    genuinely absent one.
+
+    Everything else about the value is checked HERE, at claim time, before a
+    single byte is built: an empty set, an unparseable id or a repeated id is a
+    staged intent that cannot be published, and failing on it now costs a job
+    instead of a GDAL build plus an obscure ON CONFLICT error at apply time.
+    """
+    staged = getattr(generation, "staged_source_ids", None)
+    if not isinstance(staged, list):
+        return None
+    source_ids = [
+        value if isinstance(value, uuid.UUID) else uuid.UUID(str(value))
+        for value in staged
+    ]
+    if not source_ids:
+        raise ValueError("Staged VRT source set is empty")
+    if len(set(source_ids)) != len(source_ids):
+        raise ValueError("Staged VRT source set repeats a source dataset")
+    return source_ids
+
+
+async def apply_staged_source_links(session, vrt_dataset_id, source_ids) -> None:
+    """Make ``vrt_source_links`` equal ``source_ids``, positions from order.
+
+    fix(#1327). Called only from the publish transaction — the same one that
+    swaps ``asset_uri`` and writes ``built_from`` — so the catalog's declared
+    composition becomes visible at the instant the artifact built from it does,
+    and never before.
+
+    A replace, not a diff: an upsert over the whole staged set followed by a
+    delete of everything else for this VRT. Re-running it is a no-op, which is
+    what makes a retry safe, and it needs no knowledge of what the links held
+    when the set was staged. The upsert (rather than delete-then-insert)
+    preserves ``created_at`` on rows that survive the change, so a member's
+    "linked since" is not reset by an unrelated add or remove.
+
+    The empty guard is a precondition, not a second validation: the caller
+    already refuses an empty staged set at claim time. Here it stops an empty
+    list from compiling into ``NOT IN ()`` and deleting every link a VRT has.
+    """
+    from sqlalchemy import delete
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from app.processing.raster.models import VrtSourceLink
+
+    if not source_ids:
+        raise ValueError(f"VRT {vrt_dataset_id} staged an empty source set")
+
+    stmt = pg_insert(VrtSourceLink).values(
+        [
+            {
+                "vrt_dataset_id": vrt_dataset_id,
+                "source_dataset_id": source_id,
+                "position": position,
+            }
+            for position, source_id in enumerate(source_ids)
+        ]
+    )
+    await session.execute(
+        stmt.on_conflict_do_update(
+            constraint="uq_vsl_vrt_source",
+            set_={"position": stmt.excluded.position},
+        )
+    )
+    await session.execute(
+        delete(VrtSourceLink).where(
+            VrtSourceLink.vrt_dataset_id == vrt_dataset_id,
+            VrtSourceLink.source_dataset_id.notin_(source_ids),
+        )
+    )
+
+
 async def create_vrt_dataset(
     session,
     *,
@@ -599,10 +683,18 @@ async def regenerate_vrt(
     keys. The RasterAsset pointer changes only in the same transaction that verifies
     the job attempt and generation ownership, then prior objects are reaped.
 
+    Composition source (fix(#1327)): the generation's ``staged_source_ids``
+    when it carries one — ``add_vrt_source``/``remove_vrt_source`` record the
+    intended post-mutation member set there instead of writing it into
+    ``vrt_source_links`` up front — otherwise the live link rows. The staged set
+    is applied to ``vrt_source_links`` in step 12, inside the publish
+    transaction, so the catalog's declared composition and the artifact built
+    from it become visible in the same commit.
+
     Full pipeline:
     1. Mark job running
     2. Load VRT RasterAsset
-    3. Load vrt_source_links ordered by position -> source dataset IDs
+    3. Load the member set: staged set if any, else vrt_source_links by position
     4. Load source RasterAsset rows, resolve paths
     5. Build new VRT to temp path
     6. Post-validate via rasterio
@@ -611,7 +703,8 @@ async def regenerate_vrt(
     9. Generate quicklooks (non-fatal)
     10. Write immutable generation storage keys
     11. Update RasterAsset metadata fields
-    12. Set status='ready', last_regenerated_at, clear current_generation_id
+    12. Set status='ready', last_regenerated_at, built_from, clear
+        current_generation_id, apply the staged member set to vrt_source_links
     13. Update dataset footprint geometry
     14. Mark job complete
     15. Invalidate cache, defer embedding
@@ -652,6 +745,10 @@ async def regenerate_vrt(
     vrt_id = uuid.UUID(vrt_dataset_id)
     tmp_dir: str | None = None
     generation_uuid: uuid.UUID | None = None
+    # fix(#1327): the member set this attempt is publishing, when its
+    # generation staged one. Set in phase 1 (and used for the build there),
+    # applied to vrt_source_links in phase 2's publish transaction.
+    staged_source_ids: list[uuid.UUID] | None = None
     vrt_asset_snapshot = None
     heartbeat_task: asyncio.Task[None] | None = None
     generation_heartbeat_task: asyncio.Task[None] | None = None
@@ -697,7 +794,14 @@ async def regenerate_vrt(
                 raise ValueError(f"VRT dataset {vrt_dataset_id} not found")
             vrt_asset_snapshot = vrt_asset_row
 
-            # 3. Load vrt_source_links ordered by position
+            # 3. Load vrt_source_links ordered by position — the composition
+            # currently being SERVED. fix(#1327): still read first and still
+            # required to be non-empty, for both paths. It is the default
+            # member set (step 3c may replace it with the generation's staged
+            # one), and a VRT with no links at all is a broken row either way:
+            # nothing legitimately creates one, and building "whatever the
+            # staged set says" over it would quietly repair a state worth
+            # failing on.
             links_result = await session.execute(
                 text(
                     "SELECT source_dataset_id FROM catalog.vrt_source_links "
@@ -778,6 +882,20 @@ async def regenerate_vrt(
                 if vrt_asset_row.current_generation_id != generation_uuid:
                     raise ValueError("VRT generation ownership changed before claim")
 
+            # 3c. fix(#1327): build from the STAGED member set when this
+            # generation carries one. add_vrt_source / remove_vrt_source no
+            # longer touch vrt_source_links — they record the FULL intended
+            # post-mutation set here — so the live link rows read above still
+            # describe the VRT currently being served, not the one this attempt
+            # is being asked to publish. Building from the links would rebuild
+            # the existing composition and then apply a set the artifact does
+            # not contain, which is the exact drift this pattern removes.
+            # A generation that stages nothing (plain regenerate, or one queued
+            # before the column existed) keeps the live links.
+            staged_source_ids = staged_source_ids_or_none(generation)
+            if staged_source_ids is not None:
+                source_ids = staged_source_ids
+
             await session.commit()
             generation_heartbeat_task = asyncio.create_task(
                 maintain_vrt_generation_heartbeat(generation_uuid)
@@ -787,6 +905,22 @@ async def regenerate_vrt(
             snapshot_at, ordered_assets = await snapshot_member_sources(
                 session, source_ids, raster_asset_cls=RasterAsset, dataset_cls=Dataset
             )
+            # fix(#1327): every member of the set being built must still be
+            # loadable, or the build silently publishes a mosaic missing a
+            # member it claims (snapshot_member_sources drops what it cannot
+            # find). A LIVE link cannot vanish — vrt_source_links pins its
+            # source with ON DELETE RESTRICT — but a STAGED id is not a link
+            # row yet, so the window between staging and applying is the one
+            # place a member can disappear underneath an attempt. Failing here
+            # leaves the links untouched and the served VRT intact; the caller
+            # re-issues the add or remove against the set that survived.
+            if len(ordered_assets) != len(source_ids):
+                found = {asset.dataset_id for asset in ordered_assets}
+                missing = [str(sid) for sid in source_ids if sid not in found]
+                raise ValueError(
+                    f"VRT {vrt_dataset_id} member sources are no longer "
+                    f"available: {', '.join(missing)}"
+                )
             from app.core.db.tenant_session import current_tenant_var
 
             source_paths = [
@@ -988,6 +1122,22 @@ async def regenerate_vrt(
                         vrt_asset.last_regenerated_at
                     )
                     vrt_asset_snapshot.current_generation_id = None
+
+                # 12a. fix(#1327): the staged member set lands HERE, in the
+                # transaction that publishes the artifact built from it and
+                # writes built_from — never at request time. That is the whole
+                # invariant: vrt_source_links can never describe a composition
+                # the served bytes do not have, because both become visible in
+                # one commit. Death anywhere upstream leaves the links alone.
+                #
+                # Applies the SAME list phase 1 built from, not a re-read of
+                # the generation row — the link set and the artifact then
+                # cannot disagree even in principle, exactly as built_from is
+                # derived from the ordered_assets the build used. Fenced by the
+                # current_generation_id check above: a zombie worker whose
+                # attempt the sweep already reconciled cannot reach this line.
+                if staged_source_ids is not None:
+                    await apply_staged_source_links(session, vrt_id, staged_source_ids)
 
                 # 12b. Update generation record
                 generation.status = "completed"

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -1298,3 +1298,47 @@ async def regenerate_vrt(
             )
 
             await _cleanup_orphaned_storage_keys(written_storage_keys, job_id=job_id)
+
+
+# fix(#1327 codex P1): a SECOND registered name for the SAME regeneration, used
+# only by the staged mutations (add source / remove source).
+#
+# The skew it closes: during a rolling upgrade the API can be new while a worker
+# is still pre-#1327. The new API records the membership change only in
+# `staged_source_ids`; a pre-#1327 worker does not know that column, rebuilds
+# from the live links, and marks the generation COMPLETE. An accepted add or
+# remove is silently lost, with every state machine reporting success.
+#
+# Why the name and not a marker kwarg. The pre-#1327 task signature ends in
+# `**kwargs`, and so does `tenant_task`'s wrapper, so an unknown keyword is
+# swallowed rather than raising TypeError: a kwarg cannot fence a consumer that
+# accepts anything. The task NAME can. Procrastinate resolves the name against
+# the worker's own registry, and a worker without it raises TaskNotFound, which
+# fails the job. Measured against the pinned procrastinate in
+# tests/test_vrt_staged_task_skew.py: status 'failed', attempts 1, no retry
+# scheduled (TaskNotFound never consults a retry strategy, because there is no
+# task object to ask one for).
+#
+# What that failure leaves behind is deliberately a state the existing
+# machinery already handles rather than a new one: the task never ran, so
+# vrt_source_links is untouched, the generation stays 'pending' with a NULL
+# heartbeat, and the asset stays 'regenerating' until `sweep_stale_vrt_assets`
+# reconciles it. Composition is preserved, which is the whole point of staging,
+# so the sweep restores 'ready' and the VRT keeps serving what it was serving.
+# The mutation is refused rather than half-applied, and the caller re-issues it
+# once the roll finishes.
+#
+# Plain regeneration deliberately keeps the legacy name: it changes no
+# membership, so a pre-#1327 worker executes it correctly and those deliveries
+# keep flowing during the roll.
+@task_app.task(queue="raster", retry=0)
+async def regenerate_vrt_staged(**kwargs) -> None:
+    """Regenerate a VRT whose generation carries a staged member set.
+
+    Byte-identical work to ``regenerate_vrt``: one implementation, two
+    registered names, and the staged set is read from the generation row on
+    either path. The name gates WHICH WORKERS may run it, nothing else.
+    ``regenerate_vrt.func`` is the ``tenant_task``-wrapped body, so the tenant
+    kwarg is popped and bound exactly once, here at the forward.
+    """
+    await regenerate_vrt.func(**kwargs)

--- a/backend/app/processing/raster/models.py
+++ b/backend/app/processing/raster/models.py
@@ -190,6 +190,21 @@ class VrtGeneration(Base):
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     source_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     triggered_by: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    # fix(#1327): the FULL post-mutation member set this generation intends to
+    # publish, as an ordered JSON array of source dataset ids (position implied
+    # by order). `add_vrt_source`/`remove_vrt_source` stage it here instead of
+    # mutating `vrt_source_links` up front, and the regeneration task applies it
+    # to the link table in the SAME transaction as the artifact swap. A dead
+    # attempt therefore leaves the catalog's declared composition exactly where
+    # the served bytes are, with nothing to compensate.
+    #
+    # A full set, not a delta: apply is then a replace, which is idempotent on
+    # retry and needs no knowledge of what the links held when it was staged.
+    # NULL means "this generation changes no membership" — a plain regenerate,
+    # or any generation queued before this column existed. Both build from the
+    # live links and apply nothing, so the fallback is one behavior with two
+    # producers rather than a special case.
+    staged_source_ids: Mapped[list | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -425,8 +425,15 @@ class TestVrtSourceOrphanGuard:
             yield
 
     def test_add_vrt_source_defer_failure_reverts_state_and_raises_503(self):
-        """VRT add_source defer crash must revert ``vrt_asset.status``, delete
-        the inserted source link, mark the IngestJob failed, and raise 503."""
+        """VRT add_source defer crash must revert ``vrt_asset.status``, mark the
+        IngestJob failed, and raise 503.
+
+        fix(#1327): it must also NOT delete a source link, because it never
+        inserted one — the member set is staged on the VrtGeneration row and
+        applied only when the regeneration publishes. What used to be the
+        rollback's compensating DELETE is now nothing to compensate, and this
+        test pins that direction: no statement against vrt_source_links other
+        than the ordered read the endpoint does up front."""
 
         async def _check():
             from app.processing.ingest.router import add_vrt_source
@@ -480,11 +487,9 @@ class TestVrtSourceOrphanGuard:
                     result_mock.scalars.return_value.all.return_value = [
                         existing_source_asset
                     ]
-                elif n == 6:
-                    # 6. Max position
-                    result_mock.scalar.return_value = 0
-                # n == 7: INSERT (no return needed)
-                # n == 8: DELETE (rollback re-deletes)
+                # fix(#1327): there is no 6th query. The MAX(position) lookup,
+                # the link INSERT and the rollback's compensating DELETE are
+                # all gone with the staged member set.
                 return result_mock
 
             mock_db.execute = AsyncMock(side_effect=execute_side_effect)
@@ -515,16 +520,24 @@ class TestVrtSourceOrphanGuard:
             # IngestJob marked failed
             assert mock_job.status == "failed"
             assert "vrt add_source queue dead" in mock_job.error_message
-            # At least one DELETE must have been issued for the inserted link
-            # (call index 8 onwards corresponds to the rollback DELETE).
-            assert call_count[0] >= 8
+            # fix(#1327): the link table was only READ. No INSERT to undo, so
+            # no DELETE to issue — the compensation the rollback used to owe.
+            statements = "\n".join(
+                str(call.args[0]) for call in mock_db.execute.await_args_list
+            )
+            assert "INSERT INTO catalog.vrt_source_links" not in statements
+            assert "DELETE FROM catalog.vrt_source_links" not in statements
 
         asyncio.run(_check())
 
     def test_remove_vrt_source_defer_failure_reverts_state_and_raises_503(self):
-        """VRT remove_source defer crash must revert state, re-insert the
-        deleted source link with its original position, mark the job failed,
-        and raise 503."""
+        """VRT remove_source defer crash must revert state, mark the job
+        failed, and raise 503.
+
+        fix(#1327): the rollback used to re-INSERT the link it had deleted, at
+        the position it had captured. Nothing is deleted now — the post-removal
+        set is staged on the generation — so the compensation is gone and the
+        member set is untouched throughout."""
 
         async def _check():
             from app.processing.ingest.router import remove_vrt_source
@@ -549,7 +562,7 @@ class TestVrtSourceOrphanGuard:
             mock_db.commit = AsyncMock()
 
             call_count = [0]
-            rollback_insert_params: dict = {}
+            other_member_ids = [uuid.uuid4(), uuid.uuid4()]
 
             def execute_side_effect(query, params=None):
                 call_count[0] += 1
@@ -559,19 +572,16 @@ class TestVrtSourceOrphanGuard:
                     # 1. Load VRT RasterAsset
                     result_mock.scalar_one_or_none.return_value = vrt_asset
                 elif n == 2:
-                    # 3. Source count
-                    result_mock.scalar.return_value = 3
-                elif n == 3:
-                    # 4. Link existence check — found with position=5
-                    link_row = MagicMock()
-                    link_row.position = 5
-                    result_mock.fetchone.return_value = link_row
-                elif n == 4:
-                    # 5. DELETE link
-                    pass
-                elif n == 5:
-                    # Rollback: INSERT link
-                    rollback_insert_params.update(params or {})
+                    # fix(#1327): 3. ONE ordered read of the member set — it
+                    # answers the count guard, the "is it linked" guard and the
+                    # staged post-removal set. The separate COUNT(*), the
+                    # position lookup, the DELETE and the rollback's re-INSERT
+                    # are all gone.
+                    result_mock.fetchall.return_value = [
+                        MagicMock(source_dataset_id=other_member_ids[0]),
+                        MagicMock(source_dataset_id=source_dataset_id),
+                        MagicMock(source_dataset_id=other_member_ids[1]),
+                    ]
                 return result_mock
 
             mock_db.execute = AsyncMock(side_effect=execute_side_effect)
@@ -603,9 +613,22 @@ class TestVrtSourceOrphanGuard:
             # IngestJob marked failed
             assert mock_job.status == "failed"
             assert "vrt remove_source queue dead" in mock_job.error_message
-            # Rollback re-inserted the link with the captured position=5
-            assert rollback_insert_params.get("pos") == 5
-            assert rollback_insert_params.get("src_id") == source_dataset_id
+            # fix(#1327): the member set was only READ — the removal lived on
+            # the generation and died with it.
+            statements = "\n".join(
+                str(call.args[0]) for call in mock_db.execute.await_args_list
+            )
+            assert "DELETE FROM catalog.vrt_source_links" not in statements
+            assert "INSERT INTO catalog.vrt_source_links" not in statements
+            from app.processing.raster.models import VrtGeneration
+
+            staged = [
+                call.args[0]
+                for call in mock_db.add.call_args_list
+                if isinstance(call.args[0], VrtGeneration)
+            ]
+            assert len(staged) == 1
+            assert staged[0].staged_source_ids == [str(sid) for sid in other_member_ids]
 
         asyncio.run(_check())
 

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -507,7 +507,9 @@ class TestVrtSourceOrphanGuard:
                     new=mock_create_ingest_job,
                 ),
                 patch("app.processing.ingest.router.validate_sources", return_value=[]),
-                patch("app.processing.ingest.router.regenerate_vrt") as mock_task,
+                patch(
+                    "app.processing.ingest.router.regenerate_vrt_staged"
+                ) as mock_task,
             ):
                 mock_task.defer_async = failing_defer
                 with pytest.raises(HTTPException) as exc_info:
@@ -598,7 +600,9 @@ class TestVrtSourceOrphanGuard:
                     "app.processing.ingest.router.create_ingest_job",
                     new=mock_create_ingest_job,
                 ),
-                patch("app.processing.ingest.router.regenerate_vrt") as mock_task,
+                patch(
+                    "app.processing.ingest.router.regenerate_vrt_staged"
+                ) as mock_task,
             ):
                 mock_task.defer_async = failing_defer
                 with pytest.raises(HTTPException) as exc_info:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2145,7 +2145,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1235 review r9): +8 — the single-PUT branch re-raises HTTPException
     # so the in-thread lifetime refusal stays a 409 there too, as it already
     # did on the other three signing paths.
-    "backend/app/processing/ingest/router.py": 1548,
+    # fix(#1327): -15 — add_vrt_source/remove_vrt_source stage their intended
+    # member set on the VrtGeneration row instead of writing vrt_source_links,
+    # so the MAX(position) lookup, both link INSERT/DELETE statements, the
+    # separate COUNT(*) and position reads, and the two compensating rollback
+    # statements are all gone; the endpoints gained the fix(#1327) notes that
+    # say where the member set now lives, kept out of the docstrings because
+    # FastAPI publishes those into openapi.json. Ratchet DOWN in the same
+    # commit, per the no-headroom rule. Cap 1548 -> 1537, exact.
+    "backend/app/processing/ingest/router.py": 1537,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
@@ -2370,7 +2378,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # post-expiry sweep is finished with a key, and a copy of the string in
     # each module is one rename away from a row that shields an object
     # forever. Cap 1379 -> 1380, exact.
-    "backend/app/platform/jobs/sweep.py": 1380,
+    # fix(#1327): +23 — the composition-drift branch keeps its code and gains
+    # the rationale for why it is now near-unreachable: source add/remove stage
+    # their member set and apply it at the artifact swap, so the drift this
+    # branch discriminates is no longer produced by live traffic. The comment
+    # says what the branch still guards (pre-#1327 rows, any future writer of
+    # the link table) so the next reader does not delete a check whose FALSE
+    # side went quiet. Cap 1380 -> 1403, exact.
+    "backend/app/platform/jobs/sweep.py": 1403,
     # fix(second-opinion review on #1236 review r3): first entry — crossed
     # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
     # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side
@@ -2471,7 +2486,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # VRT instead of the creation-time floor forever. Most of the lines are
     # the comment recording why it reuses generation.completed_at rather than
     # a fresh now() call. Cap 1140 -> 1150, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1150,
+    # fix(#1327): +150 — the compensable-links pattern lives here: two helpers
+    # (staged_source_ids_or_none, apply_staged_source_links) plus the phase-1
+    # switch to the staged member set, the member-still-exists check that fails
+    # a run whose staged source vanished, and the apply inside the publish
+    # transaction. Most of the lines are the reasoning: why NULL means "changes
+    # no membership", why apply is an upsert rather than delete-and-insert, and
+    # why the applied list is the one the build read. Cap 1150 -> 1300, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1300,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.
@@ -2764,7 +2786,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # filename to every viewer. Cap 1440 -> 1450, exact.
     # fix(#1372 codex r2): +5 — the collections-list raster tiles link carries
     # ?v=<tile_cache_version> like every rendered raster template.
-    "backend/app/modules/catalog/search/router.py": 1455,
+    # fix(#1327): +13 — the OGC record item counts the VRT's live member links
+    # instead of reading the in-flight generation's intended count, so this
+    # surface reports the composition being SERVED like every other one. Most
+    # of the lines are the comment explaining why the generation's own count is
+    # a fact about the attempt, not about the dataset. Cap 1455 -> 1468, exact.
+    "backend/app/modules/catalog/search/router.py": 1468,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2153,7 +2153,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # say where the member set now lives, kept out of the docstrings because
     # FastAPI publishes those into openapi.json. Ratchet DOWN in the same
     # commit, per the no-headroom rule. Cap 1548 -> 1537, exact.
-    "backend/app/processing/ingest/router.py": 1537,
+    # fix(#1327 codex P1): +8 — both staged dispatch sites say why they defer
+    # the staged task name rather than the legacy one. Cap 1537 -> 1545, exact.
+    "backend/app/processing/ingest/router.py": 1545,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
@@ -2493,7 +2495,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # transaction. Most of the lines are the reasoning: why NULL means "changes
     # no membership", why apply is an upsert rather than delete-and-insert, and
     # why the applied list is the one the build read. Cap 1150 -> 1300, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1300,
+    # fix(#1327 codex P1): +44 — a second registered task name,
+    # `regenerate_vrt_staged`, that forwards to the same body. It is the
+    # rolling-deploy gate: a pre-#1327 worker has no such task and fails the
+    # job (procrastinate TaskNotFound) instead of rebuilding from the live
+    # links and reporting success, which would silently drop an accepted add or
+    # remove. Nearly all of the lines are the comment recording why a marker
+    # KWARG could not do this (the old signature ends in `**kwargs`, so an
+    # unknown keyword is swallowed) and where the refused delivery lands.
+    # Cap 1300 -> 1344, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1344,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_regenerate_vrt_integration.py
+++ b/backend/tests/test_regenerate_vrt_integration.py
@@ -17,7 +17,9 @@ invalidation / embedding deferral calls.
 
 import hashlib
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import rasterio
@@ -439,3 +441,419 @@ async def test_regenerate_vrt_happy_path_end_to_end(
         # At least one pixel of extent
         assert bounds.right > bounds.left
         assert bounds.top > bounds.bottom
+
+    # [17] fix(#1327): this delivery staged no member set (the legacy shape
+    # this test exercises carries none), so the task built from the live links
+    # and applied nothing to them.
+    assert generation.staged_source_ids is None
+    assert await _linked_source_ids(session, vrt_db_state["vrt_dataset_id"]) == list(
+        vrt_db_state["source_dataset_ids"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# fix(#1327): staged source-link mutation.
+#
+# add_vrt_source/remove_vrt_source record the intended member set on the
+# VrtGeneration row and leave vrt_source_links alone; regenerate_vrt builds
+# from that set and applies it in the same transaction as the artifact swap.
+# The invariant these tests pin: vrt_source_links never describes a composition
+# the served VRT does not have.
+# ---------------------------------------------------------------------------
+
+
+async def _linked_source_ids(session, vrt_dataset_id) -> list[uuid.UUID]:
+    """The VRT's member set as the catalog states it, in position order."""
+    result = await session.execute(
+        text(
+            "SELECT source_dataset_id FROM catalog.vrt_source_links "
+            "WHERE vrt_dataset_id = :vrt_id ORDER BY position ASC"
+        ),
+        {"vrt_id": str(vrt_dataset_id)},
+    )
+    return [row.source_dataset_id for row in result.fetchall()]
+
+
+def _clone_source_tif(source_tifs: dict, tmp_path: Path, name: str) -> str:
+    """A THIRD TIF on disk, byte-identical to the fixture's first.
+
+    Its own key, not a second reference to an existing one: a build handed the
+    same path twice could legitimately collapse it, and these tests count
+    sources in the stored VRT to prove which member set the build read.
+    """
+    origin = next(iter(source_tifs.values()))
+    asset_uri = f"rasters/{name}/source.cog.tif"
+    dest = tmp_path / "storage" / asset_uri
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(origin.read_bytes())
+    return asset_uri
+
+
+async def _add_extra_source(session, asset_uri: str) -> uuid.UUID:
+    """Another ready raster source, NOT linked to any VRT.
+
+    Reuses the fixture's pixel content: these tests are about which members a
+    build and an apply agree on, not about pixel values.
+    """
+    from app.modules.catalog.datasets.domain.models import Dataset, Record
+    from app.processing.raster.models import RasterAsset
+
+    record = Record(
+        title=f"Staged source {uuid.uuid4().hex[:6]}",
+        record_type="raster_dataset",
+        record_status="published",
+        visibility="private",
+    )
+    session.add(record)
+    await session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"raster_src_{record.id.hex[:16]}",
+        source_format="geotiff",
+        srid=4326,
+    )
+    session.add(dataset)
+    await session.flush()
+    session.add(
+        RasterAsset(
+            dataset_id=dataset.id,
+            asset_uri=asset_uri,
+            storage_backend="local",
+            status="ready",
+            band_count=1,
+            epsg=4326,
+            width=64,
+            height=64,
+            dtype="uint8",
+        )
+    )
+    await session.flush()
+    return dataset.id
+
+
+async def _stage_generation(
+    session, vrt_db_state: dict, staged_source_ids
+) -> uuid.UUID:
+    """A pending generation carrying a staged member set, owned by the asset.
+
+    Mirrors exactly what add_vrt_source/remove_vrt_source commit: the staged
+    set on the generation, the asset pointing at it, and vrt_source_links
+    untouched.
+    """
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+
+    generation = VrtGeneration(
+        vrt_dataset_id=uuid.UUID(vrt_db_state["vrt_dataset_id"]),
+        status="pending",
+        started_at=datetime.now(timezone.utc),
+        source_count=len(staged_source_ids),
+        staged_source_ids=[str(sid) for sid in staged_source_ids],
+        triggered_by="test",
+    )
+    session.add(generation)
+    await session.flush()
+
+    asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    asset.status = "regenerating"
+    asset.current_generation_id = generation.id
+    await session.commit()
+    return generation.id
+
+
+async def test_staged_set_lands_with_the_artifact_it_describes(
+    test_db_session,
+    vrt_db_state: dict,
+    source_tifs: dict,
+    tmp_path: Path,
+    local_storage,
+    quicklook_stub,
+    clean_tables,
+):
+    """A successful run applies the staged set, and the VRT contains it.
+
+    Three properties that only mean something together: the build read the
+    STAGED members (3 sources in the stored XML, not the 2 still linked), the
+    link table now equals the staged set in staged order, and built_from — the
+    published statement of what the artifact holds — agrees with both.
+    """
+    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+
+    session = test_db_session
+    vrt_id = vrt_db_state["vrt_dataset_id"]
+    original_ids = list(vrt_db_state["source_dataset_ids"])
+
+    added_id = await _add_extra_source(
+        session, _clone_source_tif(source_tifs, tmp_path, "src-3")
+    )
+    staged = [*original_ids, added_id]
+    generation_id = await _stage_generation(session, vrt_db_state, staged)
+
+    # Pre-state: the catalog still describes the VRT actually being served.
+    assert await _linked_source_ids(session, vrt_id) == original_ids
+
+    await regenerate_vrt.func(
+        job_id=vrt_db_state["job_id"],
+        attempt_id=vrt_db_state["attempt_id"],
+        vrt_dataset_id=vrt_id,
+        generation_id=str(generation_id),
+    )
+
+    assert await _linked_source_ids(session, vrt_id) == staged
+
+    vrt_asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    await session.refresh(vrt_asset)
+    assert vrt_asset.status == "ready"
+    assert set(vrt_asset.built_from) == {str(sid) for sid in staged}
+
+    generation = (
+        await session.execute(
+            select(VrtGeneration).where(VrtGeneration.id == generation_id)
+        )
+    ).scalar_one()
+    await session.refresh(generation)
+    assert generation.status == "completed"
+
+    # The bytes themselves: the stored VRT references one source per staged
+    # member, which is what proves the BUILD used the staged set rather than
+    # the links it was about to overwrite.
+    vrt_xml = (await local_storage.get(vrt_asset.asset_uri)).decode()
+    assert vrt_xml.count("<SourceFilename") == len(staged)
+
+
+async def test_death_before_swap_leaves_source_links_untouched(
+    test_db_session,
+    vrt_db_state: dict,
+    source_tifs: dict,
+    tmp_path: Path,
+    local_storage,
+    quicklook_stub,
+    clean_tables,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The whole point of #1327: an attempt that dies changes no membership.
+
+    The build blows up after the generation is claimed — the window that used
+    to leave the catalog permanently ahead of the served bytes. Nothing about
+    the VRT's stated composition moves.
+    """
+    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+
+    session = test_db_session
+    vrt_id = vrt_db_state["vrt_dataset_id"]
+    original_ids = list(vrt_db_state["source_dataset_ids"])
+
+    added_id = await _add_extra_source(
+        session, _clone_source_tif(source_tifs, tmp_path, "src-3")
+    )
+    staged = [*original_ids, added_id]
+    generation_id = await _stage_generation(session, vrt_db_state, staged)
+
+    monkeypatch.setattr(
+        "app.processing.ingest.tasks_vrt.build_vrt",
+        MagicMock(side_effect=RuntimeError("gdalbuildvrt died mid-attempt")),
+    )
+
+    with pytest.raises(RuntimeError):
+        await regenerate_vrt.func(
+            job_id=vrt_db_state["job_id"],
+            attempt_id=vrt_db_state["attempt_id"],
+            vrt_dataset_id=vrt_id,
+            generation_id=str(generation_id),
+        )
+
+    assert await _linked_source_ids(session, vrt_id) == original_ids
+
+    vrt_asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    await session.refresh(vrt_asset)
+    assert vrt_asset.status == "failed"
+    assert vrt_asset.current_generation_id is None
+    # Nothing was published, so nothing claims the added member.
+    assert vrt_asset.built_from is None
+
+    generation = (
+        await session.execute(
+            select(VrtGeneration).where(VrtGeneration.id == generation_id)
+        )
+    ).scalar_one()
+    await session.refresh(generation)
+    assert generation.status == "failed"
+    # The intent survives for diagnosis; only a task owning the asset pointer
+    # could apply it, and this one no longer does.
+    assert generation.staged_source_ids == [str(sid) for sid in staged]
+
+
+async def test_staged_source_deleted_mid_flight_fails_the_run_cleanly(
+    test_db_session,
+    vrt_db_state: dict,
+    source_tifs: dict,
+    tmp_path: Path,
+    local_storage,
+    quicklook_stub,
+    clean_tables,
+):
+    """Set drift in the other direction: a staged member disappears.
+
+    A LIVE link pins its source (ON DELETE RESTRICT); a staged id does not,
+    so the stage->apply window is the one place a member can vanish. The run
+    must fail whole rather than publish a mosaic missing a member it claims.
+    """
+    from app.modules.catalog.datasets.domain.models import Record
+    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.raster.models import RasterAsset
+
+    session = test_db_session
+    vrt_id = vrt_db_state["vrt_dataset_id"]
+    original_ids = list(vrt_db_state["source_dataset_ids"])
+
+    added_id = await _add_extra_source(
+        session, _clone_source_tif(source_tifs, tmp_path, "src-3")
+    )
+    staged = [*original_ids, added_id]
+    generation_id = await _stage_generation(session, vrt_db_state, staged)
+
+    # The staged source goes away before the attempt runs.
+    await session.execute(
+        text(
+            "DELETE FROM catalog.records WHERE id = "
+            "(SELECT record_id FROM catalog.datasets WHERE id = :id)"
+        ),
+        {"id": str(added_id)},
+    )
+    await session.commit()
+    assert (
+        await session.execute(select(Record).where(Record.id == added_id))
+    ).scalar_one_or_none() is None
+
+    with pytest.raises(ValueError, match="no longer available"):
+        await regenerate_vrt.func(
+            job_id=vrt_db_state["job_id"],
+            attempt_id=vrt_db_state["attempt_id"],
+            vrt_dataset_id=vrt_id,
+            generation_id=str(generation_id),
+        )
+
+    assert await _linked_source_ids(session, vrt_id) == original_ids
+    vrt_asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    await session.refresh(vrt_asset)
+    assert vrt_asset.status == "failed"
+
+
+async def test_null_staged_set_builds_from_live_links_and_applies_nothing(
+    test_db_session,
+    vrt_db_state: dict,
+    source_tifs: dict,
+    tmp_path: Path,
+    local_storage,
+    quicklook_stub,
+    clean_tables,
+):
+    """Backfill semantics: a generation that stages nothing changes nothing.
+
+    A plain regenerate, and every generation queued before the column existed,
+    take this path — build from the live links, apply no link change — with an
+    unlinked raster sitting right there to prove the build did not wander.
+    """
+    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+
+    session = test_db_session
+    vrt_id = vrt_db_state["vrt_dataset_id"]
+    original_ids = list(vrt_db_state["source_dataset_ids"])
+
+    unlinked_id = await _add_extra_source(
+        session, _clone_source_tif(source_tifs, tmp_path, "src-3")
+    )
+
+    generation = VrtGeneration(
+        vrt_dataset_id=uuid.UUID(vrt_id),
+        status="pending",
+        started_at=datetime.now(timezone.utc),
+        source_count=len(original_ids),
+        triggered_by="test",
+    )
+    session.add(generation)
+    await session.flush()
+    asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    asset.current_generation_id = generation.id
+    await session.commit()
+    generation_id = generation.id
+
+    await regenerate_vrt.func(
+        job_id=vrt_db_state["job_id"],
+        attempt_id=vrt_db_state["attempt_id"],
+        vrt_dataset_id=vrt_id,
+        generation_id=str(generation_id),
+    )
+
+    assert await _linked_source_ids(session, vrt_id) == original_ids
+    await session.refresh(asset)
+    assert asset.status == "ready"
+    assert set(asset.built_from) == {str(sid) for sid in original_ids}
+    assert str(unlinked_id) not in asset.built_from
+
+
+async def test_applying_a_staged_set_is_idempotent(test_db_session, vrt_db_state: dict):
+    """Re-applying the same set is a no-op — what makes a retry safe.
+
+    Also pins the reason apply is an upsert rather than a delete-and-insert:
+    a member that survives the change keeps its ``created_at``, so "linked
+    since" is not reset by an unrelated add or removal.
+    """
+    from app.processing.ingest.tasks_vrt import apply_staged_source_links
+    from app.processing.raster.models import VrtSourceLink
+
+    session = test_db_session
+    vrt_id = uuid.UUID(vrt_db_state["vrt_dataset_id"])
+    kept_id, dropped_id = vrt_db_state["source_dataset_ids"]
+    added_id = await _add_extra_source(session, "rasters/src-1/source.cog.tif")
+    staged = [added_id, kept_id]
+
+    async def _rows():
+        result = await session.execute(
+            select(VrtSourceLink)
+            .where(VrtSourceLink.vrt_dataset_id == vrt_id)
+            .order_by(VrtSourceLink.position)
+        )
+        return list(result.scalars().all())
+
+    before = {row.source_dataset_id: row.created_at for row in await _rows()}
+
+    await apply_staged_source_links(session, vrt_id, staged)
+    await session.commit()
+    first = await _rows()
+    assert [row.source_dataset_id for row in first] == staged
+    assert [row.position for row in first] == [0, 1]
+    assert dropped_id not in {row.source_dataset_id for row in first}
+    kept_row = next(row for row in first if row.source_dataset_id == kept_id)
+    assert kept_row.created_at == before[kept_id], (
+        "a surviving member must keep its link identity across an apply"
+    )
+
+    await apply_staged_source_links(session, vrt_id, staged)
+    await session.commit()
+    second = await _rows()
+    assert [(row.id, row.source_dataset_id, row.position) for row in second] == [
+        (row.id, row.source_dataset_id, row.position) for row in first
+    ]

--- a/backend/tests/test_regenerate_vrt_integration.py
+++ b/backend/tests/test_regenerate_vrt_integration.py
@@ -579,8 +579,12 @@ async def test_staged_set_lands_with_the_artifact_it_describes(
     STAGED members (3 sources in the stored XML, not the 2 still linked), the
     link table now equals the staged set in staged order, and built_from — the
     published statement of what the artifact holds — agrees with both.
+
+    Invoked through ``regenerate_vrt_staged``, the task name a staged mutation
+    is actually delivered under (fix(#1327 codex P1)), so this exercises the
+    production entrypoint rather than the shared body behind it.
     """
-    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.ingest.tasks import regenerate_vrt_staged
     from app.processing.raster.models import RasterAsset, VrtGeneration
 
     session = test_db_session
@@ -596,7 +600,7 @@ async def test_staged_set_lands_with_the_artifact_it_describes(
     # Pre-state: the catalog still describes the VRT actually being served.
     assert await _linked_source_ids(session, vrt_id) == original_ids
 
-    await regenerate_vrt.func(
+    await regenerate_vrt_staged.func(
         job_id=vrt_db_state["job_id"],
         attempt_id=vrt_db_state["attempt_id"],
         vrt_dataset_id=vrt_id,

--- a/backend/tests/test_vrt_delete_guard_174.py
+++ b/backend/tests/test_vrt_delete_guard_174.py
@@ -4,7 +4,10 @@ Covers:
 - TestDeleteGuard: DELETE /datasets/{id} returns 409 when COG referenced by VRTs
 - TestVrtDeletion: Deleting VRT cleans only rasters/ prefix, not originals/ or source COG storage
 
-All tests are pure unit tests -- no DB, no real files, no network.
+Pure unit tests -- no DB, no real files, no network -- with two exceptions
+added by fix(#1327): the guard now also refuses to delete a source a
+still-in-flight VRT generation has STAGED (it has no link row yet), and that
+branch is SQL a mocked session cannot exercise.
 """
 
 import uuid
@@ -153,6 +156,99 @@ class TestDeleteGuard:
         assert "Mosaic A" in returned_titles
         assert "Mosaic B" in returned_titles
         assert "Mosaic C" in returned_titles
+
+    async def test_delete_cog_staged_by_an_in_flight_generation_raises_error(
+        self, test_db_session
+    ):
+        """fix(#1327): a staged member is still a dependency.
+
+        Database-backed on purpose. add_vrt_source no longer writes a
+        vrt_source_links row up front, so a source can be a declared member of
+        an in-flight VRT generation with no link row to find it by — and the
+        link half of this guard alone would have let it be deleted out from
+        under the attempt, weakening a guarantee this repo already made. The
+        guard's second branch reads the staged set, and only real SQL can show
+        it does.
+        """
+        from datetime import datetime, timezone
+
+        from app.modules.catalog.datasets.domain.service import delete_dataset
+        from app.processing.raster.models import VrtGeneration
+        from tests.factories import create_dataset, get_user_id
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await create_dataset(test_db_session, created_by=admin_id)
+        vrt = await create_dataset(test_db_session, created_by=admin_id)
+        vrt.record.record_type = "vrt_dataset"
+        source.record.record_type = "raster_dataset"
+        test_db_session.add(
+            VrtGeneration(
+                vrt_dataset_id=vrt.id,
+                status="pending",
+                started_at=datetime.now(timezone.utc),
+                source_count=1,
+                staged_source_ids=[str(source.id)],
+            )
+        )
+        await test_db_session.commit()
+
+        with pytest.raises(DependentVrtError) as exc_info:
+            await delete_dataset(test_db_session, source.id, source.record.title)
+
+        assert exc_info.value.dependents[0]["vrt_dataset_id"] == str(vrt.id)
+
+    async def test_delete_cog_staged_by_a_finished_generation_proceeds(
+        self, test_db_session
+    ):
+        """The mirror: a terminal generation's staged set is not a dependency.
+
+        It will never be applied — its attempt is over — so treating it as a
+        live reference would make every past add or remove a permanent block on
+        deleting a source that is not a member of anything.
+
+        The live generation beside it stages nothing and is the #1322 shape
+        that has to be survivable rather than merely absent: an explicitly
+        assigned None lands in JSONB as the scalar `null`, which a membership
+        test written as an array expansion would raise on. Containment answers
+        false, so the delete proceeds instead of 500-ing.
+        """
+        from datetime import datetime, timezone
+
+        from app.modules.catalog.datasets.domain.service import delete_dataset
+        from app.processing.raster.models import VrtGeneration
+        from tests.factories import create_dataset, get_user_id
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        source = await create_dataset(test_db_session, created_by=admin_id)
+        vrt = await create_dataset(test_db_session, created_by=admin_id)
+        vrt.record.record_type = "vrt_dataset"
+        source.record.record_type = "raster_dataset"
+        test_db_session.add(
+            VrtGeneration(
+                vrt_dataset_id=vrt.id,
+                status="failed",
+                started_at=datetime.now(timezone.utc),
+                source_count=1,
+                staged_source_ids=[str(source.id)],
+            )
+        )
+        test_db_session.add(
+            VrtGeneration(
+                vrt_dataset_id=vrt.id,
+                status="running",
+                started_at=datetime.now(timezone.utc),
+                source_count=2,
+                staged_source_ids=None,
+            )
+        )
+        await test_db_session.commit()
+
+        mock_storage = AsyncMock()
+        mock_storage.list = AsyncMock(return_value=[])
+        with patch(
+            "app.platform.storage.provider.get_storage", return_value=mock_storage
+        ):
+            await delete_dataset(test_db_session, source.id, source.record.title)
 
     def test_router_returns_409_for_dependent_vrt_error(self):
         """Router converts DependentVrtError to HTTP 409 with dependent VRT details."""

--- a/backend/tests/test_vrt_source_authz_1172.py
+++ b/backend/tests/test_vrt_source_authz_1172.py
@@ -201,7 +201,7 @@ def _patch_defer():
     regen_task.defer_async = AsyncMock(return_value=None)
     return (
         patch("app.processing.ingest.tasks.ingest_vrt", create_task),
-        patch("app.processing.ingest.router.regenerate_vrt", regen_task),
+        patch("app.processing.ingest.router.regenerate_vrt_staged", regen_task),
     )
 
 

--- a/backend/tests/test_vrt_source_management_174.py
+++ b/backend/tests/test_vrt_source_management_174.py
@@ -6,8 +6,13 @@ Covers:
 - TestMutationSerialization: 409 when VRT is regenerating (SRC-05)
 - TestRegenerateVrtTask: regenerate_vrt task logic (build, swap, metadata update, error handling)
 - TestStatusField: GET /datasets/{id} response includes raster.status (SRC-06)
+- TestStagedMutationOverHttp: fix(#1327) — the staged member set survives the
+  full request path, and vrt_source_links does not move
 
-All tests are pure unit tests -- no DB, no real files, no network.
+Pure unit tests -- no DB, no real files, no network -- except the last class,
+which is database-backed on purpose: the staged set is a JSONB column written
+by a real session, and a mocked db cannot show that a request wrote one column
+and left a table alone.
 """
 
 import asyncio
@@ -77,6 +82,24 @@ def _make_mock_asset(
     asset.epsg = epsg
     asset.dataset_id = uuid.uuid4()
     return asset
+
+
+def _added_generation(mock_db: AsyncMock):
+    """The single VrtGeneration the endpoint under test handed to ``db.add``.
+
+    fix(#1327): the staged member set is the endpoint's whole output now, and
+    it lives on that row — these doubles never reach a database, so the object
+    passed to ``db.add`` is the only place to read it back from.
+    """
+    from app.processing.raster.models import VrtGeneration
+
+    added = [
+        call.args[0]
+        for call in mock_db.add.call_args_list
+        if isinstance(call.args[0], VrtGeneration)
+    ]
+    assert len(added) == 1, f"expected exactly one VrtGeneration, got {len(added)}"
+    return added[0]
 
 
 def _make_mock_source_asset(band_count: int = 1, epsg: int = 4326) -> MagicMock:
@@ -289,6 +312,18 @@ class TestAddSource:
                     await add_vrt_source(dataset_id, mock_request, mock_user, mock_db)
 
             assert exc_info.value.status_code == 422
+            # fix(#1327): a rejected request stages nothing. Validation still
+            # runs synchronously and still runs BEFORE the generation exists,
+            # so an incompatible source leaves no intent behind for a task to
+            # pick up later.
+            from app.processing.raster.models import VrtGeneration
+
+            assert not [
+                call
+                for call in mock_db.add.call_args_list
+                if isinstance(call.args[0], VrtGeneration)
+            ]
+            mock_db.commit.assert_not_awaited()
 
         asyncio.run(_check())
 
@@ -307,7 +342,7 @@ class TestAddSource:
             dataset_id = uuid.uuid4()
 
             mock_asset = _make_mock_asset(status="ready")
-            mock_db, expected_job_id, mock_create_ingest_job = (
+            mock_db, expected_job_id, mock_create_ingest_job, _existing = (
                 _build_mock_db_success_add(mock_asset, dataset_id)
             )
             monkeypatch.setattr(
@@ -325,6 +360,111 @@ class TestAddSource:
 
             assert result.job_id == expected_job_id
             assert result.status == "accepted"
+
+        asyncio.run(_check())
+
+    def test_stages_post_add_set_and_leaves_links_untouched(self, monkeypatch):
+        """fix(#1327): the addition is STAGED on the generation, not applied.
+
+        The endpoint issues no write against vrt_source_links, and the
+        generation it creates carries the full post-add member set with the new
+        source last — the position the MAX(position)+1 INSERT used to give it.
+        """
+
+        async def _check():
+            from app.processing.ingest.router import add_vrt_source
+            import app.processing.ingest.router as ingest_router
+
+            source_id = uuid.uuid4()
+            mock_request = MagicMock()
+            mock_request.source_dataset_id = source_id
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+            dataset_id = uuid.uuid4()
+
+            mock_asset = _make_mock_asset(status="ready")
+            mock_db, _job_id, mock_create_ingest_job, existing_ids = (
+                _build_mock_db_success_add(mock_asset, dataset_id)
+            )
+            monkeypatch.setattr(
+                ingest_router, "create_ingest_job", mock_create_ingest_job
+            )
+
+            with (
+                patch("app.processing.ingest.router.validate_sources", return_value=[]),
+                patch("app.processing.ingest.router.regenerate_vrt") as mock_task,
+            ):
+                mock_task.defer_async = AsyncMock()
+                await add_vrt_source(dataset_id, mock_request, mock_user, mock_db)
+
+            statements = "\n".join(
+                str(call.args[0]) for call in mock_db.execute.await_args_list
+            )
+            assert "INSERT INTO catalog.vrt_source_links" not in statements
+            assert "DELETE FROM catalog.vrt_source_links" not in statements
+
+            generation = _added_generation(mock_db)
+            assert generation.staged_source_ids == [
+                *[str(sid) for sid in existing_ids],
+                str(source_id),
+            ]
+            assert generation.source_count == len(existing_ids) + 1
+            assert mock_asset.status == "regenerating"
+
+        asyncio.run(_check())
+
+    def test_rollback_on_defer_failure_leaves_links_untouched(self, monkeypatch):
+        """fix(#1327): the orphan-guard rollback no longer deletes a link row.
+
+        There is nothing to compensate — the add was never applied — so the
+        rollback restores only the asset state it flipped.
+        """
+
+        async def _check():
+            from fastapi import HTTPException
+
+            from app.processing.ingest.router import add_vrt_source
+            import app.processing.ingest.router as ingest_router
+
+            source_id = uuid.uuid4()
+            mock_request = MagicMock()
+            mock_request.source_dataset_id = source_id
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+            dataset_id = uuid.uuid4()
+
+            mock_asset = _make_mock_asset(status="ready")
+            mock_asset.current_generation_id = None
+            mock_db, _job_id, mock_create_ingest_job, _existing = (
+                _build_mock_db_success_add(mock_asset, dataset_id)
+            )
+            monkeypatch.setattr(
+                ingest_router, "create_ingest_job", mock_create_ingest_job
+            )
+
+            with (
+                patch("app.processing.ingest.router.validate_sources", return_value=[]),
+                patch(
+                    "app.processing.ingest.router.defer_async_with_tenant",
+                    new=AsyncMock(side_effect=RuntimeError("procrastinate down")),
+                ),
+            ):
+                with pytest.raises(HTTPException) as exc_info:
+                    await add_vrt_source(dataset_id, mock_request, mock_user, mock_db)
+
+            assert exc_info.value.status_code == 503
+            statements = "\n".join(
+                str(call.args[0]) for call in mock_db.execute.await_args_list
+            )
+            assert "DELETE FROM catalog.vrt_source_links" not in statements
+            assert "INSERT INTO catalog.vrt_source_links" not in statements
+            assert mock_asset.status == "ready"
+            assert mock_asset.current_generation_id is None
+            generation = _added_generation(mock_db)
+            assert generation.status == "failed"
+            # The intent survives on the failed row; only a task that owns the
+            # asset pointer could ever apply it, and this rollback gave it back.
+            assert generation.staged_source_ids is not None
 
         asyncio.run(_check())
 
@@ -447,8 +587,13 @@ class TestRemoveSource:
             mock_user.id = uuid.uuid4()
 
             mock_asset = _make_mock_asset(status="ready")
-            mock_db, expected_job_id, mock_create_ingest_job = (
-                _build_mock_db_success_remove(mock_asset, dataset_id, source_count=3)
+            mock_db, expected_job_id, mock_create_ingest_job, _remaining = (
+                _build_mock_db_success_remove(
+                    mock_asset,
+                    dataset_id,
+                    source_count=3,
+                    source_dataset_id=source_dataset_id,
+                )
             )
             monkeypatch.setattr(
                 ingest_router, "create_ingest_job", mock_create_ingest_job
@@ -462,6 +607,110 @@ class TestRemoveSource:
 
             assert result.job_id == expected_job_id
             assert result.status == "accepted"
+
+        asyncio.run(_check())
+
+    def test_stages_post_removal_set_and_leaves_links_untouched(self, monkeypatch):
+        """fix(#1327): the removal is STAGED on the generation, not applied.
+
+        Two properties in one place, because they are the same property: the
+        endpoint issues no write against vrt_source_links, and the generation
+        it creates carries the full post-removal member set in position order.
+        """
+
+        async def _check():
+            from app.processing.ingest.router import remove_vrt_source
+            import app.processing.ingest.router as ingest_router
+
+            dataset_id = uuid.uuid4()
+            source_dataset_id = uuid.uuid4()
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+
+            mock_asset = _make_mock_asset(status="ready")
+            mock_db, _job_id, mock_create_ingest_job, remaining_ids = (
+                _build_mock_db_success_remove(
+                    mock_asset,
+                    dataset_id,
+                    source_count=3,
+                    source_dataset_id=source_dataset_id,
+                )
+            )
+            monkeypatch.setattr(
+                ingest_router, "create_ingest_job", mock_create_ingest_job
+            )
+
+            with patch("app.processing.ingest.router.regenerate_vrt") as mock_task:
+                mock_task.defer_async = AsyncMock()
+                await remove_vrt_source(
+                    dataset_id, source_dataset_id, mock_user, mock_db
+                )
+
+            statements = "\n".join(
+                str(call.args[0]) for call in mock_db.execute.await_args_list
+            )
+            assert "DELETE FROM catalog.vrt_source_links" not in statements
+            assert "INSERT INTO catalog.vrt_source_links" not in statements
+
+            generation = _added_generation(mock_db)
+            assert generation.staged_source_ids == [str(sid) for sid in remaining_ids]
+            assert generation.source_count == len(remaining_ids)
+
+        asyncio.run(_check())
+
+    def test_rollback_on_defer_failure_leaves_links_untouched(self, monkeypatch):
+        """fix(#1327): the orphan-guard rollback has no link surgery left to do.
+
+        It used to re-INSERT the row it had just deleted. Nothing was deleted,
+        so the compensation is gone — and the asset state it DOES restore is
+        still restored.
+        """
+
+        async def _check():
+            from fastapi import HTTPException
+
+            from app.processing.ingest.router import remove_vrt_source
+            import app.processing.ingest.router as ingest_router
+
+            dataset_id = uuid.uuid4()
+            source_dataset_id = uuid.uuid4()
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+
+            mock_asset = _make_mock_asset(status="ready")
+            mock_asset.current_generation_id = None
+            mock_db, _job_id, mock_create_ingest_job, _remaining = (
+                _build_mock_db_success_remove(
+                    mock_asset,
+                    dataset_id,
+                    source_count=3,
+                    source_dataset_id=source_dataset_id,
+                )
+            )
+            monkeypatch.setattr(
+                ingest_router, "create_ingest_job", mock_create_ingest_job
+            )
+
+            with patch(
+                "app.processing.ingest.router.defer_async_with_tenant",
+                new=AsyncMock(side_effect=RuntimeError("procrastinate down")),
+            ):
+                with pytest.raises(HTTPException) as exc_info:
+                    await remove_vrt_source(
+                        dataset_id, source_dataset_id, mock_user, mock_db
+                    )
+
+            assert exc_info.value.status_code == 503
+            statements = "\n".join(
+                str(call.args[0]) for call in mock_db.execute.await_args_list
+            )
+            assert "vrt_source_links" not in statements.replace(
+                "SELECT source_dataset_id FROM catalog.vrt_source_links", ""
+            )
+            assert mock_asset.status == "ready"
+            assert mock_asset.current_generation_id is None
+            generation = _added_generation(mock_db)
+            assert generation.status == "failed"
 
         asyncio.run(_check())
 
@@ -531,7 +780,7 @@ class TestMutationSerialization:
             dataset_id = uuid.uuid4()
 
             mock_asset = _make_mock_asset(status="ready")
-            mock_db, _, mock_create_ingest_job = _build_mock_db_success_add(
+            mock_db, _, mock_create_ingest_job, _existing = _build_mock_db_success_add(
                 mock_asset, dataset_id
             )
             monkeypatch.setattr(
@@ -1156,6 +1405,199 @@ class TestStatusField:
 
 
 # ---------------------------------------------------------------------------
+# TestStagedSourceSetReading — fix(#1327)
+# ---------------------------------------------------------------------------
+
+
+class TestStagedSourceSetReading:
+    """What the task accepts as a staged member set, and what it refuses."""
+
+    def test_absent_and_json_null_both_mean_no_membership_change(self):
+        """The NULL fallback has to survive both shapes the column can hold.
+
+        A column never written reads back None; one written from an explicitly
+        assigned Python None holds the JSON scalar `null` and ALSO reads back
+        None (measured against Postgres — the #1322 trap). Neither is a member
+        set, and both must mean "build from the live links, apply nothing"
+        rather than an error.
+        """
+        from app.processing.ingest.tasks_vrt import staged_source_ids_or_none
+
+        assert staged_source_ids_or_none(MagicMock(staged_source_ids=None)) is None
+        # A JSONB scalar that is not an array cannot be a member set either.
+        assert staged_source_ids_or_none(MagicMock(staged_source_ids="null")) is None
+        assert staged_source_ids_or_none(MagicMock(staged_source_ids={})) is None
+
+    def test_returns_uuids_in_staged_order(self):
+        from app.processing.ingest.tasks_vrt import staged_source_ids_or_none
+
+        staged = [uuid.uuid4() for _ in range(3)]
+        generation = MagicMock(staged_source_ids=[str(sid) for sid in staged])
+        assert staged_source_ids_or_none(generation) == staged
+
+    def test_rejects_an_empty_set(self):
+        """A VRT with no members is not a publishable intent."""
+        from app.processing.ingest.tasks_vrt import staged_source_ids_or_none
+
+        with pytest.raises(ValueError, match="empty"):
+            staged_source_ids_or_none(MagicMock(staged_source_ids=[]))
+
+    def test_rejects_a_repeated_member(self):
+        """Caught here, before the build, rather than as an ON CONFLICT error
+        from the apply after a GDAL run has already been paid for."""
+        from app.processing.ingest.tasks_vrt import staged_source_ids_or_none
+
+        repeated = str(uuid.uuid4())
+        with pytest.raises(ValueError, match="repeats"):
+            staged_source_ids_or_none(
+                MagicMock(staged_source_ids=[repeated, str(uuid.uuid4()), repeated])
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestStagedMutationOverHttp — fix(#1327), database-backed
+# ---------------------------------------------------------------------------
+
+
+async def _vrt_link_ids(session, vrt_id) -> list[uuid.UUID]:
+    from sqlalchemy import text
+
+    result = await session.execute(
+        text(
+            "SELECT source_dataset_id FROM catalog.vrt_source_links "
+            "WHERE vrt_dataset_id = :id ORDER BY position ASC"
+        ),
+        {"id": str(vrt_id)},
+    )
+    return [row.source_dataset_id for row in result.fetchall()]
+
+
+async def _only_generation(session, vrt_id):
+    from sqlalchemy import select as sa_select
+
+    from app.processing.raster.models import VrtGeneration
+
+    result = await session.execute(
+        sa_select(VrtGeneration).where(VrtGeneration.vrt_dataset_id == vrt_id)
+    )
+    return result.scalar_one()
+
+
+class TestStagedMutationOverHttp:
+    """The full request path: what the endpoint writes, and what it leaves."""
+
+    async def test_add_source_stages_the_set_and_leaves_links_alone(
+        self, client, admin_auth_header, test_db_session
+    ):
+        from tests.test_vrt_source_authz_1172 import (
+            _create_raster_dataset,
+            _create_vrt_dataset,
+            _get_admin_id,
+            _link_source,
+            _patch_defer,
+        )
+
+        admin_id = await _get_admin_id(test_db_session)
+        vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+        first = await _create_raster_dataset(test_db_session, created_by=admin_id)
+        second = await _create_raster_dataset(test_db_session, created_by=admin_id)
+        incoming = await _create_raster_dataset(test_db_session, created_by=admin_id)
+        await _link_source(test_db_session, vrt_id, first, 0)
+        await _link_source(test_db_session, vrt_id, second, 1)
+
+        p_create, p_regen = _patch_defer()
+        with p_create, p_regen:
+            resp = await client.post(
+                f"/ingest/vrt/{vrt_id}/sources/",
+                json={"source_dataset_id": str(incoming)},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 202, resp.text
+        assert await _vrt_link_ids(test_db_session, vrt_id) == [first, second]
+        generation = await _only_generation(test_db_session, vrt_id)
+        assert generation.staged_source_ids == [
+            str(first),
+            str(second),
+            str(incoming),
+        ]
+        assert generation.status == "pending"
+
+    async def test_remove_source_stages_the_set_and_leaves_links_alone(
+        self, client, admin_auth_header, test_db_session
+    ):
+        from tests.test_vrt_source_authz_1172 import (
+            _create_raster_dataset,
+            _create_vrt_dataset,
+            _get_admin_id,
+            _link_source,
+            _patch_defer,
+        )
+
+        admin_id = await _get_admin_id(test_db_session)
+        vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+        linked = [
+            await _create_raster_dataset(test_db_session, created_by=admin_id)
+            for _ in range(3)
+        ]
+        for position, source_id in enumerate(linked):
+            await _link_source(test_db_session, vrt_id, source_id, position)
+
+        p_create, p_regen = _patch_defer()
+        with p_create, p_regen:
+            resp = await client.delete(
+                f"/ingest/vrt/{vrt_id}/sources/{linked[1]}/",
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 202, resp.text
+        assert await _vrt_link_ids(test_db_session, vrt_id) == linked
+        generation = await _only_generation(test_db_session, vrt_id)
+        assert generation.staged_source_ids == [str(linked[0]), str(linked[2])]
+
+    async def test_remove_source_404s_without_staging_anything(
+        self, client, admin_auth_header, test_db_session
+    ):
+        """A rejected request leaves no intent behind — the 404 path included."""
+        from sqlalchemy import func, select as sa_select
+
+        from app.processing.raster.models import VrtGeneration
+        from tests.test_vrt_source_authz_1172 import (
+            _create_raster_dataset,
+            _create_vrt_dataset,
+            _get_admin_id,
+            _link_source,
+            _patch_defer,
+        )
+
+        admin_id = await _get_admin_id(test_db_session)
+        vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+        linked = [
+            await _create_raster_dataset(test_db_session, created_by=admin_id)
+            for _ in range(3)
+        ]
+        for position, source_id in enumerate(linked):
+            await _link_source(test_db_session, vrt_id, source_id, position)
+        stranger = await _create_raster_dataset(test_db_session, created_by=admin_id)
+
+        p_create, p_regen = _patch_defer()
+        with p_create, p_regen:
+            resp = await client.delete(
+                f"/ingest/vrt/{vrt_id}/sources/{stranger}/",
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 404, resp.text
+        assert await _vrt_link_ids(test_db_session, vrt_id) == linked
+        generations = await test_db_session.execute(
+            sa_select(func.count())
+            .select_from(VrtGeneration)
+            .where(VrtGeneration.vrt_dataset_id == vrt_id)
+        )
+        assert generations.scalar() == 0
+
+
+# ---------------------------------------------------------------------------
 # Mock DB helpers
 # ---------------------------------------------------------------------------
 # These build the AsyncMock db objects needed by endpoint tests.
@@ -1264,16 +1706,21 @@ def _build_mock_db_for_validation_failure(mock_asset: MagicMock) -> AsyncMock:
     return mock_db
 
 
-def _build_mock_db_success_add(mock_asset: MagicMock, dataset_id: uuid.UUID):
+def _build_mock_db_success_add(
+    mock_asset: MagicMock, dataset_id: uuid.UUID, existing_count: int = 2
+):
     """DB: Full success path for add_vrt_source.
 
-    Returns (mock_db, expected_job_id, mock_create_ingest_job).
+    Returns (mock_db, expected_job_id, mock_create_ingest_job, existing_ids) —
+    ``existing_ids`` in position order, so a caller can assert the staged set
+    is exactly those plus the new source (fix(#1327)).
     """
     mock_db = AsyncMock()
     call_count = [0]
 
     source_asset = _make_mock_source_asset()
-    existing_source = _make_mock_source_asset()
+    existing_assets = [_make_mock_source_asset() for _ in range(existing_count)]
+    existing_ids = [asset.dataset_id for asset in existing_assets]
     job_id = uuid.uuid4()
 
     mock_job = MagicMock()
@@ -1294,16 +1741,16 @@ def _build_mock_db_success_add(mock_asset: MagicMock, dataset_id: uuid.UUID):
             # Duplicate check -- not found
             result_mock.fetchone.return_value = None
         elif n == 4:
-            # Existing source links
+            # Existing source links, in position order
             result_mock.fetchall.return_value = [
-                MagicMock(source_dataset_id=uuid.uuid4())
+                MagicMock(source_dataset_id=source_id) for source_id in existing_ids
             ]
         elif n == 5:
             # Load existing source assets
-            result_mock.scalars.return_value.all.return_value = [existing_source]
-        elif n == 6:
-            # Max position query
-            result_mock.scalar.return_value = 0
+            result_mock.scalars.return_value.all.return_value = existing_assets
+        # fix(#1327): there is no 6th query. The MAX(position) lookup and the
+        # link INSERT that followed it are gone — order in the staged set is
+        # the position.
         return result_mock
 
     mock_db.execute = AsyncMock(side_effect=execute_side_effect)
@@ -1312,15 +1759,27 @@ def _build_mock_db_success_add(mock_asset: MagicMock, dataset_id: uuid.UUID):
     async def mock_create_ingest_job(db, *args, **kwargs):
         return mock_job
 
-    return mock_db, job_id, mock_create_ingest_job
+    return mock_db, job_id, mock_create_ingest_job, existing_ids
+
+
+def _link_rows(source_ids: list[uuid.UUID]) -> list[MagicMock]:
+    """Rows as the ordered vrt_source_links SELECT returns them.
+
+    fix(#1327): remove_vrt_source reads the member set ONCE, in position order,
+    and answers the count guard, the "is it linked" guard and the staged
+    post-removal set from that single read — so these doubles supply link rows
+    where they used to supply a COUNT(*) scalar and a separate position row.
+    """
+    return [MagicMock(source_dataset_id=sid) for sid in source_ids]
 
 
 def _build_mock_db_remove_min_guard(
     mock_asset: MagicMock, source_count: int
 ) -> AsyncMock:
-    """DB: VRT found (ready), source count check returns <= 2."""
+    """DB: VRT found (ready), member set has <= 2 sources."""
     mock_db = AsyncMock()
     call_count = [0]
+    rows = _link_rows([uuid.uuid4() for _ in range(source_count)])
 
     def execute_side_effect(query, params=None):
         call_count[0] += 1
@@ -1329,8 +1788,7 @@ def _build_mock_db_remove_min_guard(
         if n == 1:
             result_mock.scalar_one_or_none.return_value = mock_asset
         elif n == 2:
-            # Source count
-            result_mock.scalar.return_value = source_count
+            result_mock.fetchall.return_value = rows
         return result_mock
 
     mock_db.execute = AsyncMock(side_effect=execute_side_effect)
@@ -1341,9 +1799,10 @@ def _build_mock_db_remove_min_guard(
 def _build_mock_db_remove_source_not_linked(
     mock_asset: MagicMock, source_count: int
 ) -> AsyncMock:
-    """DB: VRT found, source count > 2, but source link not found."""
+    """DB: VRT found with > 2 sources, none of them the requested one."""
     mock_db = AsyncMock()
     call_count = [0]
+    rows = _link_rows([uuid.uuid4() for _ in range(source_count)])
 
     def execute_side_effect(query, params=None):
         call_count[0] += 1
@@ -1352,11 +1811,7 @@ def _build_mock_db_remove_source_not_linked(
         if n == 1:
             result_mock.scalar_one_or_none.return_value = mock_asset
         elif n == 2:
-            # Source count: > 2
-            result_mock.scalar.return_value = source_count
-        elif n == 3:
-            # Link existence check -- not found
-            result_mock.fetchone.return_value = None
+            result_mock.fetchall.return_value = rows
         return result_mock
 
     mock_db.execute = AsyncMock(side_effect=execute_side_effect)
@@ -1365,11 +1820,17 @@ def _build_mock_db_remove_source_not_linked(
 
 
 def _build_mock_db_success_remove(
-    mock_asset: MagicMock, dataset_id: uuid.UUID, source_count: int
+    mock_asset: MagicMock,
+    dataset_id: uuid.UUID,
+    source_count: int,
+    source_dataset_id: uuid.UUID,
 ):
     """DB: Full success path for remove_vrt_source.
 
-    Returns (mock_db, expected_job_id, mock_create_ingest_job).
+    ``source_dataset_id`` is the member being removed and IS present in the
+    link rows the ordered read returns — otherwise the endpoint 404s.
+
+    Returns (mock_db, expected_job_id, mock_create_ingest_job, remaining_ids).
     """
     mock_db = AsyncMock()
     call_count = [0]
@@ -1379,6 +1840,11 @@ def _build_mock_db_success_remove(
     mock_job.id = job_id
     mock_job.dataset_id = None
 
+    remaining_ids = [uuid.uuid4() for _ in range(source_count - 1)]
+    # Removed member sits in the middle so the staged set proves order is kept.
+    linked_ids = [remaining_ids[0], source_dataset_id, *remaining_ids[1:]]
+    rows = _link_rows(linked_ids)
+
     def execute_side_effect(query, params=None):
         call_count[0] += 1
         result_mock = MagicMock()
@@ -1386,12 +1852,7 @@ def _build_mock_db_success_remove(
         if n == 1:
             result_mock.scalar_one_or_none.return_value = mock_asset
         elif n == 2:
-            # Source count: > 2
-            result_mock.scalar.return_value = source_count
-        elif n == 3:
-            # Link existence check -- found
-            result_mock.fetchone.return_value = MagicMock()
-        # n == 4: DELETE (no return needed)
+            result_mock.fetchall.return_value = rows
         return result_mock
 
     mock_db.execute = AsyncMock(side_effect=execute_side_effect)
@@ -1400,7 +1861,7 @@ def _build_mock_db_success_remove(
     async def mock_create_ingest_job(db, *args, **kwargs):
         return mock_job
 
-    return mock_db, job_id, mock_create_ingest_job
+    return mock_db, job_id, mock_create_ingest_job, remaining_ids
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_vrt_source_management_174.py
+++ b/backend/tests/test_vrt_source_management_174.py
@@ -6,13 +6,15 @@ Covers:
 - TestMutationSerialization: 409 when VRT is regenerating (SRC-05)
 - TestRegenerateVrtTask: regenerate_vrt task logic (build, swap, metadata update, error handling)
 - TestStatusField: GET /datasets/{id} response includes raster.status (SRC-06)
-- TestStagedMutationOverHttp: fix(#1327) — the staged member set survives the
-  full request path, and vrt_source_links does not move
+- TestStagedSourceSetReading: fix(#1327) — what the task accepts as a staged
+  member set, and what it refuses
 
-Pure unit tests -- no DB, no real files, no network -- except the last class,
-which is database-backed on purpose: the staged set is a JSONB column written
-by a real session, and a mocked db cannot show that a request wrote one column
-and left a table alone.
+All tests are pure unit tests -- no DB, no real files, no network. Keep it that
+way: the autouse `_stub_vrt_source_authz` fixture below patches module-level
+names, and a DB/client-backed test here can make a router module import for the
+FIRST time while those patches are live, permanently binding the mocks into
+that module (fix(#1327 codex P1) hit exactly this and moved its HTTP coverage
+to tests/test_vrt_staged_mutation_1327.py).
 """
 
 import asyncio
@@ -351,7 +353,9 @@ class TestAddSource:
 
             with (
                 patch("app.processing.ingest.router.validate_sources", return_value=[]),
-                patch("app.processing.ingest.router.regenerate_vrt") as mock_task,
+                patch(
+                    "app.processing.ingest.router.regenerate_vrt_staged"
+                ) as mock_task,
             ):
                 mock_task.defer_async = AsyncMock()
                 result = await add_vrt_source(
@@ -392,7 +396,9 @@ class TestAddSource:
 
             with (
                 patch("app.processing.ingest.router.validate_sources", return_value=[]),
-                patch("app.processing.ingest.router.regenerate_vrt") as mock_task,
+                patch(
+                    "app.processing.ingest.router.regenerate_vrt_staged"
+                ) as mock_task,
             ):
                 mock_task.defer_async = AsyncMock()
                 await add_vrt_source(dataset_id, mock_request, mock_user, mock_db)
@@ -599,7 +605,9 @@ class TestRemoveSource:
                 ingest_router, "create_ingest_job", mock_create_ingest_job
             )
 
-            with patch("app.processing.ingest.router.regenerate_vrt") as mock_task:
+            with patch(
+                "app.processing.ingest.router.regenerate_vrt_staged"
+            ) as mock_task:
                 mock_task.defer_async = AsyncMock()
                 result = await remove_vrt_source(
                     dataset_id, source_dataset_id, mock_user, mock_db
@@ -640,7 +648,9 @@ class TestRemoveSource:
                 ingest_router, "create_ingest_job", mock_create_ingest_job
             )
 
-            with patch("app.processing.ingest.router.regenerate_vrt") as mock_task:
+            with patch(
+                "app.processing.ingest.router.regenerate_vrt_staged"
+            ) as mock_task:
                 mock_task.defer_async = AsyncMock()
                 await remove_vrt_source(
                     dataset_id, source_dataset_id, mock_user, mock_db
@@ -789,7 +799,9 @@ class TestMutationSerialization:
 
             with (
                 patch("app.processing.ingest.router.validate_sources", return_value=[]),
-                patch("app.processing.ingest.router.regenerate_vrt") as mock_task,
+                patch(
+                    "app.processing.ingest.router.regenerate_vrt_staged"
+                ) as mock_task,
             ):
                 mock_task.defer_async = AsyncMock()
                 # Should not raise 409
@@ -1452,149 +1464,6 @@ class TestStagedSourceSetReading:
             staged_source_ids_or_none(
                 MagicMock(staged_source_ids=[repeated, str(uuid.uuid4()), repeated])
             )
-
-
-# ---------------------------------------------------------------------------
-# TestStagedMutationOverHttp — fix(#1327), database-backed
-# ---------------------------------------------------------------------------
-
-
-async def _vrt_link_ids(session, vrt_id) -> list[uuid.UUID]:
-    from sqlalchemy import text
-
-    result = await session.execute(
-        text(
-            "SELECT source_dataset_id FROM catalog.vrt_source_links "
-            "WHERE vrt_dataset_id = :id ORDER BY position ASC"
-        ),
-        {"id": str(vrt_id)},
-    )
-    return [row.source_dataset_id for row in result.fetchall()]
-
-
-async def _only_generation(session, vrt_id):
-    from sqlalchemy import select as sa_select
-
-    from app.processing.raster.models import VrtGeneration
-
-    result = await session.execute(
-        sa_select(VrtGeneration).where(VrtGeneration.vrt_dataset_id == vrt_id)
-    )
-    return result.scalar_one()
-
-
-class TestStagedMutationOverHttp:
-    """The full request path: what the endpoint writes, and what it leaves."""
-
-    async def test_add_source_stages_the_set_and_leaves_links_alone(
-        self, client, admin_auth_header, test_db_session
-    ):
-        from tests.test_vrt_source_authz_1172 import (
-            _create_raster_dataset,
-            _create_vrt_dataset,
-            _get_admin_id,
-            _link_source,
-            _patch_defer,
-        )
-
-        admin_id = await _get_admin_id(test_db_session)
-        vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
-        first = await _create_raster_dataset(test_db_session, created_by=admin_id)
-        second = await _create_raster_dataset(test_db_session, created_by=admin_id)
-        incoming = await _create_raster_dataset(test_db_session, created_by=admin_id)
-        await _link_source(test_db_session, vrt_id, first, 0)
-        await _link_source(test_db_session, vrt_id, second, 1)
-
-        p_create, p_regen = _patch_defer()
-        with p_create, p_regen:
-            resp = await client.post(
-                f"/ingest/vrt/{vrt_id}/sources/",
-                json={"source_dataset_id": str(incoming)},
-                headers=admin_auth_header,
-            )
-
-        assert resp.status_code == 202, resp.text
-        assert await _vrt_link_ids(test_db_session, vrt_id) == [first, second]
-        generation = await _only_generation(test_db_session, vrt_id)
-        assert generation.staged_source_ids == [
-            str(first),
-            str(second),
-            str(incoming),
-        ]
-        assert generation.status == "pending"
-
-    async def test_remove_source_stages_the_set_and_leaves_links_alone(
-        self, client, admin_auth_header, test_db_session
-    ):
-        from tests.test_vrt_source_authz_1172 import (
-            _create_raster_dataset,
-            _create_vrt_dataset,
-            _get_admin_id,
-            _link_source,
-            _patch_defer,
-        )
-
-        admin_id = await _get_admin_id(test_db_session)
-        vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
-        linked = [
-            await _create_raster_dataset(test_db_session, created_by=admin_id)
-            for _ in range(3)
-        ]
-        for position, source_id in enumerate(linked):
-            await _link_source(test_db_session, vrt_id, source_id, position)
-
-        p_create, p_regen = _patch_defer()
-        with p_create, p_regen:
-            resp = await client.delete(
-                f"/ingest/vrt/{vrt_id}/sources/{linked[1]}/",
-                headers=admin_auth_header,
-            )
-
-        assert resp.status_code == 202, resp.text
-        assert await _vrt_link_ids(test_db_session, vrt_id) == linked
-        generation = await _only_generation(test_db_session, vrt_id)
-        assert generation.staged_source_ids == [str(linked[0]), str(linked[2])]
-
-    async def test_remove_source_404s_without_staging_anything(
-        self, client, admin_auth_header, test_db_session
-    ):
-        """A rejected request leaves no intent behind — the 404 path included."""
-        from sqlalchemy import func, select as sa_select
-
-        from app.processing.raster.models import VrtGeneration
-        from tests.test_vrt_source_authz_1172 import (
-            _create_raster_dataset,
-            _create_vrt_dataset,
-            _get_admin_id,
-            _link_source,
-            _patch_defer,
-        )
-
-        admin_id = await _get_admin_id(test_db_session)
-        vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
-        linked = [
-            await _create_raster_dataset(test_db_session, created_by=admin_id)
-            for _ in range(3)
-        ]
-        for position, source_id in enumerate(linked):
-            await _link_source(test_db_session, vrt_id, source_id, position)
-        stranger = await _create_raster_dataset(test_db_session, created_by=admin_id)
-
-        p_create, p_regen = _patch_defer()
-        with p_create, p_regen:
-            resp = await client.delete(
-                f"/ingest/vrt/{vrt_id}/sources/{stranger}/",
-                headers=admin_auth_header,
-            )
-
-        assert resp.status_code == 404, resp.text
-        assert await _vrt_link_ids(test_db_session, vrt_id) == linked
-        generations = await test_db_session.execute(
-            sa_select(func.count())
-            .select_from(VrtGeneration)
-            .where(VrtGeneration.vrt_dataset_id == vrt_id)
-        )
-        assert generations.scalar() == 0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_vrt_source_query_count.py
+++ b/backend/tests/test_vrt_source_query_count.py
@@ -153,3 +153,61 @@ async def test_list_vrt_sources_query_count_is_flat(test_db_session) -> None:
         f"query count scales with source count: {q_small} for 1 source, "
         f"{q_large} for 8 — the per-row get_dataset N+1 is back"
     )
+
+
+async def test_record_source_count_reports_the_served_member_set(
+    test_db_session,
+) -> None:
+    """fix(#1327): every surface counts the same members.
+
+    The OGC record item used to take its ``source_count`` from the in-flight
+    VrtGeneration. That was the post-mutation number back when add/remove wrote
+    the link row up front; now that the link write happens at the artifact
+    swap, reading the generation would make this the one surface claiming a
+    member set the VRT is not serving.
+    """
+    from datetime import datetime, timezone
+
+    from app.modules.catalog.search.router import _build_raster_assets
+    from app.processing.raster.models import VrtGeneration
+
+    admin = await _admin(test_db_session)
+    vrt_id = await _make_vrt_with_sources(test_db_session, created_by=admin.id, n=2)
+    pending_member = await _make_raster_source(test_db_session, created_by=admin.id)
+
+    linked_ids = [
+        row.source_dataset_id
+        for row in (
+            await test_db_session.execute(
+                text(
+                    "SELECT source_dataset_id FROM catalog.vrt_source_links "
+                    "WHERE vrt_dataset_id = :id ORDER BY position"
+                ),
+                {"id": str(vrt_id)},
+            )
+        ).fetchall()
+    ]
+    generation = VrtGeneration(
+        vrt_dataset_id=vrt_id,
+        status="running",
+        started_at=datetime.now(timezone.utc),
+        source_count=3,
+        staged_source_ids=[str(sid) for sid in [*linked_ids, pending_member]],
+    )
+    test_db_session.add(generation)
+    await test_db_session.flush()
+    await test_db_session.execute(
+        text(
+            "UPDATE catalog.raster_assets SET status = 'regenerating', "
+            "current_generation_id = :gen WHERE dataset_id = :id"
+        ),
+        {"gen": str(generation.id), "id": str(vrt_id)},
+    )
+    await test_db_session.commit()
+
+    meta = await _build_raster_assets(test_db_session, vrt_id)
+
+    assert meta is not None
+    assert meta["source_count"] == 2, (
+        "an in-flight add must not be reported as a member of the served VRT"
+    )

--- a/backend/tests/test_vrt_staged_mutation_1327.py
+++ b/backend/tests/test_vrt_staged_mutation_1327.py
@@ -1,0 +1,353 @@
+"""fix(#1327): how a staged source mutation is written, delivered, and skewed.
+
+Three things that only mean something together:
+
+1. The endpoints write the member set to `VrtGeneration.staged_source_ids` and
+   leave `vrt_source_links` alone (database-backed, over HTTP, because the
+   staged set is a JSONB column written by a real session and a mocked db
+   cannot show that a request wrote one column and left a table alone).
+2. They deliver it under the STAGED task name, while a plain regenerate keeps
+   the legacy name.
+3. That name is what makes a version skew loud. fix(#1327 codex P1): during a
+   rolling upgrade the API can be new while a worker is still pre-#1327; the
+   old worker would ignore `staged_source_ids`, rebuild from the live links and
+   report success, silently dropping an accepted add or remove. Procrastinate
+   fails a job whose task name the worker does not have, and the test below
+   measures that against the pinned version rather than assuming it.
+
+Deliberately its own module: `test_vrt_source_management_174.py` carries an
+autouse fixture that patches authorization helpers, and a client-backed test
+living there can bind those mocks permanently into a router module that imports
+for the first time mid-patch.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+from httpx import AsyncClient
+from sqlalchemy import func, select, text
+
+from app.processing.raster.models import VrtGeneration
+from tests.test_vrt_source_authz_1172 import (
+    _create_raster_dataset,
+    _create_vrt_dataset,
+    _get_admin_id,
+    _link_source,
+)
+
+
+async def _vrt_link_ids(session, vrt_id) -> list[uuid.UUID]:
+    result = await session.execute(
+        text(
+            "SELECT source_dataset_id FROM catalog.vrt_source_links "
+            "WHERE vrt_dataset_id = :id ORDER BY position ASC"
+        ),
+        {"id": str(vrt_id)},
+    )
+    return [row.source_dataset_id for row in result.fetchall()]
+
+
+async def _only_generation(session, vrt_id):
+    result = await session.execute(
+        select(VrtGeneration).where(VrtGeneration.vrt_dataset_id == vrt_id)
+    )
+    return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# What the request writes
+# ---------------------------------------------------------------------------
+
+
+async def test_add_source_stages_the_set_and_leaves_links_alone(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+):
+    deferred = _capture_defer(monkeypatch)
+
+    admin_id = await _get_admin_id(test_db_session)
+    vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+    first = await _create_raster_dataset(test_db_session, created_by=admin_id)
+    second = await _create_raster_dataset(test_db_session, created_by=admin_id)
+    incoming = await _create_raster_dataset(test_db_session, created_by=admin_id)
+    await _link_source(test_db_session, vrt_id, first, 0)
+    await _link_source(test_db_session, vrt_id, second, 1)
+
+    resp = await client.post(
+        f"/ingest/vrt/{vrt_id}/sources/",
+        json={"source_dataset_id": str(incoming)},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert await _vrt_link_ids(test_db_session, vrt_id) == [first, second]
+    generation = await _only_generation(test_db_session, vrt_id)
+    assert generation.staged_source_ids == [str(first), str(second), str(incoming)]
+    assert generation.status == "pending"
+    assert deferred[0]["task"].name.endswith("regenerate_vrt_staged")
+
+
+async def test_remove_source_stages_the_set_and_leaves_links_alone(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+):
+    deferred = _capture_defer(monkeypatch)
+
+    admin_id = await _get_admin_id(test_db_session)
+    vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+    linked = [
+        await _create_raster_dataset(test_db_session, created_by=admin_id)
+        for _ in range(3)
+    ]
+    for position, source_id in enumerate(linked):
+        await _link_source(test_db_session, vrt_id, source_id, position)
+
+    resp = await client.delete(
+        f"/ingest/vrt/{vrt_id}/sources/{linked[1]}/", headers=admin_auth_header
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert await _vrt_link_ids(test_db_session, vrt_id) == linked
+    generation = await _only_generation(test_db_session, vrt_id)
+    assert generation.staged_source_ids == [str(linked[0]), str(linked[2])]
+    assert deferred[0]["task"].name.endswith("regenerate_vrt_staged")
+
+
+async def test_remove_source_404s_without_staging_anything(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+):
+    """A rejected request leaves no intent behind — the 404 path included."""
+    deferred = _capture_defer(monkeypatch)
+
+    admin_id = await _get_admin_id(test_db_session)
+    vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+    linked = [
+        await _create_raster_dataset(test_db_session, created_by=admin_id)
+        for _ in range(3)
+    ]
+    for position, source_id in enumerate(linked):
+        await _link_source(test_db_session, vrt_id, source_id, position)
+    stranger = await _create_raster_dataset(test_db_session, created_by=admin_id)
+
+    resp = await client.delete(
+        f"/ingest/vrt/{vrt_id}/sources/{stranger}/", headers=admin_auth_header
+    )
+
+    assert resp.status_code == 404, resp.text
+    assert await _vrt_link_ids(test_db_session, vrt_id) == linked
+    generations = await test_db_session.execute(
+        select(func.count())
+        .select_from(VrtGeneration)
+        .where(VrtGeneration.vrt_dataset_id == vrt_id)
+    )
+    assert generations.scalar() == 0
+    assert deferred == []
+
+
+# ---------------------------------------------------------------------------
+# Which task name carries it
+# ---------------------------------------------------------------------------
+
+
+def _capture_defer(monkeypatch) -> list[dict]:
+    """Record every (task, kwargs) the endpoints hand to Procrastinate.
+
+    fix(#1327 codex P1): the task NAME is the compatibility gate, so the tests
+    that care about skew assert on the delivery itself rather than on a mocked
+    task object standing in for it.
+    """
+    captured: list[dict] = []
+
+    async def _fake_defer(task, **kwargs):
+        captured.append({"task": task, "kwargs": kwargs})
+
+    monkeypatch.setattr(
+        "app.processing.ingest.router.defer_async_with_tenant", _fake_defer
+    )
+    monkeypatch.setattr(
+        "app.modules.catalog.datasets.api.router_vrt.defer_async_with_tenant",
+        _fake_defer,
+    )
+    return captured
+
+
+async def test_plain_regenerate_keeps_the_legacy_task_name(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+):
+    """The other half of the compatibility story.
+
+    A plain regeneration changes no membership, so a pre-#1327 worker runs it
+    correctly. Keeping the legacy name is what lets those deliveries keep
+    flowing while a rolling upgrade is in progress, instead of failing every
+    regeneration for the duration of the roll.
+    """
+    deferred = _capture_defer(monkeypatch)
+
+    admin_id = await _get_admin_id(test_db_session)
+    vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+    for position in range(2):
+        source_id = await _create_raster_dataset(test_db_session, created_by=admin_id)
+        await _link_source(test_db_session, vrt_id, source_id, position)
+
+    resp = await client.post(
+        f"/datasets/{vrt_id}/vrt/regenerate/", headers=admin_auth_header
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert len(deferred) == 1
+    task_name = deferred[0]["task"].name
+    assert task_name.endswith("regenerate_vrt")
+    assert not task_name.endswith("regenerate_vrt_staged")
+    generation = await _only_generation(test_db_session, vrt_id)
+    assert generation.staged_source_ids is None
+
+
+async def test_both_task_names_run_the_same_pipeline():
+    """One implementation, two registered names.
+
+    The staged name is a delivery gate, not a second code path — if it ever
+    became one, the staged set would be applied by only half the entrypoints.
+    """
+    from app.processing.ingest.tasks import regenerate_vrt, regenerate_vrt_staged
+
+    assert regenerate_vrt.name != regenerate_vrt_staged.name
+    assert regenerate_vrt.queue == regenerate_vrt_staged.queue == "raster"
+
+    seen: list[dict] = []
+
+    async def _fake_body(**kwargs):
+        seen.append(kwargs)
+
+    original = regenerate_vrt.func
+    try:
+        regenerate_vrt.func = _fake_body
+        await regenerate_vrt_staged.func(
+            job_id="j", vrt_dataset_id="d", generation_id="g"
+        )
+    finally:
+        regenerate_vrt.func = original
+
+    assert seen == [{"job_id": "j", "vrt_dataset_id": "d", "generation_id": "g"}]
+
+
+# ---------------------------------------------------------------------------
+# The skew itself
+# ---------------------------------------------------------------------------
+
+
+async def test_a_worker_without_the_staged_task_fails_the_job_loudly():
+    """The mechanism, measured against the pinned Procrastinate.
+
+    A pre-#1327 worker is exactly a worker whose registry lacks
+    ``regenerate_vrt_staged``. It must not silently do something else with the
+    delivery, because "something else" is rebuilding from the live links and
+    reporting success — the accepted mutation lost with every state machine
+    green.
+
+    A marker KWARG could not have done this: the pre-#1327 task signature ends
+    in ``**kwargs`` (so does ``tenant_task``'s wrapper), so an unknown keyword
+    is swallowed, not rejected. The name is resolved by the worker's registry,
+    which is the one thing an old worker cannot fake.
+
+    Also pins that the failure is terminal rather than retried: a missing task
+    means there is no task object to ask for a retry strategy, so nothing
+    reschedules the job behind the operator's back.
+    """
+    from procrastinate import App, testing
+    from procrastinate.worker import Worker
+
+    connector = testing.InMemoryConnector()
+    app = App(connector=connector)
+
+    @app.task(name="app.processing.ingest.tasks_vrt.regenerate_vrt", queue="raster")
+    async def legacy_regenerate(**kwargs):
+        return "ran"
+
+    async with app.open_async():
+        await app.configure_task(
+            name="app.processing.ingest.tasks_vrt.regenerate_vrt", queue="raster"
+        ).defer_async(job_id="j", vrt_dataset_id="d")
+        await app.configure_task(
+            name="app.processing.ingest.tasks_vrt.regenerate_vrt_staged",
+            queue="raster",
+        ).defer_async(job_id="j2", vrt_dataset_id="d2")
+
+        await Worker(
+            app,
+            queues=["raster"],
+            wait=False,
+            listen_notify=False,
+            install_signal_handlers=False,
+        ).run()
+
+    by_name = {row["task_name"]: row for row in connector.jobs.values()}
+    legacy = by_name["app.processing.ingest.tasks_vrt.regenerate_vrt"]
+    staged = by_name["app.processing.ingest.tasks_vrt.regenerate_vrt_staged"]
+
+    assert legacy["status"] == "succeeded", (
+        "a plain regeneration must keep running on a pre-#1327 worker"
+    )
+    assert staged["status"] == "failed", (
+        "a staged mutation must be refused by a worker that cannot apply it"
+    )
+    assert staged["attempts"] == 1, "no retry may reschedule it silently"
+
+
+async def test_a_refused_staged_delivery_converges_to_the_handled_state(
+    test_db_session,
+):
+    """Where the skew failure lands: an already-handled state, not a new one.
+
+    The refused delivery never ran, so the links are untouched, the generation
+    stays 'pending' with a NULL heartbeat, and the asset stays 'regenerating'.
+    The existing stale sweep then reconciles exactly that shape — composition
+    preserved, so the asset returns to 'ready' with the requested change simply
+    not applied, and the operator re-issues it after the roll.
+    """
+    from datetime import timedelta
+
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from app.processing.raster.models import RasterAsset
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    member = await create_dataset(test_db_session, created_by=admin_id)
+    requested = await create_dataset(test_db_session, created_by=admin_id)
+    vrt_dataset = await create_dataset(test_db_session, created_by=admin_id)
+
+    started = datetime.now(timezone.utc) - timedelta(hours=2)
+    generation = VrtGeneration(
+        vrt_dataset_id=vrt_dataset.id,
+        status="pending",  # claimed by nobody: the worker refused the delivery
+        started_at=started,
+        heartbeat_at=None,
+        source_count=2,
+        staged_source_ids=[str(member.id), str(requested.id)],
+    )
+    test_db_session.add(generation)
+    await test_db_session.flush()
+    asset = RasterAsset(
+        dataset_id=vrt_dataset.id,
+        asset_uri=f"rasters/{vrt_dataset.id}/source.vrt",
+        status="regenerating",
+        current_generation_id=generation.id,
+        built_from={str(member.id): "rasters/member/source.cog.tif"},
+    )
+    test_db_session.add(asset)
+    await test_db_session.execute(
+        text(
+            "INSERT INTO catalog.vrt_source_links"
+            "(vrt_dataset_id, source_dataset_id, position) VALUES (:v, :s, 0)"
+        ),
+        {"v": str(vrt_dataset.id), "s": str(member.id)},
+    )
+    await test_db_session.commit()
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    await sweep_stale_vrt_assets(test_db_session, cutoff)
+    await test_db_session.commit()
+
+    await test_db_session.refresh(asset)
+    await test_db_session.refresh(generation)
+    assert asset.status == "ready"
+    assert asset.current_generation_id is None
+    assert generation.status == "failed"
+    assert await _vrt_link_ids(test_db_session, vrt_dataset.id) == [member.id]

--- a/backend/tests/test_vrt_stale_sweep_gap002.py
+++ b/backend/tests/test_vrt_stale_sweep_gap002.py
@@ -901,6 +901,16 @@ async def test_sweep_stale_vrt_assets_storage_failure_never_masks_reconciliation
 # (built_from vs the live vrt_source_links set), not a timing heuristic —
 # these run against a real Postgres database so the actual
 # _COMPOSITION_PRESERVED_SQL executes, not a mock standing in for it.
+#
+# fix(#1327) changed which of these branches real traffic reaches. Source
+# add/remove now STAGE their member set on the VrtGeneration row and apply it
+# only in the publish transaction, so a dead composition-changing attempt
+# leaves vrt_source_links matching built_from and takes the restore branch —
+# proven by test_sweep_restores_ready_for_a_dead_staged_mutation below. The
+# drift cases that follow it did not go away, they changed owner: they are now
+# the shapes the sweep must still refuse to call 'ready' — a row written before
+# #1327, or any future writer of the link table outside a publish transaction.
+# Keeping them is the point of a guard.
 # ---------------------------------------------------------------------------
 
 
@@ -911,10 +921,16 @@ async def _make_vrt_with_generation(
     built_from_dataset_ids,
     linked_dataset_ids,
     started_hours_ago: float = 2,
+    staged_source_ids=None,
 ):
     """A VRT dataset with a dead 'regenerating' generation, whose published
     built_from and live vrt_source_links can be set independently — the
-    exact fork the composition-preserving check has to tell apart."""
+    exact fork the composition-preserving check has to tell apart.
+
+    fix(#1327): ``staged_source_ids`` models a dead attempt of the staged
+    kind — the member set the attempt intended to publish, recorded on the
+    generation, with the link rows still describing what is being served.
+    """
     from app.processing.raster.models import RasterAsset, VrtGeneration, VrtSourceLink
     from tests.factories import create_dataset
 
@@ -924,6 +940,11 @@ async def _make_vrt_with_generation(
         status="running",
         started_at=datetime.now(timezone.utc) - timedelta(hours=started_hours_ago),
         heartbeat_at=datetime.now(timezone.utc) - timedelta(hours=started_hours_ago),
+        staged_source_ids=(
+            None
+            if staged_source_ids is None
+            else [str(sid) for sid in staged_source_ids]
+        ),
     )
     test_db_session.add(generation)
     await test_db_session.flush()
@@ -979,12 +1000,60 @@ async def test_sweep_restores_ready_when_composition_unchanged(test_db_session):
     assert generation.status == "failed"
 
 
+async def test_sweep_restores_ready_for_a_dead_staged_mutation(test_db_session):
+    """fix(#1327): the converted case — a dead source add/remove.
+
+    This is the scenario test_sweep_keeps_failed_when_source_was_added used to
+    describe for live traffic: an add whose regeneration died before
+    publishing. Staging moved the link write into the publish transaction, so
+    the dead attempt left vrt_source_links exactly as built_from describes it
+    and there is nothing to be honest ABOUT — the sweep restores 'ready' and
+    the VRT keeps serving the composition it always had, with the requested
+    addition simply not applied. The generation's staged set survives on the
+    failed row; only a task owning the asset pointer could apply it, and this
+    sweep just cleared that pointer.
+    """
+    from app.platform.jobs.router import sweep_stale_vrt_assets
+    from tests.factories import create_dataset, get_user_id
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    original = await create_dataset(test_db_session, created_by=admin_id)
+    requested = await create_dataset(test_db_session, created_by=admin_id)
+    _vrt_dataset, generation, asset = await _make_vrt_with_generation(
+        test_db_session,
+        admin_id=admin_id,
+        built_from_dataset_ids=[original.id],  # published VRT: one member
+        linked_dataset_ids=[original.id],  # catalog says the same thing
+        staged_source_ids=[original.id, requested.id],  # the intent, unapplied
+    )
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    assets_recovered, gens_failed, _keys = await sweep_stale_vrt_assets(
+        test_db_session, cutoff
+    )
+    await test_db_session.commit()
+
+    assert (assets_recovered, gens_failed) == (1, 1)
+    await test_db_session.refresh(asset)
+    await test_db_session.refresh(generation)
+    assert asset.status == "ready"
+    assert asset.current_generation_id is None
+    assert generation.status == "failed"
+    assert generation.staged_source_ids == [str(original.id), str(requested.id)]
+
+
 async def test_sweep_keeps_failed_when_source_was_removed(test_db_session):
-    """fix(#1322 review round 3): remove_vrt_source deletes the link and
-    commits BEFORE the (now-dead) regeneration ever runs. built_from still
-    names the removed source — the published VRT still contains it — so
-    restoring 'ready' would hide that the catalog's stated composition (1
-    source) no longer matches what is actually being served (2 sources)."""
+    """fix(#1322 review round 3): a link set that shrank without the artifact
+    following it. built_from still names the removed source — the published
+    VRT still contains it — so restoring 'ready' would hide that the catalog's
+    stated composition (1 source) no longer matches what is actually being
+    served (2 sources).
+
+    fix(#1327): remove_vrt_source no longer produces this state (it stages the
+    post-removal set instead of deleting the link up front), so what this pins
+    now is the guard, not the mechanism: a row left drifted by pre-#1327 code
+    or any unforeseen writer of the link table still must not be called
+    'ready'."""
     from app.platform.jobs.router import sweep_stale_vrt_assets
     from tests.factories import create_dataset, get_user_id
 
@@ -1016,10 +1085,12 @@ async def test_sweep_keeps_failed_when_source_was_removed(test_db_session):
 
 
 async def test_sweep_keeps_failed_when_source_was_added(test_db_session):
-    """The mirror case: add_vrt_source's link INSERT already committed, so
-    the catalog claims 2 sources while the published VRT (built_from) was
-    only ever assembled from 1. Same drift, opposite direction — still not
-    safe to call 'ready'."""
+    """The mirror case: the catalog claims 2 sources while the published VRT
+    (built_from) was only ever assembled from 1. Same drift, opposite
+    direction — still not safe to call 'ready'.
+
+    fix(#1327): also no longer produced by add_vrt_source; kept for the same
+    reason as its sibling above."""
     from app.platform.jobs.router import sweep_stale_vrt_assets
     from tests.factories import create_dataset, get_user_id
 


### PR DESCRIPTION
Implements option (a) of #1327.

## The invariant

`vrt_source_links` can no longer describe a composition the served VRT does not have.

Before this, `add_vrt_source`/`remove_vrt_source` committed their link mutation in the same transaction that flipped the asset to `regenerating`, then deferred the regeneration. Those are two transactions with nothing between them to compensate, so a worker death after the first left the catalog's declared composition permanently ahead of the served bytes. #1322 taught the abandoned-attempt sweep to detect that drift and refuse to hide it, which is as far as a reconciler can honestly go.

Now the endpoints stage the full intended post-mutation member set on the `VrtGeneration` row and touch no links. `regenerate_vrt` builds from that set and applies it to `vrt_source_links` in the same transaction that swaps `asset_uri` and writes `built_from`, the commit-time pattern from #1290. Death anywhere before that swap leaves the links exactly where the artifact is, with nothing to roll back. A full set is staged rather than a delta, so applying it is a replace: self-contained, and idempotent on retry.

Concurrency improves for free. Two adds that both pass the `regenerating` guard used to insert both links while only one artifact was ever built. Now the loser's set is never applied, because applying is fenced behind the `current_generation_id` check that already gates the publish.

## Schema

One new nullable column, `catalog.vrt_generations.staged_source_ids` (JSONB, an ordered array of source dataset ids, position implied by order). Migration `0043_vrt_generations_staged_source_ids`, additive, no backfill, no data rewrite. `backend/openapi.json` is unaffected: the column is internal and no response schema changed.

## NULL means "changes no membership"

A generation with no staged set builds from the live link rows and applies nothing. That covers a plain regenerate (`regenerate_vrt_endpoint` never changed membership) and any generation queued before this column existed, including one still sitting in the queue across a rolling deploy. One fallback, two producers, no version check.

## Sweep interaction

The composition-drift branch in `sweep_stale_vrt_assets` keeps its code and gains the reason it is now near-unreachable: a dead composition-changing attempt leaves the links matching `built_from` and takes the honest restore path, so the VRT resumes serving what it always served with the requested change simply not applied. The branch still guards rows written before this change, and any future writer of the link table outside a publish transaction. Deleting a check whose FALSE side went quiet would only make the next cause invisible.

## Set drift in both directions

A staged source can be created or deleted between the request and the apply. Both are decided rather than discovered.

Deletion is the harder one. A live link pins its source with `ON DELETE RESTRICT`, but a staged id has no link row yet, so the staging window is the one place a member can vanish. Two owners, two different remedies. The dataset delete guard now also refuses to delete a source that a `pending`/`running` generation has staged, which preserves the "you cannot delete a COG a VRT depends on" guarantee that staging would otherwise have punched a hole in. If a member disappears anyway, the task refuses to build a set it cannot fully load and fails the run whole, links untouched and served VRT intact, and the caller re-issues against the set that survived.

That guard asks membership with jsonb containment rather than by expanding the array, because containment is total. An explicitly assigned `None` lands in the column as the JSON scalar `null` (measured against Postgres, the #1322 shape), which an expansion would raise on, and nothing obliges the planner to evaluate a `jsonb_typeof` guard sitting beside it in the same `AND` first. A test holds a live generation in exactly that shape.

Only `pending`/`running` generations count, so the block cannot outlive the attempt. A terminal generation's staged set is ignored, and an attempt whose worker died is marked `failed` by the existing stale sweep, which releases the source on its own.

Creation is irrelevant by construction: the staged set is closed at request time, and the apply replaces the link rows with exactly that set.

The staged value itself is validated once, at claim time, before any bytes are built. Empty, unparseable or repeated ids fail the attempt rather than surfacing later as an opaque `ON CONFLICT` error.

## Deploy skew, both directions

Staging splits one write into a producer (the API) and a consumer (the worker), so the two can disagree about what the payload means while a deployment is in flight. The default install cannot get there: `api` and `worker` share an image and are recreated together by compose, so the window belongs to the chart's rolling update, where the API can be new while a worker is still old.

New worker, old API: the delivery carries no staged set, the column reads NULL, and the task builds from the live links and applies nothing. That is the same fallback pre-column rows take, so nothing special happens during the roll.

Old worker, new API: this is the one that could lose data, and it is why the staged mutations now go out under a second registered task name, `regenerate_vrt_staged`. A pre-#1327 worker does not know that column; handed the delivery it would rebuild from the live links, publish the composition that was already being served, and mark the generation complete, dropping an accepted add or remove with every state machine reporting success.

A marker kwarg cannot fence that, and the test says so: the pre-#1327 task signature ends in `**kwargs`, and so does `tenant_task`'s wrapper, so an unknown keyword is swallowed instead of raising. The task name is resolved against the worker's own registry, which is the one thing an old worker cannot fake. Measured against the pinned Procrastinate rather than assumed: a job whose task name is absent ends `failed` with one attempt, and no retry is scheduled, because there is no task object to ask for a retry strategy. That last fact also decides the retry question in this PR: adding a bounded retry to the new task would not make the window self-healing, since the retry policy lives on the worker that does not have the task. So `retry=0` stays.

The refused delivery lands in a state the existing machinery already owns rather than a new one. The task never ran, so the links are untouched, the generation stays `pending` with a NULL heartbeat, and the asset stays `regenerating` until `sweep_stale_vrt_assets` reconciles it: composition preserved, asset restored to `ready`, requested change simply not applied, generation row `failed`. The honest cost is that the VRT 409s further mutations until that sweep runs, and the operator re-issues the add or remove after the roll. Plain regeneration keeps the legacy name on purpose, so those deliveries keep flowing to old workers for the duration.

## Report surfaces

Two surfaces reported the composition and would have disagreed after this change.

The 202 message now reads "Source add queued" / "Source removal queued". The catalog's source list still describes the VRT being served; the change joins it when the artifact containing it is published.

The OGC record item's `raster.source_count` used to be read from the in-flight `VrtGeneration`. That was the post-mutation number back when the link write happened up front. Now it would be the pending composition, leaving that one surface claiming a member set the VRT is not serving. It counts the live links instead, like the dataset detail and list surfaces already did. The generation's own count is still reported per attempt by the VRT generations endpoint, and the port method that returns it is annotated with what it may and may not be used for.

## Tests

- `test_regenerate_vrt_integration.py`: five new database-backed tests over the real task. A successful run applies the staged set, and the stored VRT XML references one source per staged member, which is what proves the build read the staged set rather than the links it was about to overwrite. A build that dies mid-attempt leaves `vrt_source_links` untouched. A staged source deleted mid-flight fails the run cleanly. A NULL staged set builds from the live links, with an unlinked raster sitting there to prove the build did not wander. Applying a staged set twice is a no-op that also preserves a surviving member's `created_at`.
- `test_vrt_source_management_174.py`: the endpoints stage the set and issue no link write, on both add and remove; the orphan-guard rollback no longer compensates a link change; a 422 leaves no generation behind. A new class pins what the task accepts as a staged set (absent and JSON-null both mean "no membership change"; empty and repeated ids are refused before the build). Plus a database-backed class that runs both endpoints over HTTP and checks the JSONB column round-trips while the link table stays put, including the 404 path.
- `test_defer_orphan_guard.py`: the two VRT defer-failure tests converted. They now assert the rollback issues no link statement at all, and that the staged set is what the endpoint wrote.
- `test_vrt_stale_sweep_gap002.py`: new coverage for a dead staged mutation taking the restore branch. The two drift scenarios are kept and re-documented as what they now defend (pre-#1327 rows, unforeseen writers) rather than deleted.
- `test_vrt_delete_guard_174.py`: two database-backed tests. An in-flight staged member blocks the delete; a terminal generation's staged set does not.
- `test_vrt_source_query_count.py`: the record item reports the served member count while an add is in flight.
- `test_vrt_staged_mutation_1327.py`: new file for the delivery and skew half. Over HTTP, add and remove write the staged set and leave the link table alone (including the 404 path, which stages nothing), and both deliver under the staged task name while a plain regenerate keeps the legacy one. The skew mechanism is measured against the pinned Procrastinate: a worker holding only the legacy task succeeds the legacy delivery and fails the staged one with no retry. A last test walks the refused delivery through the stale sweep and shows it converging on the restore path with the links untouched.

  These are in their own module for a reason worth stating: they started life in `test_vrt_source_management_174.py`, whose autouse fixture patches authorization helpers, and a client-backed test there made `router_vrt` import for the first time mid-patch, permanently binding the mocks into that module and 404-ing unrelated tests in later files. The module docstring now says not to add DB or client tests there.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
set -a && source .env.test && set +a
uv run alembic upgrade head            # plus downgrade -1 and back up again
uv run alembic check                   # "No new upgrade operations detected."
uv run python scripts/dump_openapi.py --check
uv run pytest tests/test_regenerate_vrt_integration.py tests/test_vrt_source_management_174.py \
  tests/test_vrt_stale_sweep_gap002.py tests/test_vrt_delete_guard_174.py \
  tests/test_vrt_source_query_count.py tests/test_vrt_catalog_175.py \
  tests/test_vrt_source_authz_1172.py tests/test_vrt_lifecycle_188.py tests/test_worker.py \
  tests/test_ingest_job_attempt_fencing.py tests/test_jobs_router.py -q
uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q
uv run pytest -q -n 4
```

Closes #1327
