### PR TITLE
test: consolidate six copy-pasted fixture/helper clusters in backend/tests

### DIFF
--- a/backend/tests/alembic_helpers.py
+++ b/backend/tests/alembic_helpers.py
@@ -32,12 +32,36 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from importlib.metadata import entry_points
 from pathlib import Path
 
 import sqlalchemy
 
 _BACKEND_DIR = Path(__file__).parent.parent.resolve()
 _ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
+
+
+def enterprise_migrations_present() -> bool:
+    """True when an enterprise/overlay migrations entry-point is installed.
+
+    conftest then migrates the per-worker test DB to the enterprise head (e.g.
+    e002_add_saml_columns), making the alembic environment MULTI-HEAD. The
+    core-only ``alembic`` subprocess these OSS-drift-gate roundtrip/check tests
+    shell out to can neither locate the enterprise revision nor disambiguate
+    ``head`` / ``-1`` across branches — so they are skipped under the overlay.
+    They still run (and gate drift) in the no-overlay Pytest Parallel Isolation
+    job. Core registers no ``geolens.migrations`` entry-point, so this is False
+    for community/OSS runs.
+    """
+    for ep in entry_points(group="geolens.migrations"):
+        try:
+            fn = ep.load()
+            if callable(fn) and any(Path(p).is_dir() for p in fn()):
+                return True
+        except Exception:
+            pass
+    return False
+
 
 # The remediation SQL that 0030's own error message prescribes. Collapsing a
 # two-ring seam extent to its envelope LOSES the antimeridian-crossing shape

--- a/backend/tests/alembic_helpers.py
+++ b/backend/tests/alembic_helpers.py
@@ -211,3 +211,27 @@ def run_alembic(
         env=env,
         cwd=str(_BACKEND_DIR),
     )
+
+
+async def fresh_query(query: str, params: dict | None = None):
+    """Run a query on a fresh AUTOCOMMIT connection, bypassing the test transaction.
+
+    The ``test_db_session`` fixture holds an open transaction around each
+    test. DDL/DML committed by subprocess alembic (which commits outside that
+    transaction) is invisible to the session due to transaction snapshot
+    isolation. A separate connection with AUTOCOMMIT isolation is needed to
+    observe committed changes.
+    """
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.core.config import settings
+
+    engine = create_async_engine(
+        settings.test_database_url, isolation_level="AUTOCOMMIT"
+    )
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(sqlalchemy.text(query), params or {})
+            return result.fetchall() if result.returns_rows else None
+    finally:
+        await engine.dispose()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -948,6 +948,49 @@ async def _run_with_too_many_clients_retry(
         raise last_exc
 
 
+@pytest.fixture
+async def _init_tile_pool_for_tests(request):
+    """Initialize a real asyncpg pool pointing at the test database for tile tests.
+
+    The test client uses ASGITransport which does not run the app lifespan, so
+    tile-serving tests that reach the tile pool directly must create it
+    manually. Non-autouse — consumers opt in via
+    ``@pytest.mark.usefixtures("_init_tile_pool_for_tests")`` (applied at class
+    or module scope; a module-level ``pytestmark`` gives every test in a file
+    the fixture, mirroring what ``autouse=True`` would do for that one module).
+
+    The ``request``-based guard below exists for the module-scoped consumer
+    (test_embed_tokens.py): it skips pool creation for tests that request none
+    of the DB-facing fixtures, so unit tests in that file never pay for a live
+    asyncpg connection they don't need. For every other consumer the guard is
+    a no-op in practice — each test reached via ``usefixtures`` already
+    requests ``client`` and/or ``test_db_session``.
+    """
+    db_fixtures = {
+        "admin_auth_header",
+        "clean_tables",
+        "cleanup_data_tables",
+        "client",
+        "editor_auth_header",
+        "test_db_session",
+        "viewer_auth_header",
+    }
+    if not db_fixtures.intersection(request.fixturenames):
+        yield
+        return
+
+    import app.processing.tiles.pool as pool_module
+
+    dsn = settings.test_database_url.replace("postgresql+asyncpg://", "postgresql://")
+    pool = await _run_with_too_many_clients_retry(
+        lambda: asyncpg.create_pool(dsn=dsn, min_size=1, max_size=3, command_timeout=10)
+    )
+    pool_module._tile_pool = pool
+    yield
+    await pool.close()
+    pool_module._tile_pool = None
+
+
 # Retry budget for transient "too many clients already" contention during
 # in-test session-factory acquisition (per-request `override_get_db` ->
 # `test_session_factory()`). Distinct from `_SETUP_PHASE_RETRY_BACKOFFS`:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1612,6 +1612,21 @@ def _test_db_lifecycle():
     `_skip_if_db_unavailable` then skips the DB-backed tests individually and
     everything else runs normally.
     """
+    # geolens_admin_username has no default (app/core/config.py) and this
+    # fixture seeds the ONE fixture admin user under whatever it resolves to
+    # (see _ensure_roles_and_admin below). Roughly 1,160 call sites across the
+    # suite assume that username is literally "admin" — ~1,082 through
+    # tests/factories.get_user_id(session, "admin") and ~79 that query the
+    # "admin" literal directly. If the env ever resolves it to something else,
+    # every one of those call sites fails individually with NoResultFound,
+    # scattered across the whole suite with no shared root cause. Assert it
+    # once, loudly, here instead.
+    assert settings.geolens_admin_username == "admin", (
+        "settings.geolens_admin_username must be 'admin' -- tests/factories."
+        "get_user_id and ~1,160 other call sites hardcode that username for "
+        "the fixture-seeded admin user. Check GEOLENS_ADMIN_USERNAME in the "
+        "test environment."
+    )
     global _db_unavailable_reason
     original_test_db_name = settings.postgres_db_test
     db_name = _worker_test_database_name(original_test_db_name)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,6 +6,7 @@ import uuid
 import tempfile
 import warnings
 from contextlib import asynccontextmanager, contextmanager
+from unittest.mock import patch
 
 import asyncpg.exceptions
 import pytest
@@ -2324,3 +2325,52 @@ def reset_limiter_storage() -> None:
             "reset_limiter_storage: could not reset limiter storage"
         )
     yield
+
+
+# ---------------------------------------------------------------------------
+# Extension registry reset (app.platform.extensions)
+# ---------------------------------------------------------------------------
+
+
+def _reset_registry() -> None:
+    """Clear all four extension-registry globals between tests.
+
+    ``app.platform.extensions`` tracks loaded overlay state in four module
+    globals: ``_extensions``, ``_routers``, ``_loaded``, ``_slot_owners``.
+    Per-file copies of this reset used to clear only the subset that file's
+    own tests happened to populate (``_extensions``/``_loaded`` alone in
+    most files; some also cleared ``_slot_owners``; the worker-bootstrap
+    files cleared all four). Clearing all four unconditionally is a
+    superset — globals a given file's tests never touch are a no-op to
+    clear — and it closes the latent cross-test pollution a partial reset
+    invites the moment a file starts exercising a slot its own copy-pasted
+    subset didn't anticipate.
+    """
+    import app.platform.extensions as ext_mod
+
+    ext_mod._extensions.clear()
+    ext_mod._routers.clear()
+    ext_mod._loaded = False
+    ext_mod._slot_owners.clear()
+
+
+@pytest.fixture
+def _clean_registry():
+    """Reset the extension registry AND isolate from discovered entry points.
+
+    Non-autouse — consumers opt in via
+    ``@pytest.mark.usefixtures("_clean_registry")`` (module-level
+    ``pytestmark`` in files that want it for every test, mirroring what
+    ``autouse=True`` would do for that one module).
+
+    The enterprise overlay is editable-installable in the backend test venv;
+    that install adds ``geolens.extensions`` entry points which would
+    otherwise pollute the registry whenever a test calls
+    ``load_extensions()``. Patching ``entry_points`` to default-empty gives
+    each test a known-empty discovery surface; a test can still opt in to
+    its own mock entry points via ``with patch(...)``.
+    """
+    _reset_registry()
+    with patch("app.platform.extensions.entry_points", return_value=[]):
+        yield
+    _reset_registry()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -23,6 +23,8 @@ from app.modules.auth.providers.local import hash_password
 from app.platform.cache import init_cache
 from app.core.config import settings
 
+from tests.factories import create_user
+
 # Register the multi_tenant_rls fixture so Plan 04 and Phase 1209 can request it
 # from any test file without an explicit import. The fixture lives in
 # tests/fixtures/multi_tenant_harness.py and is surfaced here via pytest_plugins.
@@ -2062,24 +2064,10 @@ async def get_auth_header(
     return {"Authorization": f"Bearer {token}"}
 
 
-async def _create_test_user(
-    client: AsyncClient,
-    admin_headers: dict,
-    role: str,
-) -> tuple[dict[str, str], str]:
-    """Create a test user with the given role and return (auth_header, user_id)."""
-    unique = uuid.uuid4().hex[:8]
-    username = f"{role}_{unique}"
-    password = "TestPass1234!"  # SEC-S16: meets 12-char + 3-class policy
-    resp = await client.post(
-        "/admin/users/",
-        json={"username": username, "password": password, "role": role},
-        headers=admin_headers,
-    )
-    assert resp.status_code == 201, f"Create {role} failed: {resp.text}"
-    user_id = resp.json()["id"]
-    headers = await get_auth_header(client, username, password)
-    return headers, user_id
+# Re-exported so the ~25 `from tests.conftest import _create_test_user` sites
+# across the suite keep working unchanged; the implementation lives in
+# tests/factories.py as create_user.
+_create_test_user = create_user
 
 
 @pytest.fixture

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -13,13 +13,21 @@ additional mutations.
 """
 
 import uuid
+from datetime import date, datetime
 
+from geoalchemy2 import WKTElement
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.auth.models import User
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import (
+    Dataset,
+    Record,
+    RecordContact,
+    RecordKeyword,
+)
+from app.processing.raster.models import RasterAsset
 
 
 async def get_user_id(session: AsyncSession, username: str) -> uuid.UUID:
@@ -32,7 +40,7 @@ async def get_user_id(session: AsyncSession, username: str) -> uuid.UUID:
 async def create_dataset(
     session: AsyncSession,
     *,
-    created_by: uuid.UUID,
+    created_by: uuid.UUID | None,
     name: str = "Test Dataset",
     table_name: str | None = None,
     visibility: str = "public",
@@ -42,21 +50,39 @@ async def create_dataset(
     description: str | None = "A test dataset",
     source_format: str = "geojson",
     source_filename: str = "test.geojson",
+    source_url: str | None = None,
     record_status: str = "published",
+    record_type: str | None = None,
     theme_category: list[str] | None = None,
     column_info: list[dict] | None = None,
+    sample_values: dict | None = None,
+    temporal_start: date | None = None,
+    temporal_end: date | None = None,
+    spatial_extent_wkt: str | None = None,
+    lineage_summary: str | None = None,
+    update_frequency: str | None = None,
+    usage_constraints: str | None = None,
+    access_constraints: str | None = None,
+    source_organization: str | None = None,
+    keywords: list[str | tuple[str, str | None]] | None = None,
+    contacts: list[dict] | None = None,
+    updated_by: uuid.UUID | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
 ) -> Dataset:
     """Insert a Record + Dataset pair directly into the DB.
 
     Superset of the per-file ``_create_dataset`` helpers found across 20+
     test files. Callers that only need a minimal dataset can rely on defaults.
+    Every field beyond the original minimal set is applied only when passed
+    (``is not None`` / truthy), so existing callers are unaffected.
     """
     if table_name is None:
         table_name = f"ds_{uuid.uuid4().hex[:12]}"
     if theme_category is None:
         theme_category = ["test"]
 
-    record = Record(
+    record_kwargs = dict(
         title=name,
         summary=description,
         theme_category=theme_category,
@@ -64,8 +90,45 @@ async def create_dataset(
         record_status=record_status,
         created_by=created_by,
     )
+    for key, value in (
+        ("record_type", record_type),
+        ("temporal_start", temporal_start),
+        ("temporal_end", temporal_end),
+        ("lineage_summary", lineage_summary),
+        ("update_frequency", update_frequency),
+        ("usage_constraints", usage_constraints),
+        ("access_constraints", access_constraints),
+        ("source_organization", source_organization),
+        ("updated_by", updated_by),
+        ("created_at", created_at),
+        ("updated_at", updated_at),
+    ):
+        if value is not None:
+            record_kwargs[key] = value
+
+    record = Record(**record_kwargs)
+    if spatial_extent_wkt is not None:
+        record.spatial_extent = WKTElement(spatial_extent_wkt, srid=4326)
     session.add(record)
     await session.flush()
+
+    if keywords:
+        for kw in keywords:
+            kw_text, vocab_uri = (kw, None) if isinstance(kw, str) else kw
+            session.add(
+                RecordKeyword(
+                    record_id=record.id,
+                    keyword=kw_text,
+                    keyword_type="theme",
+                    vocabulary_uri=vocab_uri,
+                )
+            )
+        await session.flush()
+
+    if contacts:
+        for c in contacts:
+            session.add(RecordContact(record_id=record.id, **c))
+        await session.flush()
 
     ds_kwargs = dict(
         record_id=record.id,
@@ -78,8 +141,84 @@ async def create_dataset(
     )
     if column_info is not None:
         ds_kwargs["column_info"] = column_info
+    if source_url is not None:
+        ds_kwargs["source_url"] = source_url
+    if sample_values is not None:
+        ds_kwargs["sample_values"] = sample_values
     dataset = Dataset(**ds_kwargs)
     session.add(dataset)
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+async def create_raster_dataset(
+    session: AsyncSession,
+    *,
+    created_by: uuid.UUID | None,
+    name: str = "Test Raster Dataset",
+    table_name: str | None = None,
+    visibility: str = "public",
+    record_status: str = "published",
+    record_type: str = "raster_dataset",
+    srid: int = 4326,
+    geometry_type: str | None = None,
+    feature_count: int | None = None,
+    description: str | None = None,
+    source_format: str = "geotiff",
+    source_filename: str | None = None,
+    theme_category: list[str] | None = None,
+    create_raster_asset: bool = False,
+    raster_asset_kwargs: dict | None = None,
+) -> Dataset:
+    """Insert a raster Record + Dataset pair (optionally + RasterAsset) into the DB.
+
+    Superset of the per-file ``_create_raster_dataset`` helpers found across
+    10 test files. Unlike ``create_dataset``, ``geometry_type``/``feature_count``
+    default to ``None`` (raster datasets carry no vector geometry) and
+    ``theme_category`` is only set when explicitly passed — several callers
+    rely on it staying NULL, unlike the vector factory's forced default.
+    """
+    if table_name is None:
+        table_name = f"raster_{uuid.uuid4().hex[:12]}"
+
+    record_kwargs = dict(
+        title=name,
+        summary=description,
+        visibility=visibility,
+        record_status=record_status,
+        record_type=record_type,
+        created_by=created_by,
+    )
+    if theme_category is not None:
+        record_kwargs["theme_category"] = theme_category
+
+    record = Record(**record_kwargs)
+    session.add(record)
+    await session.flush()
+
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=table_name,
+        srid=srid,
+        geometry_type=geometry_type,
+        feature_count=feature_count,
+        source_format=source_format,
+        source_filename=source_filename,
+    )
+    session.add(dataset)
+    await session.flush()
+
+    if create_raster_asset:
+        asset_kwargs = dict(
+            dataset_id=dataset.id,
+            asset_uri=f"rasters/{dataset.id}/abc123/source.cog.tif",
+            storage_backend="local",
+        )
+        asset_kwargs.update(raster_asset_kwargs or {})
+        session.add(RasterAsset(**asset_kwargs))
+        await session.flush()
+
     await session.commit()
     await session.refresh(dataset)
     return dataset

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -37,6 +37,35 @@ async def get_user_id(session: AsyncSession, username: str) -> uuid.UUID:
     return user.id
 
 
+async def create_user(
+    client: AsyncClient,
+    admin_headers: dict,
+    role: str,
+) -> tuple[dict[str, str], str]:
+    """Create a test user with the given role and return (auth_header, user_id).
+
+    Logs in inline rather than via conftest's ``get_auth_header`` — this
+    module must not import from conftest, which imports ``create_user`` from
+    here to keep ``tests.conftest._create_test_user`` importable.
+    """
+    unique = uuid.uuid4().hex[:8]
+    username = f"{role}_{unique}"
+    password = "TestPass1234!"  # SEC-S16: meets 12-char + 3-class policy
+    resp = await client.post(
+        "/admin/users/",
+        json={"username": username, "password": password, "role": role},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201, f"Create {role} failed: {resp.text}"
+    user_id = resp.json()["id"]
+    login = await client.post(
+        "/auth/login", data={"username": username, "password": password}
+    )
+    assert login.status_code == 200, f"Login failed for {username}: {login.text}"
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    return headers, user_id
+
+
 async def create_dataset(
     session: AsyncSession,
     *,

--- a/backend/tests/test_ai_provider_extension.py
+++ b/backend/tests/test_ai_provider_extension.py
@@ -15,34 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-def _reset_registry():
-    """Reset extension registry state between tests (RESEARCH.md Pitfall 6).
-
-    Mirrors test_extensions.py:10-15 verbatim. Replicated inline rather than
-    imported to avoid inter-test-file import coupling.
-    """
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._loaded = False
-
-
-@pytest.fixture(autouse=True)
-def _clean_registry():
-    """Isolate registry from environment-discovered entry points.
-
-    The enterprise overlay is editable-installable in the backend test venv;
-    that install adds ``geolens.extensions`` entry points which would
-    otherwise pollute the registry whenever a test calls ``load_extensions()``.
-    Patch ``entry_points`` to default-empty so each test starts from a
-    known-empty discovery surface and can opt in to its own mock entry
-    points via ``with patch(...)`` (Phase 226 RESEARCH.md Pitfall 6).
-    """
-    _reset_registry()
-    with patch("app.platform.extensions.entry_points", return_value=[]):
-        yield
-    _reset_registry()
+pytestmark = pytest.mark.usefixtures("_clean_registry")
 
 
 def test_default_providers_registered():

--- a/backend/tests/test_alembic_helpers.py
+++ b/backend/tests/test_alembic_helpers.py
@@ -17,13 +17,15 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta, timezone
-from importlib.metadata import entry_points
-from pathlib import Path
 
 import pytest
 from sqlalchemy import text
 
-from tests.alembic_helpers import normalize_seam_extents, run_alembic
+from tests.alembic_helpers import (
+    enterprise_migrations_present,
+    normalize_seam_extents,
+    run_alembic,
+)
 from tests.factories import create_dataset, get_user_id
 
 pytestmark = pytest.mark.anyio
@@ -33,21 +35,8 @@ pytestmark = pytest.mark.anyio
 _PRE_API_KEY_HARDENING = "0028_oauth_email_verified_backfill"
 
 
-def _enterprise_migrations_present() -> bool:
-    """Mirror the migration files' overlay skip: multi-head alembic cannot
-    disambiguate head / -1, so roundtrips run in the no-overlay job only."""
-    for entry_point in entry_points(group="geolens.migrations"):
-        try:
-            provider = entry_point.load()
-            if callable(provider) and any(Path(path).is_dir() for path in provider()):
-                return True
-        except Exception:
-            pass
-    return False
-
-
 @pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason="OSS migration round-trip runs in the no-overlay migration job",
 )
 async def test_seam_extent_no_longer_breaks_downgrade_past_0030(test_db_session):
@@ -125,7 +114,7 @@ async def _seed_expiring_key(session, *, epoch_bump: bool) -> None:
 
 
 @pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason="OSS migration round-trip runs in the no-overlay migration job",
 )
 async def test_downgrade_past_0029_refuses_while_key_state_exists(test_db_session):
@@ -162,7 +151,7 @@ async def test_downgrade_past_0029_refuses_while_key_state_exists(test_db_sessio
 
 
 @pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason="OSS migration round-trip runs in the no-overlay migration job",
 )
 async def test_key_state_no_longer_breaks_downgrade_past_0029(test_db_session):
@@ -190,7 +179,7 @@ async def test_key_state_no_longer_breaks_downgrade_past_0029(test_db_session):
 
 
 @pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason="OSS migration round-trip runs in the no-overlay migration job",
 )
 async def test_clean_database_still_downgrades_past_0029(test_db_session):

--- a/backend/tests/test_analysis_preview.py
+++ b/backend/tests/test_analysis_preview.py
@@ -16,12 +16,11 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.catalog.datasets.api import router_analysis
-from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.datasets.domain.schemas import AnalysisPreviewRequest
 from app.modules.catalog.datasets.domain.service import build_preview_sql
 from app.platform.sandbox.schemas import SandboxError
 
-from tests.factories import create_dataset, get_user_id
+from tests.factories import create_dataset, create_raster_dataset, get_user_id
 
 SQUARE = "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"
 FAR_SQUARE = "POLYGON((10 10, 10 11, 11 11, 11 10, 10 10))"
@@ -208,41 +207,23 @@ async def _create_raster_dataset(
     ``table_name`` backed by no physical table, ``source_format='geotiff'``,
     and a RasterAsset carrying ``is_dem``.
     """
-    from app.processing.raster.models import RasterAsset
-
-    record = Record(
-        title=f"Raster {uuid.uuid4().hex[:6]}",
-        record_type="raster_dataset",
-        visibility=visibility,
-        record_status="published",
+    return await create_raster_dataset(
+        session,
         created_by=created_by,
+        name=f"Raster {uuid.uuid4().hex[:6]}",
         theme_category=["test"],
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=f"raster_{record.id.hex[:16]}",
-        source_format="geotiff",
-        source_filename="elevation.tif",
+        visibility=visibility,
+        table_name=f"raster_{uuid.uuid4().hex[:16]}",
         srid=3857,
-    )
-    session.add(dataset)
-    await session.flush()
-    session.add(
-        RasterAsset(
-            dataset_id=dataset.id,
-            asset_uri=f"rasters/{dataset.id}/cog.tif",
-            storage_backend="local",
+        source_filename="elevation.tif",
+        create_raster_asset=True,
+        raster_asset_kwargs=dict(
             driver="GTiff",
             band_count=1,
             dtype="float32",
             is_dem=is_dem,
-        )
+        ),
     )
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 async def _create_mask_dataset(

--- a/backend/tests/test_attribute_search.py
+++ b/backend/tests/test_attribute_search.py
@@ -19,9 +19,9 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -41,32 +41,17 @@ async def _create_dataset(
     visibility: str = "public",
 ) -> Dataset:
     """Insert a Record + Dataset pair with optional column_info and sample_values."""
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=description or f"Description for {name}",
+    return await create_dataset(
+        session,
+        created_by=created_by,
+        name=name,
+        description=description or f"Description for {name}",
         theme_category=theme_category if theme_category is not None else [],
         visibility=visibility,
-        record_status="published",
-        created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
-        srid=4326,
-        geometry_type="MultiPolygon",
         feature_count=10,
-        source_format="geojson",
-        source_filename="test.geojson",
         column_info=column_info if column_info is not None else [],
         sample_values=sample_values if sample_values is not None else {},
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_batch_dataset_authz_1298.py
+++ b/backend/tests/test_batch_dataset_authz_1298.py
@@ -42,7 +42,7 @@ from app.modules.catalog.datasets.domain.service import get_dataset
 from app.processing.ingest.schemas import VrtCreateRequest
 from app.processing.ingest.service import create_vrt_job
 from app.processing.raster.models import RasterAsset
-from tests.factories import create_dataset
+from tests.factories import create_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -58,7 +58,7 @@ async def _admin(session) -> User:
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    return (await _admin(session)).id
+    return await get_user_id(session, "admin")
 
 
 async def _make_editor(

--- a/backend/tests/test_batch_dataset_authz_1298.py
+++ b/backend/tests/test_batch_dataset_authz_1298.py
@@ -42,7 +42,7 @@ from app.modules.catalog.datasets.domain.service import get_dataset
 from app.processing.ingest.schemas import VrtCreateRequest
 from app.processing.ingest.service import create_vrt_job
 from app.processing.raster.models import RasterAsset
-from tests.factories import create_dataset, get_user_id
+from tests.factories import create_dataset, create_raster_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -95,30 +95,17 @@ async def _create_raster_dataset(
     Same fields as test_vrt_source_authz_1172.py's helper so validate_sources
     accepts any combination of these as VRT sources.
     """
-    record = Record(
-        title=f"Batch authz raster {uuid.uuid4().hex[:6]}",
-        summary="raster source",
+    dataset = await create_raster_dataset(
+        session,
+        created_by=created_by,
+        name=f"Batch authz raster {uuid.uuid4().hex[:6]}",
+        description="raster source",
         theme_category=["test"],
         visibility=visibility,
-        record_status="published",
-        record_type="raster_dataset",
-        created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
         table_name=f"batch_authz_src_{uuid.uuid4().hex[:8]}",
-        source_format="geotiff",
         source_filename="s.tif",
-    )
-    session.add(dataset)
-    await session.flush()
-    session.add(
-        RasterAsset(
-            dataset_id=dataset.id,
-            asset_uri=f"rasters/{dataset.id}/s.cog.tif",
-            storage_backend="local",
+        create_raster_asset=True,
+        raster_asset_kwargs=dict(
             status="ready",
             epsg=4326,
             crs_wkt=None,
@@ -130,10 +117,8 @@ async def _create_raster_dataset(
             width=100,
             height=100,
             is_rotated=False,
-        )
+        ),
     )
-    await session.flush()
-    await session.commit()
     return dataset.id
 
 

--- a/backend/tests/test_collections.py
+++ b/backend/tests/test_collections.py
@@ -15,12 +15,11 @@ import pytest
 from datetime import date
 
 from httpx import AsyncClient
-from sqlalchemy import func, update
 
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 
 from tests.conftest import _create_test_user
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -39,40 +38,17 @@ async def _create_dataset(
     data_vintage_end: date | None = None,
 ) -> Dataset:
     """Insert a Record + Dataset pair directly into the DB."""
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=f"Test dataset: {name}",
-        theme_category=["test"],
-        visibility=visibility,
-        record_status="published",
+    return await create_dataset(
+        session,
         created_by=created_by,
+        name=name,
+        description=f"Test dataset: {name}",
+        visibility=visibility,
+        feature_count=100,
         temporal_start=data_vintage_start,
         temporal_end=data_vintage_end,
+        spatial_extent_wkt=extent_wkt,
     )
-    session.add(record)
-    await session.flush()
-
-    if extent_wkt:
-        await session.execute(
-            update(Record)
-            .where(Record.id == record.id)
-            .values(spatial_extent=func.ST_GeomFromText(extent_wkt, 4326))
-        )
-
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
-        srid=4326,
-        geometry_type="MultiPolygon",
-        feature_count=100,
-        source_format="geojson",
-        source_filename="test.geojson",
-    )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_column_stats_stddev.py
+++ b/backend/tests/test_column_stats_stddev.py
@@ -15,8 +15,8 @@ from httpx import AsyncClient
 from sqlalchemy import text
 
 from app.modules.catalog.datasets.domain.column_stats import get_column_stats
-from app.modules.catalog.datasets.domain.models import Dataset, Record
-from tests.factories import create_dataset, get_user_id
+from app.modules.catalog.datasets.domain.models import Dataset
+from tests.factories import create_dataset, create_raster_dataset, get_user_id
 
 TEST_TABLE_NAME = f"test_stddev_{uuid.uuid4().hex[:8]}"
 
@@ -228,29 +228,15 @@ async def _create_raster_dataset(
     is ever created -- exactly the G2/E1 bug-trigger condition.
     """
     table_name = f"raster_{uuid.uuid4().hex}"
-    record = Record(
-        title=f"Column Values Raster {table_name}",
-        summary="Test raster dataset for column-values hardening",
-        theme_category=["test"],
-        visibility="public",
-        record_status="published",
-        record_type=record_type,
+    return await create_raster_dataset(
+        session,
         created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
+        name=f"Column Values Raster {table_name}",
+        description="Test raster dataset for column-values hardening",
+        theme_category=["test"],
+        record_type=record_type,
         table_name=table_name,
-        srid=4326,
-        geometry_type=None,
-        feature_count=None,
-        source_format="geotiff",
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 @pytest.fixture

--- a/backend/tests/test_connector_extension.py
+++ b/backend/tests/test_connector_extension.py
@@ -4,12 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-
-def _reset_registry():
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._loaded = False
+from tests.conftest import _reset_registry
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_crs_wkt2_backfill_1376.py
+++ b/backend/tests/test_crs_wkt2_backfill_1376.py
@@ -25,31 +25,17 @@ import uuid
 import pytest
 import sqlalchemy as sa
 
-from tests.alembic_helpers import run_alembic as _run_alembic
+from tests.alembic_helpers import (
+    enterprise_migrations_present,
+    run_alembic as _run_alembic,
+)
 from tests.factories import create_dataset, get_user_id
 
 pytestmark = pytest.mark.anyio
 
 
-def _enterprise_migrations_present() -> bool:
-    """Mirror the sibling migration files' overlay skip: a multi-head alembic
-    cannot disambiguate ``head`` / ``-1``, so the round trip runs in the
-    no-overlay job."""
-    import pathlib
-    from importlib.metadata import entry_points
-
-    for ep in entry_points(group="geolens.migrations"):
-        try:
-            fn = ep.load()
-            if callable(fn) and any(pathlib.Path(p).is_dir() for p in fn()):
-                return True
-        except Exception:
-            pass
-    return False
-
-
 _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason=(
         "OSS migration round trip; multi-head under the enterprise overlay — "
         "runs in the no-overlay Pytest Parallel Isolation job instead."

--- a/backend/tests/test_crs_wkt2_backfill_1376.py
+++ b/backend/tests/test_crs_wkt2_backfill_1376.py
@@ -27,6 +27,7 @@ import sqlalchemy as sa
 
 from tests.alembic_helpers import (
     enterprise_migrations_present,
+    fresh_query as _fresh_query,
     run_alembic as _run_alembic,
 )
 from tests.factories import create_dataset, get_user_id
@@ -62,28 +63,6 @@ _WKT1_UTM_21N = (
 # so only a structurally broken string reaches the skip branch. Same shape
 # ``test_wkt_is_geographic.py`` uses for its unparseable case.
 _WKT1_SHAPED_GARBAGE = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84"'
-
-
-async def _fresh_query(query: str, params: dict | None = None):
-    """Read committed state on an autocommit connection.
-
-    The alembic subprocess commits outside the test session's transaction, so
-    the session's snapshot cannot see what the migration wrote (same reason
-    ``test_email_verification_migration.py`` carries this helper).
-    """
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    from app.core.config import settings
-
-    engine = create_async_engine(
-        settings.test_database_url, isolation_level="AUTOCOMMIT"
-    )
-    try:
-        async with engine.connect() as conn:
-            result = await conn.execute(sa.text(query), params or {})
-            return result.fetchall() if result.returns_rows else []
-    finally:
-        await engine.dispose()
 
 
 async def _seed_raster_asset(session, admin_id: uuid.UUID, crs_wkt: str) -> uuid.UUID:

--- a/backend/tests/test_data_serving_extension.py
+++ b/backend/tests/test_data_serving_extension.py
@@ -13,12 +13,7 @@ from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 from starlette.requests import Request
 
-
-def _reset_registry() -> None:
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._loaded = False
+from tests.conftest import _reset_registry
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_dataset_rows.py
+++ b/backend/tests/test_dataset_rows.py
@@ -14,9 +14,9 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import select, text
 
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -38,38 +38,24 @@ async def _create_dataset(
     column_info: list[dict] | None = None,
 ) -> Dataset:
     """Insert a Record + Dataset pair directly into the DB."""
-    if table_name is None:
-        table_name = f"ds_{uuid.uuid4().hex[:12]}"
     if column_info is None:
         column_info = [
             {"name": "gid", "type": "integer"},
             {"name": "name", "type": "text"},
             {"name": "pop", "type": "integer"},
         ]
-    record = Record(
-        title=name,
-        summary=description,
-        theme_category=["test"],
-        visibility=visibility,
-        record_status="published",
+    return await create_dataset(
+        session,
         created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
+        name=name,
         table_name=table_name,
+        visibility=visibility,
         srid=srid,
         geometry_type=geometry_type,
         feature_count=feature_count,
+        description=description,
         column_info=column_info,
-        source_format="geojson",
-        source_filename="test.geojson",
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_dormant_tenancy_migration_roundtrip.py
+++ b/backend/tests/test_dormant_tenancy_migration_roundtrip.py
@@ -34,6 +34,7 @@ import pytest
 import sqlalchemy as sa
 from tests.alembic_helpers import (
     enterprise_migrations_present,
+    fresh_query as _fresh_query,
     run_alembic as _run_alembic,
 )
 
@@ -117,34 +118,6 @@ class TestMigrationRoundTripExitCodes:
 # ---------------------------------------------------------------------------
 # Tests B + C: DB state after downgrade and re-upgrade
 # ---------------------------------------------------------------------------
-
-
-async def _fresh_query(query: str, params: dict | None = None):
-    """Run a query on a fresh autocommit connection, bypassing test transaction.
-
-    The ``test_db_session`` fixture holds an open transaction around each test.
-    Schema changes made by subprocess alembic (which commit outside that
-    transaction) are invisible to the session due to transaction snapshot
-    isolation.  We need a separate connection with ``AUTOCOMMIT`` isolation
-    to observe committed DDL changes.
-    """
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    from app.core.config import settings
-
-    engine = create_async_engine(
-        settings.test_database_url,
-        isolation_level="AUTOCOMMIT",
-    )
-    try:
-        async with engine.connect() as conn:
-            if params:
-                result = await conn.execute(sa.text(query), params)
-            else:
-                result = await conn.execute(sa.text(query))
-            return result.fetchall()
-    finally:
-        await engine.dispose()
 
 
 async def _fresh_execute(query: str, params: dict | None = None) -> None:

--- a/backend/tests/test_dormant_tenancy_migration_roundtrip.py
+++ b/backend/tests/test_dormant_tenancy_migration_roundtrip.py
@@ -32,7 +32,10 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
-from tests.alembic_helpers import run_alembic as _run_alembic
+from tests.alembic_helpers import (
+    enterprise_migrations_present,
+    run_alembic as _run_alembic,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -58,33 +61,8 @@ _SIX_SHARED_TABLES = [
 ]
 
 
-def _enterprise_migrations_present() -> bool:
-    """True when an enterprise/overlay migrations entry-point is installed.
-
-    conftest then migrates the per-worker test DB to the enterprise head (e.g.
-    e002_add_saml_columns), making the alembic environment MULTI-HEAD. The
-    core-only ``alembic`` subprocess these OSS-drift-gate roundtrip/check tests
-    shell out to can neither locate the enterprise revision nor disambiguate
-    ``head`` / ``-1`` across branches — so they are skipped under the overlay.
-    They still run (and gate drift) in the no-overlay Pytest Parallel Isolation
-    job. Core registers no ``geolens.migrations`` entry-point, so this is False
-    for community/OSS runs.
-    """
-    import pathlib
-    from importlib.metadata import entry_points
-
-    for ep in entry_points(group="geolens.migrations"):
-        try:
-            fn = ep.load()
-            if callable(fn) and any(pathlib.Path(p).is_dir() for p in fn()):
-                return True
-        except Exception:
-            pass
-    return False
-
-
 _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason="OSS migration drift gate; multi-head under enterprise overlay — "
     "runs in the no-overlay Pytest Parallel Isolation job instead.",
 )

--- a/backend/tests/test_email_verification_migration.py
+++ b/backend/tests/test_email_verification_migration.py
@@ -26,7 +26,10 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
-from tests.alembic_helpers import run_alembic as _run_alembic
+from tests.alembic_helpers import (
+    enterprise_migrations_present,
+    run_alembic as _run_alembic,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -36,29 +39,8 @@ _BACKEND_DIR = Path(__file__).parent.parent.resolve()
 _ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
 
 
-def _enterprise_migrations_present() -> bool:
-    """True when an enterprise/overlay migrations entry-point is installed.
-
-    The core-only ``alembic`` subprocess cannot disambiguate ``head`` / ``-1``
-    across branches in a multi-head environment, so these tests are skipped
-    under the overlay (they still run in the no-overlay Pytest Parallel
-    Isolation job).
-    """
-    import pathlib
-    from importlib.metadata import entry_points
-
-    for ep in entry_points(group="geolens.migrations"):
-        try:
-            fn = ep.load()
-            if callable(fn) and any(pathlib.Path(p).is_dir() for p in fn()):
-                return True
-        except Exception:
-            pass
-    return False
-
-
 _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason=(
         "OSS migration drift gate; multi-head under enterprise overlay — "
         "runs in the no-overlay Pytest Parallel Isolation job instead."

--- a/backend/tests/test_email_verification_migration.py
+++ b/backend/tests/test_email_verification_migration.py
@@ -25,9 +25,9 @@ Notes
 from pathlib import Path
 
 import pytest
-import sqlalchemy as sa
 from tests.alembic_helpers import (
     enterprise_migrations_present,
+    fresh_query as _fresh_query,
     run_alembic as _run_alembic,
 )
 
@@ -46,34 +46,6 @@ _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
         "runs in the no-overlay Pytest Parallel Isolation job instead."
     ),
 )
-
-
-async def _fresh_query(query: str, params: dict | None = None):
-    """Run a query on a fresh autocommit connection, bypassing the test transaction.
-
-    The ``test_db_session`` fixture holds an open transaction around each test.
-    Schema changes made by subprocess alembic (which commit outside that
-    transaction) are invisible to the session due to transaction snapshot
-    isolation.  We need a separate connection with ``AUTOCOMMIT`` isolation
-    to observe committed DDL changes.
-    """
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    from app.core.config import settings
-
-    engine = create_async_engine(
-        settings.test_database_url,
-        isolation_level="AUTOCOMMIT",
-    )
-    try:
-        async with engine.connect() as conn:
-            if params:
-                result = await conn.execute(sa.text(query), params)
-            else:
-                result = await conn.execute(sa.text(query))
-            return result.fetchall()
-    finally:
-        await engine.dispose()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_embed_tokens.py
+++ b/backend/tests/test_embed_tokens.py
@@ -20,7 +20,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
-import asyncpg
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select, text, update
@@ -40,36 +39,12 @@ from app.modules.embed_tokens.service import (
 from app.platform.cache import init_cache, tenant_cache_key
 from app.platform.cache.provider import get_cache
 
-from tests.conftest import _run_with_too_many_clients_retry
 from tests.factories import create_dataset, get_user_id
 
-
-@pytest.fixture(autouse=True)
-async def _init_tile_pool_for_tests(request):
-    """Initialize asyncpg pool for tile tests."""
-    db_fixtures = {
-        "admin_auth_header",
-        "clean_tables",
-        "cleanup_data_tables",
-        "client",
-        "editor_auth_header",
-        "test_db_session",
-        "viewer_auth_header",
-    }
-    if not db_fixtures.intersection(request.fixturenames):
-        yield
-        return
-
-    import app.processing.tiles.pool as pool_module
-
-    dsn = settings.test_database_url.replace("postgresql+asyncpg://", "postgresql://")
-    pool = await _run_with_too_many_clients_retry(
-        lambda: asyncpg.create_pool(dsn=dsn, min_size=1, max_size=3, command_timeout=10)
-    )
-    pool_module._tile_pool = pool
-    yield
-    await pool.close()
-    pool_module._tile_pool = None
+# The shared conftest fixture is non-autouse; this module-level mark applies
+# it to every test in the file, mirroring the file-scoped autouse=True this
+# module used before the fixture moved to tests/conftest.py.
+pytestmark = pytest.mark.usefixtures("_init_tile_pool_for_tests")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_embedding_provider_extension.py
+++ b/backend/tests/test_embedding_provider_extension.py
@@ -13,36 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-def _reset_registry():
-    """Reset extension registry state between tests (RESEARCH.md Pitfall 2).
-
-    Mirrors test_extensions.py:10-15 verbatim. Replicated inline rather than
-    imported to avoid inter-test-file import coupling (Phase 226 RESEARCH.md
-    Pitfall 6).
-    """
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._loaded = False
-
-
-@pytest.fixture(autouse=True)
-def _clean_registry():
-    """Isolate registry from environment-discovered entry points.
-
-    The enterprise overlay is editable-installable in the backend test venv;
-    that install adds ``geolens.extensions`` entry points which would
-    otherwise pollute the registry whenever a test calls ``load_extensions()``.
-    Patch ``entry_points`` to default-empty so each test starts from a
-    known-empty discovery surface and can opt in to its own mock entry
-    points via ``with patch(...)`` (Phase 226 RESEARCH.md Pitfall 6,
-    Phase 231 RESEARCH.md Pitfall 2).
-    """
-    _reset_registry()
-    with patch("app.platform.extensions.entry_points", return_value=[]):
-        yield
-    _reset_registry()
+pytestmark = pytest.mark.usefixtures("_clean_registry")
 
 
 def test_default_embedding_provider_registered():

--- a/backend/tests/test_embedding_vector_migration.py
+++ b/backend/tests/test_embedding_vector_migration.py
@@ -38,6 +38,7 @@ import pytest
 import sqlalchemy as sa
 from tests.alembic_helpers import (
     enterprise_migrations_present,
+    fresh_query as _fresh_query,
     run_alembic as _run_alembic,
 )
 
@@ -49,25 +50,6 @@ _BACKEND_DIR = Path(__file__).parent.parent.resolve()
 _ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
 
 _PRE_TYPED_REVISION = "0011_allow_generic_geometry_type"
-
-
-async def _fresh_query(query: str):
-    """Run a query on a fresh AUTOCOMMIT connection, bypassing the test
-    transaction, so DDL committed by subprocess alembic is visible."""
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    from app.core.config import settings
-
-    engine = create_async_engine(
-        settings.test_database_url,
-        isolation_level="AUTOCOMMIT",
-    )
-    try:
-        async with engine.connect() as conn:
-            result = await conn.execute(sa.text(query))
-            return result.fetchall() if result.returns_rows else None
-    finally:
-        await engine.dispose()
 
 
 async def _embedding_column_type() -> str:

--- a/backend/tests/test_embedding_vector_migration.py
+++ b/backend/tests/test_embedding_vector_migration.py
@@ -36,7 +36,10 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
-from tests.alembic_helpers import run_alembic as _run_alembic
+from tests.alembic_helpers import (
+    enterprise_migrations_present,
+    run_alembic as _run_alembic,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -96,24 +99,8 @@ async def _hnsw_index_is_valid() -> bool:
     return bool(rows and rows[0][0])
 
 
-def _enterprise_migrations_present() -> bool:
-    """Multi-head under the enterprise overlay; see
-    test_dormant_tenancy_migration_roundtrip.py for the full rationale."""
-    import pathlib
-    from importlib.metadata import entry_points
-
-    for ep in entry_points(group="geolens.migrations"):
-        try:
-            fn = ep.load()
-            if callable(fn) and any(pathlib.Path(p).is_dir() for p in fn()):
-                return True
-        except Exception:
-            pass
-    return False
-
-
 _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason="OSS migration test; multi-head under enterprise overlay — "
     "runs in the no-overlay Pytest Parallel Isolation job instead.",
 )

--- a/backend/tests/test_entitlement_port.py
+++ b/backend/tests/test_entitlement_port.py
@@ -16,22 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
-
-def _reset_registry():
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._loaded = False
-    ext_mod._slot_owners.clear()
-
-
-@pytest.fixture(autouse=True)
-def _clean_registry():
-    """Reset registry AND isolate from environment-discovered entry points."""
-    _reset_registry()
-    with patch("app.platform.extensions.entry_points", return_value=[]):
-        yield
-    _reset_registry()
+pytestmark = pytest.mark.usefixtures("_clean_registry")
 
 
 def _make_ep(name: str, loader_fn):

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -16,10 +16,10 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 from app.processing.export.ogr import FORMAT_MAP
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -42,38 +42,26 @@ async def _create_dataset(
     record_type: str = "vector_dataset",
 ) -> Dataset:
     """Insert a Record + Dataset pair directly into the DB."""
-    if table_name is None:
-        table_name = f"ds_{uuid.uuid4().hex[:12]}"
     if column_info is None:
         column_info = [
             {"name": "gid", "type": "integer"},
             {"name": "name", "type": "text"},
             {"name": "pop", "type": "integer"},
         ]
-    record = Record(
-        title=name,
-        summary=description,
-        visibility=visibility,
-        record_status="published",
-        record_type=record_type,
+    return await create_dataset(
+        session,
         created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
+        name=name,
         table_name=table_name,
+        theme_category=[],
+        visibility=visibility,
         srid=srid,
         geometry_type=geometry_type,
         feature_count=feature_count,
+        description=description,
+        record_type=record_type,
         column_info=column_info,
-        source_format="geojson",
-        source_filename="test.geojson",
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_extension_api_version.py
+++ b/backend/tests/test_extension_api_version.py
@@ -16,21 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-def _reset_registry():
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._loaded = False
-
-
-@pytest.fixture(autouse=True)
-def _clean_registry():
-    """Reset registry AND isolate from environment-discovered entry points."""
-    _reset_registry()
-    with patch("app.platform.extensions.entry_points", return_value=[]):
-        yield
-    _reset_registry()
+pytestmark = pytest.mark.usefixtures("_clean_registry")
 
 
 class TestExtensionApiVersionConstant:

--- a/backend/tests/test_extension_slot_guard.py
+++ b/backend/tests/test_extension_slot_guard.py
@@ -17,22 +17,9 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.conftest import _reset_registry
 
-def _reset_registry():
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._loaded = False
-    ext_mod._slot_owners.clear()
-
-
-@pytest.fixture(autouse=True)
-def _clean_registry():
-    """Reset registry AND isolate from environment-discovered entry points."""
-    _reset_registry()
-    with patch("app.platform.extensions.entry_points", return_value=[]):
-        yield
-    _reset_registry()
+pytestmark = pytest.mark.usefixtures("_clean_registry")
 
 
 def _make_ep(name: str, loader_fn):

--- a/backend/tests/test_extensions.py
+++ b/backend/tests/test_extensions.py
@@ -6,33 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-def _reset_registry():
-    """Reset extension registry state between tests."""
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._loaded = False
-    ext_mod._slot_owners.clear()
-
-
-@pytest.fixture(autouse=True)
-def _clean_registry():
-    """Reset registry AND isolate from environment-discovered entry points.
-
-    The enterprise overlay is editable-installable in the backend test
-    venv (so the enterprise migration adding overlay-only columns
-    auto-runs at session setup). That install adds the
-    ``geolens.extensions`` entry
-    point, which would otherwise pollute the registry whenever a test
-    calls ``load_extensions()``. We patch ``entry_points`` to default-empty
-    so each test starts from a known-empty discovery surface and can opt
-    in to its own mock entry points via ``with patch(...)``.
-    """
-    _reset_registry()
-    with patch("app.platform.extensions.entry_points", return_value=[]):
-        yield
-    _reset_registry()
+pytestmark = pytest.mark.usefixtures("_clean_registry")
 
 
 class TestLoadExtensions:

--- a/backend/tests/test_features_crud.py
+++ b/backend/tests/test_features_crud.py
@@ -12,7 +12,7 @@ from sqlalchemy import text
 
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 
-from tests.factories import get_user_id
+from tests.factories import create_raster_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -96,27 +96,14 @@ async def _create_raster_dataset(
     query would raise UndefinedTableError -> 500.
     """
     table_name = f"test_crud_raster_{uuid.uuid4().hex[:8]}"
-    record = Record(
-        title=f"Test Raster Layer {table_name}",
-        visibility=visibility,
-        record_status="published",
-        record_type=record_type,
+    return await create_raster_dataset(
+        session,
         created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
+        name=f"Test Raster Layer {table_name}",
+        visibility=visibility,
+        record_type=record_type,
         table_name=table_name,
-        srid=4326,
-        geometry_type=None,
-        feature_count=None,
-        source_format="geotiff",
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 async def _create_tabular_dataset(

--- a/backend/tests/test_ingest_progress.py
+++ b/backend/tests/test_ingest_progress.py
@@ -27,10 +27,10 @@ from sqlalchemy import select, text
 
 from app.platform.jobs.models import IngestJob
 
+from tests.factories import get_user_id
+
 
 async def _get_admin_id(session):
-    from tests.factories import get_user_id
-
     return await get_user_id(session, "admin")
 
 

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -25,7 +25,7 @@ from app.modules.catalog.maps.models import Map, MapLayer
 from app.modules.catalog.maps.schemas import MapLayerDiffRequest, MapLayerInput
 from app.processing.raster.models import RasterAsset
 
-from tests.factories import create_dataset, get_user_id
+from tests.factories import create_dataset, create_raster_dataset, get_user_id
 
 
 BASEMAP_CONFIG_PAYLOAD = {
@@ -4190,30 +4190,15 @@ async def _create_raster_dataset(
     visibility: str = "public",
 ) -> Dataset:
     """Insert a Record + Dataset pair with record_type='raster_dataset'."""
-    table_name = f"rds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=f"Raster dataset for map tests: {name}",
-        visibility=visibility,
-        record_status="published",
+    return await create_raster_dataset(
+        session,
         created_by=created_by,
-        record_type="raster_dataset",
-    )
-    session.add(record)
-    await session.flush()
-
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
-        srid=4326,
-        geometry_type=None,
-        source_format="geotiff",
+        name=name,
+        description=f"Raster dataset for map tests: {name}",
+        visibility=visibility,
+        table_name=f"rds_{uuid.uuid4().hex[:12]}",
         source_filename="test.tif",
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 class TestLayerTypeRoundTrip:

--- a/backend/tests/test_oauth_github_migration.py
+++ b/backend/tests/test_oauth_github_migration.py
@@ -31,7 +31,10 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
-from tests.alembic_helpers import run_alembic as _run_alembic
+from tests.alembic_helpers import (
+    enterprise_migrations_present,
+    run_alembic as _run_alembic,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers (self-contained copies — mirrors test_email_verification_migration.py)
@@ -41,29 +44,8 @@ _BACKEND_DIR = Path(__file__).parent.parent.resolve()
 _ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
 
 
-def _enterprise_migrations_present() -> bool:
-    """True when an enterprise/overlay migrations entry-point is installed.
-
-    The core-only ``alembic`` subprocess cannot disambiguate ``head`` / ``-1``
-    across branches in a multi-head environment, so these tests are skipped
-    under the overlay (they still run in the no-overlay Pytest Parallel
-    Isolation job).
-    """
-    import pathlib
-    from importlib.metadata import entry_points
-
-    for ep in entry_points(group="geolens.migrations"):
-        try:
-            fn = ep.load()
-            if callable(fn) and any(pathlib.Path(p).is_dir() for p in fn()):
-                return True
-        except Exception:
-            pass
-    return False
-
-
 _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason=(
         "OSS migration drift gate; multi-head under enterprise overlay — "
         "runs in the no-overlay Pytest Parallel Isolation job instead."

--- a/backend/tests/test_oauth_github_migration.py
+++ b/backend/tests/test_oauth_github_migration.py
@@ -33,6 +33,7 @@ import pytest
 import sqlalchemy as sa
 from tests.alembic_helpers import (
     enterprise_migrations_present,
+    fresh_query as _fresh_query,
     run_alembic as _run_alembic,
 )
 
@@ -51,36 +52,6 @@ _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
         "runs in the no-overlay Pytest Parallel Isolation job instead."
     ),
 )
-
-
-async def _fresh_query(query: str, params: dict | None = None):
-    """Run a SELECT query on a fresh autocommit connection.
-
-    The ``test_db_session`` fixture holds an open transaction around each test.
-    Schema changes made by subprocess alembic (which commit outside that
-    transaction) are invisible to the session due to transaction snapshot
-    isolation.  We need a separate connection with ``AUTOCOMMIT`` isolation
-    to observe committed DDL changes.
-
-    For DML statements (INSERT/DELETE) use ``_fresh_execute`` instead.
-    """
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    from app.core.config import settings
-
-    engine = create_async_engine(
-        settings.test_database_url,
-        isolation_level="AUTOCOMMIT",
-    )
-    try:
-        async with engine.connect() as conn:
-            if params:
-                result = await conn.execute(sa.text(query), params)
-            else:
-                result = await conn.execute(sa.text(query))
-            return result.fetchall()
-    finally:
-        await engine.dispose()
 
 
 async def _fresh_execute(query: str, params: dict | None = None) -> None:

--- a/backend/tests/test_ogc_collection_metadata.py
+++ b/backend/tests/test_ogc_collection_metadata.py
@@ -15,12 +15,11 @@ import uuid
 from datetime import date
 
 import pytest
-from geoalchemy2 import WKTElement
 from httpx import AsyncClient
-from app.modules.catalog.datasets.domain.models import Dataset, Record, RecordKeyword
+from app.modules.catalog.datasets.domain.models import Dataset
 from app.modules.catalog.search.router import _COLLECTION_META_CACHE
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 @pytest.fixture(autouse=True)
@@ -73,40 +72,20 @@ async def _create_dataset(
     data_vintage_end: date | None = None,
 ) -> Dataset:
     """Insert a Record + Dataset pair for collection metadata tests."""
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=f"Test dataset: {name}",
-        theme_category=["test"],
-        visibility=visibility,
-        record_status="published",
+    return await create_dataset(
+        session,
         created_by=created_by,
-        temporal_start=data_vintage_start,
-        temporal_end=data_vintage_end,
-    )
-    if wkt_extent is not None:
-        record.spatial_extent = WKTElement(wkt_extent, srid=4326)
-    session.add(record)
-    await session.flush()
-    if keywords:
-        for kw in keywords:
-            session.add(
-                RecordKeyword(record_id=record.id, keyword=kw, keyword_type="theme")
-            )
-        await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
+        name=name,
+        description=f"Test dataset: {name}",
+        visibility=visibility,
         srid=srid,
         geometry_type=geometry_type,
         feature_count=10,
-        source_format="geojson",
-        source_filename="test.geojson",
+        temporal_start=data_vintage_start,
+        temporal_end=data_vintage_end,
+        spatial_extent_wkt=wkt_extent,
+        keywords=keywords,
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 # WKT extent constants

--- a/backend/tests/test_ogc_cql2_filtering.py
+++ b/backend/tests/test_ogc_cql2_filtering.py
@@ -19,9 +19,9 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 from httpx import AsyncClient
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -41,31 +41,18 @@ async def _create_dataset(
     source_organization: str | None = None,
 ) -> Dataset:
     """Insert a Record + Dataset pair for CQL2 filtering tests."""
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=f"Test dataset: {name}",
+    return await create_dataset(
+        session,
+        created_by=created_by,
+        name=name,
+        description=f"Test dataset: {name}",
         theme_category=theme_category or ["test"],
         visibility=visibility,
-        record_status="published",
-        created_by=created_by,
-        source_organization=source_organization,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
         srid=srid,
         geometry_type=geometry_type,
         feature_count=10,
-        source_format="geojson",
-        source_filename="test.geojson",
+        source_organization=source_organization,
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 def _find_link(links: list[dict], rel: str) -> dict | None:

--- a/backend/tests/test_ogc_features.py
+++ b/backend/tests/test_ogc_features.py
@@ -18,7 +18,7 @@ from sqlalchemy import text
 
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 
-from tests.factories import get_user_id
+from tests.factories import create_raster_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -110,29 +110,16 @@ async def _create_raster_dataset(
     is ever created — this is exactly the (#315) bug-trigger condition.
     """
     table_name = f"test_ogc_raster_{uuid.uuid4().hex[:8]}"
-    record = Record(
-        title=f"OGC Test Raster {table_name}",
-        summary="Test raster dataset for OGC Features hardening",
+    return await create_raster_dataset(
+        session,
+        created_by=created_by,
+        name=f"OGC Test Raster {table_name}",
+        description="Test raster dataset for OGC Features hardening",
         theme_category=["test"],
         visibility=visibility,
-        record_status="published",
         record_type=record_type,
-        created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
         table_name=table_name,
-        srid=4326,
-        geometry_type=None,
-        feature_count=None,
-        source_format="geotiff",
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 async def _create_missing_table_vector_dataset(

--- a/backend/tests/test_ogc_pagination.py
+++ b/backend/tests/test_ogc_pagination.py
@@ -15,9 +15,9 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 from httpx import AsyncClient
-from app.modules.catalog.datasets.domain.models import Dataset, Record, RecordKeyword
+from app.modules.catalog.datasets.domain.models import Dataset
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -37,36 +37,18 @@ async def _create_dataset(
     keywords: list[str] | None = None,
 ) -> Dataset:
     """Insert a Record + Dataset pair for pagination tests."""
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=f"Test dataset: {name}",
+    return await create_dataset(
+        session,
+        created_by=created_by,
+        name=name,
+        description=f"Test dataset: {name}",
         theme_category=theme_category or ["test"],
         visibility=visibility,
-        record_status="published",
-        created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    if keywords:
-        for kw in keywords:
-            session.add(
-                RecordKeyword(record_id=record.id, keyword=kw, keyword_type="theme")
-            )
-        await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
         srid=srid,
         geometry_type=geometry_type,
         feature_count=10,
-        source_format="geojson",
-        source_filename="test.geojson",
+        keywords=keywords,
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 def _find_link(links: list[dict], rel: str) -> dict | None:

--- a/backend/tests/test_ogc_record_enrichment.py
+++ b/backend/tests/test_ogc_record_enrichment.py
@@ -14,11 +14,10 @@ Verifies:
 import uuid
 
 import pytest
-from geoalchemy2 import WKTElement
 from httpx import AsyncClient
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -39,35 +38,23 @@ async def _create_dataset(
     access_constraints: str | None = None,
 ) -> Dataset:
     """Insert a Record + Dataset pair for enrichment tests."""
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=f"Test dataset: {name}",
-        visibility=visibility,
-        record_status="published",
+    return await create_dataset(
+        session,
         created_by=created_by,
+        name=name,
+        description=f"Test dataset: {name}",
+        # Explicit [] rather than the factory's own ["test"] default: this
+        # file asserts an empty API "keywords" response, which is derived
+        # from theme_category.
+        theme_category=[],
+        visibility=visibility,
+        feature_count=10,
         lineage_summary=lineage_summary,
         update_frequency=update_frequency,
         usage_constraints=usage_constraints,
         access_constraints=access_constraints,
+        spatial_extent_wkt=wkt_extent,
     )
-    if wkt_extent is not None:
-        record.spatial_extent = WKTElement(wkt_extent, srid=4326)
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
-        srid=4326,
-        geometry_type="MultiPolygon",
-        feature_count=10,
-        source_format="geojson",
-        source_filename="test.geojson",
-    )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 # NYC area extent for spatial tests

--- a/backend/tests/test_ogc_records_conformance.py
+++ b/backend/tests/test_ogc_records_conformance.py
@@ -19,9 +19,7 @@ from urllib.parse import urlparse
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select
 
-from app.modules.auth.models import User
 from app.modules.catalog.collections.models import Collection
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
@@ -30,6 +28,8 @@ from app.modules.catalog.datasets.domain.models import (
     RecordKeyword,
 )
 
+from tests.factories import get_user_id
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -37,8 +37,7 @@ from app.modules.catalog.datasets.domain.models import (
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(select(User).where(User.username == "admin"))
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 async def _create_dataset(

--- a/backend/tests/test_ogc_records_conformance.py
+++ b/backend/tests/test_ogc_records_conformance.py
@@ -23,12 +23,9 @@ from httpx import AsyncClient
 from app.modules.catalog.collections.models import Collection
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
-    Record,
-    RecordContact,
-    RecordKeyword,
 )
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -54,50 +51,19 @@ async def _create_dataset(
 ) -> Dataset:
     """Create a Record + Dataset pair with optional keywords and contacts."""
     _name = name or f"ogc-conf-{uuid.uuid4().hex[:8]}"
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=_name,
-        summary=f"Test: {_name}",
-        theme_category=["test"],
-        visibility="public",
-        record_status="published",
-        record_type=record_type,
+    return await create_dataset(
+        session,
         created_by=admin_id,
-    )
-    session.add(record)
-    await session.flush()
-
-    if keywords:
-        for kw_text, vocab_uri in keywords:
-            session.add(
-                RecordKeyword(
-                    record_id=record.id,
-                    keyword=kw_text,
-                    keyword_type="theme",
-                    vocabulary_uri=vocab_uri,
-                )
-            )
-        await session.flush()
-
-    if contacts:
-        for c in contacts:
-            session.add(RecordContact(record_id=record.id, **c))
-        await session.flush()
-
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
-        srid=4326,
-        geometry_type="MultiPolygon",
+        name=_name,
+        description=f"Test: {_name}",
+        record_type=record_type,
         feature_count=10,
         source_format=source_format,
         source_filename=source_filename,
         source_url=source_url,
+        keywords=keywords,
+        contacts=contacts,
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 def _find_link(links: list[dict], rel: str) -> dict | None:

--- a/backend/tests/test_permission_extension.py
+++ b/backend/tests/test_permission_extension.py
@@ -10,22 +10,7 @@ from fastapi import HTTPException
 import pytest
 from sqlalchemy import select
 
-
-def _reset_registry():
-    """Reset extension registry state between tests."""
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._loaded = False
-
-
-@pytest.fixture(autouse=True)
-def _clean_registry():
-    """Isolate tests from environment-discovered extension entry points."""
-    _reset_registry()
-    with patch("app.platform.extensions.entry_points", return_value=[]):
-        yield
-    _reset_registry()
+pytestmark = pytest.mark.usefixtures("_clean_registry")
 
 
 def test_default_permission_extension_registered():

--- a/backend/tests/test_phase_273_cog_redirect_revalidate.py
+++ b/backend/tests/test_phase_273_cog_redirect_revalidate.py
@@ -10,13 +10,12 @@ import uuid
 from unittest.mock import AsyncMock, patch
 
 from httpx import AsyncClient
-from sqlalchemy import select
 
-from app.modules.auth.models import User
-from app.core.config import settings
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.platform.security import SSRFError
 from app.processing.raster.models import RasterAsset
+
+from tests.factories import get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -25,10 +24,7 @@ from app.processing.raster.models import RasterAsset
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(
-        select(User).where(User.username == settings.geolens_admin_username)
-    )
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 async def _create_remote_raster_dataset(

--- a/backend/tests/test_phase_273_share_token_entropy.py
+++ b/backend/tests/test_phase_273_share_token_entropy.py
@@ -10,13 +10,13 @@ import hashlib
 import secrets
 import uuid
 
-from app.modules.auth.models import User
 from app.modules.catalog.maps.models import Map, MapShareToken
 from app.modules.catalog.maps.service_public import (
     _validate_share_token,
     create_share_token,
 )
-from sqlalchemy import select
+
+from tests.factories import get_user_id
 
 
 def _decoded_byte_length(urlsafe_b64: str) -> int:
@@ -31,13 +31,7 @@ def _decoded_byte_length(urlsafe_b64: str) -> int:
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    from app.core.config import settings
-
-    result = await session.execute(
-        select(User).where(User.username == settings.geolens_admin_username)
-    )
-    user = result.scalar_one()
-    return user.id
+    return await get_user_id(session, "admin")
 
 
 async def _create_map(session, *, created_by: uuid.UUID) -> Map:

--- a/backend/tests/test_provenance_responses.py
+++ b/backend/tests/test_provenance_responses.py
@@ -6,9 +6,9 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from httpx import AsyncClient
 from app.modules.auth.models import User
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 async def _create_actor_user(
@@ -36,32 +36,19 @@ async def _create_dataset(
     created_at: datetime,
     updated_at: datetime,
 ) -> Dataset:
-    record = Record(
-        title=title,
-        summary=f"Dataset for {title}",
-        visibility="public",
-        record_status="published",
+    return await create_dataset(
+        session,
         created_by=created_by,
+        name=title,
+        description=f"Dataset for {title}",
+        theme_category=[],
+        geometry_type="Point",
+        feature_count=1,
+        source_filename="provenance.geojson",
         updated_by=updated_by,
         created_at=created_at,
         updated_at=updated_at,
     )
-    session.add(record)
-    await session.flush()
-
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=f"ds_{uuid.uuid4().hex[:12]}",
-        srid=4326,
-        geometry_type="Point",
-        feature_count=1,
-        source_format="geojson",
-        source_filename="provenance.geojson",
-    )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 async def _search_feature(

--- a/backend/tests/test_raster_schema.py
+++ b/backend/tests/test_raster_schema.py
@@ -16,10 +16,11 @@ import pytest
 import sqlalchemy.exc
 from sqlalchemy import select, text
 
-from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.maps.models import Map, MapLayer
 from app.processing.raster.models import RasterAsset
+
+from tests.factories import get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -28,8 +29,7 @@ from app.processing.raster.models import RasterAsset
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(select(User).where(User.username == "admin"))
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 async def _create_record_and_dataset(session, *, admin_id: uuid.UUID) -> Dataset:

--- a/backend/tests/test_raster_tiles.py
+++ b/backend/tests/test_raster_tiles.py
@@ -16,9 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select
 
-from app.modules.auth.models import User
 from app.core.config import settings
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.processing.raster.models import RasterAsset
@@ -27,6 +25,8 @@ from app.processing.tiles.router import (
     _raster_maxzoom_from_metadata,
 )
 
+from tests.factories import get_user_id
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -34,10 +34,7 @@ from app.processing.tiles.router import (
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(
-        select(User).where(User.username == settings.geolens_admin_username)
-    )
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 async def _create_raster_dataset(

--- a/backend/tests/test_raster_tiles.py
+++ b/backend/tests/test_raster_tiles.py
@@ -25,7 +25,7 @@ from app.processing.tiles.router import (
     _raster_maxzoom_from_metadata,
 )
 
-from tests.factories import get_user_id
+from tests.factories import create_raster_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -49,26 +49,19 @@ async def _create_raster_dataset(
     nodata: str | None = None,
 ) -> tuple[Record, Dataset, RasterAsset | None]:
     """Create a Record + Dataset (+ optional RasterAsset) for raster tests."""
-    record = Record(
-        title=f"Raster Tile Test {uuid.uuid4().hex[:6]}",
-        summary="Dataset for raster tile tests",
+    dataset = await create_raster_dataset(
+        session,
+        created_by=created_by,
+        name=f"Raster Tile Test {uuid.uuid4().hex[:6]}",
+        description="Dataset for raster tile tests",
         theme_category=["test"],
         visibility=visibility,
         record_status=record_status,
         record_type=record_type,
-        created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-
-    dataset = Dataset(
-        record_id=record.id,
         table_name=f"raster_tile_test_{uuid.uuid4().hex[:8]}",
-        source_format="geotiff",
         source_filename="test.tif",
     )
-    session.add(dataset)
-    await session.flush()
+    record = await session.get(Record, dataset.record_id)
 
     raster_asset = None
     if with_asset:
@@ -80,12 +73,9 @@ async def _create_raster_dataset(
             nodata=nodata,
         )
         session.add(raster_asset)
-        await session.flush()
-
-    await session.commit()
-    await session.refresh(dataset)
-    if raster_asset:
+        await session.commit()
         await session.refresh(raster_asset)
+
     return record, dataset, raster_asset
 
 

--- a/backend/tests/test_record_translations_migration.py
+++ b/backend/tests/test_record_translations_migration.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import pytest
-import sqlalchemy as sa
 
 from tests.repo_paths import repo_root
 from tests.alembic_helpers import (
     enterprise_migrations_present,
+    fresh_query as _fresh_query,
     run_alembic as _run_alembic,
 )
 
@@ -23,23 +23,6 @@ _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
     enterprise_migrations_present(),
     reason="OSS migration round-trip runs in the no-overlay migration job",
 )
-
-
-async def _fresh_query(query: str, params: dict | None = None):
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    from app.core.config import settings
-
-    engine = create_async_engine(
-        settings.test_database_url,
-        isolation_level="AUTOCOMMIT",
-    )
-    try:
-        async with engine.connect() as connection:
-            result = await connection.execute(sa.text(query), params or {})
-            return result.fetchall() if result.returns_rows else None
-    finally:
-        await engine.dispose()
 
 
 async def _cleanup_test_objects() -> None:

--- a/backend/tests/test_record_translations_migration.py
+++ b/backend/tests/test_record_translations_migration.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from importlib.metadata import entry_points
-from pathlib import Path
-
 import pytest
 import sqlalchemy as sa
 
 from tests.repo_paths import repo_root
-from tests.alembic_helpers import run_alembic as _run_alembic
+from tests.alembic_helpers import (
+    enterprise_migrations_present,
+    run_alembic as _run_alembic,
+)
 
 _REPO_ROOT = repo_root(__file__)
 _BACKEND_DIR = _REPO_ROOT / "backend"
@@ -19,19 +19,8 @@ _PRE_TRANSLATIONS_REVISION = "0013_backfill_geoparquet_distributions"
 _TITLE_PREFIX = "migration-0014-lock-test-"
 
 
-def _enterprise_migrations_present() -> bool:
-    for entry_point in entry_points(group="geolens.migrations"):
-        try:
-            provider = entry_point.load()
-            if callable(provider) and any(Path(path).is_dir() for path in provider()):
-                return True
-        except Exception:
-            pass
-    return False
-
-
 _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason="OSS migration round-trip runs in the no-overlay migration job",
 )
 

--- a/backend/tests/test_reupload.py
+++ b/backend/tests/test_reupload.py
@@ -20,13 +20,13 @@ from httpx import AsyncClient
 from sqlalchemy import select
 
 from app.modules.auth.models import User
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 from app.modules.catalog.datasets.domain.service import compute_schema_diff
 from app.modules.catalog.datasets.api import router_reupload
 from app.platform.jobs.models import IngestJob
 from app.platform.security import SSRFError
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 @pytest.mark.anyio
@@ -91,34 +91,21 @@ async def _create_dataset(
     record_type: str = "vector_dataset",
 ) -> Dataset:
     """Insert a Record + Dataset pair directly into the DB."""
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=f"Test dataset: {name}",
-        visibility=visibility,
-        record_status="published",
-        record_type=record_type,
+    return await create_dataset(
+        session,
         created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
-        srid=4326,
-        geometry_type="MultiPolygon",
+        name=name,
+        description=f"Test dataset: {name}",
+        theme_category=[],
+        visibility=visibility,
+        record_type=record_type,
         feature_count=100,
-        source_format="geojson",
         source_filename="original.geojson",
         column_info=[
             {"name": "name", "type": "String"},
             {"name": "value", "type": "Integer"},
         ],
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_reupload_completion_contract_1207.py
+++ b/backend/tests/test_reupload_completion_contract_1207.py
@@ -22,9 +22,10 @@ from sqlalchemy import select
 
 from app.core.config import settings
 from app.modules.catalog.datasets.api import router_reupload
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 from app.platform.jobs.models import IngestJob
 
+from tests.factories import create_dataset
 
 pytestmark = pytest.mark.anyio
 
@@ -83,30 +84,17 @@ class _FakeS3Storage:
 
 async def _create_dataset(session, *, created_by: uuid.UUID) -> Dataset:
     """Insert a Record + Dataset pair. Mirrors test_reupload.py's helper."""
-    record = Record(
-        title="Reupload Contract Dataset",
-        summary="#1207",
-        visibility="public",
-        record_status="published",
-        record_type="vector_dataset",
+    return await create_dataset(
+        session,
         created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=f"ds_{uuid.uuid4().hex[:12]}",
-        srid=4326,
-        geometry_type="MultiPolygon",
+        name="Reupload Contract Dataset",
+        description="#1207",
+        theme_category=[],
+        record_type="vector_dataset",
         feature_count=1,
-        source_format="geojson",
         source_filename="original.geojson",
         column_info=[{"name": "name", "type": "String"}],
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 @pytest.fixture

--- a/backend/tests/test_reupload_service.py
+++ b/backend/tests/test_reupload_service.py
@@ -8,13 +8,13 @@ from httpx import AsyncClient
 from sqlalchemy import select, text
 
 from app.modules.catalog.collections.models import DatasetVersion
-from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.modules.catalog.datasets.domain.models import Dataset
 from app.platform.jobs.heartbeat import attempt_scoped_staging_table
 from app.processing.ingest.ogr import IngestionError
 from app.processing.ingest.tasks import reupload_service
 from app.platform.jobs.models import IngestJob
 
-from tests.factories import get_user_id
+from tests.factories import create_dataset, get_user_id
 
 
 async def _create_dataset(
@@ -24,24 +24,14 @@ async def _create_dataset(
     name: str = "Service Reupload Dataset",
     visibility: str = "public",
 ) -> Dataset:
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=f"Test dataset: {name}",
-        visibility=visibility,
-        record_status="published",
+    return await create_dataset(
+        session,
         created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
-        srid=4326,
-        geometry_type="MultiPolygon",
+        name=name,
+        description=f"Test dataset: {name}",
+        theme_category=[],
+        visibility=visibility,
         feature_count=100,
-        source_format="geojson",
         source_filename="original.geojson",
         source_url="https://old.example.com/source",
         column_info=[
@@ -49,10 +39,6 @@ async def _create_dataset(
             {"name": "value", "type": "integer"},
         ],
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 async def _create_service_reupload_job(

--- a/backend/tests/test_saml_column_drift_gate.py
+++ b/backend/tests/test_saml_column_drift_gate.py
@@ -15,22 +15,18 @@ from pathlib import Path
 import pytest
 import sqlalchemy
 from sqlalchemy import text
-from tests.alembic_helpers import run_alembic as _run_alembic
+from tests.alembic_helpers import (
+    enterprise_migrations_present,
+    run_alembic as _run_alembic,
+)
 
 _BACKEND_DIR = Path(__file__).resolve().parent.parent
 
 SAML_COLUMNS = ("idp_entity_id", "idp_sso_url", "idp_certificate", "sp_entity_id")
 
 
-def _enterprise_migrations_present() -> bool:
-    from alembic.config import Config
-
-    cfg = Config(str(_BACKEND_DIR / "alembic.ini"))
-    return " " in (cfg.get_main_option("version_locations") or "").strip()
-
-
 _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason="OSS migration drift gate; multi-head under the enterprise overlay",
 )
 

--- a/backend/tests/test_stac_asset_model.py
+++ b/backend/tests/test_stac_asset_model.py
@@ -16,9 +16,10 @@ import pytest
 import sqlalchemy.exc
 from sqlalchemy import select
 
-from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.processing.raster.models import DatasetAsset, RasterAsset
+
+from tests.factories import get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -27,8 +28,7 @@ from app.processing.raster.models import DatasetAsset, RasterAsset
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(select(User).where(User.username == "admin"))
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 async def _create_record_and_dataset(session, *, admin_id: uuid.UUID) -> Dataset:

--- a/backend/tests/test_stac_integration.py
+++ b/backend/tests/test_stac_integration.py
@@ -11,10 +11,9 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.catalog.collections.models import Collection, CollectionDataset
-from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.standards.stac.router import STAC_UNASSIGNED_COLLECTION_ID
 
-from tests.factories import get_user_id
+from tests.factories import create_raster_dataset, get_user_id
 
 
 def _find_link(links: list[dict], rel: str) -> dict | None:
@@ -33,28 +32,14 @@ async def _create_raster_dataset(
     visibility: str = "public",
 ):
     """Create a raster dataset — STAC only serves raster_dataset/vrt_dataset records."""
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=f"Test raster dataset for STAC: {name}",
-        visibility=visibility,
-        record_status="published",
-        record_type="raster_dataset",
+    return await create_raster_dataset(
+        session,
         created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
-        srid=4326,
-        source_format="geotiff",
+        name=name,
+        description=f"Test raster dataset for STAC: {name}",
+        visibility=visibility,
         source_filename="test.tif",
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_stac_record_output.py
+++ b/backend/tests/test_stac_record_output.py
@@ -18,14 +18,14 @@ Requirements:
 import uuid
 from datetime import date
 
-from sqlalchemy import select
 
-from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.search.service import (
     _build_stac_assets,
     dataset_to_ogc_record,
 )
+
+from tests.factories import get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -34,8 +34,7 @@ from app.modules.catalog.search.service import (
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(select(User).where(User.username == "admin"))
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 async def _create_record_and_dataset(

--- a/backend/tests/test_stac_visibility.py
+++ b/backend/tests/test_stac_visibility.py
@@ -17,12 +17,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.catalog.datasets.domain.models import (
     Dataset,
-    Record,
     RecordTranslation,
 )
 
 from .conftest import _create_test_user
-from tests.factories import get_user_id
+from tests.factories import create_raster_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -39,28 +38,15 @@ async def _create_raster_dataset(
     record_status: str = "published",
 ) -> Dataset:
     """Create a raster Record + Dataset pair directly (STAC requires raster_dataset type)."""
-    table_name = f"ds_{uuid.uuid4().hex[:12]}"
-    record = Record(
-        title=name,
-        summary=f"Test raster dataset for STAC visibility: {name}",
+    return await create_raster_dataset(
+        session,
+        created_by=created_by,
+        name=name,
+        description=f"Test raster dataset for STAC visibility: {name}",
         visibility=visibility,
         record_status=record_status,
-        record_type="raster_dataset",
-        created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-    dataset = Dataset(
-        record_id=record.id,
-        table_name=table_name,
-        srid=4326,
-        source_format="geotiff",
         source_filename="test.tif",
     )
-    session.add(dataset)
-    await session.commit()
-    await session.refresh(dataset)
-    return dataset
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_tasks_common_phase_brackets.py
+++ b/backend/tests/test_tasks_common_phase_brackets.py
@@ -27,10 +27,10 @@ from sqlalchemy import select
 from app.platform.jobs.models import IngestJob
 from app.processing.ingest.tasks_common import _job_phase_session
 
+from tests.factories import get_user_id
+
 
 async def _get_admin_id(session):
-    from tests.factories import get_user_id
-
     return await get_user_id(session, "admin")
 
 

--- a/backend/tests/test_tenant_rls_migration.py
+++ b/backend/tests/test_tenant_rls_migration.py
@@ -33,7 +33,10 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
-from tests.alembic_helpers import run_alembic as _run_alembic
+from tests.alembic_helpers import (
+    enterprise_migrations_present,
+    run_alembic as _run_alembic,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -57,33 +60,8 @@ _RLS_TABLES = [
 _POLICY_NAMES = [f"tenant_isolation_{t}" for t in _RLS_TABLES]
 
 
-def _enterprise_migrations_present() -> bool:
-    """True when an enterprise/overlay migrations entry-point is installed.
-
-    conftest then migrates the per-worker test DB to the enterprise head (e.g.
-    e002_add_saml_columns), making the alembic environment MULTI-HEAD. The
-    core-only ``alembic`` subprocess these OSS-drift-gate roundtrip/check tests
-    shell out to can neither locate the enterprise revision nor disambiguate
-    ``head`` / ``-1`` across branches — so they are skipped under the overlay.
-    They still run (and gate drift) in the no-overlay Pytest Parallel Isolation
-    job. Core registers no ``geolens.migrations`` entry-point, so this is False
-    for community/OSS runs.
-    """
-    import pathlib
-    from importlib.metadata import entry_points
-
-    for ep in entry_points(group="geolens.migrations"):
-        try:
-            fn = ep.load()
-            if callable(fn) and any(pathlib.Path(p).is_dir() for p in fn()):
-                return True
-        except Exception:
-            pass
-    return False
-
-
 _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
-    _enterprise_migrations_present(),
+    enterprise_migrations_present(),
     reason="OSS migration drift gate; multi-head under enterprise overlay — "
     "runs in the no-overlay Pytest Parallel Isolation job instead.",
 )

--- a/backend/tests/test_tenant_rls_migration.py
+++ b/backend/tests/test_tenant_rls_migration.py
@@ -35,6 +35,7 @@ import pytest
 import sqlalchemy as sa
 from tests.alembic_helpers import (
     enterprise_migrations_present,
+    fresh_query as _fresh_query,
     run_alembic as _run_alembic,
 )
 
@@ -65,31 +66,6 @@ _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
     reason="OSS migration drift gate; multi-head under enterprise overlay — "
     "runs in the no-overlay Pytest Parallel Isolation job instead.",
 )
-
-
-async def _fresh_query(query: str, params: dict | None = None):
-    """Run a query on a fresh AUTOCOMMIT connection, bypassing test transaction.
-
-    DDL committed by subprocess alembic is invisible to in-flight transactions
-    (snapshot isolation).  AUTOCOMMIT ensures we observe committed schema state.
-    """
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    from app.core.config import settings
-
-    engine = create_async_engine(
-        settings.test_database_url,
-        isolation_level="AUTOCOMMIT",
-    )
-    try:
-        async with engine.connect() as conn:
-            if params:
-                result = await conn.execute(sa.text(query), params)
-            else:
-                result = await conn.execute(sa.text(query))
-            return result.fetchall()
-    finally:
-        await engine.dispose()
 
 
 async def _get_rls_state() -> dict[str, dict[str, bool]]:

--- a/backend/tests/test_tile_gzip_offload_perf005.py
+++ b/backend/tests/test_tile_gzip_offload_perf005.py
@@ -26,7 +26,6 @@ import gzip
 import uuid
 from unittest.mock import patch
 
-import asyncpg
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
@@ -34,7 +33,6 @@ from sqlalchemy import text
 from app.core.config import settings
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 
-from tests.conftest import _run_with_too_many_clients_retry
 from tests.factories import get_user_id
 
 
@@ -102,21 +100,6 @@ async def _create_point_data_table(session, table_name: str) -> None:
 async def _cleanup_data_table(session, table_name: str) -> None:
     await session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
     await session.commit()
-
-
-@pytest.fixture
-async def _init_tile_pool_for_tests():
-    """Create a real asyncpg pool for tile rendering (lifespan does not run under ASGITransport)."""
-    import app.processing.tiles.pool as pool_module
-
-    dsn = settings.test_database_url.replace("postgresql+asyncpg://", "postgresql://")
-    pool = await _run_with_too_many_clients_retry(
-        lambda: asyncpg.create_pool(dsn=dsn, min_size=1, max_size=3, command_timeout=10)
-    )
-    pool_module._tile_pool = pool
-    yield
-    await pool.close()
-    pool_module._tile_pool = None
 
 
 def _make_to_thread_spy():

--- a/backend/tests/test_tile_signing.py
+++ b/backend/tests/test_tile_signing.py
@@ -13,7 +13,6 @@ import time
 import uuid
 from unittest.mock import patch
 
-import asyncpg
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
@@ -22,7 +21,6 @@ from app.core.config import settings
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.processing.tiles.signing import generate_tile_signature
 
-from tests.conftest import _run_with_too_many_clients_retry
 from tests.factories import get_user_id
 
 
@@ -96,21 +94,6 @@ async def _create_data_table(session, table_name: str) -> None:
 async def _cleanup_data_table(session, table_name: str) -> None:
     await session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
     await session.commit()
-
-
-@pytest.fixture
-async def _init_tile_pool_for_tests():
-    """Initialize asyncpg pool for tile tests."""
-    import app.processing.tiles.pool as pool_module
-
-    dsn = settings.test_database_url.replace("postgresql+asyncpg://", "postgresql://")
-    pool = await _run_with_too_many_clients_retry(
-        lambda: asyncpg.create_pool(dsn=dsn, min_size=1, max_size=3, command_timeout=10)
-    )
-    pool_module._tile_pool = pool
-    yield
-    await pool.close()
-    pool_module._tile_pool = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_tiles.py
+++ b/backend/tests/test_tiles.py
@@ -14,7 +14,6 @@ import time
 import uuid
 from unittest.mock import AsyncMock, patch
 
-import asyncpg
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
@@ -22,7 +21,6 @@ from sqlalchemy import text
 from app.core.config import settings
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 
-from tests.conftest import _run_with_too_many_clients_retry
 from tests.factories import get_user_id
 
 
@@ -177,25 +175,6 @@ async def _create_cluster_semantics_table(
             {"name": name, "x": x, "y": y},
         )
     await session.commit()
-
-
-@pytest.fixture
-async def _init_tile_pool_for_tests():
-    """Initialize a real asyncpg pool pointing at the test database for tile tests.
-
-    The test client uses ASGITransport which does not run the app lifespan,
-    so we need to create the tile pool manually.
-    """
-    import app.processing.tiles.pool as pool_module
-
-    dsn = settings.test_database_url.replace("postgresql+asyncpg://", "postgresql://")
-    pool = await _run_with_too_many_clients_retry(
-        lambda: asyncpg.create_pool(dsn=dsn, min_size=1, max_size=3, command_timeout=10)
-    )
-    pool_module._tile_pool = pool
-    yield
-    await pool.close()
-    pool_module._tile_pool = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_vector_tile_auth.py
+++ b/backend/tests/test_vector_tile_auth.py
@@ -20,7 +20,6 @@ Requirements:
 
 import uuid
 
-import asyncpg
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select, text
@@ -28,8 +27,6 @@ from sqlalchemy import select, text
 from app.modules.auth.models import User
 from app.core.config import settings
 from app.modules.catalog.datasets.domain.models import Dataset, Record
-
-from tests.conftest import _run_with_too_many_clients_retry
 
 
 # ---------------------------------------------------------------------------
@@ -140,27 +137,6 @@ async def _get_auth_header(client: AsyncClient, username: str, password: str) ->
     )
     assert resp.status_code == 200, f"Login failed: {resp.text}"
     return {"Authorization": f"Bearer {resp.json()['access_token']}"}
-
-
-@pytest.fixture
-async def _init_tile_pool_for_tests():
-    """Initialize a real asyncpg pool pointing at the test database for tile tests.
-
-    The test client uses ASGITransport which does not run the app lifespan,
-    so the tile serving pool must be created manually.  Mirrors the fixture in
-    test_tiles.py.  The denial tests short-circuit at the auth gate (404) before
-    the pool is touched; the positive serving guard needs the pool live.
-    """
-    import app.processing.tiles.pool as pool_module
-
-    dsn = settings.test_database_url.replace("postgresql+asyncpg://", "postgresql://")
-    pool = await _run_with_too_many_clients_retry(
-        lambda: asyncpg.create_pool(dsn=dsn, min_size=1, max_size=3, command_timeout=10)
-    )
-    pool_module._tile_pool = pool
-    yield
-    await pool.close()
-    pool_module._tile_pool = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_vector_tile_auth.py
+++ b/backend/tests/test_vector_tile_auth.py
@@ -22,11 +22,11 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select, text
+from sqlalchemy import text
 
-from app.modules.auth.models import User
-from app.core.config import settings
 from app.modules.catalog.datasets.domain.models import Dataset, Record
+
+from tests.factories import get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -35,10 +35,7 @@ from app.modules.catalog.datasets.domain.models import Dataset, Record
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(
-        select(User).where(User.username == settings.geolens_admin_username)
-    )
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 async def _create_vector_dataset(

--- a/backend/tests/test_vrt_ingest_tasks.py
+++ b/backend/tests/test_vrt_ingest_tasks.py
@@ -1,17 +1,12 @@
 import uuid
 
-from sqlalchemy import select
-
-from app.modules.auth.models import User
-from app.core.config import settings
 from app.processing.ingest.tasks import create_vrt_dataset
+
+from tests.factories import get_user_id
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(
-        select(User).where(User.username == settings.geolens_admin_username)
-    )
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 class TestCreateVrtDataset:

--- a/backend/tests/test_vrt_schema_171.py
+++ b/backend/tests/test_vrt_schema_171.py
@@ -15,12 +15,12 @@ import uuid
 
 import pytest
 import sqlalchemy.exc
-from sqlalchemy import select, text
+from sqlalchemy import text
 
-from app.modules.auth.models import User
-from app.core.config import settings
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.processing.raster.models import RasterAsset
+
+from tests.factories import get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -29,10 +29,7 @@ from app.processing.raster.models import RasterAsset
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(
-        select(User).where(User.username == settings.geolens_admin_username)
-    )
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 async def _create_vrt_record_and_dataset(

--- a/backend/tests/test_vrt_source_authz_1172.py
+++ b/backend/tests/test_vrt_source_authz_1172.py
@@ -25,12 +25,12 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import AsyncClient
-from sqlalchemy import select, text
+from sqlalchemy import text
 
-from app.core.config import settings
-from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.processing.raster.models import RasterAsset
+
+from tests.factories import get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -39,10 +39,7 @@ from app.processing.raster.models import RasterAsset
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(
-        select(User).where(User.username == settings.geolens_admin_username)
-    )
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 async def _make_editor(

--- a/backend/tests/test_vrt_source_authz_1172.py
+++ b/backend/tests/test_vrt_source_authz_1172.py
@@ -30,7 +30,7 @@ from sqlalchemy import text
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.processing.raster.models import RasterAsset
 
-from tests.factories import get_user_id
+from tests.factories import create_raster_dataset, get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -82,46 +82,31 @@ async def _create_raster_dataset(
     identical dtype, single band, matching resolution) so ``validate_sources``
     returns [] for a pair of these — letting the GUARD tests reach 202.
     """
-    record = Record(
-        title=f"VRT Authz Raster {uuid.uuid4().hex[:6]}",
-        summary="raster source for VRT authz tests",
+    dataset = await create_raster_dataset(
+        session,
+        created_by=created_by,
+        name=f"VRT Authz Raster {uuid.uuid4().hex[:6]}",
+        description="raster source for VRT authz tests",
         theme_category=["test"],
         visibility=visibility,
         record_status=record_status,
-        record_type="raster_dataset",
-        created_by=created_by,
-    )
-    session.add(record)
-    await session.flush()
-
-    dataset = Dataset(
-        record_id=record.id,
         table_name=f"vrt_authz_src_{uuid.uuid4().hex[:8]}",
-        source_format="geotiff",
         source_filename="test.tif",
+        create_raster_asset=True,
+        raster_asset_kwargs=dict(
+            status="ready",
+            epsg=4326,
+            crs_wkt=None,
+            dtype="uint8",
+            nodata=None,
+            band_count=1,
+            res_x=0.001,
+            res_y=0.001,
+            width=100,
+            height=100,
+            is_rotated=False,
+        ),
     )
-    session.add(dataset)
-    await session.flush()
-
-    asset = RasterAsset(
-        dataset_id=dataset.id,
-        asset_uri=f"rasters/{dataset.id}/abc123/source.cog.tif",
-        storage_backend="local",
-        status="ready",
-        epsg=4326,
-        crs_wkt=None,
-        dtype="uint8",
-        nodata=None,
-        band_count=1,
-        res_x=0.001,
-        res_y=0.001,
-        width=100,
-        height=100,
-        is_rotated=False,
-    )
-    session.add(asset)
-    await session.flush()
-    await session.commit()
     return dataset.id
 
 

--- a/backend/tests/test_vrt_titiler.py
+++ b/backend/tests/test_vrt_titiler.py
@@ -19,14 +19,14 @@ import uuid
 import numpy as np
 import pytest
 import rasterio
-from sqlalchemy import select
 from rasterio.transform import from_origin
 
-from app.modules.auth.models import User
 from app.core.config import settings
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.processing.raster.models import RasterAsset
 from app.processing.raster.vrt import build_vrt
+
+from tests.factories import get_user_id
 
 
 # ---------------------------------------------------------------------------
@@ -74,10 +74,7 @@ _REAL_STAGING_DIR = "/app/staging"
 
 
 async def _get_admin_id(session) -> uuid.UUID:
-    result = await session.execute(
-        select(User).where(User.username == settings.geolens_admin_username)
-    )
-    return result.scalar_one().id
+    return await get_user_id(session, "admin")
 
 
 def _create_test_cog(cog_path: str) -> None:

--- a/backend/tests/test_worker_bootstrap_parity.py
+++ b/backend/tests/test_worker_bootstrap_parity.py
@@ -21,14 +21,7 @@ from unittest.mock import patch
 
 import pytest
 
-
-def _reset_registry():
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._routers.clear()
-    ext_mod._loaded = False
-    ext_mod._slot_owners.clear()
+from tests.conftest import _reset_registry
 
 
 def _reset_edition():

--- a/backend/tests/test_worker_overlay_resolution.py
+++ b/backend/tests/test_worker_overlay_resolution.py
@@ -16,15 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
-
-def _reset_registry():
-    """Reset extension registry state between tests."""
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._routers.clear()
-    ext_mod._loaded = False
-    ext_mod._slot_owners.clear()
+from tests.conftest import _reset_registry
 
 
 def _reset_edition():

--- a/backend/tests/test_worker_tile_cache_1315.py
+++ b/backend/tests/test_worker_tile_cache_1315.py
@@ -39,6 +39,8 @@ from urllib.parse import urlparse
 import pytest
 import structlog
 
+from tests.conftest import _reset_registry
+
 LIVE_REDIS_URL = os.environ.get("GEOLENS_TEST_REDIS_URL", "redis://localhost:16379/0")
 
 
@@ -81,15 +83,6 @@ def restore_tile_cache():
 # ---------------------------------------------------------------------------
 # bootstrap() wiring -- the bug itself
 # ---------------------------------------------------------------------------
-
-
-def _reset_registry():
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._routers.clear()
-    ext_mod._loaded = False
-    ext_mod._slot_owners.clear()
 
 
 def _reset_edition():

--- a/backend/tests/test_workflow_extension.py
+++ b/backend/tests/test_workflow_extension.py
@@ -9,22 +9,7 @@ import uuid
 from fastapi import HTTPException
 import pytest
 
-
-def _reset_registry():
-    """Reset extension registry state between tests."""
-    import app.platform.extensions as ext_mod
-
-    ext_mod._extensions.clear()
-    ext_mod._loaded = False
-
-
-@pytest.fixture(autouse=True)
-def _clean_registry():
-    """Isolate tests from environment-discovered extension entry points."""
-    _reset_registry()
-    with patch("app.platform.extensions.entry_points", return_value=[]):
-        yield
-    _reset_registry()
+pytestmark = pytest.mark.usefixtures("_clean_registry")
 
 
 async def _noop_check_dataset_access(db, dataset, dataset_id, user, **kwargs):


### PR DESCRIPTION
## Summary

Six mechanical DRY consolidations across `backend/tests/`. No production code
touched, and no test coverage removed — same assertions run against the same
data, just built through one shared implementation per cluster instead of N
divergent copies.

**1. `enterprise_migrations_present` (9 → 1)** — the SAML column drift gate's
guard read `version_locations` from `alembic.ini` at rest, which never
contains that key (it's set at runtime by `conftest.py`/`env.py`), so the
guard was permanently `False`. Eight sibling migration-test modules already
had the correct implementation (enumerate the `geolens.migrations`
entry-point group). Lifted one canonical copy into `tests/alembic_helpers.py`;
all nine modules now import it.

**2. `_init_tile_pool_for_tests` (5 → 1)** — byte-identical asyncpg pool setup
for tile-serving tests, previously requiring a retry fix to be hand-applied at
three of five copies separately. Moved into `conftest.py` as one non-autouse
fixture; the four class-scoped consumers keep `@pytest.mark.usefixtures`,
and `test_embed_tokens.py`'s file-scoped `autouse=True` becomes a
module-level `pytestmark` with the same mark, preserving its request-based
guard.

**3. Extension-registry reset (13 `_reset_registry` + 10 `_clean_registry` →
1 each)** — `_reset_registry` cleared varying subsets of four
`app.platform.extensions` globals across files (7 cleared two of four, 3
added a third, 3 worker-bootstrap files cleared all four) — a latent
cross-test pollution bug waiting for a file to touch a slot its own
copy-pasted subset didn't anticipate. One `_reset_registry` in `conftest.py`
now clears all four; the entry-points-patching `_clean_registry` fixture
that 8 of 13 files shared verbatim also collapsed into `conftest.py`. Two
files whose `_clean_registry` doesn't patch entry points, and three
worker-bootstrap files with their own combined registry+edition reset,
keep local fixtures but import the shared `_reset_registry`.

**4. Admin-identity resolution (15 `_get_admin_id` bodies, 3 shapes → 1) +
a boot-time guard** — bodies hardcoded `"admin"`, queried
`settings.geolens_admin_username`, or delegated to
`tests.factories.get_user_id`. That setting has no default, and roughly
1,160 other call sites elsewhere in the suite (~1,082 through
`factories.get_user_id`, ~79 querying the literal directly) assume it
resolves to `"admin"` — a mismatch would fail every one of those sites
individually with `NoResultFound` and no shared root cause. Collapsed all
15 onto `factories.get_user_id`, and added one assert in `conftest.py`'s
session-scoped `_test_db_lifecycle` that fails loudly, once, if the setting
is ever not `"admin"`. The ~1,160 direct call sites are unchanged — the
assert is what makes them safe, not a rewrite.

**5. Dataset factories (13 `_create_dataset` + 10 `_create_raster_dataset` +
7 `_fresh_query` → 3 canonical helpers)** — converted the vector copies to
thin wrappers over `factories.create_dataset`, extending it with the
optional fields each file needed (every field applies only when passed, so
existing callers are unaffected). Added `factories.create_raster_dataset`
for the 10 raster copies, which had three different return shapes (`Dataset`,
`dataset.id`, or a `(record, dataset, raster_asset)` tuple) and divergent
`RasterAsset` field sets; its `theme_category` stays `NULL` unless a caller
explicitly sets it, unlike the vector factory, since several raster callers
depend on that. Moved the AUTOCOMMIT-connection `_fresh_query` helper (needed
because subprocess alembic commits outside the test session's transaction)
into `alembic_helpers.py`.

Diffing the vector copies against the extended factory surfaced a real bug
before it shipped: the factory's own `theme_category` default of `["test"]`
changed an OGC API response's `"keywords"` field for six files that
previously left it `NULL`. Caught by a real test failure, fixed by passing
`theme_category=[]` explicitly in those wrappers.

**6. `_create_test_user` (private-in-conftest, imported by ~25 files) → 1
public factory** — moved its body to `tests/factories.py` as `create_user`;
`conftest.py` keeps `_create_test_user = create_user` so every existing
`from tests.conftest import _create_test_user` site keeps working unchanged.

## Verification

- `cd backend && uv run ruff check tests && uv run ruff format tests --check` — pass across all 518 files
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q` — 40 passed (run after every commit)
- Per-finding and cumulative smoke runs after every commit: 1,062 tests collected with zero import errors across every touched file; full execution passed for all of them, including a broad slice re-run after rebasing onto four commits that landed on `main` mid-work (two of which relocated modules these tests import — no behavior change, verified empirically)