### PR TITLE
chore(frontend): migrate AttributeTable to @tanstack/react-table v9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,11 +36,6 @@ updates:
         patterns: ["react", "react-dom", "@types/react*"]
       tanstack:
         patterns: ["@tanstack/*"]
-    ignore:
-      # fix(#1407): react-table v9 is a hand migration (AttributeTable);
-      # the major gets pulled deliberately, not via bump PR.
-      - dependency-name: "@tanstack/react-table"
-        update-types: ["version-update:semver-major"]
 
   # --- Root E2E (Playwright) — was untracked ---
   - package-ecosystem: "npm"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "@maplibre/maplibre-gl-style-spec": "^26.2.1",
         "@tailwindcss/vite": "^4.3.3",
         "@tanstack/react-query": "^5.101.4",
-        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-table": "^9.1.2",
         "@tanstack/react-virtual": "^3.14.9",
         "@turf/area": "^7.4.0",
         "@turf/distance": "^7.4.0",
@@ -3148,24 +3148,42 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@tanstack/react-table": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
-      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+    "node_modules/@tanstack/react-store": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.11.1.tgz",
+      "integrity": "sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/table-core": "8.21.3"
-      },
-      "engines": {
-        "node": ">=12"
+        "@tanstack/store": "0.11.1",
+        "use-sync-external-store": "^1.6.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-9.1.2.tgz",
+      "integrity": "sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-store": "^0.11.0",
+        "@tanstack/table-core": "9.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -3185,13 +3203,26 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@tanstack/table-core": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
-      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+    "node_modules/@tanstack/store": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.11.1.tgz",
+      "integrity": "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA==",
       "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-9.1.2.tgz",
+      "integrity": "sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "^0.11.0"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "funding": {
         "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "@maplibre/maplibre-gl-style-spec": "^26.2.1",
     "@tailwindcss/vite": "^4.3.3",
     "@tanstack/react-query": "^5.101.4",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "^9.1.2",
     "@tanstack/react-virtual": "^3.14.9",
     "@turf/area": "^7.4.0",
     "@turf/distance": "^7.4.0",

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -1,13 +1,15 @@
 import { useState, useMemo, useRef, useEffect, useCallback, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  useReactTable,
-  getCoreRowModel,
-  getSortedRowModel,
-  flexRender,
+  useTable,
+  tableFeatures,
+  rowSortingFeature,
+  columnVisibilityFeature,
+  createSortedRowModel,
+  sortFns,
   type ColumnDef,
   type SortingState,
-  type VisibilityState,
+  type ColumnVisibilityState,
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { toast } from 'sonner';
@@ -30,6 +32,19 @@ import { formatNumber } from '@/lib/format';
 import { formatMutationError } from '@/lib/error-map';
 import { coerceAttributeValue } from '@/lib/attribute-values';
 import { Loader2, ArrowUpDown, Settings2, Pencil } from 'lucide-react';
+
+// react-table v9 requires row models and sort functions to be registered
+// explicitly (v8 wired getSortedRowModel() as a table option and auto-detected
+// sortingFns). Columns here are built dynamically from the dataset's Postgres
+// column list with no per-column sortFn set, so all six built-ins must be
+// registered — the auto-detected sortFn (alphanumeric/text/datetime/basic)
+// still resolves by data type, but only if it's present in this map.
+const features = tableFeatures({
+  rowSortingFeature,
+  columnVisibilityFeature,
+  sortedRowModel: createSortedRowModel(),
+  sortFns,
+});
 
 /** Columns that are not user-editable */
 const NON_EDITABLE_COLUMNS = new Set(['gid', 'geom']);
@@ -144,7 +159,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
   const [columnFilters, setColumnFilters] = useState<Record<string, string>>({});
   const [pageSize, setPageSize] = useState(DEFAULT_ROWS_PAGE_SIZE);
   const [sorting, setSorting] = useState<SortingState>([]);
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [columnVisibility, setColumnVisibility] = useState<ColumnVisibilityState>({});
   const updateFeature = useUpdateFeature();
 
   // Debounce filters to avoid hammering the API on every keystroke
@@ -232,12 +247,11 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
     });
   }, []);
 
-  const columns = useMemo<ColumnDef<Record<string, unknown>>[]>(() => {
+  const columns = useMemo<ColumnDef<typeof features, Record<string, unknown>>[]>(() => {
     if (!data?.columns) return [];
     return data.columns.map((col) => ({
       accessorKey: col.name,
       header: `${col.name} (${col.type})`,
-      enableColumnFilter: !NON_FILTERABLE_COLUMNS.has(col.name),
       cell: (info) => {
         const rowData = info.row.original;
         const gid = rowData.gid as number;
@@ -300,16 +314,17 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
     }));
   }, [data?.columns, canEdit, compact, handleCellSave, updateFeature.isPending, editError, t]);
 
-  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table returns imperative helpers; this component keeps table state local.
-  const table = useReactTable({
-    data: data?.rows ?? [],
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    state: { sorting, columnVisibility },
-    onSortingChange: setSorting,
-    onColumnVisibilityChange: setColumnVisibility,
-  });
+  const table = useTable(
+    {
+      features,
+      data: data?.rows ?? [],
+      columns,
+      state: { sorting, columnVisibility },
+      onSortingChange: setSorting,
+      onColumnVisibilityChange: setColumnVisibility,
+    },
+    (state) => state,
+  );
 
   // PERF-07: virtualize the body so that 100-row pages render only the visible
   // window (~10-20 rows + overscan), keeping DOM-node count flat regardless of
@@ -329,6 +344,11 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
   // not — the border is absorbed into the specified height). Keep rowHeight
   // and the cell height classes in lockstep.
   const rowHeight = compact ? 28 : 44;
+  // fix(#1407): react-hooks/incompatible-library only reports the first
+  // flagged hook it finds per component. The removed useReactTable() call
+  // used to occupy that slot (suppressed below it), which silently masked
+  // this same warning on useVirtualizer() below.
+  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns imperative helpers; this component keeps virtualizer state local.
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => parentRef.current,
@@ -459,7 +479,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
                           className="flex items-center gap-1 hover:text-foreground"
                           onClick={header.column.getToggleSortingHandler()}
                         >
-                          {flexRender(header.column.columnDef.header, header.getContext())}
+                          <table.FlexRender header={header} />
                           {header.column.getIsSorted() === 'asc' ? (
                             <span> ↑</span>
                           ) : header.column.getIsSorted() === 'desc' ? (
@@ -515,7 +535,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
                     >
                       {row.getVisibleCells().map((cell) => (
                         <TableCell key={cell.id} className={`max-w-xs truncate ${cellClass}`}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          <table.FlexRender cell={cell} />
                         </TableCell>
                       ))}
                     </TableRow>

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -6,7 +6,12 @@ import {
   rowSortingFeature,
   columnVisibilityFeature,
   createSortedRowModel,
-  sortFns,
+  sortFn_alphanumeric,
+  sortFn_alphanumericCaseSensitive,
+  sortFn_basic,
+  sortFn_datetime,
+  sortFn_text,
+  sortFn_textCaseSensitive,
   type ColumnDef,
   type SortingState,
   type ColumnVisibilityState,
@@ -37,13 +42,23 @@ import { Loader2, ArrowUpDown, Settings2, Pencil } from 'lucide-react';
 // explicitly (v8 wired getSortedRowModel() as a table option and auto-detected
 // sortingFns). Columns here are built dynamically from the dataset's Postgres
 // column list with no per-column sortFn set, so all six built-ins must be
-// registered — the auto-detected sortFn (alphanumeric/text/datetime/basic)
-// still resolves by data type, but only if it's present in this map.
-const features = tableFeatures({
+// registered by name — the auto-detected sortFn (alphanumeric/text/datetime/
+// basic) still resolves by sampling each column's data, but only if its name
+// is present in this map. Registered individually rather than via the
+// library's bundled `sortFns` export, which is deprecated in favor of
+// importing only the functions actually used.
+export const features = tableFeatures({
   rowSortingFeature,
   columnVisibilityFeature,
   sortedRowModel: createSortedRowModel(),
-  sortFns,
+  sortFns: {
+    alphanumeric: sortFn_alphanumeric,
+    alphanumericCaseSensitive: sortFn_alphanumericCaseSensitive,
+    basic: sortFn_basic,
+    datetime: sortFn_datetime,
+    text: sortFn_text,
+    textCaseSensitive: sortFn_textCaseSensitive,
+  },
 });
 
 /** Columns that are not user-editable */

--- a/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
@@ -26,9 +26,13 @@ import attributeTableSrc from '@/components/dataset/AttributeTable.tsx?raw';
 // ── GLUX-002 DOM render gate ─────────────────────────────────────────────────
 import { render, screen } from '@/test/test-utils';
 import { vi } from 'vitest';
-import { AttributeTable } from '@/components/dataset/AttributeTable';
+import { AttributeTable, features } from '@/components/dataset/AttributeTable';
 import { useDatasetRows } from '@/components/dataset/hooks/use-dataset';
 import { useUpdateFeature } from '@/hooks/use-features';
+
+// ── #1407 sortFn auto-detection regression lock ─────────────────────────────
+import { renderHook } from '@testing-library/react';
+import { useTable, type ColumnDef } from '@tanstack/react-table';
 
 vi.mock('@/components/dataset/hooks/use-dataset', () => ({
   useDatasetRows: vi.fn(),
@@ -155,5 +159,75 @@ describe('AttributeTable editing contracts (E-35/E-39/E-51)', () => {
     expect(attributeTableSrc).toMatch(
       /setEditingCell\(null\);\s*setEditError\(null\);\s*\}, \[cursor, activeFilters, pageSize\]\)/,
     );
+  });
+});
+
+// ── #1407 sortFn auto-detection regression lock ──────────────────────────────
+// AttributeTable builds its columns dynamically from the dataset's Postgres
+// column list and never sets a per-column sortFn, so sorting depends on
+// react-table v9's runtime auto-detection (column_getAutoSortFn, which samples
+// each column's first 10 values) resolving to a sortFn *name* that is actually
+// registered in the `features` object exported by AttributeTable.tsx. A gap
+// there doesn't fail typecheck or build — a column with an unregistered
+// auto-detected name silently falls back to the `basic` comparator (or a
+// dev-only console.warn), which is exactly the kind of regression the v8→v9
+// migration (GH-1407) needed live verification for. This exercises the real
+// useTable()/features config end-to-end against synthetic rows shaped like
+// the Postgres column families the table actually renders — no mocking of
+// react-table itself.
+describe('#1407: react-table v9 sortFn auto-detection for dynamic columns', () => {
+  function useSortedColumn(data: Array<{ value: unknown }>) {
+    const columns: ColumnDef<typeof features, { value: unknown }>[] = [
+      { accessorKey: 'value', header: 'value' },
+    ];
+    return useTable(
+      {
+        features,
+        data,
+        columns,
+        state: { sorting: [{ id: 'value', desc: false }], columnVisibility: {} },
+        onSortingChange: () => {},
+        onColumnVisibilityChange: () => {},
+      },
+      (state) => state,
+    );
+  }
+
+  it('sorts a numeric column ascending via the auto-detected basic sortFn', () => {
+    const { result } = renderHook(() =>
+      useSortedColumn([{ value: 30 }, { value: 5 }, { value: 100 }]),
+    );
+    const sorted = result.current.getSortedRowModel().rows.map((r) => r.original.value);
+    expect(sorted).toEqual([5, 30, 100]);
+  });
+
+  it('sorts a text column via the auto-detected text sortFn', () => {
+    const { result } = renderHook(() =>
+      useSortedColumn([{ value: 'cherry' }, { value: 'Apple' }, { value: 'banana' }]),
+    );
+    const sorted = result.current.getSortedRowModel().rows.map((r) => r.original.value);
+    expect(sorted).toEqual(['Apple', 'banana', 'cherry']);
+  });
+
+  // The API serializes timestamp columns as ISO-8601 strings, never real Date
+  // instances (JSON has no Date type), so column_getAutoSortFn's `[object
+  // Date]` check never matches them — they auto-detect as 'alphanumeric', not
+  // 'datetime'. That's unchanged from v8 (same heuristic). What matters here
+  // is that zero-padded same-format ISO strings still sort chronologically
+  // under the alphanumeric comparator, and that 'alphanumeric' is registered.
+  it('sorts an ISO-timestamp-string column chronologically via the auto-detected alphanumeric sortFn', () => {
+    const { result } = renderHook(() =>
+      useSortedColumn([
+        { value: '2026-03-01T00:00:00' },
+        { value: '2024-01-01T00:00:00' },
+        { value: '2025-06-15T00:00:00' },
+      ]),
+    );
+    const sorted = result.current.getSortedRowModel().rows.map((r) => r.original.value);
+    expect(sorted).toEqual([
+      '2024-01-01T00:00:00',
+      '2025-06-15T00:00:00',
+      '2026-03-01T00:00:00',
+    ]);
   });
 });


### PR DESCRIPTION
## What

Migrates `AttributeTable.tsx` (the only frontend consumer of `@tanstack/react-table`) from v8.21.3 to v9.1.2, now that the major has settled per the issue's "When" criteria. Also removes the `@tanstack/react-table` dependabot ignore block, since the hand migration is done.

## Why

Dependabot proposed this major in #1338 (closed by hand, ignored via #1408) because v9 hadn't settled: docs were still on a `beta` branch and 9.1.0 had only just reached `latest`. It's since shipped several patches and the docs guide referenced below is current.

## v8 → v9 API changes absorbed

- `useReactTable(options)` → `useTable(options, selector)`. Passes `(state) => state` as the selector to reproduce v8's full-state re-render behavior.
- `getCoreRowModel()` / `getSortedRowModel()` table options are gone. Replaced with an explicit `features` object built via `tableFeatures({ rowSortingFeature, columnVisibilityFeature, sortedRowModel: createSortedRowModel(), sortFns: {...} })`, exported from the module so the new test below can reuse the real config instead of a re-implementation that could drift.
- `ColumnDef<TData>` → `ColumnDef<typeof features, TData>` (leading `TFeatures` generic, confirmed against the installed package's `.d.ts` — same shape applies to `Table`/`Row`/`Cell` but this component doesn't type those directly).
- `VisibilityState` → `ColumnVisibilityState`. The old name doesn't exist in v9's export list at all; confirmed by grepping the shipped `table-core` types rather than guessing.
- `flexRender(def, ctx)` → `<table.FlexRender header={header} />` / `<table.FlexRender cell={cell} />`. (The old `flexRender` function still technically exists in v9, but the component now uses the table-bound component form per the issue.)
- Sorting — the risky part per the issue, since columns here are generated dynamically from the dataset's Postgres column list with no per-column `sortFn`, relying on auto-detection:
  - Confirmed by reading the actual v9 source (`rowSortingFeature.js`, `rowSortingFeature.utils.js`) that `rowSortingFeature` still defaults every column's `sortFn` to `'auto'`, and `column_getAutoSortFn` uses the same "sample first 10 rows, check `[object Date]`, else split on digit runs" heuristic v8 used — unchanged, not a behavior regression.
  - v9 just requires the resolved name to be pre-registered, or it silently falls back to `basic`. Registered all six built-ins (`alphanumeric`, `alphanumericCaseSensitive`, `basic`, `datetime`, `text`, `textCaseSensitive`) by importing the individual `sortFn_*` functions — not the bundled `sortFns` export, which is marked deprecated upstream in favor of importing only what you use (tree-shaking doesn't help here since any of the six could be auto-selected for an arbitrary Postgres column).
  - Added a runtime test (not just a type check) exercising the real `useTable()`/`features` config against synthetic numeric, text, and ISO-timestamp-string rows, asserting sorted order. Worth calling out: timestamp columns arrive from the JSON API as ISO strings, never real `Date` instances, so they auto-detect as `alphanumeric`, not `datetime` — same as v8, and still chronologically correct for same-format zero-padded ISO strings, but worth having pinned down rather than assumed.
- `react-hooks/incompatible-library`'s suppression on the old `useReactTable` call became dead: I read the `eslint-plugin-react-hooks` source directly and its module-type provider hardcodes the property name `useReactTable` for `@tanstack/react-table` — it has no entry for `useTable`, so the rule no longer fires there. Removed the suppression.
  - Side effect: removing it unmasked the *same* warning on the unrelated `useVirtualizer()` call a few lines down — the rule only reports the first flagged hook per component, and `useReactTable` was previously occupying that slot. Verified this by running lint against the stashed original file (clean, 0 warnings) vs. this branch pre-fix (1 warning) to confirm it wasn't pre-existing. `@tanstack/react-virtual` itself is untouched and out of scope per the issue; added an equivalent suppression comment there so `npm run lint` output matches the pre-migration baseline (0 warnings).

## Incidental cleanup

Dropped `enableColumnFilter` from the column defs. It was dead even in v8 — never read via `column.getCanFilter()` or a filtered row model; the filter row is driven directly off the `NON_FILTERABLE_COLUMNS` set. v9's `ColumnDef` only exposes properties for features actually registered in `tableFeatures()`, and this component doesn't register `columnFilteringFeature` (filtering is local state + API calls, not TanStack's), so keeping the field would mean registering an unused feature just to keep a no-op property.

## Verification

All from `frontend/`:
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm run lint` — clean, 0 warnings (matches pre-migration baseline; see the incompatible-library note above)
- `npm run test:coverage` — 388 files / 4838 tests passed (13 pre-existing AttributeTable tests + 3 new sort-auto-detection tests)
- No locale files touched, so `npm run test:i18n` wasn't required

Not run from this worktree, per the dev-stack bind-mount caveat (`localhost:8080` always serves `main`, not this branch): `e2e/attribute-table-ax.spec.ts` and the issue's requested manual check of column sorting on a live dataset's text/numeric/timestamp columns. The new unit-level sort test above exercises the real `useTable`/auto-detection mechanism end-to-end and is the strongest verification available outside the live stack, but it's a synthetic-data substitute, not the live check the issue asks for — flagging that as still open for CI/manual follow-up.

Closes GH-1407
