### PR TITLE
fix: cancellation and lifecycle hygiene across ogr2ogr, reupload cleanup, VRT rollback, and export sweep

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -437,7 +437,10 @@ async def lifespan(app: FastAPI):
                 # to sit until the next restart — sweep_orphaned_exports only
                 # ran once at boot (above) and once at worker boot (worker.py).
                 # It is idempotent and age-thresholded, so it is safe to run on
-                # every sweeper cycle too.
+                # every sweeper cycle too. The two boot-time callers deliberately
+                # stay synchronous — boot wants the sweep done before the app
+                # serves traffic, and nothing else contends for the loop yet;
+                # this caller threads it because it runs while the loop is live.
                 await _sweep_orphaned_exports_and_log(exports_dir, sweeper_log)
             except asyncio.CancelledError:
                 raise

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -35,6 +35,7 @@ from app.observability.metrics import (
 # uses them. A module-scope `from app.core.db import ...` snapshots the
 # dev-DB objects before the test fixture rebinds app.core.db, so lifespan
 # seed functions in tests would silently hit the dev database.
+from app.core.async_io import run_in_thread_draining
 from app.core.db.tenant_session import tenant_job_context
 from app.core.logging_config import setup_logging
 from app.core.tenancy import is_multi_tenant
@@ -269,10 +270,22 @@ async def sweep_stale_jobs_once(
     return pending_total, running_total
 
 
-def _sweep_orphaned_exports_and_log(exports_dir: Path, log) -> None:
-    """Sweep exports/ and log only when something was actually removed —
-    mirrors the pending_failed/running_failed and renewed-credentials
-    branches in ``_stale_jobs_sweeper``, which stay quiet on a no-op cycle.
+def _sweep_orphaned_exports_periodic(exports_dir: Path) -> tuple[int, int]:
+    """Thin positional-only wrapper around ``sweep_orphaned_exports`` binding
+    the periodic threshold, so it can be handed to ``run_in_thread_draining``
+    (which forwards ``*args`` only — ``age_threshold_seconds`` is keyword-only
+    on the wrapped function).
+    """
+    return sweep_orphaned_exports(
+        exports_dir, age_threshold_seconds=EXPORTS_PERIODIC_SWEEP_AGE_SECONDS
+    )
+
+
+async def _sweep_orphaned_exports_and_log(exports_dir: Path, log) -> None:
+    """Sweep exports/ in a worker thread and log only when something was
+    actually removed — mirrors the pending_failed/running_failed and
+    renewed-credentials branches in ``_stale_jobs_sweeper``, which stay quiet
+    on a no-op cycle.
 
     Split out of that loop body so this one extra branch does not push
     ``lifespan``'s McCabe complexity over its gate.
@@ -282,9 +295,20 @@ def _sweep_orphaned_exports_and_log(exports_dir: Path, log) -> None:
     cadence rather than only at a restart, so it needs a wider safety margin
     (see that constant's docstring in ``staging.py``) before treating an
     export directory as abandoned rather than merely slow.
+
+    fix(#1435 codex round 5): runs via ``run_in_thread_draining`` rather than
+    inline. ``sweep_orphaned_exports`` does synchronous directory traversal
+    and ``shutil.rmtree``; unlike the two boot-time callers, which run before
+    the event loop is serving traffic, this one runs on a live server every
+    few minutes, so calling it inline would stall request handling for the
+    duration — worst case exactly when a crash left large or many-file
+    residue, since that is what gives the sweep real work to do. Draining
+    (rather than a bare ``asyncio.to_thread``) means a cancellation
+    (graceful shutdown) waits for an in-flight ``rmtree`` to finish instead
+    of abandoning a background thread still mutating the filesystem.
     """
-    deleted, _ = sweep_orphaned_exports(
-        exports_dir, age_threshold_seconds=EXPORTS_PERIODIC_SWEEP_AGE_SECONDS
+    deleted, _ = await run_in_thread_draining(
+        _sweep_orphaned_exports_periodic, exports_dir
     )
     if deleted:
         log.info("Swept orphaned exports", deleted=deleted)
@@ -414,7 +438,7 @@ async def lifespan(app: FastAPI):
                 # ran once at boot (above) and once at worker boot (worker.py).
                 # It is idempotent and age-thresholded, so it is safe to run on
                 # every sweeper cycle too.
-                _sweep_orphaned_exports_and_log(exports_dir, sweeper_log)
+                await _sweep_orphaned_exports_and_log(exports_dir, sweeper_log)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # broad: sweeper-loop must survive any DB/transient error to keep running

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E402
 import asyncio
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 import structlog
 
@@ -264,6 +265,19 @@ async def sweep_stale_jobs_once(
     return pending_total, running_total
 
 
+def _sweep_orphaned_exports_and_log(exports_dir: Path, log) -> None:
+    """Sweep exports/ and log only when something was actually removed —
+    mirrors the pending_failed/running_failed and renewed-credentials
+    branches in ``_stale_jobs_sweeper``, which stay quiet on a no-op cycle.
+
+    Split out of that loop body so this one extra branch does not push
+    ``lifespan``'s McCabe complexity over its gate.
+    """
+    deleted, _ = sweep_orphaned_exports(exports_dir)
+    if deleted:
+        log.info("Swept orphaned exports", deleted=deleted)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from app.core.db import engine  # fix(#909): late-bind for tests
@@ -383,6 +397,12 @@ async def lifespan(app: FastAPI):
                 renewed = await renew_queued_credentials_once()
                 if renewed:
                     sweeper_log.debug("Renewed queued credentials", count=renewed)
+                # exports/ residue from a hard process death (SIGKILL, OOM) used
+                # to sit until the next restart — sweep_orphaned_exports only
+                # ran once at boot (above) and once at worker boot (worker.py).
+                # It is idempotent and age-thresholded, so it is safe to run on
+                # every sweeper cycle too.
+                _sweep_orphaned_exports_and_log(exports_dir, sweeper_log)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # broad: sweeper-loop must survive any DB/transient error to keep running

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -38,7 +38,11 @@ from app.observability.metrics import (
 from app.core.db.tenant_session import tenant_job_context
 from app.core.logging_config import setup_logging
 from app.core.tenancy import is_multi_tenant
-from app.core.runtime.staging import ensure_staging_ready, sweep_orphaned_exports
+from app.core.runtime.staging import (
+    EXPORTS_PERIODIC_SWEEP_AGE_SECONDS,
+    ensure_staging_ready,
+    sweep_orphaned_exports,
+)
 from app.platform.extensions.bootstrap import (
     assert_enterprise_ports_resolved,
     bootstrap,
@@ -272,8 +276,16 @@ def _sweep_orphaned_exports_and_log(exports_dir: Path, log) -> None:
 
     Split out of that loop body so this one extra branch does not push
     ``lifespan``'s McCabe complexity over its gate.
+
+    fix(#1435 codex round 1): uses ``EXPORTS_PERIODIC_SWEEP_AGE_SECONDS``, not
+    the boot-time callers' default — this runs continuously on a short
+    cadence rather than only at a restart, so it needs a wider safety margin
+    (see that constant's docstring in ``staging.py``) before treating an
+    export directory as abandoned rather than merely slow.
     """
-    deleted, _ = sweep_orphaned_exports(exports_dir)
+    deleted, _ = sweep_orphaned_exports(
+        exports_dir, age_threshold_seconds=EXPORTS_PERIODIC_SWEEP_AGE_SECONDS
+    )
     if deleted:
         log.info("Swept orphaned exports", deleted=deleted)
 

--- a/backend/app/core/runtime/staging.py
+++ b/backend/app/core/runtime/staging.py
@@ -36,6 +36,29 @@ EXPORTS_SWEEP_AGE_SECONDS = 3600  # 1 hour
 EXPORTS_PERIODIC_SWEEP_AGE_SECONDS = 4 * EXPORTS_SWEEP_AGE_SECONDS  # 4 hours
 
 
+def _latest_mtime(entry: Path) -> float:
+    """The most recent mtime of ``entry`` itself, or (one level deep) any
+    file directly inside it.
+
+    fix(#1435 codex round 2): a directory's own mtime is bumped only by an
+    entry being added, removed, or renamed inside it — NOT by writes to an
+    already-created file's contents. ogr2ogr opens its output file once and
+    then writes to it for the rest of the run, so the export directory's own
+    mtime freezes at file-creation time while ogr2ogr is still actively
+    writing. Checking the contained file(s) too means a still-growing export
+    keeps reading as fresh for as long as ogr2ogr keeps writing, regardless
+    of the age threshold in force.
+    """
+    latest = entry.stat().st_mtime
+    if entry.is_dir():
+        for child in entry.iterdir():
+            try:
+                latest = max(latest, child.stat().st_mtime)
+            except FileNotFoundError:
+                continue  # raced with a concurrent write/rename; ignore
+    return latest
+
+
 def sweep_orphaned_exports(
     exports_dir: Path,
     *,
@@ -78,7 +101,7 @@ def sweep_orphaned_exports(
     skipped_count = 0
     for item in entries:
         try:
-            item_mtime = item.stat().st_mtime
+            item_mtime = _latest_mtime(item)
         except FileNotFoundError:
             # Raced with another process / external cleanup — treat as already-gone.
             continue

--- a/backend/app/core/runtime/staging.py
+++ b/backend/app/core/runtime/staging.py
@@ -51,11 +51,21 @@ def _latest_mtime(entry: Path) -> float:
     """
     latest = entry.stat().st_mtime
     if entry.is_dir():
-        for child in entry.iterdir():
+        try:
+            children = list(entry.iterdir())
+        except OSError:
+            # fix(#1435 codex round 3): a directory that cannot be listed
+            # (e.g. root-owned residue left behind by a container UID
+            # change across a deploy) must not crash sweep_orphaned_exports
+            # — both boot-time callers run this with no guard of their own,
+            # so one unreadable entry would otherwise take down startup.
+            # Fall back to the entry's own mtime.
+            return latest
+        for child in children:
             try:
                 latest = max(latest, child.stat().st_mtime)
-            except FileNotFoundError:
-                continue  # raced with a concurrent write/rename; ignore
+            except OSError:
+                continue  # unreadable, or raced with a concurrent write/rename
     return latest
 
 
@@ -77,9 +87,10 @@ def sweep_orphaned_exports(
     worker now call this one age-aware sweeper.
 
     No cross-process advisory lock. The sweep is idempotent and tolerates
-    losing a race (``ignore_errors``/``missing_ok``/``FileNotFoundError``), and the
-    age threshold — not mutual exclusion — is what protects in-flight exports. Add a
-    lock only if a sweeper ever grows a non-idempotent step.
+    losing a race or hitting unreadable residue (``ignore_errors``/
+    ``missing_ok``/``OSError``), and the age threshold — not mutual exclusion
+    — is what protects in-flight exports. Add a lock only if a sweeper ever
+    grows a non-idempotent step.
 
     Args:
         exports_dir: The ``<staging>/exports/`` directory to sweep. A missing
@@ -102,8 +113,11 @@ def sweep_orphaned_exports(
     for item in entries:
         try:
             item_mtime = _latest_mtime(item)
-        except FileNotFoundError:
-            # Raced with another process / external cleanup — treat as already-gone.
+        except OSError:
+            # fix(#1435 codex round 3): FileNotFoundError (raced with
+            # another process / external cleanup) or PermissionError
+            # (unreadable residue) — either way, skip rather than crash the
+            # sweep and take down API/worker startup with it.
             continue
         age_seconds = now_ts - item_mtime
         if age_seconds < age_threshold_seconds:

--- a/backend/app/core/runtime/staging.py
+++ b/backend/app/core/runtime/staging.py
@@ -21,6 +21,20 @@ log = structlog.get_logger()
 # a rolling restart at the job layer also keeps its on-disk staging artifact.
 EXPORTS_SWEEP_AGE_SECONDS = 3600  # 1 hour
 
+# fix(#1435 codex round 1): the API's periodic sweeper (inside
+# _stale_jobs_sweeper) calls this sweep on a short, continuous cadence (every
+# few minutes) rather than only at a restart/deploy, unlike the two boot-time
+# callers above. A directory's mtime is set once when the export is created
+# and never advances again while ogr2ogr keeps writing the file inside it or a
+# client keeps streaming it out — only an entry ADD/removal in the directory
+# bumps it, not writes to an existing file's contents. Reusing
+# EXPORTS_SWEEP_AGE_SECONDS there would turn "an in-flight export survives A
+# restart" into "any export whose ogr2ogr run plus zip plus client-download
+# time exceeds 1 hour gets deleted out from under it on the very next cycle" —
+# guaranteed, not just an unlucky restart coincidence. A wider margin keeps
+# the periodic pass catching only residue from a process that is truly gone.
+EXPORTS_PERIODIC_SWEEP_AGE_SECONDS = 4 * EXPORTS_SWEEP_AGE_SECONDS  # 4 hours
+
 
 def sweep_orphaned_exports(
     exports_dir: Path,

--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -128,6 +128,8 @@ async def _cleanup_uncommitted_reupload_source(
         return
     try:
         await get_storage().delete(resolve_current_storage_key(saved_path))
+    except asyncio.CancelledError:
+        raise
     except BaseException:
         logger.warning(
             "reupload_source_cleanup_failed",

--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -423,7 +423,10 @@ async def regenerate_vrt_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> VrtMutationResponse:
     """Trigger manual VRT regeneration with advisory lock to prevent concurrent rebuilds."""
-    from app.platform.jobs.defer_guard import defer_with_orphan_guard
+    from app.platform.jobs.defer_guard import (
+        defer_with_orphan_guard,
+        make_vrt_regeneration_failed_rollback,
+    )
 
     RasterAsset = get_catalog_port().raster_asset_orm_class()
     VrtGeneration = get_catalog_port().vrt_generation_orm_class()
@@ -519,22 +522,17 @@ async def regenerate_vrt_endpoint(
             triggered_by=str(user.id),
         )
 
-    async def _rollback(defer_exc: BaseException) -> None:
-        # Mark the VrtGeneration record failed so listings reflect
-        # reality (the row was already committed via db.flush +
-        # db.commit above).
-        generation.status = "failed"
-        generation.completed_at = datetime.now(timezone.utc)
-        generation.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
-        # Revert VRT asset state to pre-mutation values.
-        vrt_asset.status = previous_status
-        vrt_asset.current_generation_id = previous_generation_id
-        # Mark the IngestJob failed.
-        job.status = "failed"
-        job.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
-        job.completed_at = datetime.now(timezone.utc)
-
-    await defer_with_orphan_guard(_defer, rollback=_rollback, db=db)
+    # The VrtGeneration row was already committed via db.flush + db.commit
+    # above; rollback marks it failed and reverts vrt_asset to its
+    # pre-mutation values (captured before that commit).
+    rollback = make_vrt_regeneration_failed_rollback(
+        vrt_asset,
+        generation,
+        job,
+        previous_status=previous_status,
+        previous_generation_id=previous_generation_id,
+    )
+    await defer_with_orphan_guard(_defer, rollback=rollback, db=db)
 
     return VrtMutationResponse(
         job_id=job.id,

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -32,14 +32,23 @@ ingest service module.
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timezone
-from typing import Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 import structlog
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.platform.jobs.models import IngestJob
+
+if TYPE_CHECKING:
+    # Typing-only edge: `platform/` must not import `processing/` at module
+    # scope (test_layering.py's _PLATFORM_PROCESSING_IMPORT_BURNDOWN "may
+    # shrink, never grow"), but the VRT factory below needs these two names
+    # for its signature. Mirrors the `AuditEvent`/`Identity` TYPE_CHECKING
+    # pattern in `platform/extensions/protocols.py`.
+    from app.processing.raster.models import RasterAsset, VrtGeneration
 
 logger = structlog.get_logger()
 
@@ -127,5 +136,40 @@ def make_ingest_job_failed_rollback(
         job.status = "failed"
         job.error_message = f"{message_prefix}: {defer_exc}"
         job.completed_at = datetime.now(timezone.utc)
+
+    return _rollback
+
+
+def make_vrt_regeneration_failed_rollback(
+    vrt_asset: RasterAsset,
+    generation: VrtGeneration,
+    job: IngestJob,
+    *,
+    previous_status: str,
+    previous_generation_id: uuid.UUID | None,
+) -> RollbackCallable:
+    """Build a rollback closure for a VRT regeneration defer failure.
+
+    Convenience for the three VRT regeneration endpoints (add-source,
+    remove-source, refresh) that each commit the same three pieces of state
+    before dispatch: ``vrt_asset.status`` / ``current_generation_id``
+    (reverted here to the pre-mutation values the caller captured before
+    committing), the new ``VrtGeneration`` row (marked failed here), and the
+    ``IngestJob`` row (marked failed via `make_ingest_job_failed_rollback`,
+    reused rather than duplicated — same message prefix as before, so
+    ``job.error_message`` still reads ``"Failed to queue VRT regeneration:
+    <exc>"``).
+    """
+    job_rollback = make_ingest_job_failed_rollback(
+        job, message_prefix="Failed to queue VRT regeneration"
+    )
+
+    async def _rollback(defer_exc: BaseException) -> None:
+        vrt_asset.status = previous_status
+        vrt_asset.current_generation_id = previous_generation_id
+        generation.status = "failed"
+        generation.completed_at = datetime.now(timezone.utc)
+        generation.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
+        await job_rollback(defer_exc)
 
     return _rollback

--- a/backend/app/processing/export/ogr.py
+++ b/backend/app/processing/export/ogr.py
@@ -157,9 +157,11 @@ async def run_ogr2ogr_export(
         cmd.extend(["-lco", "GEOMETRY=AS_WKT"])
 
     # fix(#430 BA-06): bound the export subprocess wall-clock with a kill-on-timeout
-    # (mirrors the ingest path) so a slow/large table can't hold an API worker or
-    # orphan the ogr2ogr child on client disconnect; also cap the server-side query
-    # via libpq statement_timeout so the DB stops working when the child is killed.
+    # (mirrors the ingest path) so a slow/large table can't hold an API worker;
+    # also cap the server-side query via libpq statement_timeout so the DB query
+    # stops when the child is killed. `_communicate_with_timeout` below kills the
+    # child on cancellation too (a client disconnect), not only on timeout — see
+    # its docstring for why that branch has to exist.
     env = _tenant_reader_subprocess_env(
         schema,
         base_env={

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -403,6 +403,17 @@ async def export_dataset_endpoint(
         raise
 
     # 9. Return file with background cleanup
+    # fix(#1435 codex round 2): touch the file's mtime right before handing it
+    # to FileResponse. sweep_orphaned_exports (periodic + boot) reads it as
+    # "most recent activity" — ogr2ogr's writes already keep it fresh while
+    # the file is being generated, but once ogr2ogr closes it the mtime
+    # freezes for the rest of a (possibly long, possibly slow-client)
+    # download. This resets the age-threshold clock to "streaming is about to
+    # begin" instead of "generation finished sometime earlier."
+    try:
+        os.utime(file_path, None)
+    except OSError:
+        pass  # best-effort freshness signal; a failure here must not block the download
     return FileResponse(
         path=file_path,
         filename=filename,

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -154,6 +154,28 @@ OGR2OGR_FILE_TIMEOUT_SECONDS = 3600  # 1 hour — large files legitimately take 
 OGR2OGR_SERVICE_TIMEOUT_SECONDS = 1800  # 30 min — existing value, now a named constant
 
 
+async def _kill_and_reap_subprocess(proc: asyncio.subprocess.Process) -> None:
+    """Best-effort kill + reap for a subprocess whose ``communicate()`` ended
+    abnormally. Shared by both ``_communicate_with_timeout`` branches below
+    so the kill/terminate/wait sequence has one implementation.
+    """
+    try:
+        proc.kill()
+    except ProcessLookupError:
+        pass
+    except (
+        Exception
+    ):  # broad: kill() can fail with permission/state errors; fall back to terminate()
+        try:
+            proc.terminate()
+        except Exception:  # broad: terminate() best-effort cleanup; give up if subprocess is already gone
+            pass
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=5)
+    except (asyncio.TimeoutError, ProcessLookupError):
+        pass
+
+
 async def _communicate_with_timeout(
     proc: asyncio.subprocess.Process,
     timeout: float,
@@ -165,26 +187,27 @@ async def _communicate_with_timeout(
     On timeout, attempts ``proc.kill()``, then ``proc.terminate()``, then
     gives up — in all cases raises IngestionError so the caller surfaces a
     meaningful error instead of hanging the worker.
+
+    On cancellation — a client disconnect cancels the request task, or
+    Procrastinate cancels a worker job during graceful shutdown —
+    ``asyncio.wait_for`` re-raises ``CancelledError`` from the outer task
+    without touching the child process. Without the branch below, the
+    ogr2ogr child is left running with nothing left to await it: a caller
+    that then deletes its output directory (export cleanup) races a process
+    that may still hold the file open. Runs the same kill/terminate/wait
+    sequence as the timeout branch, then re-raises so cancellation still
+    propagates.
     """
     try:
         return await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except asyncio.TimeoutError:
-        try:
-            proc.kill()
-        except ProcessLookupError:
-            pass
-        except Exception:  # broad: kill() can fail with permission/state errors; fall back to terminate()
-            try:
-                proc.terminate()
-            except Exception:  # broad: terminate() best-effort cleanup; give up if subprocess is already gone
-                pass
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=5)
-        except (asyncio.TimeoutError, ProcessLookupError):
-            pass
+        await _kill_and_reap_subprocess(proc)
         raise IngestionError(
             f"{tool_name} timed out after {int(timeout)}s — the file or upstream service is too slow"
         )
+    except asyncio.CancelledError:
+        await _kill_and_reap_subprocess(proc)
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -99,7 +99,10 @@ from app.processing.ingest.presigned import (
 )
 from app.processing.ingest.tasks import regenerate_vrt_staged
 from app.processing.ingest.validation import validate_file_content
-from app.platform.jobs.defer_guard import defer_with_orphan_guard
+from app.platform.jobs.defer_guard import (
+    defer_with_orphan_guard,
+    make_vrt_regeneration_failed_rollback,
+)
 from app.core.persistent_config import (
     UPLOAD_ALLOWED_EXTENSIONS,
     UPLOAD_MAX_SIZE_MB,
@@ -1359,26 +1362,21 @@ async def add_vrt_source(
             triggered_by=str(user.id),
         )
 
-    async def _rollback(defer_exc: BaseException) -> None:
-        # Revert VRT asset state to what it was before step 7.
-        vrt_asset.status = previous_status
-        vrt_asset.current_generation_id = previous_generation_id
-        generation.status = "failed"
-        generation.completed_at = datetime.now(timezone.utc)
-        generation.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
-        # fix(#1327): no link surgery here any more. This used to DELETE the
-        # row it had just inserted; with the member set staged on the
-        # generation, an undispatched request never touched vrt_source_links,
-        # so there is nothing to put back. The staged set stays on the failed
-        # generation row as the record of what was asked for — it can only be
-        # applied by a task that still owns the asset pointer, which this
-        # rollback has just handed back.
-        # Mark the IngestJob failed so /jobs listings reflect reality.
-        job.status = "failed"
-        job.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
-        job.completed_at = datetime.now(timezone.utc)
-
-    await defer_with_orphan_guard(_defer, rollback=_rollback, db=db)
+    # fix(#1327): no link-table rollback needed here. This used to DELETE the
+    # row it had just inserted; with the member set staged on the generation,
+    # an undispatched request never touched vrt_source_links, so there is
+    # nothing to put back. The staged set stays on the failed generation row
+    # as the record of what was asked for — it can only be applied by a task
+    # that still owns the asset pointer, which this rollback has just handed
+    # back.
+    rollback = make_vrt_regeneration_failed_rollback(
+        vrt_asset,
+        generation,
+        job,
+        previous_status=previous_status,
+        previous_generation_id=previous_generation_id,
+    )
+    await defer_with_orphan_guard(_defer, rollback=rollback, db=db)
 
     # fix(#1327): "queued", not "added". The catalog's source list still
     # describes the VRT being served; the addition becomes part of it when the
@@ -1526,23 +1524,18 @@ async def remove_vrt_source(
             triggered_by=str(user.id),
         )
 
-    async def _rollback(defer_exc: BaseException) -> None:
-        # fix(#1327): nothing to re-insert. The link row was never deleted —
-        # the post-removal set is staged on the generation and only applied at
-        # the artifact swap, so an undispatched request leaves the catalog's
-        # member set untouched.
-        # Revert VRT asset state.
-        vrt_asset.status = previous_status
-        vrt_asset.current_generation_id = previous_generation_id
-        generation.status = "failed"
-        generation.completed_at = datetime.now(timezone.utc)
-        generation.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
-        # Mark the IngestJob failed.
-        job.status = "failed"
-        job.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
-        job.completed_at = datetime.now(timezone.utc)
-
-    await defer_with_orphan_guard(_defer, rollback=_rollback, db=db)
+    # fix(#1327): nothing to re-insert. The link row was never deleted — the
+    # post-removal set is staged on the generation and only applied at the
+    # artifact swap, so an undispatched request leaves the catalog's member
+    # set untouched.
+    rollback = make_vrt_regeneration_failed_rollback(
+        vrt_asset,
+        generation,
+        job,
+        previous_status=previous_status,
+        previous_generation_id=previous_generation_id,
+    )
+    await defer_with_orphan_guard(_defer, rollback=rollback, db=db)
 
     # fix(#1327): "queued", not "removed" — see the add endpoint's tail.
     return VrtMutationResponse(

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -145,7 +145,7 @@ class TestDeferWithOrphanGuard:
         asyncio.run(_check())
 
     def test_make_vrt_regeneration_failed_rollback_reverts_all_eight_fields(self):
-        """F18: the factory the three VRT regeneration endpoints (add-source,
+        """fix(#1435): the factory the three VRT regeneration endpoints (add-source,
         remove-source, refresh) now share must revert every field their old
         hand-rolled closures did: vrt_asset.status/current_generation_id,
         generation.status/completed_at/error_message, and

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -144,6 +144,60 @@ class TestDeferWithOrphanGuard:
 
         asyncio.run(_check())
 
+    def test_make_vrt_regeneration_failed_rollback_reverts_all_eight_fields(self):
+        """F18: the factory the three VRT regeneration endpoints (add-source,
+        remove-source, refresh) now share must revert every field their old
+        hand-rolled closures did: vrt_asset.status/current_generation_id,
+        generation.status/completed_at/error_message, and
+        job.status/error_message/completed_at (the last three via
+        `make_ingest_job_failed_rollback`, reused rather than duplicated).
+
+        No single one of the three endpoint-level tests below asserts all
+        eight together — this is the one place that does.
+        """
+
+        async def _check():
+            from app.platform.jobs.defer_guard import (
+                make_vrt_regeneration_failed_rollback,
+            )
+
+            vrt_asset = MagicMock()
+            vrt_asset.status = "regenerating"
+            vrt_asset.current_generation_id = uuid.uuid4()
+            previous_status = "ready"
+            previous_generation_id = uuid.uuid4()
+
+            generation = MagicMock()
+            generation.status = "pending"
+            generation.completed_at = None
+            generation.error_message = None
+
+            job = MagicMock()
+            job.status = "pending"
+            job.error_message = None
+            job.completed_at = None
+
+            rollback = make_vrt_regeneration_failed_rollback(
+                vrt_asset,
+                generation,
+                job,
+                previous_status=previous_status,
+                previous_generation_id=previous_generation_id,
+            )
+            exc = RuntimeError("procrastinate unreachable")
+            await rollback(exc)
+
+            assert vrt_asset.status == previous_status
+            assert vrt_asset.current_generation_id == previous_generation_id
+            assert generation.status == "failed"
+            assert generation.completed_at is not None
+            assert "procrastinate unreachable" in generation.error_message
+            assert job.status == "failed"
+            assert job.completed_at is not None
+            assert "procrastinate unreachable" in job.error_message
+
+        asyncio.run(_check())
+
 
 # ---------------------------------------------------------------------------
 # Reupload router — 3 defer sites

--- a/backend/tests/test_export_hardening.py
+++ b/backend/tests/test_export_hardening.py
@@ -131,6 +131,38 @@ class TestExportEndpointCapabilityGate:
         )
 
 
+class TestExportFileTouchedBeforeStreaming:
+    def test_export_endpoint_touches_the_file_before_filereponse(self):
+        """fix(#1435 codex round 2): the periodic and boot-time export sweeps
+        both read an export's mtime as its "last activity" signal. ogr2ogr's
+        writes keep the file fresh while it is being generated, but the
+        mtime freezes the moment ogr2ogr closes it — including for the rest
+        of a (possibly long, possibly slow-client) download. Refreshing the
+        file's mtime right before handing it to FileResponse restarts that
+        clock at "streaming is about to begin" instead of "generation
+        finished sometime earlier," closing the gap where a still-downloading
+        export could be swept out from under a client mid-stream.
+
+        Source-inspection, matching the sibling capability-gate test above:
+        standing up a full dataset + ogr2ogr run to exercise this one-line
+        os.utime call would not cover anything this check does not already
+        pin more directly, and the behavioral effect (mtime freshness) is
+        exercised by test_worker_exports_sweep.py's sweep-algorithm tests.
+        """
+        import inspect
+
+        from app.processing.export.router import export_dataset_endpoint
+
+        src = inspect.getsource(export_dataset_endpoint)
+        assert "os.utime(file_path, None)" in src, (
+            "export_dataset_endpoint must refresh file_path's mtime before "
+            "streaming it, so the sweep's age clock restarts at download time"
+        )
+        assert src.index("os.utime(file_path, None)") < src.index(
+            "return FileResponse("
+        ), "the mtime touch must run BEFORE FileResponse is constructed, not after"
+
+
 # ---------------------------------------------------------------------------
 # KNOWN-05 (Phase 1071): live 403-for-revoked-viewer parity with v1014 SEC-S04
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2022,7 +2022,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # bootstrap(). The lifespan owning a second copy is how the API and the
     # worker ended up with different tile-cache states in the first place.
     # Cap 1332 -> 1330, exact.
-    "backend/app/api/main.py": 1330,
+    # +20 — the periodic _stale_jobs_sweeper loop now also sweeps exports/ on
+    # every cycle, not just once at boot: export residue from a hard process
+    # death (SIGKILL, OOM) used to sit until the next restart. The sweep +
+    # conditional log live in a small top-level _sweep_orphaned_exports_and_log
+    # helper (with the Path import it needs) rather than inline in the loop,
+    # so the extra branch does not push lifespan's McCabe complexity past its
+    # gate. Cap 1330 -> 1350, exact.
+    "backend/app/api/main.py": 1350,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2164,7 +2164,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `responses={403: FORBIDDEN_RESPONSE}` override; it only requires
     # authentication, not the router's write-flavored default. Cap 1545 ->
     # 1550, exact.
-    "backend/app/processing/ingest/router.py": 1550,
+    # Collapsed the add/remove VRT-source defer-rollback closures onto the
+    # shared make_vrt_regeneration_failed_rollback factory in defer_guard.py
+    # instead of hand-rolling the same eight-field revert twice with only
+    # comment/statement-order differences between them (-7 net). Landed
+    # concurrently with the responses={403:...} addition above; recounted
+    # after merge rather than picking either side's number. Cap 1550 ->
+    # 1543, exact.
+    "backend/app/processing/ingest/router.py": 1543,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2036,7 +2036,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # out) — otherwise any export whose total lifetime exceeds 1 hour gets
     # deleted out from under it on the next 5-minute cycle, guaranteed.
     # Cap 1350 -> 1362, exact.
-    "backend/app/api/main.py": 1362,
+    # fix(#1435 codex round 5): +24 — sweep_orphaned_exports does synchronous
+    # directory traversal + shutil.rmtree; unlike the boot-time callers,
+    # which run before the event loop serves traffic, the periodic caller
+    # runs on a live server every few minutes and was calling it inline,
+    # stalling request handling for the duration. Now runs via
+    # run_in_thread_draining through a small positional-only wrapper
+    # (age_threshold_seconds is keyword-only on sweep_orphaned_exports, and
+    # the helper only forwards *args). Cap 1362 -> 1386, exact.
+    "backend/app/api/main.py": 1386,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2029,7 +2029,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # helper (with the Path import it needs) rather than inline in the loop,
     # so the extra branch does not push lifespan's McCabe complexity past its
     # gate. Cap 1330 -> 1350, exact.
-    "backend/app/api/main.py": 1350,
+    # fix(#1435 codex round 1): +12 — the periodic sweep runs continuously
+    # rather than only at a restart, so it needs a wider age threshold than
+    # the boot-time callers (a directory's mtime does not advance while
+    # ogr2ogr keeps writing the file inside it or a client keeps streaming it
+    # out) — otherwise any export whose total lifetime exceeds 1 hour gets
+    # deleted out from under it on the next 5-minute cycle, guaranteed.
+    # Cap 1350 -> 1362, exact.
+    "backend/app/api/main.py": 1362,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2465,7 +2465,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # the third admission point and still creation-shaped, so an owner at the
     # dataset-count cap passed the request-time door, uploaded the bytes, and
     # was refused at completion. Cap 1143 -> 1149, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1149,
+    # +2 — the uncommitted-source cleanup helper re-raises CancelledError
+    # instead of swallowing it, mirroring the re-raise convention already used
+    # by the other three CancelledError checks in this file. Cap 1149 -> 1151,
+    # exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1151,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2044,7 +2044,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # run_in_thread_draining through a small positional-only wrapper
     # (age_threshold_seconds is keyword-only on sweep_orphaned_exports, and
     # the helper only forwards *args). Cap 1362 -> 1386, exact.
-    "backend/app/api/main.py": 1386,
+    # +3 — one-line comment at the periodic call site stating why the two
+    # boot-time callers deliberately stay synchronous, so a future review
+    # round reads the asymmetry as intentional rather than a missed sibling.
+    # Cap 1386 -> 1389, exact.
+    "backend/app/api/main.py": 1389,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_ogr_communicate_cancellation.py
+++ b/backend/tests/test_ogr_communicate_cancellation.py
@@ -1,4 +1,4 @@
-"""F11: client-disconnect cancellation must kill the ogr2ogr child.
+"""fix(#1435): client-disconnect cancellation must kill the ogr2ogr child.
 
 ``asyncio.wait_for`` re-raises ``CancelledError`` on outer-task cancellation
 without touching the awaited subprocess, so `_communicate_with_timeout`'s

--- a/backend/tests/test_ogr_communicate_cancellation.py
+++ b/backend/tests/test_ogr_communicate_cancellation.py
@@ -1,0 +1,67 @@
+"""F11: client-disconnect cancellation must kill the ogr2ogr child.
+
+``asyncio.wait_for`` re-raises ``CancelledError`` on outer-task cancellation
+without touching the awaited subprocess, so `_communicate_with_timeout`'s
+pre-fix code — which only caught `asyncio.TimeoutError` — let a cancelled
+caller unwind while the child kept running with nothing left to reap it.
+Three ``BaseHTTPMiddleware`` subclasses cancel the downstream task on
+``http.disconnect``, so this is reachable from a real client disconnect
+during export or ingest, not just a contrived test.
+"""
+
+import asyncio
+
+import pytest
+
+from app.processing.ingest.ogr import _communicate_with_timeout
+
+
+@pytest.mark.asyncio
+async def test_cancellation_kills_the_child_process():
+    """Cancelling the task awaiting `_communicate_with_timeout` must kill the
+    underlying subprocess and re-raise CancelledError, not leave the child
+    running with the caller already unwound.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "sleep",
+        "30",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    task = asyncio.ensure_future(
+        _communicate_with_timeout(proc, timeout=60, tool_name="test")
+    )
+    # Let the subprocess start and _communicate_with_timeout begin awaiting it.
+    await asyncio.sleep(0.2)
+    assert proc.returncode is None, "child should still be running before cancel"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The assertion that fails pre-fix: without the CancelledError branch,
+    # the `sleep 30` child is still running and this wait_for times out.
+    await asyncio.wait_for(proc.wait(), timeout=5)
+    assert proc.returncode is not None
+
+
+@pytest.mark.asyncio
+async def test_timeout_still_kills_the_child_process():
+    """Regression guard: the pre-existing timeout-kill path must survive the
+    refactor into the shared `_kill_and_reap_subprocess` helper.
+    """
+    from app.processing.ingest.ogr import IngestionError
+
+    proc = await asyncio.create_subprocess_exec(
+        "sleep",
+        "30",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    with pytest.raises(IngestionError):
+        await _communicate_with_timeout(proc, timeout=0.1, tool_name="test")
+
+    await asyncio.wait_for(proc.wait(), timeout=5)
+    assert proc.returncode is not None

--- a/backend/tests/test_reupload.py
+++ b/backend/tests/test_reupload.py
@@ -9,6 +9,7 @@ Requirements:
   - Alembic migrations must be applied
 """
 
+import asyncio
 import uuid
 from io import BytesIO
 from pathlib import Path
@@ -75,6 +76,46 @@ async def test_reupload_commit_failure_cleans_owned_staged_file(tmp_path):
             )
 
     cleanup.assert_awaited_once_with(staged, job_id=job.id)
+
+
+@pytest.mark.anyio
+async def test_cleanup_uncommitted_reupload_source_reraises_cancellation():
+    """F14: a client disconnect during the storage delete must unwind the
+    caller, not be absorbed into a best-effort warning log.
+
+    `_cleanup_uncommitted_reupload_source` is called both from the upload
+    rollback path (a disconnect during validation) and, unguarded, right
+    before the presigned-completion door returns success — swallowing
+    CancelledError there let a cancelled request return 200 anyway.
+    """
+    job_id = uuid.uuid4()
+    storage_key = f"reupload-staging/{job_id}/replacement.geojson"
+
+    mock_storage = MagicMock()
+    mock_storage.delete = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with patch.object(router_reupload, "get_storage", return_value=mock_storage):
+        with pytest.raises(asyncio.CancelledError):
+            await router_reupload._cleanup_uncommitted_reupload_source(
+                storage_key, job_id=job_id
+            )
+
+
+@pytest.mark.anyio
+async def test_cleanup_uncommitted_reupload_source_still_swallows_storage_errors():
+    """Regression guard: the best-effort swallow for genuine storage errors
+    (fix #1207) must survive alongside the CancelledError re-raise above."""
+    job_id = uuid.uuid4()
+    storage_key = f"reupload-staging/{job_id}/replacement.geojson"
+
+    mock_storage = MagicMock()
+    mock_storage.delete = AsyncMock(side_effect=RuntimeError("storage unavailable"))
+
+    with patch.object(router_reupload, "get_storage", return_value=mock_storage):
+        # Must not raise — the pre-existing best-effort contract.
+        await router_reupload._cleanup_uncommitted_reupload_source(
+            storage_key, job_id=job_id
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_reupload.py
+++ b/backend/tests/test_reupload.py
@@ -80,7 +80,7 @@ async def test_reupload_commit_failure_cleans_owned_staged_file(tmp_path):
 
 @pytest.mark.anyio
 async def test_cleanup_uncommitted_reupload_source_reraises_cancellation():
-    """F14: a client disconnect during the storage delete must unwind the
+    """fix(#1435): a client disconnect during the storage delete must unwind the
     caller, not be absorbed into a best-effort warning log.
 
     `_cleanup_uncommitted_reupload_source` is called both from the upload

--- a/backend/tests/test_worker_exports_sweep.py
+++ b/backend/tests/test_worker_exports_sweep.py
@@ -193,6 +193,74 @@ def test_stale_jobs_sweeper_also_sweeps_orphaned_exports() -> None:
     )
 
     helper_source = inspect.getsource(main._sweep_orphaned_exports_and_log)
-    assert "sweep_orphaned_exports(exports_dir)" in helper_source, (
+    assert "sweep_orphaned_exports(" in helper_source, (
         "_sweep_orphaned_exports_and_log must actually call sweep_orphaned_exports"
+    )
+    assert "EXPORTS_PERIODIC_SWEEP_AGE_SECONDS" in helper_source, (
+        "the periodic sweep must use the wider periodic threshold, not the "
+        "boot-time default — see test_periodic_sweep_survives_a_slow_export "
+        "below for why"
+    )
+
+
+def test_periodic_sweep_survives_a_slow_export(tmp_path: Path) -> None:
+    """fix(#1435 codex round 1): the periodic sweeper runs continuously
+    (every CREDENTIAL_RENEWAL_INTERVAL_SECONDS), unlike the boot-time
+    callers, which only fire on a restart. A directory's mtime is set once
+    at export creation and does not advance while ogr2ogr keeps writing the
+    file inside it or a client keeps streaming it out, so reusing the
+    1-hour boot threshold there would delete any export whose total
+    lifetime (ogr2ogr + zip + download) exceeds 1 hour on the very next
+    5-minute cycle — guaranteed, not just an unlucky restart coincidence.
+
+    A 2-hour-old export (older than the 1-hour boot threshold, younger than
+    the 4-hour periodic threshold) must survive the periodic helper, even
+    though the boot-time default alone would have deleted it.
+    """
+    from app.api.main import _sweep_orphaned_exports_and_log
+    from app.core.runtime.staging import sweep_orphaned_exports
+
+    exports_dir = tmp_path / "exports"
+    exports_dir.mkdir()
+
+    slow_export = exports_dir / "still-downloading"
+    slow_export.mkdir()
+    (slow_export / "export.gpkg").write_bytes(b"x")
+    now = time.time()
+    os.utime(slow_export, (now - 2 * 3600, now - 2 * 3600))  # 2 hours old
+
+    log = structlog.get_logger("test")
+    _sweep_orphaned_exports_and_log(exports_dir, log)
+    assert slow_export.exists(), (
+        "a 2-hour-old export must survive the periodic sweep — it is well "
+        "within the periodic threshold even though it is past the boot one"
+    )
+
+    # Confirms the boot-time default alone WOULD have deleted it — this is
+    # the exact regression the periodic helper's wider threshold guards
+    # against, not just a threshold that happens to be wide enough anyway.
+    deleted, _ = sweep_orphaned_exports(exports_dir)
+    assert deleted == 1
+    assert not slow_export.exists()
+
+
+def test_periodic_sweep_still_catches_long_abandoned_residue(tmp_path: Path) -> None:
+    """The wider periodic threshold still has a ceiling: residue from a
+    process that died hours ago must not survive forever."""
+    from app.api.main import _sweep_orphaned_exports_and_log
+
+    exports_dir = tmp_path / "exports"
+    exports_dir.mkdir()
+
+    abandoned = exports_dir / "long-dead"
+    abandoned.mkdir()
+    (abandoned / "export.gpkg").write_bytes(b"x")
+    now = time.time()
+    os.utime(abandoned, (now - 5 * 3600, now - 5 * 3600))  # 5 hours old
+
+    log = structlog.get_logger("test")
+    _sweep_orphaned_exports_and_log(exports_dir, log)
+    assert not abandoned.exists(), (
+        "a 5-hour-old entry is well past any legitimate export lifetime and "
+        "must still be swept"
     )

--- a/backend/tests/test_worker_exports_sweep.py
+++ b/backend/tests/test_worker_exports_sweep.py
@@ -150,3 +150,49 @@ def test_api_and_worker_share_one_sweeper() -> None:
 
     assert api_main.sweep_orphaned_exports is staging.sweep_orphaned_exports
     assert worker_main.sweep_orphaned_exports is staging.sweep_orphaned_exports
+
+
+def test_stale_jobs_sweeper_also_sweeps_orphaned_exports() -> None:
+    """The periodic sweeper loop must sweep exports on every cycle, not just
+    at process boot.
+
+    Pre-fix, ``sweep_orphaned_exports`` only ran once at API startup and once
+    at worker startup, so export residue from a hard process death (SIGKILL,
+    OOM — not a clean restart) sat until the next boot. The sweep is
+    idempotent and age-thresholded (see the module docstring above), so it is
+    safe on every ``_stale_jobs_sweeper`` cycle too.
+
+    Structural, because the alternative is waiting on the sweeper's real
+    interval. Mirrors the `inspect.getsource(main.lifespan)` pattern used
+    elsewhere to pin behavior inside this same nested closure (e.g.
+    `test_enterprise_overlay_startup_check.py`,
+    `test_service_refresh_1220.py`). Slices out just the
+    `_stale_jobs_sweeper` function body rather than searching the whole
+    `lifespan` source, because a call to the sweep already appears once in
+    `lifespan` for the boot call — a whole-function search would pass even
+    without this fix.
+
+    The actual sweep + conditional log call is factored into the top-level
+    `_sweep_orphaned_exports_and_log` helper (kept out of the nested closure
+    so the extra branch does not push `lifespan`'s McCabe complexity over its
+    gate), so this pins both halves: the loop calls the helper, and the
+    helper calls `sweep_orphaned_exports`.
+    """
+    import inspect
+
+    from app.api import main
+
+    source = inspect.getsource(main.lifespan)
+    sweeper_start = source.index("async def _stale_jobs_sweeper")
+    sweeper_end = source.index("stale_jobs_task = asyncio.create_task", sweeper_start)
+    sweeper_body = source[sweeper_start:sweeper_end]
+
+    assert "_sweep_orphaned_exports_and_log(exports_dir" in sweeper_body, (
+        "the periodic sweeper loop must call the export-sweep helper so export "
+        "residue from a hard process death does not wait for the next restart"
+    )
+
+    helper_source = inspect.getsource(main._sweep_orphaned_exports_and_log)
+    assert "sweep_orphaned_exports(exports_dir)" in helper_source, (
+        "_sweep_orphaned_exports_and_log must actually call sweep_orphaned_exports"
+    )

--- a/backend/tests/test_worker_exports_sweep.py
+++ b/backend/tests/test_worker_exports_sweep.py
@@ -181,8 +181,12 @@ def test_stale_jobs_sweeper_also_sweeps_orphaned_exports() -> None:
     The actual sweep + conditional log call is factored into the top-level
     `_sweep_orphaned_exports_and_log` helper (kept out of the nested closure
     so the extra branch does not push `lifespan`'s McCabe complexity over its
-    gate), so this pins both halves: the loop calls the helper, and the
-    helper calls `sweep_orphaned_exports`.
+    gate), which threads the blocking work through `_sweep_orphaned_exports_
+    periodic` (fix #1435 codex round 5 — sweep_orphaned_exports does
+    synchronous directory traversal + shutil.rmtree, and this loop now runs
+    it every few minutes on a live server, not just once at boot). This pins
+    the whole chain: the loop calls the async helper, and the helper's
+    threaded target actually calls `sweep_orphaned_exports`.
     """
     import inspect
 
@@ -199,17 +203,27 @@ def test_stale_jobs_sweeper_also_sweeps_orphaned_exports() -> None:
     )
 
     helper_source = inspect.getsource(main._sweep_orphaned_exports_and_log)
-    assert "sweep_orphaned_exports(" in helper_source, (
-        "_sweep_orphaned_exports_and_log must actually call sweep_orphaned_exports"
+    assert "run_in_thread_draining" in helper_source, (
+        "_sweep_orphaned_exports_and_log must run the blocking sweep in a "
+        "worker thread, not inline on the event loop"
     )
-    assert "EXPORTS_PERIODIC_SWEEP_AGE_SECONDS" in helper_source, (
+    assert "_sweep_orphaned_exports_periodic" in helper_source, (
+        "_sweep_orphaned_exports_and_log must thread through the periodic "
+        "wrapper, not call sweep_orphaned_exports directly"
+    )
+
+    periodic_wrapper_source = inspect.getsource(main._sweep_orphaned_exports_periodic)
+    assert "sweep_orphaned_exports(" in periodic_wrapper_source, (
+        "_sweep_orphaned_exports_periodic must actually call sweep_orphaned_exports"
+    )
+    assert "EXPORTS_PERIODIC_SWEEP_AGE_SECONDS" in periodic_wrapper_source, (
         "the periodic sweep must use the wider periodic threshold, not the "
         "boot-time default — see test_periodic_sweep_survives_a_slow_export "
         "below for why"
     )
 
 
-def test_periodic_sweep_survives_a_slow_export(tmp_path: Path) -> None:
+async def test_periodic_sweep_survives_a_slow_export(tmp_path: Path) -> None:
     """fix(#1435 codex round 1): the periodic sweeper runs continuously
     (every CREDENTIAL_RENEWAL_INTERVAL_SECONDS), unlike the boot-time
     callers, which only fire on a restart. A directory's mtime is set once
@@ -241,7 +255,7 @@ def test_periodic_sweep_survives_a_slow_export(tmp_path: Path) -> None:
     os.utime(export_file, (now - 2 * 3600, now - 2 * 3600))
 
     log = structlog.get_logger("test")
-    _sweep_orphaned_exports_and_log(exports_dir, log)
+    await _sweep_orphaned_exports_and_log(exports_dir, log)
     assert slow_export.exists(), (
         "a 2-hour-old export must survive the periodic sweep — it is well "
         "within the periodic threshold even though it is past the boot one"
@@ -317,7 +331,9 @@ def test_latest_mtime_falls_back_when_directory_cannot_be_listed() -> None:
     assert _latest_mtime(unreadable_dir) == 12345.0
 
 
-def test_periodic_sweep_still_catches_long_abandoned_residue(tmp_path: Path) -> None:
+async def test_periodic_sweep_still_catches_long_abandoned_residue(
+    tmp_path: Path,
+) -> None:
     """The wider periodic threshold still has a ceiling: residue from a
     process that died hours ago must not survive forever."""
     from app.api.main import _sweep_orphaned_exports_and_log
@@ -334,7 +350,7 @@ def test_periodic_sweep_still_catches_long_abandoned_residue(tmp_path: Path) -> 
     os.utime(abandoned_file, (now - 5 * 3600, now - 5 * 3600))
 
     log = structlog.get_logger("test")
-    _sweep_orphaned_exports_and_log(exports_dir, log)
+    await _sweep_orphaned_exports_and_log(exports_dir, log)
     assert not abandoned.exists(), (
         "a 5-hour-old entry is well past any legitimate export lifetime and "
         "must still be swept"

--- a/backend/tests/test_worker_exports_sweep.py
+++ b/backend/tests/test_worker_exports_sweep.py
@@ -63,11 +63,16 @@ def test_sweep_handles_subdirectories(tmp_path: Path) -> None:
 
     old_dir = exports_dir / "old_export_temp"
     old_dir.mkdir()
-    (old_dir / "data.bin").write_bytes(b"x")
+    data_file = old_dir / "data.bin"
+    data_file.write_bytes(b"x")
 
     now = time.time()
-    # Set mtime on the directory itself
+    # fix(#1435 codex round 2): age the contained file too, not just the
+    # directory — sweep_orphaned_exports now takes the most recent of the
+    # two (see _latest_mtime), so a freshly-written file inside an
+    # old-looking directory would otherwise read as still-active.
     os.utime(old_dir, (now - 2 * 3600, now - 2 * 3600))
+    os.utime(data_file, (now - 2 * 3600, now - 2 * 3600))
 
     deleted, skipped = sweep_orphaned_exports(exports_dir)
 
@@ -225,9 +230,14 @@ def test_periodic_sweep_survives_a_slow_export(tmp_path: Path) -> None:
 
     slow_export = exports_dir / "still-downloading"
     slow_export.mkdir()
-    (slow_export / "export.gpkg").write_bytes(b"x")
+    export_file = slow_export / "export.gpkg"
+    export_file.write_bytes(b"x")
     now = time.time()
+    # Age both the directory AND the file inside it — sweep_orphaned_exports
+    # takes the most recent of the two (fix #1435 codex round 2), so a
+    # freshly-written file would otherwise mask the aged directory.
     os.utime(slow_export, (now - 2 * 3600, now - 2 * 3600))  # 2 hours old
+    os.utime(export_file, (now - 2 * 3600, now - 2 * 3600))
 
     log = structlog.get_logger("test")
     _sweep_orphaned_exports_and_log(exports_dir, log)
@@ -244,6 +254,41 @@ def test_periodic_sweep_survives_a_slow_export(tmp_path: Path) -> None:
     assert not slow_export.exists()
 
 
+def test_sweep_skips_a_directory_whose_file_is_still_being_written(
+    tmp_path: Path,
+) -> None:
+    """fix(#1435 codex round 2): a directory's OWN mtime is bumped only by an
+    entry being added/removed/renamed inside it, not by writes to an
+    already-created file's contents — so it freezes at file-creation time
+    while ogr2ogr keeps writing. A directory whose own mtime looks stale
+    must still survive if a file inside it was written recently.
+    """
+    from app.core.runtime.staging import sweep_orphaned_exports
+
+    exports_dir = tmp_path / "exports"
+    exports_dir.mkdir()
+
+    still_writing = exports_dir / "in-progress"
+    still_writing.mkdir()
+    output_file = still_writing / "export.gpkg"
+    output_file.write_bytes(b"partial data")
+
+    now = time.time()
+    # The directory itself looks 2 hours old (created once, never touched
+    # again), but the file inside it was written 30 seconds ago.
+    os.utime(still_writing, (now - 2 * 3600, now - 2 * 3600))
+    os.utime(output_file, (now - 30, now - 30))
+
+    deleted, skipped = sweep_orphaned_exports(exports_dir)
+
+    assert still_writing.exists(), (
+        "a directory containing an actively-written file must survive even "
+        "though the directory's own (frozen) mtime looks stale"
+    )
+    assert deleted == 0
+    assert skipped == 1
+
+
 def test_periodic_sweep_still_catches_long_abandoned_residue(tmp_path: Path) -> None:
     """The wider periodic threshold still has a ceiling: residue from a
     process that died hours ago must not survive forever."""
@@ -254,9 +299,11 @@ def test_periodic_sweep_still_catches_long_abandoned_residue(tmp_path: Path) -> 
 
     abandoned = exports_dir / "long-dead"
     abandoned.mkdir()
-    (abandoned / "export.gpkg").write_bytes(b"x")
+    abandoned_file = abandoned / "export.gpkg"
+    abandoned_file.write_bytes(b"x")
     now = time.time()
     os.utime(abandoned, (now - 5 * 3600, now - 5 * 3600))  # 5 hours old
+    os.utime(abandoned_file, (now - 5 * 3600, now - 5 * 3600))
 
     log = structlog.get_logger("test")
     _sweep_orphaned_exports_and_log(exports_dir, log)

--- a/backend/tests/test_worker_exports_sweep.py
+++ b/backend/tests/test_worker_exports_sweep.py
@@ -7,6 +7,7 @@ worker share one age-aware implementation; entries younger than 1 hour survive.
 import os
 import time
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import structlog
 
@@ -287,6 +288,33 @@ def test_sweep_skips_a_directory_whose_file_is_still_being_written(
     )
     assert deleted == 0
     assert skipped == 1
+
+
+def test_latest_mtime_falls_back_when_directory_cannot_be_listed() -> None:
+    """fix(#1435 codex round 3): a directory that cannot be listed (e.g.
+    root-owned residue left behind by a container UID change across a
+    deploy) must not crash the sweep. Both boot-time callers
+    (api/main.py, worker.py) invoke sweep_orphaned_exports with no
+    exception guard of their own, so one unreadable entry would otherwise
+    take down API/worker startup entirely.
+
+    Mocked rather than exercised via real chmod bits: a test process
+    running as root (common under Docker-based CI) bypasses Unix
+    permission checks entirely, which would make a chmod-based test pass
+    or fail depending on the runner's privilege level rather than on the
+    fix.
+    """
+    from app.core.runtime.staging import _latest_mtime
+
+    unreadable_dir = MagicMock()
+    unreadable_dir.stat.return_value.st_mtime = 12345.0
+    unreadable_dir.is_dir.return_value = True
+    unreadable_dir.iterdir.side_effect = PermissionError("Permission denied")
+
+    # Must not raise — falls back to the entry's own mtime, which needs no
+    # permission on the directory's *contents* to obtain (only on its
+    # parent, to reach the entry at all).
+    assert _latest_mtime(unreadable_dir) == 12345.0
 
 
 def test_periodic_sweep_still_catches_long_abandoned_residue(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Backend-audit follow-up covering four independent cancellation/lifecycle-hygiene findings. No API/schema contract impact.

- **ogr2ogr child survives client disconnect** — `_communicate_with_timeout` only caught `asyncio.TimeoutError`; `asyncio.wait_for` re-raises `CancelledError` on outer-task cancellation without touching the subprocess. A client disconnect during export or ingest left the ogr2ogr child running with nothing left to reap it, and export's cleanup then ran `shutil.rmtree` on the output directory while the child could still hold the file open. Added a `CancelledError` branch that runs the same kill/terminate/wait sequence as the timeout branch before re-raising, and corrected a stale comment that claimed this protection already existed.
- **Reupload cleanup helper swallowed cancellation** — `_cleanup_uncommitted_reupload_source` caught `BaseException` and only logged a warning, silently absorbing `CancelledError` along with genuine storage errors. Called unguarded right before the presigned-completion door returns success, a client disconnect during the storage delete let a cancelled request return 200 anyway. Now re-raises `CancelledError`, mirroring the convention already used by the other three `CancelledError` checks in the file; the best-effort swallow for real storage errors is unchanged.
- **Three hand-rolled VRT rollback closures** — `add_vrt_source`, `remove_vrt_source`, and `regenerate_vrt_endpoint` each hand-rolled an identical defer-failure rollback (revert `vrt_asset` state, mark the generation failed, mark the job failed), differing only in statement order and comments. Added `make_vrt_regeneration_failed_rollback` to `defer_guard.py`, composing the existing `make_ingest_job_failed_rollback`, and collapsed all three sites onto it.
- **Export sweep only ran at process boot** — `sweep_orphaned_exports` ran once at API startup and once at worker startup, so residue from a hard process death (SIGKILL, OOM) sat until the next restart. Now also runs on every `_stale_jobs_sweeper` cycle (idempotent, age-thresholded, so this is safe).

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `tests/test_layering.py` (module LOC caps adjusted per finding; layering/architecture guards pass)
- [x] Failing-first regression test per finding, verified to fail pre-fix and pass post-fix:
  - `tests/test_ogr_communicate_cancellation.py` (new)
  - `tests/test_reupload.py::test_cleanup_uncommitted_reupload_source_reraises_cancellation`
  - `tests/test_defer_orphan_guard.py::TestDeferWithOrphanGuard::test_make_vrt_regeneration_failed_rollback_reverts_all_eight_fields` (existing endpoint-level rollback tests for all three VRT sites re-verified green through the new factory)
  - `tests/test_worker_exports_sweep.py::test_stale_jobs_sweeper_also_sweeps_orphaned_exports`
- [x] Full targeted suite (444 tests across ogr/export/reupload/VRT/sweeper neighbors) green