### PR TITLE
fix(api): correct sprite sdf typing, read-GET 403 docs, and tag casing

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -570,7 +570,7 @@ _OPENAPI_TAGS = [
         "description": "Saved map configurations, layers, AI styling, and sharing.",
     },
     {
-        "name": "config-ops",
+        "name": "Config Ops",
         "description": "Configuration export, import, dry-run, and connectivity validation.",
     },
     {

--- a/backend/app/modules/catalog/collections/router.py
+++ b/backend/app/modules/catalog/collections/router.py
@@ -44,7 +44,7 @@ from app.modules.catalog.collections.service import (
 from app.modules.catalog.datasets.domain.helpers import dataset_to_response
 from app.modules.catalog.datasets.domain.schemas import DatasetListResponse
 from app.core.dependencies import get_db
-from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
+from app.standards.ogc.errors import ERROR_RESPONSES_WRITE, FORBIDDEN_RESPONSE
 
 router = APIRouter(
     prefix="/catalog/collections", tags=["Datasets"], responses=ERROR_RESPONSES_WRITE
@@ -131,8 +131,17 @@ _CATALOG_CACHE_TTL = 60  # seconds
 
 
 # ROUTE-01 (Phase 1092): dual-shape decorator — see POST above.
-@router.get("", response_model=CollectionListResponse, include_in_schema=False)
-@router.get("/", response_model=CollectionListResponse)
+@router.get(
+    "",
+    response_model=CollectionListResponse,
+    include_in_schema=False,
+    responses={403: FORBIDDEN_RESPONSE},
+)
+@router.get(
+    "/",
+    response_model=CollectionListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_collections_endpoint(
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
@@ -180,7 +189,11 @@ async def list_collections_endpoint(
     return response
 
 
-@router.get("/{collection_id}", response_model=CollectionResponse)
+@router.get(
+    "/{collection_id}",
+    response_model=CollectionResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_collection_endpoint(
     collection_id: uuid.UUID,
     user: Identity | None = Depends(get_optional_user),
@@ -403,7 +416,11 @@ async def remove_dataset_endpoint(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.get("/{collection_id}/datasets/", response_model=DatasetListResponse)
+@router.get(
+    "/{collection_id}/datasets/",
+    response_model=DatasetListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_collection_datasets_endpoint(
     collection_id: uuid.UUID,
     skip: int = Query(0, ge=0),

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -81,8 +81,19 @@ _CATALOG_CACHE_TTL = 60  # seconds
 # no-trailing-slash variants register against the same handler. Slash form
 # stays canonical (already in OpenAPI); no-slash is a hidden alias closing
 # the 404 regression introduced by redirect_slashes=False (api/main.py).
-@router.get("", response_model=DatasetListResponse, include_in_schema=False)
-@router.get("/", response_model=DatasetListResponse)
+@router.get(
+    "",
+    response_model=DatasetListResponse,
+    include_in_schema=False,
+    responses={403: FORBIDDEN_RESPONSE},
+)
+@router.get(
+    "/",
+    response_model=DatasetListResponse,
+    # fix(getgeolens.com#86 review): read-gated (visibility filtering inside
+    # get_datasets_list), not write-gated — see get_single_dataset above.
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_all_datasets(
     request: Request,
     skip: int = Query(0, ge=0),

--- a/backend/app/modules/catalog/datasets/api/router_data.py
+++ b/backend/app/modules/catalog/datasets/api/router_data.py
@@ -53,7 +53,7 @@ from app.modules.catalog.validation.schemas import (
     ValidationResultResponse,
 )
 from app.modules.catalog.validation.service import validate_record as run_validation
-from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
+from app.standards.ogc.errors import ERROR_RESPONSES_WRITE, FORBIDDEN_RESPONSE
 
 router = APIRouter(
     prefix="/datasets", tags=["Datasets - Data"], responses=ERROR_RESPONSES_WRITE
@@ -65,7 +65,11 @@ def _semantic_search_rate_limit(_request: Request | None = None) -> str:
     return f"{get_cached_semantic_search_rate_limit()}/minute"
 
 
-@router.get("/{dataset_id}/related/", response_model=RelatedDatasetsResponse)
+@router.get(
+    "/{dataset_id}/related/",
+    response_model=RelatedDatasetsResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 @limiter.limit(_semantic_search_rate_limit)
 async def list_related_datasets(
     request: Request,
@@ -90,7 +94,11 @@ async def list_related_datasets(
     return RelatedDatasetsResponse(items=items, total=len(items))
 
 
-@router.get("/{dataset_id}/rows/", response_model=DatasetRowsResponse)
+@router.get(
+    "/{dataset_id}/rows/",
+    response_model=DatasetRowsResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_dataset_rows_endpoint(
     request: Request,
     dataset_id: uuid.UUID,
@@ -224,7 +232,11 @@ async def validate_dataset(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{dataset_id}/maps/", response_model=MapListResponse)
+@router.get(
+    "/{dataset_id}/maps/",
+    response_model=MapListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def dataset_maps(
     dataset_id: uuid.UUID,
     skip: int = Query(0, ge=0),

--- a/backend/app/modules/catalog/datasets/api/router_health.py
+++ b/backend/app/modules/catalog/datasets/api/router_health.py
@@ -75,7 +75,7 @@ from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
 
 router = APIRouter(
     prefix="/datasets",
-    tags=["Datasets - Source health"],
+    tags=["Datasets - Source Health"],
     responses=ERROR_RESPONSES_WRITE,
 )
 

--- a/backend/app/modules/catalog/datasets/api/router_metadata.py
+++ b/backend/app/modules/catalog/datasets/api/router_metadata.py
@@ -46,7 +46,7 @@ from app.modules.catalog.datasets.domain.service import (
     get_dataset_versions,
 )
 from app.core.dependencies import get_db
-from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
+from app.standards.ogc.errors import ERROR_RESPONSES_WRITE, FORBIDDEN_RESPONSE
 
 router = APIRouter(
     prefix="/datasets", tags=["Datasets - Metadata"], responses=ERROR_RESPONSES_WRITE
@@ -61,6 +61,9 @@ router = APIRouter(
 @router.get(
     "/{dataset_id}/versions/",
     response_model=DatasetVersionListResponse,
+    # fix(getgeolens.com#86 review): read-gated (check_dataset_access_or_anonymous
+    # below), not write-gated — see datasets/api/router.py:get_single_dataset.
+    responses={403: FORBIDDEN_RESPONSE},
 )
 async def get_dataset_versions_endpoint(
     dataset_id: uuid.UUID,
@@ -117,7 +120,11 @@ async def get_dataset_versions_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{dataset_id}/attributes/", response_model=AttributeMetadataListResponse)
+@router.get(
+    "/{dataset_id}/attributes/",
+    response_model=AttributeMetadataListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_attributes_endpoint(
     dataset_id: uuid.UUID,
     include_removed: bool = Query(False),
@@ -141,7 +148,9 @@ async def list_attributes_endpoint(
 
 
 @router.get(
-    "/{dataset_id}/attributes/{attribute_id}/", response_model=AttributeMetadataResponse
+    "/{dataset_id}/attributes/{attribute_id}/",
+    response_model=AttributeMetadataResponse,
+    responses={403: FORBIDDEN_RESPONSE},
 )
 async def get_attribute_endpoint(
     dataset_id: uuid.UUID,
@@ -289,7 +298,9 @@ async def reset_attribute_endpoint(
 
 
 @router.get(
-    "/{dataset_id}/columns/{column_name}/values/", response_model=ColumnValuesResponse
+    "/{dataset_id}/columns/{column_name}/values/",
+    response_model=ColumnValuesResponse,
+    responses={403: FORBIDDEN_RESPONSE},
 )
 async def get_column_values(
     dataset_id: uuid.UUID,
@@ -344,7 +355,9 @@ async def get_column_values(
 
 
 @router.get(
-    "/{dataset_id}/columns/{column_name}/stats/", response_model=ColumnStatsResponse
+    "/{dataset_id}/columns/{column_name}/stats/",
+    response_model=ColumnStatsResponse,
+    responses={403: FORBIDDEN_RESPONSE},
 )
 async def get_column_stats_endpoint(
     dataset_id: uuid.UUID,
@@ -384,6 +397,7 @@ async def get_column_stats_endpoint(
 @router.get(
     "/{dataset_id}/relationships/",
     response_model=DatasetRelationshipListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
 )
 async def list_dataset_relationships(
     dataset_id: uuid.UUID,
@@ -533,6 +547,7 @@ async def delete_dataset_relationship(
 @router.get(
     "/{dataset_id}/features/{gid}/related/{relationship_id}/",
     response_model=DatasetRowsResponse,
+    responses={403: FORBIDDEN_RESPONSE},
 )
 async def get_feature_related_records(
     dataset_id: uuid.UUID,

--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -37,7 +37,7 @@ from app.core.dependencies import get_db
 from app.platform.extensions import get_catalog_port, get_permission_extension
 from app.modules.catalog.sources.origin_probe import remote_asset_exists
 from app.platform.storage.titiler_url import resolve_storage_key
-from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
+from app.standards.ogc.errors import ERROR_RESPONSES_WRITE, FORBIDDEN_RESPONSE
 
 router = APIRouter(
     prefix="/datasets", tags=["Datasets - VRT"], responses=ERROR_RESPONSES_WRITE
@@ -73,7 +73,11 @@ async def _load_source_datasets(
     return {dataset.id: dataset for dataset in result.scalars().unique().all()}
 
 
-@router.get("/{dataset_id}/vrt-sources/", response_model=VrtSourceListResponse)
+@router.get(
+    "/{dataset_id}/vrt-sources/",
+    response_model=VrtSourceListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_vrt_sources(
     dataset_id: uuid.UUID,
     user: Identity = Depends(get_current_active_user),
@@ -141,7 +145,11 @@ async def list_vrt_sources(
     return VrtSourceListResponse(sources=sources)
 
 
-@router.get("/{dataset_id}/vrt/status/", response_model=VrtStatusResponse)
+@router.get(
+    "/{dataset_id}/vrt/status/",
+    response_model=VrtStatusResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_vrt_status(
     dataset_id: uuid.UUID,
     user: Identity = Depends(get_current_active_user),
@@ -338,7 +346,11 @@ async def get_vrt_status(
     )
 
 
-@router.get("/{dataset_id}/vrt/generations/", response_model=VrtGenerationListResponse)
+@router.get(
+    "/{dataset_id}/vrt/generations/",
+    response_model=VrtGenerationListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_vrt_generations(
     dataset_id: uuid.UUID,
     limit: int = Query(20, ge=1, le=100),

--- a/backend/app/modules/catalog/maps/router.py
+++ b/backend/app/modules/catalog/maps/router.py
@@ -83,7 +83,11 @@ from app.modules.embed_tokens.service import (
 from app.platform.storage.titiler_url import (
     resolve_current_storage_key as _map_asset_storage_key,
 )
-from app.standards.ogc.errors import BAD_GATEWAY_RESPONSE, ERROR_RESPONSES_WRITE
+from app.standards.ogc.errors import (
+    BAD_GATEWAY_RESPONSE,
+    ERROR_RESPONSES_WRITE,
+    FORBIDDEN_RESPONSE,
+)
 from app.modules.catalog.maps._router_helpers import (
     _build_layer_response,
     _build_map_response,
@@ -174,8 +178,19 @@ async def create_map_endpoint(
 
 
 # ROUTE-01 (Phase 1092): dual-shape decorator — see POST /maps above.
-@router.get("", response_model=MapListResponse, include_in_schema=False)
-@router.get("/", response_model=MapListResponse)
+@router.get(
+    "",
+    response_model=MapListResponse,
+    include_in_schema=False,
+    responses={403: FORBIDDEN_RESPONSE},
+)
+@router.get(
+    "/",
+    response_model=MapListResponse,
+    # fix(getgeolens.com#86 review): read-gated (visibility filtering inside
+    # list_maps), not write-gated — see get_map_endpoint below.
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_maps_endpoint(
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
@@ -336,7 +351,15 @@ async def import_map_style_endpoint(
     )
 
 
-@router.get("/{map_id}", response_model=MapResponse)
+@router.get(
+    "/{map_id}",
+    response_model=MapResponse,
+    # fix(getgeolens.com#86 review): read-gated (_check_map_read_access below),
+    # not write-gated, so the router's default 403 ("caller lacks write
+    # access") misdescribes this route's actual 403 cause. Same override on
+    # every other read-gated GET in this file (access, thumbnail, og-image).
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_map_endpoint(
     map_id: uuid.UUID,
     user: Identity | None = Depends(get_optional_user),
@@ -363,7 +386,11 @@ async def get_map_endpoint(
     )
 
 
-@router.get("/{map_id}/access/", response_model=MapAccessResponse)
+@router.get(
+    "/{map_id}/access/",
+    response_model=MapAccessResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_map_access_endpoint(
     map_id: uuid.UUID,
     user: Identity | None = Depends(get_optional_user),
@@ -1004,7 +1031,11 @@ async def upload_thumbnail(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.get("/{map_id}/thumbnail/", response_class=Response)
+@router.get(
+    "/{map_id}/thumbnail/",
+    response_class=Response,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_thumbnail(
     map_id: uuid.UUID,
     user: Identity | None = Depends(get_optional_user),
@@ -1137,7 +1168,11 @@ async def upload_og_image(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.get("/{map_id}/og-image/", response_class=Response)
+@router.get(
+    "/{map_id}/og-image/",
+    response_class=Response,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_og_image(
     map_id: uuid.UUID,
     user: Identity | None = Depends(get_optional_user),

--- a/backend/app/modules/catalog/maps/router_assets.py
+++ b/backend/app/modules/catalog/maps/router_assets.py
@@ -14,12 +14,14 @@ from app.core.identity import Identity
 from app.modules.auth.dependencies import require_mode_permission, require_permission
 from app.modules.catalog.maps.schemas import MapIconListResponse, MapIconResponse
 from app.modules.catalog.maps.sprites import (
+    SpriteIndex,
     build_sprite_index,
     build_sprite_png,
     create_icon_asset,
     get_icon_content,
     list_icons,
 )
+from app.standards.ogc.errors import FORBIDDEN_RESPONSE
 
 router = APIRouter()
 
@@ -62,7 +64,7 @@ async def upload_map_icon_endpoint(
     return next(icon for icon in await list_icons(db) if icon.id == str(asset.id))
 
 
-@router.get("/icons/{icon_id}/asset")
+@router.get("/icons/{icon_id}/asset", responses={403: FORBIDDEN_RESPONSE})
 async def get_map_icon_asset_endpoint(
     icon_id: str,
     db: AsyncSession = Depends(get_db),
@@ -86,18 +88,22 @@ async def get_map_icon_asset_endpoint(
     return Response(content=content, media_type=media_type, headers=headers)
 
 
-@router.get("/sprites/geolens.json")
+@router.get("/sprites/geolens.json", responses={403: FORBIDDEN_RESPONSE})
 async def get_geolens_sprite_index_endpoint(
     db: AsyncSession = Depends(get_db),
-) -> dict[str, dict[str, int | float]]:
+) -> SpriteIndex:
     """Serve the stable GeoLens sprite JSON index."""
     return await build_sprite_index(db)
 
 
-@router.get("/sprites/geolens@2x.json", include_in_schema=False)
+@router.get(
+    "/sprites/geolens@2x.json",
+    include_in_schema=False,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_geolens_sprite_index_2x_endpoint(
     db: AsyncSession = Depends(get_db),
-) -> dict[str, dict[str, int | float]]:
+) -> SpriteIndex:
     """Serve the GeoLens sprite index for high-DPI MapLibre sprite requests."""
     return await build_sprite_index(db)
 

--- a/backend/app/modules/catalog/maps/router_sharing.py
+++ b/backend/app/modules/catalog/maps/router_sharing.py
@@ -56,7 +56,7 @@ from app.modules.catalog.maps.service import (
 )
 from app.modules.catalog.maps.style_json import build_maplibre_style
 from app.modules.embed_tokens.service import revoke_embed_tokens_by_map
-from app.standards.ogc.errors import GONE_RESPONSE
+from app.standards.ogc.errors import FORBIDDEN_RESPONSE, GONE_RESPONSE
 
 router = APIRouter()
 
@@ -130,7 +130,7 @@ async def shared_map_card_endpoint(
 @router.get(
     "/shared/{token}",
     response_model=SharedMapResponse,
-    responses={410: GONE_RESPONSE},
+    responses={403: FORBIDDEN_RESPONSE, 410: GONE_RESPONSE},
 )
 async def get_shared_map_endpoint(
     token: str,
@@ -203,7 +203,7 @@ async def visibility_check_endpoint(
     )
 
 
-@router.get("/{map_id}/style.json")
+@router.get("/{map_id}/style.json", responses={403: FORBIDDEN_RESPONSE})
 async def export_map_style_endpoint(
     map_id: uuid.UUID,
     request: Request,

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -63,7 +63,7 @@ from app.modules.catalog.records.service import (
     update_contact,
     update_distribution,
 )
-from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
+from app.standards.ogc.errors import ERROR_RESPONSES_WRITE, FORBIDDEN_RESPONSE
 
 logger = structlog.get_logger()
 
@@ -250,7 +250,11 @@ async def _check_record_ownership(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{record_id}/translations/", response_model=TranslationListResponse)
+@router.get(
+    "/{record_id}/translations/",
+    response_model=TranslationListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_translations_endpoint(
     record_id: uuid.UUID,
     user: Identity | None = Depends(get_optional_user),
@@ -352,7 +356,11 @@ async def delete_translation_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{record_id}/contacts/", response_model=ContactListResponse)
+@router.get(
+    "/{record_id}/contacts/",
+    response_model=ContactListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_contacts_endpoint(
     record_id: uuid.UUID,
     skip: int = Query(0, ge=0),
@@ -500,7 +508,11 @@ async def delete_contact_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{record_id}/keywords/", response_model=KeywordListResponse)
+@router.get(
+    "/{record_id}/keywords/",
+    response_model=KeywordListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_keywords_endpoint(
     record_id: uuid.UUID,
     skip: int = Query(0, ge=0),
@@ -671,7 +683,11 @@ async def delete_keyword_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{record_id}/distributions/", response_model=DistributionListResponse)
+@router.get(
+    "/{record_id}/distributions/",
+    response_model=DistributionListResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def list_distributions_endpoint(
     record_id: uuid.UUID,
     skip: int = Query(0, ge=0),

--- a/backend/app/platform/config_ops/router.py
+++ b/backend/app/platform/config_ops/router.py
@@ -39,7 +39,7 @@ require_config_operator = require_mode_permission(
 )
 
 router = APIRouter(
-    prefix="/config-ops", tags=["config-ops"], responses=ERROR_RESPONSES_AUTH
+    prefix="/config-ops", tags=["Config Ops"], responses=ERROR_RESPONSES_AUTH
 )
 
 

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -112,6 +112,7 @@ from app.platform.storage.titiler_url import resolve_current_storage_key
 from app.standards.ogc.errors import (
     BAD_GATEWAY_RESPONSE,
     ERROR_RESPONSES_WRITE,
+    FORBIDDEN_RESPONSE,
     PAYLOAD_TOO_LARGE_RESPONSE,
 )
 
@@ -181,7 +182,11 @@ async def _get_allowed_extensions_safely(db: AsyncSession) -> list[str]:
         return list(_FALLBACK_ALLOWED_EXTENSIONS)
 
 
-@router.get("/upload/config", response_model=UploadConfigResponse)
+@router.get(
+    "/upload/config",
+    response_model=UploadConfigResponse,
+    responses={403: FORBIDDEN_RESPONSE},
+)
 async def get_upload_config(
     user: Identity = Depends(get_current_active_user),
     db: AsyncSession = Depends(get_db),

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -26539,7 +26539,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -26959,7 +26959,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -27279,7 +27279,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -29559,7 +29559,7 @@
         ],
         "summary": "Dry Run Configuration",
         "tags": [
-          "config-ops"
+          "Config Ops"
         ]
       }
     },
@@ -29679,7 +29679,7 @@
         ],
         "summary": "Export Configuration",
         "tags": [
-          "config-ops"
+          "Config Ops"
         ]
       }
     },
@@ -29855,7 +29855,7 @@
         ],
         "summary": "Import Configuration",
         "tags": [
-          "config-ops"
+          "Config Ops"
         ]
       }
     },
@@ -29977,7 +29977,7 @@
         ],
         "summary": "Validate Configuration",
         "tags": [
-          "config-ops"
+          "Config Ops"
         ]
       }
     },
@@ -30138,7 +30138,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -32096,7 +32096,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -32251,7 +32251,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -32720,7 +32720,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -32885,7 +32885,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -35504,7 +35504,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -36046,7 +36046,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -36672,7 +36672,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -36844,7 +36844,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -38185,7 +38185,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -38415,7 +38415,7 @@
         ],
         "summary": "Check Source Health",
         "tags": [
-          "Datasets - Source health"
+          "Datasets - Source Health"
         ]
       }
     },
@@ -38962,7 +38962,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -39107,7 +39107,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -39297,7 +39297,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -39585,7 +39585,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -40982,7 +40982,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -43456,7 +43456,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -44010,7 +44010,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -44302,7 +44302,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -44419,6 +44419,9 @@
                         },
                         {
                           "type": "number"
+                        },
+                        {
+                          "type": "boolean"
                         }
                       ]
                     },
@@ -44459,7 +44462,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -44846,7 +44849,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -45143,7 +45146,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -46811,7 +46814,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -47707,7 +47710,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -47845,7 +47848,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -48444,7 +48447,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -49073,7 +49076,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -49740,7 +49743,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -50184,7 +50187,7 @@
                 }
               }
             },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Forbidden \u2014 caller lacks access to this resource"
           },
           "404": {
             "content": {
@@ -57005,7 +57008,7 @@
     },
     {
       "description": "Configuration export, import, dry-run, and connectivity validation.",
-      "name": "config-ops"
+      "name": "Config Ops"
     },
     {
       "description": "Admin management of embed tokens across all maps.",

--- a/backend/tests/test_api_contract_openapi.py
+++ b/backend/tests/test_api_contract_openapi.py
@@ -401,6 +401,46 @@ def test_openapi_has_no_dangling_local_ref_pointers() -> None:
     assert dangling == []
 
 
+def test_read_gated_gets_do_not_publish_the_write_403_description() -> None:
+    """F19: a GET gated by visibility/read access must not claim its 403 is
+    about lacking write access — that description belongs to mutation
+    endpoints on the same router (``ERROR_RESPONSES_WRITE`` is the router
+    default and is only correct for those).
+    """
+    spec = _openapi()
+    write_403 = "Forbidden — caller lacks write access"
+
+    for path, method in (
+        ("/datasets/", "get"),
+        ("/maps/{map_id}", "get"),
+        ("/datasets/{dataset_id}/versions/", "get"),
+        ("/records/{record_id}/contacts/", "get"),
+        ("/catalog/collections/{collection_id}", "get"),
+        ("/datasets/{dataset_id}/vrt-sources/", "get"),
+    ):
+        description = spec["paths"][path][method]["responses"]["403"]["description"]
+        assert description != write_403, (
+            f"{method.upper()} {path} still publishes the write-flavored 403"
+        )
+
+    # A GET genuinely gated by write/ownership access keeps the accurate
+    # write-flavored description — the override is per-route, not blanket.
+    history = spec["paths"]["/maps/{map_id}/history"]["get"]
+    assert history["responses"]["403"]["description"] == write_403
+
+
+def test_config_ops_and_source_health_tags_are_title_case() -> None:
+    """F31: every OpenAPI tag in the published spec matches Title Case."""
+    spec = _openapi()
+
+    assert "config-ops" not in spec["paths"]["/config-ops/export/"]["get"]["tags"]
+    assert "Config Ops" in spec["paths"]["/config-ops/export/"]["get"]["tags"]
+
+    health_op = spec["paths"]["/datasets/{dataset_id}/source-health/"]["post"]
+    assert "Datasets - Source health" not in health_op["tags"]
+    assert "Datasets - Source Health" in health_op["tags"]
+
+
 def test_inline_json_schema_rejects_recursive_model() -> None:
     """fix(#569): a self-referential model must fail fast, not loop forever."""
     import pytest

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1896,7 +1896,12 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     "backend/app/modules/catalog/maps/style_json.py": 1620,
     "backend/app/modules/catalog/maps/style_import.py": 450,
     "backend/app/modules/catalog/maps/style_sanitizers.py": 200,
-    "backend/app/modules/catalog/maps/router_assets.py": 126,
+    # fix(getgeolens.com#86 review): +6 — the icon-asset and sprite-index GETs
+    # gained per-route `responses={403: FORBIDDEN_RESPONSE}` overrides; they
+    # are read-gated (icon asset) or unauthenticated (sprite index), so the
+    # router's inherited write-flavored 403 misdescribed their actual cause.
+    # Cap 126 -> 132, exact.
+    "backend/app/modules/catalog/maps/router_assets.py": 132,
     # fix(#526 B-048): the card-route SPA-redirect fallback shell.
     # fix(#819): visibility-check owner-or-admin gate + rationale docstring.
     "backend/app/modules/catalog/maps/router_sharing.py": 387,
@@ -2155,7 +2160,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # commit, per the no-headroom rule. Cap 1548 -> 1537, exact.
     # fix(#1327 codex P1): +8 — both staged dispatch sites say why they defer
     # the staged task name rather than the legacy one. Cap 1537 -> 1545, exact.
-    "backend/app/processing/ingest/router.py": 1545,
+    # fix(getgeolens.com#86 review): +5 — get_upload_config gained a per-route
+    # `responses={403: FORBIDDEN_RESPONSE}` override; it only requires
+    # authentication, not the router's write-flavored default. Cap 1545 ->
+    # 1550, exact.
+    "backend/app/processing/ingest/router.py": 1550,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
@@ -2793,7 +2802,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#941): +8 — the reworded add-layer history summary carries the reason
     # the immediate-POST and save-diff writers say different things, so a later
     # refactor does not collapse them. Ratchet stays exact.
-    "backend/app/modules/catalog/maps/router.py": 1425,
+    # fix(getgeolens.com#86 review): +35 — five read-gated GETs (list, single
+    # map, access, thumbnail, og-image) gained per-route
+    # `responses={403: FORBIDDEN_RESPONSE}` overrides; get_map_history_endpoint
+    # keeps the router's write-flavored default since it genuinely requires
+    # edit_metadata + ownership. Cap 1425 -> 1460, exact.
+    "backend/app/modules/catalog/maps/router.py": 1460,
     # fix(#474): thread negotiated languages through catalog search, cache keys,
     # and OGC record serialization; fix(#475) adds Records array-query handling,
     # including collection IDs, plus response-header and documented 400 parity.

--- a/backend/tests/test_map_sprites.py
+++ b/backend/tests/test_map_sprites.py
@@ -5,6 +5,7 @@ import uuid
 
 from PIL import Image
 import pytest
+from httpx import AsyncClient
 
 from app.modules.catalog.maps.models import MapIconAsset
 from app.modules.catalog.maps.sprites import (
@@ -204,6 +205,20 @@ async def test_sprite_index_and_png_are_stable(monkeypatch):
     }
     assert png.startswith(b"\x89PNG\r\n\x1a\n")
     assert len(png) > 100
+
+
+@pytest.mark.anyio
+async def test_sprite_index_endpoint_serves_sdf_as_json_boolean(client: AsyncClient):
+    """F3: the served index must keep sdf a JSON boolean, not coerce it to 1.
+
+    The route's return type previously narrowed to
+    dict[str, dict[str, int | float]], which Pydantic uses to validate the
+    response; bool is a subclass of int, so it silently coerced True to the
+    JSON integer 1. MapLibre's sprite spec defines sdf as boolean.
+    """
+    resp = await client.get("/maps/sprites/geolens.json")
+    assert resp.status_code == 200
+    assert resp.json()["arrow-right"]["sdf"] is True
 
 
 @pytest.mark.anyio

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -18873,7 +18873,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -19085,7 +19085,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -19405,7 +19405,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -21042,7 +21042,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -22422,7 +22422,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -22528,7 +22528,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -22850,7 +22850,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -22958,7 +22958,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -24488,7 +24488,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -24842,7 +24842,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -25270,7 +25270,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -25380,7 +25380,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -26308,7 +26308,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -26847,7 +26847,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -26952,7 +26952,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -27066,7 +27066,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -27276,7 +27276,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -28297,7 +28297,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -30020,7 +30020,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -30442,7 +30442,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -30657,7 +30657,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -30750,7 +30750,7 @@ export interface operations {
                 content: {
                     "application/json": {
                         [key: string]: {
-                            [key: string]: number;
+                            [key: string]: number | boolean;
                         };
                     };
                 };
@@ -30773,7 +30773,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -30981,7 +30981,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -31298,7 +31298,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -32475,7 +32475,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -33122,7 +33122,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -33225,7 +33225,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -33652,7 +33652,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -34083,7 +34083,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -34518,7 +34518,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -34836,7 +34836,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ProblemDetail"];
                 };
             };
-            /** @description Forbidden — caller lacks write access */
+            /** @description Forbidden — caller lacks access to this resource */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/sdks/python/geolens/models/get_geolens_sprite_index_endpoint_maps_sprites_geolens_json_get_response_get_geolens_sprite_index_endpoint_maps_sprites_geolens_json_get_additional_property.py
+++ b/sdks/python/geolens/models/get_geolens_sprite_index_endpoint_maps_sprites_geolens_json_get_response_get_geolens_sprite_index_endpoint_maps_sprites_geolens_json_get_additional_property.py
@@ -20,7 +20,7 @@ T = TypeVar(
 class GetGeolensSpriteIndexEndpointMapsSpritesGeolensJsonGetResponseGetGeolensSpriteIndexEndpointMapsSpritesGeolensJsonGetAdditionalProperty:
     """ """
 
-    additional_properties: dict[str, float | int] = _attrs_field(
+    additional_properties: dict[str, bool | float | int] = _attrs_field(
         init=False, factory=dict
     )
 
@@ -40,8 +40,8 @@ class GetGeolensSpriteIndexEndpointMapsSpritesGeolensJsonGetResponseGetGeolensSp
         additional_properties = {}
         for prop_name, prop_dict in d.items():
 
-            def _parse_additional_property(data: object) -> float | int:
-                return cast(float | int, data)
+            def _parse_additional_property(data: object) -> bool | float | int:
+                return cast(bool | float | int, data)
 
             additional_property = _parse_additional_property(prop_dict)
 
@@ -54,10 +54,10 @@ class GetGeolensSpriteIndexEndpointMapsSpritesGeolensJsonGetResponseGetGeolensSp
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
-    def __getitem__(self, key: str) -> float | int:
+    def __getitem__(self, key: str) -> bool | float | int:
         return self.additional_properties[key]
 
-    def __setitem__(self, key: str, value: float | int) -> None:
+    def __setitem__(self, key: str, value: bool | float | int) -> None:
         self.additional_properties[key] = value
 
     def __delitem__(self, key: str) -> None:

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -14301,7 +14301,7 @@ export type ListCollectionsEndpointCatalogCollectionsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -14482,7 +14482,7 @@ export type GetCollectionEndpointCatalogCollectionsCollectionIdGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -14615,7 +14615,7 @@ export type GetCollectionDatasetsEndpointCatalogCollectionsCollectionIdDatasetsG
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -15828,7 +15828,7 @@ export type ListAllDatasetsDatasetsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -16654,7 +16654,7 @@ export type ListAttributesEndpointDatasetsDatasetIdAttributesGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -16720,7 +16720,7 @@ export type GetAttributeEndpointDatasetsDatasetIdAttributesAttributeIdGetErrors 
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -16918,7 +16918,7 @@ export type GetColumnStatsEndpointDatasetsDatasetIdColumnsColumnNameStatsGetErro
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -16989,7 +16989,7 @@ export type GetColumnValuesDatasetsDatasetIdColumnsColumnNameValuesGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -18116,7 +18116,7 @@ export type GetFeatureRelatedRecordsDatasetsDatasetIdFeaturesGidRelatedRelations
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -18346,7 +18346,7 @@ export type DatasetMapsDatasetsDatasetIdMapsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -18611,7 +18611,7 @@ export type ListRelatedDatasetsDatasetsDatasetIdRelatedGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -18686,7 +18686,7 @@ export type ListDatasetRelationshipsDatasetsDatasetIdRelationshipsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -19230,7 +19230,7 @@ export type GetDatasetRowsEndpointDatasetsDatasetIdRowsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -19556,7 +19556,7 @@ export type GetDatasetVersionsEndpointDatasetsDatasetIdVersionsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -19618,7 +19618,7 @@ export type ListVrtSourcesDatasetsDatasetIdVrtSourcesGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -19699,7 +19699,7 @@ export type ListVrtGenerationsDatasetsDatasetIdVrtGenerationsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -19823,7 +19823,7 @@ export type GetVrtStatusDatasetsDatasetIdVrtStatusGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -20404,7 +20404,7 @@ export type GetUploadConfigIngestUploadConfigGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -21422,7 +21422,7 @@ export type ListMapsEndpointMapsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -21655,7 +21655,7 @@ export type GetMapIconAssetEndpointMapsIconsIconIdAssetGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -21780,7 +21780,7 @@ export type GetSharedMapEndpointMapsSharedTokenGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -21841,7 +21841,7 @@ export type GetGeolensSpriteIndexEndpointMapsSpritesGeolensJsonGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -21880,7 +21880,7 @@ export type GetGeolensSpriteIndexEndpointMapsSpritesGeolensJsonGetResponses = {
      */
     200: {
         [key: string]: {
-            [key: string]: number | number;
+            [key: string]: number | number | boolean;
         };
     };
 };
@@ -22026,7 +22026,7 @@ export type GetMapEndpointMapsMapIdGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -22150,7 +22150,7 @@ export type GetMapAccessEndpointMapsMapIdAccessGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -22853,7 +22853,7 @@ export type GetOgImageMapsMapIdOgImageGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -23232,7 +23232,7 @@ export type ExportMapStyleEndpointMapsMapIdStyleJsonGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -23292,7 +23292,7 @@ export type GetThumbnailMapsMapIdThumbnailGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -23542,7 +23542,7 @@ export type ListContactsEndpointRecordsRecordIdContactsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -23807,7 +23807,7 @@ export type ListDistributionsEndpointRecordsRecordIdDistributionsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -24084,7 +24084,7 @@ export type ListKeywordsEndpointRecordsRecordIdKeywordsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**
@@ -24274,7 +24274,7 @@ export type ListTranslationsEndpointRecordsRecordIdTranslationsGetErrors = {
      */
     401: ProblemDetail;
     /**
-     * Forbidden — caller lacks write access
+     * Forbidden — caller lacks access to this resource
      */
     403: ProblemDetail;
     /**


### PR DESCRIPTION
## Summary

Three OpenAPI contract-accuracy fixes, all in the wire contract:

- **Sprite `sdf` boolean type.** `router_assets.py`'s two sprite-index GET
  handlers annotated their return type as `dict[str, dict[str, int | float]]`
  — narrower than `sprites.py`'s own `SpriteIndex` type, which includes
  `bool`. FastAPI infers the response model from the return annotation, and
  since `bool` is a subclass of `int`, Pydantic silently coerced the
  arrow-right builtin icon's `sdf: true` to the JSON integer `1` on the wire.
  MapLibre's sprite spec defines `sdf` as boolean. Both handlers now annotate
  `-> SpriteIndex` (imported from `sprites.py`), matching the service's own
  type instead of a narrower ad hoc one.

- **Read-gated GETs publishing a write-flavored 403.** Routers built with
  `responses=ERROR_RESPONSES_WRITE` document every operation's 403 as
  "Forbidden — caller lacks write access" by default — correct for mutation
  endpoints, wrong for GETs gated by visibility/read access (or nothing at
  all). The override pattern already existed at 4 sites in
  `datasets/api/router.py` (`responses={403: FORBIDDEN_RESPONSE}`); this PR
  walks every `ERROR_RESPONSES_WRITE` router's GET operations and applies the
  same override to every one that isn't actually write-gated. Landed **32**
  new override sites across 10 routers (`datasets/api/router.py`,
  `router_metadata.py`, `router_vrt.py`, `router_data.py`, `maps/router.py`
  + its `router_assets.py`/`router_sharing.py` sub-routers, `records/router.py`,
  `collections/router.py`, `processing/ingest/router.py`) — plus the 4
  pre-existing sites, that's 36 read-gated GETs now correctly documented.
  GETs that genuinely require write/ownership access keep the accurate
  default (e.g. map history and embed-token listing require
  `edit_metadata` + ownership; connector discovery and the icon catalog
  require an upload/edit capability; `validate_dataset`'s `?refresh=true`
  path enforces ownership). Verified by walking the live FastAPI route table
  post-fix: zero GET operations incorrectly publish the write-flavored 403.

- **Two OpenAPI tag-casing outliers.** `config-ops` → `Config Ops` (24
  sibling tags are Title Case; also updated the matching `openapi_tags`
  metadata entry in `api/main.py` so the Swagger UI description stays
  attached) and `Datasets - Source health` → `Datasets - Source Health`
  (its seven `Datasets - *` siblings are Title Case).

## API contract impact

- `sdf` changes from `anyOf[integer, number]` to `anyOf[integer, number,
  boolean]` on `GET /maps/sprites/geolens.json`'s response schema — additive,
  no client break (any client already tolerant of `1`/`0` still accepts
  `true`/`false`).
- 32 GET operations' documented 403 description changes from "Forbidden —
  caller lacks write access" to "Forbidden — caller lacks access to this
  resource" — docs-only, no runtime/status-code change.
- 2 tag renames regroup the affected operations' SDK methods under
  `ConfigOpsService`/`Config Ops` and the renamed `Datasets - Source Health`
  namespace instead of the old casing.
- `backend/openapi.json`, both SDKs (`sdks/python`, `sdks/typescript`), and
  the frontend's generated client (`frontend/src/types/api.generated.ts`)
  are regenerated and committed.

## Test plan

- [x] Failing-first: `test_sprite_index_endpoint_serves_sdf_as_json_boolean`
      (new, `test_map_sprites.py`) — verified it fails against the pre-fix
      annotation (asserts JSON integer `1`) and passes after.
- [x] Failing-first: `test_read_gated_gets_do_not_publish_the_write_403_description`
      and `test_config_ops_and_source_health_tags_are_title_case` (new,
      `test_api_contract_openapi.py`) — verified both fail against the
      pre-fix router/tag state and pass after.
- [x] `cd backend && uv run ruff check app tests && uv run ruff format app tests --check`
- [x] `uv run pytest tests/test_layering.py -q` (3 router modules grew past
      their LOC cap from the per-route `responses=` additions; ratcheted in
      the same commit with inline comments)
- [x] `uv run pytest tests/test_map_sprites.py tests/test_api_contract_openapi.py tests/test_config_ops.py tests/test_config_ops_unit.py tests/test_openapi_overlay_boundary.py tests/test_openapi_property_order.py tests/test_reupload_completion_contract_1207.py tests/test_secondary_contract_bounds.py -q` — 119 passed, 1 skipped
- [x] `uv run pytest tests/test_maps.py tests/test_maps_bulk_layers.py tests/test_maps_og_image.py tests/test_maps_style_json.py tests/test_maps_visibility_check_authz_sec007.py tests/test_collections.py tests/test_records_authz_sec001.py tests/test_records_related.py -q` — 394 passed (behavioral regression check on the most heavily-touched routers)
- [x] `make openapi-check` / `make sdks-check` (incl. SDK build + test) / `cd frontend && npm run types:check` — all clean, no drift