### PR TITLE
refactor(seams): move the rate limiter, the role lookup, and the embed-token reads to their owning layers

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -44,7 +44,7 @@ from app.platform.extensions.bootstrap import (
 )
 from app.modules.auth.models import Role, User, UserRole
 from app.modules.auth.providers.local import hash_password
-from app.modules.auth.router import limiter
+from app.platform.ratelimit import limiter
 from app.processing.ingest.tasks import task_app
 from app.api.middleware.body_limit import RequestBodyLimitMiddleware
 from app.api.middleware.cors import DynamicCORSMiddleware

--- a/backend/app/modules/admin/router.py
+++ b/backend/app/modules/admin/router.py
@@ -41,7 +41,7 @@ from app.modules.admin.service import (
 from app.modules.quota.service import get_user_quota_usage_bulk
 from app.modules.audit.service import AuditEvent, audit_emit, audit_emit_durable
 from app.modules.auth.dependencies import require_mode_permission, require_permission
-from app.modules.auth.router import limiter  # HARDEN-01: shared rate-limiter instance
+from app.platform.ratelimit import limiter  # HARDEN-01: shared rate-limiter instance
 from app.modules.auth.models import User
 from app.modules.auth.schemas import UserResponse
 from app.processing.export.service import safe_content_disposition

--- a/backend/app/modules/admin/router_operations.py
+++ b/backend/app/modules/admin/router_operations.py
@@ -26,7 +26,7 @@ from app.modules.admin.service import AdminService
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.modules.auth.dependencies import require_mode_permission, require_permission
 from app.modules.auth.models import ApiKey, User
-from app.modules.auth.router import limiter
+from app.platform.ratelimit import limiter
 from app.modules.auth.schemas import ApiKeyCreateResponse
 
 router = APIRouter()

--- a/backend/app/modules/auth/dependencies.py
+++ b/backend/app/modules/auth/dependencies.py
@@ -17,7 +17,7 @@ from app.core.config import settings
 from app.core.dependencies import get_db
 from app.core.identity import Identity
 from app.modules.auth.models import ApiKey, User
-from app.modules.catalog.authorization import get_user_roles
+from app.modules.auth.permissions import get_user_roles
 from app.platform.extensions import get_identity_extension, get_permission_extension
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")

--- a/backend/app/modules/auth/permissions.py
+++ b/backend/app/modules/auth/permissions.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 import copy
 from typing import Any
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.identity import Identity
+from app.modules.auth.models import Role, UserRole
 from app.core.permissions import (
     ALL_CAPABILITIES,
     CREATE_LAYERS,
@@ -39,6 +42,7 @@ __all__ = [
     "UPLOAD",
     "USE_AI_CHAT",
     "get_effective_permissions",
+    "get_user_roles",
     "user_has_capability",
     "validate_permission_matrix",
 ]
@@ -109,6 +113,28 @@ def validate_permission_matrix(matrix: Any) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Role resolution
+# ---------------------------------------------------------------------------
+
+
+async def get_user_roles(db: AsyncSession, user: Identity) -> set[str]:
+    """Get the set of role names for a user.
+
+    Replaces the per-router ``_get_user_roles()`` duplicates. Lives here rather
+    than in ``catalog.authorization`` (its home until this move) because the
+    query reads the auth-owned ``Role``/``UserRole`` tables and touches nothing
+    catalog; ``catalog.authorization`` re-exports it so its callers are
+    unaffected.
+    """
+    result = await db.execute(
+        select(Role.name)
+        .join(UserRole, Role.id == UserRole.role_id)
+        .where(UserRole.user_id == user.id)
+    )
+    return {row[0] for row in result.all()}
+
+
+# ---------------------------------------------------------------------------
 # Effective permissions (DB override merged with defaults)
 # ---------------------------------------------------------------------------
 
@@ -117,9 +143,9 @@ async def user_has_capability(db: AsyncSession, user: Any, capability: str) -> b
     """Return True if *user* holds *capability* via any of their assigned roles.
 
     Used for break-glass exemptions (e.g. DOMAIN-04 manage_settings bypass).
-    Resolves roles via get_user_roles (catalog.authorization) and checks the
-    effective permission matrix; does NOT add DB code to domain_validation.py
-    (that module is DB-free by contract, T-1235 purity gate).
+    Resolves roles via get_user_roles above and checks the effective permission
+    matrix; does NOT add DB code to domain_validation.py (that module is DB-free
+    by contract, T-1235 purity gate).
 
     Args:
         db:         Async DB session.
@@ -129,10 +155,6 @@ async def user_has_capability(db: AsyncSession, user: Any, capability: str) -> b
     Returns:
         True if any of the user's roles grant the requested capability.
     """
-    from app.modules.catalog.authorization import (
-        get_user_roles,
-    )  # LAZY — avoids circular
-
     roles = await get_user_roles(db, user)
     matrix = await get_effective_permissions(db)
     return any(matrix.get(role, {}).get(capability, False) for role in roles)

--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -5,8 +5,6 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -48,20 +46,13 @@ from app.core.persistent_config import (
     PASSWORD_LOGIN_ENABLED,
     REFRESH_TOKEN_EXPIRE_DAYS,
     REGISTRATION_ENABLED,
-    get_cached_global_rate_limit,
     get_cached_login_rate_limit,
 )
 from app.modules.auth.domain_policy import enforce_email_domain_gate
+from app.platform.ratelimit import limiter
 from app.standards.ogc.errors import BAD_GATEWAY_RESPONSE, ERROR_RESPONSES_AUTH
 
 router = APIRouter(prefix="/auth", tags=["Auth"], responses=ERROR_RESPONSES_AUTH)
-
-
-def _global_rate_limit(_request: Request | None = None) -> str:
-    return f"{get_cached_global_rate_limit()}/second"
-
-
-limiter = Limiter(key_func=get_remote_address, default_limits=[_global_rate_limit])
 
 
 def _login_rate_limit(_request: Request | None = None) -> str:

--- a/backend/app/modules/catalog/authorization.py
+++ b/backend/app/modules/catalog/authorization.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.core.identity import Identity
-from app.modules.auth.models import Role, UserRole
+from app.modules.auth.permissions import get_user_roles as _get_user_roles
 from app.platform.extensions import get_permission_extension
 
 
@@ -66,16 +66,20 @@ def apply_visibility_filter(
 
 
 async def get_user_roles(db: AsyncSession, user: Identity) -> set[str]:
-    """Get the set of role names for a user.
+    """Role names for a user. The query itself lives in ``auth.permissions``.
 
-    Replaces the per-router ``_get_user_roles()`` duplicates.
+    It selects the auth-owned ``Role``/``UserRole`` tables and reads nothing
+    catalog, so auth owns it; keeping it callable from here leaves the ~40
+    catalog call sites and the ``catalog.authorization`` import path unchanged
+    while ``auth.dependencies`` stops importing catalog to get it.
+
+    A delegating def rather than a bare re-export on purpose:
+    ``test_permission_chokepoints_use_extension`` reads this file's
+    ``async def get_user_roles`` as the end of the ``apply_visibility_filter``
+    block it inspects, and tests that patch
+    ``catalog.authorization.get_user_roles`` keep working through it.
     """
-    result = await db.execute(
-        select(Role.name)
-        .join(UserRole, Role.id == UserRole.role_id)
-        .where(UserRole.user_id == user.id)
-    )
-    return {row[0] for row in result.all()}
+    return await _get_user_roles(db, user)
 
 
 async def check_dataset_access_or_anonymous(

--- a/backend/app/modules/catalog/datasets/api/router_data.py
+++ b/backend/app/modules/catalog/datasets/api/router_data.py
@@ -44,7 +44,7 @@ from app.modules.catalog.datasets.domain.service import (
 )
 from app.core.dependencies import get_db
 from app.core.persistent_config import get_cached_semantic_search_rate_limit
-from app.modules.auth.router import limiter
+from app.platform.ratelimit import limiter
 from app.platform.extensions import get_catalog_port, get_workflow_extension
 from app.platform.extensions.defaults import DefaultWorkflowExtension
 from app.platform.extensions.protocols import WorkflowTransitionContext

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -26,8 +26,11 @@ from app.modules.catalog.maps.service_shared import (
     _apply_map_visibility_filter,
     _extract_dem_vertical_units,
 )
-from app.modules.embed_tokens.models import EmbedToken
 from app.modules.embed_tokens.service import resolve_embed_scope_for_map
+from app.modules.embed_tokens.sharing import (
+    active_embed_count_subquery,
+    get_active_allowed_origins,
+)
 from app.platform.extensions import (
     DefaultPermissionExtension,
     RecordAudience,
@@ -514,33 +517,12 @@ async def get_shared_map(
             session, embed_token, token_obj.map_id, request
         )
 
-    # SEC-S08 (Phase 1062-05): query the active EmbedToken for this map to
-    # surface allowed_origins. The router uses this to emit a per-token
-    # frame-ancestors CSP header. ShareToken and EmbedToken are distinct
-    # primitives — a map may have one without the other.
-    #
-    # CR-04 (Phase 1062 review): include non-expiring tokens (expires_at IS NULL)
-    # in the query. In PostgreSQL, NULL > now() evaluates to NULL (falsy), so
-    # the original `expires_at > func.now()` predicate silently excluded
-    # non-expiring EmbedTokens, causing the CSP header to fall back to
-    # "frame-ancestors 'self'" and breaking embed framing for community-edition
-    # tokens (which default to no expiry).
-    embed_stmt = (
-        select(EmbedToken.allowed_origins)
-        .where(
-            EmbedToken.map_id == token_obj.map_id,
-            EmbedToken.is_active == True,  # noqa: E712
-            or_(
-                EmbedToken.expires_at.is_(None),
-                EmbedToken.expires_at > func.now(),
-            ),
-        )
-        .order_by(EmbedToken.created_at.desc())
-        .limit(1)
+    # SEC-S08 (Phase 1062-05): the router emits a per-token frame-ancestors CSP
+    # header from these origins. The query (including why non-expiring tokens
+    # need an explicit NULL branch) lives behind the embed-tokens seam.
+    allowed_origins: list[str] | None = await get_active_allowed_origins(
+        session, token_obj.map_id
     )
-    allowed_origins: list[str] | None = (
-        await session.execute(embed_stmt)
-    ).scalar_one_or_none()
 
     RasterAsset = get_catalog_port().raster_asset_orm_class()
 
@@ -766,8 +748,6 @@ async def list_share_tokens(
     from sqlalchemy.orm import aliased
     from sqlalchemy.sql import ColumnElement
 
-    from app.modules.embed_tokens.models import EmbedToken
-
     # Most-recent share token per map (DISTINCT ON map_id, preferring an active
     # token, then newest). map_id has no unique constraint, so a map may have
     # several historical tokens — collapse to one row per map.
@@ -783,15 +763,7 @@ async def list_share_tokens(
     )
     share = aliased(MapShareToken, latest_token_sub)
 
-    embed_count_sub = (
-        select(
-            EmbedToken.map_id,
-            func.count().label("embed_count"),
-        )
-        .where(EmbedToken.is_active.is_(True))
-        .group_by(EmbedToken.map_id)
-        .subquery()
-    )
+    embed_count_sub = active_embed_count_subquery()
     # Built once and used for both the SELECT list and (when sorted on) the
     # ORDER BY, so the number the row displays and the number it is ordered by
     # cannot drift apart.

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -80,7 +80,7 @@ from app.core.persistent_config import (
     SEMANTIC_SEARCH_ENABLED,
     get_cached_semantic_search_rate_limit,
 )
-from app.modules.auth.router import limiter
+from app.platform.ratelimit import limiter
 
 logger = structlog.stdlib.get_logger(__name__)
 

--- a/backend/app/modules/embed_tokens/sharing.py
+++ b/backend/app/modules/embed_tokens/sharing.py
@@ -1,0 +1,72 @@
+"""Stable embed-token-owned query contracts for cross-domain consumers.
+
+The mirror of ``app.modules.catalog.maps.sharing``. That module exists so
+embed-token code can ask map questions without importing catalog ORM models;
+this one exists so map code can ask embed-token questions without importing
+``EmbedToken``. Keeping both directions on scalar/DTO/query helpers is what
+keeps the maps-sharing and embed-token pair free of an import cycle.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Subquery, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.embed_tokens.models import EmbedToken
+
+
+async def get_active_allowed_origins(
+    session: AsyncSession, map_id: uuid.UUID
+) -> list[str] | None:
+    """``allowed_origins`` of the map's current active embed token.
+
+    ``None`` when the map has no active token, ``[]`` when a token exists with
+    no origins recorded — the public-map path turns this into a per-token
+    ``frame-ancestors`` CSP directive, so those two cases are not
+    interchangeable.
+
+    SEC-S08 (Phase 1062-05). A share token and an embed token are distinct
+    primitives: a map may have either without the other.
+
+    CR-04 (Phase 1062 review): a non-expiring token has ``expires_at IS NULL``,
+    and in PostgreSQL ``NULL > now()`` evaluates to NULL (falsy). The expiry
+    predicate must admit NULL explicitly, or community-edition tokens — which
+    default to no expiry — silently fall out, the header falls back to
+    ``frame-ancestors 'self'``, and embed framing breaks.
+    """
+    stmt = (
+        select(EmbedToken.allowed_origins)
+        .where(
+            EmbedToken.map_id == map_id,
+            EmbedToken.is_active == True,  # noqa: E712
+            or_(
+                EmbedToken.expires_at.is_(None),
+                EmbedToken.expires_at > func.now(),
+            ),
+        )
+        .order_by(EmbedToken.created_at.desc())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+def active_embed_count_subquery() -> Subquery:
+    """Per-map count of ACTIVE embed tokens, as a joinable subquery.
+
+    Columns: ``map_id`` and ``embed_count``. A subquery rather than a scalar
+    helper because the caller (the admin share-token listing) needs the count
+    for a whole page of maps in one statement, in both the SELECT list and the
+    ORDER BY. A map with no active token has no row here, so the caller
+    coalesces the outer-joined value to 0.
+    """
+    return (
+        select(
+            EmbedToken.map_id,
+            func.count().label("embed_count"),
+        )
+        .where(EmbedToken.is_active.is_(True))
+        .group_by(EmbedToken.map_id)
+        .subquery()
+    )

--- a/backend/app/modules/settings/router.py
+++ b/backend/app/modules/settings/router.py
@@ -25,7 +25,7 @@ from app.core.persistent_config import (
     PASSWORD_LOGIN_ENABLED,
     _registry,
 )
-from app.modules.auth.router import limiter
+from app.platform.ratelimit import limiter
 from app.core.public_urls import _is_env_only, get_public_api_url, get_public_app_url
 from app.core.db.models import AppSetting
 from app.core.db.tenant_schema import tenant_data_schema

--- a/backend/app/modules/settings/router_public.py
+++ b/backend/app/modules/settings/router_public.py
@@ -16,7 +16,7 @@ from app.core.persistent_config import (
     REQUIRE_METADATA_FOR_PUBLISH,
     get_cached_basemap_proxy_rate_limit,
 )
-from app.modules.auth.router import limiter
+from app.platform.ratelimit import limiter
 from app.modules.settings.schemas import (
     BasemapPublicResponse,
     BrandingResponse,

--- a/backend/app/platform/ratelimit.py
+++ b/backend/app/platform/ratelimit.py
@@ -1,0 +1,32 @@
+"""The process-wide SlowAPI limiter, in a home that is cheap to import.
+
+Ten modules — five routers under ``modules/``, three under ``processing/``,
+and ``api/main.py``, which binds it to ``app.state.limiter`` — need this
+instance at module scope for their ``@limiter.limit`` decorators. It used to
+live in ``app.modules.auth.router``, so importing a rate limiter registered
+that router's 28 auth routes and pulled its whole transitive import graph as a
+side effect. That is the API-edge coupling fix(#836) removed from the platform
+ports (``test_platform_never_imports_processing_routers``), reached from the
+other direction.
+
+Nothing here may import ``app.modules.*``: the layering guard forbids it for
+platform/, and an import cycle is the concrete reason — ``modules/auth`` and
+four other domains import this module.
+
+``_global_rate_limit`` is a callable rather than a literal because the global
+limit is admin-editable at runtime; SlowAPI re-evaluates the default per
+request, so a settings change takes effect without a restart.
+"""
+
+from fastapi import Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from app.core.persistent_config import get_cached_global_rate_limit
+
+
+def _global_rate_limit(_request: Request | None = None) -> str:
+    return f"{get_cached_global_rate_limit()}/second"
+
+
+limiter = Limiter(key_func=get_remote_address, default_limits=[_global_rate_limit])

--- a/backend/app/processing/ai/query_router.py
+++ b/backend/app/processing/ai/query_router.py
@@ -58,7 +58,7 @@ from app.core.dependencies import get_db
 from app.core.identity import Identity
 from app.modules.audit.service import AuditEvent, audit_emit_durable
 from app.modules.auth.dependencies import require_permission
-from app.modules.auth.router import limiter
+from app.platform.ratelimit import limiter
 from app.platform.sandbox import SandboxError, SandboxResult, validate_and_execute
 from app.standards.ogc.errors import ERROR_RESPONSES_AUTH, RATE_LIMIT_RESPONSE
 

--- a/backend/app/processing/ai/router.py
+++ b/backend/app/processing/ai/router.py
@@ -69,7 +69,7 @@ from app.core.persistent_config import (
     MAX_AI_TOKENS_PER_USER_PER_DAY,
 )
 from app.processing.ai.token_usage import AITokenUsage
-from app.modules.auth.router import limiter
+from app.platform.ratelimit import limiter
 from app.platform.sandbox.validator import build_table_allowlist
 from app.standards.ogc.errors import BAD_GATEWAY_RESPONSE, ERROR_RESPONSES_AUTH
 

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -64,7 +64,7 @@ from app.processing.tiles.service import (
     get_tile,
     parse_cols_param,
 )
-from app.modules.auth.router import limiter
+from app.platform.ratelimit import limiter
 from app.processing.tiles.schemas import (
     RasterTileToken,
     TileTokenBatchRequest,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1904,7 +1904,7 @@ async def client(tmp_path):
     structlog.contextvars.bind_contextvars(service="api")
 
     # Disable rate limiter during tests
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     limiter.enabled = False
 
@@ -2269,7 +2269,7 @@ def reset_limiter_storage() -> None:
     Called for every test function to ensure determinism under `pytest -n 4`.
     """
     try:
-        from app.modules.auth.router import limiter
+        from app.platform.ratelimit import limiter
 
         limiter._storage.reset()
     except Exception:

--- a/backend/tests/test_admin_rate_limit.py
+++ b/backend/tests/test_admin_rate_limit.py
@@ -24,13 +24,13 @@ from httpx import AsyncClient
 
 
 def _toggle_limiter(enabled: bool) -> None:
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     limiter.enabled = enabled
 
 
 def _reset_storage() -> None:
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     limiter._storage.reset()
 
@@ -46,7 +46,7 @@ async def test_admin_mutation_429(client: AsyncClient, admin_auth_header: dict) 
 
     A single call after a fresh storage reset must NOT return 429.
     """
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     original_enabled = limiter.enabled
     try:
@@ -109,7 +109,7 @@ async def test_settings_update_429(
 
     A single call after a fresh storage reset must NOT return 429.
     """
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     original_enabled = limiter.enabled
     try:
@@ -159,7 +159,7 @@ async def test_oauth_provider_create_429(
 
     A single call after a fresh storage reset must NOT return 429.
     """
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     original_enabled = limiter.enabled
     try:
@@ -225,7 +225,7 @@ async def test_alias_bypass_guard(client: AsyncClient, admin_auth_header: dict) 
     Strategy: exhaust the limit via the no-slash form (POST /admin/users), then
     assert that further calls to the same no-slash alias return 429.
     """
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     original_enabled = limiter.enabled
     try:

--- a/backend/tests/test_embed_framing_csp.py
+++ b/backend/tests/test_embed_framing_csp.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.catalog.maps.models import Map, MapShareToken
 from app.modules.embed_tokens.models import EmbedToken
+from app.modules.embed_tokens.sharing import get_active_allowed_origins
 
 from tests.factories import get_user_id
 
@@ -348,6 +349,56 @@ async def test_shared_map_csp_header_drops_wildcard_origin(
     assert "*" not in csp, (
         f"CSP MUST NOT contain '*' — _build_frame_ancestors failed to drop wildcard, got: {csp!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# The embed-tokens seam the CSP path reads through
+# ---------------------------------------------------------------------------
+
+
+async def test_active_allowed_origins_seam_ignores_inactive_tokens(
+    test_db_session: AsyncSession,
+):
+    """``get_active_allowed_origins`` returns the ACTIVE token's origins only.
+
+    The origins above reach the CSP header through this helper rather than
+    through an inline ``select(EmbedToken...)`` in the maps service, so the
+    is_active predicate is pinned here where it lives. Revoked tokens are kept
+    (soft-revoke sets is_active=False), and a revoked partner origin coming
+    back would re-grant framing to a partner whose access was withdrawn.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_public_map(test_db_session, created_by=admin_id)
+    # Revoked first: uq_embed_tokens_one_active_per_map allows only one ACTIVE
+    # token per map, so this is the shape a re-issued token actually leaves.
+    await _create_embed_token(
+        test_db_session,
+        map_id=map_obj.id,
+        created_by=admin_id,
+        allowed_origins=["https://revoked.example"],
+        is_active=False,
+    )
+    await _create_embed_token(
+        test_db_session,
+        map_id=map_obj.id,
+        created_by=admin_id,
+        allowed_origins=["https://current.example"],
+    )
+    await test_db_session.commit()
+
+    origins = await get_active_allowed_origins(test_db_session, map_obj.id)
+    assert origins == ["https://current.example"]
+
+
+async def test_active_allowed_origins_seam_returns_none_without_a_token(
+    test_db_session: AsyncSession,
+):
+    """No active token is ``None``, not ``[]`` — the caller renders them apart."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    map_obj = await _create_public_map(test_db_session, created_by=admin_id)
+    await test_db_session.commit()
+
+    assert await get_active_allowed_origins(test_db_session, map_obj.id) is None
 
 
 def test_e2e_sec_audit_s08_skips_when_no_share_token():

--- a/backend/tests/test_event_signup_health.py
+++ b/backend/tests/test_event_signup_health.py
@@ -243,7 +243,7 @@ class TestHealthAlert:
         disabled only by the `client` fixture, so without this these tests
         depend on another test having run first — a leaked-global ordering
         dependency that breaks under xdist (Pytest Parallel Isolation)."""
-        from app.modules.auth.router import limiter
+        from app.platform.ratelimit import limiter
 
         prev = limiter.enabled
         limiter.enabled = False

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -235,7 +235,7 @@ def test_health_endpoint_is_rate_limited():
     from _route_limits). After the fix it has its own generous @limiter.limit,
     so it appears in _route_limits and not in _exempt_routes.
     """
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     assert "app.api.main.health" in limiter._route_limits, (
         "/health must carry an explicit @limiter.limit (GAP-016)."

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -87,7 +87,7 @@ async def test_body_size_limit_allows_normal(client: AsyncClient):
 @pytest.mark.anyio
 async def test_rate_limiting(client: AsyncClient):
     """When rate limiter is enabled and client exceeds limit, response is 429."""
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     original_enabled = limiter.enabled
     original_limits = limiter._default_limits
@@ -146,7 +146,7 @@ async def test_rate_limit_health_excluded(client: AsyncClient):
     default in slowapi, so a tight 2/second default never trips the Docker
     healthcheck / LB polling — exactly the property this test guards.
     """
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     original_enabled = limiter.enabled
     original_limits = limiter._default_limits
@@ -173,7 +173,7 @@ async def test_rate_limit_health_excluded(client: AsyncClient):
 @pytest.mark.anyio
 async def test_ai_endpoint_rate_limit(client: AsyncClient, admin_auth_header: dict):
     """AI endpoints respect their per-route rate limit (10/minute for generate)."""
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     original_enabled = limiter.enabled
     try:
@@ -206,7 +206,7 @@ async def test_rate_limit_429_includes_retry_after(client: AsyncClient):
     with bad credentials so slowapi fires before the handler body, then asserts
     the final 429 advertises the back-off window.
     """
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     original_enabled = limiter.enabled
     try:
@@ -267,7 +267,7 @@ async def test_http_exception_handler_preserves_response_headers(detail):
 @pytest.mark.anyio
 async def test_global_rate_limit_configurable(client: AsyncClient):
     """Global rate limit is configurable and defaults to 60/second."""
-    from app.modules.auth.router import _global_rate_limit
+    from app.platform.ratelimit import _global_rate_limit
     from app.core.persistent_config import get_cached_global_rate_limit
 
     assert get_cached_global_rate_limit() == 60

--- a/backend/tests/test_module_import_seams.py
+++ b/backend/tests/test_module_import_seams.py
@@ -5,11 +5,15 @@ expensive still returns the right object. Each is asserted in a fresh
 interpreter: inside the pytest process every module is already loaded, so a
 ``sys.modules`` check here would pass no matter where anything lived.
 
-The shared rate limiter lived in ``app.modules.auth.router``, so the ten
-modules that decorate routes with it executed 28 auth route registrations and
-that router's transitive imports to get a ``Limiter`` instance. It now lives in
-``app.platform.ratelimit``, which the platform layering guard already forbids
-from importing ``app.modules.*`` at all.
+- The shared rate limiter lived in ``app.modules.auth.router``, so the ten
+  modules that decorate routes with it executed 28 auth route registrations
+  and that router's transitive imports to get a ``Limiter`` instance. It now
+  lives in ``app.platform.ratelimit``, which the platform layering guard
+  already forbids from importing ``app.modules.*`` at all.
+- ``auth.dependencies`` imported ``catalog.authorization`` for a role lookup
+  that reads only auth-owned tables, which made the two highest-fan-in modules
+  in the backend mutually dependent. The query lives in ``auth.permissions``
+  now, and catalog re-exports it.
 """
 
 from __future__ import annotations
@@ -19,6 +23,7 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -67,3 +72,32 @@ def test_rate_limiter_home_imports_no_product_module(tmp_path: Path):
         "app.platform.ratelimit reached a product module: "
         f"{sorted(m for m in loaded if m.startswith('app.modules.'))}"
     )
+
+
+def test_auth_dependencies_imports_no_catalog_module(tmp_path: Path):
+    """Auth must not import catalog to resolve a user's roles."""
+    loaded = _app_modules_loaded_by(
+        "import app.modules.auth.dependencies", tmp_path / "dependencies.json"
+    )
+
+    assert not {m for m in loaded if m.startswith("app.modules.catalog")}, (
+        "app.modules.auth.dependencies imported catalog: "
+        f"{sorted(m for m in loaded if m.startswith('app.modules.catalog'))}. "
+        "get_user_roles lives in app.modules.auth.permissions."
+    )
+
+
+async def test_catalog_authorization_delegates_role_lookup_to_auth(monkeypatch):
+    """The catalog entry point is a re-export, never a second implementation.
+
+    Its ~40 callers still import ``get_user_roles`` from here, so the name has
+    to stay; what must not come back is the query behind it.
+    """
+    from app.modules.catalog import authorization
+
+    delegate = AsyncMock(return_value={"editor"})
+    monkeypatch.setattr(authorization, "_get_user_roles", delegate)
+
+    session, user = object(), object()
+    assert await authorization.get_user_roles(session, user) == {"editor"}
+    delegate.assert_awaited_once_with(session, user)

--- a/backend/tests/test_module_import_seams.py
+++ b/backend/tests/test_module_import_seams.py
@@ -1,0 +1,69 @@
+"""What a module drags in when you import it.
+
+Seams whose cost is invisible at the call site, because an import that is too
+expensive still returns the right object. Each is asserted in a fresh
+interpreter: inside the pytest process every module is already loaded, so a
+``sys.modules`` check here would pass no matter where anything lived.
+
+The shared rate limiter lived in ``app.modules.auth.router``, so the ten
+modules that decorate routes with it executed 28 auth route registrations and
+that router's transitive imports to get a ``Limiter`` instance. It now lives in
+``app.platform.ratelimit``, which the platform layering guard already forbids
+from importing ``app.modules.*`` at all.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _app_modules_loaded_by(import_statement: str, out_path: Path) -> set[str]:
+    """The ``app.*`` modules a fresh interpreter loads for *import_statement*.
+
+    The child writes to a file rather than stdout: importing app code
+    configures structlog and emits startup log lines, which would sit in the
+    middle of anything printed.
+    """
+    script = textwrap.dedent(f"""
+        import json, sys
+        {import_statement}
+        with open({str(out_path)!r}, "w") as fh:
+            json.dump(sorted(m for m in sys.modules if m.startswith("app.")), fh)
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=BACKEND_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"`{import_statement}` failed in a fresh interpreter "
+            f"(rc={result.returncode}):\n{result.stderr}"
+        )
+    return set(json.loads(out_path.read_text()))
+
+
+def test_rate_limiter_home_imports_no_product_module(tmp_path: Path):
+    """Importing the limiter must not register anyone's routes."""
+    loaded = _app_modules_loaded_by(
+        "import app.platform.ratelimit", tmp_path / "ratelimit.json"
+    )
+
+    assert "app.modules.auth.router" not in loaded, (
+        "importing the rate limiter executes the auth router's route "
+        "registrations again — the coupling this module was split out to end"
+    )
+    assert not {m for m in loaded if m.startswith("app.modules.")}, (
+        "app.platform.ratelimit reached a product module: "
+        f"{sorted(m for m in loaded if m.startswith('app.modules.'))}"
+    )

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -30,7 +30,7 @@ from app.core.persistent_config import (
     get_cached_semantic_search_rate_limit,
     get_cached_basemap_proxy_rate_limit,
 )
-from app.modules.auth.router import limiter
+from app.platform.ratelimit import limiter
 
 pytestmark = pytest.mark.anyio
 

--- a/backend/tests/test_register_verification_flow.py
+++ b/backend/tests/test_register_verification_flow.py
@@ -74,7 +74,7 @@ def _patch_limiter(monkeypatch):
     """Disable rate limiter for all tests in this module."""
     # The conftest already does this via limiter.enabled = False but
     # re-confirm it here since new endpoints also use the same limiter.
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
 
     monkeypatch.setattr(limiter, "enabled", False)
 

--- a/backend/tests/test_sandbox_query_endpoint_565.py
+++ b/backend/tests/test_sandbox_query_endpoint_565.py
@@ -1616,7 +1616,7 @@ async def test_each_rate_limit_dimension_fires(
 ):
     """Both limit callables are live: lower one dimension to 2/minute and the
     endpoint 429s, whichever dimension it is."""
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
     from app.processing.ai import query_router
 
     monkeypatch.setattr(query_router, attr, "2/minute")
@@ -1638,7 +1638,7 @@ async def test_rate_limited_requests_are_not_durably_audited(
     """fix(#565 codex P2): a 429 IS the limiter shedding load, so writing a
     durable audit row per throttled request would defeat the throttle. The
     successful call is audited (query.execute); the 429s add no reject rows."""
-    from app.modules.auth.router import limiter
+    from app.platform.ratelimit import limiter
     from app.processing.ai import query_router
 
     owner = await _admin_id(client, admin_auth_header)


### PR DESCRIPTION
Three structural moves. No behavior change, no API/schema/config impact — `backend/openapi.json` is byte-identical (`dump_openapi.py --check` exits 0 with no regen).

## The rate limiter no longer lives in an API-edge router

`limiter` was defined in `app/modules/auth/router.py`, a module with 28 route decorators, and ten modules imported it at load time: `settings/router.py`, `settings/router_public.py`, `admin/router.py`, `admin/router_operations.py`, `catalog/datasets/api/router_data.py`, `catalog/search/router.py`, `processing/tiles/router.py`, `processing/ai/router.py`, `processing/ai/query_router.py`, and `api/main.py`, which binds it to `app.state.limiter`. Importing a rate limiter executed those 28 route registrations plus auth's whole transitive import graph.

It now lives in `app/platform/ratelimit.py` with `_global_rate_limit`, the persistent-config-driven default callable. Measured in a fresh interpreter: importing the limiter's home loaded 49 `app.*` modules before and loads 26 after, with zero `app.modules.*`. Every importer (app code and tests) points at the new home; auth's router keeps its own `@limiter.limit` decorators and its login-specific limit.

This is the same defect class `fix(#836)` closed from the other side, where `test_platform_never_imports_processing_routers` stopped the platform ports importing `processing/ingest/router.py` for a constant.

## `get_user_roles` moved to the domain that owns the tables

It sat in `catalog/authorization.py` but selects `Role` joined to `UserRole` and touches nothing catalog, and `auth/dependencies.py` imported it back — so the two highest-fan-in modules in the backend depended on each other at domain level. The query moves to `auth/permissions.py`, next to `user_has_capability`, which was resolving roles through a function-local "LAZY — avoids circular" import of that same function. That workaround is gone with the cycle it was working around.

`catalog/authorization.py` keeps `get_user_roles` as a delegating def, so its ~40 callers and their import path are unchanged. It stays a `def` rather than a bare re-export for two reasons: `test_permission_chokepoints_use_extension` reads that `async def` as the end of the `apply_visibility_filter` block it inspects, and the tests that patch the catalog-side name keep working through it.

## Maps reads embed tokens through a seam instead of the ORM

`maps/service_public.py` imported the `EmbedToken` ORM and queried it inline twice: the active token's `allowed_origins`, which becomes the shared-map `frame-ancestors` CSP directive, and the per-map active-token count in the admin share-token listing.

The reverse direction already has this seam and documents why — `maps/sharing.py` exists so embed-token code can ask map questions without importing catalog ORM models, which is what keeps the pair free of an import cycle. This adds the mirror, `embed_tokens/sharing.py`, exposing `get_active_allowed_origins()` and `active_embed_count_subquery()`. The CR-04 rationale for why the expiry predicate must admit `NULL` explicitly now lives with the query rather than at one call site.

The other maps-to-embed_tokens edges stay, because none of them reach for the ORM: `maps/router.py` and `router_sharing.py` call the embed-tokens service to revoke tokens, and `maps/schemas.py` and `sharing_policy.py` import an error-message constant from its schemas.

## Tests

`backend/tests/test_module_import_seams.py` asserts both import seams in a fresh subprocess — inside pytest every module is already loaded, so a `sys.modules` check there would pass regardless of where anything lives. Both fail on `main` (49 modules / auth router present; `catalog.authorization` present), as does the delegation test. Two focused cases in `test_embed_framing_csp.py` pin that the seam returns the active token's origins and skips a revoked one, and `None` rather than `[]` when there is no token.

## Verification

```
cd backend && uv run ruff check app tests && uv run ruff format app tests --check
cd backend && uv run pytest tests/test_layering.py tests/test_module_import_seams.py -q   # 43 passed
cd backend && uv run pytest tests/test_rate_limits.py tests/test_admin_rate_limit.py tests/test_middleware.py \
  tests/test_health.py tests/test_register_verification_flow.py tests/test_event_signup_health.py \
  tests/test_sandbox_query_endpoint_565.py -q                                            # 137 passed
cd backend && uv run pytest tests/test_permission_extension.py tests/test_batch_dataset_authz_1298.py \
  tests/test_vrt_creation_173.py tests/test_vrt_source_management_174.py tests/test_defer_orphan_guard.py \
  tests/test_permission_audience.py tests/test_processing_port.py tests/test_tenant_cache_partitioning.py \
  tests/test_auth.py -q                                                                  # 169 passed
cd backend && uv run pytest tests/test_embed_framing_csp.py tests/test_embed_tokens.py \
  tests/test_embed_frame_policy.py tests/test_embed_tokens_csp_no_wildcard.py tests/test_admin_share_token_sort.py \
  tests/test_embed_tokens_origin_bypass.py tests/test_embed_token_expiry_cache.py tests/test_csp_sec020.py -q
                                                                                         # 112 passed
cd backend && PYTHONPATH=. uv run python scripts/dump_openapi.py --check                 # exit 0, no drift
```