### PR TITLE
refactor(stac): route raster-asset reads through CatalogPort

### DIFF
--- a/backend/app/core/catalog_port.py
+++ b/backend/app/core/catalog_port.py
@@ -269,6 +269,19 @@ class CatalogPort(Protocol):
         self, session: AsyncSession, dataset_ids: list[uuid.UUID]
     ) -> dict[str, dict[str, Any]]: ...
 
+    # The same rows without the VRT assembly fields. `vrt_type` is forwarded to
+    # a record's properties when present (search/service_records.py), and the
+    # STAC item surface must not grow that property — so its reader asks for
+    # the narrower answer rather than trimming the wider one.
+    #
+    # A separate method rather than an `include_vrt` keyword on the call above:
+    # widening an existing port method's signature is an EXTENSION_API_VERSION
+    # bump under platform/extensions/version.py (the 2 -> 3 entry bumped for
+    # exactly that shape), while an additive method is explicitly not.
+    async def fetch_raster_meta_bulk_without_vrt(
+        self, session: AsyncSession, dataset_ids: list[uuid.UUID]
+    ) -> dict[str, dict[str, Any]]: ...
+
     # How many members ONE generation is assembling. fix(#1327): that is the
     # attempt's intended set, which for a source add/remove is not what the VRT
     # is serving until the attempt publishes — so this is a fact about the

--- a/backend/app/core/catalog_port.py
+++ b/backend/app/core/catalog_port.py
@@ -274,10 +274,13 @@ class CatalogPort(Protocol):
     # STAC item surface must not grow that property — so its reader asks for
     # the narrower answer rather than trimming the wider one.
     #
-    # A separate method rather than an `include_vrt` keyword on the call above:
-    # widening an existing port method's signature is an EXTENSION_API_VERSION
-    # bump under platform/extensions/version.py (the 2 -> 3 entry bumped for
-    # exactly that shape), while an additive method is explicitly not.
+    # REQUIRED, which is why EXTENSION_API_VERSION went 5 -> 6: every STAC
+    # item and item-page response calls it, so an overlay that replaces the
+    # `catalog_port` slot without it serves AttributeError instead of a page.
+    # A separate method rather than an `include_vrt` keyword on the call above
+    # because widening an existing port method's signature is a bump under the
+    # same rule (the 2 -> 3 entry), and this shape keeps the wider reading
+    # working unchanged for the callers that need `vrt_type`.
     async def fetch_raster_meta_bulk_without_vrt(
         self, session: AsyncSession, dataset_ids: list[uuid.UUID]
     ) -> dict[str, dict[str, Any]]: ...

--- a/backend/app/platform/extensions/defaults_catalog_port.py
+++ b/backend/app/platform/extensions/defaults_catalog_port.py
@@ -419,6 +419,11 @@ class DefaultCatalogPort:
 
         return await fetch_raster_meta_bulk(session, dataset_ids)
 
+    async def fetch_raster_meta_bulk_without_vrt(self, session, dataset_ids):  # type: ignore[no-untyped-def]
+        from app.processing.raster.queries import fetch_raster_meta_bulk
+
+        return await fetch_raster_meta_bulk(session, dataset_ids, include_vrt=False)
+
     async def get_vrt_generation_source_count(self, session, generation_id):  # type: ignore[no-untyped-def]
         from sqlalchemy import select
 

--- a/backend/app/platform/extensions/version.py
+++ b/backend/app/platform/extensions/version.py
@@ -72,7 +72,18 @@ logger = logging.getLogger(__name__)
 # comments defer "until the next EXTENSION_API_VERSION bump" are NOT removed
 # here — that removal is a separate change with its own review, and a bump
 # forced by an unrelated Protocol addition is not the occasion for it.
-EXTENSION_API_VERSION: int = 5
+#
+# 5 -> 6 (refactor(stac)): CatalogPort gained a required
+# ``fetch_raster_meta_bulk_without_vrt`` method — the raster-meta read narrowed
+# to what a STAC Item may carry, now that the STAC router reads through the
+# port instead of importing processing ORM. Every item and item-page response
+# calls it, including an empty page, so an overlay that replaces the
+# ``catalog_port`` slot without it would load cleanly at version 5 and then
+# raise AttributeError on the first STAC request. The additive shape is not an
+# exemption here: the "do NOT bump for new optional methods" carve-out above
+# means methods with a default no-op, and a Protocol method a structural
+# implementer must supply is required by definition.
+EXTENSION_API_VERSION: int = 6
 
 
 def check_extension_api_version(name: str, declared_version: int | None) -> None:

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -49,7 +49,7 @@ from app.modules.catalog.datasets.domain.models import (
 from app.modules.catalog.features.service import parse_bbox
 from app.core.dependencies import get_db
 from app.core.public_urls import get_public_api_url, get_public_app_url
-from app.processing.raster.models import DatasetAsset, RasterAsset
+from app.platform.extensions import get_catalog_port
 from app.standards.ogc.errors import ERROR_RESPONSES_PUBLIC, NOT_FOUND_RESPONSE
 from app.standards.ogc.utils import (
     content_language_for_record_languages,
@@ -218,10 +218,8 @@ async def _fetch_dataset_asset_rows(
     """Bulk-fetch DatasetAsset rows grouped by dataset ID."""
     if not dataset_ids:
         return {}
-    da_stmt = select(DatasetAsset).where(DatasetAsset.dataset_id.in_(dataset_ids))
-    da_result = await db.execute(da_stmt)
     by_dataset: dict[str, list[dict]] = {}
-    for da in da_result.scalars().all():
+    for da in await get_catalog_port().list_dataset_assets(db, dataset_ids):
         ds_key = str(da.dataset_id)
         by_dataset.setdefault(ds_key, []).append(
             {
@@ -242,12 +240,11 @@ async def _fetch_raster_meta(
 ) -> dict[str, dict]:
     """Bulk-fetch raster metadata for a set of dataset IDs.
 
-    Delegates to the shared raster/queries helper (KISS-6). STAC items don't
-    need vrt_type/resolution_strategy at this layer, so include_vrt=False.
+    Reads the shared raster query through CatalogPort (KISS-6). STAC items
+    don't need vrt_type/resolution_strategy at this layer, which is what the
+    port's ``_without_vrt`` reader means.
     """
-    from app.processing.raster.queries import fetch_raster_meta_bulk
-
-    return await fetch_raster_meta_bulk(db, dataset_ids, include_vrt=False)
+    return await get_catalog_port().fetch_raster_meta_bulk_without_vrt(db, dataset_ids)
 
 
 # fix(#1108 review): sentinel distinguishing "the page loop did not precompute
@@ -728,6 +725,7 @@ async def get_collections(
             return result
 
     async def _fetch_projection_codes() -> dict[str, list[str]]:
+        RasterAsset = get_catalog_port().raster_asset_orm_class()
         epsg_stmt = (
             select(
                 CollectionDataset.collection_id,
@@ -935,6 +933,7 @@ async def get_collection(
             return result or None
 
     async def _fetch_projection() -> dict | None:
+        RasterAsset = get_catalog_port().raster_asset_orm_class()
         projection_stmt = (
             select(func.distinct(RasterAsset.epsg))
             .join(Dataset, Dataset.id == RasterAsset.dataset_id)

--- a/backend/tests/test_catalog_port.py
+++ b/backend/tests/test_catalog_port.py
@@ -1,0 +1,47 @@
+"""CatalogPort contract tests.
+
+Mirrors ``test_processing_port.py``'s conformance shape for the sibling port:
+the community default satisfies the Protocol, and a method the Protocol
+requires is genuinely required — which is what an ``EXTENSION_API_VERSION``
+bump exists to make the loader refuse at boot.
+"""
+
+from __future__ import annotations
+
+from app.core.catalog_port import CatalogPort
+from app.platform.extensions.defaults import DefaultCatalogPort
+
+
+def test_default_catalog_port_satisfies_the_contract() -> None:
+    assert isinstance(DefaultCatalogPort(), CatalogPort)
+
+
+def test_a_port_missing_the_narrow_raster_meta_read_does_not_satisfy_the_contract() -> (
+    None
+):
+    """refactor(stac): why EXTENSION_API_VERSION went 5 -> 6.
+
+    ``fetch_raster_meta_bulk_without_vrt`` is a REQUIRED method, not an
+    optional one. Every STAC item and item-page response reads raster metadata
+    through it — including an empty page — so an overlay that replaces the
+    ``catalog_port`` slot without it would answer AttributeError instead of a
+    page. The loader has to refuse such an overlay at boot, and the version
+    bump is what makes it refuse.
+
+    The overlay that ships today is unaffected either way: it wraps the prior
+    implementation as a pure ``__getattr__`` delegate and so inherits the
+    method. This test is about the ones that do not.
+    """
+
+    class _OverlayPortWithoutIt:
+        """Everything the default offers, minus the one method under test."""
+
+        def __init__(self) -> None:
+            self._inner = DefaultCatalogPort()
+
+        def __getattr__(self, name):  # type: ignore[no-untyped-def]
+            if name == "fetch_raster_meta_bulk_without_vrt":
+                raise AttributeError(name)
+            return getattr(self._inner, name)
+
+    assert not isinstance(_OverlayPortWithoutIt(), CatalogPort)

--- a/backend/tests/test_extension_api_version.py
+++ b/backend/tests/test_extension_api_version.py
@@ -60,13 +60,22 @@ class TestExtensionApiVersionConstant:
         swap call it inside their write transactions whenever the modality
         they measured differs from the stored one, so an overlay that replaces
         the ``processing_port`` key without it raises AttributeError mid-write
-        instead of being refused at boot.
+        instead of being refused at boot. v6 adds the required
+        ``fetch_raster_meta_bulk_without_vrt`` method to ``CatalogPort``
+        (refactor(stac)), the same case on the sibling port: the STAC router
+        reads raster metadata through it on every item and item-page response,
+        including an empty page, so an overlay that replaces the
+        ``catalog_port`` key without it answers AttributeError instead of a
+        page. Being additive is not an exemption — the convention's
+        "new optional methods" carve-out means methods with a default no-op,
+        and a Protocol method a structural implementer must supply is
+        required.
 
         Update this pin, and the note above it, whenever the constant moves.
         """
         from app.platform.extensions.version import EXTENSION_API_VERSION
 
-        assert EXTENSION_API_VERSION == 5
+        assert EXTENSION_API_VERSION == 6
 
 
 class TestCheckExtensionApiVersion:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1771,7 +1771,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # reupload_service.
         # feat(#1266): +5 — the STAC re-resolution task delegation, the third
         # instance of that same three-line shape. Cap 440 -> 445.
-        "backend/app/platform/extensions/defaults_catalog_port.py": 445,
+        # refactor(stac): +5 — fetch_raster_meta_bulk_without_vrt, the narrower
+        # reading of the raster-meta query the STAC item surface takes. Same
+        # deferred-import shape as its sibling; a separate method rather than a
+        # keyword because widening a port signature is an
+        # EXTENSION_API_VERSION bump. Cap 445 -> 450.
+        "backend/app/platform/extensions/defaults_catalog_port.py": 450,
         # feat(#683): +58 — run_analysis_preview carries a clip mask DATASET
         # now, which costs a widened signature (one param per line once ruff
         # wraps it) plus the mask's shape and size gates. Those live here on
@@ -2863,7 +2868,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1432): -15 — the two inline bbox parsers and
     # _require_finite_bbox collapse onto the shared parse_bbox, which now takes
     # the POST list as well as the GET string. Cap 1870 -> 1855, still exact.
-    "backend/app/standards/stac/router.py": 1855,
+    # refactor(stac): -1 — the raster-asset reads go through CatalogPort, so
+    # the DatasetAsset select and the deferred raster-queries import give way
+    # to port calls. Cap 1855 -> 1854, still exact.
+    "backend/app/standards/stac/router.py": 1854,
     # Central tenant-bound scope resolution replaced duplicated inline logic.
     # fix(#836): +1 — the RASTER_FAMILY_RECORD_TYPES import that replaces four
     # pasted family literals. Same +1 on the stac and search routers.

--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -3969,7 +3969,20 @@ class TestInternalAssetKeysNeverReachAnyResponse:
                 for node in ast.walk(ast.parse(src))
                 if isinstance(node, ast.Attribute)
             }
-            if not names & {"is_public_asset_key", "_build_stac_assets"}:
+            # `build_assets` is the public facade over `_build_stac_assets` and
+            # is how a module outside search/ names the delegation — it hands
+            # `stac_asset_rows` straight to the private builder and consumes
+            # them nowhere else. refactor(stac): the STAC router reached this
+            # gate only once its DatasetAsset fetch moved onto the port; before
+            # that it hand-rolled `select(DatasetAsset)` and matched neither
+            # fetch name, so the guard never looked at it. That blind spot —
+            # fetching without naming the seam — is what the docstring above
+            # calls "a fourth is a normal thing to add".
+            if not names & {
+                "is_public_asset_key",
+                "_build_stac_assets",
+                "build_assets",
+            }:
                 offenders.append(str(path))
         assert offenders == [], (
             "these modules turn dataset_assets rows into payloads without "

--- a/backend/tests/test_standards_layering.py
+++ b/backend/tests/test_standards_layering.py
@@ -1,0 +1,102 @@
+"""Standards-layer import guard: ``backend/app/standards/`` may not reach into
+``app.processing.*``.
+
+``test_layering.py::test_no_catalog_imports_processing`` holds
+``backend/app/modules/catalog/`` to a strict zero on ``app.processing``
+references, and catalog pays a real ergonomic cost to honor it (see the
+comment at ``catalog/sources/preview.py``). ``standards/`` was never held to
+the same rule, so the STAC router welded catalog ORM to processing ORM in one
+module — the backend's largest router acting as an unguarded bridge between
+two domains that are otherwise kept apart. A rename in
+``processing/raster/models.py`` broke STAC output with no layering signal.
+
+The rule is the same one catalog follows: processing-owned ORM classes,
+queries, and helpers are reached through ``CatalogPort``
+(``app.core.catalog_port``), whose community implementation defers every
+``app.processing`` import into a method body.
+
+This walks the AST rather than grepping, for two reasons: an import is a
+syntactic fact and a comment mentioning the module name is not one, and
+``git grep`` is blind to files that are not yet tracked. Both module-scope
+and function-scope imports count — a deferred import inside a function is the
+exact shape this guard exists to catch.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+STANDARDS_ROOT = BACKEND_ROOT / "app" / "standards"
+
+# Both spellings resolve to the same package; the second is how the repo is
+# imported when `backend/` itself is on the path.
+_BANNED_ROOTS = ("app.processing", "backend.app.processing")
+
+
+def _is_banned(module: str | None) -> bool:
+    if not module:
+        return False
+    return any(
+        module == root or module.startswith(f"{root}.") for root in _BANNED_ROOTS
+    )
+
+
+def _absolute_module(path: Path, node: ast.ImportFrom) -> str | None:
+    """Resolve ``node``'s target to a dotted module name.
+
+    A relative import states its target as a hop count plus a suffix, so
+    ``from ...processing.raster.models import RasterAsset`` inside
+    ``app/standards/stac/`` names the banned package without spelling it.
+    Resolve against the file's own package so the guard reads the target, not
+    the syntax used to write it.
+    """
+    if node.level == 0:
+        return node.module
+
+    package = path.parent.relative_to(BACKEND_ROOT).parts
+    # level 1 is the containing package, level 2 its parent, and so on.
+    trimmed = package[: len(package) - (node.level - 1)]
+    if not trimmed:
+        # Climbs past the `app` package root — not a resolvable target.
+        return None
+    parts = [*trimmed, *(node.module.split(".") if node.module else [])]
+    return ".".join(parts)
+
+
+def _processing_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    rel = path.relative_to(BACKEND_ROOT.parent)
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_banned(alias.name):
+                    offenders.append(f"{rel}:{node.lineno}: import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            module = _absolute_module(path, node)
+            if _is_banned(module):
+                names = ", ".join(alias.name for alias in node.names)
+                offenders.append(f"{rel}:{node.lineno}: from {module} import {names}")
+    return offenders
+
+
+@pytest.mark.architecture
+def test_standards_does_not_import_processing() -> None:
+    """No module under ``app/standards/`` imports ``app.processing`` at any scope."""
+    offenders: list[str] = []
+    for path in sorted(STANDARDS_ROOT.rglob("*.py")):
+        offenders.extend(_processing_imports(path))
+
+    assert not offenders, (
+        "backend/app/standards/ imports app.processing directly. Processing-owned "
+        "ORM classes, queries, and helpers must be reached through CatalogPort "
+        "(app.core.catalog_port) — get_catalog_port().raster_asset_orm_class() for "
+        "query construction, or a port read method for a whole answer. This is the "
+        "rule backend/app/modules/catalog/ already follows "
+        "(test_layering.py::test_no_catalog_imports_processing). Offending "
+        "imports:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## What

`backend/app/standards/stac/router.py` reached into processing-owned ORM directly: `from app.processing.raster.models import DatasetAsset, RasterAsset` at module scope, plus a deferred `from app.processing.raster.queries import fetch_raster_meta_bulk` inside a helper. All four read sites now go through `CatalogPort`, the same seam `backend/app/modules/catalog/` uses for the same data.

| Read site | Before | After |
| --- | --- | --- |
| `_fetch_dataset_asset_rows` | `select(DatasetAsset).where(...)` | `get_catalog_port().list_dataset_assets(...)` |
| `_fetch_raster_meta` | `fetch_raster_meta_bulk(db, ids, include_vrt=False)` | `get_catalog_port().fetch_raster_meta_bulk_without_vrt(...)` |
| `_fetch_projection_codes` (collections list) | module-scope `RasterAsset` | `get_catalog_port().raster_asset_orm_class()` |
| `_fetch_projection` (single collection) | module-scope `RasterAsset` | `get_catalog_port().raster_asset_orm_class()` |

## Why

`test_layering.py::test_no_catalog_imports_processing` holds `backend/app/modules/catalog/` to a strict zero on `app.processing` references, and catalog pays a real ergonomic cost to honor it. `standards/` was never held to the same rule, so the backend's largest router sat between the two domains as an unguarded bridge welding catalog ORM to processing ORM. A refactor of `processing/raster/models.py` broke STAC output with no layering signal — the failure showed up as wrong STAC responses rather than as a gate.

## No output-shape change, and how that was verified

Pure read-path indirection. The SQL is unchanged: the port's `list_dataset_assets` issues the same `select(DatasetAsset).where(dataset_id.in_(...))` the router had inline, and the two projection queries are byte-identical with the ORM class resolved through the port instead of imported.

- Full STAC suite before the change: **282 passed**. After: **283 passed** (282 + the new structural pin). No test changed its expectations.
- `dump_openapi.py --check` exits 0 — no schema drift, no SDK regeneration.

The one narrowing that is load-bearing is `include_vrt=False`: `vrt_type` becomes an item property when present (`search/service_records.py`), so a STAC Item would grow a property if the reader took the wider answer. That is why the new port method exists rather than the existing one being reused.

## Port compatibility and the version bump

`fetch_raster_meta_bulk_without_vrt` is an **additive method** rather than an `include_vrt` keyword on the existing `fetch_raster_meta_bulk`, because widening an existing port method's signature is a bump under `platform/extensions/version.py` (the 2 -> 3 entry) and because it leaves the wider reading working unchanged for the callers that need `vrt_type`.

The additive shape is **not** an exemption from the bump, which review round 1 correctly caught. `EXTENSION_API_VERSION` goes **5 -> 6**: the method is required, not optional. Every STAC item and item-page response calls it — including an empty page — so an overlay that replaces the `catalog_port` slot without it would load cleanly at version 5 and then raise `AttributeError` on the first STAC request. The "do NOT bump for new optional methods" carve-out means methods carrying a default no-op; a Protocol method a structural implementer must supply is required by definition. That is the same reading that took the constant 4 -> 5 for `reconcile_distributions`.

`test_catalog_port.py` states it as a test, mirroring the 4 -> 5 precedent: a port missing the method does not satisfy `CatalogPort`, so the loader refuses the overlay at boot rather than serving an AttributeError later.

Worth noting for whoever updates the overlay packages: the only overlay that claims the `catalog_port` slot wraps the prior implementation as a pure `__getattr__` delegate, so it inherits the new method regardless of what version it declares.

## Structural pin

New `backend/tests/test_standards_layering.py` walks every module under `backend/app/standards/` as an AST and fails on any `app.processing` import at module **or** function scope. AST rather than `git grep` for two reasons: an import is a syntactic fact where a comment mentioning the module name is not, and `git grep` is blind to untracked files. Relative imports are resolved against the file's own package, so `from ...processing.raster.models import ...` is caught too.

On the pre-change tree it fails, naming both offenders:

```
backend/app/standards/stac/router.py:52: from app.processing.raster.models import DatasetAsset, RasterAsset
backend/app/standards/stac/router.py:248: from app.processing.raster.queries import fetch_raster_meta_bulk
```

After the change it passes, and `rg "app\.processing" backend/app/standards` returns nothing.

## One guard widened, deliberately

`test_raster_replace_1221.py::test_every_dataset_asset_consumer_crosses_the_boundary` pins that any module fetching `DatasetAsset` rows either applies the `is_public_asset_key` allowlist itself or delegates to the builder that does, so internal keys like `archived_original:*` cannot reach a response. Moving the STAC fetch onto the port brought that router into the guard's scope **for the first time** — it previously hand-rolled `select(DatasetAsset)` and matched neither fetch name, so the guard never looked at it.

The router does cross the boundary: its rows go only to `dataset_to_ogc_record` and `build_assets`, and both hand them to `_build_stac_assets`, which drops every non-public key. Nothing iterates the rows into a payload on its own terms. The accepted-name set gains `build_assets` — the public facade over the private builder, and the name a module outside `search/` can actually call.

Net effect on the guard: it now inspects three modules instead of two, each crossing the boundary. It got stronger, not weaker.

## Verification

```
cd backend && uv run ruff check app tests && uv run ruff format app tests --check
set -a && source ../.env.test && set +a
uv run pytest tests/test_layering.py tests/test_standards_layering.py tests/test_catalog_port.py -q
uv run pytest tests/test_stac_*.py -q                       # 283 passed
uv run pytest tests/test_extensions.py tests/test_cloud_overlay_side_by_side.py \
  tests/test_worker_bootstrap_parity.py tests/test_worker_overlay_resolution.py \
  tests/test_entitlement_port.py tests/test_notification_port.py \
  tests/test_processing_port.py tests/test_workflow_extension.py \
  tests/test_datasets.py -q                                 # 159 passed, 12 skipped
uv run pytest tests/test_raster_replace_1221.py tests/test_vrt_catalog_175.py \
  tests/test_quicklook_predicate.py tests/test_phase_274_async_parallelization.py \
  tests/test_raster_dataset_assets_bug041.py tests/test_dp01_ingest_write_path.py -q
PYTHONPATH=. uv run python scripts/dump_openapi.py --check  # exit 0
```

LOC ratchets adjusted in the same commit: `stac/router.py` 1855 -> 1854, `defaults_catalog_port.py` 445 -> 450, both exact with a comment saying what the lines bought.

Backend-audit follow-up (F7).