### PR TITLE
fix(datasets): purge the tile cache when a vector dataset is deleted

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -186,6 +186,27 @@ async def delete_dataset(
     # Delete the record (CASCADE handles dataset deletion)
     await session.delete(dataset.record)
 
+    if record_type not in RASTER_FAMILY_RECORD_TYPES:
+        # fix(#1427): purge the dropped table's MVT tiles. The cache key is
+        # `tile:{table}:{z}:{x}:{y}` with no dataset id and no content version,
+        # and generate_table_name collides only against LIVE rows and relations
+        # — so the name freed above is immediately reusable, and whoever draws
+        # it next is authorized on its own visibility while served this
+        # dataset's bytes for up to tile_cache_ttl.
+        #
+        # Purging here rather than after the caller's commit is safe because
+        # the DROP above already holds ACCESS EXCLUSIVE on the table: a tile
+        # query that could re-cache pre-delete rows is blocked on that lock
+        # until this transaction ends, and finds no relation once it commits.
+        # Doing it here also covers single delete, bulk delete, and any future
+        # caller from one place. Raster/VRT are excluded — their tiles come
+        # from Titiler, and that branch drops no table to free a name.
+        from app.platform.cache.provider import get_tile_cache
+
+        tile_cache = get_tile_cache()
+        if tile_cache is not None:
+            await tile_cache.invalidate_table(table_name)
+
     # Audit trail for an irreversible operation (DROP TABLE for vector,
     # storage cleanup for raster/VRT). The DB-side row deletion is logged
     # by the audit_emit() facade in the calling router.

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -194,13 +194,16 @@ async def delete_dataset(
         # it next is authorized on its own visibility while served this
         # dataset's bytes for up to tile_cache_ttl.
         #
-        # Purging here rather than after the caller's commit is safe because
-        # the DROP above already holds ACCESS EXCLUSIVE on the table: a tile
-        # query that could re-cache pre-delete rows is blocked on that lock
-        # until this transaction ends, and finds no relation once it commits.
-        # Doing it here also covers single delete, bulk delete, and any future
-        # caller from one place. Raster/VRT are excluded — their tiles come
-        # from Titiler, and that branch drops no table to free a name.
+        # This closes the durable window, not the whole class: an in-flight
+        # tile request that already released its DB transaction can still write
+        # pre-delete bytes back after this runs, and with REDIS_URL unset each
+        # API worker holds its own LRU that a purge from one worker cannot
+        # reach. Both need a generation dimension in the cache key — #1429.
+        # Placed here rather than after the caller's commit because that
+        # ordering does not change either residual, and here it covers single
+        # delete, bulk delete, and future callers from one place. Raster/VRT
+        # are excluded — their tiles come from Titiler, and that branch drops
+        # no table to free a name.
         from app.platform.cache.provider import get_tile_cache
 
         tile_cache = get_tile_cache()

--- a/backend/tests/test_dataset_delete_tile_cache_purge.py
+++ b/backend/tests/test_dataset_delete_tile_cache_purge.py
@@ -14,6 +14,11 @@ Every other write path that changes what a table's tiles should show
 already purges: metadata edits (``datasets/api/router.py``), feature edits
 (``features/router.py``), reupload and PostGIS refresh
 (``processing/ingest/``). Delete was the gap.
+
+The purge closes the durable window only. An in-flight tile request can
+still write pre-delete bytes back after it, and a per-worker in-memory
+cache is out of its reach; both need a generation dimension in the cache
+key (#1429) and are deliberately not asserted here.
 """
 
 import gzip

--- a/backend/tests/test_dataset_delete_tile_cache_purge.py
+++ b/backend/tests/test_dataset_delete_tile_cache_purge.py
@@ -1,0 +1,151 @@
+"""Deleting a vector dataset must purge that table's MVT tile cache.
+
+The tile cache key is ``tile:{table}:{z}:{x}:{y}`` — no dataset id, no
+content version — and ``generate_table_name`` only collides against LIVE
+rows and relations, so a table name freed by a delete is immediately
+reusable. Without a purge on delete, the next dataset that lands on the
+freed name is authorized on its OWN visibility while being served the
+deleted dataset's cached bytes for up to ``tile_cache_ttl`` (default 300s,
+tunable to 86400). Delete a private dataset, re-upload a public one that
+draws the same table name, and the deleted private geometry is served to
+anonymous callers.
+
+Every other write path that changes what a table's tiles should show
+already purges: metadata edits (``datasets/api/router.py``), feature edits
+(``features/router.py``), reupload and PostGIS refresh
+(``processing/ingest/``). Delete was the gap.
+"""
+
+import gzip
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import fakeredis.aioredis
+import pytest
+
+from app.platform.cache import provider as cache_provider
+from app.platform.cache.tile_cache import TileCacheProvider
+
+TABLE_NAME = "test_table"
+
+
+class _MockStorage:
+    """Storage stand-in: delete_dataset reaps originals/ and vectors/."""
+
+    async def list(self, prefix: str) -> list[str]:
+        return []
+
+    async def delete(self, key: str) -> None:  # pragma: no cover - nothing listed
+        raise AssertionError("no keys were listed")
+
+
+def _mock_dataset(record_type: str, title: str) -> MagicMock:
+    ds = MagicMock()
+    ds.id = uuid.uuid4()
+    ds.table_name = TABLE_NAME
+    ds.record = MagicMock()
+    ds.record.title = title
+    ds.record.record_type = record_type
+    return ds
+
+
+@pytest.fixture
+def tile_cache(monkeypatch):
+    """Install a fakeredis-backed tile cache as the process singleton."""
+    provider = TileCacheProvider.__new__(TileCacheProvider)
+    provider._client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    monkeypatch.setattr(cache_provider, "_tile_cache", provider)
+    return provider
+
+
+async def _seed(provider: TileCacheProvider, table: str) -> None:
+    """Seed the two cache-key shapes the tile router writes for a table."""
+    await provider.set(table, 5, 10, 15, gzip.compress(b"private roads"), ttl=300)
+    # Clustered tiles hang extra segments off the table key
+    # (_cluster_cache_table_key in processing/tiles/router.py).
+    await provider.set(
+        f"{table}:cluster:v3:r50:z12", 5, 10, 15, gzip.compress(b"clustered"), ttl=300
+    )
+
+
+async def _run_delete(dataset: MagicMock) -> str:
+    from app.modules.catalog.datasets.domain.service import delete_dataset
+
+    session = AsyncMock()
+    no_dependents = MagicMock()
+    no_dependents.all.return_value = []
+    session.execute = AsyncMock(return_value=no_dependents)
+
+    with (
+        patch(
+            "app.modules.catalog.datasets.domain.service.get_dataset",
+            AsyncMock(return_value=dataset),
+        ),
+        patch("app.platform.storage.provider.get_storage", return_value=_MockStorage()),
+    ):
+        return await delete_dataset(session, dataset.id, dataset.record.title)
+
+
+@pytest.mark.asyncio
+async def test_vector_delete_purges_tile_cache(tile_cache):
+    """Deleting a vector dataset evicts every cached tile for its table."""
+    await _seed(tile_cache, TABLE_NAME)
+    assert await tile_cache.get(TABLE_NAME, 5, 10, 15) is not None
+
+    dataset = _mock_dataset("vector_dataset", "Roads")
+    assert await _run_delete(dataset) == TABLE_NAME
+
+    assert await tile_cache.get(TABLE_NAME, 5, 10, 15) is None, (
+        "a table name freed by delete is immediately reusable — leaving its "
+        "tiles cached serves the deleted dataset's bytes to whoever gets the "
+        "name next"
+    )
+    assert await tile_cache.get(f"{TABLE_NAME}:cluster:v3:r50:z12", 5, 10, 15) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_leaves_other_tables_cached(tile_cache):
+    """Purge is scoped to the deleted table, not the whole tile cache."""
+    await _seed(tile_cache, TABLE_NAME)
+    await _seed(tile_cache, "other_table")
+
+    await _run_delete(_mock_dataset("vector_dataset", "Roads"))
+
+    assert await tile_cache.get("other_table", 5, 10, 15) is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("record_type", ["raster_dataset", "vrt_dataset"])
+async def test_raster_delete_does_not_purge_mvt_cache(tile_cache, record_type):
+    """Raster tiles come from Titiler, never from the table-keyed MVT cache.
+
+    The raster branch also drops no table, so there is no freed name for a
+    later dataset to inherit.
+    """
+    await _seed(tile_cache, TABLE_NAME)
+
+    await _run_delete(_mock_dataset(record_type, "My Raster"))
+
+    assert await tile_cache.get(TABLE_NAME, 5, 10, 15) is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_succeeds_when_tile_cache_is_unavailable(monkeypatch):
+    """No tile cache in this process (get_tile_cache() -> None) must not break delete."""
+    monkeypatch.setattr(cache_provider, "_tile_cache", None)
+
+    dataset = _mock_dataset("vector_dataset", "Roads")
+    assert await _run_delete(dataset) == TABLE_NAME
+
+
+@pytest.mark.asyncio
+async def test_delete_survives_a_tile_cache_backend_failure(monkeypatch):
+    """A purge that cannot reach its backend must not roll back the delete."""
+    provider = TileCacheProvider.__new__(TileCacheProvider)
+    failing_client = AsyncMock()
+    failing_client.scan.side_effect = ConnectionError("Redis unavailable")
+    provider._client = failing_client
+    monkeypatch.setattr(cache_provider, "_tile_cache", provider)
+
+    dataset = _mock_dataset("vector_dataset", "Roads")
+    assert await _run_delete(dataset) == TABLE_NAME


### PR DESCRIPTION
## What

`delete_dataset` drops the PostGIS table and cleans managed storage, but it never purged that table's MVT tile cache. This adds the purge, for non-raster record types, inside `delete_dataset` itself.

## Why

The tile cache key is `tile:{table}:{z}:{x}:{y}` (plus an optional column-projection suffix). It carries no dataset id and no content version. `generate_table_name` collides only against **live** rows and relations, so a table name freed by a delete is immediately available to the next ingest.

Put together, that is a cross-dataset read: delete a private dataset backed by table `roads`, upload a public dataset that draws `roads` again, and for up to `tile_cache_ttl` (default 300s, tunable to 86400) the tile endpoint authorizes the request against the **new** dataset's visibility while serving the **old** dataset's cached bytes. Deleted private geometry reaches anonymous callers.

Every sibling write path that changes what a table's tiles should show already purges for this exact reason — metadata edits (`datasets/api/router.py`), feature edits (`features/router.py`), reupload and PostGIS refresh (`processing/ingest/`). Delete was the one path that didn't.

## What this does and does not close

It closes the durable window: the cached bytes that would otherwise survive the full TTL in the cache the deleting worker can reach.

It does **not** close the whole class, and the code comment says so. Two residual windows survive, both raised in review and both tracked in #1429 with the analysis:

- An in-flight tile request releases its database transaction as soon as it has `tile_data`, then emits a usage event and gzips before calling `tile_cache.set()`. A reader past that point can write pre-delete bytes back after the purge has run.
- With `REDIS_URL` unset each API worker holds its own LRU, and the checked-in production default is two workers. A purge from the worker that handled the DELETE cannot reach the other one.

Both need a generation dimension in the cache key so a new occupant of a reused table name can never read the previous occupant's entries. That is a cross-cutting change to the cache-key contract and to the PERF-11 metrics contract, which is why it is a separate issue rather than more scope here. This PR is a strict improvement on no purge at all and does not depend on the outcome of #1429.

## Approach notes

- **In the service, not the routers.** Both delete endpoints (single and bulk) called only `invalidate_catalog_cache()`. Putting the purge in `delete_dataset` covers both plus any future caller from one place.
- **Ordering.** The purge runs before the caller commits. Moving it after the commit would shrink the in-flight-writer window by the duration of the commit without closing it, so it is not worth giving up the single choke point. If the caller rolls back instead, the worst case is a cold cache for a dataset that still exists.
- **Raster and VRT excluded.** Their tiles are served by Titiler, never from the table-keyed MVT cache, and that branch drops no table to free a name.
- **Failures cannot fail the delete.** No new error handling was added because none is needed: `TileCacheProvider.invalidate_table` already swallows backend errors, matching how every sibling call site relies on it. There is a test for it.
- **Cluster tiles are covered.** Clustered tiles are cached under `{table}:cluster:v3:r{r}:z{z}`, which the `tile:{table}:*` scan pattern matches. The test asserts this rather than assuming it.

## Impacts

None on schema, API contract, or config. Behavior-only; `openapi.json` and the SDKs are untouched.

## Also out of scope

The tile router's process-local `_dataset_cache` (`processing/tiles/router.py`, 60s TTL) still holds the deleted dataset's metadata for up to 60s. `catalog/` cannot import `app.processing.*` (enforced by `test_layering.py::test_no_catalog_imports_processing`), and the cache is process-local anyway, so evicting it from the deleting worker would leave every other worker stale — a purge that logs success while doing nothing, the failure shape `init_tile_cache`'s worker mode already exists to avoid. It is the same root cause and is covered by #1429.

## Verification

Test written first and confirmed failing before the fix (`test_vector_delete_purges_tile_cache`), passing after.

```
cd backend && uv run ruff check app tests && uv run ruff format app tests --check
cd backend && uv run pytest tests/test_layering.py -q                                  # 40 passed
cd backend && uv run pytest tests/test_dataset_delete_tile_cache_purge.py -q           # 6 passed
cd backend && uv run pytest tests/test_dataset_delete_tile_cache_purge.py \
    tests/test_vrt_delete_guard_174.py tests/test_raster_ingest.py \
    tests/test_datasets.py tests/test_dataset_metadata_idor.py -q                      # 126 passed
cd backend && uv run pytest tests/test_tile_cache.py tests/test_tile_cache_scope_sec009.py \
    tests/test_tile_cache_cols_key.py tests/test_phase_274_tile_cache.py \
    tests/test_worker_tile_cache_1315.py -q                                            # 78 passed, 3 skipped
```