### PR TITLE
fix(tiles): key tile caches by dataset id so a reused table name cannot leak

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -49,7 +49,7 @@ from app.modules.catalog.datasets.domain.schemas import (
 )
 from app.platform.refresh.service import list_runs_for_dataset
 from app.platform.cache import get_cache, tenant_cache_key
-from app.platform.cache.provider import get_tile_cache
+from app.platform.cache.provider import get_tile_cache, notify_table_invalidated
 from app.platform.cache.tiles import invalidate_catalog_cache
 from app.modules.catalog.collections.service import get_dataset_collections
 from app.modules.catalog.datasets.domain.service import (
@@ -483,6 +483,10 @@ async def bulk_delete_datasets_endpoint(
             # Commit per-item so a later failure cannot orphan storage objects
             # that were already deleted for successfully-committed datasets.
             await db.commit()
+            # fix(#1429): only now is the delete visible to a concurrent tile
+            # request, so only now can the tile router's table_name -> metadata
+            # map be evicted without the request re-caching the deleted row.
+            notify_table_invalidated(table_name)
             results.append(
                 BulkDeleteResultItem(dataset_id=item.dataset_id, status="deleted")
             )
@@ -576,6 +580,12 @@ async def delete_dataset_endpoint(
 
     # Invalidate caches after dataset deletion
     await invalidate_catalog_cache()
+    # fix(#1429): only now is the delete visible to a concurrent tile request,
+    # so only now can the tile router's table_name -> metadata map be evicted
+    # without the request re-caching the deleted row. That map decides
+    # visibility, so a stale entry would authorize a successor drawing this
+    # freed table name under the deleted dataset's rules.
+    notify_table_invalidated(table_name)
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -194,21 +194,30 @@ async def delete_dataset(
         # it next is authorized on its own visibility while served this
         # dataset's bytes for up to tile_cache_ttl.
         #
-        # This closes the durable window, not the whole class: an in-flight
-        # tile request that already released its DB transaction can still write
-        # pre-delete bytes back after this runs, and with REDIS_URL unset each
-        # API worker holds its own LRU that a purge from one worker cannot
-        # reach. Both need a generation dimension in the cache key — #1429.
-        # Placed here rather than after the caller's commit because that
-        # ordering does not change either residual, and here it covers single
-        # delete, bulk delete, and future callers from one place. Raster/VRT
-        # are excluded — their tiles come from Titiler, and that branch drops
-        # no table to free a name.
-        from app.platform.cache.provider import get_tile_cache
+        # fix(#1429) made the purge no longer load-bearing for correctness —
+        # tile keys now carry the dataset id, so a successor drawing this name
+        # cannot read these entries whether or not the purge lands. It stays
+        # because the orphaned entries are dead weight until their TTL, and
+        # because it is what every sibling write path does. Placed here rather
+        # than after the caller's commit so single delete, bulk delete, and
+        # future callers get it from one place. Raster/VRT are excluded — their
+        # tiles come from Titiler, and that branch drops no table to free a name.
+        from app.platform.cache.provider import (
+            get_tile_cache,
+            notify_table_invalidated,
+        )
 
         tile_cache = get_tile_cache()
         if tile_cache is not None:
             await tile_cache.invalidate_table(table_name)
+
+        # fix(#1429): the tile router's process-local table_name -> metadata map
+        # decides authorization, so it must forget this name before a successor
+        # can inherit the deleted dataset's visibility. Cannot be called
+        # directly — `catalog/` must not import `app.processing.*` — so it goes
+        # through the platform listener seam. In-process only; see the note on
+        # notify_table_invalidated for what that leaves open.
+        notify_table_invalidated(table_name)
 
     # Audit trail for an irreversible operation (DROP TABLE for vector,
     # storage cleanup for raster/VRT). The DB-side row deletion is logged

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -202,22 +202,18 @@ async def delete_dataset(
         # than after the caller's commit so single delete, bulk delete, and
         # future callers get it from one place. Raster/VRT are excluded — their
         # tiles come from Titiler, and that branch drops no table to free a name.
-        from app.platform.cache.provider import (
-            get_tile_cache,
-            notify_table_invalidated,
-        )
+        from app.platform.cache.provider import get_tile_cache
 
         tile_cache = get_tile_cache()
         if tile_cache is not None:
             await tile_cache.invalidate_table(table_name)
 
-        # fix(#1429): the tile router's process-local table_name -> metadata map
-        # decides authorization, so it must forget this name before a successor
-        # can inherit the deleted dataset's visibility. Cannot be called
-        # directly — `catalog/` must not import `app.processing.*` — so it goes
-        # through the platform listener seam. In-process only; see the note on
-        # notify_table_invalidated for what that leaves open.
-        notify_table_invalidated(table_name)
+    # fix(#1429): the matching eviction of the tile router's table_name ->
+    # metadata map is NOT here, it is at the two delete endpoints after their
+    # commit. That map is populated from `catalog.datasets`, which the DROP
+    # above does not lock, so a concurrent tile request inside this still-open
+    # transaction reads the not-yet-deleted row and re-caches the dataset we
+    # just evicted. Only a commit makes the delete visible to that reader.
 
     # Audit trail for an irreversible operation (DROP TABLE for vector,
     # storage cleanup for raster/VRT). The DB-side row deletion is logged

--- a/backend/app/platform/cache/provider.py
+++ b/backend/app/platform/cache/provider.py
@@ -146,12 +146,20 @@ def get_tile_cache() -> "TileCacheProvider | InMemoryTileCacheProvider | None":
 # `app.processing.*` (test_layering.py::test_no_catalog_imports_processing),
 # but both sides may import `platform/`.
 #
-# Scope, stated plainly: listeners are in-process. A delete handled by one
-# uvicorn worker cannot evict another worker's map, so multi-worker
-# deployments keep a bounded window equal to the map's 60s TTL. That is the
-# same bounded-staleness tradeoff already documented for visibility changes in
-# processing/tiles/router.py. Closing it for every worker needs a cross-process
-# notification channel, which this codebase does not have.
+# Call this AFTER the triggering transaction commits. The map is populated
+# from `catalog.datasets`, which a dataset delete does not lock, so a notify
+# from inside the open transaction is undone by any concurrent tile request:
+# it still reads the not-yet-deleted row and re-caches what was just evicted.
+#
+# Scope, stated plainly, because two windows survive even post-commit:
+#   - Listeners are in-process. A delete handled by one uvicorn worker cannot
+#     evict another worker's map, so multi-worker deployments keep a window
+#     bounded by that map's 60s TTL.
+#   - A request whose catalog read was already in flight when the eviction ran
+#     writes its result afterwards. Bounded by one query, not by the TTL.
+# Both are the same bounded-staleness tradeoff already documented for
+# visibility changes in processing/tiles/router.py. Closing either for every
+# worker needs a cross-process notification channel this codebase lacks.
 _table_invalidation_listeners: list[Callable[[str], None]] = []
 
 

--- a/backend/app/platform/cache/provider.py
+++ b/backend/app/platform/cache/provider.py
@@ -156,10 +156,18 @@ def get_tile_cache() -> "TileCacheProvider | InMemoryTileCacheProvider | None":
 #     evict another worker's map, so multi-worker deployments keep a window
 #     bounded by that map's 60s TTL.
 #   - A request whose catalog read was already in flight when the eviction ran
-#     writes its result afterwards. Bounded by one query, not by the TTL.
+#     writes its result afterwards. The opportunity is only one query wide,
+#     but an entry that does land then lives the full TTL like any other — the
+#     narrow window buys a short race, not a short consequence.
 # Both are the same bounded-staleness tradeoff already documented for
-# visibility changes in processing/tiles/router.py. Closing either for every
-# worker needs a cross-process notification channel this codebase lacks.
+# visibility changes in processing/tiles/router.py, with one difference that
+# matters: there the stale entry describes the SAME dataset, here it can
+# describe a predecessor of a reused table name. Neither is closable by a
+# notification channel in this topology — REDIS_URL is unset by default, and
+# LISTEN/NOTIFY needs a session-pinned connection that transaction-mode
+# PgBouncer (a supported topology, see the SET LOCAL note in
+# processing/tiles/router.py) does not provide. The fix is to stop reusing
+# table names, tracked in #1443.
 _table_invalidation_listeners: list[Callable[[str], None]] = []
 
 

--- a/backend/app/platform/cache/provider.py
+++ b/backend/app/platform/cache/provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol
 
 import structlog
@@ -129,3 +130,48 @@ def get_tile_cache() -> "TileCacheProvider | InMemoryTileCacheProvider | None":
     be the cache anyone reads.
     """
     return _tile_cache
+
+
+# --- Table invalidation listeners (fix #1429) ---
+#
+# The tile router keeps a process-local map of table_name -> dataset metadata
+# so it does not hit the DB per tile request. That map is keyed on a name a
+# delete frees for reuse, so after a delete it can hand a successor dataset
+# the DELETED dataset's visibility and owner. Versioning the tile cache key
+# does not reach it: the stale entry is what decides authorization, before any
+# cache key is built.
+#
+# This is the seam that lets the catalog delete path tell the tile router to
+# drop that entry without importing it — `catalog/` must not import
+# `app.processing.*` (test_layering.py::test_no_catalog_imports_processing),
+# but both sides may import `platform/`.
+#
+# Scope, stated plainly: listeners are in-process. A delete handled by one
+# uvicorn worker cannot evict another worker's map, so multi-worker
+# deployments keep a bounded window equal to the map's 60s TTL. That is the
+# same bounded-staleness tradeoff already documented for visibility changes in
+# processing/tiles/router.py. Closing it for every worker needs a cross-process
+# notification channel, which this codebase does not have.
+_table_invalidation_listeners: list[Callable[[str], None]] = []
+
+
+def register_table_invalidation_listener(listener: Callable[[str], None]) -> None:
+    """Register a callable invoked with a table name when that table changes."""
+    _table_invalidation_listeners.append(listener)
+
+
+def notify_table_invalidated(table_name: str) -> None:
+    """Tell every listener a table's identity or contents changed.
+
+    Best-effort and never raises: callers run this beside a cache purge, and a
+    listener failure must not fail the operation that triggered it.
+    """
+    for listener in _table_invalidation_listeners:
+        try:
+            listener(table_name)
+        except Exception:  # broad: listener internals are not this call's to know
+            logger.warning(
+                "table_invalidation_listener_failed",
+                table_name=table_name,
+                exc_info=True,
+            )

--- a/backend/app/platform/cache/tile_cache.py
+++ b/backend/app/platform/cache/tile_cache.py
@@ -20,6 +20,16 @@ does not match the documented ``data.*`` shape (lowercase, starts with
 a letter, ``[a-z0-9_]`` only, max 63 chars) is collapsed to the literal
 ``"_other"`` so a malicious or unexpected caller cannot explode the
 metric label set.
+
+fix(#1429): the ``table`` argument is the tile router's composite table
+segment, not a bare table name. It carries the tenant id, the dataset id
+that makes a reused table name safe, and the cluster parameters, so it
+never matches ``_safe_label``'s shape — deriving the metric label from it
+collapsed every request to ``"_other"``. Readers now pass the bare table
+name as ``label``; ``_safe_label`` still bounds it, so an unexpected value
+cannot explode the label set. Invalidation is unaffected: the dataset id
+sits AFTER the table segment, so ``tile:{table}:*`` still matches every
+key for a table regardless of which dataset wrote it.
 """
 
 import re
@@ -79,14 +89,21 @@ def _invalidation_table_segment(table: str) -> str:
 class TileCacheProvider:
     """Binary tile cache backed by Redis.
 
-    Cache key format: ``tile:{table}:{z}:{x}:{y}``
+    Cache key format: ``tile:{table}:{z}:{x}:{y}``, where ``table`` is the
+    composite table segment the tile router builds — see the module docstring.
     """
 
     def __init__(self, url: str) -> None:
         self._client = redis_async.from_url(url, decode_responses=False)
 
     async def get(
-        self, table: str, z: int, x: int, y: int, cols_key: str = ""
+        self,
+        table: str,
+        z: int,
+        x: int,
+        y: int,
+        cols_key: str = "",
+        label: str | None = None,
     ) -> bytes | None:
         """Return cached tile bytes or None on miss/error.
 
@@ -94,10 +111,13 @@ class TileCacheProvider:
         different additional column projections (data-driven styling).
         Empty string preserves the original cache key shape for callers
         that don't pass additional columns.
+
+        `label` is the bare table name for the PERF-11 metric; see
+        ``_safe_label``.
         """
         suffix = f":{cols_key}" if cols_key else ""
         key = f"tile:{table}:{z}:{x}:{y}{suffix}"
-        label = _safe_label(table)
+        label = _safe_label(table if label is None else label)
         try:
             data = await self._client.get(key)
             if data is not None:
@@ -120,7 +140,10 @@ class TileCacheProvider:
         ttl: int = 300,
         cols_key: str = "",
     ) -> None:
-        """Store tile bytes with TTL. Silent on failure."""
+        """Store tile bytes with TTL. Silent on failure.
+
+        Takes no ``label``: writes emit no Prometheus metric, only reads do.
+        """
         suffix = f":{cols_key}" if cols_key else ""
         key = f"tile:{table}:{z}:{x}:{y}{suffix}"
         try:
@@ -177,12 +200,18 @@ class InMemoryTileCacheProvider:
         self._cache: LRUCache[str, tuple[bytes, float]] = LRUCache(maxsize=max_entries)
 
     async def get(
-        self, table: str, z: int, x: int, y: int, cols_key: str = ""
+        self,
+        table: str,
+        z: int,
+        x: int,
+        y: int,
+        cols_key: str = "",
+        label: str | None = None,
     ) -> bytes | None:
         """Return cached tile bytes or None on miss / TTL expiry."""
         suffix = f":{cols_key}" if cols_key else ""
         key = f"tile:{table}:{z}:{x}:{y}{suffix}"
-        label = _safe_label(table)
+        label = _safe_label(table if label is None else label)
         entry = self._cache.get(key)
         if entry is None:
             tile_cache_misses.labels(table_name=label).inc()

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -38,7 +38,10 @@ from app.modules.auth.dependencies import get_optional_user
 from app.core.config import settings
 from app.core.dependencies import get_db
 from app.modules.embed_tokens.service import validate_embed_token_access
-from app.platform.cache.provider import get_tile_cache
+from app.platform.cache.provider import (
+    get_tile_cache,
+    register_table_invalidation_listener,
+)
 from app.platform.extensions import (
     get_billing_extensions,
     get_data_serving_extension,
@@ -260,6 +263,32 @@ class _DatasetMeta(NamedTuple):
 _dataset_cache: LRUCache[str, tuple[float, _DatasetMeta]] = LRUCache(maxsize=256)
 # threading.Lock is safe here — cache reads/writes are synchronous, no await inside lock
 _dataset_cache_lock = threading.Lock()
+
+
+def _evict_dataset_meta(table_name: str) -> None:
+    """Drop every cached meta entry for a table name.
+
+    fix(#1429): this cache decides authorization — visibility, record_status
+    and created_by are read from the snapshot rather than re-queried. Keying
+    tile bytes by dataset id cannot help here, because the stale entry is what
+    picks the dataset in the first place: after a delete frees ``roads`` and a
+    new dataset draws it, a worker holding the old entry serves the NEW table's
+    rows under the DELETED dataset's visibility.
+
+    Both key shapes are swept — bare ``table_name`` in single-tenant and
+    ``{tid}:{table_name}`` in multi-tenant — because a process can hold entries
+    from before a mode transition, and a delete arrives with only the name.
+    """
+    suffix = f":{table_name}"
+    with _dataset_cache_lock:
+        stale = [
+            key for key in _dataset_cache if key == table_name or key.endswith(suffix)
+        ]
+        for key in stale:
+            _dataset_cache.pop(key, None)
+
+
+register_table_invalidation_listener(_evict_dataset_meta)
 
 # ---------------------------------------------------------------------------
 # PERF-002: Short-TTL cache for raster dataset/asset metadata.
@@ -1807,13 +1836,39 @@ def _ensure_clusterable_dataset(meta: _DatasetMeta) -> None:
         )
 
 
+def _generation_table_key(table_name: str, dataset_id: uuid.UUID) -> str:
+    """Table segment plus the generation that makes a reused name safe.
+
+    fix(#1429): a vector delete drops the table and the catalog row, and
+    ``generate_table_name`` collides only against LIVE rows and relations, so
+    the freed name is immediately redrawable. Every tile cache key was the
+    table name alone, which meant the next dataset to draw ``roads`` read the
+    previous one's cached bytes while being authorized on its own visibility.
+    The dataset id is a UUID and is never reissued, so keying on it makes that
+    read impossible rather than merely short-lived — the purge on delete, the
+    TTL, and whether the purge even reached this process all stop mattering.
+
+    Position is load-bearing: the id goes AFTER the table segment so the
+    ``tile:{table}:*`` patterns in ``invalidate_table`` still match every key
+    for a table whichever dataset wrote it, and no invalidation caller changes.
+    """
+    return f"{table_name}:ds{dataset_id.hex}"
+
+
 def _cluster_cache_table_key(
-    table_name: str, *, cluster_radius: int, cluster_max_zoom: int
+    table_name: str,
+    *,
+    dataset_id: uuid.UUID,
+    cluster_radius: int,
+    cluster_max_zoom: int,
 ) -> str:
     # fix(#868): the version tag pins the cluster SQL semantics. Bump it whenever
     # _build_cluster_tile_query changes the emitted tile geometry/properties, or a
     # deploy keeps serving stale cluster tiles until TTL expiry. v2 -> v3: #874.
-    return f"{table_name}:cluster:v3:r{cluster_radius}:z{cluster_max_zoom}"
+    return (
+        f"{_generation_table_key(table_name, dataset_id)}"
+        f":cluster:v3:r{cluster_radius}:z{cluster_max_zoom}"
+    )
 
 
 async def _acquire_and_serve_tile(
@@ -2015,6 +2070,7 @@ async def cluster_tile_endpoint(
     )
     cluster_cache_key = _cluster_tenant_prefix + _cluster_cache_table_key(
         table_name,
+        dataset_id=meta.dataset_id,
         cluster_radius=cluster_radius,
         cluster_max_zoom=cluster_max_zoom,
     )
@@ -2022,7 +2078,7 @@ async def cluster_tile_endpoint(
     tile_cache = get_tile_cache()
     if tile_cache is not None:
         cached = await tile_cache.get(
-            cluster_cache_key, z, x, y, cols_key=cols_cache_key
+            cluster_cache_key, z, x, y, cols_key=cols_cache_key, label=table_name
         )
         if cached is not None:
             if len(cached) == 0:
@@ -2164,8 +2220,11 @@ async def tile_endpoint(
     # cached tile binary.  single_tenant: no prefix — byte-identical to
     # pre-1209 behavior (T-1209-CR-01).
     _tile_tid = _require_tile_tenant_context()
+    _tile_generation_key = _generation_table_key(table_name, meta.dataset_id)
     _tile_cache_key = (
-        f"{_tile_tid}:{table_name}" if _tile_tid is not None else table_name
+        f"{_tile_tid}:{_tile_generation_key}"
+        if _tile_tid is not None
+        else _tile_generation_key
     )
     _tile_serving_limiter, _tile_cache_control = _get_tile_serving_controls(
         str(_tile_tid or "anon")
@@ -2174,7 +2233,9 @@ async def tile_endpoint(
     # Check tile cache before hitting PostGIS
     tile_cache = get_tile_cache()
     if tile_cache is not None:
-        cached = await tile_cache.get(_tile_cache_key, z, x, y, cols_key=cols_cache_key)
+        cached = await tile_cache.get(
+            _tile_cache_key, z, x, y, cols_key=cols_cache_key, label=table_name
+        )
         if cached is not None:
             if len(cached) == 0:
                 # Empty sentinel — tile was previously confirmed empty

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1964,7 +1964,12 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #   standards/stac/router.py entered the allowlist at 1547 for the virtual
 #     unassigned Collection, deterministic multi-membership selection, and HTTP
 #     Link parity required by the 2026-07-12 compliance remediation.
-#   tiles/router.py   1500 → 1660 → 1850 → 1920 → 2050 → 2090. Raster meta TTLCache
+#   tiles/router.py   1500 → 1660 → 1850 → 1920 → 2050 → 2090 → 2329. fix(#1429) bought
+#     the generation dimension in the tile cache key: `_generation_table_key`, the
+#     dataset-id parameter threaded through `_cluster_cache_table_key`, and
+#     `_evict_dataset_meta` plus its listener registration, which is what stops a
+#     freed table name from serving its successor under the deleted dataset's
+#     visibility. Raster meta TTLCache
 #     (1176 PERF-002), SET LOCAL ROLE binding (1209-03 DP-02), cloud fairness/metering
 #     seams (1213-06), the cold-tier seam (1214-04), terrainrgb nodata (#186), and
 #     empty-tile Cache-Control (#430 V-03). NOTE: `_check_cold_rehydrate` is pinned to
@@ -2973,7 +2978,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # writes and a predictable future `v` can no longer park a pre-swap
     # snapshot on the key the swap is about to make legitimate.
     # Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2268,
+    "backend/app/processing/tiles/router.py": 2329,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_tile_cache_generation_key_1429.py
+++ b/backend/tests/test_tile_cache_generation_key_1429.py
@@ -1,0 +1,272 @@
+"""A reused table name must never let one dataset read another's tiles (#1429).
+
+`generate_table_name` collides only against LIVE catalog rows and LIVE
+relations, so a vector delete frees its table name for immediate reuse.
+Every tile cache key used to be that name alone, which made the cache a
+cross-dataset channel: delete private "Roads" (table ``roads``), upload a
+public "Roads" that draws ``roads`` again, and the tile endpoint authorized
+against the NEW dataset while serving the OLD dataset's bytes.
+
+#1427 added a purge on delete, which removed the durable window but not the
+class — an in-flight writer could restore bytes after the purge, and a purge
+from one uvicorn worker never reached another worker's in-memory LRU.
+
+The fix is a generation dimension: the dataset UUID, which is never reissued,
+goes into the key after the table segment. The successor reads a different key
+space, so it cannot see the predecessor's entries whether or not the purge ran,
+whether or not it reached this process, and whether or not the TTL expired.
+Position matters — after the table segment, so `tile:{table}:*` invalidation
+still matches every key for a table.
+"""
+
+import gzip
+import uuid
+from contextlib import asynccontextmanager
+
+import fakeredis.aioredis
+import pytest
+
+from app.platform.cache.tile_cache import (
+    InMemoryTileCacheProvider,
+    TileCacheProvider,
+    _safe_label,
+    tile_cache_hits,
+)
+from app.processing.tiles.router import (
+    _cluster_cache_table_key,
+    _generation_table_key,
+)
+
+TABLE = "roads"
+TILE = (5, 10, 15)
+
+# Both providers implement the same get/set/invalidate_table contract, and the
+# reuse hazard is a property of the KEY, so every case runs against both.
+PROVIDER_KINDS = ["redis", "in_memory"]
+
+
+@asynccontextmanager
+async def _provider(kind: str):
+    """Yield a tile cache provider, closing the fake Redis client afterwards.
+
+    The client owns a connection pool; leaving one open per test leaks
+    event-loop resources into the rest of the session.
+    """
+    if kind == "in_memory":
+        yield InMemoryTileCacheProvider()
+        return
+
+    provider = TileCacheProvider.__new__(TileCacheProvider)
+    provider._client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    try:
+        yield provider
+    finally:
+        await provider._client.aclose()
+
+
+def _cluster_key(table: str, dataset_id: uuid.UUID) -> str:
+    return _cluster_cache_table_key(
+        table, dataset_id=dataset_id, cluster_radius=50, cluster_max_zoom=12
+    )
+
+
+# ---------------------------------------------------------------------------
+# The reuse scenario — the reason this key shape exists
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", PROVIDER_KINDS)
+async def test_successor_cannot_read_predecessor_tiles(kind):
+    """Dataset B, drawing A's freed table name, never reads A's cached bytes.
+
+    Deliberately performs NO purge between the two datasets. That models the
+    two windows #1427 could not close: an in-flight writer restoring bytes
+    after the purge, and a second uvicorn worker whose LRU the purge never
+    reached. Under the old table-only key both would hand B the bytes A wrote.
+    """
+    async with _provider(kind) as provider:
+        dataset_a, dataset_b = uuid.uuid4(), uuid.uuid4()
+
+        key_a = _generation_table_key(TABLE, dataset_a)
+        await provider.set(key_a, *TILE, gzip.compress(b"A private geometry"), ttl=300)
+        assert await provider.get(key_a, *TILE) is not None
+
+        key_b = _generation_table_key(TABLE, dataset_b)
+        assert await provider.get(key_b, *TILE) is None, (
+            "the successor of a reused table name read the deleted dataset's tile"
+        )
+
+
+@pytest.mark.parametrize("kind", PROVIDER_KINDS)
+async def test_successor_cannot_read_predecessor_cluster_tiles(kind):
+    """Same for clustered tiles, which hang extra segments off the table key."""
+    async with _provider(kind) as provider:
+        dataset_a, dataset_b = uuid.uuid4(), uuid.uuid4()
+
+        await provider.set(
+            _cluster_key(TABLE, dataset_a), *TILE, gzip.compress(b"A"), ttl=300
+        )
+
+        assert await provider.get(_cluster_key(TABLE, dataset_b), *TILE) is None
+
+
+def test_generation_key_places_the_id_after_the_table_segment():
+    """Position is what keeps `tile:{table}:*` invalidation working."""
+    dataset_id = uuid.uuid4()
+    key = _generation_table_key(TABLE, dataset_id)
+
+    assert key.startswith(f"{TABLE}:"), (
+        "the dataset id must follow the table segment — a leading id would "
+        "make every invalidate_table pattern miss"
+    )
+    assert dataset_id.hex in key
+    assert _cluster_key(TABLE, dataset_id).startswith(f"{TABLE}:")
+
+
+# ---------------------------------------------------------------------------
+# Invalidation still reaches every key shape for a table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", PROVIDER_KINDS)
+async def test_invalidate_table_still_purges_every_generation(kind):
+    """A per-table purge hits all key shapes, for every dataset that held the name.
+
+    Invalidation callers pass a bare table name and know nothing about
+    generations, so a purge must not become generation-scoped by accident.
+    """
+    async with _provider(kind) as provider:
+        older, newer = uuid.uuid4(), uuid.uuid4()
+
+        await provider.set(_generation_table_key(TABLE, older), *TILE, b"old", ttl=300)
+        await provider.set(_generation_table_key(TABLE, newer), *TILE, b"new", ttl=300)
+        await provider.set(_cluster_key(TABLE, newer), *TILE, b"clustered", ttl=300)
+        await provider.set(
+            _generation_table_key(TABLE, newer), *TILE, b"cols", ttl=300, cols_key="a,b"
+        )
+
+        await provider.invalidate_table(TABLE)
+
+        assert await provider.get(_generation_table_key(TABLE, older), *TILE) is None
+        assert await provider.get(_generation_table_key(TABLE, newer), *TILE) is None
+        assert await provider.get(_cluster_key(TABLE, newer), *TILE) is None
+        assert (
+            await provider.get(
+                _generation_table_key(TABLE, newer), *TILE, cols_key="a,b"
+            )
+            is None
+        )
+
+
+@pytest.mark.parametrize("kind", PROVIDER_KINDS)
+async def test_invalidate_table_does_not_purge_a_prefix_sibling(kind):
+    """`roads` must not evict `roads_2` — the suffix generate_table_name hands out."""
+    async with _provider(kind) as provider:
+        dataset_id = uuid.uuid4()
+        sibling = _generation_table_key("roads_2", dataset_id)
+
+        await provider.set(sibling, *TILE, b"x", ttl=300)
+
+        await provider.invalidate_table("roads")
+
+        assert await provider.get(sibling, *TILE) == b"x"
+
+
+# ---------------------------------------------------------------------------
+# PERF-11 label (fix #1429 restores it for composite keys)
+# ---------------------------------------------------------------------------
+
+
+def _hits(label: str) -> float:
+    return tile_cache_hits.labels(table_name=label)._value.get()
+
+
+@pytest.mark.parametrize("kind", PROVIDER_KINDS)
+async def test_explicit_label_survives_a_composite_key(kind):
+    """A generation/tenant/cluster key must still report its bare table name.
+
+    Derived from the key string it collapses to `_other`, which is what the
+    multi-tenant and clustered paths already did before this change.
+    """
+    async with _provider(kind) as provider:
+        label = "label_probe"
+        tile_cache_hits.labels(table_name=label)._value.set(0)
+        other_before = _hits("_other")
+
+        composite = f"{uuid.uuid4()}:{_cluster_key(label, uuid.uuid4())}"
+        assert _safe_label(composite) == "_other", (
+            "precondition: the router's key is not label-shaped"
+        )
+
+        await provider.set(composite, *TILE, b"tile", ttl=300)
+        assert await provider.get(composite, *TILE, label=label) == b"tile"
+
+        assert _hits(label) == 1
+        assert _hits("_other") == other_before
+
+
+@pytest.mark.parametrize("kind", PROVIDER_KINDS)
+async def test_explicit_label_is_still_cardinality_bounded(kind):
+    """An unexpected explicit label collapses to `_other` like a derived one."""
+    async with _provider(kind) as provider:
+        other_before = _hits("_other")
+
+        key = _generation_table_key(TABLE, uuid.uuid4())
+        await provider.set(key, *TILE, b"tile", ttl=300)
+        await provider.get(key, *TILE, label="Robert'); DROP TABLE--")
+
+        assert _hits("_other") == other_before + 1
+
+
+# ---------------------------------------------------------------------------
+# Dataset-metadata cache eviction (the authorization half)
+# ---------------------------------------------------------------------------
+
+
+def test_delete_evicts_cached_dataset_meta_for_the_freed_name():
+    """The table_name -> meta map must forget a deleted name.
+
+    That map decides visibility, so a stale entry would let a successor
+    drawing the same table name be served under the DELETED dataset's
+    authorization — a window no cache key can close, because the stale entry
+    is what picks the dataset before any key is built.
+    """
+    from app.platform.cache.provider import notify_table_invalidated
+    from app.processing.tiles import router as tiles_router
+
+    tenant = uuid.uuid4()
+    sibling = "roads_2"
+    # The map is module state shared with the rest of the session — seed it,
+    # then put back exactly what was there.
+    with tiles_router._dataset_cache_lock:
+        before = dict(tiles_router._dataset_cache)
+        tiles_router._dataset_cache[TABLE] = (0.0, "single-tenant entry")
+        tiles_router._dataset_cache[f"{tenant}:{TABLE}"] = (0.0, "tenant entry")
+        tiles_router._dataset_cache[sibling] = (0.0, "unrelated table")
+
+    try:
+        notify_table_invalidated(TABLE)
+
+        assert TABLE not in tiles_router._dataset_cache
+        assert f"{tenant}:{TABLE}" not in tiles_router._dataset_cache
+        assert sibling in tiles_router._dataset_cache, (
+            "eviction must not take out a table whose name merely shares a prefix"
+        )
+    finally:
+        with tiles_router._dataset_cache_lock:
+            tiles_router._dataset_cache.clear()
+            tiles_router._dataset_cache.update(before)
+
+
+def test_notify_table_invalidated_never_raises():
+    """A listener failure must not fail the delete that triggered it."""
+    from app.platform.cache import provider as cache_provider
+
+    def _explode(_table_name: str) -> None:
+        raise RuntimeError("listener is broken")
+
+    cache_provider.register_table_invalidation_listener(_explode)
+    try:
+        cache_provider.notify_table_invalidated(TABLE)
+    finally:
+        cache_provider._table_invalidation_listeners.remove(_explode)

--- a/backend/tests/test_tile_cache_generation_key_1429.py
+++ b/backend/tests/test_tile_cache_generation_key_1429.py
@@ -258,6 +258,40 @@ def test_delete_evicts_cached_dataset_meta_for_the_freed_name():
             tiles_router._dataset_cache.update(before)
 
 
+async def test_meta_eviction_happens_after_commit_not_inside_delete_dataset():
+    """`delete_dataset` must NOT evict; the endpoints must, after they commit.
+
+    The map is built from `catalog.datasets`, which the DROP does not lock, so
+    an eviction inside the still-open transaction is undone by any concurrent
+    tile request — it reads the not-yet-deleted row and re-caches it. This
+    pins the placement, since the ordering is invisible in a single-threaded
+    test and only shows up under concurrency.
+    """
+    import inspect
+
+    from app.modules.catalog.datasets.api import router as datasets_router
+    from app.modules.catalog.datasets.domain import service_lifecycle
+
+    assert "notify_table_invalidated(" not in inspect.getsource(
+        service_lifecycle.delete_dataset
+    ), (
+        "delete_dataset does not commit, so evicting there races any concurrent "
+        "tile request; the endpoints evict after their commit instead"
+    )
+
+    for handler in (
+        datasets_router.delete_dataset_endpoint,
+        datasets_router.bulk_delete_datasets_endpoint,
+    ):
+        source = inspect.getsource(handler)
+        assert "notify_table_invalidated(" in source, (
+            f"{handler.__name__} must evict the tile router's metadata map"
+        )
+        assert source.index("await db.commit()") < source.index(
+            "notify_table_invalidated("
+        ), f"{handler.__name__} must evict AFTER its commit, not before"
+
+
 def test_notify_table_invalidated_never_raises():
     """A listener failure must not fail the delete that triggered it."""
     from app.platform.cache import provider as cache_provider

--- a/backend/tests/test_tiles.py
+++ b/backend/tests/test_tiles.py
@@ -343,7 +343,7 @@ class TestTileEndpoint:
         """Cluster tile cache keys are separate from normal vector tile keys."""
         table_name = f"cluster_cache_{uuid.uuid4().hex[:8]}"
         user_id = await get_user_id(test_db_session, settings.geolens_admin_username)
-        await _create_tile_test_dataset(
+        dataset = await _create_tile_test_dataset(
             test_db_session, created_by=user_id, table_name=table_name
         )
         mock_cache = AsyncMock()
@@ -362,8 +362,16 @@ class TestTileEndpoint:
         # its cache lookups carry a cols_key segment (empty without cols=).
         # fix(#868): the key carries the cluster SQL semantic version, bumped to
         # v3 by fix(#874) (per-cluster expansion_zoom) so deploys drop stale tiles.
+        # fix(#1429): the dataset id sits between the table and the cluster
+        # segments, so a reused table name cannot read the previous dataset's
+        # cluster tiles, and `label` carries the bare table name for the metric.
         mock_cache.get.assert_awaited_once_with(
-            f"{table_name}:cluster:v3:r64:z12", 0, 0, 0, cols_key=""
+            f"{table_name}:ds{dataset.id.hex}:cluster:v3:r64:z12",
+            0,
+            0,
+            0,
+            cols_key="",
+            label=table_name,
         )
 
     async def test_empty_tile_returns_204(


### PR DESCRIPTION
Closes #1429.

## Why

`generate_table_name` collides only against **live** catalog rows and **live** relations, so a vector delete frees its table name for immediate reuse. Every tile cache key was that name alone, which made the cache a cross-dataset channel: delete a private dataset backed by `roads`, upload a public one that draws `roads` again, and the tile endpoint authorized against the new dataset while serving the old dataset's bytes.

#1427 added a purge on delete. That removed the durable window but not the class, because a purge has to *reach* the entry to work, and two paths guarantee it sometimes doesn't:

- An in-flight tile request releases its database transaction as soon as it has `tile_data`, then emits a usage event and gzips before calling `tile_cache.set()`. It can write pre-delete bytes back after the purge.
- With `REDIS_URL` unset each uvicorn worker holds a private LRU, and the checked-in production default is two workers. A purge from the worker that handled the DELETE never touches the other one.

## What changed

The dataset UUID is never reissued, so putting it in the key makes the bad read **impossible** rather than merely short-lived. The successor reads a different key space whether or not the purge ran, whether or not it reached this process, and whether or not the TTL expired.

```
before  tile:{tenant?}:{table}:{z}/{x}/{y}
after   tile:{tenant?}:{table}:ds{dataset_id.hex}:{z}/{x}/{y}
```

**Position is load-bearing.** The id goes *after* the table segment, so the `tile:{table}:*` patterns in `invalidate_table` still match every key for a table regardless of which dataset wrote it. That is why **none of the eight invalidation call sites change** — they pass a bare table name and know nothing about generations. There is a test asserting exactly this, including that `roads` still does not evict `roads_2`.

Both providers are covered. The key is built by the tile router and passed through, so the Redis and in-memory implementations needed no key logic of their own; every test runs against both.

### Two things fall out of the same root cause

**The authorization half — improved, not closed.** The tile router's process-local `table_name -> metadata` map decides visibility, `record_status` and `created_by` from a cached snapshot. No cache key can fix that, because the stale entry is what *picks the dataset* before any key is built, and the vector tile route is addressed by table name so the dataset id is the lookup's result rather than an input.

The deleting worker now evicts that map, **after its commit**, via a listener seam in `platform/cache/provider.py` (`catalog/` may not import `app.processing.*`; both may import `platform/`). Placement is load-bearing and was wrong in the first push: `delete_dataset` does not commit, and the `DROP TABLE` there locks only the data table, not `catalog.datasets` — so an eviction from inside the open transaction is undone by any concurrent tile request, which still reads the not-yet-deleted row and re-caches it. There is a structural test pinning the ordering, since it is invisible to a single-threaded functional test.

Two windows survive and are written down in the code rather than implied: another uvicorn worker's map is unreachable (bounded by its 60s TTL), and a catalog read already in flight when the eviction ran writes its result back afterwards (a one-query-wide race, but the entry it leaves lives a full TTL). Neither is closable by propagating the invalidation in this topology — `REDIS_URL` is unset by default, and `LISTEN`/`NOTIFY` needs a session-pinned connection transaction-mode PgBouncer does not provide. Both need the same precondition removed instead: a freed table name being redrawn. That is **#1443**, with three costed options. This PR does not depend on its outcome.

The notify is deliberately **not** wired into the reupload/refresh purges: those run in the worker process, whose map is empty, so it would evict nothing while looking like it worked — the failure shape `init_tile_cache`'s worker mode exists to avoid.

**The metric.** `_safe_label` derives the Prometheus `table_name` label from the key string, and the router's key was already composite (tenant prefix, cluster parameters), so multi-tenant and clustered requests had been reporting `_other` since those keys were introduced. Adding the dataset id would have collapsed the rest. Readers now pass the bare table name explicitly, which fixes the pre-existing collapse as well; `_safe_label` still bounds it, so an unexpected value cannot explode the label set. `set` takes no label — writes emit no metric.

## Cache-format version

There is no server-side key-shape version constant to bump. `tile_cache_version` is a per-dataset integer used only as a client-facing `?v=` URL buster, and the cluster key's inline `v3` tag pins cluster *SQL semantics*, which this change does not touch.

A key-shape change orphans every entry written under the old shape. Those entries are unreachable by construction (nothing will ever compute the old key again) and are not reachable by `invalidate_table` either, since the pattern is anchored on the table segment they still carry — in fact `tile:{table}:*` does still match them, so a later purge for that table sweeps them. Otherwise they age out at `tile_cache_ttl`, default 300s. The practical effect of deploying is one TTL window of cold tile cache. Raster is unaffected: its meta cache is keyed by `dataset_id` already, so it never had the reuse hazard.

## Impacts

None on schema, API contract, or config. Behavior-only; `openapi.json` and the SDKs are untouched. `tiles/router.py`'s LOC ratchet moves 2268 → 2329 with a comment recording what the lines bought.

## Verification

Failing-first: the pre-#1429 key shape was reproduced directly (both datasets keying on the bare table name) and the successor read the predecessor's bytes —
`AssertionError: the successor of a reused table name read the deleted dataset's tile: b'A private geometry'`.
That probe was then deleted; the shipped suite asserts the successor gets `None`.

```
cd backend && uv run ruff check app tests && uv run ruff format app tests --check
cd backend && uv run pytest tests/test_layering.py -q                                # 40 passed
cd backend && uv run pytest tests/test_tile_cache_generation_key_1429.py -q          # 15 passed
# every test that imports the cache or the tiles router, serially, 3x:
cd backend && uv run pytest $(rg -l "platform.cache|processing.tiles|tile_cache" tests/) -q -p no:randomly
                                                                                     # 1504 passed, 3 skipped
```

One test needed updating: `test_tiles.py::test_cluster_tile_cache_key_includes_options` pins the exact cluster cache lookup, and now asserts the generation segment and the explicit label.
