### PR TITLE
chore(release): v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-12
+
+### Added
+
+- **Coding agents can now query dataset contents through the MCP server.**
+  A hardened read-only SQL endpoint exposes the NL-to-SQL sandbox directly:
+  queries run against the caller's RBAC-scoped table allowlist with the
+  sandbox's statement validation, row, byte, and timeout caps, and the MCP
+  server surfaces it as a `query` tool alongside the existing catalog reads
+  (#1406).
+- **Chat query results can be saved as datasets from the builder.** The
+  result-preview overlay a chat query renders in the map builder now has a
+  save path that materializes the preview into a real dataset (#1403).
+- **Predicate chat queries offer a layer-filter follow-up.** When a chat
+  answer is a predicate over a layer's features, the panel offers applying
+  it as that layer's filter instead of leaving the answer stranded in the
+  transcript (#1402).
+- **Distributions can be reordered around a primary.** The dataset page's
+  distributions list gains a set-primary control, and writing a new primary
+  demotes the incumbent instead of leaving two rows both claiming it
+  (#1399, #1393).
+- **Source validation failures read as sentences.** The machine codes the
+  source validator emits are mapped to user-facing strings in all four
+  locales instead of leaking code identifiers into the UI (#1397).
+
 ### Changed
 
 - **A raster CRS override now assigns the CRS instead of reprojecting to
@@ -22,6 +47,52 @@ and releases use semantic versioning.
   ingest rather than kept as a second permanent copy. Deliberate
   reproject-at-ingest is not offered; rasters are reprojected at serve time
   and at export time (#1291).
+- **A refresh run's `origin_kind` is documented as the door it executed
+  through, not the dataset's origin.** The API description, both backend
+  vocabularies, and the Source panel's run history now state the
+  distinction explicitly; a run's kind and its dataset's origin can
+  visibly disagree (a STAC-imported raster mid-replacement shows origin
+  "stac" next to a run recorded "upload") and equality was never the
+  contract (#1422).
+
+### Fixed
+
+- **A VRT's declared composition can no longer disagree with the served
+  mosaic.** Adding or removing a VRT source stages the intended member set
+  on the generation and applies it to the catalog in the same transaction
+  that publishes the regenerated artifact. A worker death between accepting
+  the mutation and finishing the build now leaves the catalog exactly as it
+  was instead of describing sources the served VRT does not have. A
+  mid-flight deletion of a staged source fails the run whole, and rolling
+  deployments are fenced: an outdated worker refuses the staged job loudly
+  instead of silently dropping the change (#1424).
+- **VRT regeneration now invalidates tile caches.** The regeneration swap
+  rolls the dataset's tile cache version the way every other refresh door
+  already did, so a regeneration that changes the mosaic's shape stops
+  serving pre-swap tiles from the URL-keyed and in-process caches until
+  TTLs happen to expire (#1425).
+- **Raster tile metadata stops going stale across API processes.** The
+  per-process raster metadata cache keys on the tile URL's version
+  parameter, so a raster replace, VRT regeneration, or source refresh is
+  observed by every API worker immediately instead of after a
+  sixty-second window. A request naming a future version cannot
+  pre-poison the cache for the swap that later arrives (#1421).
+- **Dataset pages notice refreshes started elsewhere.** Returning focus to
+  an open dataset tab refetches the run history unconditionally, so a
+  refresh dispatched by the CLI or another editor is observed and the
+  page's caches roll instead of staying stale until remount (#1420).
+- **Interrupted presigned uploads no longer strand objects.** Storage
+  objects from presigned uploads whose tracking row never completed are
+  reconciled against the tracking table and swept (#1401).
+- **A reupload that removes geometry retires the synthetic geometry row**
+  instead of leaving the dataset claiming a spatial column it no longer
+  has (#1389).
+- **VRT validation refuses sources whose pixel geometry was never
+  measured** instead of composing them into a mosaic with undefined
+  resolution (#1388).
+- **Tenant-ownership adoption completes on the head schema.** The
+  forward-only adoption path used by operators reaches the current schema
+  without requiring an intermediate checkout (#1405).
 
 ## [1.11.1] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and releases use semantic versioning.
 - **Source validation failures read as sentences.** The machine codes the
   source validator emits are mapped to user-facing strings in all four
   locales instead of leaking code identifiers into the UI (#1397).
+- **The showcase seed gains a Hurricane Exposure map, and three global
+  showcase maps render on the globe.** `seed-showcase.py` adds a seventh
+  map joining hurricane tracks against coastal exposure, and the
+  world-spanning showcase maps switch from mercator to globe projection
+  (#1404).
 
 ### Changed
 
@@ -2064,7 +2069,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.11.1...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.12.0...HEAD
+[1.12.0]: https://github.com/geolens-io/geolens/compare/v1.11.1...v1.12.0
 [1.11.1]: https://github.com/geolens-io/geolens/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/geolens-io/geolens/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/geolens-io/geolens/compare/v1.9.0...v1.10.0

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -628,7 +628,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.11.1"
+_FALLBACK_APP_VERSION = "1.12.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18432,7 +18432,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.11.1"
+    "version": "1.12.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.11.1"
+version = "1.12.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.11.1"
+version = "1.12.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.11.1"
+version = "1.12.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.12.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.11.1"
+version = "1.12.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.11.1"
+version = "1.12.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.11.1"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.11.1
+package_version_override: 1.12.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.11.1"
+version = "1.12.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Release bump for v1.12.0: all 19 version sites stamped by `make bump`, changelog backfilled for everything on main since v1.11.1 (5 added, 2 changed, 8 fixed entries plus the srid_override entry that landed with #1423).

Highlights: the read-only MCP query tool over the hardened sandbox SQL endpoint (#1406), staged VRT source-link mutations with swap-commit application (#1424, #1425), version-keyed raster tile metadata cache (#1421), and srid_override moving from reprojection to CRS assignment (#1423).

Pre-tag verification, run on the exact tree this PR bumps: full Playwright e2e suite green against the rebuilt dev stack, frontend build/typecheck/lint/coverage green, alembic drift clean with migration 0043 round-tripped, openapi/sdks/cli/version gates green, and three live path smokes: a CRS-less ingest with srid_override (correct footprint at 7.69E 46.93N, EPSG 32632 stored, zero gdalwarp invocations), a staged-links remove/add round-trip on the 62-source Matterhorn VRT (links untouched while staged, applied at swap), and a regeneration showing tile_cache_version rolling 1 to 2. The last smoke is what surfaced #1425 pre-tag.

Config impact: version sites only. No schema, no API surface beyond what the listed PRs already landed.