### PR TITLE
docs: link The Spatial Net from the Community section

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -358,6 +358,7 @@ API und Worker exportieren sofort Prometheus-Metriken (HTTP-Rate/Latenz/Fehler, 
 - [GitHub Discussions](https://github.com/geolens-io/geolens/discussions): Fragen, Ideen und Präsentationen
 - [Support](SUPPORT.md): Hilfe und Weiterleitung von Problemen
 - [Beitragsleitfaden](.github/CONTRIBUTING.md): Entwicklungsumgebung, Codestil und PR-Richtlinien
+- [The Spatial Net](https://thespatial.net): eine kostenlose, werbefreie Community-Website, die ich ebenfalls betreibe, mit offenen Gehaltsdaten für Geo-Berufe, einer Jobbörse und Community-Events auf einer Karte. Anderes Projekt, dieselben Leute.
 
 ## Bekannte Einschränkungen
 

--- a/README.es.md
+++ b/README.es.md
@@ -359,6 +359,7 @@ La API y el worker exportan métricas Prometheus de serie (tasa/latencia/errores
 - [GitHub Discussions](https://github.com/geolens-io/geolens/discussions): preguntas, ideas y demostraciones
 - [Soporte](SUPPORT.md): dónde pedir ayuda y cómo se canalizan los problemas
 - [Guía de contribución](.github/CONTRIBUTING.md): configuración de desarrollo, estilo de código y directrices para PRs
+- [The Spatial Net](https://thespatial.net): un sitio comunitario gratuito y sin anuncios que también mantengo, con datos salariales abiertos para perfiles geoespaciales, un tablón de empleo y eventos de la comunidad en un mapa. Proyecto distinto, la misma gente.
 
 ## Limitaciones conocidas
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -358,6 +358,7 @@ L’API et le worker exportent nativement des métriques Prometheus (taux/latenc
 - [GitHub Discussions](https://github.com/geolens-io/geolens/discussions) : questions, idées et présentations
 - [Assistance](SUPPORT.md) : où demander de l’aide et comment les problèmes sont orientés
 - [Guide de contribution](.github/CONTRIBUTING.md) : environnement de développement, style et règles de PR
+- [The Spatial Net](https://thespatial.net) : un site communautaire gratuit et sans publicité que je maintiens également, avec des données de rémunération ouvertes pour les métiers du géospatial, un tableau d’offres d’emploi et les événements de la communauté sur une carte. Projet différent, les mêmes personnes.
 
 ## Limitations connues
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ see [RUNBOOK.md §4](RUNBOOK.md#4-monitoring) for the setup steps.
 - [GitHub Discussions](https://github.com/geolens-io/geolens/discussions): questions, ideas, show and tell
 - [Support](SUPPORT.md): where to ask for help and how problems get routed
 - [Contributing Guide](.github/CONTRIBUTING.md): development setup, code style, and PR guidelines
+- [The Spatial Net](https://thespatial.net): a free, ad-free community site I also run, with open pay data for geospatial roles, a jobs board, and community events on a map. Different project, same people.
 
 ## Known limitations
 


### PR DESCRIPTION
One bullet added to the Community list in all four READMEs (en/es/fr/de).

```
- [The Spatial Net](https://thespatial.net): a free, ad-free community site I also
  run, with open pay data for geospatial roles, a jobs board, and community events
  on a map. Different project, same people.
```

## Why this wording and this placement

**"I also run" is doing the work.** It discloses the relationship rather than implying an endorsement, and it is the reason this belongs in **Community** and not in the header, the hero, or the badge row. A README earns trust by being documentation; a promo block in one costs more than the referral is worth.

**Translated rather than English-only.** The es/fr/de Community bullets are already localised, so a lone English line would be visible drift. The French line follows that file's existing space-before-colon convention. ⚠️ **A native read on the three translations is still worth doing** — they are mine, not a translator's.

## Context

The GeoLens r/gis post sits at ~26 upvotes / 14K views with uniformly positive comments, and there is currently no path from any of it to The Spatial Net. Same audience: open-source-friendly, Esri-skeptical geospatial practitioners.

There is also a specific reason to land this **before** The Spatial Net's own announcement rather than after: somebody in that thread will connect the two projects and ask about the relationship. Better the link already exists in both places than that the first public statement of it is the maintainer explaining himself in a comment.

## Deliberately NOT included

**The app footer.** `frontend/src/components/layout/AppFooter.tsx` is an i18n'd component wired through `external-links.ts` and `t('footer.*')`, and it ships in the **self-hosted product**, not only the demo. Adding a cross-promo link there would put a link to another of the maintainer's sites into the footer of every self-hosted GeoLens deployment. That is a product decision about what an Apache-2.0 self-hosted install shows its own users, not a copy change, and it is exactly the sort of thing the audience that made this project land would notice. Raising it rather than doing it.