### PR TITLE
fix(vrt): bump tile_cache_version in the regeneration swap transaction

### DIFF
--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -1164,6 +1164,16 @@ async def regenerate_vrt(
                     # now() — one swap, one timestamp, no clock skew between
                     # the two records of it.
                     vrt_dataset.last_refreshed_at = generation.completed_at
+                    # fix(#1329 follow-up): the VRT swap is the third
+                    # pointer-swap door and never rolled the version the way
+                    # raster replace does (tasks_raster_swap). Without the
+                    # bump, pre-swap tiles stay valid in every version-keyed
+                    # cache (the nginx tile cache via the URL `v=`, the
+                    # per-process raster meta cache) until their TTLs, so a
+                    # regeneration that changes band shape can render wrong
+                    # until they expire. Same transaction as the pointer swap,
+                    # same as every other door.
+                    vrt_dataset.bump_tile_cache_version()
                     if meta.get("bbox_wkt"):
                         vrt_dataset.record.spatial_extent = func.ST_GeomFromText(
                             meta["bbox_wkt"], 4326

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2504,7 +2504,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # KWARG could not do this (the old signature ends in `**kwargs`, so an
     # unknown keyword is swallowed) and where the refused delivery lands.
     # Cap 1300 -> 1344, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1344,
+    # fix(#1329 follow-up): +10 — bump tile_cache_version in the VRT swap
+    # transaction; the third pointer-swap door finally rolls the version.
+    "backend/app/processing/ingest/tasks_vrt.py": 1354,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_regenerate_vrt_integration.py
+++ b/backend/tests/test_regenerate_vrt_integration.py
@@ -302,6 +302,15 @@ async def test_regenerate_vrt_happy_path_end_to_end(
 
     session = test_db_session
 
+    # fix(#1329 follow-up): capture the pre-swap version so [17] asserts the
+    # bump itself, not a hardcoded absolute.
+    pre_version_result = await session.execute(
+        select(Dataset.tile_cache_version).where(
+            Dataset.id == uuid.UUID(vrt_db_state["vrt_dataset_id"])
+        )
+    )
+    pre_tile_cache_version = pre_version_result.scalar_one()
+
     # --- INVOKE ------------------------------------------------------------
     # Call the underlying coroutine via Task.func, bypassing the queue.
     await regenerate_vrt.func(
@@ -432,6 +441,12 @@ async def test_regenerate_vrt_happy_path_end_to_end(
     # completed_at instant — not a separate now() call.
     assert vrt_dataset.last_refreshed_at is not None
     assert vrt_dataset.last_refreshed_at == generation.completed_at
+
+    # [17] fix(#1329 follow-up): the swap rolls tile_cache_version in the
+    # same transaction as the pointer swap, like every other refresh door.
+    # The URL `v=` buster and the raster meta cache key both read it, so an
+    # unbumped swap leaves pre-swap tiles valid until cache TTLs expire.
+    assert vrt_dataset.tile_cache_version == pre_tile_cache_version + 1
 
     # --- BONUS: Rasterio re-open + bounds sanity check ---------------------
     # (per CONTEXT.md Claude's Discretion + RESEARCH.md recommendation)


### PR DESCRIPTION
Adds the missing `tile_cache_version` bump to the VRT regeneration swap transaction.

## What surfaced it

Pre-release smoke on the merged wave ran a live add/remove round-trip against the 62-source Matterhorn VRT. Both swaps completed correctly (staged links applied at swap commit, composition restored), but the dataset's `tile_cache_version` sat at 1 through both. Issue #1329 recorded all three pointer-swap doors as bumping the version in the swap transaction; that was true for raster replace (`tasks_raster_swap.py:107`) and the refresh strategies, and never true for the VRT door. `git log -S tile_cache_version` on `tasks_vrt.py` comes back empty: the bump never existed there.

## Why it matters

Both tile-serving caches key on the version. The nginx tile cache rolls on the URL `v=` parameter (#1372), and the per-process raster metadata cache keys on it since #1421. An unbumped swap means tile URLs never change, so pre-swap tiles stay valid in both caches until their TTLs expire. Bounded and self-healing, but visible exactly when a regeneration changes the raster's shape: adding or removing a source that flips band count or dtype can render errors rather than stale imagery, which is the same failure mode #1329 closed for the other two doors.

## The change

One call in the regeneration swap transaction, next to `last_refreshed_at`: `vrt_dataset.bump_tile_cache_version()`. Same transaction as the `asset_uri` swap, `built_from`, and the staged-link apply, so the version and the pointer roll together or not at all. The initial-create path stays unbumped on purpose: it publishes the dataset's first artifact, so no older tile can exist in any cache.

Corrects the record on closed #1329: the issue's "all three swap paths already bump it" premise held for two of the three.

## Verification

- Assertion [17] added to `test_regenerate_vrt_happy_path_end_to_end`: captures the pre-swap version and asserts the increment (fails against the previous code).
- `test_regenerate_vrt_integration.py` + `test_vrt_staged_mutation_1327.py`: 13 passed.
- `test_layering.py`: 40 passed, `tasks_vrt.py` cap 1344 to 1354 with justification.
- `ruff check` and `ruff format --check` clean.

Refs #1329, #1372, #1421, #1424.
