### PR TITLE
feat(auth): deliver browser refresh tokens as httpOnly cookies with CSRF protection

### DIFF
--- a/.run-tests.zsh
+++ b/.run-tests.zsh
@@ -1,0 +1,5 @@
+#!/bin/zsh
+set -e
+cd "$(dirname "$0")/backend"
+set -a; source ../.env.test; set +a
+uv run pytest "$@"

--- a/backend/app/modules/auth/cookies.py
+++ b/backend/app/modules/auth/cookies.py
@@ -130,42 +130,47 @@ def read_refresh_cookie(request: Request) -> str | None:
     return request.cookies.get(REFRESH_COOKIE_NAME)
 
 
-def is_same_origin_as_request(request: Request, url: str) -> bool:
-    """Whether *url* shares scheme+host+port with this request's own origin.
-
-    Used by the OAuth callback: a cookie it sets is scoped to the host the
-    browser used to reach the API, so it is only usable afterwards when the SPA
-    lives on that same origin. A false answer falls back to the pre-GH-1302
-    fragment delivery rather than handing the browser a cookie it will never
-    send back — mismatch degrades, it never locks anyone out.
-    """
+def _origin_parts(url: str) -> tuple[str, str, int | None] | None:
+    """(scheme, host, effective port), or None when *url* has no usable origin."""
     try:
-        target = urlsplit(url)
-        target_host, target_port = target.hostname, target.port
+        parts = urlsplit(url)
+        host, port = parts.hostname, parts.port
     except ValueError:
-        return False
-    if not target.scheme or not target_host:
-        return False
+        return None
+    if not parts.scheme or not host:
+        return None
+    scheme = parts.scheme.lower()
+    # fix(#1446): EFFECTIVE port. A URL that spells out its default port
+    # ("https://example.com:443") is the same origin as one that omits it, but
+    # a raw string comparison called that a mismatch.
+    effective = port if port is not None else {"https": 443, "http": 80}.get(scheme)
+    return scheme, host.lower(), effective
 
-    target_scheme = target.scheme.lower()
-    request_scheme = (request.url.scheme or "").lower()
-    if target_scheme != request_scheme:
-        return False
-    if target_host.lower() != (request.url.hostname or "").lower():
-        return False
 
-    # fix(#1446): compare EFFECTIVE ports. A PUBLIC_APP_URL that spells out its
-    # default port ("https://example.com:443") against a Host header that omits
-    # it is the same origin to a browser, but comparing raw netlocs called it a
-    # mismatch and silently dropped that deployment back to fragment delivery.
-    def _effective_port(scheme: str, port: int | None) -> int | None:
-        if port is not None:
-            return port
-        return {"https": 443, "http": 80}.get(scheme)
+def is_same_origin(url_a: str, url_b: str) -> bool:
+    """Whether two absolute URLs share scheme, host, and effective port.
 
-    return _effective_port(target_scheme, target_port) == _effective_port(
-        request_scheme, request.url.port
-    )
+    Used by the OAuth callback to decide cookie-vs-fragment delivery: a cookie
+    it sets is scoped to the host the browser used to reach the API, so it is
+    only usable afterwards when the SPA lives on that same origin.
+
+    fix(#1446): both sides are now the deployment's CONFIGURED public URLs
+    rather than the live request's host. Deriving one side from the request was
+    wrong under any proxy that rewrites Host — the shipped Vite dev proxy sets
+    ``changeOrigin: true``, which replaces Host with the API target and keeps
+    the browser-facing host only in ``X-Forwarded-Host``, so the check reported
+    a mismatch and silently reverted dev to fragment delivery. Comparing two
+    configured values needs no trust decision about forwarded headers at all.
+
+    A false answer degrades to the pre-GH-1302 fragment path rather than
+    handing the browser a cookie it will never send back — it never locks
+    anyone out.
+    """
+    origin_a = _origin_parts(url_a)
+    origin_b = _origin_parts(url_b)
+    if origin_a is None or origin_b is None:
+        return False
+    return origin_a == origin_b
 
 
 def enforce_csrf(request: Request) -> None:

--- a/backend/app/modules/auth/cookies.py
+++ b/backend/app/modules/auth/cookies.py
@@ -69,8 +69,8 @@ def issue_browser_session(
     request: Request,
     refresh_token: str,
     expire_days: int,
-) -> str:
-    """Attach the refresh + CSRF cookies to *response*. Returns the CSRF token.
+) -> None:
+    """Attach the refresh + CSRF cookies to *response*.
 
     ``SameSite=Lax``: the only route under the cookie's ``Path`` is a POST, and
     Lax and Strict are identical for a same-origin XHR POST (Lax's extra
@@ -102,7 +102,6 @@ def issue_browser_session(
         samesite="lax",
         path="/",
     )
-    return csrf_token
 
 
 def clear_browser_session(response: Response, request: Request) -> None:

--- a/backend/app/modules/auth/cookies.py
+++ b/backend/app/modules/auth/cookies.py
@@ -141,13 +141,30 @@ def is_same_origin_as_request(request: Request, url: str) -> bool:
     """
     try:
         target = urlsplit(url)
+        target_host, target_port = target.hostname, target.port
     except ValueError:
         return False
-    if not target.scheme or not target.netloc:
+    if not target.scheme or not target_host:
         return False
-    return (
-        target.scheme.lower() == (request.url.scheme or "").lower()
-        and target.netloc.lower() == (request.url.netloc or "").lower()
+
+    target_scheme = target.scheme.lower()
+    request_scheme = (request.url.scheme or "").lower()
+    if target_scheme != request_scheme:
+        return False
+    if target_host.lower() != (request.url.hostname or "").lower():
+        return False
+
+    # fix(#1446): compare EFFECTIVE ports. A PUBLIC_APP_URL that spells out its
+    # default port ("https://example.com:443") against a Host header that omits
+    # it is the same origin to a browser, but comparing raw netlocs called it a
+    # mismatch and silently dropped that deployment back to fragment delivery.
+    def _effective_port(scheme: str, port: int | None) -> int | None:
+        if port is not None:
+            return port
+        return {"https": 443, "http": 80}.get(scheme)
+
+    return _effective_port(target_scheme, target_port) == _effective_port(
+        request_scheme, request.url.port
     )
 
 

--- a/backend/app/modules/auth/cookies.py
+++ b/backend/app/modules/auth/cookies.py
@@ -1,10 +1,11 @@
 """Browser refresh-token cookie + CSRF primitives (GH-1302).
 
 The refresh token is the only credential that moves into a cookie. Access
-tokens keep travelling as ``Authorization: Bearer`` headers, so **no**
-state-changing endpoint authenticates from a cookie — exactly one route does:
-``POST /auth/refresh``. CSRF enforcement is therefore scoped to that route
-rather than to every mutator.
+tokens keep travelling as ``Authorization: Bearer`` headers, so the cookie
+only ever authenticates the two session-lifecycle routes: ``POST
+/auth/refresh``, and ``POST /auth/logout`` as the credential of last resort.
+CSRF enforcement is therefore scoped to exactly those cookie-authenticated
+requests rather than to every mutator.
 
 Browser mode is negotiated explicitly with the ``X-GeoLens-Auth-Mode: cookie``
 request header. Header-sniffing (``Accept`` / ``Sec-Fetch-Mode``) was rejected:
@@ -116,8 +117,8 @@ def clear_browser_session(response: Response, request: Request) -> None:
     """Expire both cookies. Safe to call when no cookie was ever set.
 
     Deletion works from any request path: the browser applies a ``Set-Cookie``
-    whose name/path/domain match regardless of where the response came from, so
-    ``/auth/logout`` can clear a cookie scoped to ``/auth/refresh``.
+    whose name/path/domain match regardless of where the response came from,
+    so this can run from ``/auth/logout`` and the OAuth callback alike.
     """
     response.delete_cookie(
         REFRESH_COOKIE_NAME,
@@ -153,6 +154,26 @@ def _origin_parts(url: str) -> tuple[str, str, int | None] | None:
     # a raw string comparison called that a mismatch.
     effective = port if port is not None else {"https": 443, "http": 80}.get(scheme)
     return scheme, host.lower(), effective
+
+
+def api_path_is_cookie_scoped(request: Request, api_url: str) -> bool:
+    """Whether *api_url*'s path is the mount point this cookie is scoped under.
+
+    fix(#1446): same origin is necessary but not sufficient. ``root_path`` is
+    fixed at ``/api`` (api/main.py), so the cookie is always scoped to
+    ``/api/auth`` — while ``PUBLIC_API_URL`` / ``FRONTEND_API_BASE_URL`` are
+    documented as accepting any path form. A deployment mounted at, say,
+    ``/geolens-api`` would be handed a cookie the browser never sends back to
+    ``/geolens-api/auth/refresh/``, and cookie mode ships no fragment token to
+    fall back on, so the session would silently stop refreshing. Mirrors the
+    same guard in the SPA's ``cookieAuthAvailable()``.
+    """
+    root_path = request.scope.get("root_path", "").rstrip("/")
+    try:
+        configured = urlsplit(api_url).path
+    except ValueError:
+        return False
+    return configured.rstrip("/") == root_path
 
 
 def is_same_origin(url_a: str, url_b: str) -> bool:

--- a/backend/app/modules/auth/cookies.py
+++ b/backend/app/modules/auth/cookies.py
@@ -136,6 +136,24 @@ def clear_browser_session(response: Response, request: Request) -> None:
 
 
 def read_refresh_cookie(request: Request) -> str | None:
+    """The refresh cookie's value, or None when absent or not trustworthy.
+
+    fix(#1446): refuses DUPLICATE cookies of this name outright. An attacker on
+    a sibling subdomain who holds their own valid refresh token can toss a
+    parent-``Domain`` cookie with this name; the browser then sends both, a
+    parser keeps one of the two, and the victim's refresh would rotate
+    whichever token won — installing the attacker's session under the victim's
+    UI (login CSRF). The attacker can only ADD a shadow, never remove the
+    victim's host cookie, so duplicates are the attack's fingerprint: refusing
+    them turns account confusion into a one-time re-login prompt.
+    """
+    raw = request.headers.get("cookie", "")
+    seen = 0
+    for part in raw.split(";"):
+        if part.split("=", 1)[0].strip() == REFRESH_COOKIE_NAME:
+            seen += 1
+    if seen > 1:
+        return None
     return request.cookies.get(REFRESH_COOKIE_NAME)
 
 

--- a/backend/app/modules/auth/cookies.py
+++ b/backend/app/modules/auth/cookies.py
@@ -41,20 +41,28 @@ def wants_cookie_auth(request: Request) -> bool:
 
 
 def refresh_cookie_path(request: Request) -> str:
-    """Externally-visible path of the refresh route, for ``Path=`` scoping.
+    """Externally-visible ``Path=`` scope for the refresh cookie.
 
     The app runs with ``root_path="/api"`` behind both the dev Vite proxy and
     the production nginx ``location /api/`` block, and neither forwards the
     prefix upstream. Deriving the path from ``root_path`` keeps the cookie
     correctly scoped under any mount point instead of hardcoding ``/api``.
 
-    Scoping to the refresh route (rather than ``/``) keeps the cookie off
-    catalog, tile, and upload traffic entirely: it cannot leak through access
+    Scoping to ``/auth`` (rather than ``/``) keeps the cookie off catalog,
+    tile, upload, and export traffic entirely: it cannot leak through access
     logs or intermediary proxies on the hot path, and it cannot be replayed
-    against any other endpoint.
+    against any endpoint outside this router.
+
+    fix(#1446): this was ``/auth/refresh``, which was too tight. RFC 6265
+    path-matching meant the browser never sent the cookie to ``/auth/logout``,
+    so the cookie-authenticated logout path — the one that revokes a session
+    whose access token has already expired — could not fire at all in a real
+    browser. Widening to the auth router is the trade: the cookie now rides
+    same-origin ``/auth/*`` requests (login, me, config, api-keys) instead of
+    the refresh route alone, and still never touches the data plane.
     """
     root_path = request.scope.get("root_path", "").rstrip("/")
-    return f"{root_path}/auth/refresh"
+    return f"{root_path}/auth"
 
 
 def _secure_cookies() -> bool:

--- a/backend/app/modules/auth/cookies.py
+++ b/backend/app/modules/auth/cookies.py
@@ -1,0 +1,178 @@
+"""Browser refresh-token cookie + CSRF primitives (GH-1302).
+
+The refresh token is the only credential that moves into a cookie. Access
+tokens keep travelling as ``Authorization: Bearer`` headers, so **no**
+state-changing endpoint authenticates from a cookie — exactly one route does:
+``POST /auth/refresh``. CSRF enforcement is therefore scoped to that route
+rather than to every mutator.
+
+Browser mode is negotiated explicitly with the ``X-GeoLens-Auth-Mode: cookie``
+request header. Header-sniffing (``Accept`` / ``Sec-Fetch-Mode``) was rejected:
+it decides a security-relevant behaviour from values proxies rewrite and
+non-browser callers can spoof, and it would silently stop returning the JSON
+refresh token to curl/Postman/CI callers that happen to send a browsery
+``Accept``. Absent the header every response is byte-identical to the
+pre-GH-1302 contract, which is what keeps the CLI and the generated SDKs
+working.
+"""
+
+import secrets
+from urllib.parse import urlsplit
+
+from fastapi import HTTPException, Request, Response, status
+
+from app.core.config import settings
+
+REFRESH_COOKIE_NAME = "geolens_refresh"
+CSRF_COOKIE_NAME = "geolens_csrf"
+CSRF_HEADER_NAME = "X-CSRF-Token"
+AUTH_MODE_HEADER = "X-GeoLens-Auth-Mode"
+COOKIE_AUTH_MODE = "cookie"
+
+# The CSRF cookie must be readable by the SPA (double-submit), so it is NOT
+# HttpOnly. It is not a credential: possession alone authenticates nothing.
+_CSRF_TOKEN_BYTES = 32
+
+
+def wants_cookie_auth(request: Request) -> bool:
+    """Whether the caller explicitly opted into the browser cookie flow."""
+    header = request.headers.get(AUTH_MODE_HEADER, "")
+    return header.strip().lower() == COOKIE_AUTH_MODE
+
+
+def refresh_cookie_path(request: Request) -> str:
+    """Externally-visible path of the refresh route, for ``Path=`` scoping.
+
+    The app runs with ``root_path="/api"`` behind both the dev Vite proxy and
+    the production nginx ``location /api/`` block, and neither forwards the
+    prefix upstream. Deriving the path from ``root_path`` keeps the cookie
+    correctly scoped under any mount point instead of hardcoding ``/api``.
+
+    Scoping to the refresh route (rather than ``/``) keeps the cookie off
+    catalog, tile, and upload traffic entirely: it cannot leak through access
+    logs or intermediary proxies on the hot path, and it cannot be replayed
+    against any other endpoint.
+    """
+    root_path = request.scope.get("root_path", "").rstrip("/")
+    return f"{root_path}/auth/refresh"
+
+
+def _secure_cookies() -> bool:
+    """SEC-005: same production switch that hides the API docs and sets
+    ``https_only`` on SessionMiddleware. Development and test runs have no TLS
+    terminator, so a ``Secure`` cookie there would be silently dropped."""
+    return settings.is_production
+
+
+def issue_browser_session(
+    response: Response,
+    request: Request,
+    refresh_token: str,
+    expire_days: int,
+) -> str:
+    """Attach the refresh + CSRF cookies to *response*. Returns the CSRF token.
+
+    ``SameSite=Lax``: the only route under the cookie's ``Path`` is a POST, and
+    Lax and Strict are identical for a same-origin XHR POST (Lax's extra
+    allowance covers top-level GET navigation, which no route here serves). No
+    concrete reason to deviate to Strict was found.
+    """
+    max_age = expire_days * 24 * 60 * 60
+    secure = _secure_cookies()
+    path = refresh_cookie_path(request)
+
+    response.set_cookie(
+        REFRESH_COOKIE_NAME,
+        refresh_token,
+        max_age=max_age,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        path=path,
+    )
+
+    csrf_token = secrets.token_urlsafe(_CSRF_TOKEN_BYTES)
+    # Path="/" so any tab on the app can read it, whatever route it loaded on.
+    response.set_cookie(
+        CSRF_COOKIE_NAME,
+        csrf_token,
+        max_age=max_age,
+        httponly=False,
+        secure=secure,
+        samesite="lax",
+        path="/",
+    )
+    return csrf_token
+
+
+def clear_browser_session(response: Response, request: Request) -> None:
+    """Expire both cookies. Safe to call when no cookie was ever set.
+
+    Deletion works from any request path: the browser applies a ``Set-Cookie``
+    whose name/path/domain match regardless of where the response came from, so
+    ``/auth/logout`` can clear a cookie scoped to ``/auth/refresh``.
+    """
+    response.delete_cookie(
+        REFRESH_COOKIE_NAME,
+        path=refresh_cookie_path(request),
+        httponly=True,
+        secure=_secure_cookies(),
+        samesite="lax",
+    )
+    response.delete_cookie(
+        CSRF_COOKIE_NAME,
+        path="/",
+        secure=_secure_cookies(),
+        samesite="lax",
+    )
+
+
+def read_refresh_cookie(request: Request) -> str | None:
+    return request.cookies.get(REFRESH_COOKIE_NAME)
+
+
+def is_same_origin_as_request(request: Request, url: str) -> bool:
+    """Whether *url* shares scheme+host+port with this request's own origin.
+
+    Used by the OAuth callback: a cookie it sets is scoped to the host the
+    browser used to reach the API, so it is only usable afterwards when the SPA
+    lives on that same origin. A false answer falls back to the pre-GH-1302
+    fragment delivery rather than handing the browser a cookie it will never
+    send back — mismatch degrades, it never locks anyone out.
+    """
+    try:
+        target = urlsplit(url)
+    except ValueError:
+        return False
+    if not target.scheme or not target.netloc:
+        return False
+    return (
+        target.scheme.lower() == (request.url.scheme or "").lower()
+        and target.netloc.lower() == (request.url.netloc or "").lower()
+    )
+
+
+def enforce_csrf(request: Request) -> None:
+    """Double-submit check for cookie-authenticated refresh. Raises 403.
+
+    Double-submit was chosen over a bare enforced-custom-header rule because
+    this deployment's CORS allowlist is operator-configurable at runtime
+    (``CORS_ALLOWED_ORIGINS``, and ``DynamicCORSMiddleware`` emits
+    ``Access-Control-Allow-Credentials: true`` for every listed origin). The
+    "custom header implies a preflight the attacker cannot pass" guarantee is
+    only ever as strong as that list; comparing a value the attacker cannot
+    read does not depend on it. It is also directly exercisable by a plain HTTP
+    client, with no browser preflight to simulate.
+    """
+    header_token = request.headers.get(CSRF_HEADER_NAME)
+    cookie_token = request.cookies.get(CSRF_COOKIE_NAME)
+    if not header_token or not cookie_token:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Missing CSRF token",
+        )
+    if not secrets.compare_digest(header_token, cookie_token):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid CSRF token",
+        )

--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -10,7 +10,11 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.modules.auth.cookies import is_same_origin, issue_browser_session
+from app.modules.auth.cookies import (
+    api_path_is_cookie_scoped,
+    is_same_origin,
+    issue_browser_session,
+)
 from app.modules.auth.oauth.encryption import decrypt_secret
 from app.modules.auth.oauth.schemas import OAuthProviderPublic
 from app.modules.auth.oauth.service import (
@@ -335,7 +339,9 @@ async def oauth_callback(
         # cross-origin SPA cannot send that cookie back, so it keeps the
         # pre-GH-1302 fragment delivery.
         api_url = await get_public_api_url(db, request=request, for_external_use=True)
-        cookie_mode = is_same_origin(frontend_url, api_url)
+        cookie_mode = is_same_origin(
+            frontend_url, api_url
+        ) and api_path_is_cookie_scoped(request, api_url)
         redirect_url = (
             f"{frontend_url}/oauth/callback"
             f"#token={access_token}"

--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -10,7 +10,7 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.modules.auth.cookies import is_same_origin_as_request, issue_browser_session
+from app.modules.auth.cookies import is_same_origin, issue_browser_session
 from app.modules.auth.oauth.encryption import decrypt_secret
 from app.modules.auth.oauth.schemas import OAuthProviderPublic
 from app.modules.auth.oauth.service import (
@@ -334,7 +334,8 @@ async def oauth_callback(
         # marker tells the callback page not to expect a body token. A
         # cross-origin SPA cannot send that cookie back, so it keeps the
         # pre-GH-1302 fragment delivery.
-        cookie_mode = is_same_origin_as_request(request, frontend_url)
+        api_url = await get_public_api_url(db, request=request, for_external_use=True)
+        cookie_mode = is_same_origin(frontend_url, api_url)
         redirect_url = (
             f"{frontend_url}/oauth/callback"
             f"#token={access_token}"

--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -10,6 +10,7 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.modules.auth.cookies import is_same_origin_as_request, issue_browser_session
 from app.modules.auth.oauth.encryption import decrypt_secret
 from app.modules.auth.oauth.schemas import OAuthProviderPublic
 from app.modules.auth.oauth.service import (
@@ -326,25 +327,37 @@ async def oauth_callback(
         )
         await db.commit()
 
+        # GH-1302: when the SPA shares this request's origin, the refresh token
+        # is delivered as an httpOnly cookie and never enters the fragment —
+        # the fragment is readable by any script on the landing page and was
+        # the same exfiltration surface as localStorage. The `auth_mode=cookie`
+        # marker tells the callback page not to expect a body token. A
+        # cross-origin SPA cannot send that cookie back, so it keeps the
+        # pre-GH-1302 fragment delivery.
+        cookie_mode = is_same_origin_as_request(request, frontend_url)
         redirect_url = (
             f"{frontend_url}/oauth/callback"
             f"#token={access_token}"
-            f"&refresh_token={refresh_token}"
-            f"&expires_in={expire_minutes * 60}"
+            + ("" if cookie_mode else f"&refresh_token={refresh_token}")
+            + f"&expires_in={expire_minutes * 60}"
+            + ("&auth_mode=cookie" if cookie_mode else "")
         )
-        # SEC-13 / L-67: the redirect URL carries access_token + refresh_token
-        # in the fragment (#token=...&refresh_token=...). Without
+        # SEC-13 / L-67: the redirect URL carries the access_token (and, on the
+        # cross-origin fallback, the refresh_token) in the fragment. Without
         # `Referrer-Policy: no-referrer`, the browser may include the FULL
         # callback URL (which contains the IdP's `code=` query param) in
         # subsequent Referer headers to third-party assets loaded by the
         # post-redirect page — leaking the auth code. Per-redirect override of
         # the global `strict-origin-when-cross-origin` from
         # SecurityHeadersMiddleware.
-        return RedirectResponse(
+        redirect = RedirectResponse(
             url=redirect_url,
             status_code=302,
             headers={"Referrer-Policy": "no-referrer"},
         )
+        if cookie_mode:
+            issue_browser_session(redirect, request, refresh_token, expire_days)
+        return redirect
 
     except HTTPException:
         raise  # Let 404s from build_oauth_client pass through

--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -8,6 +8,13 @@ from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.modules.auth.cookies import (
+    clear_browser_session,
+    enforce_csrf,
+    issue_browser_session,
+    read_refresh_cookie,
+    wants_cookie_auth,
+)
 from app.modules.auth.dependencies import get_current_active_user, get_optional_user
 from app.modules.auth.models import ApiKey, User
 from app.core.identity import Identity
@@ -75,10 +82,17 @@ def _login_rate_limit(_request: Request | None = None) -> str:
 @limiter.limit(_login_rate_limit)
 async def login(
     request: Request,
+    response: Response,
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: AsyncSession = Depends(get_db),
 ) -> TokenResponse:
-    """Authenticate with username and password, receive a JWT token."""
+    """Authenticate with username and password, receive a JWT token.
+
+    GH-1302: a caller sending ``X-GeoLens-Auth-Mode: cookie`` receives the
+    refresh token as an httpOnly cookie and a null ``refresh_token`` in the
+    body. Without that header the response is unchanged, which is what keeps
+    the CLI, the generated SDKs, Postman, and CI logins working.
+    """
     from app.modules.audit.service import (
         AuditEvent,
         audit_emit,
@@ -195,6 +209,14 @@ async def login(
         ),
     )
     await db.commit()
+
+    if wants_cookie_auth(request):
+        issue_browser_session(response, request, refresh_token, expire_days)
+        return TokenResponse(
+            access_token=token,
+            refresh_token=None,
+            expires_in=expire_minutes * 60,
+        )
     return TokenResponse(
         access_token=token,
         refresh_token=refresh_token,
@@ -212,7 +234,8 @@ async def login(
 @limiter.limit("30/minute")
 async def refresh(
     request: Request,
-    body: RefreshRequest,
+    response: Response,
+    body: RefreshRequest | None = None,
     db: AsyncSession = Depends(get_db),
 ) -> TokenResponse:
     """Exchange a valid refresh token for a new access + refresh token pair.
@@ -221,7 +244,36 @@ async def refresh(
     tokens are opaque and carry no bearer ``tid`` claim, so tenant middleware
     binds the database transaction from that same-origin host before the user
     row is resolved and the next tenant-bound access token is minted.
+
+    GH-1302: with ``X-GeoLens-Auth-Mode: cookie`` the presented token is read
+    from the httpOnly cookie (falling back to the body once, so a session
+    established before the cookie flow shipped migrates on its next refresh
+    instead of being logged out), the double-submit CSRF token is enforced, and
+    the rotated token goes back out as a cookie with a null body
+    ``refresh_token``. Without the header this endpoint behaves exactly as
+    before.
     """
+    cookie_mode = wants_cookie_auth(request)
+    body_token = body.refresh_token if body is not None else None
+
+    if cookie_mode:
+        cookie_token = read_refresh_cookie(request)
+        # CSRF is enforced only when the cookie is what authenticates the call.
+        # A migrating caller presenting a body token holds a bearer-equivalent
+        # secret no cross-site page can read, so gating that path on a CSRF
+        # cookie it does not have yet would strand every pre-upgrade session.
+        if cookie_token is not None:
+            enforce_csrf(request)
+        presented_token = cookie_token or body_token
+    else:
+        presented_token = body_token
+
+    if not presented_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+
     # Read token lifetimes from PersistentConfig (hot-reloadable)
     expire_minutes = await ACCESS_TOKEN_EXPIRE_MINUTES.get(db)
     expire_days = await REFRESH_TOKEN_EXPIRE_DAYS.get(db)
@@ -243,13 +295,13 @@ async def refresh(
     #   continuation for users who already authenticated via SSO.  Only the DOMAIN
     #   check (which is an authorization PERIMETER, not a method selector) belongs
     #   at refresh.
-    user = await service.get_user_from_refresh_token(body.refresh_token)
+    user = await service.get_user_from_refresh_token(presented_token)
     if user is not None:
         await enforce_email_domain_gate(db, user.email, break_glass_user=user)
 
     try:
         access_token, refresh_token = await service.rotate_refresh_token(
-            body.refresh_token,
+            presented_token,
             expire_minutes=expire_minutes,
             expire_days=expire_days,
         )
@@ -257,6 +309,14 @@ async def refresh(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired refresh token",
+        )
+
+    if cookie_mode:
+        issue_browser_session(response, request, refresh_token, expire_days)
+        return TokenResponse(
+            access_token=access_token,
+            refresh_token=None,
+            expires_in=expire_minutes * 60,
         )
     return TokenResponse(
         access_token=access_token,
@@ -665,7 +725,13 @@ async def logout(
         ),
     )
     await db.commit()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    logout_response = Response(status_code=status.HTTP_204_NO_CONTENT)
+    # GH-1302: revocation above already kills the server-side row; clearing the
+    # cookies stops the browser from replaying a dead credential (and from
+    # holding a stale CSRF value into the next session). Unconditional — a
+    # non-browser caller simply has no such cookies to clear.
+    clear_browser_session(logout_response, request)
+    return logout_response
 
 
 @router.post("/download-token/{dataset_id}", response_model=DownloadTokenResponse)

--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -691,7 +691,7 @@ async def resend_verification(
 @router.post("/logout/", status_code=status.HTTP_204_NO_CONTENT)
 async def logout(
     request: Request,
-    current_user: User = Depends(get_current_active_user),
+    identity: Identity | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Revoke all refresh tokens and bump token_version for the current user.
@@ -704,6 +704,13 @@ async def logout(
     fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
     outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
     must not revoke them. Security events (password change, role change) do.
+
+    fix(#1446): the refresh COOKIE can authenticate this call when the access
+    token has aged out. Requiring a live bearer token meant a user returning
+    after their 15-minute access token expired got a 401 here while their
+    multi-day refresh cookie stayed valid — the UI reported a clean logout and
+    the session survived it. CSRF is enforced on that path exactly as it is for
+    /auth/refresh, since the cookie is then the credential.
     """
     from app.modules.audit.service import (
         AuditEvent,
@@ -711,14 +718,28 @@ async def logout(
     )  # LAZY — preserved per D-17
 
     service = AuthService(db)
+    user_id: uuid.UUID | None = identity.id if identity is not None else None
+    if user_id is None:
+        cookie_token = read_refresh_cookie(request)
+        if cookie_token is not None:
+            enforce_csrf(request)
+            cookie_user = await service.get_user_from_refresh_token(cookie_token)
+            if cookie_user is not None:
+                user_id = cookie_user.id
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     # commit=False: fold the token revocation and the audit row into one
     # transaction, mirroring change_password below (fix(#1230): logout was
     # the third gap in the "wrong password, right password, logout" trail).
-    await service.revoke_all_tokens(current_user.id, commit=False)
+    await service.revoke_all_tokens(user_id, commit=False)
     await audit_emit(
         db,
         AuditEvent(
-            user_id=current_user.id,
+            user_id=user_id,
             action="user.logout",
             resource_type="user",
             ip_address=get_client_ip(request),

--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -732,15 +732,23 @@ async def logout(
         # the transport a cross-site page can cause the browser to attach. A
         # body token is bearer-equivalent and unreadable cross-site, the same
         # reasoning /auth/refresh applies.
-        presented = read_refresh_cookie(request)
-        if presented is not None:
+        cookie_token = read_refresh_cookie(request)
+        if cookie_token is not None:
             enforce_csrf(request)
-        elif body is not None:
-            presented = body.refresh_token
-        if presented is not None:
+        # fix(#1446): try every presented credential, cookie first. Unlike
+        # /auth/refresh — where the cookie is authoritative so a stale
+        # localStorage value cannot resurrect an old token family — logout is
+        # best-effort revocation, and a dead cookie left in the jar must not
+        # shadow a live body token (a split-origin install can hold both
+        # after a same-origin era). Failing here leaves the session alive.
+        body_token = body.refresh_token if body is not None else None
+        for presented in (cookie_token, body_token):
+            if presented is None:
+                continue
             token_user = await service.get_user_from_refresh_token(presented)
             if token_user is not None:
                 user_id = token_user.id
+                break
     if user_id is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -692,6 +692,7 @@ async def resend_verification(
 async def logout(
     request: Request,
     identity: Identity | None = Depends(get_optional_user),
+    body: RefreshRequest | None = None,
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Revoke all refresh tokens and bump token_version for the current user.
@@ -720,12 +721,26 @@ async def logout(
     service = AuthService(db)
     user_id: uuid.UUID | None = identity.id if identity is not None else None
     if user_id is None:
-        cookie_token = read_refresh_cookie(request)
-        if cookie_token is not None:
+        # fix(#1446): fall back to a presented refresh token when the access
+        # token has aged out — otherwise logout 401s while a multi-day refresh
+        # credential stays valid, and the UI reports a clean sign-out.
+        #
+        # Two transports, because the deployment topology decides which one a
+        # browser has: the cookie (same-origin installs), and the body token
+        # (split-origin installs, which keep the pre-GH-1302 flow — see
+        # lib/auth-transport.ts). CSRF is enforced only for the cookie: it is
+        # the transport a cross-site page can cause the browser to attach. A
+        # body token is bearer-equivalent and unreadable cross-site, the same
+        # reasoning /auth/refresh applies.
+        presented = read_refresh_cookie(request)
+        if presented is not None:
             enforce_csrf(request)
-            cookie_user = await service.get_user_from_refresh_token(cookie_token)
-            if cookie_user is not None:
-                user_id = cookie_user.id
+        elif body is not None:
+            presented = body.refresh_token
+        if presented is not None:
+            token_user = await service.get_user_from_refresh_token(presented)
+            if token_user is not None:
+                user_id = token_user.id
     if user_id is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/modules/auth/schemas.py
+++ b/backend/app/modules/auth/schemas.py
@@ -14,8 +14,15 @@ UserStatus = Literal["active", "pending", "suspended", "deactivated"]
 
 class TokenResponse(BaseModel):
     access_token: str = Field(description="JWT access token for Authorization header")
-    refresh_token: str = Field(
-        description="Opaque token used to obtain a new access token"
+    refresh_token: str | None = Field(
+        default=None,
+        description=(
+            "Opaque token used to obtain a new access token. Always present for "
+            "programmatic callers (CLI, SDKs, CI). Null when the caller opted "
+            "into the browser cookie flow with 'X-GeoLens-Auth-Mode: cookie', "
+            "in which case the token is delivered as an httpOnly cookie instead "
+            "(GH-1302)."
+        ),
     )
     token_type: str = "bearer"
     expires_in: int = Field(description="Seconds until the access token expires")
@@ -198,7 +205,11 @@ class UserResponse(BaseModel):
 
 
 class RefreshRequest(BaseModel):
-    refresh_token: str = Field(max_length=512)
+    # GH-1302: optional so a browser on the cookie flow can POST an empty body
+    # (its token rides in the httpOnly cookie). Programmatic callers keep
+    # sending it, and the handler still rejects a request that supplies
+    # neither.
+    refresh_token: str | None = Field(default=None, max_length=512)
 
 
 class PermissionsResponse(BaseModel):

--- a/backend/app/modules/auth/schemas.py
+++ b/backend/app/modules/auth/schemas.py
@@ -209,11 +209,12 @@ class UserResponse(BaseModel):
 
 
 class RefreshRequest(BaseModel):
-    # GH-1302: optional so a browser on the cookie flow can POST an empty body
-    # (its token rides in the httpOnly cookie). Programmatic callers keep
-    # sending it, and the handler still rejects a request that supplies
-    # neither.
-    refresh_token: str | None = Field(default=None, max_length=512)
+    # fix(#1446): stays REQUIRED. Only the body as a whole is optional (the
+    # route signature is `RefreshRequest | None = None`) so a browser on the
+    # cookie flow can POST nothing at all. Defaulting the field would instead
+    # declare `{}` a valid body, which the server can do nothing with — it
+    # would only reach the handler and 401.
+    refresh_token: str = Field(max_length=512)
 
 
 class PermissionsResponse(BaseModel):

--- a/backend/app/modules/auth/schemas.py
+++ b/backend/app/modules/auth/schemas.py
@@ -14,8 +14,12 @@ UserStatus = Literal["active", "pending", "suspended", "deactivated"]
 
 class TokenResponse(BaseModel):
     access_token: str = Field(description="JWT access token for Authorization header")
+    # fix(#1446): required-but-nullable, NOT optional. Every login/refresh
+    # response serializes this key (as a string, or null in cookie mode), so
+    # omitting `default=` keeps it in OpenAPI's `required` list and stops the
+    # generated SDKs from exposing an `Unset`/absent shape the server never
+    # emits.
     refresh_token: str | None = Field(
-        default=None,
         description=(
             "Opaque token used to obtain a new access token. Always present for "
             "programmatic callers (CLI, SDKs, CI). Null when the caller opted "

--- a/backend/app/modules/auth/service.py
+++ b/backend/app/modules/auth/service.py
@@ -250,14 +250,29 @@ class AuthService:
             raise ValueError("User account is not active")
 
         # Re-read the presented row now that the lock is held. A new statement
-        # takes a new snapshot, so a revocation that committed while we waited
-        # is visible here and cannot be rotated past. This must run BEFORE the
+        # takes a new snapshot, so anything that committed while we waited is
+        # visible here and cannot be rotated past. This must run BEFORE the
         # retire/revoke below: that write autoflushes, and the re-check would
         # then read back our own pending mutation and reject a valid token.
+        #
+        # fix(#1446): re-check liveness, not just revocation. Waiting on the
+        # lock is unbounded, so the token can lapse in the meantime — either by
+        # simply reaching its own expiry, or because the rotation we were
+        # queued behind shortened it to the grace cutoff. Checking `revoked`
+        # alone would happily rotate an expired token into a fresh session.
+        # A token still inside the grace window has a future expires_at and is
+        # deliberately still accepted (fix(#621)).
         recheck = await self.db.execute(
-            select(RefreshToken.revoked).where(RefreshToken.id == stored.id)
+            select(RefreshToken.revoked, RefreshToken.expires_at).where(
+                RefreshToken.id == stored.id
+            )
         )
-        if recheck.scalar_one_or_none() is not False:
+        current = recheck.one_or_none()
+        if (
+            current is None
+            or current.revoked
+            or current.expires_at <= datetime.now(UTC)
+        ):
             raise ValueError("Invalid or expired refresh token")
 
         # fix(#621): rotation grace window. Instant revocation stranded the

--- a/backend/app/modules/auth/service.py
+++ b/backend/app/modules/auth/service.py
@@ -229,6 +229,37 @@ class AuthService:
         if stored is None:
             raise ValueError("Invalid or expired refresh token")
 
+        # fix(#1446): serialize against revoke_all_tokens on the OWNER row.
+        # Both paths now take this lock first, which is what makes the two
+        # interleavings safe:
+        #   - rotate wins the lock: it inserts its replacement and commits;
+        #     revoke then runs its UPDATE afterwards, and because that
+        #     statement takes a fresh snapshot it sees and revokes the new row.
+        #   - revoke wins: it revokes and commits; rotate acquires the lock and
+        #     the re-check below sees revoked=True, so it raises instead of
+        #     minting a successor.
+        # Without it, a rotation that read its row before a concurrent logout
+        # could commit a still-active replacement afterwards — and since
+        # fix(#1302) that also reinstalls the cookies the logout just deleted,
+        # reviving a session the user ended.
+        user_result = await self.db.execute(
+            select(User).where(User.id == stored.user_id).with_for_update()
+        )
+        user = user_result.scalar_one_or_none()
+        if user is None or not user.is_active or user.status != "active":
+            raise ValueError("User account is not active")
+
+        # Re-read the presented row now that the lock is held. A new statement
+        # takes a new snapshot, so a revocation that committed while we waited
+        # is visible here and cannot be rotated past. This must run BEFORE the
+        # retire/revoke below: that write autoflushes, and the re-check would
+        # then read back our own pending mutation and reject a valid token.
+        recheck = await self.db.execute(
+            select(RefreshToken.revoked).where(RefreshToken.id == stored.id)
+        )
+        if recheck.scalar_one_or_none() is not False:
+            raise ValueError("Invalid or expired refresh token")
+
         # fix(#621): rotation grace window. Instant revocation stranded the
         # losers of a multi-tab refresh race: every tab presents the same
         # rotating token, one caller wins, and the rest were left holding a
@@ -248,14 +279,6 @@ class AuthService:
                 stored.expires_at = grace_cutoff
         else:
             stored.revoked = True
-
-        # Load user and verify active status
-        user_result = await self.db.execute(
-            select(User).where(User.id == stored.user_id)
-        )
-        user = user_result.scalar_one_or_none()
-        if user is None or not user.is_active or user.status != "active":
-            raise ValueError("User account is not active")
 
         # Issue new pair
         identity = AuthenticatedIdentity(user_id=user.id, username=user.username)
@@ -300,6 +323,15 @@ class AuthService:
 
         Returns the new token_version value.
         """
+        # fix(#1446): take the owner-row lock BEFORE revoking, matching
+        # rotate_refresh_token. Ordering is the whole point — a concurrent
+        # rotation must either finish before this revocation's UPDATE takes its
+        # snapshot (so its replacement row is seen and revoked) or block here
+        # and find its own row already revoked.
+        await self.db.execute(
+            select(User.id).where(User.id == user_id).with_for_update()
+        )
+
         # 1. Revoke all active refresh tokens for the user.
         await self.db.execute(
             update(RefreshToken)

--- a/backend/app/modules/auth/service.py
+++ b/backend/app/modules/auth/service.py
@@ -287,10 +287,18 @@ class AuthService:
         # Explicit revocation (logout / revoke_all_tokens) still sets
         # revoked=True on every active row — in-grace ones included — so a
         # hard logout remains instant. grace=0 restores single-use revocation.
+        #
+        # fix(#1446): compare against the POST-LOCK expiry (`current`), not the
+        # `stored` ORM object read before the lock. When several refreshes read
+        # the same long-lived token and then queue here, every queued caller
+        # still holds the original multi-day expiry on `stored`, so each would
+        # find it later than its own cutoff and push the retirement further
+        # out — ratcheting the window open instead of closing it, which is the
+        # opposite of "never EXTEND".
         grace = settings.refresh_rotation_grace_seconds
         if grace > 0:
             grace_cutoff = datetime.now(UTC) + timedelta(seconds=grace)
-            if stored.expires_at > grace_cutoff:
+            if current.expires_at > grace_cutoff:
                 stored.expires_at = grace_cutoff
         else:
             stored.revoked = True

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17323,6 +17323,7 @@
         },
         "required": [
           "access_token",
+          "refresh_token",
           "expires_in"
         ],
         "title": "TokenResponse",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -25162,6 +25162,23 @@
       "post": {
         "description": "Revoke all refresh tokens and bump token_version for the current user.\n\nSEC-S15 (Phase 1062-01): revoke_all_tokens bumps User.token_version so the\naccess JWT used for this logout call (and any other outstanding access JWTs)\nare rejected on the next authenticated request \u2014 closing the\n\"logout doesn't invalidate the access JWT\" gap.\n\nfix(#821): logout deliberately does NOT bump key_epoch \u2014 API keys exist to\noutlive browser sessions (CI, MCP servers, tile URLs), so session hygiene\nmust not revoke them. Security events (password change, role change) do.\n\nfix(#1446): the refresh COOKIE can authenticate this call when the access\ntoken has aged out. Requiring a live bearer token meant a user returning\nafter their 15-minute access token expired got a 401 here while their\nmulti-day refresh cookie stayed valid \u2014 the UI reported a clean logout and\nthe session survived it. CSRF is enforced on that path exactly as it is for\n/auth/refresh, since the cookie is then the credential.",
         "operationId": "logout_auth_logout__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RefreshRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
         "responses": {
           "204": {
             "description": "Successful Response"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -13580,18 +13580,14 @@
       "RefreshRequest": {
         "properties": {
           "refresh_token": {
-            "anyOf": [
-              {
-                "maxLength": 512,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Refresh Token"
+            "maxLength": 512,
+            "title": "Refresh Token",
+            "type": "string"
           }
         },
+        "required": [
+          "refresh_token"
+        ],
         "title": "RefreshRequest",
         "type": "object"
       },
@@ -25164,7 +25160,7 @@
     },
     "/auth/logout/": {
       "post": {
-        "description": "Revoke all refresh tokens and bump token_version for the current user.\n\nSEC-S15 (Phase 1062-01): revoke_all_tokens bumps User.token_version so the\naccess JWT used for this logout call (and any other outstanding access JWTs)\nare rejected on the next authenticated request \u2014 closing the\n\"logout doesn't invalidate the access JWT\" gap.\n\nfix(#821): logout deliberately does NOT bump key_epoch \u2014 API keys exist to\noutlive browser sessions (CI, MCP servers, tile URLs), so session hygiene\nmust not revoke them. Security events (password change, role change) do.",
+        "description": "Revoke all refresh tokens and bump token_version for the current user.\n\nSEC-S15 (Phase 1062-01): revoke_all_tokens bumps User.token_version so the\naccess JWT used for this logout call (and any other outstanding access JWTs)\nare rejected on the next authenticated request \u2014 closing the\n\"logout doesn't invalidate the access JWT\" gap.\n\nfix(#821): logout deliberately does NOT bump key_epoch \u2014 API keys exist to\noutlive browser sessions (CI, MCP servers, tile URLs), so session hygiene\nmust not revoke them. Security events (password change, role change) do.\n\nfix(#1446): the refresh COOKIE can authenticate this call when the access\ntoken has aged out. Requiring a live bearer token meant a user returning\nafter their 15-minute access token expired got a 401 here while their\nmulti-day refresh cookie stayed valid \u2014 the UI reported a clean logout and\nthe session survived it. CSRF is enforced on that path exactly as it is for\n/auth/refresh, since the cookie is then the credential.",
         "operationId": "logout_auth_logout__post",
         "responses": {
           "204": {
@@ -25261,6 +25257,7 @@
           }
         },
         "security": [
+          {},
           {
             "OAuth2PasswordBearer": []
           },

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -13580,14 +13580,18 @@
       "RefreshRequest": {
         "properties": {
           "refresh_token": {
-            "maxLength": 512,
-            "title": "Refresh Token",
-            "type": "string"
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Token"
           }
         },
-        "required": [
-          "refresh_token"
-        ],
         "title": "RefreshRequest",
         "type": "object"
       },
@@ -17295,9 +17299,16 @@
             "type": "string"
           },
           "refresh_token": {
-            "description": "Opaque token used to obtain a new access token",
-            "title": "Refresh Token",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque token used to obtain a new access token. Always present for programmatic callers (CLI, SDKs, CI). Null when the caller opted into the browser cookie flow with 'X-GeoLens-Auth-Mode: cookie', in which case the token is delivered as an httpOnly cookie instead (GH-1302).",
+            "title": "Refresh Token"
           },
           "token_type": {
             "default": "bearer",
@@ -17312,7 +17323,6 @@
         },
         "required": [
           "access_token",
-          "refresh_token",
           "expires_in"
         ],
         "title": "TokenResponse",
@@ -25032,7 +25042,7 @@
     },
     "/auth/login": {
       "post": {
-        "description": "Authenticate with username and password, receive a JWT token.",
+        "description": "Authenticate with username and password, receive a JWT token.\n\nGH-1302: a caller sending ``X-GeoLens-Auth-Mode: cookie`` receives the\nrefresh token as an httpOnly cookie and a null ``refresh_token`` in the\nbody. Without that header the response is unchanged, which is what keeps\nthe CLI, the generated SDKs, Postman, and CI logins working.",
         "operationId": "login_auth_login_post",
         "requestBody": {
           "content": {
@@ -25979,17 +25989,24 @@
     },
     "/auth/refresh/": {
       "post": {
-        "description": "Exchange a valid refresh token for a new access + refresh token pair.\n\nMulti-tenant clients must call this endpoint on their tenant host. Refresh\ntokens are opaque and carry no bearer ``tid`` claim, so tenant middleware\nbinds the database transaction from that same-origin host before the user\nrow is resolved and the next tenant-bound access token is minted.",
+        "description": "Exchange a valid refresh token for a new access + refresh token pair.\n\nMulti-tenant clients must call this endpoint on their tenant host. Refresh\ntokens are opaque and carry no bearer ``tid`` claim, so tenant middleware\nbinds the database transaction from that same-origin host before the user\nrow is resolved and the next tenant-bound access token is minted.\n\nGH-1302: with ``X-GeoLens-Auth-Mode: cookie`` the presented token is read\nfrom the httpOnly cookie (falling back to the body once, so a session\nestablished before the cookie flow shipped migrates on its next refresh\ninstead of being logged out), the double-submit CSRF token is enforced, and\nthe rotated token goes back out as a cookie with a null body\n``refresh_token``. Without the header this endpoint behaves exactly as\nbefore.",
         "operationId": "refresh_auth_refresh__post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RefreshRequest"
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RefreshRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {

--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -13,6 +13,8 @@ client's request path, so httpx's own jar would never replay it. Tests read the
 jar by hand via ``_arm_cookies``.
 """
 
+from datetime import UTC, datetime
+
 from httpx import AsyncClient
 
 from app.core.config import settings
@@ -500,6 +502,81 @@ class TestRotationRevocationRace:
                 "/auth/refresh/", json={"refresh_token": rotated_value}
             )
             assert rotated.status_code == 401, "rotated token outlived logout"
+
+
+class TestGraceWindowCannotRatchetOpen:
+    """fix(#1446): queued rotations must not each push the retirement cutoff
+    further out. Each holds an ORM row read BEFORE the lock, still carrying the
+    original multi-day expiry, so comparing against that instead of the
+    post-lock value extends the window on every pass — the opposite of the
+    'never EXTEND' invariant the grace window (fix(#621)) is built on."""
+
+    async def test_concurrent_rotations_do_not_extend_the_retirement_cutoff(
+        self, client: AsyncClient, test_db_session, monkeypatch
+    ):
+        import hashlib
+
+        import anyio
+        from sqlalchemy import select
+
+        from app.modules.auth.models import RefreshToken
+        from app.modules.auth.service import AuthService
+
+        original_create_access_token = AuthService.create_access_token
+
+        # Long enough that a ratcheted cutoff clears the tolerance below. With
+        # a short stall the extension is only a fraction of a second and the
+        # assertion cannot tell it from timing noise.
+        stall_seconds = 2.5
+
+        async def _stalled_create_access_token(self, *args, **kwargs):
+            await anyio.sleep(stall_seconds)
+            return await original_create_access_token(self, *args, **kwargs)
+
+        refresh_token = (await _login(client, cookie_mode=False)).json()[
+            "refresh_token"
+        ]
+        token_hash = hashlib.sha256(refresh_token.encode()).hexdigest()
+
+        grace = settings.refresh_rotation_grace_seconds
+        assert grace > 0, "this test is about the grace window"
+
+        async def _rotate() -> None:
+            await client.post("/auth/refresh/", json={"refresh_token": refresh_token})
+
+        client.cookies.clear()
+        monkeypatch.setattr(
+            AuthService, "create_access_token", _stalled_create_access_token
+        )
+        # Anchor to a fixed instant taken BEFORE either rotation runs. Measuring
+        # against "now" after the fact hides the bug: the queued caller stalls
+        # again after setting its cutoff, so the extension has already elapsed
+        # by the time the assertion runs.
+        started_at = datetime.now(UTC)
+        # Both read the row while it still carries its original expiry, then
+        # queue on the owner lock — the interleaving that exposes the stale
+        # comparison.
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_rotate)
+            tg.start_soon(_rotate)
+        monkeypatch.undo()
+
+        row = (
+            await test_db_session.execute(
+                select(RefreshToken.expires_at).where(
+                    RefreshToken.token_hash == token_hash
+                )
+            )
+        ).scalar_one()
+        # Retired to about one grace window measured from the START, NOT to the
+        # original multi-day lifetime and not to a cutoff the queued caller
+        # pushed out by its own stall. The tolerance sits well under the stall,
+        # so a ratchet is unambiguous.
+        overshoot = (row - started_at).total_seconds() - grace
+        assert overshoot <= 1, (
+            f"retirement cutoff was extended {overshoot:.2f}s beyond the "
+            f"{grace}s grace window measured from the start of the race"
+        )
 
 
 class TestOriginComparison:

--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -1,0 +1,318 @@
+"""GH-1302: browser refresh tokens in httpOnly cookies with CSRF protection.
+
+The compatibility contract these tests pin down: without the explicit
+``X-GeoLens-Auth-Mode: cookie`` opt-in every response is byte-identical to the
+pre-GH-1302 shape, which is what keeps the CLI, the generated SDKs, and CI
+logins working. With it, the refresh token leaves the JSON body entirely.
+
+The test client talks to the ASGI app directly, so it never traverses the
+``/api`` rewrite that nginx and the Vite dev proxy apply. The cookie's ``Path``
+is derived from ``root_path`` (``/api``) and therefore does NOT match the
+client's request path, so httpx's own jar would never replay it. Tests read the
+``Set-Cookie`` attributes directly (asserting the real values) and re-arm the
+jar by hand via ``_arm_cookies``.
+"""
+
+from httpx import AsyncClient
+
+from app.core.config import settings
+from app.modules.auth.cookies import CSRF_COOKIE_NAME, REFRESH_COOKIE_NAME
+
+ADMIN_USER = settings.geolens_admin_username
+ADMIN_PASS = settings.geolens_admin_password.get_secret_value()
+
+COOKIE_MODE = {"X-GeoLens-Auth-Mode": "cookie"}
+
+
+async def _login(client: AsyncClient, *, cookie_mode: bool):
+    headers = dict(COOKIE_MODE) if cookie_mode else {}
+    resp = await client.post(
+        "/auth/login",
+        data={"username": ADMIN_USER, "password": ADMIN_PASS},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp
+
+
+def _cookie_attrs(resp, name: str) -> dict[str, str]:
+    """Parse the Set-Cookie header for *name* into a lowercased attribute map."""
+    for header in resp.headers.get_list("set-cookie"):
+        if not header.startswith(f"{name}="):
+            continue
+        parts = [p.strip() for p in header.split(";")]
+        attrs: dict[str, str] = {"value": parts[0].split("=", 1)[1]}
+        for part in parts[1:]:
+            key, _, value = part.partition("=")
+            attrs[key.lower()] = value
+        return attrs
+    raise AssertionError(
+        f"no Set-Cookie for {name!r} in {resp.headers.get_list('set-cookie')}"
+    )
+
+
+def _arm_cookies(client: AsyncClient, refresh: str | None, csrf: str | None) -> None:
+    """Load the jar as a browser would, replacing anything already there.
+
+    Set on the client rather than per-request: httpx deprecated per-request
+    ``cookies=`` because its persistence semantics are ambiguous.
+    """
+    client.cookies.clear()
+    if refresh is not None:
+        client.cookies.set(REFRESH_COOKIE_NAME, refresh)
+    if csrf is not None:
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+
+
+class TestProgrammaticCallersUnchanged:
+    """Compat guard for the CLI / SDK / CI JSON path (no opt-in header)."""
+
+    async def test_login_without_optin_returns_body_token_and_no_cookies(
+        self, client: AsyncClient
+    ):
+        resp = await _login(client, cookie_mode=False)
+        assert resp.json()["refresh_token"]
+        assert not resp.headers.get_list("set-cookie")
+
+    async def test_refresh_without_optin_returns_body_token_and_no_cookies(
+        self, client: AsyncClient
+    ):
+        refresh_token = (await _login(client, cookie_mode=False)).json()[
+            "refresh_token"
+        ]
+        client.cookies.clear()
+
+        resp = await client.post(
+            "/auth/refresh/", json={"refresh_token": refresh_token}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["refresh_token"]
+        assert data["refresh_token"] != refresh_token
+        assert not resp.headers.get_list("set-cookie")
+
+    async def test_refresh_without_optin_needs_no_csrf(self, client: AsyncClient):
+        """A CSRF token must never become mandatory for the JSON path — that
+        would break every non-browser caller."""
+        refresh_token = (await _login(client, cookie_mode=False)).json()[
+            "refresh_token"
+        ]
+        client.cookies.clear()
+
+        resp = await client.post(
+            "/auth/refresh/", json={"refresh_token": refresh_token}
+        )
+        assert resp.status_code == 200
+
+
+class TestBrowserCookieFlow:
+    async def test_login_sets_httponly_refresh_cookie_and_nulls_body_token(
+        self, client: AsyncClient
+    ):
+        resp = await _login(client, cookie_mode=True)
+
+        assert resp.json()["refresh_token"] is None
+        refresh = _cookie_attrs(resp, REFRESH_COOKIE_NAME)
+        assert "httponly" in refresh
+        assert refresh["path"] == "/api/auth/refresh"
+        assert refresh["samesite"].lower() == "lax"
+        assert refresh["value"]
+
+    async def test_csrf_cookie_is_readable_and_not_a_credential(
+        self, client: AsyncClient
+    ):
+        """The double-submit token must be script-readable (the SPA echoes it
+        back), unlike the refresh cookie."""
+        resp = await _login(client, cookie_mode=True)
+        csrf = _cookie_attrs(resp, CSRF_COOKIE_NAME)
+        assert "httponly" not in csrf
+        assert csrf["path"] == "/"
+        assert csrf["value"]
+
+    async def test_cookie_refresh_rotates_and_keeps_token_out_of_body(
+        self, client: AsyncClient
+    ):
+        login = await _login(client, cookie_mode=True)
+        refresh_value = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf_value = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        _arm_cookies(client, refresh_value, csrf_value)
+
+        resp = await client.post(
+            "/auth/refresh/",
+            headers={**COOKIE_MODE, "X-CSRF-Token": csrf_value},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["access_token"]
+        assert data["refresh_token"] is None
+
+        rotated = _cookie_attrs(resp, REFRESH_COOKIE_NAME)
+        assert rotated["value"] != refresh_value
+        assert "httponly" in rotated
+
+    async def test_cookie_refresh_needs_no_request_body(self, client: AsyncClient):
+        """The browser sends no body at all — the credential is the cookie."""
+        login = await _login(client, cookie_mode=True)
+        refresh_value = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf_value = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        _arm_cookies(client, refresh_value, csrf_value)
+
+        resp = await client.post(
+            "/auth/refresh/",
+            headers={**COOKIE_MODE, "X-CSRF-Token": csrf_value},
+        )
+        assert resp.status_code == 200, resp.text
+
+
+class TestCsrfEnforcement:
+    """AC: a state-changing request carrying the session cookie but no CSRF
+    token is rejected."""
+
+    async def test_cookie_without_csrf_header_is_rejected(self, client: AsyncClient):
+        login = await _login(client, cookie_mode=True)
+        refresh_value = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf_value = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        _arm_cookies(client, refresh_value, csrf_value)
+
+        resp = await client.post("/auth/refresh/", headers=COOKIE_MODE)
+        assert resp.status_code == 403
+        assert "CSRF" in resp.json()["detail"]
+
+    async def test_mismatched_csrf_header_is_rejected(self, client: AsyncClient):
+        login = await _login(client, cookie_mode=True)
+        refresh_value = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf_value = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        _arm_cookies(client, refresh_value, csrf_value)
+
+        resp = await client.post(
+            "/auth/refresh/",
+            headers={**COOKIE_MODE, "X-CSRF-Token": "not-the-right-token"},
+        )
+        assert resp.status_code == 403
+
+    async def test_rejected_csrf_leaves_the_refresh_token_usable(
+        self, client: AsyncClient
+    ):
+        """A forged cross-site refresh must not burn the victim's session."""
+        login = await _login(client, cookie_mode=True)
+        refresh_value = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf_value = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        _arm_cookies(client, refresh_value, csrf_value)
+
+        forged = await client.post("/auth/refresh/", headers=COOKIE_MODE)
+        assert forged.status_code == 403
+
+        legitimate = await client.post(
+            "/auth/refresh/",
+            headers={**COOKIE_MODE, "X-CSRF-Token": csrf_value},
+        )
+        assert legitimate.status_code == 200
+
+
+class TestTransitionFromBodyTokens:
+    """Sessions established before this shipped hold a localStorage refresh
+    token. Their first post-deploy refresh must migrate them to the cookie
+    rather than logging them out."""
+
+    async def test_body_token_under_cookie_mode_migrates_to_cookie(
+        self, client: AsyncClient
+    ):
+        legacy_token = (await _login(client, cookie_mode=False)).json()["refresh_token"]
+        client.cookies.clear()
+
+        resp = await client.post(
+            "/auth/refresh/",
+            headers=COOKIE_MODE,
+            json={"refresh_token": legacy_token},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["refresh_token"] is None
+
+        migrated = _cookie_attrs(resp, REFRESH_COOKIE_NAME)
+        assert "httponly" in migrated
+        assert migrated["value"] != legacy_token
+
+    async def test_cookie_wins_over_a_stale_body_token(self, client: AsyncClient):
+        """Once the cookie exists it is authoritative, so a stale localStorage
+        value left behind by the migration cannot resurrect an old family."""
+        stale = (await _login(client, cookie_mode=False)).json()["refresh_token"]
+        login = await _login(client, cookie_mode=True)
+        refresh_value = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf_value = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        _arm_cookies(client, refresh_value, csrf_value)
+
+        resp = await client.post(
+            "/auth/refresh/",
+            headers={**COOKIE_MODE, "X-CSRF-Token": csrf_value},
+            json={"refresh_token": stale},
+        )
+        assert resp.status_code == 200
+
+        # The stale body token was never presented, so it still rotates cleanly.
+        client.cookies.clear()
+        still_valid = await client.post("/auth/refresh/", json={"refresh_token": stale})
+        assert still_valid.status_code == 200
+
+    async def test_missing_credential_entirely_is_401_not_422(
+        self, client: AsyncClient
+    ):
+        client.cookies.clear()
+        resp = await client.post("/auth/refresh/", headers=COOKIE_MODE)
+        assert resp.status_code == 401
+
+
+class TestLogoutClearsCookies:
+    async def test_logout_expires_both_cookies(self, client: AsyncClient):
+        login = await _login(client, cookie_mode=True)
+        access = login.json()["access_token"]
+
+        resp = await client.post(
+            "/auth/logout/", headers={"Authorization": f"Bearer {access}"}
+        )
+        assert resp.status_code == 204
+
+        for name, path in (
+            (REFRESH_COOKIE_NAME, "/api/auth/refresh"),
+            (CSRF_COOKIE_NAME, "/"),
+        ):
+            cleared = _cookie_attrs(resp, name)
+            assert cleared["path"] == path
+            assert cleared["value"] in ("", '""')
+
+    async def test_logout_revokes_the_cookie_token_server_side(
+        self, client: AsyncClient
+    ):
+        """Clearing the cookie is cosmetic on its own; the row must die too."""
+        login = await _login(client, cookie_mode=True)
+        refresh_value = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf_value = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        access = login.json()["access_token"]
+
+        await client.post(
+            "/auth/logout/", headers={"Authorization": f"Bearer {access}"}
+        )
+        _arm_cookies(client, refresh_value, csrf_value)
+
+        resp = await client.post(
+            "/auth/refresh/",
+            headers={**COOKIE_MODE, "X-CSRF-Token": csrf_value},
+        )
+        assert resp.status_code == 401
+
+
+class TestSecureFlagFollowsProductionPosture:
+    """SEC-005: same switch that hides the docs and sets SessionMiddleware's
+    https_only. Dev/test have no TLS terminator, so a Secure cookie there would
+    be dropped silently."""
+
+    async def test_secure_absent_in_development(self, client: AsyncClient):
+        resp = await _login(client, cookie_mode=True)
+        assert "secure" not in _cookie_attrs(resp, REFRESH_COOKIE_NAME)
+
+    async def test_secure_set_in_production(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(
+            type(settings), "is_production", property(lambda self: True)
+        )
+        resp = await _login(client, cookie_mode=True)
+        assert "secure" in _cookie_attrs(resp, REFRESH_COOKIE_NAME)
+        assert "secure" in _cookie_attrs(resp, CSRF_COOKIE_NAME)

--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -368,6 +368,32 @@ class TestLogoutClearsCookies:
         resp = await client.post("/auth/logout/")
         assert resp.status_code == 401
 
+    # fix(#1446): a split-origin deployment has no usable cookie and keeps its
+    # refresh token in the store. Without a body transport, an expired access
+    # token there means logout 401s and the session outlives it.
+    async def test_a_body_refresh_token_can_authenticate_logout(
+        self, client: AsyncClient
+    ):
+        refresh_token = (await _login(client, cookie_mode=False)).json()[
+            "refresh_token"
+        ]
+        client.cookies.clear()
+
+        resp = await client.post("/auth/logout/", json={"refresh_token": refresh_token})
+        assert resp.status_code == 204, resp.text
+
+        after = await client.post(
+            "/auth/refresh/", json={"refresh_token": refresh_token}
+        )
+        assert after.status_code == 401
+
+    async def test_a_bogus_body_refresh_token_is_401(self, client: AsyncClient):
+        client.cookies.clear()
+        resp = await client.post(
+            "/auth/logout/", json={"refresh_token": "not-a-real-token"}
+        )
+        assert resp.status_code == 401
+
     async def test_logout_revokes_the_cookie_token_server_side(
         self, client: AsyncClient
     ):
@@ -387,6 +413,93 @@ class TestLogoutClearsCookies:
             headers={**COOKIE_MODE, "X-CSRF-Token": csrf_value},
         )
         assert resp.status_code == 401
+
+
+class TestRotationRevocationRace:
+    """fix(#1446): a rotation that read its row before a concurrent logout must
+    not commit a still-active replacement afterwards. Client-side guards cannot
+    help here — the browser applies the late Set-Cookie and the row is already
+    in the database — so rotation and revocation serialize on the owner row."""
+
+    async def test_a_rotation_racing_logout_never_leaves_a_live_session(
+        self, client: AsyncClient, monkeypatch
+    ):
+        import anyio
+
+        from app.modules.auth.service import AuthService
+
+        # Force the interleaving instead of hoping for it. Firing both requests
+        # and hoping to land in the window passes with or without the fix, which
+        # would make this test decorative. Stalling rotation right after it has
+        # read its row and taken the owner lock puts logout squarely inside the
+        # danger window: unserialized, logout commits its revocation first and
+        # rotation then inserts a live successor; serialized, logout blocks on
+        # the lock and its revocation sees the successor.
+        original_create_access_token = AuthService.create_access_token
+
+        async def _stalled_create_access_token(self, *args, **kwargs):
+            await anyio.sleep(0.75)
+            return await original_create_access_token(self, *args, **kwargs)
+
+        login = await _login(client, cookie_mode=True)
+        refresh_value = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf_value = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        access = login.json()["access_token"]
+
+        results: dict[str, int] = {}
+
+        async def _refresh() -> None:
+            resp = await client.post(
+                "/auth/refresh/",
+                headers={
+                    **COOKIE_MODE,
+                    "X-CSRF-Token": csrf_value,
+                    "Cookie": (
+                        f"{REFRESH_COOKIE_NAME}={refresh_value}; "
+                        f"{CSRF_COOKIE_NAME}={csrf_value}"
+                    ),
+                },
+            )
+            results["refresh"] = resp.status_code
+            if resp.status_code == 200:
+                results["rotated"] = 1
+                attrs = _cookie_attrs(resp, REFRESH_COOKIE_NAME)
+                results["rotated_value"] = attrs["value"]  # type: ignore[assignment]
+
+        async def _logout() -> None:
+            # Let rotation reach the stall (and take the lock) first.
+            await anyio.sleep(0.2)
+            resp = await client.post(
+                "/auth/logout/", headers={"Authorization": f"Bearer {access}"}
+            )
+            results["logout"] = resp.status_code
+
+        client.cookies.clear()
+        monkeypatch.setattr(
+            AuthService, "create_access_token", _stalled_create_access_token
+        )
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_refresh)
+            tg.start_soon(_logout)
+        monkeypatch.undo()
+
+        assert results["logout"] == 204
+
+        # Whatever the interleaving, no refresh credential may survive: neither
+        # the original nor any replacement the rotation managed to mint.
+        client.cookies.clear()
+        original = await client.post(
+            "/auth/refresh/", json={"refresh_token": refresh_value}
+        )
+        assert original.status_code == 401, "original token outlived logout"
+
+        rotated_value = results.get("rotated_value")
+        if rotated_value:
+            client.cookies.clear()
+            rotated = await client.post(
+                "/auth/refresh/", json={"refresh_token": rotated_value}
+            )
+            assert rotated.status_code == 401, "rotated token outlived logout"
 
 
 class TestOriginComparison:

--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -19,7 +19,7 @@ from app.core.config import settings
 from app.modules.auth.cookies import (
     CSRF_COOKIE_NAME,
     REFRESH_COOKIE_NAME,
-    is_same_origin_as_request,
+    is_same_origin,
 )
 
 ADMIN_USER = settings.geolens_admin_username
@@ -283,6 +283,53 @@ class TestLogoutClearsCookies:
             assert cleared["path"] == path
             assert cleared["value"] in ("", '""')
 
+    # fix(#1446): a user returning after their 15-minute access token expired
+    # would otherwise get a 401 here while their multi-day refresh cookie
+    # stayed valid — the UI reports a clean logout and the session survives it.
+    async def test_the_cookie_alone_can_authenticate_logout(self, client: AsyncClient):
+        login = await _login(client, cookie_mode=True)
+        refresh_value = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf_value = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        _arm_cookies(client, refresh_value, csrf_value)
+
+        # No Authorization header at all — as if the access token had expired.
+        resp = await client.post(
+            "/auth/logout/", headers={**COOKIE_MODE, "X-CSRF-Token": csrf_value}
+        )
+        assert resp.status_code == 204, resp.text
+
+        _arm_cookies(client, refresh_value, csrf_value)
+        after = await client.post(
+            "/auth/refresh/",
+            headers={**COOKIE_MODE, "X-CSRF-Token": csrf_value},
+        )
+        assert after.status_code == 401
+
+    async def test_cookie_authenticated_logout_still_requires_csrf(
+        self, client: AsyncClient
+    ):
+        """Otherwise a cross-site page could force-logout any signed-in user."""
+        login = await _login(client, cookie_mode=True)
+        refresh_value = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf_value = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        _arm_cookies(client, refresh_value, csrf_value)
+
+        resp = await client.post("/auth/logout/", headers=COOKIE_MODE)
+        assert resp.status_code == 403
+
+        # The session must survive the rejected attempt.
+        _arm_cookies(client, refresh_value, csrf_value)
+        still_alive = await client.post(
+            "/auth/refresh/",
+            headers={**COOKIE_MODE, "X-CSRF-Token": csrf_value},
+        )
+        assert still_alive.status_code == 200
+
+    async def test_logout_without_any_credential_is_401(self, client: AsyncClient):
+        client.cookies.clear()
+        resp = await client.post("/auth/logout/")
+        assert resp.status_code == 401
+
     async def test_logout_revokes_the_cookie_token_server_side(
         self, client: AsyncClient
     ):
@@ -306,41 +353,30 @@ class TestLogoutClearsCookies:
 
 class TestOriginComparison:
     """fix(#1446): the OAuth callback decides cookie-vs-fragment delivery from
-    this. Spelling out a default port is the same origin to a browser, and
-    comparing raw netlocs silently dropped such deployments back to putting the
-    refresh token in the URL fragment."""
+    this, comparing the deployment's two CONFIGURED public URLs. Deriving one
+    side from the live request was wrong under any Host-rewriting proxy (the
+    shipped Vite dev proxy sets changeOrigin: true), and spelling out a default
+    port must not read as a different origin."""
 
-    @staticmethod
-    def _request(url: str):
-        from starlette.datastructures import URL
-
-        class _FakeRequest:
-            def __init__(self, value: str) -> None:
-                self.url = URL(value)
-
-        return _FakeRequest(url)
+    def test_the_shipped_topology_is_same_origin(self):
+        # SPA at the root, API under /api on the same host.
+        assert is_same_origin("https://geo.example.com", "https://geo.example.com/api")
 
     def test_explicit_default_port_matches_an_omitted_one(self):
-        req = self._request("https://example.com/auth/callback")
-        assert is_same_origin_as_request(req, "https://example.com:443")
-        assert is_same_origin_as_request(
-            self._request("http://example.com/auth/callback"), "http://example.com:80"
-        )
+        assert is_same_origin("https://example.com:443", "https://example.com")
+        assert is_same_origin("http://example.com:80", "http://example.com")
 
-    def test_plain_match_and_case_insensitive_host(self):
-        req = self._request("https://Example.COM/auth/callback")
-        assert is_same_origin_as_request(req, "https://example.com")
+    def test_host_comparison_is_case_insensitive(self):
+        assert is_same_origin("https://Example.COM", "https://example.com/api")
 
     def test_genuinely_different_origins_do_not_match(self):
-        req = self._request("https://example.com/auth/callback")
-        assert not is_same_origin_as_request(req, "https://elsewhere.example")
-        assert not is_same_origin_as_request(req, "http://example.com")
-        assert not is_same_origin_as_request(req, "https://example.com:8443")
+        assert not is_same_origin("https://example.com", "https://elsewhere.example")
+        assert not is_same_origin("https://example.com", "http://example.com")
+        assert not is_same_origin("https://example.com", "https://example.com:8443")
 
     def test_unusable_values_are_not_same_origin(self):
-        req = self._request("https://example.com/auth/callback")
-        assert not is_same_origin_as_request(req, "/relative/path")
-        assert not is_same_origin_as_request(req, "")
+        assert not is_same_origin("https://example.com", "/relative/path")
+        assert not is_same_origin("https://example.com", "")
 
 
 class TestSecureFlagFollowsProductionPosture:

--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -16,7 +16,11 @@ jar by hand via ``_arm_cookies``.
 from httpx import AsyncClient
 
 from app.core.config import settings
-from app.modules.auth.cookies import CSRF_COOKIE_NAME, REFRESH_COOKIE_NAME
+from app.modules.auth.cookies import (
+    CSRF_COOKIE_NAME,
+    REFRESH_COOKIE_NAME,
+    is_same_origin_as_request,
+)
 
 ADMIN_USER = settings.geolens_admin_username
 ADMIN_PASS = settings.geolens_admin_password.get_secret_value()
@@ -298,6 +302,45 @@ class TestLogoutClearsCookies:
             headers={**COOKIE_MODE, "X-CSRF-Token": csrf_value},
         )
         assert resp.status_code == 401
+
+
+class TestOriginComparison:
+    """fix(#1446): the OAuth callback decides cookie-vs-fragment delivery from
+    this. Spelling out a default port is the same origin to a browser, and
+    comparing raw netlocs silently dropped such deployments back to putting the
+    refresh token in the URL fragment."""
+
+    @staticmethod
+    def _request(url: str):
+        from starlette.datastructures import URL
+
+        class _FakeRequest:
+            def __init__(self, value: str) -> None:
+                self.url = URL(value)
+
+        return _FakeRequest(url)
+
+    def test_explicit_default_port_matches_an_omitted_one(self):
+        req = self._request("https://example.com/auth/callback")
+        assert is_same_origin_as_request(req, "https://example.com:443")
+        assert is_same_origin_as_request(
+            self._request("http://example.com/auth/callback"), "http://example.com:80"
+        )
+
+    def test_plain_match_and_case_insensitive_host(self):
+        req = self._request("https://Example.COM/auth/callback")
+        assert is_same_origin_as_request(req, "https://example.com")
+
+    def test_genuinely_different_origins_do_not_match(self):
+        req = self._request("https://example.com/auth/callback")
+        assert not is_same_origin_as_request(req, "https://elsewhere.example")
+        assert not is_same_origin_as_request(req, "http://example.com")
+        assert not is_same_origin_as_request(req, "https://example.com:8443")
+
+    def test_unusable_values_are_not_same_origin(self):
+        req = self._request("https://example.com/auth/callback")
+        assert not is_same_origin_as_request(req, "/relative/path")
+        assert not is_same_origin_as_request(req, "")
 
 
 class TestSecureFlagFollowsProductionPosture:

--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -55,6 +55,23 @@ def _cookie_attrs(resp, name: str) -> dict[str, str]:
     )
 
 
+def _path_matches(request_path: str, cookie_path: str) -> bool:
+    """RFC 6265 5.1.4 path-match, so tests reason the way a browser does.
+
+    fix(#1446): `_arm_cookies` loads the jar with an UNSCOPED cookie, which is
+    convenient for exercising handlers but structurally blind to `Path=` being
+    wrong. The cookie-authenticated logout route was unreachable in a real
+    browser while its handler test passed. Assert the scope explicitly.
+    """
+    if request_path == cookie_path:
+        return True
+    if not request_path.startswith(cookie_path):
+        return False
+    if cookie_path.endswith("/"):
+        return True
+    return request_path[len(cookie_path)] == "/"
+
+
 def _arm_cookies(client: AsyncClient, refresh: str | None, csrf: str | None) -> None:
     """Load the jar as a browser would, replacing anything already there.
 
@@ -118,9 +135,30 @@ class TestBrowserCookieFlow:
         assert resp.json()["refresh_token"] is None
         refresh = _cookie_attrs(resp, REFRESH_COOKIE_NAME)
         assert "httponly" in refresh
-        assert refresh["path"] == "/api/auth/refresh"
+        assert refresh["path"] == "/api/auth"
         assert refresh["samesite"].lower() == "lax"
         assert refresh["value"]
+
+    async def test_cookie_scope_reaches_refresh_and_logout_but_not_the_data_plane(
+        self, client: AsyncClient
+    ):
+        """The Path must cover BOTH routes that consume the cookie. Scoped to
+        /auth/refresh alone, a browser never sent it to /auth/logout and the
+        cookie-authenticated logout path could not fire (fix(#1446))."""
+        resp = await _login(client, cookie_mode=True)
+        cookie_path = _cookie_attrs(resp, REFRESH_COOKIE_NAME)["path"]
+
+        assert _path_matches("/api/auth/refresh/", cookie_path)
+        assert _path_matches("/api/auth/logout/", cookie_path)
+        # Still off the data plane: no catalog, tile, upload, or export traffic
+        # ever carries the refresh credential.
+        for hot_path in (
+            "/api/datasets/",
+            "/api/maps/",
+            "/api/tiles/1/2/3.pbf",
+            "/api/collections/",
+        ):
+            assert not _path_matches(hot_path, cookie_path)
 
     async def test_csrf_cookie_is_readable_and_not_a_credential(
         self, client: AsyncClient
@@ -276,7 +314,7 @@ class TestLogoutClearsCookies:
         assert resp.status_code == 204
 
         for name, path in (
-            (REFRESH_COOKIE_NAME, "/api/auth/refresh"),
+            (REFRESH_COOKIE_NAME, "/api/auth"),
             (CSRF_COOKIE_NAME, "/"),
         ):
             cleared = _cookie_attrs(resp, name)

--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -21,6 +21,7 @@ from app.core.config import settings
 from app.modules.auth.cookies import (
     CSRF_COOKIE_NAME,
     REFRESH_COOKIE_NAME,
+    api_path_is_cookie_scoped,
     is_same_origin,
 )
 
@@ -396,6 +397,36 @@ class TestLogoutClearsCookies:
         )
         assert resp.status_code == 401
 
+    async def test_a_dead_cookie_does_not_shadow_a_live_body_token(
+        self, client: AsyncClient
+    ):
+        """fix(#1446): logout tries every presented credential. A revoked
+        cookie left in the jar must not eat the logout of a split-origin
+        caller presenting its live body token — that 401 would leave the
+        live session unrevoked while the UI reports a clean sign-out."""
+        dead = await _login(client, cookie_mode=True)
+        dead_refresh = _cookie_attrs(dead, REFRESH_COOKIE_NAME)["value"]
+        dead_csrf = _cookie_attrs(dead, CSRF_COOKIE_NAME)["value"]
+        access = dead.json()["access_token"]
+        # Revoke the cookie's session while its value stays in the jar.
+        await client.post(
+            "/auth/logout/", headers={"Authorization": f"Bearer {access}"}
+        )
+
+        live_token = (await _login(client, cookie_mode=False)).json()["refresh_token"]
+        _arm_cookies(client, dead_refresh, dead_csrf)
+
+        resp = await client.post(
+            "/auth/logout/",
+            headers={"X-CSRF-Token": dead_csrf},
+            json={"refresh_token": live_token},
+        )
+        assert resp.status_code == 204, resp.text
+
+        client.cookies.clear()
+        after = await client.post("/auth/refresh/", json={"refresh_token": live_token})
+        assert after.status_code == 401
+
     async def test_logout_revokes_the_cookie_token_server_side(
         self, client: AsyncClient
     ):
@@ -605,6 +636,37 @@ class TestOriginComparison:
     def test_unusable_values_are_not_same_origin(self):
         assert not is_same_origin("https://example.com", "/relative/path")
         assert not is_same_origin("https://example.com", "")
+
+
+class TestApiPathMustMatchCookieScope:
+    """fix(#1446): same origin is necessary but not sufficient. root_path is
+    fixed at /api, so a deployment that mounts the API elsewhere would get a
+    cookie the browser never sends — and cookie mode ships no fragment token to
+    fall back on."""
+
+    @staticmethod
+    def _request(root_path: str = "/api"):
+        class _FakeRequest:
+            scope = {"root_path": root_path}
+
+        return _FakeRequest()
+
+    def test_the_shipped_mount_point_matches(self):
+        assert api_path_is_cookie_scoped(self._request(), "https://example.com/api")
+        # Trailing slash is the same mount point.
+        assert api_path_is_cookie_scoped(self._request(), "https://example.com/api/")
+
+    def test_a_different_mount_point_does_not(self):
+        assert not api_path_is_cookie_scoped(
+            self._request(), "https://example.com/geolens-api"
+        )
+        assert not api_path_is_cookie_scoped(self._request(), "https://example.com")
+
+    def test_it_follows_root_path_rather_than_hardcoding_api(self):
+        assert api_path_is_cookie_scoped(
+            self._request(root_path="/geolens-api"),
+            "https://example.com/geolens-api",
+        )
 
 
 class TestSecureFlagFollowsProductionPosture:

--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -448,6 +448,69 @@ class TestLogoutClearsCookies:
         assert resp.status_code == 401
 
 
+class TestDuplicateCookieRefusal:
+    """fix(#1446): a sibling-subdomain attacker can toss a parent-Domain shadow
+    of the refresh cookie; the browser then sends BOTH and a parser keeps one.
+    Duplicates are the attack's fingerprint — the attacker can add a shadow but
+    never remove the victim's host cookie — so the server refuses them."""
+
+    async def test_duplicate_refresh_cookies_are_refused(self, client: AsyncClient):
+        login = await _login(client, cookie_mode=True)
+        real = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        client.cookies.clear()
+
+        resp = await client.post(
+            "/auth/refresh/",
+            headers={
+                **COOKIE_MODE,
+                "X-CSRF-Token": csrf,
+                "Cookie": (
+                    f"{REFRESH_COOKIE_NAME}={real}; "
+                    f"{REFRESH_COOKIE_NAME}=tossed-shadow; "
+                    f"{CSRF_COOKIE_NAME}={csrf}"
+                ),
+            },
+        )
+        assert resp.status_code == 401
+
+        # The legitimate cookie alone still rotates — refusal keys on the
+        # duplicate, not on the value.
+        _arm_cookies(client, real, csrf)
+        ok = await client.post(
+            "/auth/refresh/", headers={**COOKIE_MODE, "X-CSRF-Token": csrf}
+        )
+        assert ok.status_code == 200
+
+    async def test_duplicate_cookies_fall_through_to_the_body_token_at_logout(
+        self, client: AsyncClient
+    ):
+        """A shadowed cookie reads as absent, so logout still revokes via the
+        body token instead of 401ing the teardown."""
+        login = await _login(client, cookie_mode=True)
+        real = _cookie_attrs(login, REFRESH_COOKIE_NAME)["value"]
+        csrf = _cookie_attrs(login, CSRF_COOKIE_NAME)["value"]
+        body_token = (await _login(client, cookie_mode=False)).json()["refresh_token"]
+        client.cookies.clear()
+
+        resp = await client.post(
+            "/auth/logout/",
+            headers={
+                "Cookie": (
+                    f"{REFRESH_COOKIE_NAME}={real}; "
+                    f"{REFRESH_COOKIE_NAME}=tossed-shadow; "
+                    f"{CSRF_COOKIE_NAME}={csrf}"
+                ),
+            },
+            json={"refresh_token": body_token},
+        )
+        assert resp.status_code == 204, resp.text
+
+        client.cookies.clear()
+        after = await client.post("/auth/refresh/", json={"refresh_token": body_token})
+        assert after.status_code == 401
+
+
 class TestRotationRevocationRace:
     """fix(#1446): a rotation that read its row before a concurrent logout must
     not commit a still-active replacement afterwards. Client-side guards cannot

--- a/backend/tests/test_csp_sec020.py
+++ b/backend/tests/test_csp_sec020.py
@@ -7,6 +7,10 @@ refresh tokens from the geolens-auth localStorage key. These assert the SPA HTML
 now ships a script-src/default-src CSP and that the FOUC script is externalized
 (so no inline <script> exists for script-src 'self' to block). Fail on main.
 
+fix(#1302): the refresh token has since moved out of localStorage into an
+httpOnly cookie, so the exfil surface described above is now the access token
+alone. The CSP assertions here are unchanged and still load-bearing.
+
 The CSP was verified live against the production build: the app, login, and the
 MapLibre map builder (external basemap tiles, web workers, inline styles) all
 render with zero CSP violations.

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,12 +1,70 @@
 import { test, expect } from '@playwright/test';
+import { getAuthToken } from './helpers/catalog';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+
+// fix(#1446): logout is now a real server-side security event —
+// revoke_all_tokens bumps token_version and revokes every refresh row for the
+// user. Running this flow as the shared admin therefore destroyed the saved
+// storageState session that every parallel spec depends on, minutes into the
+// run (the pre-#1446 SPA never called /auth/logout/, which is what made a
+// shared session survivable). The flow gets its own throwaway user so the
+// revocation lands on nobody else.
+const LOGOUT_USER = 'e2e-logout-probe';
+const LOGOUT_PASS = 'E2e-Logout-Probe-42';
+
+async function adminHeaders(): Promise<Record<string, string>> {
+  return {
+    Authorization: `Bearer ${getAuthToken()}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+async function deleteProbeUser(): Promise<void> {
+  const headers = await adminHeaders();
+  const list = await fetch(
+    `${BASE_URL}/api/admin/users/?search=${LOGOUT_USER}`,
+    { headers },
+  );
+  if (!list.ok) return;
+  const data = await list.json();
+  const users: { id: string; username: string }[] = data.users ?? data.items ?? [];
+  const probe = users.find((u) => u.username === LOGOUT_USER);
+  if (!probe) return;
+  await fetch(`${BASE_URL}/api/admin/users/${probe.id}`, {
+    method: 'DELETE',
+    headers,
+  });
+}
 
 test.describe('Authentication Flow', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  test('login, see dashboard, logout', async ({ page }) => {
-    const adminUser = process.env.GEOLENS_ADMIN_USERNAME ?? 'admin';
-    const adminPass = process.env.GEOLENS_ADMIN_PASSWORD ?? 'admin';
+  test.beforeAll(async () => {
+    const res = await fetch(`${BASE_URL}/api/admin/users/`, {
+      method: 'POST',
+      headers: await adminHeaders(),
+      body: JSON.stringify({
+        username: LOGOUT_USER,
+        password: LOGOUT_PASS,
+        role: 'viewer',
+      }),
+    });
+    // 400 "Username already taken" = leftover from an interrupted run. The
+    // password is deterministic, so the login below still proves it usable.
+    if (!res.ok && res.status !== 400) {
+      throw new Error(
+        `Could not create logout probe user: ${res.status} ${await res.text()}`,
+      );
+    }
+  });
 
+  test.afterAll(async () => {
+    // Best effort — a leftover probe user is tolerated by beforeAll anyway.
+    await deleteProbeUser().catch(() => {});
+  });
+
+  test('login, see dashboard, logout', async ({ page }) => {
     await page.goto('/login');
 
     // Verify login page
@@ -15,8 +73,8 @@ test.describe('Authentication Flow', () => {
     ).toBeVisible();
 
     // Fill credentials
-    await page.getByLabel('Username').fill(adminUser);
-    await page.locator('#password').fill(adminPass);
+    await page.getByLabel('Username').fill(LOGOUT_USER);
+    await page.locator('#password').fill(LOGOUT_PASS);
 
     // Submit
     await page.getByRole('button', { name: 'Sign In' }).click();

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -50,9 +50,9 @@ test.describe('Authentication Flow', () => {
         role: 'viewer',
       }),
     });
-    // 400 "Username already taken" = leftover from an interrupted run. The
+    // 409 "Username already taken" = leftover from an interrupted run. The
     // password is deterministic, so the login below still proves it usable.
-    if (!res.ok && res.status !== 400) {
+    if (!res.ok && res.status !== 409) {
       throw new Error(
         `Could not create logout probe user: ${res.status} ${await res.text()}`,
       );

--- a/frontend/src/api/__tests__/bug-035-refresh-aware-helpers.test.ts
+++ b/frontend/src/api/__tests__/bug-035-refresh-aware-helpers.test.ts
@@ -77,7 +77,9 @@ describe('BUG-035: streamGenerateMap is refresh-aware', () => {
 
     await drain(streamGenerateMap({ prompt: 'p' }));
 
-    expect(mockRefresh).toHaveBeenCalledWith('r');
+    // fix(#1446): the second arg is the abort signal that lets a logout
+    // abandon an in-flight refresh before its Set-Cookie can land.
+    expect(mockRefresh).toHaveBeenCalledWith('r', expect.any(AbortSignal));
     // The stream request carried the refreshed token, not the stale one.
     const headers: Headers = mockFetch.mock.calls[0][1].headers;
     expect(headers.get('Authorization')).toBe('Bearer fresh-token');

--- a/frontend/src/api/__tests__/client.session-expiry.test.ts
+++ b/frontend/src/api/__tests__/client.session-expiry.test.ts
@@ -35,13 +35,15 @@ function jsonResponse(data: unknown, status = 200): Response {
   } as Response;
 }
 
-// Refresh tokens rotate, so every session's token value is unique — the
-// notification latch is keyed on it.
+// fix(#1302): the latch is keyed on the ACCESS token now that the refresh token
+// is an httpOnly cookie JS cannot read. Access tokens rotate on every login and
+// every refresh (each is a fresh JWT with its own jti), so each session's value
+// is unique — which is the property the latch needs.
 let sessionCounter = 0;
 function signIn() {
   sessionCounter += 1;
   useAuthStore.setState({
-    token: 'stale-access-token',
+    token: `stale-access-token-${sessionCounter}`,
     refreshToken: `dead-refresh-token-${sessionCounter}`,
     // Far enough out that the proactive-refresh branch does not fire.
     expiresAt: Date.now() + 120_000,
@@ -123,7 +125,7 @@ describe('session-expiry notification (fix #628)', () => {
     await expect(apiFetch('/b/')).rejects.toMatchObject({ status: 401 });
     expect(handler).toHaveBeenCalledTimes(1);
 
-    // A fresh sign-in mints a NEW (rotated) refresh token; its death is a new event.
+    // A fresh sign-in mints a NEW (rotated) access token; its death is a new event.
     signIn();
     await expect(apiFetch('/c/')).rejects.toMatchObject({ status: 401 });
     expect(handler).toHaveBeenCalledTimes(2);

--- a/frontend/src/api/__tests__/client.session-expiry.test.ts
+++ b/frontend/src/api/__tests__/client.session-expiry.test.ts
@@ -1,6 +1,6 @@
 import { apiFetch, ApiError, onSessionExpired } from '@/api/client';
 import { useAuthStore } from '@/stores/auth-store';
-import { refreshAccessToken } from '@/api/auth';
+import { refreshAccessToken, logoutSession } from '@/api/auth';
 
 // fix(#628): the fetch core must treat "401 + the follow-up refresh is also
 // dead" as a single session-death event: clear the persisted auth state and
@@ -10,6 +10,7 @@ import { refreshAccessToken } from '@/api/auth';
 
 vi.mock('@/api/auth', () => ({
   refreshAccessToken: vi.fn(),
+  logoutSession: vi.fn(() => Promise.resolve()),
 }));
 
 const mockFetch = vi.fn();
@@ -63,6 +64,22 @@ describe('session-expiry notification (fix #628)', () => {
   afterEach(() => {
     unregister();
     useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+  });
+
+  // fix(#1446): the refresh may have failed transiently (429, 5xx, dropped
+  // connection), leaving a perfectly valid httpOnly refresh cookie behind a UI
+  // that says "signed out". Clearing the store cannot reach that credential,
+  // so revocation is dispatched on the way out.
+  it('revokes server-side when the refresh failed transiently rather than definitively', async () => {
+    signIn();
+    mockFetch.mockResolvedValue(errorResponse(401));
+    vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('rate limited', 429));
+
+    await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401 });
+
+    expect(logoutSession).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().token).toBeNull();
   });
 
   it('401 + dead refresh: clears the store and invokes the handler exactly once across N concurrent requests', async () => {

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -261,18 +261,39 @@ describe('apiFetch', () => {
     });
   });
 
-  it('logs out and throws on 401 when no refresh token', async () => {
-    useAuthStore.setState({ token: 'expired-token', refreshToken: null });
+  // fix(#1302): with no stored refresh token the session may still be alive —
+  // the credential is an httpOnly cookie JS cannot see — so a 401 must still
+  // attempt a refresh. Only when that refresh also fails is the session dead.
+  it('still attempts a cookie refresh on 401 with no stored refresh token', async () => {
+    const { refreshAccessToken } = await import('@/api/auth');
+    vi.mocked(refreshAccessToken).mockRejectedValueOnce(new Error('refresh failed'));
+
+    useAuthStore.setState({ token: 'cookie-session-token', refreshToken: null });
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(401))
+      .mockResolvedValueOnce(errorResponse(401));
+
+    await expect(apiFetch('/protected/')).rejects.toThrow(ApiError);
+    expect(refreshAccessToken).toHaveBeenCalledWith(null);
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  it('does not attempt a refresh on an anonymous 401', async () => {
+    const { refreshAccessToken } = await import('@/api/auth');
+
+    useAuthStore.setState({ token: null, refreshToken: null });
     mockFetch.mockResolvedValueOnce(errorResponse(401));
 
     await expect(apiFetch('/protected/')).rejects.toThrow(ApiError);
-    expect(useAuthStore.getState().token).toBeNull();
+    expect(refreshAccessToken).not.toHaveBeenCalled();
   });
 
   it('logs out and throws on 401 when refresh fails', async () => {
     const { refreshAccessToken } = await import('@/api/auth');
     vi.mocked(refreshAccessToken).mockRejectedValueOnce(new Error('refresh failed'));
 
+    // A distinct access token per test: the session-death latch dedupes on it,
+    // and real sessions never reuse one (every JWT carries a fresh jti).
     useAuthStore.setState({ token: 'expired-token', refreshToken: 'bad-refresh' });
     // First call returns 401; refresh fails but token remains, so retry also gets 401
     mockFetch

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -188,7 +188,7 @@ describe('apiFetch', () => {
 
     const result = await apiFetch('/protected/');
     expect(result).toEqual({ ok: true });
-    expect(mockRefresh).toHaveBeenCalledWith('my-refresh');
+    expect(mockRefresh).toHaveBeenCalledWith('my-refresh', expect.any(AbortSignal));
     expect(mockFetch).toHaveBeenCalledTimes(2);
 
     // Verify retry used the new token
@@ -278,7 +278,7 @@ describe('apiFetch', () => {
       .mockResolvedValueOnce(errorResponse(401));
 
     await expect(apiFetch('/protected/')).rejects.toThrow(ApiError);
-    expect(refreshAccessToken).toHaveBeenCalledWith(null);
+    expect(refreshAccessToken).toHaveBeenCalledWith(null, expect.any(AbortSignal));
     expect(useAuthStore.getState().token).toBeNull();
   });
 

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -4,6 +4,10 @@ import type { TokenResponse } from '@/types/api';
 
 vi.mock('@/api/auth', () => ({
   refreshAccessToken: vi.fn(),
+  // fix(#1446): the 401 path now dispatches a best-effort server revocation,
+  // because a transiently-failed refresh leaves a live httpOnly cookie that
+  // clearing the store cannot reach.
+  logoutSession: vi.fn(() => Promise.resolve()),
 }));
 
 const mockFetch = vi.fn();

--- a/frontend/src/api/__tests__/ingest-session-expiry-1446.test.ts
+++ b/frontend/src/api/__tests__/ingest-session-expiry-1446.test.ts
@@ -1,0 +1,80 @@
+import { useAuthStore } from '@/stores/auth-store';
+import { onSessionExpired } from '@/api/client';
+
+// fix(#1446): the XHR upload path cleared the store directly on a terminal
+// 401. Since the refresh credential became an httpOnly cookie, that leaves it
+// and its server-side row alive while the client considers the user signed
+// out. It also skipped the signed-out prompt every other surface shows
+// (fix(#628)). It now routes through notifySessionExpired.
+
+const mockLogoutSession = vi.fn<() => Promise<void>>();
+vi.mock('@/api/auth', () => ({
+  refreshAccessToken: vi.fn(() => Promise.reject(new Error('rate limited'))),
+  logoutSession: () => mockLogoutSession(),
+}));
+
+class FakeXHR {
+  static queue: number[] = [];
+  status = 0;
+  responseText = '{}';
+  upload = { onprogress: null as unknown };
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  open() {}
+  setRequestHeader() {}
+  send() {
+    this.status = FakeXHR.queue.shift() ?? 500;
+    this.responseText = '{"detail":"nope"}';
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
+describe('upload auth failure (fix #1446)', () => {
+  let handler: ReturnType<typeof vi.fn<() => void>>;
+  let unregister: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogoutSession.mockResolvedValue(undefined);
+    handler = vi.fn<() => void>();
+    unregister = onSessionExpired(handler);
+    (globalThis as unknown as { XMLHttpRequest: unknown }).XMLHttpRequest = FakeXHR;
+  });
+
+  afterEach(() => {
+    unregister();
+    useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+  });
+
+  it('revokes server-side and prompts once when an upload 401s terminally', async () => {
+    const { uploadFile } = await import('@/api/ingest');
+    // Both the original attempt and the post-refresh retry return 401.
+    FakeXHR.queue = [401, 401];
+    useAuthStore.setState({
+      token: 'stale-access',
+      refreshToken: null,
+      expiresAt: Date.now() + 120_000,
+    });
+
+    await expect(
+      uploadFile(new File(['x'], 'a.geojson')),
+    ).rejects.toMatchObject({ status: 401 });
+
+    expect(mockLogoutSession).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  it('does not revoke on an anonymous upload 401 (no session to end)', async () => {
+    const { uploadFile } = await import('@/api/ingest');
+    FakeXHR.queue = [401];
+    useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null });
+
+    await expect(
+      uploadFile(new File(['x'], 'a.geojson')),
+    ).rejects.toMatchObject({ status: 401 });
+
+    expect(mockLogoutSession).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -73,6 +73,62 @@ describe('browser refresh transport', () => {
   });
 });
 
+// fix(#1446): logout races its wait against a short timer, so a slow refresh
+// can still be running when the store is torn down. If that refresh then wrote
+// its rotated tokens back, the browser would be fully signed in again while
+// sitting on /login.
+describe('late refresh after logout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    window.localStorage.clear();
+  });
+
+  it('discards rotated tokens when a logout landed mid-flight', async () => {
+    let resolveRefresh: (value: unknown) => void = () => {};
+    vi.doMock('@/api/auth', () => ({
+      refreshAccessToken: vi.fn(
+        () => new Promise((resolve) => { resolveRefresh = resolve; }),
+      ),
+    }));
+
+    const { tryRefresh } = await import('@/api/client');
+    const { useAuthStore: store } = await import('@/stores/auth-store');
+
+    store.setState({ token: 'live-access', refreshToken: null, expiresAt: Date.now() + 60_000 });
+    const pending = tryRefresh();
+
+    // The user logs out while the refresh is still in flight.
+    store.getState().logout();
+
+    resolveRefresh({ access_token: 'rotated', refresh_token: null, expires_in: 900 });
+    expect(await pending).toBe(false);
+
+    expect(store.getState().token).toBeNull();
+    expect(window.localStorage.getItem('geolens-auth') ?? '').not.toContain('rotated');
+  });
+
+  it('still applies rotated tokens when no logout intervened', async () => {
+    let resolveRefresh: (value: unknown) => void = () => {};
+    vi.doMock('@/api/auth', () => ({
+      refreshAccessToken: vi.fn(
+        () => new Promise((resolve) => { resolveRefresh = resolve; }),
+      ),
+    }));
+
+    const { tryRefresh } = await import('@/api/client');
+    const { useAuthStore: store } = await import('@/stores/auth-store');
+
+    store.setState({ token: 'live-access', refreshToken: null, expiresAt: Date.now() + 60_000 });
+    const pending = tryRefresh();
+
+    resolveRefresh({ access_token: 'rotated', refresh_token: null, expires_in: 900 });
+    expect(await pending).toBe(true);
+
+    expect(store.getState().token).toBe('rotated');
+  });
+});
+
 describe('persisted auth state', () => {
   beforeEach(() => {
     window.localStorage.clear();

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -204,10 +204,13 @@ describe('late refresh after logout', () => {
   // writes its rotated tokens back and re-persists the session for every tab.
   it('discards rotated tokens when another tab logged out', async () => {
     let resolveRefresh: (value: unknown) => void = () => {};
+    let capturedSignal: AbortSignal | undefined;
     vi.doMock('@/api/auth', () => ({
-      refreshAccessToken: vi.fn(
-        () => new Promise((resolve) => { resolveRefresh = resolve; }),
-      ),
+      refreshAccessToken: vi.fn((_token: string | null, signal?: AbortSignal) => {
+        capturedSignal = signal;
+        return new Promise((resolve) => { resolveRefresh = resolve; });
+      }),
+      logoutSession: vi.fn(() => Promise.resolve()),
     }));
 
     const { tryRefresh } = await import('@/api/client');
@@ -224,6 +227,13 @@ describe('late refresh after logout', () => {
     );
     window.dispatchEvent(new StorageEvent('storage', { key: 'geolens-auth' }));
     await vi.waitFor(() => expect(store.getState().token).toBeNull());
+
+    // fix(#1446): the request is abandoned too, not just its store write — a
+    // response the browser never processes cannot apply a stale Set-Cookie
+    // over a cookie a later login issued. Waited for rather than asserted
+    // directly: the token clears inside rehydrate(), which resolves before the
+    // listener's continuation runs the abort.
+    await vi.waitFor(() => expect(capturedSignal?.aborted).toBe(true));
 
     resolveRefresh({ access_token: 'rotated', refresh_token: null, expires_in: 900 });
     await pending;

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -150,6 +150,48 @@ describe('browser refresh transport', () => {
     });
   });
 
+  // fix(#1446): logout revokes EVERY refresh token for the user and deletes
+  // the cookies, so a request that lands after a fresh login revokes the new
+  // session's row, and a delayed response erases its cookie. Login waits.
+  it('does not let a new login overtake a logout still in flight', async () => {
+    const order: string[] = [];
+    let finishLogout: () => void = () => {};
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishLogout = () => {
+            order.push('logout');
+            resolve({
+              ok: true,
+              status: 204,
+              statusText: 'No Content',
+              json: () => Promise.reject(new Error('no body')),
+              headers: new Headers(),
+            } as Response);
+          };
+        }),
+    );
+    mockFetch.mockImplementationOnce(() => {
+      order.push('login');
+      return Promise.resolve(
+        jsonResponse({ access_token: 'a1', refresh_token: null, expires_in: 900 }),
+      );
+    });
+
+    useAuthStore.setState({ token: 'old-access' });
+    void logoutSession().catch(() => {});
+    const loginPromise = login('someone', 'secret');
+
+    // Login must still be parked on the pending revocation.
+    await Promise.resolve();
+    expect(order).toEqual([]);
+
+    finishLogout();
+    await loginPromise;
+
+    expect(order).toEqual(['logout', 'login']);
+  });
+
   it('opts login into the cookie flow', async () => {
     mockFetch.mockResolvedValueOnce(
       jsonResponse({ access_token: 'a1', refresh_token: null, expires_in: 900 }),

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -84,10 +84,33 @@ describe('browser refresh transport', () => {
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('/api/auth/logout/');
     expect(init.method).toBe('POST');
-    expect(init.headers).toEqual({ Authorization: 'Bearer live-access' });
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer live-access' });
     expect(init.credentials).toBe('same-origin');
     // Exactly one request: no proactive-refresh detour.
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // fix(#1446): when the access token has already expired there is no bearer
+  // token to send, and the refresh cookie authenticates the call server-side.
+  // That path is CSRF-protected, so the double-submit token must ride along.
+  it('logout carries the CSRF token so the cookie can authenticate it', async () => {
+    document.cookie = 'geolens_csrf=csrf-abc; path=/';
+    useAuthStore.setState({ token: null });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      statusText: 'No Content',
+      json: () => Promise.reject(new Error('no body')),
+      headers: new Headers(),
+    } as Response);
+
+    await logoutSession();
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toEqual({
+      'X-GeoLens-Auth-Mode': 'cookie',
+      'X-CSRF-Token': 'csrf-abc',
+    });
   });
 
   it('opts login into the cookie flow', async () => {

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -161,6 +161,40 @@ describe('late refresh after logout', () => {
     expect(window.localStorage.getItem('geolens-auth') ?? '').not.toContain('rotated');
   });
 
+  // fix(#1446): sessionEpoch is per-tab, so a logout in ANOTHER tab cannot
+  // reach it through the persisted blob. The storage listener bumps it on the
+  // present->absent transition; without that, this tab's in-flight refresh
+  // writes its rotated tokens back and re-persists the session for every tab.
+  it('discards rotated tokens when another tab logged out', async () => {
+    let resolveRefresh: (value: unknown) => void = () => {};
+    vi.doMock('@/api/auth', () => ({
+      refreshAccessToken: vi.fn(
+        () => new Promise((resolve) => { resolveRefresh = resolve; }),
+      ),
+    }));
+
+    const { tryRefresh } = await import('@/api/client');
+    const { useAuthStore: store } = await import('@/stores/auth-store');
+
+    store.setState({ token: 'live-access', refreshToken: null, expiresAt: Date.now() + 60_000 });
+    const pending = tryRefresh();
+
+    // Tab A logged out: it wrote a token-less blob, and this tab's `storage`
+    // listener rehydrates from it.
+    window.localStorage.setItem(
+      'geolens-auth',
+      JSON.stringify({ state: { token: null, expiresAt: null, user: null }, version: 1 }),
+    );
+    window.dispatchEvent(new StorageEvent('storage', { key: 'geolens-auth' }));
+    await vi.waitFor(() => expect(store.getState().token).toBeNull());
+
+    resolveRefresh({ access_token: 'rotated', refresh_token: null, expires_in: 900 });
+    await pending;
+
+    expect(store.getState().token).toBeNull();
+    expect(window.localStorage.getItem('geolens-auth') ?? '').not.toContain('rotated');
+  });
+
   it('still applies rotated tokens when no logout intervened', async () => {
     let resolveRefresh: (value: unknown) => void = () => {};
     vi.doMock('@/api/auth', () => ({

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -86,6 +86,8 @@ describe('browser refresh transport', () => {
     expect(init.method).toBe('POST');
     expect(init.headers).toMatchObject({ Authorization: 'Bearer live-access' });
     expect(init.credentials).toBe('same-origin');
+    // fix(#1446): survives an immediate close/navigate after clicking Logout.
+    expect(init.keepalive).toBe(true);
     // Exactly one request: no proactive-refresh detour.
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -115,6 +115,41 @@ describe('browser refresh transport', () => {
     });
   });
 
+  // fix(#1446): a 2xx whose body fails to parse still installed the cookies,
+  // so bailing out without revoking reports a failed sign-in over a live
+  // server-side session.
+  it('revokes when a successful login response fails to parse', async () => {
+    document.cookie = 'geolens_csrf=csrf-abc; path=/';
+    useAuthStore.setState({ token: null });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+        headers: new Headers(),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        json: () => Promise.reject(new Error('no body')),
+        headers: new Headers(),
+      } as Response);
+
+    await expect(login('someone', 'secret')).rejects.toThrow(SyntaxError);
+
+    const logoutCall = mockFetch.mock.calls.find(
+      ([url]) => (url as string) === '/api/auth/logout/',
+    );
+    expect(logoutCall).toBeDefined();
+    // The freshly-set cookie is what authenticates it — no bearer token was
+    // ever stored.
+    expect((logoutCall?.[1] as RequestInit).headers).toMatchObject({
+      'X-CSRF-Token': 'csrf-abc',
+    });
+  });
+
   it('opts login into the cookie flow', async () => {
     mockFetch.mockResolvedValueOnce(
       jsonResponse({ access_token: 'a1', refresh_token: null, expires_in: 900 }),
@@ -237,12 +272,25 @@ describe('persisted auth state', () => {
   });
 
   it('drops a legacy refresh token from storage once the migrating refresh spends it', () => {
-    // Pre-GH-1302 shape: rehydrated into memory, but never written back.
+    // Pre-GH-1302 shape: rehydrated into memory, kept until spent.
     useAuthStore.setState({ refreshToken: 'legacy-refresh-token' });
     useAuthStore.getState().setTokens('access-2', null, 900);
 
     const raw = window.localStorage.getItem('geolens-auth');
     expect(raw).not.toContain('legacy-refresh-token');
     expect(useAuthStore.getState().refreshToken).toBeNull();
+  });
+
+  // fix(#1446): zustand writes the persisted blob on its own after migrating a
+  // version-0 shape. Stripping the legacy token on that write would strand a
+  // tab closed before the migrating refresh ran — no body token on the next
+  // load, and no cookie either, so an otherwise-valid session dies at expiry.
+  it('keeps an unspent legacy refresh token across a store write', () => {
+    useAuthStore.setState({ token: 'access-1', refreshToken: 'legacy-refresh-token' });
+    // Any unrelated write, as zustand performs post-migration.
+    useAuthStore.setState({ expiresAt: Date.now() + 900_000 });
+
+    const raw = window.localStorage.getItem('geolens-auth') ?? '';
+    expect(JSON.parse(raw).state.refreshToken).toBe('legacy-refresh-token');
   });
 });

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -1,4 +1,4 @@
-import { login, logoutSession, refreshAccessToken } from '@/api/auth';
+import { awaitPendingLogout, login, logoutSession, refreshAccessToken } from '@/api/auth';
 import { useAuthStore } from '@/stores/auth-store';
 
 // fix(#1302): AC — after login the persisted `geolens-auth` value holds no
@@ -190,6 +190,44 @@ describe('browser refresh transport', () => {
     await loginPromise;
 
     expect(order).toEqual(['logout', 'login']);
+  });
+
+  // fix(#1446): two teardown paths can each dispatch a revocation (a terminal
+  // getMe 401 and a login catch, say). A single last-write-wins slot let
+  // awaitPendingLogout return once the LATER request settled, while the
+  // earlier one was still holding the user lock server-side — free to revoke
+  // rows a new sign-in just created. Every outstanding revocation must drain.
+  it('waits for every concurrent logout, not just the latest', async () => {
+    useAuthStore.setState({ token: 'live-access' });
+    const done204 = () =>
+      ({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        json: () => Promise.reject(new Error('no body')),
+        headers: new Headers(),
+      }) as Response;
+    let resolveSlow: (r: Response) => void = () => {};
+    mockFetch.mockImplementationOnce(
+      () => new Promise<Response>((resolve) => (resolveSlow = resolve)),
+    );
+    mockFetch.mockImplementationOnce(() => Promise.resolve(done204()));
+
+    const slowLogout = logoutSession();
+    const fastLogout = logoutSession();
+    await fastLogout;
+
+    let drained = false;
+    const drain = awaitPendingLogout().then(() => {
+      drained = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(drained).toBe(false);
+
+    resolveSlow(done204());
+    await slowLogout;
+    await drain;
+    expect(drained).toBe(true);
   });
 
   it('opts login into the cookie flow', async () => {

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -1,0 +1,103 @@
+import { login, refreshAccessToken } from '@/api/auth';
+import { useAuthStore } from '@/stores/auth-store';
+
+// fix(#1302): AC — after login the persisted `geolens-auth` value holds no
+// refresh token, and the refresh call carries the cookie plus its double-submit
+// CSRF header instead of a body token.
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(data),
+    headers: new Headers(),
+  } as Response;
+}
+
+function lastInit(): RequestInit {
+  return mockFetch.mock.calls[mockFetch.mock.calls.length - 1][1] as RequestInit;
+}
+
+describe('browser refresh transport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.cookie = 'geolens_csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+  });
+
+  it('sends no body when the credential is the cookie', async () => {
+    document.cookie = 'geolens_csrf=csrf-abc; path=/';
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ access_token: 'a1', refresh_token: null, expires_in: 900 }),
+    );
+
+    const result = await refreshAccessToken(null);
+
+    expect(result.refresh_token).toBeNull();
+    const init = lastInit();
+    expect(init.body).toBeUndefined();
+    expect(init.credentials).toBe('same-origin');
+    expect(init.headers).toMatchObject({
+      'X-GeoLens-Auth-Mode': 'cookie',
+      'X-CSRF-Token': 'csrf-abc',
+    });
+  });
+
+  it('sends a legacy body token once, under the cookie header, to migrate a session', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ access_token: 'a1', refresh_token: null, expires_in: 900 }),
+    );
+
+    await refreshAccessToken('legacy-refresh-token');
+
+    const init = lastInit();
+    expect(JSON.parse(init.body as string)).toEqual({
+      refresh_token: 'legacy-refresh-token',
+    });
+    expect(init.headers).toMatchObject({ 'X-GeoLens-Auth-Mode': 'cookie' });
+  });
+
+  it('opts login into the cookie flow', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ access_token: 'a1', refresh_token: null, expires_in: 900 }),
+    );
+
+    await login('someone', 'secret');
+
+    const init = lastInit();
+    expect(init.credentials).toBe('same-origin');
+    expect(init.headers).toMatchObject({ 'X-GeoLens-Auth-Mode': 'cookie' });
+  });
+});
+
+describe('persisted auth state', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('writes no refresh token to localStorage', () => {
+    useAuthStore.getState().setAuth('access-1', null, 900, {
+      id: 'u1',
+      username: 'someone',
+      roles: ['admin'],
+    } as never);
+
+    const raw = window.localStorage.getItem('geolens-auth');
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string).state).not.toHaveProperty('refreshToken');
+    expect(raw).not.toContain('refreshToken');
+  });
+
+  it('drops a legacy refresh token from storage once the migrating refresh spends it', () => {
+    // Pre-GH-1302 shape: rehydrated into memory, but never written back.
+    useAuthStore.setState({ refreshToken: 'legacy-refresh-token' });
+    useAuthStore.getState().setTokens('access-2', null, 900);
+
+    const raw = window.localStorage.getItem('geolens-auth');
+    expect(raw).not.toContain('legacy-refresh-token');
+    expect(useAuthStore.getState().refreshToken).toBeNull();
+  });
+});

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -232,6 +232,32 @@ describe('late refresh after logout', () => {
     expect(window.localStorage.getItem('geolens-auth') ?? '').not.toContain('rotated');
   });
 
+  // fix(#1446): the epoch guard stops the store write, but the browser applies
+  // a response's Set-Cookie regardless. If the user signs in again before a
+  // stale refresh response lands, that cookie would replace the new session's
+  // credential with the one the logout revoked. Aborting means the response is
+  // never processed at all.
+  it('aborts an in-flight refresh so its Set-Cookie can never land', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.doMock('@/api/auth', () => ({
+      refreshAccessToken: vi.fn((_token: string | null, signal?: AbortSignal) => {
+        capturedSignal = signal;
+        return new Promise(() => {});
+      }),
+      logoutSession: vi.fn(() => Promise.resolve()),
+    }));
+
+    const { tryRefresh, abortInflightRefresh } = await import('@/api/client');
+    const { useAuthStore: store } = await import('@/stores/auth-store');
+
+    store.setState({ token: 'live-access', refreshToken: null, expiresAt: Date.now() + 60_000 });
+    void tryRefresh();
+
+    expect(capturedSignal?.aborted).toBe(false);
+    abortInflightRefresh();
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
   it('still applies rotated tokens when no logout intervened', async () => {
     let resolveRefresh: (value: unknown) => void = () => {};
     vi.doMock('@/api/auth', () => ({

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -1,4 +1,4 @@
-import { login, refreshAccessToken } from '@/api/auth';
+import { login, logoutSession, refreshAccessToken } from '@/api/auth';
 import { useAuthStore } from '@/stores/auth-store';
 
 // fix(#1302): AC — after login the persisted `geolens-auth` value holds no
@@ -58,6 +58,36 @@ describe('browser refresh transport', () => {
       refresh_token: 'legacy-refresh-token',
     });
     expect(init.headers).toMatchObject({ 'X-GeoLens-Auth-Mode': 'cookie' });
+  });
+
+  // fix(#1446): the request must be fully formed before the caller tears down
+  // local state. Routing it through apiFetch would await a proactive refresh
+  // first when the token is near expiry, and a caller that stopped waiting
+  // during that window got a logout POST with no Authorization header — while
+  // the refresh had already installed a rotated cookie.
+  it('logout captures the bearer token synchronously and sends it', async () => {
+    useAuthStore.setState({ token: 'live-access', expiresAt: Date.now() + 1_000 });
+    mockFetch.mockImplementationOnce(() => {
+      // Mid-flight teardown must not affect the request already dispatched.
+      useAuthStore.getState().logout();
+      return Promise.resolve({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        json: () => Promise.reject(new Error('no body')),
+        headers: new Headers(),
+      } as Response);
+    });
+
+    await logoutSession();
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/api/auth/logout/');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({ Authorization: 'Bearer live-access' });
+    expect(init.credentials).toBe('same-origin');
+    // Exactly one request: no proactive-refresh detour.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('opts login into the cookie flow', async () => {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -222,6 +222,7 @@ const REFRESH_TIMEOUT_MS = 30_000;
 
 export async function refreshAccessToken(
   refreshToken: string | null,
+  abortSignal?: AbortSignal,
 ): Promise<TokenResponse> {
   const headers: Record<string, string> = { ...cookieAuthHeaders() };
   if (refreshToken) headers['Content-Type'] = 'application/json';
@@ -235,7 +236,14 @@ export async function refreshAccessToken(
     // anything awaiting a refresh (logout, most visibly), and worse, leaves
     // tryRefresh's inflight singleton un-cleared — its `finally` never runs —
     // which wedges every later refresh for the life of the tab.
-    signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
+    //
+    // The caller's signal is composed in so a logout can abandon an in-flight
+    // refresh outright. That matters beyond saving a request: an aborted
+    // response is never processed, so its `Set-Cookie` cannot land and
+    // overwrite a cookie issued by a later login.
+    signal: abortSignal
+      ? AbortSignal.any([abortSignal, AbortSignal.timeout(REFRESH_TIMEOUT_MS)])
+      : AbortSignal.timeout(REFRESH_TIMEOUT_MS),
     ...(refreshToken ? { body: JSON.stringify({ refresh_token: refreshToken }) } : {}),
   });
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -32,7 +32,16 @@ export async function login(
     throw new Error(translateApiErrorDetail(detail, response.status));
   }
 
-  return response.json() as Promise<TokenResponse>;
+  try {
+    return (await response.json()) as TokenResponse;
+  } catch (err) {
+    // fix(#1446): the response was 2xx, so the browser has already applied the
+    // refresh and CSRF cookies. Failing here without revoking would report a
+    // failed sign-in over a live server-side session. The bearer token was
+    // never stored, but the freshly-set cookie authenticates the revocation.
+    void logoutSession().catch(() => {});
+    throw err;
+  }
 }
 
 export async function getMe(): Promise<UserResponse> {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -179,6 +179,8 @@ export async function resendVerification(email: string): Promise<MessageResponse
  * cookie-mode header, lets the backend rotate it and hand back a cookie instead
  * — the session migrates in place rather than being logged out.
  */
+const REFRESH_TIMEOUT_MS = 30_000;
+
 export async function refreshAccessToken(
   refreshToken: string | null,
 ): Promise<TokenResponse> {
@@ -189,6 +191,12 @@ export async function refreshAccessToken(
     method: 'POST',
     headers,
     credentials: 'same-origin',
+    // fix(#1446): this call bypasses apiFetch, so it never inherited the
+    // fix(#438) DATA-04 request bound and could hang forever. That stalls
+    // anything awaiting a refresh (logout, most visibly), and worse, leaves
+    // tryRefresh's inflight singleton un-cleared — its `finally` never runs —
+    // which wedges every later refresh for the life of the tab.
+    signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
     ...(refreshToken ? { body: JSON.stringify({ refresh_token: refreshToken }) } : {}),
   });
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,6 +1,7 @@
 import { API_BASE } from '@/lib/constants';
 import { cookieAuthHeaders } from '@/lib/auth-transport';
-import { apiFetch } from './client';
+import { useAuthStore } from '@/stores/auth-store';
+import { apiFetch, safeFetch } from './client';
 import { translateApiErrorDetail } from '@/lib/error-map';
 import type { TokenResponse, UserResponse, AuthConfigResponse, MessageResponse, SignupResponse, MyApiKeyResponse, ApiKeyCreateResponse, ApiKeyScope, OAuthProviderPublic, UserQuotaUsage } from '@/types/api';
 
@@ -38,6 +39,8 @@ export async function getMe(): Promise<UserResponse> {
   return apiFetch<UserResponse>('/auth/me/');
 }
 
+const LOGOUT_TIMEOUT_MS = 3_000;
+
 /**
  * fix(#1446): end the session on the server, not just in this tab.
  *
@@ -48,18 +51,24 @@ export async function getMe(): Promise<UserResponse> {
  * client-side logout would leave a live cookie (and its server row) behind for
  * the remainder of its lifetime. Only the server's `Set-Cookie` can clear it.
  *
- * Routed through apiFetch deliberately: if the access token has aged out, the
- * 401 path refreshes from the cookie and retries, so logout still lands.
- *
- * fix(#1446): bounded well below apiFetch's 30s default. The caller blocks on
- * this before tearing down local state, so a blackholed connection would
- * otherwise leave someone looking signed-in for half a minute after clicking
- * Logout.
+ * Deliberately a plain fetch rather than `apiFetch`, reading the bearer token
+ * synchronously so the request is fully formed and in flight before the caller
+ * tears down local state. Routing it through `apiFetch` looked appealing (its
+ * 401 path can refresh from the cookie and retry) but is wrong here: when the
+ * access token sits inside the proactive-refresh window, `apiFetch` awaits a
+ * refresh BEFORE dispatching. If the caller stopped waiting during that
+ * window, the refresh still installed a rotated cookie while the logout POST
+ * then went out with no Authorization header at all — leaving exactly the live
+ * credential this call exists to revoke.
  */
-const LOGOUT_TIMEOUT_MS = 3_000;
-
 export async function logoutSession(): Promise<void> {
-  await apiFetch<void>('/auth/logout/', { method: 'POST', timeoutMs: LOGOUT_TIMEOUT_MS });
+  const token = useAuthStore.getState().token;
+  await safeFetch(`${API_BASE}/auth/logout/`, {
+    method: 'POST',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    credentials: 'same-origin',
+    signal: AbortSignal.timeout(LOGOUT_TIMEOUT_MS),
+  });
 }
 
 export async function registerUser(data: {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -63,9 +63,15 @@ const LOGOUT_TIMEOUT_MS = 3_000;
  */
 export async function logoutSession(): Promise<void> {
   const token = useAuthStore.getState().token;
+  // fix(#1446): carry the cookie-mode headers too. When the access token has
+  // aged out, the refresh cookie authenticates this call server-side, and that
+  // path requires the double-submit CSRF token.
+  const headers: Record<string, string> = { ...cookieAuthHeaders() };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
   await safeFetch(`${API_BASE}/auth/logout/`, {
     method: 'POST',
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    headers,
     credentials: 'same-origin',
     signal: AbortSignal.timeout(LOGOUT_TIMEOUT_MS),
   });

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,5 @@
 import { API_BASE } from '@/lib/constants';
-import { cookieAuthHeaders } from '@/lib/auth-transport';
+import { cookieAuthAvailable, cookieAuthHeaders } from '@/lib/auth-transport';
 import { useAuthStore } from '@/stores/auth-store';
 import { apiFetch, safeFetch } from './client';
 import { translateApiErrorDetail } from '@/lib/error-map';
@@ -62,18 +62,27 @@ const LOGOUT_TIMEOUT_MS = 3_000;
  * credential this call exists to revoke.
  */
 export async function logoutSession(): Promise<void> {
-  const token = useAuthStore.getState().token;
+  const { token, refreshToken } = useAuthStore.getState();
   // fix(#1446): carry the cookie-mode headers too. When the access token has
-  // aged out, the refresh cookie authenticates this call server-side, and that
-  // path requires the double-submit CSRF token.
+  // aged out, the refresh credential authenticates this call server-side, and
+  // the cookie transport requires the double-submit CSRF token.
   const headers: Record<string, string> = { ...cookieAuthHeaders() };
   if (token) headers.Authorization = `Bearer ${token}`;
+
+  // A split-origin deployment has no usable cookie and keeps its refresh token
+  // in the store, so present that instead — otherwise an expired access token
+  // means logout 401s and the session outlives it there.
+  const body = !cookieAuthAvailable() && refreshToken
+    ? JSON.stringify({ refresh_token: refreshToken })
+    : undefined;
+  if (body) headers['Content-Type'] = 'application/json';
 
   await safeFetch(`${API_BASE}/auth/logout/`, {
     method: 'POST',
     headers,
     credentials: 'same-origin',
     signal: AbortSignal.timeout(LOGOUT_TIMEOUT_MS),
+    ...(body ? { body } : {}),
   });
 }
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -9,6 +9,13 @@ export async function login(
   username: string,
   password: string,
 ): Promise<TokenResponse> {
+  // fix(#1446): never overtake a logout still in flight. It revokes every
+  // refresh token for the user and deletes the cookies, so landing after this
+  // login would revoke the new session's row or erase its cookie. Bounded by
+  // logoutSession's own 3s timeout, and only waits when one is actually
+  // pending.
+  await awaitPendingLogout();
+
   // SP-11: route is /auth/login (no trailing slash) so the POST body is
   // preserved without a 307 redirect.
   const response = await fetch(`${API_BASE}/auth/login`, {
@@ -70,6 +77,19 @@ const LOGOUT_TIMEOUT_MS = 3_000;
  * then went out with no Authorization header at all — leaving exactly the live
  * credential this call exists to revoke.
  */
+/**
+ * fix(#1446): the in-flight revocation, tracked so a new login cannot overtake
+ * it. Logout revokes EVERY refresh token for the user and deletes the cookies,
+ * so a request that lands after a fresh login would revoke the new session's
+ * row, and a delayed response would erase its cookie.
+ */
+let pendingLogout: Promise<void> | null = null;
+
+/** Wait for any in-flight logout revocation to settle. */
+export async function awaitPendingLogout(): Promise<void> {
+  if (pendingLogout) await pendingLogout;
+}
+
 export async function logoutSession(): Promise<void> {
   const { token, refreshToken } = useAuthStore.getState();
   // fix(#1446): carry the cookie-mode headers too. When the access token has
@@ -86,7 +106,7 @@ export async function logoutSession(): Promise<void> {
     : undefined;
   if (body) headers['Content-Type'] = 'application/json';
 
-  await safeFetch(`${API_BASE}/auth/logout/`, {
+  const request = safeFetch(`${API_BASE}/auth/logout/`, {
     method: 'POST',
     headers,
     credentials: 'same-origin',
@@ -99,6 +119,19 @@ export async function logoutSession(): Promise<void> {
     keepalive: true,
     ...(body ? { body } : {}),
   });
+
+  // Callers dispatch without awaiting, so this is what lets a subsequent login
+  // wait for the revocation to settle rather than race it.
+  const settled = request.then(
+    () => undefined,
+    () => undefined,
+  );
+  pendingLogout = settled;
+  void settled.then(() => {
+    if (pendingLogout === settled) pendingLogout = null;
+  });
+
+  await request;
 }
 
 export async function registerUser(data: {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -83,11 +83,18 @@ const LOGOUT_TIMEOUT_MS = 3_000;
  * so a request that lands after a fresh login would revoke the new session's
  * row, and a delayed response would erase its cookie.
  */
-let pendingLogout: Promise<void> | null = null;
+// fix(#1446): a Set, not a single slot. Concurrent teardown paths can each
+// dispatch a revocation (a terminal getMe 401 and a login-catch, say), and
+// last-write-wins would let awaitPendingLogout return while the older request
+// is still holding the user lock server-side — free to revoke rows a new
+// sign-in just created.
+const pendingLogouts = new Set<Promise<void>>();
 
-/** Wait for any in-flight logout revocation to settle. */
+/** Wait for every in-flight logout revocation to settle. */
 export async function awaitPendingLogout(): Promise<void> {
-  if (pendingLogout) await pendingLogout;
+  while (pendingLogouts.size > 0) {
+    await Promise.allSettled([...pendingLogouts]);
+  }
 }
 
 export async function logoutSession(): Promise<void> {
@@ -126,9 +133,9 @@ export async function logoutSession(): Promise<void> {
     () => undefined,
     () => undefined,
   );
-  pendingLogout = settled;
+  pendingLogouts.add(settled);
   void settled.then(() => {
-    if (pendingLogout === settled) pendingLogout = null;
+    pendingLogouts.delete(settled);
   });
 
   await request;

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -50,9 +50,16 @@ export async function getMe(): Promise<UserResponse> {
  *
  * Routed through apiFetch deliberately: if the access token has aged out, the
  * 401 path refreshes from the cookie and retries, so logout still lands.
+ *
+ * fix(#1446): bounded well below apiFetch's 30s default. The caller blocks on
+ * this before tearing down local state, so a blackholed connection would
+ * otherwise leave someone looking signed-in for half a minute after clicking
+ * Logout.
  */
+const LOGOUT_TIMEOUT_MS = 3_000;
+
 export async function logoutSession(): Promise<void> {
-  await apiFetch<void>('/auth/logout/', { method: 'POST' });
+  await apiFetch<void>('/auth/logout/', { method: 'POST', timeoutMs: LOGOUT_TIMEOUT_MS });
 }
 
 export async function registerUser(data: {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -38,6 +38,23 @@ export async function getMe(): Promise<UserResponse> {
   return apiFetch<UserResponse>('/auth/me/');
 }
 
+/**
+ * fix(#1446): end the session on the server, not just in this tab.
+ *
+ * The endpoint has always revoked the refresh-token rows and bumped
+ * token_version, but nothing in the SPA ever called it — clearing localStorage
+ * was enough to strand the browser. fix(#1302) removed that property: the
+ * refresh credential is now an httpOnly cookie JS cannot touch, so a purely
+ * client-side logout would leave a live cookie (and its server row) behind for
+ * the remainder of its lifetime. Only the server's `Set-Cookie` can clear it.
+ *
+ * Routed through apiFetch deliberately: if the access token has aged out, the
+ * 401 path refreshes from the cookie and retries, so logout still lands.
+ */
+export async function logoutSession(): Promise<void> {
+  await apiFetch<void>('/auth/logout/', { method: 'POST' });
+}
+
 export async function registerUser(data: {
   username: string;
   password: string;

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -82,6 +82,12 @@ export async function logoutSession(): Promise<void> {
     headers,
     credentials: 'same-origin',
     signal: AbortSignal.timeout(LOGOUT_TIMEOUT_MS),
+    // fix(#1446): callers dispatch this without awaiting, so a user who clicks
+    // Logout and immediately closes or navigates the tab would otherwise have
+    // the request cancelled at unload — local state already cleared, refresh
+    // row and cookie still alive. keepalive is built for exactly this, and the
+    // request is far inside its 64KB budget.
+    keepalive: true,
     ...(body ? { body } : {}),
   });
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,4 +1,5 @@
 import { API_BASE } from '@/lib/constants';
+import { cookieAuthHeaders } from '@/lib/auth-transport';
 import { apiFetch } from './client';
 import { translateApiErrorDetail } from '@/lib/error-map';
 import type { TokenResponse, UserResponse, AuthConfigResponse, MessageResponse, SignupResponse, MyApiKeyResponse, ApiKeyCreateResponse, ApiKeyScope, OAuthProviderPublic, UserQuotaUsage } from '@/types/api';
@@ -11,7 +12,11 @@ export async function login(
   // preserved without a 307 redirect.
   const response = await fetch(`${API_BASE}/auth/login`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    // fix(#1302): opt into the httpOnly refresh cookie. The response's
+    // refresh_token is null in that mode, so nothing token-shaped reaches
+    // localStorage.
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...cookieAuthHeaders() },
+    credentials: 'same-origin',
     body: new URLSearchParams({ username, password }),
   });
 
@@ -141,13 +146,26 @@ export async function resendVerification(email: string): Promise<MessageResponse
   return response.json() as Promise<MessageResponse>;
 }
 
+/**
+ * fix(#1302): in cookie mode the credential rides in the httpOnly cookie and
+ * `refreshToken` is null, so the body is omitted entirely.
+ *
+ * The one exception is the transition: a session that logged in before this
+ * shipped still holds a localStorage refresh token. Sending it once, under the
+ * cookie-mode header, lets the backend rotate it and hand back a cookie instead
+ * — the session migrates in place rather than being logged out.
+ */
 export async function refreshAccessToken(
-  refreshToken: string,
+  refreshToken: string | null,
 ): Promise<TokenResponse> {
+  const headers: Record<string, string> = { ...cookieAuthHeaders() };
+  if (refreshToken) headers['Content-Type'] = 'application/json';
+
   const response = await fetch(`${API_BASE}/auth/refresh/`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ refresh_token: refreshToken }),
+    headers,
+    credentials: 'same-origin',
+    ...(refreshToken ? { body: JSON.stringify({ refresh_token: refreshToken }) } : {}),
   });
 
   if (!response.ok) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import { API_BASE } from '@/lib/constants';
+import { cookieAuthAvailable } from '@/lib/auth-transport';
 import { translateApiErrorDetail } from '@/lib/error-map';
 import { useAuthStore } from '@/stores/auth-store';
 import { refreshAccessToken } from './auth';
@@ -33,12 +34,16 @@ let inflightRefresh: Promise<void> | null = null;
 // is about to fail the same way (silent 403 tiles, quiet query errors, generic
 // toasts). Instead of letting each surface invent its own failure UX, clear
 // the session once and notify a single app-level handler (the signed-out
-// dialog host). The latch is keyed on the dead refresh token's value: the
-// burst of concurrent in-flight failures all captured the same token, so they
-// collapse to one notification, while the next session (refresh tokens
-// rotate, so its token is always new) notifies again.
+// dialog host). The latch is keyed on the dead session's ACCESS token: the
+// burst of concurrent in-flight failures all captured the same value, so they
+// collapse to one notification, while the next session notifies again.
+//
+// fix(#1302): this used to latch on the refresh token, which is no longer
+// visible to JS. The access token has the same two properties the latch needs —
+// stable across a failure burst, and different for every session, since it
+// rotates on each refresh.
 let sessionExpiredHandler: (() => void) | null = null;
-let lastNotifiedRefreshToken: string | null = null;
+let lastNotifiedSessionKey: string | null = null;
 
 /** Register the app-level signed-out handler. Returns an unregister fn. */
 export function onSessionExpired(handler: () => void): () => void {
@@ -48,16 +53,21 @@ export function onSessionExpired(handler: () => void): () => void {
   };
 }
 
-export function notifySessionExpired(deadRefreshToken: string): void {
-  if (deadRefreshToken === lastNotifiedRefreshToken) return;
-  lastNotifiedRefreshToken = deadRefreshToken;
+export function notifySessionExpired(deadSessionKey: string): void {
+  if (deadSessionKey === lastNotifiedSessionKey) return;
+  lastNotifiedSessionKey = deadSessionKey;
   useAuthStore.getState().logout();
   sessionExpiredHandler?.();
 }
 
 export async function tryRefresh(): Promise<boolean> {
-  const { refreshToken } = useAuthStore.getState();
-  if (!refreshToken) return false;
+  const { refreshToken, token } = useAuthStore.getState();
+  // fix(#1302): in cookie mode the credential is invisible to JS, so a stored
+  // refresh token is no longer proof a session exists — an access token is.
+  // `refreshToken` is still consulted because a pre-GH-1302 session carries one
+  // for exactly one migrating refresh, and because cross-origin deployments
+  // never leave cookie mode's starting gate.
+  if (!refreshToken && !(token && cookieAuthAvailable())) return false;
 
   if (inflightRefresh) {
     await inflightRefresh;
@@ -71,9 +81,11 @@ export async function tryRefresh(): Promise<boolean> {
   const promise = (async () => {
     try {
       const tokens = await refreshAccessToken(refreshToken);
+      // fix(#1302): null in cookie mode, which also clears the legacy
+      // localStorage token once the migrating refresh has spent it.
       useAuthStore.getState().setTokens(
         tokens.access_token,
-        tokens.refresh_token,
+        tokens.refresh_token ?? null,
         tokens.expires_in,
       );
     } catch (err) {
@@ -160,11 +172,12 @@ export async function authenticatedRawFetch(
   });
 
   if (response.status === 401) {
-    // fix(#628): only a session that existed can expire. A real session always
-    // holds a refresh token; an anonymous 401 (or the transient token-only
-    // state mid-login) must not raise the signed-out prompt. Captured BEFORE
-    // tryRefresh so every concurrent failure holds the same dead token.
-    const sessionRefreshToken = useAuthStore.getState().refreshToken;
+    // fix(#628): only a session that existed can expire; an anonymous 401 must
+    // not raise the signed-out prompt. Captured BEFORE tryRefresh so every
+    // concurrent failure holds the same dead value.
+    // fix(#1302): keyed on the access token now that the refresh token is a
+    // cookie. Every real session has one, and it is cleared on logout.
+    const deadSessionKey = useAuthStore.getState().token;
     const refreshed = await tryRefresh();
     if (refreshed) {
       const retry = await safeFetch(target, {
@@ -177,8 +190,8 @@ export async function authenticatedRawFetch(
       // a spurious logout.
       if (retry.status !== 401) return retry;
     }
-    if (sessionRefreshToken) {
-      notifySessionExpired(sessionRefreshToken);
+    if (deadSessionKey) {
+      notifySessionExpired(deadSessionKey);
     } else {
       useAuthStore.getState().logout();
     }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -78,9 +78,17 @@ export async function tryRefresh(): Promise<boolean> {
   // not in the outer try/finally — so a third caller that arrives between
   // resolution and the outer finally can't observe `inflightRefresh === null`
   // and kick off a second refresh cycle. WR-02 (1045-REVIEW.md).
+  // fix(#1446): a logout can land while this request is in flight — most
+  // easily when logout itself triggers the proactive refresh and then stops
+  // waiting on it. Writing the rotated tokens afterwards would re-populate the
+  // store and localStorage, signing the browser back in while it sits on
+  // /login. Capture the epoch now and refuse the write if it moved.
+  const epochAtStart = useAuthStore.getState().sessionEpoch;
+
   const promise = (async () => {
     try {
       const tokens = await refreshAccessToken(refreshToken);
+      if (useAuthStore.getState().sessionEpoch !== epochAtStart) return;
       // fix(#1302): null in cookie mode, which also clears the legacy
       // localStorage token once the migrating refresh has spent it.
       useAuthStore.getState().setTokens(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,7 +2,7 @@ import { API_BASE } from '@/lib/constants';
 import { cookieAuthAvailable } from '@/lib/auth-transport';
 import { translateApiErrorDetail } from '@/lib/error-map';
 import { useAuthStore } from '@/stores/auth-store';
-import { refreshAccessToken } from './auth';
+import { logoutSession, refreshAccessToken } from './auth';
 import i18n from '@/i18n/i18n';
 
 // fix(#438): DATA-04 — a request whose socket hangs used to spin forever and
@@ -56,6 +56,14 @@ export function onSessionExpired(handler: () => void): () => void {
 export function notifySessionExpired(deadSessionKey: string): void {
   if (deadSessionKey === lastNotifiedSessionKey) return;
   lastNotifiedSessionKey = deadSessionKey;
+  // fix(#1446): the refresh that got us here may have failed transiently — a
+  // 429, a 5xx, a dropped connection — in which case the refresh cookie and
+  // its server-side row are still perfectly valid behind a UI that now says
+  // "signed out". Since fix(#1302) that credential is httpOnly, so clearing
+  // the store cannot touch it. Dispatch a best-effort revocation on the way
+  // out. logoutSession issues a plain fetch, so this cannot recurse back
+  // through the 401 interceptor that called us.
+  void logoutSession().catch(() => {});
   useAuthStore.getState().logout();
   sessionExpiredHandler?.();
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -28,6 +28,18 @@ export class ApiError extends Error {
 // /auth/refresh/ POST per refresh cycle. Cleared in finally so the next
 // expiration starts fresh.
 let inflightRefresh: Promise<void> | null = null;
+let inflightRefreshAbort: AbortController | null = null;
+
+/**
+ * fix(#1446): abandon any refresh still in flight, so its response — and the
+ * `Set-Cookie` riding on it — is never processed. Called when the session ends
+ * deliberately, where a rotated cookie arriving after a subsequent login would
+ * silently replace the new session's credential with a revoked one.
+ */
+export function abortInflightRefresh(): void {
+  inflightRefreshAbort?.abort();
+  inflightRefreshAbort = null;
+}
 
 // fix(#628): once a request 401s AND the follow-up refresh cannot produce a
 // working token, the session is conclusively dead — every surface in the app
@@ -63,6 +75,7 @@ export function notifySessionExpired(deadSessionKey: string): void {
   // the store cannot touch it. Dispatch a best-effort revocation on the way
   // out. logoutSession issues a plain fetch, so this cannot recurse back
   // through the 401 interceptor that called us.
+  abortInflightRefresh();
   void logoutSession().catch(() => {});
   useAuthStore.getState().logout();
   sessionExpiredHandler?.();
@@ -93,9 +106,17 @@ export async function tryRefresh(): Promise<boolean> {
   // /login. Capture the epoch now and refuse the write if it moved.
   const epochAtStart = useAuthStore.getState().sessionEpoch;
 
+  // fix(#1446): the epoch guard stops a late refresh writing to the store, but
+  // it cannot stop the BROWSER applying that response's Set-Cookie — which
+  // could overwrite a cookie a later login already issued, killing the new
+  // session. Aborting the request means the response is never processed at
+  // all, so the stale cookie never lands.
+  const controller = new AbortController();
+  inflightRefreshAbort = controller;
+
   const promise = (async () => {
     try {
-      const tokens = await refreshAccessToken(refreshToken);
+      const tokens = await refreshAccessToken(refreshToken, controller.signal);
       if (useAuthStore.getState().sessionEpoch !== epochAtStart) return;
       // fix(#1302): null in cookie mode, which also clears the legacy
       // localStorage token once the migrating refresh has spent it.
@@ -112,6 +133,7 @@ export async function tryRefresh(): Promise<boolean> {
       // Refresh failed -- will fall through to logout
     } finally {
       inflightRefresh = null;
+      if (inflightRefreshAbort === controller) inflightRefreshAbort = null;
     }
   })();
   inflightRefresh = promise;

--- a/frontend/src/api/ingest.ts
+++ b/frontend/src/api/ingest.ts
@@ -1,4 +1,4 @@
-import { apiFetch, ApiError, tryRefresh } from './client';
+import { apiFetch, ApiError, notifySessionExpired, tryRefresh } from './client';
 import { uploadChunks } from './_presignedUpload';
 import { API_BASE } from '@/lib/constants';
 import { translateApiErrorDetail } from '@/lib/error-map';
@@ -60,8 +60,15 @@ async function xhrUpload<T>(
     });
 
   let res = await attempt();
-  if (res.status === 401 && (await tryRefresh())) {
-    res = await attempt();
+  // fix(#1446): capture the dead session BEFORE refreshing, matching
+  // authenticatedRawFetch — every concurrent failure then keys the
+  // notification latch on the same value.
+  let deadSessionKey: string | null = null;
+  if (res.status === 401) {
+    deadSessionKey = useAuthStore.getState().token;
+    if (await tryRefresh()) {
+      res = await attempt();
+    }
   }
 
   if (res.status < 200 || res.status >= 300) {
@@ -72,7 +79,19 @@ async function xhrUpload<T>(
     } catch {
       // Non-JSON failures use the localized status category below.
     }
-    if (res.status === 401) useAuthStore.getState().logout();
+    // fix(#1446): route terminal auth failure through the shared path instead
+    // of clearing the store directly. Since the refresh credential became an
+    // httpOnly cookie, a store-only logout leaves it and its server-side row
+    // alive; notifySessionExpired dispatches the revocation. It also gives
+    // uploads the same single signed-out prompt every other surface shows
+    // (fix(#628)), which this call site never had.
+    if (res.status === 401) {
+      if (deadSessionKey) {
+        notifySessionExpired(deadSessionKey);
+      } else {
+        useAuthStore.getState().logout();
+      }
+    }
     throw new ApiError(translateApiErrorDetail(detail, res.status), res.status, detail);
   }
 

--- a/frontend/src/components/auth/OAuthButtons.tsx
+++ b/frontend/src/components/auth/OAuthButtons.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { getOAuthProviders } from '@/api/auth';
+import { awaitPendingLogout, getOAuthProviders } from '@/api/auth';
 import { queryKeys } from '@/lib/query-keys';
 import { Button } from '@/components/ui/button';
 import { API_BASE } from '@/lib/constants';
@@ -142,7 +142,13 @@ export function OAuthButtons({ showDivider = true }: { showDivider?: boolean } =
               className="h-10 w-full"
               title={compact ? label : undefined}
               aria-label={compact ? label : undefined}
-              onClick={() => {
+              onClick={async () => {
+                // fix(#1446): OAuth is a second sign-in entry point and needs
+                // the same guard password login has. A logout dispatched
+                // moments earlier revokes every refresh token and deletes the
+                // cookies, so a fast callback could install the new session
+                // only for the older logout to revoke it.
+                await awaitPendingLogout();
                 window.location.href = `${API_BASE}/auth/oauth/${provider.slug}/login`;
               }}
             >

--- a/frontend/src/components/auth/__tests__/OAuthButtons.test.tsx
+++ b/frontend/src/components/auth/__tests__/OAuthButtons.test.tsx
@@ -1,13 +1,55 @@
 import { render, screen, waitFor } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
 import { OAuthButtons } from '../OAuthButtons';
+
+const mockAwaitPendingLogout = vi.fn<() => Promise<void>>();
 
 vi.mock('@/api/auth', () => ({
   getOAuthProviders: vi.fn().mockResolvedValue([
     { slug: 'github', display_name: 'GitHub', provider_type: 'github' },
   ]),
+  awaitPendingLogout: () => mockAwaitPendingLogout(),
 }));
 
 describe('OAuthButtons', () => {
+  beforeEach(() => {
+    mockAwaitPendingLogout.mockReset();
+    mockAwaitPendingLogout.mockResolvedValue(undefined);
+  });
+
+  // fix(#1446): OAuth is a second sign-in entry point. A logout dispatched
+  // moments earlier revokes every refresh token and deletes the cookies, so a
+  // fast callback could install the new session only for the older logout to
+  // revoke it. Password login already waits; this path must too.
+  it('waits for a pending logout before redirecting to the provider', async () => {
+    let releaseLogout: () => void = () => {};
+    mockAwaitPendingLogout.mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseLogout = resolve;
+      }),
+    );
+    const hrefs: string[] = [];
+    const original = Object.getOwnPropertyDescriptor(window, 'location');
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, set href(v: string) { hrefs.push(v); } },
+    });
+
+    try {
+      render(<OAuthButtons />);
+      const button = await screen.findByRole('button', { name: /sign in with github/i });
+      await userEvent.click(button);
+
+      expect(mockAwaitPendingLogout).toHaveBeenCalledTimes(1);
+      expect(hrefs).toEqual([]);
+
+      releaseLogout();
+      await waitFor(() => expect(hrefs).toEqual(['/api/auth/oauth/github/login']));
+    } finally {
+      if (original) Object.defineProperty(window, 'location', original);
+    }
+  });
+
   it('renders a GitHub button with the GitHub mark icon and localized label', async () => {
     render(<OAuthButtons />);
 

--- a/frontend/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
+++ b/frontend/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
@@ -16,6 +16,10 @@ import type { AuthConfigResponse } from '@/types/api';
 vi.mock('@/api/auth', () => ({
   getAuthConfig: vi.fn().mockRejectedValue(new Error('not stubbed')),
   refreshAccessToken: vi.fn(),
+  // fix(#1446): notifySessionExpired dispatches a best-effort server
+  // revocation — a transiently-failed refresh leaves a live httpOnly cookie
+  // that clearing the store cannot reach.
+  logoutSession: vi.fn(() => Promise.resolve()),
 }));
 
 function LoginProbe() {

--- a/frontend/src/components/builder/BuilderMap.tsx
+++ b/frontend/src/components/builder/BuilderMap.tsx
@@ -788,7 +788,10 @@ export const BuilderMap = memo(function BuilderMap({
             // fix(#628): once the session is conclusively dead the global
             // signed-out dialog owns the UX — the stale reload-toast is
             // noise on top of it. Keep it only while a session exists.
-            if (useAuthStore.getState().refreshToken) {
+            // fix(#1446): keyed on the ACCESS token. The refresh token is an
+            // httpOnly cookie now, so it reads as null for every cookie-mode
+            // user and this predicate would suppress the toast permanently.
+            if (useAuthStore.getState().token) {
               toast.error(t('builderMap.authError', { defaultValue: 'Session expired — reload the page to restore tile access.' }), {
                 id: 'builder-map-auth-error',
               });

--- a/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
+++ b/frontend/src/components/builder/__tests__/BuilderMap.raster-tile-auth.test.tsx
@@ -223,8 +223,12 @@ describe('BuilderMap raster/DEM tile auth errors (fix #890)', () => {
     reportState.push.mockClear();
     reportState.remint.mockClear();
     vi.mocked(toast.error).mockClear();
-    // A live session: the auth toast is gated on refreshToken (fix #628).
-    useAuthStore.setState({ refreshToken: 'refresh-token' });
+    // A live session: the auth toast is gated on the session existing
+    // (fix #628). fix(#1446): keyed on the ACCESS token — the refresh token is
+    // an httpOnly cookie now and reads as null for every cookie-mode user, so
+    // seeding only refreshToken here would assert against a state real
+    // sessions no longer reach.
+    useAuthStore.setState({ token: 'access-token', refreshToken: null });
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     tileTokenState.tokens = [
       {
@@ -237,7 +241,7 @@ describe('BuilderMap raster/DEM tile auth errors (fix #890)', () => {
 
   afterEach(() => {
     errorSpy.mockRestore();
-    useAuthStore.setState({ refreshToken: null });
+    useAuthStore.setState({ token: null, refreshToken: null });
   });
 
   it('logs a raster 403 exactly once and never claims a re-sign/re-mint', async () => {

--- a/frontend/src/hooks/__tests__/use-auth.test.tsx
+++ b/frontend/src/hooks/__tests__/use-auth.test.tsx
@@ -20,11 +20,13 @@ vi.mock('react-router', async () => {
 const mockLogin = vi.fn<(u: string, p: string) => Promise<TokenResponse>>();
 const mockGetMe = vi.fn<() => Promise<UserResponse>>();
 const mockRefresh = vi.fn();
+const mockLogoutSession = vi.fn<() => Promise<void>>();
 
 vi.mock('@/api/auth', () => ({
   login: (...args: unknown[]) => mockLogin(...(args as [string, string])),
   getMe: () => mockGetMe(),
   refreshAccessToken: (...args: unknown[]) => mockRefresh(...args),
+  logoutSession: () => mockLogoutSession(),
 }));
 
 function mockUser(overrides?: Partial<UserResponse>): UserResponse {
@@ -45,6 +47,7 @@ describe('useAuth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetMe.mockResolvedValue(mockUser());
+    mockLogoutSession.mockResolvedValue(undefined);
     useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
   });
 
@@ -94,17 +97,51 @@ describe('useAuth', () => {
     ).rejects.toThrow('Invalid credentials');
   });
 
-  it('logout clears store and navigates to /login', () => {
+  it('logout clears store and navigates to /login', async () => {
     useAuthStore.setState({ token: 'abc', refreshToken: 'ref', expiresAt: 999, user: mockUser() });
 
     const { result } = renderHook(() => useAuth());
 
-    act(() => {
-      result.current.logout();
+    await act(async () => {
+      await result.current.logout();
     });
 
     expect(useAuthStore.getState().token).toBeNull();
     expect(useAuthStore.getState().user).toBeNull();
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+  });
+
+  // fix(#1446): the refresh credential is an httpOnly cookie since fix(#1302),
+  // so only the server can end the session. A logout that just clears the store
+  // would leave a live cookie behind.
+  it('logout revokes the session server-side before clearing local state', async () => {
+    useAuthStore.setState({ token: 'abc', refreshToken: null, expiresAt: 999, user: mockUser() });
+    let tokenAtRequestTime: string | null = null;
+    mockLogoutSession.mockImplementation(async () => {
+      tokenAtRequestTime = useAuthStore.getState().token;
+    });
+
+    const { result } = renderHook(() => useAuth());
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(mockLogoutSession).toHaveBeenCalledTimes(1);
+    // The bearer token must still be present when the request goes out.
+    expect(tokenAtRequestTime).toBe('abc');
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  it('logout still clears local state when the server call fails', async () => {
+    useAuthStore.setState({ token: 'abc', refreshToken: null, expiresAt: 999, user: mockUser() });
+    mockLogoutSession.mockRejectedValueOnce(new Error('offline'));
+
+    const { result } = renderHook(() => useAuth());
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(useAuthStore.getState().token).toBeNull();
     expect(mockNavigate).toHaveBeenCalledWith('/login');
   });
 
@@ -204,8 +241,8 @@ describe('useAuth', () => {
 
       const { result } = renderWithQueryClient(queryClient);
 
-      act(() => {
-        result.current.logout();
+      await act(async () => {
+        await result.current.logout();
       });
 
       // Cache for ['auth','me'] must be gone after logout

--- a/frontend/src/hooks/__tests__/use-auth.test.tsx
+++ b/frontend/src/hooks/__tests__/use-auth.test.tsx
@@ -159,34 +159,23 @@ describe('useAuth', () => {
     expect(useAuthStore.getState().token).toBeNull();
   });
 
-  // fix(#1446): the bound is on the WAIT, not just the request — a 401 inside
-  // logoutSession detours through tryRefresh, whose own fetch carries a
-  // separate deadline the logout signal cannot reach.
-  it('logout stops waiting on a stalled server call and tears down anyway', async () => {
-    vi.useFakeTimers();
-    try {
-      useAuthStore.setState({ token: 'abc', refreshToken: null, expiresAt: 999, user: mockUser() });
-      // Never settles, mimicking a stalled refresh detour.
-      mockLogoutSession.mockImplementation(() => new Promise<void>(() => {}));
+  // fix(#1446): revocation is DISPATCHED, never awaited. logoutSession forms
+  // its request with a synchronously-captured bearer token, so teardown cannot
+  // strip its credential, and a stalled network cannot hold the user on an
+  // authenticated screen.
+  it('logout tears down immediately without waiting on the server call', async () => {
+    useAuthStore.setState({ token: 'abc', refreshToken: null, expiresAt: 999, user: mockUser() });
+    // Never settles, mimicking a blackholed connection.
+    mockLogoutSession.mockImplementation(() => new Promise<void>(() => {}));
 
-      const { result } = renderHook(() => useAuth());
-      let done = false;
-      const pending = result.current.logout().then(() => {
-        done = true;
-      });
+    const { result } = renderHook(() => useAuth());
+    await act(async () => {
+      await result.current.logout();
+    });
 
-      expect(done).toBe(false);
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(3_000);
-      });
-      await pending;
-
-      expect(done).toBe(true);
-      expect(useAuthStore.getState().token).toBeNull();
-      expect(mockNavigate).toHaveBeenCalledWith('/login');
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(mockLogoutSession).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().token).toBeNull();
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
   });
 
   it('logout still clears local state when the server call fails', async () => {

--- a/frontend/src/hooks/__tests__/use-auth.test.tsx
+++ b/frontend/src/hooks/__tests__/use-auth.test.tsx
@@ -97,6 +97,33 @@ describe('useAuth', () => {
     ).rejects.toThrow('Invalid credentials');
   });
 
+  // fix(#1446): login installs the refresh cookie before getMe() runs, so a
+  // failure there must revoke server-side — a store reset cannot reach the
+  // httpOnly cookie, and the UI would claim the sign-in failed while the
+  // credential stayed live.
+  it('revokes the session when getMe fails after a successful login', async () => {
+    mockLogin.mockResolvedValueOnce({
+      access_token: 'abc',
+      refresh_token: null,
+      token_type: 'bearer',
+      expires_in: 900,
+    });
+    // Not `...Once`: the hook's own meQuery also calls getMe once the token is
+    // set, and would otherwise eat the single rejection.
+    mockGetMe.mockRejectedValue(new Error('me failed'));
+
+    const { result } = renderHook(() => useAuth());
+
+    await expect(
+      act(async () => {
+        await result.current.login('user', 'pass');
+      }),
+    ).rejects.toThrow('me failed');
+
+    expect(mockLogoutSession).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
   it('logout clears store and navigates to /login', async () => {
     useAuthStore.setState({ token: 'abc', refreshToken: 'ref', expiresAt: 999, user: mockUser() });
 

--- a/frontend/src/hooks/__tests__/use-auth.test.tsx
+++ b/frontend/src/hooks/__tests__/use-auth.test.tsx
@@ -159,6 +159,36 @@ describe('useAuth', () => {
     expect(useAuthStore.getState().token).toBeNull();
   });
 
+  // fix(#1446): the bound is on the WAIT, not just the request — a 401 inside
+  // logoutSession detours through tryRefresh, whose own fetch carries a
+  // separate deadline the logout signal cannot reach.
+  it('logout stops waiting on a stalled server call and tears down anyway', async () => {
+    vi.useFakeTimers();
+    try {
+      useAuthStore.setState({ token: 'abc', refreshToken: null, expiresAt: 999, user: mockUser() });
+      // Never settles, mimicking a stalled refresh detour.
+      mockLogoutSession.mockImplementation(() => new Promise<void>(() => {}));
+
+      const { result } = renderHook(() => useAuth());
+      let done = false;
+      const pending = result.current.logout().then(() => {
+        done = true;
+      });
+
+      expect(done).toBe(false);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_000);
+      });
+      await pending;
+
+      expect(done).toBe(true);
+      expect(useAuthStore.getState().token).toBeNull();
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('logout still clears local state when the server call fails', async () => {
     useAuthStore.setState({ token: 'abc', refreshToken: null, expiresAt: 999, user: mockUser() });
     mockLogoutSession.mockRejectedValueOnce(new Error('offline'));

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -6,6 +6,9 @@ import { useAuthStore } from '@/stores/auth-store';
 import { login as apiLogin, getMe, logoutSession } from '@/api/auth';
 import { tryRefresh } from '@/api/client';
 
+/** Longest the UI waits on server-side revocation before tearing down locally. */
+const LOGOUT_MAX_WAIT_MS = 3_000;
+
 export function useAuth() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -99,11 +102,18 @@ export function useAuth() {
     // Set-Cookie. A failure here (offline, or a session already dead) must not
     // trap the user in a session they asked to leave, so the local teardown
     // runs either way.
-    try {
-      await logoutSession();
-    } catch {
-      // Intentionally swallowed — see above.
-    }
+    // fix(#1446): bound the WAIT, not just the request. logoutSession's own
+    // timeout covers its fetch, but a 401 there detours through tryRefresh,
+    // whose request carries a separate deadline this signal cannot reach.
+    // Racing a timer caps how long the user stares at an authenticated screen
+    // regardless of which leg stalls. The request keeps running and may still
+    // revoke; we simply stop waiting on it.
+    await Promise.race([
+      logoutSession().catch(() => {
+        // Offline, or a session already dead. Local teardown proceeds.
+      }),
+      new Promise<void>((resolve) => setTimeout(resolve, LOGOUT_MAX_WAIT_MS)),
+    ]);
     // BUG-021: clear the ['auth','me'] cache on logout so a subsequent login
     // does not see the previous user's cached identity.
     queryClient.removeQueries({ queryKey: queryKeys.auth.me });

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -69,7 +69,17 @@ export function useAuth() {
       // stale capabilities. Remove (not invalidate) so capability gates fail
       // closed until the new user's permissions are fetched.
       queryClient.removeQueries({ queryKey: queryKeys.auth.permissions });
-      const userResponse = await getMe();
+      let userResponse;
+      try {
+        userResponse = await getMe();
+      } catch (err) {
+        // fix(#1446): login already installed the refresh cookie. Bailing out
+        // with only a store reset would leave that credential live while the
+        // UI reports a failed sign-in, so revoke it before surfacing the error.
+        await logoutSession().catch(() => {});
+        useAuthStore.getState().logout();
+        throw err;
+      }
       setAuth(
         tokenResponse.access_token,
         // fix(#1302): null in cookie mode — the refresh token arrived as an

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -3,7 +3,7 @@ import { queryKeys } from '@/lib/query-keys';
 import { useNavigate } from 'react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/stores/auth-store';
-import { login as apiLogin, getMe } from '@/api/auth';
+import { login as apiLogin, getMe, logoutSession } from '@/api/auth';
 import { tryRefresh } from '@/api/client';
 
 export function useAuth() {
@@ -82,7 +82,18 @@ export function useAuth() {
     [setAuth, queryClient],
   );
 
-  const logout = useCallback(() => {
+  const logout = useCallback(async () => {
+    // fix(#1446): revoke server-side BEFORE tearing down local state. The
+    // request needs the bearer token that storeLogout is about to clear, and
+    // since fix(#1302) the refresh cookie can only be removed by the server's
+    // Set-Cookie. A failure here (offline, or a session already dead) must not
+    // trap the user in a session they asked to leave, so the local teardown
+    // runs either way.
+    try {
+      await logoutSession();
+    } catch {
+      // Intentionally swallowed — see above.
+    }
     // BUG-021: clear the ['auth','me'] cache on logout so a subsequent login
     // does not see the previous user's cached identity.
     queryClient.removeQueries({ queryKey: queryKeys.auth.me });

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/stores/auth-store';
 import { login as apiLogin, getMe, logoutSession } from '@/api/auth';
-import { tryRefresh } from '@/api/client';
+import { abortInflightRefresh, tryRefresh } from '@/api/client';
 
 export function useAuth() {
   const navigate = useNavigate();
@@ -106,6 +106,11 @@ export function useAuth() {
     // below cannot affect it. Waiting would only buy a confirmation we never
     // act on, at the cost of holding the user on an authenticated screen for
     // as long as the network stalls.
+    // fix(#1446): abandon any refresh still in flight first. Its response
+    // carries a Set-Cookie the browser would apply on arrival, and if the user
+    // signs in again before it lands it would overwrite the new session's
+    // cookie with the token this logout is about to revoke.
+    abortInflightRefresh();
     void logoutSession().catch(() => {
       // Offline, or a session already dead. Local teardown proceeds regardless.
     });

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -72,7 +72,9 @@ export function useAuth() {
       const userResponse = await getMe();
       setAuth(
         tokenResponse.access_token,
-        tokenResponse.refresh_token,
+        // fix(#1302): null in cookie mode — the refresh token arrived as an
+        // httpOnly cookie and is never held in JS.
+        tokenResponse.refresh_token ?? null,
         tokenResponse.expires_in,
         userResponse,
       );

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -6,9 +6,6 @@ import { useAuthStore } from '@/stores/auth-store';
 import { login as apiLogin, getMe, logoutSession } from '@/api/auth';
 import { tryRefresh } from '@/api/client';
 
-/** Longest the UI waits on server-side revocation before tearing down locally. */
-const LOGOUT_MAX_WAIT_MS = 3_000;
-
 export function useAuth() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -79,7 +76,8 @@ export function useAuth() {
         // fix(#1446): login already installed the refresh cookie. Bailing out
         // with only a store reset would leave that credential live while the
         // UI reports a failed sign-in, so revoke it before surfacing the error.
-        await logoutSession().catch(() => {});
+        // Dispatched, not awaited — same reasoning as logout below.
+        void logoutSession().catch(() => {});
         useAuthStore.getState().logout();
         throw err;
       }
@@ -102,18 +100,15 @@ export function useAuth() {
     // Set-Cookie. A failure here (offline, or a session already dead) must not
     // trap the user in a session they asked to leave, so the local teardown
     // runs either way.
-    // fix(#1446): bound the WAIT, not just the request. logoutSession's own
-    // timeout covers its fetch, but a 401 there detours through tryRefresh,
-    // whose request carries a separate deadline this signal cannot reach.
-    // Racing a timer caps how long the user stares at an authenticated screen
-    // regardless of which leg stalls. The request keeps running and may still
-    // revoke; we simply stop waiting on it.
-    await Promise.race([
-      logoutSession().catch(() => {
-        // Offline, or a session already dead. Local teardown proceeds.
-      }),
-      new Promise<void>((resolve) => setTimeout(resolve, LOGOUT_MAX_WAIT_MS)),
-    ]);
+    // fix(#1446): dispatch, do not await. logoutSession reads the bearer token
+    // synchronously and issues a plain fetch, so the request is already in
+    // flight with its credential attached by the time this returns — teardown
+    // below cannot affect it. Waiting would only buy a confirmation we never
+    // act on, at the cost of holding the user on an authenticated screen for
+    // as long as the network stalls.
+    void logoutSession().catch(() => {
+      // Offline, or a session already dead. Local teardown proceeds regardless.
+    });
     // BUG-021: clear the ['auth','me'] cache on logout so a subsequent login
     // does not see the previous user's cached identity.
     queryClient.removeQueries({ queryKey: queryKeys.auth.me });

--- a/frontend/src/lib/__tests__/auth-transport.test.ts
+++ b/frontend/src/lib/__tests__/auth-transport.test.ts
@@ -43,6 +43,27 @@ describe('cookieAuthAvailable', () => {
     vi.resetModules();
   });
 
+  // fix(#1446): the backend scopes the cookie under its fixed `/api` root_path,
+  // so a same-origin base mounted elsewhere gets a cookie the browser never
+  // sends — and cookie mode returns no body token to fall back on.
+  it('is false for a same-origin base mounted outside the cookie scope', async () => {
+    vi.doMock('@/lib/constants', () => ({ API_BASE: '/geolens-api' }));
+    vi.resetModules();
+    const mod = await import('@/lib/auth-transport');
+    expect(mod.cookieAuthAvailable()).toBe(false);
+    vi.doUnmock('@/lib/constants');
+    vi.resetModules();
+  });
+
+  it('tolerates a trailing slash on the default base', async () => {
+    vi.doMock('@/lib/constants', () => ({ API_BASE: '/api/' }));
+    vi.resetModules();
+    const mod = await import('@/lib/auth-transport');
+    expect(mod.cookieAuthAvailable()).toBe(true);
+    vi.doUnmock('@/lib/constants');
+    vi.resetModules();
+  });
+
   it('is true for a protocol-relative base that resolves to this origin', async () => {
     vi.doMock('@/lib/constants', () => ({
       API_BASE: `//${window.location.host}/api`,

--- a/frontend/src/lib/__tests__/auth-transport.test.ts
+++ b/frontend/src/lib/__tests__/auth-transport.test.ts
@@ -29,6 +29,30 @@ describe('cookieAuthAvailable', () => {
     vi.doUnmock('@/lib/constants');
     vi.resetModules();
   });
+
+  // fix(#1446): a protocol-relative base has no scheme but is still
+  // cross-origin. Treating "no http(s):// prefix" as same-origin opted such a
+  // deployment into cookie mode while withholding the cookie, so sessions
+  // stopped refreshing at access-token expiry.
+  it('is false for a protocol-relative cross-origin base', async () => {
+    vi.doMock('@/lib/constants', () => ({ API_BASE: '//api.elsewhere.example/v1' }));
+    vi.resetModules();
+    const mod = await import('@/lib/auth-transport');
+    expect(mod.cookieAuthAvailable()).toBe(false);
+    vi.doUnmock('@/lib/constants');
+    vi.resetModules();
+  });
+
+  it('is true for a protocol-relative base that resolves to this origin', async () => {
+    vi.doMock('@/lib/constants', () => ({
+      API_BASE: `//${window.location.host}/api`,
+    }));
+    vi.resetModules();
+    const mod = await import('@/lib/auth-transport');
+    expect(mod.cookieAuthAvailable()).toBe(true);
+    vi.doUnmock('@/lib/constants');
+    vi.resetModules();
+  });
 });
 
 describe('readCsrfCookie', () => {

--- a/frontend/src/lib/__tests__/auth-transport.test.ts
+++ b/frontend/src/lib/__tests__/auth-transport.test.ts
@@ -1,0 +1,76 @@
+import { cookieAuthAvailable, readCsrfCookie, cookieAuthHeaders } from '@/lib/auth-transport';
+
+// fix(#1302): the refresh token moved into an httpOnly cookie. These pin the
+// two decisions that gate the flow: whether the cookie can work at all (it only
+// replays to the origin that set it), and how the double-submit CSRF token is
+// carried.
+
+vi.mock('@/lib/constants', () => ({ API_BASE: '/api' }));
+
+describe('cookieAuthAvailable', () => {
+  it('is true for the default relative API base (same origin by construction)', () => {
+    expect(cookieAuthAvailable()).toBe(true);
+  });
+
+  it('is true for an absolute base on this origin', async () => {
+    vi.doMock('@/lib/constants', () => ({ API_BASE: `${window.location.origin}/api` }));
+    vi.resetModules();
+    const mod = await import('@/lib/auth-transport');
+    expect(mod.cookieAuthAvailable()).toBe(true);
+    vi.doUnmock('@/lib/constants');
+    vi.resetModules();
+  });
+
+  it('is false for a cross-origin API base, which cannot replay the cookie', async () => {
+    vi.doMock('@/lib/constants', () => ({ API_BASE: 'https://api.elsewhere.example/v1' }));
+    vi.resetModules();
+    const mod = await import('@/lib/auth-transport');
+    expect(mod.cookieAuthAvailable()).toBe(false);
+    vi.doUnmock('@/lib/constants');
+    vi.resetModules();
+  });
+});
+
+describe('readCsrfCookie', () => {
+  afterEach(() => {
+    document.cookie = 'geolens_csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+  });
+
+  it('returns null when the cookie is absent', () => {
+    expect(readCsrfCookie()).toBeNull();
+  });
+
+  it('reads the token, and is not confused by neighbouring cookies', () => {
+    document.cookie = 'other=first; path=/';
+    document.cookie = 'geolens_csrf=csrf-value-123; path=/';
+    expect(readCsrfCookie()).toBe('csrf-value-123');
+  });
+});
+
+describe('cookieAuthHeaders', () => {
+  afterEach(() => {
+    document.cookie = 'geolens_csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+  });
+
+  it('opts in without a CSRF token before one exists (first login)', () => {
+    expect(cookieAuthHeaders()).toEqual({ 'X-GeoLens-Auth-Mode': 'cookie' });
+  });
+
+  it('echoes the CSRF cookie back as a header once set', () => {
+    document.cookie = 'geolens_csrf=csrf-value-123; path=/';
+    expect(cookieAuthHeaders()).toEqual({
+      'X-GeoLens-Auth-Mode': 'cookie',
+      'X-CSRF-Token': 'csrf-value-123',
+    });
+  });
+
+  it('sends nothing when cookie mode is unavailable, leaving the legacy call intact', async () => {
+    vi.doMock('@/lib/constants', () => ({ API_BASE: 'https://api.elsewhere.example/v1' }));
+    vi.resetModules();
+    const mod = await import('@/lib/auth-transport');
+    document.cookie = 'geolens_csrf=csrf-value-123; path=/';
+    expect(mod.cookieAuthHeaders()).toEqual({});
+    vi.doUnmock('@/lib/constants');
+    vi.resetModules();
+  });
+});

--- a/frontend/src/lib/auth-transport.ts
+++ b/frontend/src/lib/auth-transport.ts
@@ -18,6 +18,12 @@ export const AUTH_MODE_HEADER = 'X-GeoLens-Auth-Mode';
 export const CSRF_HEADER = 'X-CSRF-Token';
 export const CSRF_COOKIE_NAME = 'geolens_csrf';
 
+/**
+ * Mount point the refresh cookie is scoped under. The backend derives its
+ * `Path` from the ASGI `root_path`, which `api/main.py` fixes at `/api`.
+ */
+const COOKIE_SCOPED_API_PATH = '/api';
+
 export function cookieAuthAvailable(): boolean {
   if (typeof window === 'undefined') return false;
   try {
@@ -28,7 +34,17 @@ export function cookieAuthAvailable(): boolean {
     // 'same-origin'` withheld the cookie — every session would have stopped
     // refreshing once its access token expired. Resolution handles the
     // relative default correctly too.
-    return new URL(API_BASE, window.location.href).origin === window.location.origin;
+    const base = new URL(API_BASE, window.location.href);
+    if (base.origin !== window.location.origin) return false;
+    // fix(#1446): same origin is necessary but not sufficient — the PATH has to
+    // fall inside the cookie's scope too. FRONTEND_API_BASE_URL is documented
+    // as "URL path or absolute URL", so a deployment can mount the API at, say,
+    // `/geolens-api` behind a rewriting proxy. The cookie would still be scoped
+    // to `/api/auth`, the browser would never send it to `/geolens-api/auth/
+    // refresh/`, and no body token comes back in cookie mode — so the session
+    // would silently stop refreshing. Such deployments stay on the body-token
+    // flow, which works at any mount point.
+    return base.pathname.replace(/\/+$/, '') === COOKIE_SCOPED_API_PATH;
   } catch {
     return false;
   }

--- a/frontend/src/lib/auth-transport.ts
+++ b/frontend/src/lib/auth-transport.ts
@@ -1,0 +1,53 @@
+import { API_BASE } from '@/lib/constants';
+
+/**
+ * GH-1302: how this browser talks to /auth/login and /auth/refresh/.
+ *
+ * The refresh token moves into an httpOnly cookie, which the browser will only
+ * replay to the origin that set it. Both shipped deployments put the API on the
+ * app's own origin — the dev Vite proxy (`/api` -> API, `rewrite` strips the
+ * prefix) and the production nginx `location /api/` block — and `API_BASE`
+ * defaults to the relative `/api`, so cookie mode is the normal path.
+ *
+ * A deployment that repoints `API_BASE_URL` at a different origin cannot use
+ * the cookie (its refresh POST is cross-site, and `SameSite=Lax` withholds it),
+ * so those installs stay on the pre-GH-1302 body-token flow rather than being
+ * handed a credential the browser would never send back.
+ */
+export const AUTH_MODE_HEADER = 'X-GeoLens-Auth-Mode';
+export const CSRF_HEADER = 'X-CSRF-Token';
+export const CSRF_COOKIE_NAME = 'geolens_csrf';
+
+export function cookieAuthAvailable(): boolean {
+  if (typeof window === 'undefined') return false;
+  // Relative base (the default) is same-origin by construction.
+  if (!/^https?:\/\//i.test(API_BASE)) return true;
+  try {
+    return new URL(API_BASE, window.location.href).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+export function readCsrfCookie(): string | null {
+  if (typeof document === 'undefined') return null;
+  for (const entry of document.cookie.split(';')) {
+    const [name, ...rest] = entry.trim().split('=');
+    if (name === CSRF_COOKIE_NAME) return decodeURIComponent(rest.join('='));
+  }
+  return null;
+}
+
+/**
+ * Headers that opt this request into the cookie flow. Empty when cookie mode is
+ * unavailable, which leaves the request byte-identical to the legacy call.
+ */
+export function cookieAuthHeaders(): Record<string, string> {
+  if (!cookieAuthAvailable()) return {};
+  const headers: Record<string, string> = { [AUTH_MODE_HEADER]: 'cookie' };
+  const csrf = readCsrfCookie();
+  // Absent on the very first login and on the one migrating refresh, where the
+  // backend has no cookie to compare against and so does not require it.
+  if (csrf) headers[CSRF_HEADER] = csrf;
+  return headers;
+}

--- a/frontend/src/lib/auth-transport.ts
+++ b/frontend/src/lib/auth-transport.ts
@@ -20,9 +20,14 @@ export const CSRF_COOKIE_NAME = 'geolens_csrf';
 
 export function cookieAuthAvailable(): boolean {
   if (typeof window === 'undefined') return false;
-  // Relative base (the default) is same-origin by construction.
-  if (!/^https?:\/\//i.test(API_BASE)) return true;
   try {
+    // fix(#1446): resolve EVERY base against the page URL rather than treating
+    // "no http(s):// prefix" as proof of same-origin. A protocol-relative base
+    // like `//api.example.com` has no scheme yet is cross-origin, and
+    // misreading it opted the app into cookie mode while `credentials:
+    // 'same-origin'` withheld the cookie — every session would have stopped
+    // refreshing once its access token expired. Resolution handles the
+    // relative default correctly too.
     return new URL(API_BASE, window.location.href).origin === window.location.origin;
   } catch {
     return false;

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -41,6 +41,14 @@ export function OAuthCallbackPage() {
     window.history.replaceState({}, '', '/oauth/callback');
 
     if (!token || !expiresIn || (!refreshToken && !cookieMode)) {
+      // fix(#1446): a truncated or malformed fragment still arrived on a
+      // response that installed the cookies, so bailing out here without
+      // revoking leaves a live credential behind a UI reporting failure. The
+      // freshly-set CSRF cookie authenticates it; there is no bearer token to
+      // send. Unconditional — on the legacy fragment path there is no cookie,
+      // so the call simply 401s and costs nothing.
+      void logoutSession().catch(() => {});
+      useAuthStore.getState().logout();
       navigate('/login', { replace: true });
       return;
     }

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/auth-store';
 import { useDocumentTitle } from '@/hooks/use-document-title';
-import { getMe } from '@/api/auth';
+import { getMe, logoutSession } from '@/api/auth';
 import { Loader2 } from 'lucide-react';
 
 export function OAuthCallbackPage() {
@@ -56,7 +56,12 @@ export function OAuthCallbackPage() {
         const target = redirect && redirect.startsWith('/') ? redirect : '/';
         navigate(target, { replace: true });
       })
-      .catch(() => {
+      .catch(async () => {
+        // fix(#1446): the backend already installed the refresh cookie before
+        // redirecting here, so clearing the store alone would strand a
+        // replayable credential the UI claims is gone. Best-effort server
+        // revocation first, while the temporary bearer token is still set.
+        await logoutSession().catch(() => {});
         useAuthStore.getState().logout();
         navigate('/login', { replace: true });
       });

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -31,11 +31,16 @@ export function OAuthCallbackPage() {
     const token = params.get('token');
     const refreshToken = params.get('refresh_token');
     const expiresIn = params.get('expires_in');
+    // fix(#1302): with auth_mode=cookie the backend delivered the refresh token
+    // as an httpOnly cookie on the redirect, so the fragment carries no
+    // refresh_token to require. The fragment is readable by any script on this
+    // page, which made it the same exfiltration surface as localStorage.
+    const cookieMode = params.get('auth_mode') === 'cookie';
 
     // Clean URL immediately (remove fragment with tokens)
     window.history.replaceState({}, '', '/oauth/callback');
 
-    if (!token || !refreshToken || !expiresIn) {
+    if (!token || !expiresIn || (!refreshToken && !cookieMode)) {
       navigate('/login', { replace: true });
       return;
     }
@@ -45,7 +50,7 @@ export function OAuthCallbackPage() {
 
     getMe()
       .then((user) => {
-        useAuthStore.getState().setAuth(token, refreshToken, parseInt(expiresIn, 10), user);
+        useAuthStore.getState().setAuth(token, refreshToken ?? null, parseInt(expiresIn, 10), user);
         const redirect = sessionStorage.getItem('geolens-login-redirect');
         sessionStorage.removeItem('geolens-login-redirect');
         const target = redirect && redirect.startsWith('/') ? redirect : '/';

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -56,12 +56,13 @@ export function OAuthCallbackPage() {
         const target = redirect && redirect.startsWith('/') ? redirect : '/';
         navigate(target, { replace: true });
       })
-      .catch(async () => {
+      .catch(() => {
         // fix(#1446): the backend already installed the refresh cookie before
         // redirecting here, so clearing the store alone would strand a
-        // replayable credential the UI claims is gone. Best-effort server
-        // revocation first, while the temporary bearer token is still set.
-        await logoutSession().catch(() => {});
+        // replayable credential the UI claims is gone. logoutSession captures
+        // the temporary bearer token synchronously, so dispatching it here
+        // sends a fully-formed request before the store is cleared below.
+        void logoutSession().catch(() => {});
         useAuthStore.getState().logout();
         navigate('/login', { replace: true });
       });

--- a/frontend/src/pages/__tests__/OAuthCallbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/OAuthCallbackPage.test.tsx
@@ -1,0 +1,84 @@
+import { render, waitFor } from '@/test/test-utils';
+import { OAuthCallbackPage } from '@/pages/OAuthCallbackPage';
+import { useAuthStore } from '@/stores/auth-store';
+import type { UserResponse } from '@/types/api';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockGetMe = vi.fn<() => Promise<UserResponse>>();
+const mockLogoutSession = vi.fn<() => Promise<void>>();
+vi.mock('@/api/auth', () => ({
+  getMe: () => mockGetMe(),
+  logoutSession: () => mockLogoutSession(),
+}));
+
+function setHash(hash: string) {
+  window.history.replaceState({}, '', `/oauth/callback${hash}`);
+}
+
+describe('OAuthCallbackPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogoutSession.mockResolvedValue(undefined);
+    useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+  });
+
+  // fix(#1302): with auth_mode=cookie the refresh token arrives as an httpOnly
+  // cookie on the redirect and never enters the fragment, which any script on
+  // this page can read.
+  it('completes sign-in from a cookie-mode fragment carrying no refresh token', async () => {
+    const user = { id: '1', username: 'someone', roles: ['viewer'] } as UserResponse;
+    mockGetMe.mockResolvedValueOnce(user);
+    setHash('#token=access-1&expires_in=900&auth_mode=cookie');
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() => expect(useAuthStore.getState().user).toEqual(user));
+    expect(useAuthStore.getState().token).toBe('access-1');
+    expect(useAuthStore.getState().refreshToken).toBeNull();
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+
+  it('still accepts a legacy fragment refresh token (cross-origin fallback)', async () => {
+    const user = { id: '1', username: 'someone', roles: ['viewer'] } as UserResponse;
+    mockGetMe.mockResolvedValueOnce(user);
+    setHash('#token=access-1&refresh_token=legacy-r1&expires_in=900');
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() => expect(useAuthStore.getState().user).toEqual(user));
+    expect(useAuthStore.getState().refreshToken).toBe('legacy-r1');
+  });
+
+  // fix(#1446): the cookie is already installed by the time this page runs, so
+  // a failed setup must revoke server-side — clearing the store cannot reach an
+  // httpOnly cookie, and the UI would send the user to /login while the
+  // credential stayed replayable.
+  it('revokes the session when getMe fails after the cookie was installed', async () => {
+    mockGetMe.mockRejectedValueOnce(new Error('me failed'));
+    setHash('#token=access-1&expires_in=900&auth_mode=cookie');
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() => expect(mockLogoutSession).toHaveBeenCalledTimes(1));
+    expect(useAuthStore.getState().token).toBeNull();
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true }),
+    );
+  });
+
+  it('sends an incomplete fragment back to /login', async () => {
+    setHash('#expires_in=900');
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true }),
+    );
+    expect(mockGetMe).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/__tests__/OAuthCallbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/OAuthCallbackPage.test.tsx
@@ -71,8 +71,11 @@ describe('OAuthCallbackPage', () => {
     );
   });
 
-  it('sends an incomplete fragment back to /login', async () => {
-    setHash('#expires_in=900');
+  // fix(#1446): the cookies were installed by the response that redirected
+  // here, so a fragment too incomplete to finish sign-in still leaves a live
+  // credential unless it is revoked.
+  it('revokes before sending an incomplete fragment back to /login', async () => {
+    setHash('#expires_in=900&auth_mode=cookie');
 
     render(<OAuthCallbackPage />);
 
@@ -80,5 +83,6 @@ describe('OAuthCallbackPage', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true }),
     );
     expect(mockGetMe).not.toHaveBeenCalled();
+    expect(mockLogoutSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, type PersistOptions } from 'zustand/middleware';
+import { cookieAuthAvailable } from '@/lib/auth-transport';
 import type { UserResponse } from '@/types/api';
 
 interface AuthState {
@@ -7,8 +8,13 @@ interface AuthState {
   refreshToken: string | null;
   expiresAt: number | null;
   user: UserResponse | null;
-  setAuth: (token: string, refreshToken: string, expiresIn: number, user: UserResponse) => void;
-  setTokens: (token: string, refreshToken: string, expiresIn: number) => void;
+  setAuth: (
+    token: string,
+    refreshToken: string | null,
+    expiresIn: number,
+    user: UserResponse,
+  ) => void;
+  setTokens: (token: string, refreshToken: string | null, expiresIn: number) => void;
   logout: () => void;
   isAdmin: () => boolean;
   isEditor: () => boolean;
@@ -52,17 +58,29 @@ const persistConfig: PersistOptions<AuthState> = {
     return persistedState as AuthState;
   },
   /**
-   * fix(#438): DATA-05 — persisting the JWT + refresh token in localStorage is a
-   * deliberate multi-tab trade-off: the cross-tab `storage` listener below keeps
-   * every tab converged on the latest rotated (single-use) refresh token, which
-   * an in-memory-only store could not do. `partialize` makes the persisted
-   * surface explicit — only these auth fields are written, never any transient
-   * UI state that might later be added to the store.
+   * `partialize` makes the persisted surface explicit — only these auth fields
+   * are written, never any transient UI state that might later be added.
+   *
+   * fix(#1302): the refresh token is no longer among them. It now lives in an
+   * httpOnly cookie the browser attaches to /auth/refresh/ by itself, which
+   * also subsumes what the cross-tab `storage` listener below used to do for it
+   * — every tab shares one cookie jar, so rotation converges without any
+   * JS-visible copy. `refreshToken` survives in the in-memory shape only so a
+   * pre-GH-1302 blob can be rehydrated once and handed to the migrating
+   * refresh; it is never written back.
+   *
+   * fix(#438) DATA-05 still applies to the ACCESS token, which stays in
+   * localStorage for cross-tab convergence. Moving it to memory is tracked
+   * separately in GH-1302's remaining acceptance criteria.
+   *
+   * A deployment whose API sits on a different origin cannot use the cookie
+   * (see lib/auth-transport.ts), so it keeps persisting the refresh token
+   * rather than losing its session on every reload.
    */
   partialize: (state) =>
     ({
       token: state.token,
-      refreshToken: state.refreshToken,
+      ...(cookieAuthAvailable() ? {} : { refreshToken: state.refreshToken }),
       expiresAt: state.expiresAt,
       user: state.user,
     }) as unknown as AuthState,
@@ -102,13 +120,16 @@ export const useAuthStore = create<AuthState>()(
 /**
  * Cross-tab token sync.
  *
- * Refresh tokens are single-use: the backend revokes a refresh token the moment
- * it is rotated (auth/service.py rotate_refresh_token). Without this listener,
- * a refresh in one tab leaves every OTHER tab holding the now-revoked token in
- * memory — the next request there 401s, its refresh 401s, and the tab logs out
- * (e.g. "saved a map → logged out" with two tabs open). The `storage` event
- * fires only in the tabs that did NOT make the change, so rehydrating here makes
- * all tabs converge on the latest rotated token (and propagates logout).
+ * Originally this existed because refresh tokens were single-use and lived in
+ * localStorage: a refresh in one tab left every OTHER tab holding a revoked
+ * token, and the next request there logged the tab out (e.g. "saved a map →
+ * logged out" with two tabs open). fix(#1302) moved the refresh token into a
+ * cookie, which all tabs already share, so that half is handled by the browser.
+ *
+ * The listener still earns its place for the ACCESS token, which remains in
+ * localStorage: rehydrating keeps every tab on the freshest access token and
+ * propagates logout. The `storage` event fires only in the tabs that did NOT
+ * make the change.
  */
 if (typeof window !== 'undefined') {
   window.addEventListener('storage', (e) => {

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import { persist, type PersistOptions } from 'zustand/middleware';
-import { cookieAuthAvailable } from '@/lib/auth-transport';
 import type { UserResponse } from '@/types/api';
 
 interface AuthState {
@@ -73,26 +72,32 @@ const persistConfig: PersistOptions<AuthState> = {
    * `partialize` makes the persisted surface explicit — only these auth fields
    * are written, never any transient UI state that might later be added.
    *
-   * fix(#1302): the refresh token is no longer among them. It now lives in an
-   * httpOnly cookie the browser attaches to /auth/refresh/ by itself, which
-   * also subsumes what the cross-tab `storage` listener below used to do for it
-   * — every tab shares one cookie jar, so rotation converges without any
-   * JS-visible copy. `refreshToken` survives in the in-memory shape only so a
-   * pre-GH-1302 blob can be rehydrated once and handed to the migrating
-   * refresh; it is never written back.
+   * fix(#1302): the refresh token is no longer among them for a cookie-mode
+   * session. It lives in an httpOnly cookie the browser attaches to /auth by
+   * itself, which also subsumes what the cross-tab `storage` listener below
+   * used to do for it — every tab shares one cookie jar, so rotation converges
+   * without any JS-visible copy.
+   *
+   * fix(#1446): the condition is "is there a token in memory", not "is cookie
+   * mode available". Two sessions legitimately still hold one, and stripping it
+   * from storage before it is spent loses the session on the next reload:
+   *   - a cross-origin deployment, which cannot use the cookie at all (see
+   *     lib/auth-transport.ts) and keeps using body tokens indefinitely;
+   *   - a pre-GH-1302 session mid-migration, whose legacy token is what the
+   *     next refresh trades for a cookie. Zustand writes the persisted blob on
+   *     its own after migrating a version-0 shape, so a tab closed before that
+   *     refresh ran would otherwise come back with neither credential.
+   * Once the migrating refresh spends it, `setTokens` stores null and it stops
+   * being persisted for good.
    *
    * fix(#438) DATA-05 still applies to the ACCESS token, which stays in
    * localStorage for cross-tab convergence. Moving it to memory is tracked
    * separately in GH-1302's remaining acceptance criteria.
-   *
-   * A deployment whose API sits on a different origin cannot use the cookie
-   * (see lib/auth-transport.ts), so it keeps persisting the refresh token
-   * rather than losing its session on every reload.
    */
   partialize: (state) =>
     ({
       token: state.token,
-      ...(cookieAuthAvailable() ? {} : { refreshToken: state.refreshToken }),
+      ...(state.refreshToken ? { refreshToken: state.refreshToken } : {}),
       expiresAt: state.expiresAt,
       user: state.user,
     }) as unknown as AuthState,

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand';
 import { persist, type PersistOptions } from 'zustand/middleware';
+// Cyclic with '@/api/client' (it imports this store), which is safe here:
+// neither module touches the other at import time, and a hoisted function
+// declaration is initialized before either body runs.
+import { abortInflightRefresh } from '@/api/client';
 import type { UserResponse } from '@/types/api';
 
 interface AuthState {
@@ -174,6 +178,11 @@ if (typeof window !== 'undefined') {
         // ended (and re-persisting it for every tab). Bump on the
         // present->absent transition so that write is refused.
         useAuthStore.setState((s) => ({ sessionEpoch: s.sessionEpoch + 1 }));
+        // The epoch only blocks the store write. Abort the request too, so the
+        // browser never processes a response whose Set-Cookie could later
+        // overwrite a cookie issued by a subsequent login — the same reason
+        // the in-tab logout path aborts.
+        abortInflightRefresh();
         const path = window.location.pathname;
         if (path !== '/login' && path !== '/register') {
           window.location.assign('/login');

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -8,6 +8,16 @@ interface AuthState {
   refreshToken: string | null;
   expiresAt: number | null;
   user: UserResponse | null;
+  /**
+   * fix(#1446): bumped on every logout so a refresh that was already in flight
+   * can tell its session ended and decline to write rotated tokens back. Without
+   * it, a slow refresh resolving after teardown re-populates the store (and
+   * localStorage), signing the browser back in on the login page.
+   *
+   * In-memory and per-tab: deliberately absent from `partialize`, since it
+   * orders events within one tab's lifetime and means nothing across reloads.
+   */
+  sessionEpoch: number;
   setAuth: (
     token: string,
     refreshToken: string | null,
@@ -93,6 +103,7 @@ export const useAuthStore = create<AuthState>()(
       refreshToken: null,
       expiresAt: null,
       user: null,
+      sessionEpoch: 0,
       setAuth: (token, refreshToken, expiresIn, user) =>
         set({
           token,
@@ -106,7 +117,14 @@ export const useAuthStore = create<AuthState>()(
           refreshToken,
           expiresAt: Date.now() + expiresIn * 1000,
         }),
-      logout: () => set({ token: null, refreshToken: null, expiresAt: null, user: null }),
+      logout: () =>
+        set((state) => ({
+          token: null,
+          refreshToken: null,
+          expiresAt: null,
+          user: null,
+          sessionEpoch: state.sessionEpoch + 1,
+        })),
       isAdmin: () => get().user?.roles.includes('admin') ?? false,
       isEditor: () => {
         const roles = get().user?.roles ?? [];

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -16,6 +16,8 @@ interface AuthState {
    *
    * In-memory and per-tab: deliberately absent from `partialize`, since it
    * orders events within one tab's lifetime and means nothing across reloads.
+   * Cross-tab logout therefore cannot propagate through the persisted blob —
+   * the `storage` listener below bumps it explicitly instead.
    */
   sessionEpoch: number;
   setAuth: (
@@ -160,6 +162,13 @@ if (typeof window !== 'undefined') {
       // it to /login. Skip if already on a public auth route so we don't loop.
       const stillLoggedIn = !!useAuthStore.getState().token;
       if (hadToken && !stillLoggedIn) {
+        // fix(#1446): another tab logged out. Rehydration clears this tab's
+        // token but cannot touch its epoch, which is per-tab — so a refresh
+        // already in flight here would still see a matching epoch and write
+        // its rotated tokens back, resurrecting the session the other tab just
+        // ended (and re-persisting it for every tab). Bump on the
+        // present->absent transition so that write is refused.
+        useAuthStore.setState((s) => ({ sessionEpoch: s.sessionEpoch + 1 }));
         const path = window.location.pathname;
         if (path !== '/login' && path !== '/register') {
           window.location.assign('/login');

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -12836,7 +12836,7 @@ export interface components {
              * Refresh Token
              * @description Opaque token used to obtain a new access token. Always present for programmatic callers (CLI, SDKs, CI). Null when the caller opted into the browser cookie flow with 'X-GeoLens-Auth-Mode: cookie', in which case the token is delivered as an httpOnly cookie instead (GH-1302).
              */
-            refresh_token?: string | null;
+            refresh_token: string | null;
             /**
              * Token Type
              * @default bearer

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -17804,7 +17804,11 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RefreshRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             204: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -898,6 +898,13 @@ export interface paths {
          *     fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
          *     outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
          *     must not revoke them. Security events (password change, role change) do.
+         *
+         *     fix(#1446): the refresh COOKIE can authenticate this call when the access
+         *     token has aged out. Requiring a live bearer token meant a user returning
+         *     after their 15-minute access token expired got a 401 here while their
+         *     multi-day refresh cookie stayed valid — the UI reported a clean logout and
+         *     the session survived it. CSRF is enforced on that path exactly as it is for
+         *     /auth/refresh, since the cookie is then the credential.
          */
         post: operations["logout_auth_logout__post"];
         delete?: never;
@@ -11052,7 +11059,7 @@ export interface components {
         /** RefreshRequest */
         RefreshRequest: {
             /** Refresh Token */
-            refresh_token?: string | null;
+            refresh_token: string;
         };
         /** RegisterRequest */
         RegisterRequest: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -864,6 +864,11 @@ export interface paths {
         /**
          * Login
          * @description Authenticate with username and password, receive a JWT token.
+         *
+         *     GH-1302: a caller sending ``X-GeoLens-Auth-Mode: cookie`` receives the
+         *     refresh token as an httpOnly cookie and a null ``refresh_token`` in the
+         *     body. Without that header the response is unchanged, which is what keeps
+         *     the CLI, the generated SDKs, Postman, and CI logins working.
          */
         post: operations["login_auth_login_post"];
         delete?: never;
@@ -1050,6 +1055,14 @@ export interface paths {
          *     tokens are opaque and carry no bearer ``tid`` claim, so tenant middleware
          *     binds the database transaction from that same-origin host before the user
          *     row is resolved and the next tenant-bound access token is minted.
+         *
+         *     GH-1302: with ``X-GeoLens-Auth-Mode: cookie`` the presented token is read
+         *     from the httpOnly cookie (falling back to the body once, so a session
+         *     established before the cookie flow shipped migrates on its next refresh
+         *     instead of being logged out), the double-submit CSRF token is enforced, and
+         *     the rotated token goes back out as a cookie with a null body
+         *     ``refresh_token``. Without the header this endpoint behaves exactly as
+         *     before.
          */
         post: operations["refresh_auth_refresh__post"];
         delete?: never;
@@ -11039,7 +11052,7 @@ export interface components {
         /** RefreshRequest */
         RefreshRequest: {
             /** Refresh Token */
-            refresh_token: string;
+            refresh_token?: string | null;
         };
         /** RegisterRequest */
         RegisterRequest: {
@@ -12821,9 +12834,9 @@ export interface components {
             access_token: string;
             /**
              * Refresh Token
-             * @description Opaque token used to obtain a new access token
+             * @description Opaque token used to obtain a new access token. Always present for programmatic callers (CLI, SDKs, CI). Null when the caller opted into the browser cookie flow with 'X-GeoLens-Auth-Mode: cookie', in which case the token is delivered as an httpOnly cookie instead (GH-1302).
              */
-            refresh_token: string;
+            refresh_token?: string | null;
             /**
              * Token Type
              * @default bearer
@@ -18440,9 +18453,9 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody: {
+        requestBody?: {
             content: {
-                "application/json": components["schemas"]["RefreshRequest"];
+                "application/json": components["schemas"]["RefreshRequest"] | null;
             };
         };
         responses: {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -71,7 +71,8 @@ export interface MapBasemapConfig {
 
 export interface TokenResponse {
   access_token: string;
-  refresh_token: string;
+  /** fix(#1302): null when the caller opted into the browser cookie flow. */
+  refresh_token: string | null;
   token_type: string;
   expires_in: number;
 }

--- a/sdks/python/geolens/api/auth/login_auth_login_post.py
+++ b/sdks/python/geolens/api/auth/login_auth_login_post.py
@@ -105,6 +105,11 @@ def sync_detailed(
 
      Authenticate with username and password, receive a JWT token.
 
+    GH-1302: a caller sending ``X-GeoLens-Auth-Mode: cookie`` receives the
+    refresh token as an httpOnly cookie and a null ``refresh_token`` in the
+    body. Without that header the response is unchanged, which is what keeps
+    the CLI, the generated SDKs, Postman, and CI logins working.
+
     Args:
         body (BodyLoginAuthLoginPost):
 
@@ -136,6 +141,11 @@ def sync(
 
      Authenticate with username and password, receive a JWT token.
 
+    GH-1302: a caller sending ``X-GeoLens-Auth-Mode: cookie`` receives the
+    refresh token as an httpOnly cookie and a null ``refresh_token`` in the
+    body. Without that header the response is unchanged, which is what keeps
+    the CLI, the generated SDKs, Postman, and CI logins working.
+
     Args:
         body (BodyLoginAuthLoginPost):
 
@@ -161,6 +171,11 @@ async def asyncio_detailed(
     """Login
 
      Authenticate with username and password, receive a JWT token.
+
+    GH-1302: a caller sending ``X-GeoLens-Auth-Mode: cookie`` receives the
+    refresh token as an httpOnly cookie and a null ``refresh_token`` in the
+    body. Without that header the response is unchanged, which is what keeps
+    the CLI, the generated SDKs, Postman, and CI logins working.
 
     Args:
         body (BodyLoginAuthLoginPost):
@@ -190,6 +205,11 @@ async def asyncio(
     """Login
 
      Authenticate with username and password, receive a JWT token.
+
+    GH-1302: a caller sending ``X-GeoLens-Auth-Mode: cookie`` receives the
+    refresh token as an httpOnly cookie and a null ``refresh_token`` in the
+    body. Without that header the response is unchanged, which is what keeps
+    the CLI, the generated SDKs, Postman, and CI logins working.
 
     Args:
         body (BodyLoginAuthLoginPost):

--- a/sdks/python/geolens/api/auth/logout_auth_logout_post.py
+++ b/sdks/python/geolens/api/auth/logout_auth_logout_post.py
@@ -101,6 +101,13 @@ def sync_detailed(
     outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
     must not revoke them. Security events (password change, role change) do.
 
+    fix(#1446): the refresh COOKIE can authenticate this call when the access
+    token has aged out. Requiring a live bearer token meant a user returning
+    after their 15-minute access token expired got a 401 here while their
+    multi-day refresh cookie stayed valid — the UI reported a clean logout and
+    the session survived it. CSRF is enforced on that path exactly as it is for
+    /auth/refresh, since the cookie is then the credential.
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
@@ -135,6 +142,13 @@ def sync(
     outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
     must not revoke them. Security events (password change, role change) do.
 
+    fix(#1446): the refresh COOKIE can authenticate this call when the access
+    token has aged out. Requiring a live bearer token meant a user returning
+    after their 15-minute access token expired got a 401 here while their
+    multi-day refresh cookie stayed valid — the UI reported a clean logout and
+    the session survived it. CSRF is enforced on that path exactly as it is for
+    /auth/refresh, since the cookie is then the credential.
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
@@ -164,6 +178,13 @@ async def asyncio_detailed(
     fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
     outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
     must not revoke them. Security events (password change, role change) do.
+
+    fix(#1446): the refresh COOKIE can authenticate this call when the access
+    token has aged out. Requiring a live bearer token meant a user returning
+    after their 15-minute access token expired got a 401 here while their
+    multi-day refresh cookie stayed valid — the UI reported a clean logout and
+    the session survived it. CSRF is enforced on that path exactly as it is for
+    /auth/refresh, since the cookie is then the credential.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -196,6 +217,13 @@ async def asyncio(
     fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
     outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
     must not revoke them. Security events (password change, role change) do.
+
+    fix(#1446): the refresh COOKIE can authenticate this call when the access
+    token has aged out. Requiring a live bearer token meant a user returning
+    after their 15-minute access token expired got a 401 here while their
+    multi-day refresh cookie stayed valid — the UI reported a clean logout and
+    the session survived it. CSRF is enforced on that path exactly as it is for
+    /auth/refresh, since the cookie is then the credential.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/api/auth/logout_auth_logout_post.py
+++ b/sdks/python/geolens/api/auth/logout_auth_logout_post.py
@@ -4,19 +4,33 @@ from typing import Any, cast
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
 from ... import errors
 
 from ...models.problem_detail import ProblemDetail
+from ...models.refresh_request import RefreshRequest
+from ...types import Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    body: None | RefreshRequest | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
 
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/auth/logout/",
     }
 
+    if isinstance(body, RefreshRequest):
+        _kwargs["json"] = body.to_dict()
+    elif not isinstance(body, Unset):
+        _kwargs["json"] = body
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -87,6 +101,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient,
+    body: None | RefreshRequest | Unset = UNSET,
 ) -> Response[Any | ProblemDetail]:
     r"""Logout
 
@@ -108,6 +123,9 @@ def sync_detailed(
     the session survived it. CSRF is enforced on that path exactly as it is for
     /auth/refresh, since the cookie is then the credential.
 
+    Args:
+        body (None | RefreshRequest | Unset):
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
@@ -116,7 +134,9 @@ def sync_detailed(
         Response[Any | ProblemDetail]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        body=body,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -128,6 +148,7 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient,
+    body: None | RefreshRequest | Unset = UNSET,
 ) -> Any | ProblemDetail | None:
     r"""Logout
 
@@ -149,6 +170,9 @@ def sync(
     the session survived it. CSRF is enforced on that path exactly as it is for
     /auth/refresh, since the cookie is then the credential.
 
+    Args:
+        body (None | RefreshRequest | Unset):
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
@@ -159,12 +183,14 @@ def sync(
 
     return sync_detailed(
         client=client,
+        body=body,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
+    body: None | RefreshRequest | Unset = UNSET,
 ) -> Response[Any | ProblemDetail]:
     r"""Logout
 
@@ -186,6 +212,9 @@ async def asyncio_detailed(
     the session survived it. CSRF is enforced on that path exactly as it is for
     /auth/refresh, since the cookie is then the credential.
 
+    Args:
+        body (None | RefreshRequest | Unset):
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
@@ -194,7 +223,9 @@ async def asyncio_detailed(
         Response[Any | ProblemDetail]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        body=body,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -204,6 +235,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient,
+    body: None | RefreshRequest | Unset = UNSET,
 ) -> Any | ProblemDetail | None:
     r"""Logout
 
@@ -224,6 +256,9 @@ async def asyncio(
     multi-day refresh cookie stayed valid — the UI reported a clean logout and
     the session survived it. CSRF is enforced on that path exactly as it is for
     /auth/refresh, since the cookie is then the credential.
+
+    Args:
+        body (None | RefreshRequest | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -236,5 +271,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            body=body,
         )
     ).parsed

--- a/sdks/python/geolens/api/auth/refresh_auth_refresh_post.py
+++ b/sdks/python/geolens/api/auth/refresh_auth_refresh_post.py
@@ -4,17 +4,18 @@ from typing import Any
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
 from ... import errors
 
 from ...models.problem_detail import ProblemDetail
 from ...models.refresh_request import RefreshRequest
 from ...models.token_response import TokenResponse
+from ...types import Unset
 
 
 def _get_kwargs(
     *,
-    body: RefreshRequest,
+    body: None | RefreshRequest | Unset = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -23,7 +24,10 @@ def _get_kwargs(
         "url": "/auth/refresh/",
     }
 
-    _kwargs["json"] = body.to_dict()
+    if isinstance(body, RefreshRequest):
+        _kwargs["json"] = body.to_dict()
+    elif not isinstance(body, Unset):
+        _kwargs["json"] = body
 
     headers["Content-Type"] = "application/json"
 
@@ -99,7 +103,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
-    body: RefreshRequest,
+    body: None | RefreshRequest | Unset = UNSET,
 ) -> Response[ProblemDetail | TokenResponse]:
     """Refresh
 
@@ -110,8 +114,16 @@ def sync_detailed(
     binds the database transaction from that same-origin host before the user
     row is resolved and the next tenant-bound access token is minted.
 
+    GH-1302: with ``X-GeoLens-Auth-Mode: cookie`` the presented token is read
+    from the httpOnly cookie (falling back to the body once, so a session
+    established before the cookie flow shipped migrates on its next refresh
+    instead of being logged out), the double-submit CSRF token is enforced, and
+    the rotated token goes back out as a cookie with a null body
+    ``refresh_token``. Without the header this endpoint behaves exactly as
+    before.
+
     Args:
-        body (RefreshRequest):
+        body (None | RefreshRequest | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -135,7 +147,7 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
-    body: RefreshRequest,
+    body: None | RefreshRequest | Unset = UNSET,
 ) -> ProblemDetail | TokenResponse | None:
     """Refresh
 
@@ -146,8 +158,16 @@ def sync(
     binds the database transaction from that same-origin host before the user
     row is resolved and the next tenant-bound access token is minted.
 
+    GH-1302: with ``X-GeoLens-Auth-Mode: cookie`` the presented token is read
+    from the httpOnly cookie (falling back to the body once, so a session
+    established before the cookie flow shipped migrates on its next refresh
+    instead of being logged out), the double-submit CSRF token is enforced, and
+    the rotated token goes back out as a cookie with a null body
+    ``refresh_token``. Without the header this endpoint behaves exactly as
+    before.
+
     Args:
-        body (RefreshRequest):
+        body (None | RefreshRequest | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -166,7 +186,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
-    body: RefreshRequest,
+    body: None | RefreshRequest | Unset = UNSET,
 ) -> Response[ProblemDetail | TokenResponse]:
     """Refresh
 
@@ -177,8 +197,16 @@ async def asyncio_detailed(
     binds the database transaction from that same-origin host before the user
     row is resolved and the next tenant-bound access token is minted.
 
+    GH-1302: with ``X-GeoLens-Auth-Mode: cookie`` the presented token is read
+    from the httpOnly cookie (falling back to the body once, so a session
+    established before the cookie flow shipped migrates on its next refresh
+    instead of being logged out), the double-submit CSRF token is enforced, and
+    the rotated token goes back out as a cookie with a null body
+    ``refresh_token``. Without the header this endpoint behaves exactly as
+    before.
+
     Args:
-        body (RefreshRequest):
+        body (None | RefreshRequest | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -200,7 +228,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
-    body: RefreshRequest,
+    body: None | RefreshRequest | Unset = UNSET,
 ) -> ProblemDetail | TokenResponse | None:
     """Refresh
 
@@ -211,8 +239,16 @@ async def asyncio(
     binds the database transaction from that same-origin host before the user
     row is resolved and the next tenant-bound access token is minted.
 
+    GH-1302: with ``X-GeoLens-Auth-Mode: cookie`` the presented token is read
+    from the httpOnly cookie (falling back to the body once, so a session
+    established before the cookie flow shipped migrates on its next refresh
+    instead of being logged out), the double-submit CSRF token is enforced, and
+    the rotated token goes back out as a cookie with a null body
+    ``refresh_token``. Without the header this endpoint behaves exactly as
+    before.
+
     Args:
-        body (RefreshRequest):
+        body (None | RefreshRequest | Unset):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/models/refresh_request.py
+++ b/sdks/python/geolens/models/refresh_request.py
@@ -6,10 +6,6 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
-
-from typing import cast
-
 
 T = TypeVar("T", bound="RefreshRequest")
 
@@ -18,39 +14,29 @@ T = TypeVar("T", bound="RefreshRequest")
 class RefreshRequest:
     """
     Attributes:
-        refresh_token (None | str | Unset):
+        refresh_token (str):
     """
 
-    refresh_token: None | str | Unset = UNSET
+    refresh_token: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        refresh_token: None | str | Unset
-        if isinstance(self.refresh_token, Unset):
-            refresh_token = UNSET
-        else:
-            refresh_token = self.refresh_token
+        refresh_token = self.refresh_token
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update({})
-        if refresh_token is not UNSET:
-            field_dict["refresh_token"] = refresh_token
+        field_dict.update(
+            {
+                "refresh_token": refresh_token,
+            }
+        )
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
-        def _parse_refresh_token(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        refresh_token = _parse_refresh_token(d.pop("refresh_token", UNSET))
+        refresh_token = d.pop("refresh_token")
 
         refresh_request = cls(
             refresh_token=refresh_token,

--- a/sdks/python/geolens/models/refresh_request.py
+++ b/sdks/python/geolens/models/refresh_request.py
@@ -6,6 +6,10 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
+from typing import cast
+
 
 T = TypeVar("T", bound="RefreshRequest")
 
@@ -14,29 +18,39 @@ T = TypeVar("T", bound="RefreshRequest")
 class RefreshRequest:
     """
     Attributes:
-        refresh_token (str):
+        refresh_token (None | str | Unset):
     """
 
-    refresh_token: str
+    refresh_token: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        refresh_token = self.refresh_token
+        refresh_token: None | str | Unset
+        if isinstance(self.refresh_token, Unset):
+            refresh_token = UNSET
+        else:
+            refresh_token = self.refresh_token
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "refresh_token": refresh_token,
-            }
-        )
+        field_dict.update({})
+        if refresh_token is not UNSET:
+            field_dict["refresh_token"] = refresh_token
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        refresh_token = d.pop("refresh_token")
+
+        def _parse_refresh_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        refresh_token = _parse_refresh_token(d.pop("refresh_token", UNSET))
 
         refresh_request = cls(
             refresh_token=refresh_token,

--- a/sdks/python/geolens/models/token_response.py
+++ b/sdks/python/geolens/models/token_response.py
@@ -8,6 +8,8 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
+from typing import cast
+
 
 T = TypeVar("T", bound="TokenResponse")
 
@@ -17,23 +19,29 @@ class TokenResponse:
     """
     Attributes:
         access_token (str): JWT access token for Authorization header
-        refresh_token (str): Opaque token used to obtain a new access token
         expires_in (int): Seconds until the access token expires
+        refresh_token (None | str | Unset): Opaque token used to obtain a new access token. Always present for
+            programmatic callers (CLI, SDKs, CI). Null when the caller opted into the browser cookie flow with 'X-GeoLens-
+            Auth-Mode: cookie', in which case the token is delivered as an httpOnly cookie instead (GH-1302).
         token_type (str | Unset):  Default: 'bearer'.
     """
 
     access_token: str
-    refresh_token: str
     expires_in: int
+    refresh_token: None | str | Unset = UNSET
     token_type: str | Unset = "bearer"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         access_token = self.access_token
 
-        refresh_token = self.refresh_token
-
         expires_in = self.expires_in
+
+        refresh_token: None | str | Unset
+        if isinstance(self.refresh_token, Unset):
+            refresh_token = UNSET
+        else:
+            refresh_token = self.refresh_token
 
         token_type = self.token_type
 
@@ -42,10 +50,11 @@ class TokenResponse:
         field_dict.update(
             {
                 "access_token": access_token,
-                "refresh_token": refresh_token,
                 "expires_in": expires_in,
             }
         )
+        if refresh_token is not UNSET:
+            field_dict["refresh_token"] = refresh_token
         if token_type is not UNSET:
             field_dict["token_type"] = token_type
 
@@ -56,16 +65,23 @@ class TokenResponse:
         d = dict(src_dict)
         access_token = d.pop("access_token")
 
-        refresh_token = d.pop("refresh_token")
-
         expires_in = d.pop("expires_in")
+
+        def _parse_refresh_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        refresh_token = _parse_refresh_token(d.pop("refresh_token", UNSET))
 
         token_type = d.pop("token_type", UNSET)
 
         token_response = cls(
             access_token=access_token,
-            refresh_token=refresh_token,
             expires_in=expires_in,
+            refresh_token=refresh_token,
             token_type=token_type,
         )
 

--- a/sdks/python/geolens/models/token_response.py
+++ b/sdks/python/geolens/models/token_response.py
@@ -19,29 +19,26 @@ class TokenResponse:
     """
     Attributes:
         access_token (str): JWT access token for Authorization header
+        refresh_token (None | str): Opaque token used to obtain a new access token. Always present for programmatic
+            callers (CLI, SDKs, CI). Null when the caller opted into the browser cookie flow with 'X-GeoLens-Auth-Mode:
+            cookie', in which case the token is delivered as an httpOnly cookie instead (GH-1302).
         expires_in (int): Seconds until the access token expires
-        refresh_token (None | str | Unset): Opaque token used to obtain a new access token. Always present for
-            programmatic callers (CLI, SDKs, CI). Null when the caller opted into the browser cookie flow with 'X-GeoLens-
-            Auth-Mode: cookie', in which case the token is delivered as an httpOnly cookie instead (GH-1302).
         token_type (str | Unset):  Default: 'bearer'.
     """
 
     access_token: str
+    refresh_token: None | str
     expires_in: int
-    refresh_token: None | str | Unset = UNSET
     token_type: str | Unset = "bearer"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         access_token = self.access_token
 
-        expires_in = self.expires_in
+        refresh_token: None | str
+        refresh_token = self.refresh_token
 
-        refresh_token: None | str | Unset
-        if isinstance(self.refresh_token, Unset):
-            refresh_token = UNSET
-        else:
-            refresh_token = self.refresh_token
+        expires_in = self.expires_in
 
         token_type = self.token_type
 
@@ -50,11 +47,10 @@ class TokenResponse:
         field_dict.update(
             {
                 "access_token": access_token,
+                "refresh_token": refresh_token,
                 "expires_in": expires_in,
             }
         )
-        if refresh_token is not UNSET:
-            field_dict["refresh_token"] = refresh_token
         if token_type is not UNSET:
             field_dict["token_type"] = token_type
 
@@ -65,23 +61,21 @@ class TokenResponse:
         d = dict(src_dict)
         access_token = d.pop("access_token")
 
-        expires_in = d.pop("expires_in")
-
-        def _parse_refresh_token(data: object) -> None | str | Unset:
+        def _parse_refresh_token(data: object) -> None | str:
             if data is None:
                 return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
+            return cast(None | str, data)
 
-        refresh_token = _parse_refresh_token(d.pop("refresh_token", UNSET))
+        refresh_token = _parse_refresh_token(d.pop("refresh_token"))
+
+        expires_in = d.pop("expires_in")
 
         token_type = d.pop("token_type", UNSET)
 
         token_response = cls(
             access_token=access_token,
-            expires_in=expires_in,
             refresh_token=refresh_token,
+            expires_in=expires_in,
             token_type=token_type,
         )
 

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -995,6 +995,13 @@ export const loginAuthLoginPost = <ThrowOnError extends boolean = false>(options
  * fix(#821): logout deliberately does NOT bump key_epoch — API keys exist to
  * outlive browser sessions (CI, MCP servers, tile URLs), so session hygiene
  * must not revoke them. Security events (password change, role change) do.
+ *
+ * fix(#1446): the refresh COOKIE can authenticate this call when the access
+ * token has aged out. Requiring a live bearer token meant a user returning
+ * after their 15-minute access token expired got a 401 here while their
+ * multi-day refresh cookie stayed valid — the UI reported a clean logout and
+ * the session survived it. CSRF is enforced on that path exactly as it is for
+ * /auth/refresh, since the cookie is then the credential.
  */
 export const logoutAuthLogoutPost = <ThrowOnError extends boolean = false>(options?: Options<LogoutAuthLogoutPostData, ThrowOnError>): RequestResult<LogoutAuthLogoutPostResponses, LogoutAuthLogoutPostErrors, ThrowOnError> => (options?.client ?? client).post<LogoutAuthLogoutPostResponses, LogoutAuthLogoutPostErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -966,6 +966,11 @@ export const createDownloadTokenEndpointAuthDownloadTokenDatasetIdPost = <ThrowO
  * Login
  *
  * Authenticate with username and password, receive a JWT token.
+ *
+ * GH-1302: a caller sending ``X-GeoLens-Auth-Mode: cookie`` receives the
+ * refresh token as an httpOnly cookie and a null ``refresh_token`` in the
+ * body. Without that header the response is unchanged, which is what keeps
+ * the CLI, the generated SDKs, Postman, and CI logins working.
  */
 export const loginAuthLoginPost = <ThrowOnError extends boolean = false>(options: Options<LoginAuthLoginPostData, ThrowOnError>): RequestResult<LoginAuthLoginPostResponses, LoginAuthLoginPostErrors, ThrowOnError> => (options.client ?? client).post<LoginAuthLoginPostResponses, LoginAuthLoginPostErrors, ThrowOnError>({
     ...urlSearchParamsBodySerializer,
@@ -1104,13 +1109,21 @@ export const oauthLoginAuthOauthProviderSlugLoginGet = <ThrowOnError extends boo
  * tokens are opaque and carry no bearer ``tid`` claim, so tenant middleware
  * binds the database transaction from that same-origin host before the user
  * row is resolved and the next tenant-bound access token is minted.
+ *
+ * GH-1302: with ``X-GeoLens-Auth-Mode: cookie`` the presented token is read
+ * from the httpOnly cookie (falling back to the body once, so a session
+ * established before the cookie flow shipped migrates on its next refresh
+ * instead of being logged out), the double-submit CSRF token is enforced, and
+ * the rotated token goes back out as a cookie with a null body
+ * ``refresh_token``. Without the header this endpoint behaves exactly as
+ * before.
  */
-export const refreshAuthRefreshPost = <ThrowOnError extends boolean = false>(options: Options<RefreshAuthRefreshPostData, ThrowOnError>): RequestResult<RefreshAuthRefreshPostResponses, RefreshAuthRefreshPostErrors, ThrowOnError> => (options.client ?? client).post<RefreshAuthRefreshPostResponses, RefreshAuthRefreshPostErrors, ThrowOnError>({
+export const refreshAuthRefreshPost = <ThrowOnError extends boolean = false>(options?: Options<RefreshAuthRefreshPostData, ThrowOnError>): RequestResult<RefreshAuthRefreshPostResponses, RefreshAuthRefreshPostErrors, ThrowOnError> => (options?.client ?? client).post<RefreshAuthRefreshPostResponses, RefreshAuthRefreshPostErrors, ThrowOnError>({
     url: '/auth/refresh/',
     ...options,
     headers: {
         'Content-Type': 'application/json',
-        ...options.headers
+        ...options?.headers
     }
 });
 

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -1014,7 +1014,11 @@ export const logoutAuthLogoutPost = <ThrowOnError extends boolean = false>(optio
         }
     ],
     url: '/auth/logout/',
-    ...options
+    ...options,
+    headers: {
+        'Content-Type': 'application/json',
+        ...options?.headers
+    }
 });
 
 /**

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -10269,7 +10269,7 @@ export type TokenResponse = {
      *
      * Opaque token used to obtain a new access token. Always present for programmatic callers (CLI, SDKs, CI). Null when the caller opted into the browser cookie flow with 'X-GeoLens-Auth-Mode: cookie', in which case the token is delivered as an httpOnly cookie instead (GH-1302).
      */
-    refresh_token?: string | null;
+    refresh_token: string | null;
     /**
      * Token Type
      */

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -7952,7 +7952,7 @@ export type RefreshRequest = {
     /**
      * Refresh Token
      */
-    refresh_token: string;
+    refresh_token?: string | null;
 };
 
 /**
@@ -10267,9 +10267,9 @@ export type TokenResponse = {
     /**
      * Refresh Token
      *
-     * Opaque token used to obtain a new access token
+     * Opaque token used to obtain a new access token. Always present for programmatic callers (CLI, SDKs, CI). Null when the caller opted into the browser cookie flow with 'X-GeoLens-Auth-Mode: cookie', in which case the token is delivered as an httpOnly cookie instead (GH-1302).
      */
-    refresh_token: string;
+    refresh_token?: string | null;
     /**
      * Token Type
      */
@@ -14060,7 +14060,10 @@ export type OauthLoginAuthOauthProviderSlugLoginGetErrors = {
 export type OauthLoginAuthOauthProviderSlugLoginGetError = OauthLoginAuthOauthProviderSlugLoginGetErrors[keyof OauthLoginAuthOauthProviderSlugLoginGetErrors];
 
 export type RefreshAuthRefreshPostData = {
-    body: RefreshRequest;
+    /**
+     * Body
+     */
+    body?: RefreshRequest | null;
     path?: never;
     query?: never;
     url: '/auth/refresh/';

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -13688,7 +13688,10 @@ export type LoginAuthLoginPostResponses = {
 export type LoginAuthLoginPostResponse = LoginAuthLoginPostResponses[keyof LoginAuthLoginPostResponses];
 
 export type LogoutAuthLogoutPostData = {
-    body?: never;
+    /**
+     * Body
+     */
+    body?: RefreshRequest | null;
     path?: never;
     query?: never;
     url: '/auth/logout/';

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -7952,7 +7952,7 @@ export type RefreshRequest = {
     /**
      * Refresh Token
      */
-    refresh_token?: string | null;
+    refresh_token: string;
 };
 
 /**


### PR DESCRIPTION
## Design

Issue #1302 is labeled `needs-design`. Each decision below, and why.

### D1 — Scope is the refresh token, and that collapses the CSRF surface

Access tokens keep travelling as `Authorization: Bearer` headers out of the zustand store. No general state-changing endpoint authenticates from a cookie — only the two session-lifecycle routes do, `POST /auth/refresh/` and (as a fallback, see D7) `POST /auth/logout/`. CSRF enforcement lands on those two and nowhere else.

This is the difference between this PR and the cost estimate in the issue, which said "the CSRF primitive touches `frontend/src/api/client.ts` and every mutator call site". That estimate assumed the access token moved to a cookie at the same time. It hasn't, so no mutator call site changes.

The issue's remaining acceptance criteria — access token out of web storage, and the `BroadcastChannel` coordination that would need — are **not** addressed here. See Follow-ups.

### D2 — Browser mode is negotiated explicitly, not sniffed

Clients opt in with `X-GeoLens-Auth-Mode: cookie` on `/auth/login` and `/auth/refresh/`. Absent that header, every response is byte-identical to before.

The issue suggested detecting browsers via `Accept` / `Sec-Fetch-Mode`. Rejected: that decides a security-relevant behavior from headers proxies rewrite and non-browser callers can spoof, and it would silently stop returning the JSON refresh token to any curl/Postman/CI caller that happened to send a browsery `Accept`. An explicit opt-in is deterministic, testable, and fails safe toward the legacy contract.

### D3 — Cookie attributes

`geolens_refresh`: `HttpOnly`, `SameSite=Lax`, `Secure` when `settings.is_production`, `Path` = `<root_path>/auth`.

- **Secure** rides the existing SEC-005 switch — the same `is_production` that hides the API docs and sets `https_only` on `SessionMiddleware`. Dev and test have no TLS terminator, where a `Secure` cookie is dropped silently.
- **Lax, not Strict.** They are behaviorally identical for this cookie: the only route under its `Path` is a POST, and Lax's extra allowance covers top-level GET navigation, which no route here serves. No concrete reason to deviate was found, so this follows the stated default.
- **Path-scoped to the auth router**, derived from `request.scope["root_path"]` rather than hardcoding `/api`. The cookie never rides catalog, tile, upload, or export traffic, so it cannot leak through access logs or intermediary proxies on the hot path, and cannot be replayed outside this router. It is scoped to `/auth` rather than `/auth/refresh` because RFC 6265 path-matching would otherwise withhold it from `/auth/logout`, where it is the credential of last resort (see D8).

### D4 — CSRF: double-submit, layered on an already-enforced custom header

The server sets a readable companion cookie `geolens_csrf` (not a credential — possession alone authenticates nothing) and requires it echoed in `X-CSRF-Token`, compared with `secrets.compare_digest`.

There are two independent layers here, which is the point:

1. Cookie mode *requires* the custom `X-GeoLens-Auth-Mode` header, so a cross-origin caller already needs a CORS preflight it cannot pass.
2. The double-submit value must match, which holds even if layer 1 is weakened.

Layer 2 is not redundant. This deployment's CORS allowlist is operator-configurable at runtime (`CORS_ALLOWED_ORIGINS`, and `DynamicCORSMiddleware` emits `Access-Control-Allow-Credentials: true` for every listed origin), so the "custom header implies an unpassable preflight" guarantee is only ever as strong as an operator's origin list. Comparing a value the attacker cannot read does not depend on that list. It is also directly exercisable by a plain HTTP client, with no browser preflight to simulate — which is how the acceptance criterion is actually tested.

CSRF is enforced only when a refresh **cookie** is present. A migrating caller presenting a body token holds a bearer-equivalent secret no cross-site page can read, so requiring a CSRF cookie it does not have yet would strand every pre-upgrade session.

### D5 — Proxy posture: verified same-origin, not assumed

- Dev: `frontend/vite.config.ts` proxies `/api` with `rewrite: (p) => p.replace(/^\/api/, '')`.
- Prod: `frontend/nginx.conf` `location /api/ { rewrite ^/api/(.*) /$1 break; proxy_pass ... }`.
- `API_BASE` is `getEnvConfig().API_BASE_URL || '/api'` — relative by default.

Both shipped paths are same-origin, which is what makes `SameSite=Lax` workable. The FastAPI app runs with `root_path="/api"`, and neither proxy forwards the prefix upstream, so `root_path` is the correct source for the cookie's `Path`.

### D6 — OAuth callback stops putting the refresh token in the URL fragment

The callback redirect carried `#token=...&refresh_token=...`. A fragment is readable by any script on the landing page, so it was the same exfiltration surface as `localStorage`. When the configured `PUBLIC_APP_URL` shares the callback request's own origin, the refresh token now goes out as a cookie on the 302 and the fragment carries `auth_mode=cookie` instead. A cross-origin SPA could not send that cookie back, so it keeps the old fragment delivery — mismatch degrades, it never locks anyone out.

### D7 — Logout actually ends the session

Nothing in the SPA ever called `POST /auth/logout/`. That was survivable while clearing `localStorage` destroyed the only copy of the refresh token; it stops being survivable the moment the credential is a cookie JS cannot touch. Logout is now called, and it accepts three credentials in order: the bearer token, the refresh cookie (CSRF enforced — it is the transport a cross-site page can cause the browser to attach), and a body refresh token (for split-origin installs, which have no usable cookie). The request is dispatched with a synchronously-captured token and not awaited, so teardown is immediate and nothing downstream can strip its credential.

Server-side, rotation and revocation serialize on the owner `User` row. Without that, a refresh that read its row before a concurrent logout could commit a live replacement afterwards — and reinstall the cookies the logout had just deleted.

### D8 — Rotation and rollout

Rotation is unchanged: `rotate_refresh_token` already rotates on every refresh, including the `#621` grace window. Reuse detection was not cheap to add on top of that grace window, so it stays a follow-up.

Existing browser sessions hold a refresh token in `localStorage`. Their first refresh after deploy sends it once, under the cookie-mode header; the backend rotates it and returns a cookie, and the store writes back `null`. The session migrates in place and the deploy logs nobody out.

### Product-level tradeoff, flagged rather than decided silently

**A deployment that repoints `API_BASE_URL` at a different origin does not get this hardening.** Its refresh POST is cross-site, `SameSite=Lax` withholds the cookie, so the frontend detects the cross-origin base (`lib/auth-transport.ts`) and stays on the body-token flow, still persisting the refresh token. This keeps such installs working instead of handing them a credential the browser would never send back, but it means the "no refresh token in web storage" guarantee holds for the shipped same-origin posture only. Covering split-origin deployments needs a `Domain=`-scoped cookie and a `SameSite=None` decision, which is a real product call about supported topologies rather than something to settle by convention.

## What changed

**Backend** — new `backend/app/modules/auth/cookies.py` holds the cookie/CSRF primitives. `/auth/login`, `/auth/refresh/`, and the OAuth callback issue cookies in opt-in mode; `/auth/logout/` clears them, and now resolves its user from the bearer token, the refresh cookie, or a body token. `TokenResponse.refresh_token` becomes required-but-nullable. `RefreshRequest` is unchanged — only the refresh route's *body* became optional, so a browser can POST nothing at all. Rotation and revocation serialize on the owner row.

**Frontend** — new `lib/auth-transport.ts` decides whether cookie mode is usable and builds the opt-in headers. The auth store stops persisting `refreshToken` (it survives in the in-memory shape only, so a legacy blob can be rehydrated once for the migrating refresh). `client.ts`'s session-death latch keys on the access token now that the refresh token is invisible to JS; access tokens rotate per login and per refresh, so it keeps both properties the latch needs.

## API / config impact

- `TokenResponse.refresh_token`: `str` → `str | null`, still required. Regenerated `backend/openapi.json`, both SDKs, and `frontend/src/types/api.generated.ts`.
- `RefreshRequest` is unchanged; the generated request model is byte-identical to main. The refresh route's body became optional, and `/auth/logout/` gained an optional one.
- `/auth/logout/` moved from a hard bearer requirement to bearer-or-refresh-credential, so its OpenAPI security marker changed.
- No new config, no migration, no new user-facing strings (so no locale changes).
- JWT signing, validation, expiry, `jti`, and `token_version` are untouched, as the issue predicted.

## CLI / SDK compatibility

The hard constraint was that `cli/geolens_cli` and the generated SDKs keep working. They authenticate by storing a bearer token (keyring or `credentials.toml`) and refresh through the generated SDK with the token in the body — `cli/geolens_cli/auth.py:231` builds `RefreshRequest(refresh_token=refresh)`. They never send the opt-in header, so they stay on the JSON path.

Verified rather than assumed:

- `make cli-test` — CLI unit suite plus the round-trip integration test: 8 passed, 2 skipped.
- The regenerated `TokenResponse` moved `refresh_token` after `expires_in` and gave it a default. Checked for positional construction across `cli/`, `sdks/python/geolens/auth.py`, and `mcp/`: there is none, and the generated `sync_detailed` keeps `body` keyword-only, so the v1.10.0-style positional break does not recur.
- Parsed both response shapes through the regenerated model and ran the CLI's exact `try_refresh` logic against them: the JSON path still rotates its stored token, and a cookie-mode response degrades to "store access token, no rotation" rather than crashing.
- `backend/tests/test_auth_refresh_cookies_1302.py::TestProgrammaticCallersUnchanged` pins the no-opt-in contract: body token present, zero `Set-Cookie`, and no CSRF token ever required on that path.

## Verification

```
cd backend && uv run ruff check app tests && uv run ruff format --check app tests   # clean
cd backend && uv run pytest tests/test_auth.py tests/test_auth_refresh_logout.py \
    tests/test_auth_refresh_cookies_1302.py tests/test_oauth.py \
    tests/test_api_key_auth.py tests/test_opaque_token_tenant_isolation.py -q       # 212 passed
cd backend && uv run pytest tests/test_layering.py -q                               # 47 passed
make openapi-check                                                                  # clean
make sdks-check                                                                      # clean
make cli-test                                                                        # 8 passed, 2 skipped
cd frontend && npm ci && npm run build && npm run lint && npm run typecheck          # clean
cd frontend && npm run test:coverage                                                 # 391 files, 4864 passed
```

Playwright was deliberately not run: this branch lives in a worktree, and the dev stack bind-mounts the main checkout, so an e2e run here would exercise `main`'s app code rather than this change. Its result would be meaningless in both directions. The e2e auth path was checked by reading instead: `e2e/auth.setup.ts` saves `page.context().storageState()`, which captures cookies alongside `localStorage`, so the refresh cookie is persisted and replayed across specs; and `e2e/dataset-detail.spec.ts` extracts the **access** token from `geolens-auth`, which is still there. This wants a real e2e pass on CI before merge.

### Review-driven changes

Codex review ran eight rounds and found nine issues, five of them P1. The substantive ones, because they changed the design rather than patching it:

- **Logout was never called by the SPA at all.** Pre-existing, but this PR turned it from survivable into a live-credential leak.
- **Two half-completed sign-in paths** (OAuth callback, and login when `getMe` fails) installed the cookie and then reported failure, stranding it.
- **A late refresh could resurrect a logged-out session**, both within a tab and across tabs. Guarded with a session generation rather than by patching the one path that exposed it.
- **The cookie's `Path` excluded `/auth/logout`**, making the cookie-authenticated logout unreachable in a real browser while its test passed — the test helper loaded an unscoped cookie. The test now asserts scope with real RFC 6265 path-matching.
- **Rotation racing revocation** could commit a live successor after logout. Serialized on the owner row.
- **A tossed sibling-subdomain cookie could shadow the real one** (login CSRF): duplicate `geolens_refresh` names in the Cookie header are now refused outright. The attacker can add a shadow but never remove the victim's host cookie, so duplicates are the attack's fingerprint; the cost under active attack is a one-time re-login.
- **Concurrent teardown dispatches coalesce**: `awaitPendingLogout` drains every outstanding revocation, not just the most recently dispatched one.

Three regression tests for these were verified against the unfixed code — each fails without its fix. Two earlier versions of those tests passed with and without the fix, and were rewritten once that was discovered.

## Terminal teardown sites (enumerated)

Every place the SPA ends a session, listed in full so the set can be reviewed as a set rather than discovered one call site at a time:

| # | Site | What it does |
|---|------|--------------|
| 1 | Explicit logout (`hooks/use-auth.ts`) | dispatches `logoutSession()` (not awaited, `keepalive`), aborts any in-flight refresh, clears the store |
| 2 | Session-expiry latch `notifySessionExpired` (`api/client.ts`; reached from `authenticatedFetch`, `authenticatedRawFetch`, and the XHR upload path in `api/ingest.ts`) | dispatches `logoutSession()`, clears the store, raises the signed-out prompt once (latched on the dead access token) |
| 3 | Anonymous terminal 401 (same three call sites when no access token existed at failure time) | clears the store only. Deliberate: this state is reachable only after a refresh attempt already failed, so the cookie is dead, absent, or unusable, and there is no credential left to authenticate a revocation with (see "Considered and not done") |
| 4 | OAuth callback failures (malformed fragment early return; `getMe` rejection) | dispatches `logoutSession()`, clears the store |
| 5 | Password login failing after the cookie was installed (`api/auth.ts` failed-parse path) | revokes before surfacing the error |
| 6 | Cross-tab logout (`stores/auth-store.ts` storage listener) | bumps the session epoch and aborts any in-flight refresh; the originating tab already dispatched the revocation |

## Considered and not done

- **Server-side cookie clear on a 401 refresh.** A refresh that fails with a dead cookie could append cookie-expiring `Set-Cookie` headers to its 401. Not done: the client tears down on that 401 anyway, a dead cookie authenticates nothing, and the next login overwrites both cookies. It would be cosmetics on an error path.
- **Recovering from a lost CSRF cookie.** If the readable `geolens_csrf` cookie is deleted while the HttpOnly refresh cookie survives, refresh and cookie-authenticated logout both 403 and script cannot read or present the refresh credential to repair the pair. Deliberate: re-minting a CSRF pair on an unauthenticated endpoint would let any cross-site page mint a matching pair, which defeats double-submit. The session self-heals at the next login (both cookies overwritten) or at cookie expiry. Until then the residual is liveness (a prompt to sign in again), never credential exposure.
- **Cross-tab login racing a logout's server round trip.** `pendingLogout` serializes what one tab can observe; it cannot span tabs or outlive its own timeout. The durable fix is server-side, revocation scoped to tokens issued at or before the logout request's timestamp, recorded under Follow-ups as "Time-scoped revocation" together with why logout keeps its revoke-everything scope. Filed as GH-1455, which also records the suspended-tab variant: a tab that misses the intermediate cleared-storage state because queued storage events observe only the latest value. The overwriting token is already revoked server-side, so the residual there is liveness too.

## Acceptance criteria

- [x] After login, the persisted `geolens-auth` value contains no refresh token — `refresh-cookie-1302.test.ts`. (Access token deliberately still present; out of scope per D1.)
- [x] `document.cookie` cannot read the refresh credential — `HttpOnly` asserted in `test_auth_refresh_cookies_1302.py`.
- [x] A state-changing request carrying the session cookie but no CSRF token is rejected — `TestCsrfEnforcement`, including that a rejected forgery leaves the victim's token usable.
- [x] Refresh rotation, logout, and cross-tab logout still invalidate the right sessions — `TestLogoutClearsCookies` covers both the cookie clear and the server-side revocation.
- [x] SDK, CLI, and CI smoke logins keep working through the JSON path — see above.
- [ ] Access token in memory only, and `BroadcastChannel` multi-tab coordination — not attempted here.

## Follow-ups

- Access token out of web storage. It is the larger half of the issue and the one that forces the `BroadcastChannel` work and the CSRF primitive at every mutator call site.
- Refresh-token reuse detection. Interacts with the `#621` rotation grace window, which deliberately lets a retired token mint one more pair, so naive reuse detection would fire on the legitimate multi-tab race.
- Split-origin deployment support for the cookie flow (see the flagged tradeoff).
- Time-scoped revocation. `revoke_all_tokens` means "kill every refresh token for this user, as of now", so a login that commits while a logout is in flight is inside that set by definition. The client serializes the paths it can see (same-tab login and OAuth both wait on a pending revocation), but that cannot span tabs or outlive the client-side timeout. Closing it properly needs revocation scoped to rows issued at or before the request's own timestamp, with matching treatment for the `token_version` bump. Deliberately not narrowing logout's scope instead: revoking every session is what makes logout a security event, and SEC-S15 builds access-JWT invalidation on it. The residual failure is liveness only — a session that ends early and prompts a re-login, never one that outlives its logout. Filed as GH-1455.

Closes GH-1302



