### PR TITLE
fix(stac): clamp over-limit item pages and share one bbox parser

### DIFF
--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import math
 import re
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from shapely.errors import GEOSException
@@ -93,8 +94,13 @@ def _geom_write_exprs(
     return base, base
 
 
-def parse_bbox(bbox_str: str) -> list[float]:
-    """Parse a comma-separated bbox string into a 4- or 6-element list.
+def parse_bbox(bbox: str | Sequence[float]) -> list[float]:
+    """Parse a bbox into a 4-element ``[minx, miny, maxx, maxy]`` list.
+
+    Accepts either a comma-separated string (the query-parameter spelling) or
+    an already-split sequence of numbers (the JSON request-body spelling, e.g.
+    STAC Item Search POST), so every GeoLens surface answers a given bbox the
+    same way.
 
     Accepts:
       - 4 values: minx, miny, maxx, maxy (2D)
@@ -102,15 +108,26 @@ def parse_bbox(bbox_str: str) -> list[float]:
         accepted but ignored for spatial queries)
 
     Allows antimeridian-crossing bboxes where minx > maxx (e.g. 170,-45,-170,-30).
+    Allows degenerate boxes where miny == maxy: OGC API Features and STAC both
+    define bbox bounds as lower <= upper, so a zero-height (line) or zero-area
+    (point) box is a legal filter.
     Raises ValueError if not 4 or 6 values, or latitude bounds are invalid.
     """
-    parts = bbox_str.split(",")
-    if len(parts) not in (4, 6):
-        raise ValueError("bbox must have 4 or 6 comma-separated values")
-    values = [float(p) for p in parts]
+    if isinstance(bbox, str):
+        parts = bbox.split(",")
+        if len(parts) not in (4, 6):
+            raise ValueError("bbox must have 4 or 6 comma-separated values")
+        values = [float(p) for p in parts]
+    else:
+        values = [float(v) for v in bbox]
+        if len(values) not in (4, 6):
+            raise ValueError("bbox must have 4 or 6 values")
     # SEC-FU-06 (sec-audit-20260519.md): reject NaN/Inf coordinates. Python's float() accepts
-    # "nan", "inf", "-inf" — PostGIS handles these inconsistently and they can produce
-    # malformed geometries with downstream null-pointer or sequential-scan amplification.
+    # "nan", "inf", "-inf" (and JSON 1e400 parses to +Inf) — PostGIS handles these
+    # inconsistently and they can produce malformed geometries with downstream
+    # null-pointer or sequential-scan amplification. This is the single home for the
+    # guard: STAC once carried its own copy and the guard had to be re-applied there
+    # (#430 BA-12) because the copy existed.
     for i, v in enumerate(values):
         if not math.isfinite(v):
             raise ValueError(
@@ -120,9 +137,10 @@ def parse_bbox(bbox_str: str) -> list[float]:
     if len(values) == 6:
         # 3D bbox: extract 2D envelope (minx, miny, maxx, maxy)
         values = [values[0], values[1], values[3], values[4]]
-    # Only validate latitude (lon wraps at antimeridian)
-    if values[1] >= values[3]:
-        raise ValueError("bbox miny must be less than maxy")
+    # Only validate latitude (lon wraps at antimeridian). Equality passes: the
+    # spec bound is lower <= upper, and a degenerate box is a legal filter.
+    if values[1] > values[3]:
+        raise ValueError("bbox miny must be less than or equal to maxy")
     return values
 
 

--- a/backend/app/modules/catalog/search/schemas.py
+++ b/backend/app/modules/catalog/search/schemas.py
@@ -5,6 +5,8 @@ from datetime import date, datetime
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.modules.catalog.features.service import parse_bbox
+
 
 class SearchParams(BaseModel):
     """Query parameters for dataset search."""
@@ -51,17 +53,11 @@ class SearchParams(BaseModel):
     @field_validator("bbox")
     @classmethod
     def validate_bbox(cls, v: str | None) -> str | None:
+        # Validate through the shared parser rather than a third copy of the
+        # split/collapse/compare logic: the copies drifted before, and the one
+        # here was also missing the SEC-FU-06 non-finite guard.
         if v is not None:
-            parts = v.split(",")
-            if len(parts) not in (4, 6):
-                raise ValueError("bbox must have 4 or 6 comma-separated values")
-            floats = [float(p) for p in parts]
-            # For 6-element (3D) bbox, validate the 2D envelope
-            miny = floats[1]
-            maxy = floats[3] if len(floats) == 4 else floats[4]
-            # Allow antimeridian-crossing bboxes (minx > maxx)
-            if miny >= maxy:
-                raise ValueError("bbox miny must be less than maxy")
+            parse_bbox(v)
         return v
 
 

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import math
 import re
 import uuid
 from collections.abc import Sequence
@@ -47,6 +46,7 @@ from app.modules.catalog.datasets.domain.models import (
     Record,
     RecordKeyword,
 )
+from app.modules.catalog.features.service import parse_bbox
 from app.core.dependencies import get_db
 from app.core.public_urls import get_public_api_url, get_public_app_url
 from app.processing.raster.models import DatasetAsset, RasterAsset
@@ -86,6 +86,12 @@ class GeoJSONResponse(JSONResponse):
 
 # Record types eligible for STAC
 _STAC_RECORD_TYPES = RASTER_FAMILY_RECORD_TYPES
+
+# Page-size ceiling shared by every item-returning STAC handler (H-24 lowered it
+# from 1000 to bound deep-paging cost). An over-maximum limit is CLAMPED, never
+# rejected: the STAC Item Search spec requires it and stac-api-validator
+# enforces it. One constant so a future ceiling change cannot miss a handler.
+_STAC_MAX_LIMIT = 200
 
 # STAC Items must be collection-scoped to remain browsable by machine clients.
 # This virtual collection does not create or mutate a catalog Collection; it is
@@ -369,24 +375,6 @@ async def _visible_derived_from_id(
     )
     found = (await db.execute(stmt)).scalars().first()
     return str(source_id) if found is not None else None
-
-
-def _require_finite_bbox(values: list[float]) -> None:
-    """Reject NaN/Inf bbox coordinates before ST_MakeEnvelope.
-
-    fix(#430 BA-12): mirrors the OGC ``parse_bbox`` SEC-FU-06 guard, which STAC's
-    inline bbox parsing was missing.
-    """
-    for i, v in enumerate(values):
-        if not math.isfinite(v):
-            raise ValueError(f"bbox coordinate at index {i} is non-finite ({v!r})")
-    # South > north is always invalid; longitude order is NOT checked because
-    # west > east legitimately means an antimeridian-crossing box.
-    south, north = (
-        (values[1], values[3]) if len(values) == 4 else (values[1], values[4])
-    )
-    if south > north:
-        raise ValueError("bbox south latitude is greater than north latitude")
 
 
 # RFC 3339 date-time as required by the STAC API spec: full date + time with a
@@ -1003,18 +991,29 @@ async def get_collection_items(
     datetime_param: str | None = Query(
         None, alias="datetime", description="OGC datetime interval"
     ),
-    limit: int = Query(10, ge=1, le=200),
+    limit: int = Query(
+        10,
+        ge=1,
+        description=(
+            f"Maximum number of items returned. Values above {_STAC_MAX_LIMIT} "
+            f"are clamped to {_STAC_MAX_LIMIT}, per the STAC Item Search spec's "
+            "clamp-don't-reject recommendation."
+        ),
+    ),
     offset: int = Query(
         0,
         ge=0,
         description=(
             "Legacy offset-based pagination. Phase 269 H-24 lowered the "
-            "max limit to 200 and recommends keyset cursors via the rel=next "
-            "link for deep paging."
+            f"max limit to {_STAC_MAX_LIMIT} and recommends keyset cursors via "
+            "the rel=next link for deep paging."
         ),
     ),
 ) -> JSONResponse:
     """List STAC Items within a collection."""
+    # Clamp before the page links are built so rel=next/prev advertise the
+    # limit actually served.
+    limit = min(limit, _STAC_MAX_LIMIT)
     stac_api_url, public_api_url = await _resolve_urls(db, request)
     # fix(#315 follow-up): raster_tiles assets are served at the public APP origin.
     public_app_url = await get_public_app_url(db, request=request)
@@ -1030,13 +1029,7 @@ async def get_collection_items(
     # Filter by bbox (antimeridian-aware)
     if bbox:
         try:
-            parts = bbox.split(",")
-            if len(parts) not in (4, 6):
-                raise ValueError("need 4 or 6 values")
-            bbox_vals = [float(p) for p in parts]
-            _require_finite_bbox(bbox_vals)
-            if len(bbox_vals) == 6:
-                bbox_vals = [bbox_vals[0], bbox_vals[1], bbox_vals[3], bbox_vals[4]]
+            bbox_vals = parse_bbox(bbox)
         except (ValueError, TypeError) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1388,20 +1381,10 @@ def _build_search_filters(
         filters.append(Record.spatial_extent.op("&&")(func.ST_Envelope(_geom)))
         filters.append(func.ST_Intersects(Record.spatial_extent, _geom))
     elif bbox:
-        # Filter by bbox (only if intersects not provided) — accept string or list
+        # Filter by bbox (only if intersects not provided). parse_bbox takes the
+        # GET string and the POST list, so both spellings validate identically.
         try:
-            if isinstance(bbox, str):
-                parts = bbox.split(",")
-                if len(parts) not in (4, 6):
-                    raise ValueError("need 4 or 6 values")
-                bbox_vals = [float(p) for p in parts]
-            else:
-                bbox_vals = [float(v) for v in bbox]
-                if len(bbox_vals) not in (4, 6):
-                    raise ValueError("need 4 or 6 values")
-            _require_finite_bbox(bbox_vals)
-            if len(bbox_vals) == 6:
-                bbox_vals = [bbox_vals[0], bbox_vals[1], bbox_vals[3], bbox_vals[4]]
+            bbox_vals = parse_bbox(bbox)
         except (ValueError, TypeError) as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1677,9 +1660,9 @@ async def search_get(
         10,
         ge=1,
         description=(
-            "Maximum number of items returned. Values above 200 are clamped "
-            "to 200, per the STAC Item Search spec's clamp-don't-reject "
-            "recommendation."
+            f"Maximum number of items returned. Values above {_STAC_MAX_LIMIT} "
+            f"are clamped to {_STAC_MAX_LIMIT}, per the STAC Item Search spec's "
+            "clamp-don't-reject recommendation."
         ),
     ),
     offset: int = Query(
@@ -1687,7 +1670,7 @@ async def search_get(
         ge=0,
         description=(
             "Legacy offset-based pagination. Phase 269 H-24 lowered the "
-            "max limit to 200 from 1000 to bound deep-paging cost."
+            f"max limit to {_STAC_MAX_LIMIT} from 1000 to bound deep-paging cost."
         ),
     ),
 ) -> JSONResponse:
@@ -1709,7 +1692,7 @@ async def search_get(
         intersects=intersects,
         # STAC Item Search: limits above the server maximum are clamped, not
         # rejected (stac-api-validator enforces this).
-        limit=min(limit, 200),
+        limit=min(limit, _STAC_MAX_LIMIT),
         offset=offset,
         public_app_url=public_app_url,
         preferred_languages=parse_accept_languages(request),
@@ -1740,11 +1723,13 @@ class StacSearchBody(BaseModel):
         default=10,
         ge=1,
         # WR-01 (Phase 1071 review) aligned GET/POST ceilings at le=200; the
-        # STAC hardening pass replaces the hard bound with clamping on both
-        # handlers — the Item Search spec (and stac-api-validator) requires
-        # over-limit values to be clamped to the server maximum, not rejected.
+        # STAC hardening pass replaces the hard bound with clamping on all three
+        # item-returning handlers — the Item Search spec (and stac-api-validator)
+        # requires over-limit values to be clamped to the server maximum, not
+        # rejected.
         description=(
-            "Maximum number of items returned. Values above 200 are clamped to 200."
+            f"Maximum number of items returned. Values above {_STAC_MAX_LIMIT} "
+            f"are clamped to {_STAC_MAX_LIMIT}."
         ),
     )
     offset: int = Field(
@@ -1799,9 +1784,9 @@ async def search_post(
         collections=body.collections,
         ids=body.ids,
         intersects=body.intersects,
-        # Over-limit values clamp to the 200-item operational ceiling (H-24),
-        # required by the Item Search spec instead of a le=200 rejection.
-        limit=max(1, min(body.limit, 200)),
+        # Over-limit values clamp to the operational ceiling (H-24), required by
+        # the Item Search spec instead of a le=200 rejection.
+        limit=max(1, min(body.limit, _STAC_MAX_LIMIT)),
         offset=max(0, body.offset),
         public_app_url=public_app_url,
         preferred_languages=parse_accept_languages(request),

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -55396,12 +55396,13 @@
             }
           },
           {
+            "description": "Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 10,
-              "maximum": 200,
+              "description": "Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation.",
               "minimum": 1,
               "title": "Limit",
               "type": "integer"

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -299,12 +299,13 @@ class TestExportValidation:
     async def test_export_invalid_bbox_bounds(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
     ):
-        """Request with bbox=10,10,5,5 (miny >= maxy) returns 400.
+        """Request with bbox=10,10,5,5 (miny > maxy) returns 400.
 
         The rejected pair is the LATITUDE one. ``parse_bbox``
         (app/modules/catalog/features/service.py) deliberately allows
         minx > maxx, which is how an antimeridian-crossing bbox is spelled
-        (170,-45,-170,-30); only ``values[1] >= values[3]`` raises.
+        (170,-45,-170,-30); only ``values[1] > values[3]`` raises. Equality is
+        allowed — a degenerate box is legal under OGC API Features and STAC.
         """
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await _create_dataset(

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2846,7 +2846,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # visibility for the whole page (one query, mirroring PERF-5's
     # spatial_extent_geojson) instead of one round trip per item at limit=200.
     # Cap 1843 -> 1870, still exact.
-    "backend/app/standards/stac/router.py": 1870,
+    # fix(stac limit/bbox conformance): -15 — the two inline bbox parsers and
+    # _require_finite_bbox collapse onto the shared parse_bbox, which now takes
+    # the POST list as well as the GET string. Cap 1870 -> 1855, still exact.
+    "backend/app/standards/stac/router.py": 1855,
     # Central tenant-bound scope resolution replaced duplicated inline logic.
     # fix(#836): +1 — the RASTER_FAMILY_RECORD_TYPES import that replaces four
     # pasted family literals. Same +1 on the stac and search routers.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2846,7 +2846,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # visibility for the whole page (one query, mirroring PERF-5's
     # spatial_extent_geojson) instead of one round trip per item at limit=200.
     # Cap 1843 -> 1870, still exact.
-    # fix(stac limit/bbox conformance): -15 — the two inline bbox parsers and
+    # fix(#1432): -15 — the two inline bbox parsers and
     # _require_finite_bbox collapse onto the shared parse_bbox, which now takes
     # the POST list as well as the GET string. Cap 1870 -> 1855, still exact.
     "backend/app/standards/stac/router.py": 1855,

--- a/backend/tests/test_stac_limit_bbox_conformance.py
+++ b/backend/tests/test_stac_limit_bbox_conformance.py
@@ -1,0 +1,313 @@
+"""STAC over-limit clamping and shared bbox parsing across catalog surfaces.
+
+Two conformance gaps are pinned here:
+
+1. ``GET /stac/collections/{id}/items`` rejected an over-maximum ``limit`` with
+   a 422 while both Item Search handlers clamped it. The STAC Item Search spec
+   (and stac-api-validator) require a limit above the server maximum to be
+   clamped to that maximum, not rejected.
+
+2. STAC parsed bbox inline in two handlers instead of calling the shared
+   ``parse_bbox``, and the copies had drifted: a zero-height bbox was accepted
+   by STAC and rejected by OGC Features, per-dataset features, export and
+   catalog search. OGC API Features and STAC both define a bbox with
+   lower <= upper latitude, so a degenerate box is legal and every surface now
+   accepts it. Non-finite coordinates (SEC-FU-06) stay rejected everywhere.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.features.service import parse_bbox
+from app.standards.stac.router import (
+    STAC_UNASSIGNED_COLLECTION_ID as STAC_UNASSIGNED,
+    _STAC_MAX_LIMIT,
+)
+
+from tests.factories import get_user_id
+
+# Zero-height: south == north. Legal per OGC API Features / STAC (lower <= upper).
+ZERO_HEIGHT_BBOX = "-74.10,40.70,-73.90,40.70"
+# Inverted latitude: south > north. Invalid on every surface.
+INVERTED_BBOX = "-74.10,40.80,-73.90,40.70"
+# SEC-FU-06: non-finite coordinates are rejected on every surface.
+NAN_BBOX = "-74.10,nan,-73.90,40.80"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def stac_raster_dataset(client: AsyncClient, test_db_session) -> Dataset:
+    """A public published raster dataset, so `geolens-unassigned` resolves."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"test_stac_conf_{uuid.uuid4().hex[:8]}"
+    record = Record(
+        title=f"STAC Conformance Raster {table_name}",
+        summary="Raster record backing the STAC limit/bbox conformance tests",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        record_type="raster_dataset",
+        created_by=admin_id,
+    )
+    test_db_session.add(record)
+    await test_db_session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        source_format="geotiff",
+        source_filename="conformance.tif",
+    )
+    test_db_session.add(dataset)
+    await test_db_session.commit()
+    await test_db_session.refresh(dataset)
+    return dataset
+
+
+@pytest.fixture
+async def vector_dataset(client: AsyncClient, test_db_session) -> Dataset:
+    """A public vector dataset with a real backing table for the OGC path."""
+    admin_id = await get_user_id(test_db_session, "admin")
+    table_name = f"test_stac_conf_vec_{uuid.uuid4().hex[:8]}"
+    await test_db_session.execute(
+        text(
+            f"CREATE TABLE IF NOT EXISTS data.{table_name} ("
+            f"gid SERIAL PRIMARY KEY, "
+            f"geom geometry(Point, 4326), "
+            f"geom_4326 geometry(Geometry, 4326), "
+            f"name TEXT)"
+        )
+    )
+    await test_db_session.execute(
+        text(f"GRANT SELECT ON data.{table_name} TO geolens_reader")
+    )
+    await test_db_session.execute(
+        text(
+            f"INSERT INTO data.{table_name} (geom, geom_4326, name) VALUES ("
+            f"ST_SetSRID(ST_MakePoint(-74.0, 40.7), 4326), "
+            f"ST_SetSRID(ST_MakePoint(-74.0, 40.7), 4326), 'a')"
+        )
+    )
+    record = Record(
+        title=f"STAC Conformance Vector {table_name}",
+        summary="Vector record backing the STAC/OGC bbox parity tests",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        created_by=admin_id,
+    )
+    test_db_session.add(record)
+    await test_db_session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=4326,
+        geometry_type="POINT",
+        feature_count=1,
+        column_info=[{"name": "name", "type": "text"}],
+        source_format="created",
+    )
+    test_db_session.add(dataset)
+    await test_db_session.commit()
+    await test_db_session.refresh(dataset)
+    yield dataset
+    await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
+    await test_db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Over-limit clamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_collection_items_over_limit_is_clamped_not_rejected(
+    client: AsyncClient, stac_raster_dataset: Dataset
+):
+    """An over-maximum limit clamps to the server maximum instead of 422ing."""
+    resp = await client.get(
+        f"/stac/collections/{STAC_UNASSIGNED}/items", params={"limit": 1000}
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert len(data["features"]) <= _STAC_MAX_LIMIT
+    assert data["context"]["limit"] == _STAC_MAX_LIMIT
+
+
+@pytest.mark.anyio
+async def test_all_three_item_handlers_clamp_the_same_over_limit(
+    client: AsyncClient, stac_raster_dataset: Dataset
+):
+    """Collection items, GET search and POST search agree on the clamp."""
+    items = await client.get(
+        f"/stac/collections/{STAC_UNASSIGNED}/items", params={"limit": 1000}
+    )
+    search_get = await client.get("/stac/search", params={"limit": 1000})
+    search_post = await client.post("/stac/search", json={"limit": 1000})
+
+    for resp in (items, search_get, search_post):
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["context"]["limit"] == _STAC_MAX_LIMIT
+
+
+@pytest.mark.anyio
+async def test_collection_items_below_max_limit_is_untouched(
+    client: AsyncClient, stac_raster_dataset: Dataset
+):
+    """Clamping must not disturb a limit inside the allowed range."""
+    resp = await client.get(
+        f"/stac/collections/{STAC_UNASSIGNED}/items", params={"limit": 3}
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["context"]["limit"] == 3
+    assert len(data["features"]) <= 3
+
+
+@pytest.mark.anyio
+async def test_collection_items_zero_limit_still_rejected(
+    client: AsyncClient, stac_raster_dataset: Dataset
+):
+    """ge=1 survives the le=200 removal — limit=0 is still rejected.
+
+    Request-validation errors surface as an RFC 7807 400, not FastAPI's raw 422.
+    """
+    resp = await client.get(
+        f"/stac/collections/{STAC_UNASSIGNED}/items", params={"limit": 0}
+    )
+    assert resp.status_code == 400
+    assert "greater than or equal to 1" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Shared bbox parsing — degenerate boxes
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bbox_accepts_zero_height_box():
+    """A degenerate (line) box has lower == upper latitude, which is legal."""
+    assert parse_bbox(ZERO_HEIGHT_BBOX) == [-74.10, 40.70, -73.90, 40.70]
+
+
+def test_parse_bbox_accepts_zero_area_point_box():
+    assert parse_bbox("-74.10,40.70,-74.10,40.70") == [-74.10, 40.70, -74.10, 40.70]
+
+
+def test_parse_bbox_still_rejects_inverted_latitude():
+    with pytest.raises(ValueError, match="less than or equal to"):
+        parse_bbox(INVERTED_BBOX)
+
+
+def test_parse_bbox_still_allows_antimeridian_crossing():
+    """west > east crosses the antimeridian and stays legal."""
+    assert parse_bbox("170,-45,-170,-30") == [170.0, -45.0, -170.0, -30.0]
+
+
+@pytest.mark.anyio
+async def test_zero_height_bbox_accepted_by_stac_and_ogc_features(
+    client: AsyncClient, stac_raster_dataset: Dataset, vector_dataset: Dataset
+):
+    """The same degenerate bbox is accepted identically on STAC and OGC."""
+    stac_items = await client.get(
+        f"/stac/collections/{STAC_UNASSIGNED}/items",
+        params={"bbox": ZERO_HEIGHT_BBOX},
+    )
+    stac_search = await client.get("/stac/search", params={"bbox": ZERO_HEIGHT_BBOX})
+    ogc_items = await client.get(
+        f"/collections/{vector_dataset.id}/items", params={"bbox": ZERO_HEIGHT_BBOX}
+    )
+    catalog_search = await client.get(
+        "/search/datasets/", params={"bbox": ZERO_HEIGHT_BBOX}
+    )
+
+    statuses = {
+        "stac_items": stac_items.status_code,
+        "stac_search": stac_search.status_code,
+        "ogc_items": ogc_items.status_code,
+        "catalog_search": catalog_search.status_code,
+    }
+    assert statuses == dict.fromkeys(statuses, 200), (
+        f"surfaces disagree on a zero-height bbox: {statuses}"
+    )
+
+
+@pytest.mark.anyio
+async def test_zero_height_bbox_accepted_by_stac_search_post(
+    client: AsyncClient, stac_raster_dataset: Dataset
+):
+    resp = await client.post(
+        "/stac/search", json={"bbox": [-74.10, 40.70, -73.90, 40.70]}
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Shared bbox parsing — invalid input stays invalid everywhere
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_inverted_latitude_bbox_rejected_on_every_surface(
+    client: AsyncClient, stac_raster_dataset: Dataset, vector_dataset: Dataset
+):
+    responses = {
+        "stac_items": await client.get(
+            f"/stac/collections/{STAC_UNASSIGNED}/items",
+            params={"bbox": INVERTED_BBOX},
+        ),
+        "stac_search": await client.get("/stac/search", params={"bbox": INVERTED_BBOX}),
+        "ogc_items": await client.get(
+            f"/collections/{vector_dataset.id}/items", params={"bbox": INVERTED_BBOX}
+        ),
+        "catalog_search": await client.get(
+            "/search/datasets/", params={"bbox": INVERTED_BBOX}
+        ),
+    }
+    statuses = {name: resp.status_code for name, resp in responses.items()}
+    assert statuses == dict.fromkeys(statuses, 400), statuses
+
+
+@pytest.mark.anyio
+async def test_non_finite_bbox_rejected_on_every_surface(
+    client: AsyncClient, stac_raster_dataset: Dataset, vector_dataset: Dataset
+):
+    """SEC-FU-06 survives the move to the shared parser on all callers."""
+    responses = {
+        "stac_items": await client.get(
+            f"/stac/collections/{STAC_UNASSIGNED}/items", params={"bbox": NAN_BBOX}
+        ),
+        "stac_search": await client.get("/stac/search", params={"bbox": NAN_BBOX}),
+        "ogc_items": await client.get(
+            f"/collections/{vector_dataset.id}/items", params={"bbox": NAN_BBOX}
+        ),
+        "catalog_search": await client.get(
+            "/search/datasets/", params={"bbox": NAN_BBOX}
+        ),
+        "export": await client.get(
+            f"/datasets/{vector_dataset.id}/export",
+            params={"format": "geojson", "bbox": NAN_BBOX},
+        ),
+    }
+    statuses = {name: resp.status_code for name, resp in responses.items()}
+    assert statuses == dict.fromkeys(statuses, 400), statuses
+
+
+@pytest.mark.anyio
+async def test_non_finite_bbox_rejected_by_stac_search_post(
+    client: AsyncClient, stac_raster_dataset: Dataset
+):
+    """JSON 1e400 parses to +Inf — the POST body path must reject it too."""
+    resp = await client.post(
+        "/stac/search",
+        content='{"bbox": [-74.10, 1e400, -73.90, 40.80]}',
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 400, resp.text

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -38335,6 +38335,7 @@ export interface operations {
                 bbox?: string | null;
                 /** @description OGC datetime interval */
                 datetime?: string | null;
+                /** @description Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation. */
                 limit?: number;
                 /** @description Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 and recommends keyset cursors via the rel=next link for deep paging. */
                 offset?: number;

--- a/sdks/python/geolens/api/stac/get_collection_items_stac_collections_collection_id_items_get.py
+++ b/sdks/python/geolens/api/stac/get_collection_items_stac_collections_collection_id_items_get.py
@@ -122,7 +122,8 @@ def sync_detailed(
         collection_id (str):
         bbox (None | str | Unset): Bounding box: west,south,east,north
         datetime_ (None | str | Unset): OGC datetime interval
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
+            200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
             to 200 and recommends keyset cursors via the rel=next link for deep paging. Default: 0.
 
@@ -166,7 +167,8 @@ def sync(
         collection_id (str):
         bbox (None | str | Unset): Bounding box: west,south,east,north
         datetime_ (None | str | Unset): OGC datetime interval
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
+            200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
             to 200 and recommends keyset cursors via the rel=next link for deep paging. Default: 0.
 
@@ -205,7 +207,8 @@ async def asyncio_detailed(
         collection_id (str):
         bbox (None | str | Unset): Bounding box: west,south,east,north
         datetime_ (None | str | Unset): OGC datetime interval
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
+            200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
             to 200 and recommends keyset cursors via the rel=next link for deep paging. Default: 0.
 
@@ -247,7 +250,8 @@ async def asyncio(
         collection_id (str):
         bbox (None | str | Unset): Bounding box: west,south,east,north
         datetime_ (None | str | Unset): OGC datetime interval
-        limit (int | Unset):  Default: 10.
+        limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
+            200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
         offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
             to 200 and recommends keyset cursors via the rel=next link for deep paging. Default: 0.
 

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -26480,6 +26480,8 @@ export type GetCollectionItemsStacCollectionsCollectionIdItemsGetData = {
         datetime?: string | null;
         /**
          * Limit
+         *
+         * Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation.
          */
         limit?: number;
         /**


### PR DESCRIPTION
## What

Two STAC conformance gaps, both cases of the same handler being left out of an earlier pass.

**Over-limit pages were rejected, not clamped.** `GET /stac/collections/{id}/items` declared `limit` with `le=200`, so `limit=1000` came back as a 400 while both Item Search handlers clamped the same value and returned 200. The STAC Item Search spec, and `stac-api-validator` with it, require an over-maximum limit to be clamped to the server maximum. The ceiling now lives in one module constant, `_STAC_MAX_LIMIT`, read by all three item-returning handlers, so the next change to it cannot miss one.

**STAC hand-rolled bbox parsing at two sites** instead of calling the shared `parse_bbox`, and the copies had drifted. STAC accepted a zero-height bbox that OGC Features, per-dataset features, export and catalog search all rejected with a 400. That duplication had already cost a security guard once: the SEC-FU-06 NaN/Inf check had to be re-applied to the STAC copy (#430 BA-12) because the copy existed. Both sites now call `parse_bbox`, which takes the POST body's list of floats as well as the GET query string. `SearchParams` carried a third copy of the same logic, without the finite guard, and now validates through `parse_bbox` too.

The degenerate-box disagreement is settled toward the spec rather than toward the majority. OGC API Features and STAC both define bbox bounds as lower <= upper, so a zero-height (line) or zero-area (point) box is a legal filter. `parse_bbox` relaxes `miny >= maxy` to `miny > maxy`. Antimeridian crossing (`west > east`) is unchanged, and the finite-coordinate guard still applies to every caller from its single home.

The one bbox validator deliberately left alone is `AnalysisPreviewRequest._validate_bbox`: it rejects antimeridian crossing on purpose, because it feeds `ST_MakeEnvelope` directly with no two-envelope split, and its comment says so. It already uses `>` and already has the finite guard, so it agrees with the new shared rule where the rules overlap.

## API contract impact

- `GET /stac/collections/{id}/items`: the `limit` parameter loses its `maximum: 200` constraint and gains the clamp description. A value above 200 now returns 200 with at most 200 items instead of a 400. Values below 1 are still rejected (`ge=1` is untouched).
- **Behavior relaxation across five surfaces**: a zero-height or zero-area bbox goes from 400 to 200 on OGC Features, per-dataset features, export, catalog search and saved-search params. STAC already accepted it. Nothing that was accepted before is rejected now.
- Regenerated artifacts committed: `backend/openapi.json`, `sdks/python/geolens/api/stac/get_collection_items_stac_collections_collection_id_items_get.py`, `sdks/typescript/src/client/types.gen.ts`, `frontend/src/types/api.generated.ts`. The whole regen diff is the one parameter above.
- `backend/tests/test_layering.py`: the `stac/router.py` LOC cap drops 1870 -> 1855, since deleting the two inline parsers and `_require_finite_bbox` shrinks the file.

## Verification

Failing-first, on the pre-fix tree:

```
7 failed, 6 passed
AssertionError: surfaces disagree on a zero-height bbox:
  {'stac_items': 200, 'stac_search': 200, 'ogc_items': 400, 'catalog_search': 400}
AssertionError: {"title":"Bad Request","status":400,
  "detail":"query.limit: Input should be less than or equal to 200"}
```

After:

```
cd backend && set -a && source ../.env.test && set +a && uv run pytest \
  tests/test_stac_limit_bbox_conformance.py tests/test_stac_api.py \
  tests/test_stac_integration.py tests/test_stac_search_validation.py \
  tests/test_stac_search_dos_sec023.py tests/test_stac_validation.py \
  tests/test_stac_visibility.py tests/test_stac_datetime_filter.py \
  tests/test_stac_record_output.py tests/test_stac_serializer.py \
  tests/test_parse_bbox_isfinite.py -q                                  # 137 passed

uv run pytest tests/test_ogc_features.py tests/test_ogc_pagination.py \
  tests/test_ogc_discovery.py tests/test_ogc_public_access.py \
  tests/test_ogc_records_conformance.py tests/test_ogc_cql2_filtering.py \
  tests/test_ogc_collection_metadata.py tests/test_ogc_queryables.py -q  # 131 passed

uv run pytest tests/test_export*.py tests/test_search*.py \
  tests/test_saved_searches.py tests/test_features_crud.py \
  tests/test_antimeridian_extent.py tests/test_antimeridian_rollup.py -q # 293 passed

uv run pytest tests/test_layering.py -q                                  # 40 passed
uv run ruff check app tests && uv run ruff format app tests --check      # clean
make openapi-check && make sdks-check                                    # clean
```
