### PR TITLE
fix(api): correct sprite-route error contract; dedupe test helpers

### DIFF
--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -41,6 +41,7 @@ from app.processing.ingest.router import router as ingest_router
 from app.platform.jobs.router import router as jobs_router
 from app.modules.catalog.layers.router import layers_router
 from app.modules.catalog.maps.router import router as maps_router
+from app.modules.catalog.maps.router_assets import sprites_router as maps_sprites_router
 from app.standards.ogc.router import ogc_features_router, ogc_router
 from app.modules.catalog.records.router import router as records_router
 from app.modules.catalog.search.router import collections_router, search_router
@@ -87,6 +88,10 @@ api_router.include_router(collections_crud_router)
 api_router.include_router(ogc_features_router)
 
 api_router.include_router(maps_router)
+# fix: sprites are unauthenticated reads; mounted as a sibling of maps_router
+# (not nested inside it) so they don't inherit its ERROR_RESPONSES_WRITE
+# defaults — see the comment on sprites_router in maps/router_assets.py.
+api_router.include_router(maps_sprites_router)
 api_router.include_router(ai_router)
 # feat(#565): raw sandbox SQL endpoint (POST /query/), consumed by the MCP
 # `query` tool. Auth-only; see processing/ai/query_router.py.

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -88,9 +88,10 @@ api_router.include_router(collections_crud_router)
 api_router.include_router(ogc_features_router)
 
 api_router.include_router(maps_router)
-# fix: sprites are unauthenticated reads; mounted as a sibling of maps_router
-# (not nested inside it) so they don't inherit its ERROR_RESPONSES_WRITE
-# defaults — see the comment on sprites_router in maps/router_assets.py.
+# fix(#1440): sprites are unauthenticated reads; mounted as a sibling of
+# maps_router (not nested inside it) so they don't inherit its
+# ERROR_RESPONSES_WRITE defaults — see the comment on sprites_router in
+# maps/router_assets.py.
 api_router.include_router(maps_sprites_router)
 api_router.include_router(ai_router)
 # feat(#565): raw sandbox SQL endpoint (POST /query/), consumed by the MCP

--- a/backend/app/modules/catalog/maps/router_assets.py
+++ b/backend/app/modules/catalog/maps/router_assets.py
@@ -21,7 +21,7 @@ from app.modules.catalog.maps.sprites import (
     get_icon_content,
     list_icons,
 )
-from app.standards.ogc.errors import FORBIDDEN_RESPONSE
+from app.standards.ogc.errors import ERROR_RESPONSES_PUBLIC, FORBIDDEN_RESPONSE
 
 router = APIRouter()
 
@@ -88,7 +88,21 @@ async def get_map_icon_asset_endpoint(
     return Response(content=content, media_type=media_type, headers=headers)
 
 
-@router.get("/sprites/geolens.json", responses={403: FORBIDDEN_RESPONSE})
+# Sprites are anonymous, unauthenticated reads (MapLibre fetches them before any
+# auth context exists). FastAPI's `responses=` merge is additive along the whole
+# include chain — a route only ever gains keys from an ancestor router, never
+# loses one — so nesting this router under `router` (in turn nested under the
+# maps router's `responses=ERROR_RESPONSES_WRITE`) would still leak a 401/403/409
+# these routes can never emit. `sprites_router` is therefore mounted directly on
+# `api_router` in api/router.py, as a sibling of the maps router rather than a
+# descendant, carrying its own `/maps` prefix so the published paths are
+# unchanged.
+sprites_router = APIRouter(
+    prefix="/maps", tags=["Maps"], responses=ERROR_RESPONSES_PUBLIC
+)
+
+
+@sprites_router.get("/sprites/geolens.json")
 async def get_geolens_sprite_index_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> SpriteIndex:
@@ -96,11 +110,7 @@ async def get_geolens_sprite_index_endpoint(
     return await build_sprite_index(db)
 
 
-@router.get(
-    "/sprites/geolens@2x.json",
-    include_in_schema=False,
-    responses={403: FORBIDDEN_RESPONSE},
-)
+@sprites_router.get("/sprites/geolens@2x.json", include_in_schema=False)
 async def get_geolens_sprite_index_2x_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> SpriteIndex:
@@ -108,7 +118,7 @@ async def get_geolens_sprite_index_2x_endpoint(
     return await build_sprite_index(db)
 
 
-@router.get("/sprites/geolens.png")
+@sprites_router.get("/sprites/geolens.png")
 async def get_geolens_sprite_png_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
@@ -120,7 +130,7 @@ async def get_geolens_sprite_png_endpoint(
     )
 
 
-@router.get("/sprites/geolens@2x.png", include_in_schema=False)
+@sprites_router.get("/sprites/geolens@2x.png", include_in_schema=False)
 async def get_geolens_sprite_png_2x_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> Response:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -44442,27 +44442,7 @@
                 }
               }
             },
-            "description": "Bad request \u2014 invalid payload"
-          },
-          "401": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unauthorized \u2014 missing or invalid credentials"
-          },
-          "403": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Forbidden \u2014 caller lacks access to this resource"
+            "description": "Bad request \u2014 invalid query parameters or payload"
           },
           "404": {
             "content": {
@@ -44473,16 +44453,6 @@
               }
             },
             "description": "Not found"
-          },
-          "409": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Conflict \u2014 resource state prevents the operation"
           },
           "422": {
             "content": {
@@ -44561,27 +44531,7 @@
                 }
               }
             },
-            "description": "Bad request \u2014 invalid payload"
-          },
-          "401": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unauthorized \u2014 missing or invalid credentials"
-          },
-          "403": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Forbidden \u2014 caller lacks write access"
+            "description": "Bad request \u2014 invalid query parameters or payload"
           },
           "404": {
             "content": {
@@ -44592,16 +44542,6 @@
               }
             },
             "description": "Not found"
-          },
-          "409": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Conflict \u2014 resource state prevents the operation"
           },
           "422": {
             "content": {

--- a/backend/tests/test_dormant_tenancy_migration_roundtrip.py
+++ b/backend/tests/test_dormant_tenancy_migration_roundtrip.py
@@ -28,8 +28,6 @@ Notes
   project memory note on concurrent DB probes.
 """
 
-from pathlib import Path
-
 import pytest
 import sqlalchemy as sa
 from tests.alembic_helpers import (
@@ -41,9 +39,6 @@ from tests.alembic_helpers import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_BACKEND_DIR = Path(__file__).parent.parent.resolve()
-_ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
 
 _FOUR_PARTIAL_INDEXES = {
     "uq_users_username_global",

--- a/backend/tests/test_email_verification_migration.py
+++ b/backend/tests/test_email_verification_migration.py
@@ -22,8 +22,6 @@ Notes
             uv run pytest tests/test_email_verification_migration.py -x -q
 """
 
-from pathlib import Path
-
 import pytest
 from tests.alembic_helpers import (
     enterprise_migrations_present,
@@ -34,10 +32,6 @@ from tests.alembic_helpers import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_BACKEND_DIR = Path(__file__).parent.parent.resolve()
-_ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
-
 
 _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
     enterprise_migrations_present(),

--- a/backend/tests/test_embedding_vector_migration.py
+++ b/backend/tests/test_embedding_vector_migration.py
@@ -32,7 +32,6 @@ Notes
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
@@ -45,9 +44,6 @@ from tests.alembic_helpers import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_BACKEND_DIR = Path(__file__).parent.parent.resolve()
-_ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
 
 _PRE_TYPED_REVISION = "0011_allow_generic_geometry_type"
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1917,7 +1917,7 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # are read-gated (icon asset) or unauthenticated (sprite index), so the
     # router's inherited write-flavored 403 misdescribed their actual cause.
     # Cap 126 -> 132, exact.
-    # fix: +10 — the sprite-index override above only reworded the 403; the
+    # fix(#1440): +10 — the sprite-index override above only reworded the 403; the
     # sprite JSON and PNG routes take no auth at all, so no 401/403/409 can
     # occur regardless of description. FastAPI's router `responses=` merge is
     # additive along the whole include chain (an ancestor's key always shows

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1917,7 +1917,17 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # are read-gated (icon asset) or unauthenticated (sprite index), so the
     # router's inherited write-flavored 403 misdescribed their actual cause.
     # Cap 126 -> 132, exact.
-    "backend/app/modules/catalog/maps/router_assets.py": 132,
+    # fix: +10 — the sprite-index override above only reworded the 403; the
+    # sprite JSON and PNG routes take no auth at all, so no 401/403/409 can
+    # occur regardless of description. FastAPI's router `responses=` merge is
+    # additive along the whole include chain (an ancestor's key always shows
+    # through unless a route sets that same key itself), so a same-file
+    # sibling router nested under the maps router's ERROR_RESPONSES_WRITE
+    # would still leak those keys. All four sprite routes moved to
+    # `sprites_router`, mounted with ERROR_RESPONSES_PUBLIC directly on
+    # api_router (api/router.py) as a sibling of the maps router rather than
+    # a descendant. Cap 132 -> 142, exact.
+    "backend/app/modules/catalog/maps/router_assets.py": 142,
     # fix(#526 B-048): the card-route SPA-redirect fallback shell.
     # fix(#819): visibility-check owner-or-admin gate + rationale docstring.
     "backend/app/modules/catalog/maps/router_sharing.py": 387,

--- a/backend/tests/test_oauth_github_migration.py
+++ b/backend/tests/test_oauth_github_migration.py
@@ -27,8 +27,6 @@ Notes
             uv run pytest tests/test_oauth_github_migration.py -x -q
 """
 
-from pathlib import Path
-
 import pytest
 import sqlalchemy as sa
 from tests.alembic_helpers import (
@@ -40,10 +38,6 @@ from tests.alembic_helpers import (
 # ---------------------------------------------------------------------------
 # Helpers (self-contained copies — mirrors test_email_verification_migration.py)
 # ---------------------------------------------------------------------------
-
-_BACKEND_DIR = Path(__file__).parent.parent.resolve()
-_ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
-
 
 _SKIP_UNDER_OVERLAY = pytest.mark.skipif(
     enterprise_migrations_present(),

--- a/backend/tests/test_raster_tiles.py
+++ b/backend/tests/test_raster_tiles.py
@@ -25,6 +25,7 @@ from app.processing.tiles.router import (
     _raster_maxzoom_from_metadata,
 )
 
+from tests.conftest import get_auth_header
 from tests.factories import create_raster_dataset, get_user_id
 
 
@@ -271,14 +272,6 @@ class TestRasterTokenZoomMetadata:
         assert _raster_maxzoom_from_metadata(asset, None) == 17
 
 
-async def _get_auth_header(client: AsyncClient, username: str, password: str) -> dict:
-    resp = await client.post(
-        "/auth/login", data={"username": username, "password": password}
-    )
-    assert resp.status_code == 200, f"Login failed: {resp.text}"
-    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
-
-
 # ---------------------------------------------------------------------------
 # Auth-check endpoint tests
 # ---------------------------------------------------------------------------
@@ -374,7 +367,7 @@ class TestRasterAuthCheck:
             test_db_session, created_by=admin_id, visibility="private"
         )
 
-        auth_header = await _get_auth_header(
+        auth_header = await get_auth_header(
             client,
             settings.geolens_admin_username,
             settings.geolens_admin_password.get_secret_value(),
@@ -559,7 +552,7 @@ class TestRasterAuthCheck:
             headers=admin_auth_header,
         )
         assert resp.status_code == 201
-        viewer_header = await _get_auth_header(client, username, password)
+        viewer_header = await get_auth_header(client, username, password)
 
         resp = await client.get(
             "/tiles/raster-auth-check/",
@@ -687,7 +680,7 @@ class TestRasterAuthRbacParity:
             test_db_session, created_by=admin_id, visibility="private"
         )
 
-        admin_auth_header = await _get_auth_header(
+        admin_auth_header = await get_auth_header(
             client,
             settings.geolens_admin_username,
             settings.geolens_admin_password.get_secret_value(),
@@ -700,7 +693,7 @@ class TestRasterAuthRbacParity:
             headers=admin_auth_header,
         )
         assert resp.status_code == 201
-        viewer_header = await _get_auth_header(client, username, password)
+        viewer_header = await get_auth_header(client, username, password)
 
         # Path A: inline RBAC in raster-auth-check
         auth_check_resp = await client.get(

--- a/backend/tests/test_tenant_rls_migration.py
+++ b/backend/tests/test_tenant_rls_migration.py
@@ -29,8 +29,6 @@ Notes
     uv run pytest tests/test_tenant_rls_migration.py -x -q
 """
 
-from pathlib import Path
-
 import pytest
 import sqlalchemy as sa
 from tests.alembic_helpers import (
@@ -42,9 +40,6 @@ from tests.alembic_helpers import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_BACKEND_DIR = Path(__file__).parent.parent.resolve()
-_ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
 
 _RLS_TABLES = [
     "users",

--- a/backend/tests/test_vector_tile_auth.py
+++ b/backend/tests/test_vector_tile_auth.py
@@ -128,14 +128,6 @@ async def _cleanup_data_table(session, table_name: str) -> None:
     await session.commit()
 
 
-async def _get_auth_header(client: AsyncClient, username: str, password: str) -> dict:
-    resp = await client.post(
-        "/auth/login", data={"username": username, "password": password}
-    )
-    assert resp.status_code == 200, f"Login failed: {resp.text}"
-    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
-
-
 # ---------------------------------------------------------------------------
 # SEC-01 regression tests
 # ---------------------------------------------------------------------------

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -30755,26 +30755,8 @@ export interface operations {
                     };
                 };
             };
-            /** @description Bad request — invalid payload */
+            /** @description Bad request — invalid query parameters or payload */
             400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized — missing or invalid credentials */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden — caller lacks access to this resource */
-            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -30784,15 +30766,6 @@ export interface operations {
             };
             /** @description Not found */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Conflict — resource state prevents the operation */
-            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -30858,26 +30831,8 @@ export interface operations {
                     "application/json": unknown;
                 };
             };
-            /** @description Bad request — invalid payload */
+            /** @description Bad request — invalid query parameters or payload */
             400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized — missing or invalid credentials */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden — caller lacks write access */
-            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -30887,15 +30842,6 @@ export interface operations {
             };
             /** @description Not found */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Conflict — resource state prevents the operation */
-            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/sdks/python/geolens/api/maps/get_geolens_sprite_index_endpoint_maps_sprites_geolens_json_get.py
+++ b/sdks/python/geolens/api/maps/get_geolens_sprite_index_endpoint_maps_sprites_geolens_json_get.py
@@ -42,25 +42,10 @@ def _parse_response(
 
         return response_400
 
-    if response.status_code == 401:
-        response_401 = ProblemDetail.from_dict(response.json())
-
-        return response_401
-
-    if response.status_code == 403:
-        response_403 = ProblemDetail.from_dict(response.json())
-
-        return response_403
-
     if response.status_code == 404:
         response_404 = ProblemDetail.from_dict(response.json())
 
         return response_404
-
-    if response.status_code == 409:
-        response_409 = ProblemDetail.from_dict(response.json())
-
-        return response_409
 
     if response.status_code == 422:
         response_422 = ProblemDetail.from_dict(response.json())

--- a/sdks/python/geolens/api/maps/get_geolens_sprite_png_endpoint_maps_sprites_geolens_png_get.py
+++ b/sdks/python/geolens/api/maps/get_geolens_sprite_png_endpoint_maps_sprites_geolens_png_get.py
@@ -32,25 +32,10 @@ def _parse_response(
 
         return response_400
 
-    if response.status_code == 401:
-        response_401 = ProblemDetail.from_dict(response.json())
-
-        return response_401
-
-    if response.status_code == 403:
-        response_403 = ProblemDetail.from_dict(response.json())
-
-        return response_403
-
     if response.status_code == 404:
         response_404 = ProblemDetail.from_dict(response.json())
 
         return response_404
-
-    if response.status_code == 409:
-        response_409 = ProblemDetail.from_dict(response.json())
-
-        return response_409
 
     if response.status_code == 422:
         response_422 = ProblemDetail.from_dict(response.json())

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -21833,25 +21833,13 @@ export type GetGeolensSpriteIndexEndpointMapsSpritesGeolensJsonGetData = {
 
 export type GetGeolensSpriteIndexEndpointMapsSpritesGeolensJsonGetErrors = {
     /**
-     * Bad request — invalid payload
+     * Bad request — invalid query parameters or payload
      */
     400: ProblemDetail;
-    /**
-     * Unauthorized — missing or invalid credentials
-     */
-    401: ProblemDetail;
-    /**
-     * Forbidden — caller lacks access to this resource
-     */
-    403: ProblemDetail;
     /**
      * Not found
      */
     404: ProblemDetail;
-    /**
-     * Conflict — resource state prevents the operation
-     */
-    409: ProblemDetail;
     /**
      * Validation error
      */
@@ -21896,25 +21884,13 @@ export type GetGeolensSpritePngEndpointMapsSpritesGeolensPngGetData = {
 
 export type GetGeolensSpritePngEndpointMapsSpritesGeolensPngGetErrors = {
     /**
-     * Bad request — invalid payload
+     * Bad request — invalid query parameters or payload
      */
     400: ProblemDetail;
-    /**
-     * Unauthorized — missing or invalid credentials
-     */
-    401: ProblemDetail;
-    /**
-     * Forbidden — caller lacks write access
-     */
-    403: ProblemDetail;
     /**
      * Not found
      */
     404: ProblemDetail;
-    /**
-     * Conflict — resource state prevents the operation
-     */
-    409: ProblemDetail;
     /**
      * Validation error
      */


### PR DESCRIPTION
## Summary

Three small residuals surfaced by this wave's own reports, bundled since each is a one- or two-file cleanup.

**Sprite-route 401/403/409 contract fix.** The four map sprite routes (`geolens.json`, `geolens@2x.json`, `geolens.png`, `geolens@2x.png`) take only `Depends(get_db)` — no auth at all — yet inherited the maps router's write-flavored `ERROR_RESPONSES_WRITE` and published a 401/403/409 contract they can never emit. PR #1434 had reworded the JSON routes' 403 to the read-flavored description, but couldn't remove it.

Investigating why a route-level `responses={}` override can't drop an inherited key led to a second finding: FastAPI's router `responses=` merge is additive along the *whole* include chain, not just the immediate parent. A same-file sibling router (`sprites_router`, built with `responses=ERROR_RESPONSES_PUBLIC`) nested under the maps router still leaked 401/403/409 through, because the maps router's `ERROR_RESPONSES_WRITE` is unioned in at every level below it for any key the descendant route doesn't itself set. Verified against the FastAPI 0.135.2 source (`_RouterIncludeContext.for_include`/`.combine`) and empirically against the generated `openapi.json`.

The fix moves the four sprite routes onto `sprites_router`, mounted with `ERROR_RESPONSES_PUBLIC` directly on `api_router` (`backend/app/api/router.py`) as a **sibling** of the maps router rather than a descendant, so the write-flavored defaults never enter the chain. Paths, tags, and operation IDs are unchanged — only the two published sprite operations' response docs changed (401/403/409 dropped, 400's wording corrected to the public-profile text). `backend/app/modules/catalog/maps/router_assets.py`'s reviewed-cap ratchet in `test_layering.py` is bumped 132 → 142 with an explanatory comment.

The icon-asset endpoint (`/maps/icons/{icon_id}/asset`) has the same unauthenticated-yet-403-documented shape but is intentionally left untouched here — out of scope for this PR, noted for a follow-up.

**Test helper dedup.** `test_raster_tiles.py` carried a local `_get_auth_header` byte-identical to the one in `test_vector_tile_auth.py` and functionally identical to `tests.conftest.get_auth_header`. `test_raster_tiles.py` now imports the shared helper (matching `test_auth.py`, `test_ingest.py`, `test_api_key_scope_875.py`). `test_vector_tile_auth.py`'s copy turned out to have zero call sites in that file (it only exercises anonymous-access denial), so it's deleted outright rather than replaced with an unused import.

**Vestigial migration-test constants.** `_BACKEND_DIR`/`_ALEMBIC_INI` in five migration test files were dead — leftover from a guard that predates the current `alembic_helpers`-based approach. Removed, along with the now-unused `pathlib.Path` import each was the sole user of.

## Contract impact

`backend/openapi.json`, both SDKs, and `frontend/src/types/api.generated.ts` are regenerated. The only behavioral change is documentation: the sprite JSON/PNG GET operations no longer claim 401/403/409 responses they could never return, and their 400 description now matches the public-endpoint wording used elsewhere (e.g. dataset export). No runtime behavior changed — verified via `test_map_sprites.py` (all 14 sprite tests) and `test_api_contract_openapi.py`.

## Verification

- `cd backend && uv run ruff check app tests && uv run ruff format app tests --check`
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q` — 40 passed
- `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_map_sprites.py tests/test_raster_tiles.py tests/test_vector_tile_auth.py tests/test_tenant_rls_migration.py tests/test_email_verification_migration.py tests/test_embedding_vector_migration.py tests/test_oauth_github_migration.py tests/test_dormant_tenancy_migration_roundtrip.py tests/test_api_contract_openapi.py -q` — 140 passed
- `make openapi-check` and `make sdks-check` (including the TypeScript SDK's own build + tests) — both pass clean