### PR TITLE
fix(maps): bound and offload the sprite-sheet render

### DIFF
--- a/backend/app/modules/catalog/maps/sprites.py
+++ b/backend/app/modules/catalog/maps/sprites.py
@@ -61,6 +61,12 @@ _PATH_TOKEN_RE = re.compile(
     r"[MmZzLlHhVvCcQqSsTtAa]|[-+]?(?:\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?"
 )
 SPRITE_CELL_SIZE = 24
+# fix(#1428 codex r1): how many icons the sheet render holds in flight at once —
+# it bounds both the concurrent storage reads and the icon bytes resident while
+# they are composited. The catalog has no size limit, so this cannot be "all of
+# them": 8 icons at MAX_ICON_BYTES is 4 MiB, and still 8x the serial read it
+# replaced.
+_SPRITE_RENDER_BATCH = 8
 
 
 @dataclass(frozen=True)
@@ -647,17 +653,15 @@ async def build_sprite_png(session: AsyncSession) -> bytes:
         return png
 
 
-async def _load_icon_payloads(
+async def _uploaded_icon_assets(
     session: AsyncSession, icons: list[MapIconResponse]
-) -> IconPayloads:
-    """Resolve every icon's bytes and media type, ordered to match ``icons``.
+) -> dict[str, MapIconAsset]:
+    """The rows behind the uploaded icons, keyed by response id, in one query.
 
-    fix(#1428): all of the render's I/O happens here, because the composite that
-    consumes the result runs in a worker thread and an ``AsyncSession`` cannot be
-    used from one. Uploaded rows come back in a single query and their stored
-    objects are fetched concurrently, replacing a per-icon round trip.
+    fix(#1428): every DB read the render needs happens here, before any of it
+    reaches a worker thread — an ``AsyncSession`` cannot be used from one. It
+    also replaces the per-icon ``session.get`` the serial loop issued.
     """
-    builtin_icons = {icon.slug: icon for icon in DEFAULT_ICONS}
     asset_ids: list[uuid.UUID] = []
     for icon in icons:
         if icon.builtin:
@@ -666,14 +670,19 @@ async def _load_icon_payloads(
             asset_ids.append(uuid.UUID(icon.id))
         except ValueError:
             continue
+    if not asset_ids:
+        return {}
+    result = await session.execute(
+        select(MapIconAsset).where(MapIconAsset.id.in_(asset_ids))
+    )
+    return {str(asset.id): asset for asset in result.scalars().all()}
 
-    assets: dict[str, MapIconAsset] = {}
-    if asset_ids:
-        result = await session.execute(
-            select(MapIconAsset).where(MapIconAsset.id.in_(asset_ids))
-        )
-        assets = {str(asset.id): asset for asset in result.scalars().all()}
 
+async def _load_icon_payloads(
+    icons: list[MapIconResponse], assets: dict[str, MapIconAsset]
+) -> IconPayloads:
+    """Read one batch of icons' bytes, fetching the stored ones concurrently."""
+    builtin_icons = {icon.slug: icon for icon in DEFAULT_ICONS}
     payloads: IconPayloads = [None] * len(icons)
     stored: list[tuple[int, MapIconAsset]] = []
     for position, icon in enumerate(icons):
@@ -701,18 +710,22 @@ async def _load_icon_payloads(
     return payloads
 
 
-def _compose_sprite_png(icons: list[MapIconResponse], payloads: IconPayloads) -> bytes:
-    sheet = Image.new(
-        "RGBA",
-        (len(icons) * SPRITE_CELL_SIZE, SPRITE_CELL_SIZE),
-        (0, 0, 0, 0),
-    )
-    for index, (icon, payload) in enumerate(zip(icons, payloads)):
+def _paste_icon_cells(
+    sheet: Image.Image,
+    start: int,
+    icons: list[MapIconResponse],
+    payloads: IconPayloads,
+) -> None:
+    """Render one batch of icons into their cells, ``start`` cells in."""
+    for offset, (icon, payload) in enumerate(zip(icons, payloads)):
         if payload is None:
             image = _placeholder_icon(icon.sprite_id)
         else:
             image = _render_icon(payload[0], payload[1], icon.sprite_id)
-        sheet.alpha_composite(image, (index * SPRITE_CELL_SIZE, 0))
+        sheet.alpha_composite(image, ((start + offset) * SPRITE_CELL_SIZE, 0))
+
+
+def _encode_sprite_png(sheet: Image.Image) -> bytes:
     out = BytesIO()
     sheet.save(out, format="PNG")
     return out.getvalue()
@@ -723,8 +736,21 @@ async def _render_sprite_png(
 ) -> bytes:
     if not icons:
         return _blank_png(SPRITE_CELL_SIZE)
-    payloads = await _load_icon_payloads(session, icons)
-    # fix(#1428): decode, resample and re-encode are CPU-bound and scale with the
-    # stored icons' pixel count, on a route that takes no auth. Off the loop, so
-    # one large icon stalls a thread instead of every other request in flight.
-    return await run_in_thread_draining(_compose_sprite_png, icons, payloads)
+    assets = await _uploaded_icon_assets(session, icons)
+    sheet = Image.new(
+        "RGBA",
+        (len(icons) * SPRITE_CELL_SIZE, SPRITE_CELL_SIZE),
+        (0, 0, 0, 0),
+    )
+    # fix(#1428 codex r1): a batch at a time, so neither the read fan-out nor the
+    # bytes held at once scale with the catalog. The whole-catalog gather this
+    # replaced retained every blob until the last one landed — up to
+    # MAX_ICON_BYTES per uploaded icon, on a route that takes no auth.
+    for start in range(0, len(icons), _SPRITE_RENDER_BATCH):
+        batch = icons[start : start + _SPRITE_RENDER_BATCH]
+        payloads = await _load_icon_payloads(batch, assets)
+        # fix(#1428): decode and resample are CPU-bound and scale with the stored
+        # icons' pixel count. Off the loop, so one large icon stalls a thread
+        # instead of every other request in flight.
+        await run_in_thread_draining(_paste_icon_cells, sheet, start, batch, payloads)
+    return await run_in_thread_draining(_encode_sprite_png, sheet)

--- a/backend/app/modules/catalog/maps/sprites.py
+++ b/backend/app/modules/catalog/maps/sprites.py
@@ -257,10 +257,26 @@ def _asset_response(asset: MapIconAsset) -> MapIconResponse:
     )
 
 
-async def list_icons(session: AsyncSession) -> list[MapIconResponse]:
+async def _load_icon_catalog(
+    session: AsyncSession,
+) -> tuple[list[MapIconResponse], list[MapIconAsset]]:
+    """The icon catalog, as sprite responses plus the uploaded rows behind them.
+
+    fix(#1428 codex r2): the sheet render needs those rows to reach storage, and
+    this is the query that already loads all of them. Re-reading them by id cost
+    a second query that grew a bind parameter per icon — past 32k uploads that
+    is more parameters than the driver accepts, on a route that takes no auth.
+    """
     result = await session.execute(select(MapIconAsset).order_by(MapIconAsset.name))
-    uploaded = [_asset_response(asset) for asset in result.scalars().all()]
-    return [_builtin_response(icon) for icon in DEFAULT_ICONS] + uploaded
+    uploaded = list(result.scalars().all())
+    icons = [_builtin_response(icon) for icon in DEFAULT_ICONS]
+    icons += [_asset_response(asset) for asset in uploaded]
+    return icons, uploaded
+
+
+async def list_icons(session: AsyncSession) -> list[MapIconResponse]:
+    icons, _uploaded = await _load_icon_catalog(session)
+    return icons
 
 
 async def create_icon_asset(
@@ -636,7 +652,7 @@ def _build_sprite_index(icons: list[MapIconResponse]) -> SpriteIndex:
 async def build_sprite_png(session: AsyncSession) -> bytes:
     global _sprite_index_cache, _sprite_png_cache
 
-    icons = await list_icons(session)
+    icons, uploaded = await _load_icon_catalog(session)
     signature = _sprite_signature(icons)
     if _sprite_png_cache is not None and _sprite_png_cache.signature == signature:
         return _sprite_png_cache.png
@@ -644,38 +660,13 @@ async def build_sprite_png(session: AsyncSession) -> bytes:
     async with _sprite_cache_lock:
         if _sprite_png_cache is not None and _sprite_png_cache.signature == signature:
             return _sprite_png_cache.png
-        png = await _render_sprite_png(session, icons)
+        png = await _render_sprite_png(icons, uploaded)
         _sprite_index_cache = SpriteIndexCache(
             signature=signature,
             index=_build_sprite_index(icons),
         )
         _sprite_png_cache = SpritePngCache(signature=signature, png=png)
         return png
-
-
-async def _uploaded_icon_assets(
-    session: AsyncSession, icons: list[MapIconResponse]
-) -> dict[str, MapIconAsset]:
-    """The rows behind the uploaded icons, keyed by response id, in one query.
-
-    fix(#1428): every DB read the render needs happens here, before any of it
-    reaches a worker thread — an ``AsyncSession`` cannot be used from one. It
-    also replaces the per-icon ``session.get`` the serial loop issued.
-    """
-    asset_ids: list[uuid.UUID] = []
-    for icon in icons:
-        if icon.builtin:
-            continue
-        try:
-            asset_ids.append(uuid.UUID(icon.id))
-        except ValueError:
-            continue
-    if not asset_ids:
-        return {}
-    result = await session.execute(
-        select(MapIconAsset).where(MapIconAsset.id.in_(asset_ids))
-    )
-    return {str(asset.id): asset for asset in result.scalars().all()}
 
 
 async def _load_icon_payloads(
@@ -732,11 +723,13 @@ def _encode_sprite_png(sheet: Image.Image) -> bytes:
 
 
 async def _render_sprite_png(
-    session: AsyncSession, icons: list[MapIconResponse]
+    icons: list[MapIconResponse], uploaded: list[MapIconAsset]
 ) -> bytes:
+    """Composite the sheet. Takes rows, not a session — fix(#1428): every cell is
+    drawn in a worker thread, and an ``AsyncSession`` cannot be used from one."""
     if not icons:
         return _blank_png(SPRITE_CELL_SIZE)
-    assets = await _uploaded_icon_assets(session, icons)
+    assets = {str(asset.id): asset for asset in uploaded}
     sheet = Image.new(
         "RGBA",
         (len(icons) * SPRITE_CELL_SIZE, SPRITE_CELL_SIZE),

--- a/backend/app/modules/catalog/maps/sprites.py
+++ b/backend/app/modules/catalog/maps/sprites.py
@@ -34,6 +34,7 @@ from PIL import Image, ImageColor, ImageDraw, UnidentifiedImageError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.async_io import run_in_thread_draining
 from app.modules.catalog.maps.models import MapIconAsset
 from app.modules.catalog.maps.schemas import MapIconResponse
 from app.platform.storage import get_storage
@@ -47,6 +48,11 @@ from app.platform.storage import get_storage
 _stdlib_ET.register_namespace("", "http://www.w3.org/2000/svg")
 
 MAX_ICON_BYTES = 512 * 1024
+# fix(#1428): compressed size says nothing about decoded size. A 9000x9000 RGBA
+# PNG is ~330 KiB on the wire — inside MAX_ICON_BYTES — and ~320 MB once decoded
+# into a 24px sprite cell. Bound the dimensions too. 1024 is far more than a
+# sprite cell (24px, 48 at @2x) can show and holds one decode to ~4 MiB.
+MAX_ICON_DIMENSION = 1024
 SUPPORTED_MEDIA_TYPES = {"image/svg+xml": ".svg", "image/png": ".png"}
 
 _SLUG_RE = re.compile(r"[^a-z0-9_-]+")
@@ -67,6 +73,9 @@ class BuiltinIcon:
 
 SpriteIndex = dict[str, dict[str, int | float | bool]]
 SpriteSignature = tuple[tuple[str, str, str, int | None], ...]
+# One (content, media_type) per catalog icon, positionally aligned; None where
+# the icon no longer resolves and the sheet draws a placeholder instead.
+IconPayloads = list[tuple[bytes, str] | None]
 
 
 @dataclass(frozen=True)
@@ -164,10 +173,21 @@ def validate_icon_upload(
         raise ValueError("Icon file is too large")
     media_type = _media_type_from_upload(filename, content_type)
     if media_type == "image/png":
+        # fix(#1428): verify() consumes the image object, so read .size first.
+        # Image.open is lazy — that costs an IHDR parse and no pixel decode.
         try:
-            Image.open(BytesIO(content)).verify()
-        except (UnidentifiedImageError, OSError, SyntaxError):
-            raise ValueError("PNG icon content is invalid")
+            image = Image.open(BytesIO(content))
+            width, height = image.size
+            image.verify()
+        except Image.DecompressionBombError as exc:
+            # PIL raises this from open() on absurd IHDR dimensions. That is an
+            # oversized icon, not a corrupt one, and it used to escape as a 500.
+            raise ValueError("PNG icon dimensions are too large") from exc
+        except (UnidentifiedImageError, OSError, IndexError, SyntaxError) as exc:
+            # IndexError: verify() indexes the chunk list on a PNG with no IDAT.
+            raise ValueError("PNG icon content is invalid") from exc
+        if max(width, height) > MAX_ICON_DIMENSION:
+            raise ValueError("PNG icon dimensions are too large")
     if media_type == "image/svg+xml":
         prefix = content[:512].lower()
         if b"<svg" not in prefix:
@@ -548,6 +568,10 @@ def _render_icon(content: bytes, media_type: str, seed: str) -> Image.Image:
         ValueError,
         IndexError,
         SyntaxError,
+        # fix(#1428): an icon stored before MAX_ICON_DIMENSION existed can still
+        # trip PIL's own bomb guard. Degrade that cell to the placeholder rather
+        # than 500 the whole sprite sheet.
+        Image.DecompressionBombError,
     ):
         return _placeholder_icon(seed)
 
@@ -623,23 +647,84 @@ async def build_sprite_png(session: AsyncSession) -> bytes:
         return png
 
 
-async def _render_sprite_png(
+async def _load_icon_payloads(
     session: AsyncSession, icons: list[MapIconResponse]
-) -> bytes:
-    if not icons:
-        return _blank_png(SPRITE_CELL_SIZE)
+) -> IconPayloads:
+    """Resolve every icon's bytes and media type, ordered to match ``icons``.
+
+    fix(#1428): all of the render's I/O happens here, because the composite that
+    consumes the result runs in a worker thread and an ``AsyncSession`` cannot be
+    used from one. Uploaded rows come back in a single query and their stored
+    objects are fetched concurrently, replacing a per-icon round trip.
+    """
+    builtin_icons = {icon.slug: icon for icon in DEFAULT_ICONS}
+    asset_ids: list[uuid.UUID] = []
+    for icon in icons:
+        if icon.builtin:
+            continue
+        try:
+            asset_ids.append(uuid.UUID(icon.id))
+        except ValueError:
+            continue
+
+    assets: dict[str, MapIconAsset] = {}
+    if asset_ids:
+        result = await session.execute(
+            select(MapIconAsset).where(MapIconAsset.id.in_(asset_ids))
+        )
+        assets = {str(asset.id): asset for asset in result.scalars().all()}
+
+    payloads: IconPayloads = [None] * len(icons)
+    stored: list[tuple[int, MapIconAsset]] = []
+    for position, icon in enumerate(icons):
+        if icon.builtin:
+            builtin = builtin_icons.get(icon.sprite_id)
+            if builtin is not None:
+                payloads[position] = (builtin.content, builtin.media_type)
+            continue
+        asset = assets.get(icon.id)
+        if asset is not None:
+            stored.append((position, asset))
+
+    if stored:
+        storage = get_storage()
+        # return_exceptions so a failing read cannot leave its siblings running
+        # unretrieved; the first failure is re-raised, as the serial loop did.
+        blobs = await asyncio.gather(
+            *(storage.get(asset.storage_key) for _, asset in stored),
+            return_exceptions=True,
+        )
+        for (position, asset), blob in zip(stored, blobs):
+            if isinstance(blob, BaseException):
+                raise blob
+            payloads[position] = (blob, asset.media_type)
+    return payloads
+
+
+def _compose_sprite_png(icons: list[MapIconResponse], payloads: IconPayloads) -> bytes:
     sheet = Image.new(
         "RGBA",
         (len(icons) * SPRITE_CELL_SIZE, SPRITE_CELL_SIZE),
         (0, 0, 0, 0),
     )
-    for index, icon in enumerate(icons):
-        content = await get_icon_content(session, icon.id)
-        if content is None:
+    for index, (icon, payload) in enumerate(zip(icons, payloads)):
+        if payload is None:
             image = _placeholder_icon(icon.sprite_id)
         else:
-            image = _render_icon(content[0], content[1], icon.sprite_id)
+            image = _render_icon(payload[0], payload[1], icon.sprite_id)
         sheet.alpha_composite(image, (index * SPRITE_CELL_SIZE, 0))
     out = BytesIO()
     sheet.save(out, format="PNG")
     return out.getvalue()
+
+
+async def _render_sprite_png(
+    session: AsyncSession, icons: list[MapIconResponse]
+) -> bytes:
+    if not icons:
+        return _blank_png(SPRITE_CELL_SIZE)
+    payloads = await _load_icon_payloads(session, icons)
+    # fix(#1428): decode, resample and re-encode are CPU-bound and scale with the
+    # stored icons' pixel count, on a route that takes no auth. Off the loop, so
+    # one large icon stalls a thread instead of every other request in flight.
+    return await run_in_thread_draining(_compose_sprite_png, icons, payloads)

--- a/backend/app/modules/catalog/maps/sprites.py
+++ b/backend/app/modules/catalog/maps/sprites.py
@@ -48,11 +48,27 @@ from app.platform.storage import get_storage
 _stdlib_ET.register_namespace("", "http://www.w3.org/2000/svg")
 
 MAX_ICON_BYTES = 512 * 1024
-# fix(#1428): compressed size says nothing about decoded size. A 9000x9000 RGBA
-# PNG is ~330 KiB on the wire — inside MAX_ICON_BYTES — and ~320 MB once decoded
-# into a 24px sprite cell. Bound the dimensions too. 1024 is far more than a
-# sprite cell (24px, 48 at @2x) can show and holds one decode to ~4 MiB.
+# fix(#1428): compressed size says nothing about decoded size — a 9000x9000 PNG
+# is ~79 KiB on the wire, inside MAX_ICON_BYTES, and ~320 MB once decoded into a
+# 24px cell. Two caps bound that, and they are deliberately different numbers
+# because they answer different questions:
+#
+#   MAX_ICON_DIMENSION is a PRODUCT bound, on what may be uploaded from here on.
+#   1024 is far more than a sprite cell (24px, 48 at @2x) can show, so it costs
+#   a new icon nothing and holds its decode to ~4 MiB.
+#
+#   MAX_RENDER_PIXELS is a MEMORY bound, on what is ALREADY stored — where the
+#   upload cap gets no say, since those rows predate it. Re-using the upload cap
+#   at render would blank icons that draw correctly on maps today, so this one
+#   is set by what a single decode may cost instead: 24M px is ~96 MB of RGBA,
+#   and decodes are sequential within a batch, so it bounds the peak. Anything
+#   plausible (~4900px square, or any shape under that area) still renders its
+#   real art; only DoS-scale artifacts degrade to the placeholder.
+#
+# Area rather than dimensions, because cost tracks area: a 12000x160 strip is
+# 1.9M px and cheaper to decode than a 2048 square.
 MAX_ICON_DIMENSION = 1024
+MAX_RENDER_PIXELS = 24_000_000
 SUPPORTED_MEDIA_TYPES = {"image/svg+xml": ".svg", "image/png": ".png"}
 
 _SLUG_RE = re.compile(r"[^a-z0-9_-]+")
@@ -575,7 +591,14 @@ def _placeholder_icon(seed: str) -> Image.Image:
 def _render_icon(content: bytes, media_type: str, seed: str) -> Image.Image:
     try:
         if media_type == "image/png":
-            source = Image.open(BytesIO(content)).convert("RGBA")
+            source = Image.open(BytesIO(content))
+            # fix(#1428 codex r4): .size comes off the header — convert() is what
+            # allocates. Refuse in between, so a stored artifact never reaches
+            # the decode. This is the gate for everything between the bound and
+            # Pillow's own bomb threshold, which sits ~7x higher.
+            if source.width * source.height > MAX_RENDER_PIXELS:
+                return _placeholder_icon(seed)
+            source = source.convert("RGBA")
         else:
             root = ElementTree.fromstring(content)
             source = Image.new(
@@ -590,9 +613,9 @@ def _render_icon(content: bytes, media_type: str, seed: str) -> Image.Image:
         ValueError,
         IndexError,
         SyntaxError,
-        # fix(#1428): an icon stored before MAX_ICON_DIMENSION existed can still
-        # trip PIL's own bomb guard. Degrade that cell to the placeholder rather
-        # than 500 the whole sprite sheet.
+        # fix(#1428): past ~179M px Pillow refuses from open() itself, before
+        # the MAX_RENDER_PIXELS check above can measure anything. Degrade that
+        # cell too, rather than 500 the whole sprite sheet.
         Image.DecompressionBombError,
     ):
         return _placeholder_icon(seed)

--- a/backend/tests/test_map_sprites.py
+++ b/backend/tests/test_map_sprites.py
@@ -10,7 +10,6 @@ import zlib
 from PIL import Image
 from httpx import AsyncClient
 import pytest
-from httpx import AsyncClient
 
 from app.modules.catalog.maps import sprites
 from app.modules.catalog.maps.models import MapIconAsset

--- a/backend/tests/test_map_sprites.py
+++ b/backend/tests/test_map_sprites.py
@@ -1,15 +1,23 @@
 """Tests for map sprite and icon helper behavior."""
 
 from io import BytesIO
+import struct
+import threading
 import uuid
+import zlib
 
 from PIL import Image
+from httpx import AsyncClient
 import pytest
 from httpx import AsyncClient
 
+from app.modules.catalog.maps import sprites
 from app.modules.catalog.maps.models import MapIconAsset
 from app.modules.catalog.maps.sprites import (
+    MAX_ICON_BYTES,
+    SPRITE_CELL_SIZE,
     _path_points,
+    _placeholder_icon,
     _render_icon,
     build_sprite_index,
     build_sprite_png,
@@ -41,8 +49,11 @@ class FakeSession:
     def __init__(self, rows=None):
         self.rows = rows or []
         self.added = []
+        self.execute_count = 0
+        self.get_count = 0
 
     async def execute(self, _stmt):
+        self.execute_count += 1
         return _ExecuteResult(self.rows)
 
     def add(self, obj):
@@ -53,6 +64,7 @@ class FakeSession:
         return None
 
     async def get(self, _model, ident):
+        self.get_count += 1
         for row in self.rows:
             if row.id == ident:
                 return row
@@ -88,6 +100,38 @@ def _asset(**overrides):
 def _png_bytes() -> bytes:
     out = BytesIO()
     Image.new("RGBA", (1, 1), (255, 0, 0, 255)).save(out, format="PNG")
+    return out.getvalue()
+
+
+def _png_chunk(kind: bytes, data: bytes) -> bytes:
+    return (
+        struct.pack(">I", len(data))
+        + kind
+        + data
+        + struct.pack(">I", zlib.crc32(kind + data) & 0xFFFFFFFF)
+    )
+
+
+def _png_header_only(width: int, height: int) -> bytes:
+    """A PNG header with no pixel data — PIL reads ``size`` from IHDR alone.
+
+    Lets a test stage absurd dimensions (and the decompression-bomb refusal PIL
+    raises from ``Image.open`` for them) without materializing the pixels.
+    """
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _png_chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+        + _png_chunk(b"IEND", b"")
+    )
+
+
+def _large_png_bytes(size: int = 4096) -> bytes:
+    """A real, decodable PNG whose dimensions are over the cap but whose bytes
+    are well under it — the shape the byte cap alone cannot catch. Sizes are
+    written out rather than derived from MAX_ICON_DIMENSION so that moving the
+    cap has to face these tests."""
+    out = BytesIO()
+    Image.new("L", (size, size), 0).save(out, format="PNG")
     return out.getvalue()
 
 
@@ -339,3 +383,156 @@ async def test_create_icon_asset_clears_sprite_cache(monkeypatch):
     await build_sprite_png(session)
 
     assert storage.get_count == 3
+
+
+# The sprite sheet is rendered by PIL behind an unauthenticated route, so the
+# tests below pin the three bounds that keep one uploaded icon from costing the
+# whole API: an upload-time dimension cap, a render that degrades instead of
+# raising, and I/O that is batched and off the event loop.
+
+
+def test_validate_icon_upload_rejects_oversized_png_dimensions():
+    content = _large_png_bytes()
+
+    # the byte cap passes this file; only a dimension cap stops it
+    assert len(content) < MAX_ICON_BYTES
+    with pytest.raises(ValueError, match="dimensions"):
+        validate_icon_upload("huge.png", "image/png", content)
+
+
+def test_validate_icon_upload_accepts_png_at_the_dimension_cap():
+    content = _large_png_bytes(1024)  # MAX_ICON_DIMENSION
+
+    _slug, media_type, sanitized = validate_icon_upload("ok.png", "image/png", content)
+
+    assert media_type == "image/png"
+    assert sanitized == content
+
+
+def test_validate_icon_upload_rejects_decompression_bomb_png():
+    # PIL refuses these from Image.open itself, before any pixel decode; the
+    # upload must still land as a 400-shaped ValueError, not an unhandled raise.
+    with pytest.raises(ValueError, match="dimensions"):
+        validate_icon_upload("bomb.png", "image/png", _png_header_only(14000, 14000))
+
+
+def test_validate_icon_upload_rejects_png_without_pixel_data():
+    # verify() raises IndexError (not OSError) on a PNG with no IDAT chunk.
+    with pytest.raises(ValueError, match="invalid"):
+        validate_icon_upload("empty.png", "image/png", _png_header_only(64, 64))
+
+
+def test_render_icon_degrades_decompression_bomb_to_placeholder():
+    rendered = _render_icon(_png_header_only(14000, 14000), "image/png", "bus")
+
+    assert rendered.size == (SPRITE_CELL_SIZE, SPRITE_CELL_SIZE)
+    assert rendered.tobytes() == _placeholder_icon("bus").tobytes()
+
+
+@pytest.mark.anyio
+async def test_sprite_png_renders_when_a_stored_icon_is_oversized(monkeypatch):
+    """An icon stored before the dimension cap existed cannot 500 the sheet."""
+    storage = FakeStorage()
+    storage.objects["maps/icons/bomb.png"] = _png_header_only(14000, 14000)
+    monkeypatch.setattr("app.modules.catalog.maps.sprites.get_storage", lambda: storage)
+    session = FakeSession(
+        rows=[
+            _asset(
+                slug="bomb",
+                media_type="image/png",
+                storage_key="maps/icons/bomb.png",
+            )
+        ]
+    )
+
+    png = await build_sprite_png(session)
+
+    assert png.startswith(b"\x89PNG\r\n\x1a\n")
+    assert Image.open(BytesIO(png)).size == (4 * SPRITE_CELL_SIZE, SPRITE_CELL_SIZE)
+
+
+@pytest.mark.anyio
+async def test_sprite_png_loads_uploaded_icons_in_one_query(monkeypatch):
+    storage = FakeStorage()
+    rows = []
+    for slug in ("bus", "train", "tram"):
+        storage.objects[f"maps/icons/{slug}.png"] = _png_bytes()
+        rows.append(
+            _asset(
+                slug=slug,
+                media_type="image/png",
+                storage_key=f"maps/icons/{slug}.png",
+            )
+        )
+    monkeypatch.setattr("app.modules.catalog.maps.sprites.get_storage", lambda: storage)
+    session = FakeSession(rows=rows)
+
+    await build_sprite_png(session)
+
+    # one listing query plus one batched fetch for the uploaded rows — not a
+    # per-icon session.get()
+    assert session.execute_count == 2
+    assert session.get_count == 0
+    assert storage.get_count == 3
+
+
+@pytest.mark.anyio
+async def test_sprite_png_composites_off_the_event_loop(monkeypatch):
+    """PIL decode/resample/encode must not run on the event loop thread."""
+    storage = FakeStorage()
+    storage.objects["maps/icons/bus.png"] = _png_bytes()
+    monkeypatch.setattr("app.modules.catalog.maps.sprites.get_storage", lambda: storage)
+    session = FakeSession(
+        rows=[
+            _asset(slug="bus", media_type="image/png", storage_key="maps/icons/bus.png")
+        ]
+    )
+    composite_threads = []
+    original = sprites._compose_sprite_png
+
+    def _record(*args):
+        composite_threads.append(threading.current_thread())
+        return original(*args)
+
+    monkeypatch.setattr(sprites, "_compose_sprite_png", _record)
+
+    await build_sprite_png(session)
+
+    assert composite_threads and threading.main_thread() not in composite_threads
+
+
+@pytest.mark.anyio
+async def test_sprite_png_route_serves_the_sheet(client: AsyncClient):
+    resp = await client.get("/maps/sprites/geolens.png")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/png"
+    assert resp.headers["cache-control"] == "public, max-age=3600"
+    sheet = Image.open(BytesIO(resp.content))
+    assert sheet.height == SPRITE_CELL_SIZE
+    # one cell per catalog icon, the three built-ins at minimum
+    assert sheet.width >= 3 * SPRITE_CELL_SIZE
+    assert sheet.width % SPRITE_CELL_SIZE == 0
+
+
+@pytest.mark.anyio
+async def test_sprite_png_2x_route_serves_the_sheet(client: AsyncClient):
+    resp = await client.get("/maps/sprites/geolens@2x.png")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/png"
+    assert Image.open(BytesIO(resp.content)).height == SPRITE_CELL_SIZE
+
+
+@pytest.mark.anyio
+async def test_icon_upload_route_rejects_oversized_dimensions(
+    client: AsyncClient, admin_auth_header: dict[str, str]
+):
+    resp = await client.post(
+        "/maps/icons",
+        headers=admin_auth_header,
+        files={"file": ("huge.png", _large_png_bytes(), "image/png")},
+    )
+
+    assert resp.status_code == 400
+    assert "dimensions" in resp.json()["detail"]

--- a/backend/tests/test_map_sprites.py
+++ b/backend/tests/test_map_sprites.py
@@ -133,14 +133,24 @@ def _png_header_only(width: int, height: int) -> bytes:
     )
 
 
+def _real_png_bytes(width: int, height: int) -> bytes:
+    """A real, decodable PNG at the given dimensions.
+
+    Grayscale and single-colored, so staging tens of millions of pixels costs a
+    few KB on the wire and no measurable time to build — which is the whole
+    problem: nothing about the byte count reflects what decoding will cost.
+    """
+    out = BytesIO()
+    Image.new("L", (width, height), 0).save(out, format="PNG")
+    return out.getvalue()
+
+
 def _large_png_bytes(size: int = 4096) -> bytes:
     """A real, decodable PNG whose dimensions are over the cap but whose bytes
     are well under it — the shape the byte cap alone cannot catch. Sizes are
     written out rather than derived from MAX_ICON_DIMENSION so that moving the
     cap has to face these tests."""
-    out = BytesIO()
-    Image.new("L", (size, size), 0).save(out, format="PNG")
-    return out.getvalue()
+    return _real_png_bytes(size, size)
 
 
 @pytest.fixture(autouse=True)
@@ -435,6 +445,47 @@ def test_render_icon_degrades_decompression_bomb_to_placeholder():
 
     assert rendered.size == (SPRITE_CELL_SIZE, SPRITE_CELL_SIZE)
     assert rendered.tobytes() == _placeholder_icon("bus").tobytes()
+
+
+# The upload cap only governs icons uploaded from here on. The three tests below
+# pin the separate render-side bound that governs what is ALREADY stored: it is
+# a memory bound, set high enough that every plausible existing icon still draws
+# its real art, and low enough that a DoS-scale artifact never reaches a decode.
+
+
+def test_render_icon_degrades_a_stored_dos_scale_png_to_placeholder():
+    # 9000x9000 is 81M px: under Pillow's own bomb threshold, so nothing stopped
+    # it, ~79 KB on the wire, so the byte cap let it in before MAX_ICON_DIMENSION
+    # existed — and ~320 MB to decode on an unauthenticated cold render.
+    content = _real_png_bytes(9000, 9000)
+    assert len(content) < MAX_ICON_BYTES
+
+    rendered = _render_icon(content, "image/png", "bus")
+
+    assert rendered.tobytes() == _placeholder_icon("bus").tobytes()
+
+
+def test_render_icon_still_draws_a_large_but_plausible_stored_png():
+    """An icon stored before the upload cap existed keeps rendering its real art.
+
+    This is the property that makes the render bound a memory bound rather than
+    the upload cap applied late: 2048px is over MAX_ICON_DIMENSION, so re-using
+    the upload cap here would silently blank it on maps that display it today.
+    """
+    rendered = _render_icon(_real_png_bytes(2048, 2048), "image/png", "bus")
+
+    assert rendered.tobytes() != _placeholder_icon("bus").tobytes()
+    assert rendered.getpixel((12, 12)) == (0, 0, 0, 255)
+
+
+def test_render_bound_counts_pixels_not_dimensions():
+    # 12000x160 is 1.9M px — wider than any dimension cap would allow, and
+    # cheaper to decode than the 2048 square above. Cost tracks area, so the
+    # bound does too.
+    rendered = _render_icon(_real_png_bytes(12000, 160), "image/png", "bus")
+
+    assert rendered.tobytes() != _placeholder_icon("bus").tobytes()
+    assert any(rendered.tobytes()[3::4])
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_map_sprites.py
+++ b/backend/tests/test_map_sprites.py
@@ -1,5 +1,6 @@
 """Tests for map sprite and icon helper behavior."""
 
+import asyncio
 from io import BytesIO
 import struct
 import threading
@@ -16,6 +17,7 @@ from app.modules.catalog.maps.models import MapIconAsset
 from app.modules.catalog.maps.sprites import (
     MAX_ICON_BYTES,
     SPRITE_CELL_SIZE,
+    _SPRITE_RENDER_BATCH,
     _path_points,
     _placeholder_icon,
     _render_icon,
@@ -75,6 +77,8 @@ class FakeStorage:
     def __init__(self):
         self.objects = {}
         self.get_count = 0
+        self.in_flight = 0
+        self.max_in_flight = 0
 
     async def put(self, key, data):
         self.objects[key] = data if isinstance(data, bytes) else data.read()
@@ -82,6 +86,11 @@ class FakeStorage:
 
     async def get(self, key):
         self.get_count += 1
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        # yield, so concurrent callers actually overlap and are counted
+        await asyncio.sleep(0)
+        self.in_flight -= 1
         return self.objects[key]
 
 
@@ -487,18 +496,52 @@ async def test_sprite_png_composites_off_the_event_loop(monkeypatch):
             _asset(slug="bus", media_type="image/png", storage_key="maps/icons/bus.png")
         ]
     )
-    composite_threads = []
-    original = sprites._compose_sprite_png
+    render_threads = []
 
-    def _record(*args):
-        composite_threads.append(threading.current_thread())
-        return original(*args)
+    def _recorded(name):
+        original = getattr(sprites, name)
 
-    monkeypatch.setattr(sprites, "_compose_sprite_png", _record)
+        def _record(*args):
+            render_threads.append(threading.current_thread())
+            return original(*args)
+
+        return _record
+
+    for name in ("_paste_icon_cells", "_encode_sprite_png"):
+        monkeypatch.setattr(sprites, name, _recorded(name))
 
     await build_sprite_png(session)
 
-    assert composite_threads and threading.main_thread() not in composite_threads
+    # both the per-cell render and the sheet encode, off the main thread
+    assert len(render_threads) == 2
+    assert threading.main_thread() not in render_threads
+
+
+@pytest.mark.anyio
+async def test_sprite_png_bounds_icon_reads_in_flight(monkeypatch):
+    """A large catalog must not fan out one storage read per icon at once.
+
+    fix(#1428 codex r1): the reads and the icon bytes they return are both held
+    a batch at a time — an unbounded gather retained up to MAX_ICON_BYTES per
+    uploaded icon before the first cell was drawn.
+    """
+    storage = FakeStorage()
+    rows = []
+    for index in range(_SPRITE_RENDER_BATCH * 3):
+        key = f"maps/icons/icon-{index}.png"
+        storage.objects[key] = _png_bytes()
+        rows.append(
+            _asset(slug=f"icon-{index}", media_type="image/png", storage_key=key)
+        )
+    monkeypatch.setattr("app.modules.catalog.maps.sprites.get_storage", lambda: storage)
+    session = FakeSession(rows=rows)
+
+    await build_sprite_png(session)
+
+    assert storage.get_count == _SPRITE_RENDER_BATCH * 3
+    assert storage.max_in_flight <= _SPRITE_RENDER_BATCH
+    # still a fan-out, not a serial read
+    assert storage.max_in_flight > 1
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_map_sprites.py
+++ b/backend/tests/test_map_sprites.py
@@ -461,7 +461,7 @@ async def test_sprite_png_renders_when_a_stored_icon_is_oversized(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_sprite_png_loads_uploaded_icons_in_one_query(monkeypatch):
+async def test_sprite_png_loads_the_icon_catalog_in_one_query(monkeypatch):
     storage = FakeStorage()
     rows = []
     for slug in ("bus", "train", "tram"):
@@ -478,9 +478,9 @@ async def test_sprite_png_loads_uploaded_icons_in_one_query(monkeypatch):
 
     await build_sprite_png(session)
 
-    # one listing query plus one batched fetch for the uploaded rows — not a
-    # per-icon session.get()
-    assert session.execute_count == 2
+    # fix(#1428 codex r2): the listing query and nothing else — no per-icon
+    # session.get(), and no second lookup binding one parameter per icon
+    assert session.execute_count == 1
     assert session.get_count == 0
     assert storage.get_count == 3
 


### PR DESCRIPTION
Backend-audit follow-up on the map sprite sheet.

## What

`GET /maps/sprites/geolens.png` (and the `@2x` twin) takes no auth, and on a cache miss it decoded every icon in the catalog with PIL directly on the event loop — one storage read per icon in series, then `Image.open().convert("RGBA")`, a LANCZOS `thumbnail()`, and `save()` inline. Validation capped bytes but not pixels, and the two are only loosely related: a 9000x9000 PNG is 79 KiB on the wire, inside the 512 KiB cap, and costs roughly 320 MB and a third of a second to decode. Every other request in flight waits through that.

Two smaller holes in the same path: PIL raises `DecompressionBombError` from `Image.open` on absurd IHDR dimensions, and `verify()` raises `IndexError` on a PNG with no IDAT chunk. Neither is named in the handlers that were supposed to catch bad image bytes, so both surfaced as 500s — on upload, and on the sprite route for a row already in the database.

## Changes

Two pixel caps, deliberately different numbers because they answer different questions:

- `MAX_ICON_DIMENSION` (1024px) is a **product** bound on what may be uploaded from here on, checked off the IHDR header that `Image.open` parses lazily. It is far past what a 24px sprite cell (48 at `@2x`) can show, so it costs a new icon nothing.
- `MAX_RENDER_PIXELS` (24M px) is a **memory** bound on what is already stored, where the upload cap gets no say — those rows predate it. Checked between `Image.open` and `convert()`, so an oversized artifact never reaches the allocation. Re-using the upload cap here would blank icons that draw correctly on maps today; 24M px (~96 MB of RGBA, and decodes are sequential within a batch) lets anything plausible up to ~4900px render its real art while DoS-scale artifacts degrade to the placeholder. It bounds area rather than dimensions because cost tracks area: a 12000x160 strip is 1.9M px and cheaper than a 2048 square.

Alongside those:

- `validate_icon_upload` maps `DecompressionBombError` and `IndexError` to `ValueError`, which the route already turns into a 400.
- `_render_icon` catches `DecompressionBombError`, which fires from `open()` above ~179M px before the pixel check can measure anything, so that cell degrades instead of 500ing the sheet.
- The render works `_SPRITE_RENDER_BATCH` icons at a time: each batch's stored objects are fetched concurrently, then composited in a worker thread. The catalog has no size limit, so neither the read fan-out nor the icon bytes held at once may scale with it.
- The listing query that the render already runs now hands its rows down, so the render issues no second query and `_render_sprite_png` takes no session — which is what handing the composite to a thread needed to be true anyway.

## Impacts

- **API contract: none.** The PNG handlers have no `response_model` and their signatures are untouched; `openapi.json` and the SDKs are unchanged.
- **Behavior change on upload:** a PNG over 1024px on either axis is now rejected with 400 `PNG icon dimensions are too large`. Worth knowing before it reaches anyone uploading large source art.
- **Behavior change on render, bounded deliberately:** a stored icon above 24M pixels draws as the placeholder instead of its art. Nothing under that changes, so no icon a real map displays today is affected.
- No schema or config changes.

## Verification

```
cd backend && uv run ruff check app tests && uv run ruff format app tests --check
cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q
cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_map_sprites.py tests/test_phase_273_icon_csp.py tests/test_phase_273_svg_defusedxml.py tests/test_maps.py tests/test_maps_style_json.py -q
```

Twelve new tests, each failing against the code it targets for its own reason: the 4096px upload was accepted (`DID NOT RAISE`), the bomb-sized and IDAT-less uploads escaped as `DecompressionBombError` / `IndexError`, the stored 81M-px icon rendered its full art rather than the placeholder, the catalog read counted three round trips instead of one, the storage reads had no ceiling on how many ran at once, and the composite had no worker thread to run on. Two of them guard the property the render bound must not break — a 2048px and a 12000x160 stored icon still draw real art. The sheet route itself had zero coverage before this; it now asserts 200, `image/png`, and a decodable sheet one cell wide per icon.