### PR TITLE
fix(catalog): detach on registered-dataset delete instead of dropping the operator's table

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -19,6 +19,7 @@ from app.core.db.tenant_session import current_tenant_var
 from app.core.db.tenant_schema import tenant_data_schema
 from app.core.tenancy import is_multi_tenant
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
+from app.platform.dataset_origin import geolens_owns_table
 from app.platform.storage.titiler_url import resolve_storage_key
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -40,6 +41,24 @@ class DatasetTitleMismatchError(ValueError):
     public-safe case apart from other ValueErrors (e.g. a malformed
     persisted table name) can do so by type rather than by message content.
     """
+
+
+async def _reap_managed_storage(prefixes: list[str], tenant_id: str | None) -> None:
+    """Delete every object under GeoLens-managed prefixes for one dataset.
+
+    Extracted from ``delete_dataset``'s two branches (which reaped identically
+    from different prefix lists) when fix(#1452) added a branch of its own and
+    pushed the function past ruff's complexity ceiling. The import stays
+    function-local so tests keep patching the provider attribute.
+    """
+    from app.platform.storage.provider import get_storage
+
+    storage = get_storage()
+    for prefix in prefixes:
+        physical_prefix = resolve_storage_key(prefix, tenant_id=tenant_id)
+        keys = await storage.list(physical_prefix)
+        if keys:
+            await asyncio.gather(*(storage.delete(key) for key in keys))
 
 
 class DependentVrtError(Exception):
@@ -64,6 +83,12 @@ async def delete_dataset(
     Raises ValueError if dataset not found, name mismatch, or invalid table name.
     For raster datasets, storage cleanup happens before DB deletion so that a
     storage failure prevents any DB changes (no orphaned records).
+
+    fix(#1452): a dataset registered from an existing PostGIS table is DETACHED
+    rather than dropped — the catalog row, its grants, its tiles and its search
+    and embedding rows go, and the operator's table survives with its rows,
+    exactly as registration left it. See
+    :func:`app.platform.dataset_origin.geolens_owns_table`.
     """
     # Function-local import via the service.py façade is intentional — it lets
     # tests mock `service.get_dataset` to inject fixture datasets without DB.
@@ -84,9 +109,16 @@ async def delete_dataset(
 
     record_type = dataset.record.record_type
 
-    if record_type in RASTER_FAMILY_RECORD_TYPES:
-        from app.platform.storage.provider import get_storage
+    # fix(#1452): registration copies no data — it points the catalog at a
+    # table the operator built and keeps writing to. Deleting the dataset
+    # therefore has to detach, not drop, or the delete destroys the original
+    # rather than a GeoLens-managed copy. Resolved once here because the DROP
+    # and the name retirement below are two effects of this one answer.
+    owns_table = geolens_owns_table(
+        dataset.source_format, record_type, dataset.origin_ref
+    )
 
+    if record_type in RASTER_FAMILY_RECORD_TYPES:
         if record_type == "raster_dataset":
             # Guard: prevent deletion if any VRT still references this COG.
             #
@@ -147,63 +179,92 @@ async def delete_dataset(
         # Clean up managed storage artifacts before touching the DB.
         # If any storage delete fails the exception propagates and the
         # caller's transaction rolls back, leaving the DB record intact.
-        storage = get_storage()
         tenant_id = current_tenant_var.get()
         if is_multi_tenant() and tenant_id is None:
             raise RuntimeError(
                 "Dataset deletion is missing tenant context in multi-tenant mode"
             )
-        for prefix in prefixes:
-            physical_prefix = resolve_storage_key(prefix, tenant_id=tenant_id)
-            keys = await storage.list(physical_prefix)
-            if keys:
-                await asyncio.gather(*(storage.delete(key) for key in keys))
+        await _reap_managed_storage(prefixes, tenant_id)
     else:
         # Vector datasets: drop the PostGIS data table AND clean managed storage.
         # fix(#430 BA-17): vector ingest persists originals/{id}/ (archived source) and
         # vectors/{id}/quicklook_256.png; the old vector branch only dropped the
         # table, orphaning both objects forever (no reaper).
-        from app.platform.storage.provider import get_storage
-
         tenant_id = current_tenant_var.get()
         if is_multi_tenant() and tenant_id is None:
             raise RuntimeError(
                 "Dataset deletion is missing tenant context in multi-tenant mode"
             )
         data_schema = tenant_data_schema(tenant_id)
-        await session.execute(
-            text(
-                f"DROP TABLE IF EXISTS "
-                f"{_safe_table_ref(table_name, schema=data_schema)}"
+        if owns_table:
+            await session.execute(
+                text(
+                    f"DROP TABLE IF EXISTS "
+                    f"{_safe_table_ref(table_name, schema=data_schema)}"
+                )
             )
+        # The storage reap below runs either way: `originals/` and `vectors/`
+        # hold GeoLens-produced artifacts keyed by dataset id (an archived
+        # source, a quicklook), never the operator's table. A detached dataset
+        # has no claim on them once its row is gone.
+        #
+        # Detach leaves the table as REGISTRATION left it, which is not the
+        # same as untouched: register_existing_table may have added a
+        # geom_4326 column and its GIST index, granted SELECT to the reader
+        # role, and linearized an existing geom_4326 in place. None of that is
+        # undone here, deliberately.
+        #
+        # Undoing it would be this path writing to a relation GeoLens does not
+        # own, and each undo is worse than the state it removes: dropping a
+        # column rewrites the operator's table under a lock to delete a
+        # harmless one, revoking the grant removes a privilege that reaches
+        # nothing (every read resolves a table through `catalog.datasets`, and
+        # the row is going), and the linearization is not reversible at all
+        # since the pre-linear geometries are gone. Re-registering the table
+        # re-applies all three idempotently.
+        await _reap_managed_storage(
+            [f"originals/{dataset_id}/", f"vectors/{dataset_id}/"], tenant_id
         )
-        storage = get_storage()
-        for prefix in (f"originals/{dataset_id}/", f"vectors/{dataset_id}/"):
-            physical_prefix = resolve_storage_key(prefix, tenant_id=tenant_id)
-            keys = await storage.list(physical_prefix)
-            if keys:
-                await asyncio.gather(*(storage.delete(key) for key in keys))
 
     # fix(#1443): retire the name before releasing it. This is the one site
     # where a name a LIVE dataset row carried stops being carried by one, and
     # that is exactly the condition under which the tile router's table_name ->
     # metadata map could be holding an entry for it — that map is populated
-    # only from catalog.datasets. Recorded for every record type, not just the
-    # vector branch that drops a table: the raster/VRT branch drops nothing,
-    # but its dataset row goes, so the name it occupied in the catalog probe is
-    # freed just the same, and _resolve_dataset_meta does not filter on
-    # record_type before caching what it found.
+    # only from catalog.datasets. Record TYPE does not gate it — the raster/VRT
+    # branch drops nothing, but its dataset row goes, so the name it occupied in
+    # the catalog probe is freed just the same, and _resolve_dataset_meta does
+    # not filter on record_type before caching what it found. Ownership does
+    # gate it, which is the #1452 paragraph below.
     #
     # session.add, so it lands in the caller's transaction alongside the DROP
     # and the record delete. A crash between them can therefore roll back the
     # whole delete, but can never commit a freed name with no tombstone.
-    session.add(
-        RetiredTableName(
-            table_name=table_name,
-            tenant_id=dataset.tenant_id,
-            dataset_id=dataset_id,
+    #
+    # fix(#1452): except when the delete detached instead of dropping. The
+    # recording rule is "retire a name iff a catalog.datasets row pointed at it
+    # when it was freed", and a detach frees nothing — the relation is still
+    # there, still holding the operator's rows, still occupying the name.
+    # Retiring it anyway would make the operator's own table permanently
+    # unregisterable, since register_existing_table refuses a retired name and
+    # deliberately refuses rather than renames.
+    #
+    # What that costs is bounded and is not GH-1443's hazard. A successor can
+    # only be the SAME physical table re-registered by whoever can still see
+    # it: the surviving relation makes the name collide in generate_table_name's
+    # pg_class probe, so no ingest can draw it. A tile worker holding the
+    # predecessor's metadata past the delete therefore serves the same rows it
+    # was cached for, under a visibility that can be up to the 60s meta-cache
+    # TTL stale — the bounded-staleness tradeoff processing/tiles/router.py
+    # already documents for any visibility change, not a predecessor's
+    # visibility over a different dataset's rows.
+    if owns_table:
+        session.add(
+            RetiredTableName(
+                table_name=table_name,
+                tenant_id=dataset.tenant_id,
+                dataset_id=dataset_id,
+            )
         )
-    )
 
     # Delete the record (CASCADE handles dataset deletion)
     await session.delete(dataset.record)
@@ -247,6 +308,12 @@ async def delete_dataset(
         table_name=table_name,
         record_type=record_type,
         title=confirm_title,
+        # fix(#1452): here rather than in the router's audit_emit details,
+        # following the split the paragraph above states — this log line
+        # covers the PHYSICAL artifact, audit_emit covers the DB row. It is
+        # also the only place the answer survives: the dataset row that
+        # decided it is deleted a few lines up.
+        table_detached=not owns_table,
     )
 
     return table_name

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -135,8 +135,8 @@ async def delete_dataset(
     # fix(#1452): registration copies no data — it points the catalog at a
     # table the operator built and keeps writing to. Deleting the dataset
     # therefore has to detach, not drop, or the delete destroys the original
-    # rather than a GeoLens-managed copy. Resolved once here because the DROP
-    # and the name retirement below are two effects of this one answer.
+    # rather than a GeoLens-managed copy. This answer decides the DROP alone;
+    # the name retirement asks the separate question below.
     owns_table = geolens_owns_table(
         dataset.source_format, record_type, dataset.origin_ref
     )

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -61,6 +61,29 @@ async def _reap_managed_storage(prefixes: list[str], tenant_id: str | None) -> N
             await asyncio.gather(*(storage.delete(key) for key in keys))
 
 
+async def _relation_exists(
+    session: AsyncSession, table_name: str, *, schema: str
+) -> bool:
+    """Whether a relation of this name currently exists in ``schema``.
+
+    pg_catalog rather than information_schema, for the reason
+    ``generate_table_name``'s collision probe gives: the SQL standard filters
+    information_schema to relations the current role holds a privilege on, so
+    a role that does not own the relation can be blind to exactly the one
+    being asked about. pg_class is visible to every role and covers every
+    relation kind that can hold the name.
+    """
+    result = await session.execute(
+        text(
+            "SELECT EXISTS ("
+            " SELECT 1 FROM pg_catalog.pg_class c"
+            " JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace"
+            " WHERE n.nspname = :schema AND c.relname = :table_name)"
+        ).bindparams(schema=schema, table_name=table_name)
+    )
+    return bool(result.scalar())
+
+
 class DependentVrtError(Exception):
     """Raised when attempting to delete a COG referenced by VRT datasets."""
 
@@ -117,6 +140,22 @@ async def delete_dataset(
     owns_table = geolens_owns_table(
         dataset.source_format, record_type, dataset.origin_ref
     )
+
+    # fix(#1452 review round 1): whether this delete FREES the name is a
+    # separate question from whether GeoLens owns the table, and the tombstone
+    # below follows this one. A detach frees nothing only while the relation is
+    # still there to occupy the name. A registered dataset whose table the
+    # operator already dropped frees it exactly the way an ingested delete
+    # does, and skipping the tombstone there would reopen GH-1443: nothing
+    # would stop generate_table_name handing the name to the next ingest while
+    # a worker that missed this delete still authorizes against the dataset
+    # being deleted here.
+    #
+    # True by default so every path that does not lower it retires the name.
+    # The two mistakes are not symmetric: a missing tombstone is the
+    # disclosure GH-1443 exists to prevent, while an extra one costs an
+    # operator a rename before they can re-register.
+    name_is_freed = True
 
     if record_type in RASTER_FAMILY_RECORD_TYPES:
         if record_type == "raster_dataset":
@@ -203,6 +242,15 @@ async def delete_dataset(
                     f"{_safe_table_ref(table_name, schema=data_schema)}"
                 )
             )
+        else:
+            # The name stays taken only if the relation is still there. Asked
+            # inside this transaction, so a concurrent DROP either committed
+            # before this read (answers False, name retired) or lands after
+            # it. The latter is the residual noted in the retirement comment
+            # below.
+            name_is_freed = not await _relation_exists(
+                session, table_name, schema=data_schema
+            )
         # The storage reap below runs either way: `originals/` and `vectors/`
         # hold GeoLens-produced artifacts keyed by dataset id (an archived
         # source, a quicklook), never the operator's table. A detached dataset
@@ -240,24 +288,38 @@ async def delete_dataset(
     # and the record delete. A crash between them can therefore roll back the
     # whole delete, but can never commit a freed name with no tombstone.
     #
-    # fix(#1452): except when the delete detached instead of dropping. The
-    # recording rule is "retire a name iff a catalog.datasets row pointed at it
-    # when it was freed", and a detach frees nothing — the relation is still
-    # there, still holding the operator's rows, still occupying the name.
-    # Retiring it anyway would make the operator's own table permanently
-    # unregisterable, since register_existing_table refuses a retired name and
-    # deliberately refuses rather than renames.
+    # fix(#1452): except when the delete detached AND left the relation behind.
+    # The recording rule is "retire a name iff a catalog.datasets row pointed at
+    # it when it was freed", and freed is a fact about the RELATION: a surviving
+    # detached table still holds its rows and still occupies its name, so
+    # nothing was released. Retiring it anyway would make the operator's own
+    # table permanently unregisterable, since register_existing_table refuses a
+    # retired name and deliberately refuses rather than renames.
     #
-    # What that costs is bounded and is not GH-1443's hazard. A successor can
-    # only be the SAME physical table re-registered by whoever can still see
-    # it: the surviving relation makes the name collide in generate_table_name's
-    # pg_class probe, so no ingest can draw it. A tile worker holding the
-    # predecessor's metadata past the delete therefore serves the same rows it
-    # was cached for, under a visibility that can be up to the 60s meta-cache
-    # TTL stale — the bounded-staleness tradeoff processing/tiles/router.py
-    # already documents for any visibility change, not a predecessor's
-    # visibility over a different dataset's rows.
-    if owns_table:
+    # fix(#1452 review round 1) is why this reads `name_is_freed` and not
+    # `owns_table`: a registered dataset whose table was ALREADY gone frees the
+    # name outright, and skipping its tombstone reopened GH-1443 through the
+    # ingest door. That case is now probed and retired like any other.
+    #
+    # What the surviving-relation case costs is bounded and is not GH-1443's
+    # hazard. generate_table_name collides against live relations, so the table
+    # standing there keeps every ingest off the name; the only successor is that
+    # same table, re-registered by whoever can still see it. A tile worker
+    # holding the predecessor's metadata past the delete therefore serves the
+    # same rows it was cached for, under a visibility that can be up to the 60s
+    # meta-cache TTL stale — the bounded-staleness tradeoff
+    # processing/tiles/router.py already documents for any visibility change,
+    # not a predecessor's visibility over a different dataset's rows.
+    #
+    # ONE residual remains, and closing it needs a schema change this fix does
+    # not make: if the operator drops that relation AFTER this transaction
+    # reads it, the name goes free with no tombstone. Telling "the table I
+    # detached" from "a new table wearing its name" needs the relation's
+    # identity stored on the tombstone (pg_class.oid), so registration could
+    # accept the first and refuse the second while generate_table_name refuses
+    # both. Until then the exposure is an operator dropping their own table
+    # inside the same 60s window in which a new ingest must also draw the name.
+    if name_is_freed:
         session.add(
             RetiredTableName(
                 table_name=table_name,
@@ -312,8 +374,11 @@ async def delete_dataset(
         # following the split the paragraph above states — this log line
         # covers the PHYSICAL artifact, audit_emit covers the DB row. It is
         # also the only place the answer survives: the dataset row that
-        # decided it is deleted a few lines up.
+        # decided it is deleted a few lines up. Both flags are recorded
+        # because they disagree in the one case worth reading about later: a
+        # detach whose table was already gone retires the name.
         table_detached=not owns_table,
+        name_retired=name_is_freed,
     )
 
     return table_name

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -27,12 +27,15 @@ This lives under ``platform/`` rather than in the datasets domain because
 both ``app.modules.catalog`` and ``app.processing.ingest`` write origins, and
 processing/ may not import catalog (``test_no_processing_imports_catalog``).
 It imports nothing from either side: the write helper is duck-typed on the
-Dataset ORM instance.
+Dataset ORM instance. The one import is ``app.core``, the layer every other
+layer may import.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 
 # Formats whose rows were pulled from a remote OGC/Esri service. Mirrors
 # SERVICE_FORMATS in frontend/src/components/dataset/OriginBadge.tsx.
@@ -137,7 +140,21 @@ ORIGIN_REF_KEYS: dict[str, frozenset[str]] = {
     ),
     "upload": frozenset({"filename", "file_hash"}),
     # Gate 2: GeoLens-internal table only. No host/port/DSN/credential key.
-    "postgis": frozenset({"table_name"}),
+    #
+    # fix(#1452): `managed` is the one bit that separates the two callers of
+    # register_existing_table. Both produce a postgis origin, and until this
+    # key existed nothing told them apart: an operator registering a table
+    # they built, and the analysis materialize path registering a table
+    # GeoLens just CTAS'd. Delete has to tell them apart, because dropping
+    # the first destroys data GeoLens never created a copy of. Absent means
+    # NOT managed, which is what makes the back catalog — every dataset
+    # registered before this key existed — fall on the side that preserves
+    # the operator's table. That default costs a leaked table for analysis
+    # outputs registered before this shipped; the other default costs
+    # irreversible loss of data GeoLens does not own, so the asymmetry
+    # decides it. It is an ownership fact about the SAME table the pointer
+    # names, not a second pointer, so gate 2 is untouched.
+    "postgis": frozenset({"table_name", "managed"}),
     # A dataset drawn in the app came from nowhere; it carries no payload.
     "created": frozenset(),
 }
@@ -166,7 +183,9 @@ def classify_origin(
     return "upload"
 
 
-def set_postgis_origin(dataset: Any, table_name: str, *, schema: str) -> None:
+def set_postgis_origin(
+    dataset: Any, table_name: str, *, schema: str, managed: bool = False
+) -> None:
     """Stamp a registered PostGIS table's origin.
 
     Separate from the generic writer because the pointer and the ref's
@@ -184,11 +203,72 @@ def set_postgis_origin(dataset: Any, table_name: str, *, schema: str) -> None:
     ``data_t_<tenant>``. Callers pass the schema they actually created,
     granted, and read the table in, which makes the pointer agree with
     physical placement by construction rather than by a parallel derivation.
+
+    ``managed`` says GeoLens created the table it is about to register and may
+    drop it again (fix #1452). It is passed as ``True``/``None`` rather than
+    ``True``/``False`` so an unmanaged registration stores the exact ref shape
+    it stored before the key existed — ``build_origin_ref`` omits ``None`` —
+    and every reader goes through :func:`geolens_owns_table`, which reads an
+    absent key and a stored ``false`` the same way.
     """
     qualified = f"{schema}.{table_name}"
     set_dataset_origin(
-        dataset, "postgis", uri=f"postgis://{qualified}", table_name=qualified
+        dataset,
+        "postgis",
+        uri=f"postgis://{qualified}",
+        table_name=qualified,
+        managed=True if managed else None,
     )
+
+
+def geolens_owns_table(
+    source_format: str | None,
+    record_type: str | None,
+    origin_ref: Any,
+) -> bool:
+    """Whether GeoLens created this dataset's physical table and may drop it.
+
+    fix(#1452): the question ``delete_dataset`` has to answer before it issues
+    a DROP. Every origin but ``postgis`` describes data GeoLens materialized
+    into a table of its own making — an upload run through ogr2ogr, a service
+    or STAC pull, a layer drawn in the app — so the table is GeoLens's to
+    reclaim. ``postgis`` is the registered-in-place origin, where registration
+    copies no data and the catalog row is a reference to a table the operator
+    built; dropping that destroys the original, not a managed copy.
+
+    The one exception is the analysis materialize path, which CTAS's its own
+    output table and then registers it through the same helper an operator
+    uses. It stamps ``managed`` on the ref, and that is the only thing
+    separating the two — see ``ORIGIN_REF_KEYS['postgis']`` for why an absent
+    key resolves to "not ours".
+
+    Also the condition for retiring the name in ``catalog.retired_table_names``
+    (GH-1443), because the two questions have one answer: a name is freed only
+    when the relation behind it is gone. A detached table still exists and
+    still holds the operator's rows, so retiring its name would free nothing
+    and would permanently refuse the re-registration that is the whole point
+    of leaving the table alone.
+
+    ``origin_ref`` is typed ``Any`` on purpose: the column is JSONB and the ORM
+    hands back whatever is stored, which is not necessarily what
+    ``build_origin_ref`` would have written. The caller is one line above a
+    DROP, so the shape is checked rather than assumed.
+    """
+    # Registration is the only writer of a postgis origin and it only ever
+    # creates vector datasets, so a raster or VRT is GeoLens's by construction.
+    # Stated structurally rather than left to classify_origin, which would
+    # answer "postgis" for a raster whose source_format happened to be NULL and
+    # silently stop retiring its name (GH-1443). Every raster path stamps a
+    # format today; this makes that a fact rather than a dependency.
+    if record_type in RASTER_FAMILY_RECORD_TYPES:
+        return True
+    if classify_origin(source_format, record_type) != "postgis":
+        return True
+    if not isinstance(origin_ref, dict):
+        return False
+    # `is True`, not truthiness: a stored "yes" or 1 is not a claim this
+    # function is willing to drop a table on.
+    return origin_ref.get("managed") is True
 
 
 def service_layer_identity(

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -1283,6 +1283,13 @@ async def _materialize(
                     table_name=out_table, title=title, visibility="private"
                 ),
                 requester,
+                # fix(#1452): this output table was CTAS'd a few lines up, so
+                # it is GeoLens's to drop when the dataset is deleted. Without
+                # this it would be indistinguishable from a table an operator
+                # registered — same postgis origin, same null source_format —
+                # and the detach that protects the operator's table would leak
+                # one of these on every delete.
+                managed=True,
             )
             # feat(#765): provenance before the completing commit, so a
             # registered output can never be visible without its lineage.

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -632,6 +632,8 @@ async def register_existing_table(
     session: AsyncSession,
     request: RegisterRequest,
     user: Identity,
+    *,
+    managed: bool = False,
 ) -> "Any":
     """Register an existing data-schema table into the dataset catalog.
 
@@ -650,6 +652,16 @@ async def register_existing_table(
     and analysis for that dataset only; other datasets are unaffected.
     STORED GENERATED ``geom_4326`` columns fall under the same
     contract -- their generation expression must produce linear output.
+
+    fix(#1452): ``managed`` declares that the CALLER created the table it is
+    handing over, so deleting the resulting dataset may drop it again. It
+    defaults to False because the two register endpoints take a table name
+    from an operator and GeoLens has no claim on what it names; the analysis
+    materialize path, which CTAS's its own output and registers it through
+    this same function, is the one caller that passes True. Getting this
+    wrong in the True direction drops a table GeoLens does not own, which is
+    the bug GH-1452 exists to fix -- so it is an explicit argument at the one
+    call site that can answer it, never a guess made from the table's shape.
     """
     table_name = request.table_name
 
@@ -814,7 +826,7 @@ async def register_existing_table(
     # fills it in the database, so the ORM attribute never sees the real
     # value. _schema comes from the active tenant context and already fails
     # closed in multi-tenant mode when that context is missing.
-    set_postgis_origin(dataset, table_name, schema=_schema)
+    set_postgis_origin(dataset, table_name, schema=_schema, managed=managed)
 
     return dataset
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -217,6 +217,7 @@ _TENANCY_GLOBAL_STATE_MODULES = {
     # (2) cluster-global geolens_reader role GRANT/REVOKE mutators — must not run
     #     concurrently with each other or the group above (pg_shdepend contention).
     "test_analysis_materialize",  # register_existing_table → grant_reader_access
+    "test_registered_delete_detach_1452",  # same: registers real tables
     "test_embed_tokens",
     "test_features_crud",
     "test_features_geojson_z",

--- a/backend/tests/test_analysis_materialize.py
+++ b/backend/tests/test_analysis_materialize.py
@@ -1274,7 +1274,7 @@ class TestMaterializeWorker:
         real_register = ingest_service.register_existing_table
         out_tables: list[str] = []
 
-        async def sweeping_register(session, request, user):
+        async def sweeping_register(session, request, user, **kwargs):
             # The sweep lands between the build commit and the terminal
             # write: fail the row out from under the worker on its own
             # session, exactly as the platform's stale-job sweep does.
@@ -1289,7 +1289,7 @@ class TestMaterializeWorker:
                     )
                 )
                 await sweeper.commit()
-            return await real_register(session, request, user)
+            return await real_register(session, request, user, **kwargs)
 
         with patch.object(ingest_service, "register_existing_table", sweeping_register):
             await _materialize(
@@ -1342,7 +1342,7 @@ class TestMaterializeWorker:
 
         out_tables: list[str] = []
 
-        async def sweeping_register(session, request, user):
+        async def sweeping_register(session, request, user, **kwargs):
             out_tables.append(request.table_name)
             async with core_db.async_session() as sweeper:
                 await sweeper.execute(

--- a/backend/tests/test_dataset_source_state.py
+++ b/backend/tests/test_dataset_source_state.py
@@ -205,11 +205,23 @@ class TestOriginRefAllowlist:
         with pytest.raises(ValueError, match="rejects key"):
             build_origin_ref("postgis", **{key: "db.internal"})
 
-    def test_postgis_ref_holds_only_the_table_name(self) -> None:
-        assert ORIGIN_REF_KEYS["postgis"] == frozenset({"table_name"})
+    def test_postgis_ref_holds_the_table_name_and_who_owns_it(self) -> None:
+        """fix(#1452): `managed` joined `table_name`, and nothing else did.
+
+        It says whether GeoLens created the table the pointer already names,
+        which is what delete needs to know before it drops one. That is an
+        ownership fact about the same relation, not a second address, so gate
+        2 is untouched — the connection-detail rejections above still hold.
+        """
+        assert ORIGIN_REF_KEYS["postgis"] == frozenset({"table_name", "managed"})
         assert build_origin_ref("postgis", table_name="data.parcels") == {
             "kind": "postgis",
             "table_name": "data.parcels",
+        }
+        assert build_origin_ref("postgis", table_name="data.buf", managed=True) == {
+            "kind": "postgis",
+            "table_name": "data.buf",
+            "managed": True,
         }
 
     def test_absent_values_are_omitted_not_stored_as_null(self) -> None:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1763,6 +1763,16 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # pool this way. Three fast point lookups aren't worth that risk.
         # Cap 443 -> 429, exact.
         "backend/app/modules/catalog/datasets/domain/service_query.py": 429,
+        # fix(#1452): first explicit cap for this module — it sat under the
+        # 350 default until the detach landed. +65 over the pre-change 350:
+        # _reap_managed_storage (the reap loop both branches had inline,
+        # extracted when the new conditional pushed delete_dataset past
+        # ruff C901), _relation_exists (the pg_class probe that decides
+        # whether a detach freed the name), and the two decisions delete now
+        # makes with the reasoning behind them: drop-vs-detach, and the
+        # GH-1443 retirement that follows the relation rather than the
+        # dataset. Cap 350 -> 415, exact.
+        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 415,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2728,7 +2728,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # single-tenant namespace, and where a row retired before a single -> multi
     # transition sits, since nothing back-stamps this table. Cap 1166 -> 1199,
     # exact.
-    "backend/app/processing/ingest/service.py": 1199,
+    # fix(#1452): +12 — the `managed` keyword and the docstring paragraph that
+    # says why it is an explicit argument rather than a guess. Registration is
+    # called both by an operator handing over a table they own and by the
+    # analysis materialize path handing over one it just CTAS'd, and delete now
+    # drops only the second; the caller is the only place that knows which.
+    # Cap 1199 -> 1211, exact.
+    "backend/app/processing/ingest/service.py": 1211,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.
@@ -2951,7 +2957,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # set out to admit. _ungroupable_type_name and its ARRAY branch stay —
     # dissolve's by_field really does group by a user-chosen column. Cap
     # 1449 -> 1413, exact.
-    "backend/app/processing/analysis/tasks.py": 1413,
+    # fix(#1452): +7 — managed=True on the output registration, with the note
+    # that this table was CTAS'd here so delete may reclaim it. Without the
+    # flag it is indistinguishable from an operator's registered table and
+    # every analysis output would leak one on delete. Cap 1413 -> 1420, exact.
+    "backend/app/processing/analysis/tasks.py": 1420,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_raster_ingest.py
+++ b/backend/tests/test_raster_ingest.py
@@ -444,13 +444,27 @@ class _MockRecord:
 class _MockDataset:
     """Minimal Dataset stand-in for delete_dataset tests."""
 
-    def __init__(self, dataset_id: uuid.UUID, title: str, record_type: str):
+    def __init__(
+        self,
+        dataset_id: uuid.UUID,
+        title: str,
+        record_type: str,
+        source_format: str | None = "geotiff",
+    ):
         self.id = dataset_id
         self.table_name = "test_table"
         # delete_dataset copies this onto the retired-name row (GH-1443), which
         # is what scopes the retirement to a tenant. None is the single-tenant
         # value a real row carries here.
         self.tenant_id = None
+        # fix(#1452): delete_dataset asks geolens_owns_table whether it may
+        # drop the table and retire the name. These two fields are the whole
+        # input to that question, and the defaults describe an ingested
+        # dataset — the case every test in this class exercises. A registered
+        # table is source_format=None with a postgis origin_ref, and is
+        # covered in test_registered_delete_detach_1452.py.
+        self.source_format = source_format
+        self.origin_ref = None
         self.record = _MockRecord(title, record_type)
 
 
@@ -605,7 +619,9 @@ class TestRasterDeleteCascadeRemovesStorage:
                 vectors_prefix: vector_keys,
             }
         )
-        mock_dataset = _MockDataset(dataset_id, "My Vector", "vector_dataset")
+        mock_dataset = _MockDataset(
+            dataset_id, "My Vector", "vector_dataset", source_format="geojson"
+        )
         session = mock.AsyncMock()
         # AsyncSession.add is synchronous; an AsyncMock would turn
         # delete_dataset's retired-name write (GH-1443) into an

--- a/backend/tests/test_registered_delete_detach_1452.py
+++ b/backend/tests/test_registered_delete_detach_1452.py
@@ -234,6 +234,85 @@ class TestRegisteredDeleteDetaches:
         await test_db_session.commit()
 
 
+class TestDetachOfAnAlreadyMissingTableStillRetires:
+    """fix(#1452 review round 1): a detach only frees nothing while the
+    relation is there to occupy the name.
+
+    A registered dataset whose table the operator already dropped frees its
+    name outright. Skipping the tombstone for it reopened GH-1443 through the
+    ingest door: nothing kept generate_table_name from handing the name to a
+    new dataset while a worker that missed the delete still authorized against
+    the deleted one.
+    """
+
+    async def test_a_vanished_table_frees_the_name_and_it_is_retired(
+        self, test_db_session: AsyncSession
+    ):
+        table_name = await _operator_table(test_db_session)
+        title = f"Vanished {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title)
+
+        # The operator drops their own table behind GeoLens's back.
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert await _retired_count(test_db_session, table_name) == 1, (
+            "the name was released with no tombstone — generate_table_name "
+            "would hand it to the next ingest while a stale tile worker still "
+            "authorizes against the deleted dataset"
+        )
+
+    async def test_the_freed_name_is_not_handed_to_a_new_ingest(
+        self, test_db_session: AsyncSession
+    ):
+        """The retirement's actual job, asked through generate_table_name."""
+        from app.processing.ingest.service import generate_table_name
+
+        table_name = await _operator_table(test_db_session)
+        title = f"Vanished {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title)
+
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        redrawn, _ = await generate_table_name(table_name, test_db_session)
+        assert redrawn == f"{table_name}_2", (
+            f"the freed name {table_name} was handed straight back to a new "
+            "ingest (GH-1443)"
+        )
+
+    async def test_a_surviving_table_keeps_its_name_off_new_ingests(
+        self, test_db_session: AsyncSession
+    ):
+        """The other half: the relation itself is what holds the name.
+
+        This is why the detach case can skip the tombstone at all. The name is
+        unavailable to ingest either way; only the reason differs.
+        """
+        from app.processing.ingest.service import generate_table_name
+
+        table_name = await _operator_table(test_db_session)
+        title = f"Surviving {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert await _retired_count(test_db_session, table_name) == 0
+        redrawn, _ = await generate_table_name(table_name, test_db_session)
+        assert redrawn == f"{table_name}_2", (
+            "generate_table_name drew a name a live relation still occupies"
+        )
+
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+
 class TestIngestedDeleteStillDrops:
     """#1444 must not regress: an ingested table is still dropped and retired."""
 

--- a/backend/tests/test_registered_delete_detach_1452.py
+++ b/backend/tests/test_registered_delete_detach_1452.py
@@ -1,0 +1,379 @@
+"""Deleting a REGISTERED dataset must detach, never drop.
+
+fix(#1452). ``register_existing_table`` points the catalog at a table the
+operator built, and registration copies no data — the dataset row is a
+reference, not a managed copy. ``delete_dataset``'s vector branch dropped it
+anyway, so removing a catalog entry destroyed the operator's original.
+
+The two halves of the contract are tested here together because they are one
+answer with two effects: GeoLens drops the table AND retires its name when it
+created the table (ingest, analysis output), and does NEITHER when it did not.
+Retiring a detached name would be worse than pointless — ``register_existing_table``
+refuses a retired name, so it would leave the operator holding a table their own
+catalog can never accept again.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.catalog.datasets.domain.models import RetiredTableName
+from app.platform.dataset_origin import geolens_owns_table
+from app.processing.ingest.schemas import RegisterRequest
+from app.processing.ingest.service import register_existing_table
+from tests.factories import create_dataset, get_user_id
+
+
+class _MockStorage:
+    """delete_dataset reaps originals/ and vectors/; nothing is staged here."""
+
+    async def list(self, prefix: str) -> list[str]:
+        return []
+
+    async def delete(self, key: str) -> None:  # pragma: no cover - nothing listed
+        raise AssertionError("no keys were listed")
+
+
+async def _delete(session: AsyncSession, dataset_id: uuid.UUID, title: str) -> str:
+    from app.modules.catalog.datasets.domain.service import delete_dataset
+
+    with patch(
+        "app.platform.storage.provider.get_storage", return_value=_MockStorage()
+    ):
+        return await delete_dataset(session, dataset_id, title)
+
+
+async def _table_exists(session: AsyncSession, table_name: str) -> bool:
+    result = await session.execute(
+        text(
+            "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_class c "
+            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname = 'data' AND c.relname = :t)"
+        ).bindparams(t=table_name)
+    )
+    return bool(result.scalar())
+
+
+async def _retired_count(session: AsyncSession, table_name: str) -> int:
+    result = await session.execute(
+        select(func.count())
+        .select_from(RetiredTableName)
+        .where(RetiredTableName.table_name == table_name)
+    )
+    return int(result.scalar_one())
+
+
+async def _operator_table(session: AsyncSession, rows: int = 3) -> str:
+    """A table the OPERATOR created, with rows GeoLens never copied."""
+    table_name = f"operator_{uuid.uuid4().hex[:12]}"
+    await session.execute(
+        text(f'CREATE TABLE data."{table_name}" (gid serial primary key, note text)')
+    )
+    await session.execute(
+        text(
+            f'INSERT INTO data."{table_name}" (note) SELECT g::text '
+            f"FROM generate_series(1, :n) g"
+        ).bindparams(n=rows)
+    )
+    await session.commit()
+    return table_name
+
+
+async def _spatial_operator_table(session: AsyncSession, rows: int = 2) -> str:
+    """An operator table with a geom column, so registration adds geom_4326."""
+    table_name = f"operator_geo_{uuid.uuid4().hex[:10]}"
+    await session.execute(
+        text(
+            f'CREATE TABLE data."{table_name}" '
+            f"(gid serial primary key, geom geometry(Point, 4326))"
+        )
+    )
+    await session.execute(
+        text(
+            f'INSERT INTO data."{table_name}" (geom) '
+            f"SELECT ST_SetSRID(ST_MakePoint(g, g), 4326) "
+            f"FROM generate_series(1, :n) g"
+        ).bindparams(n=rows)
+    )
+    await session.commit()
+    return table_name
+
+
+async def _column_names(session: AsyncSession, table_name: str) -> set[str]:
+    result = await session.execute(
+        text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = 'data' AND table_name = :t"
+        ).bindparams(t=table_name)
+    )
+    return {row[0] for row in result.all()}
+
+
+async def _register(
+    session: AsyncSession, table_name: str, title: str, *, managed: bool = False
+):
+    admin_id = await get_user_id(session, "admin")
+    dataset = await register_existing_table(
+        session,
+        RegisterRequest(table_name=table_name, title=title),
+        SimpleNamespace(id=admin_id),
+        managed=managed,
+    )
+    await session.commit()
+    return dataset
+
+
+class TestRegisteredDeleteDetaches:
+    async def test_delete_leaves_the_operators_table_and_its_rows_alone(
+        self, test_db_session: AsyncSession
+    ):
+        table_name = await _operator_table(test_db_session, rows=3)
+        title = f"Registered {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert await _table_exists(test_db_session, table_name), (
+            "the delete dropped a table GeoLens never created — registration "
+            "copies no data, so this destroyed the operator's original"
+        )
+        surviving = await test_db_session.execute(
+            text(f'SELECT count(*) FROM data."{table_name}"')
+        )
+        assert surviving.scalar_one() == 3, "rows were deleted out of a detached table"
+
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+    async def test_a_spatial_table_keeps_its_geometry_and_the_added_4326_column(
+        self, test_db_session: AsyncSession
+    ):
+        """Detach leaves the table as REGISTRATION left it, not as it was born.
+
+        Registration adds ``geom_4326`` and its index to a table that has a
+        geom column. Delete undoes none of that: dropping the column would
+        rewrite the operator's table under a lock to remove something
+        harmless, and re-registering re-adds it idempotently anyway.
+        """
+        table_name = await _spatial_operator_table(test_db_session, rows=2)
+        title = f"Spatial {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title)
+        assert "geom_4326" in await _column_names(test_db_session, table_name)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert await _table_exists(test_db_session, table_name)
+        assert {"gid", "geom", "geom_4326"} <= await _column_names(
+            test_db_session, table_name
+        )
+        surviving = await test_db_session.execute(
+            text(f'SELECT count(*) FROM data."{table_name}" WHERE geom IS NOT NULL')
+        )
+        assert surviving.scalar_one() == 2
+
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+    async def test_the_catalog_row_and_its_grants_are_gone(
+        self, test_db_session: AsyncSession
+    ):
+        """Detach is about the TABLE. Everything catalog-side still goes."""
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        table_name = await _operator_table(test_db_session)
+        title = f"Registered {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title)
+        dataset_id = dataset.id
+
+        await _delete(test_db_session, dataset_id, title)
+        await test_db_session.commit()
+
+        remaining = await test_db_session.execute(
+            select(func.count()).select_from(Dataset).where(Dataset.id == dataset_id)
+        )
+        assert remaining.scalar_one() == 0
+
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+    async def test_the_name_is_not_retired_so_the_table_can_be_registered_again(
+        self, test_db_session: AsyncSession
+    ):
+        """The whole point of leaving the table: the operator can re-adopt it.
+
+        ``register_existing_table`` refuses a retired name (fix #1444), so a
+        tombstone here would strand the operator's own table permanently.
+        """
+        table_name = await _operator_table(test_db_session)
+        title = f"Registered {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert await _retired_count(test_db_session, table_name) == 0, (
+            "a detached name was tombstoned — nothing was freed, and the "
+            "operator can now never re-register their own table"
+        )
+
+        second = await _register(
+            test_db_session, table_name, f"Re-registered {uuid.uuid4().hex[:6]}"
+        )
+        assert second.table_name == table_name
+        assert second.id != dataset.id
+
+        await _delete(test_db_session, second.id, second.record.title)
+        await test_db_session.commit()
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+
+class TestIngestedDeleteStillDrops:
+    """#1444 must not regress: an ingested table is still dropped and retired."""
+
+    async def test_ingested_delete_drops_the_table_and_retires_the_name(
+        self, test_db_session: AsyncSession
+    ):
+        from app.processing.ingest.service import generate_table_name
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        title = f"Ingested {uuid.uuid4().hex[:6]}"
+        table_name, _ = await generate_table_name(title, test_db_session)
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name=title,
+            table_name=table_name,
+            record_type="vector_dataset",
+            source_format="geojson",
+        )
+        await test_db_session.execute(
+            text(f'CREATE TABLE data."{table_name}" (marker integer)')
+        )
+        await test_db_session.commit()
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert not await _table_exists(test_db_session, table_name), (
+            "GeoLens created this table from an upload; delete must reclaim it"
+        )
+        assert await _retired_count(test_db_session, table_name) == 1
+
+    async def test_a_managed_registration_is_dropped_and_retired(
+        self, test_db_session: AsyncSession
+    ):
+        """The analysis materialize path CTAS's its output, then registers it.
+
+        Same postgis origin and same null source_format as an operator's
+        table, so ``managed`` is the only thing that keeps delete reclaiming
+        it. Without it every analysis output would leak a table.
+        """
+        table_name = await _operator_table(test_db_session)
+        title = f"Analysis output {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title, managed=True)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert not await _table_exists(test_db_session, table_name)
+        assert await _retired_count(test_db_session, table_name) == 1
+
+
+class TestOwnershipRule:
+    """``geolens_owns_table`` decides both the DROP and the retirement."""
+
+    @pytest.mark.parametrize(
+        "source_format,record_type,origin_ref,owned",
+        [
+            ("geojson", "vector_dataset", None, True),
+            ("shapefile", "vector_dataset", None, True),
+            ("created", "vector_dataset", None, True),
+            ("wfs", "vector_dataset", None, True),
+            ("stac", "raster_dataset", None, True),
+            ("geotiff", "raster_dataset", None, True),
+            # A raster with no stamped format must not read as registered-in-
+            # place. Registration only ever creates vector datasets, so the
+            # record type settles it before the origin rule is consulted; the
+            # name still gets retired (GH-1443).
+            (None, "raster_dataset", None, True),
+            (None, "raster_dataset", {"kind": "postgis"}, True),
+            # A VRT composes other datasets and classifies as originless. It
+            # drops no table, but its catalog name is still freed, so #1444's
+            # retirement has to keep firing for it.
+            (None, "vrt_dataset", None, True),
+            # Registered in place: null source_format IS the postgis origin.
+            (None, "vector_dataset", None, False),
+            (None, "vector_dataset", {"kind": "postgis"}, False),
+            ("", "vector_dataset", {"kind": "postgis", "table_name": "data.x"}, False),
+            # Stored false and an absent key mean the same thing, so a row
+            # written before the key existed reads as "not ours".
+            (None, "vector_dataset", {"kind": "postgis", "managed": False}, False),
+            (None, "vector_dataset", {"kind": "postgis", "managed": True}, True),
+            # JSONB can hold shapes build_origin_ref never writes, and the
+            # caller is one line above a DROP. Only a dict saying managed is
+            # ours; a truthy-but-not-True value is not a claim.
+            (None, "vector_dataset", "data.parcels", False),
+            (None, "vector_dataset", ["postgis"], False),
+            (None, "vector_dataset", {"kind": "postgis", "managed": "yes"}, False),
+            (None, "vector_dataset", {"kind": "postgis", "managed": None}, False),
+        ],
+    )
+    def test_truth_table(self, source_format, record_type, origin_ref, owned):
+        assert geolens_owns_table(source_format, record_type, origin_ref) is owned
+
+    def test_managed_is_ignored_for_every_other_origin(self):
+        """`managed` is a postgis-only key; it cannot make an upload unowned."""
+        assert geolens_owns_table("geojson", "vector_dataset", {"managed": False})
+
+
+class TestManagedIsStampedOnlyWhereItIsClaimed:
+    async def test_operator_registration_stores_the_pre_1452_ref_shape(
+        self, test_db_session: AsyncSession
+    ):
+        """An unmanaged registration writes exactly what it wrote before.
+
+        ``managed`` is passed as True/None so the key is OMITTED rather than
+        stored false — the back catalog and a fresh operator registration are
+        then byte-identical, and neither can be misread as managed.
+        """
+        table_name = await _operator_table(test_db_session)
+        dataset = await _register(
+            test_db_session, table_name, f"Plain {uuid.uuid4().hex[:6]}"
+        )
+
+        assert dataset.origin_ref == {
+            "kind": "postgis",
+            "table_name": f"data.{table_name}",
+        }
+
+        await _delete(test_db_session, dataset.id, dataset.record.title)
+        await test_db_session.commit()
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+    async def test_managed_registration_stamps_the_ref(
+        self, test_db_session: AsyncSession
+    ):
+        table_name = await _operator_table(test_db_session)
+        dataset = await _register(
+            test_db_session,
+            table_name,
+            f"Managed {uuid.uuid4().hex[:6]}",
+            managed=True,
+        )
+
+        assert dataset.origin_ref == {
+            "kind": "postgis",
+            "managed": True,
+            "table_name": f"data.{table_name}",
+        }
+
+        await _delete(test_db_session, dataset.id, dataset.record.title)
+        await test_db_session.commit()

--- a/backend/tests/test_tenant_attribution_materialize.py
+++ b/backend/tests/test_tenant_attribution_materialize.py
@@ -466,7 +466,14 @@ class TestMaterializeStampsTenantAttribution:
             "origin_uri does not name the tenant schema the table lives in.\n"
             f"  stored={row.origin_uri!r} expected='postgis://{qualified}'"
         )
-        assert row.origin_ref == {"kind": "postgis", "table_name": qualified}
+        # fix(#1452): the analysis materialize path CTAS'd this output table
+        # and registers it with managed=True, so delete may drop it again.
+        # An operator-registered table carries no `managed` key at all.
+        assert row.origin_ref == {
+            "kind": "postgis",
+            "table_name": qualified,
+            "managed": True,
+        }
         # The pointer and the ref are two spellings of one fact.
         assert row.origin_uri == f"postgis://{row.origin_ref['table_name']}"
         # And the shared schema must not appear anywhere in it.
@@ -509,7 +516,7 @@ class TestMaterializeStampsTenantAttribution:
         real_register = ingest_service.register_existing_table
         stamped: dict[str, object] = {}
 
-        async def _register_without_tenant_guc(session, request, user):
+        async def _register_without_tenant_guc(session, request, user, **kwargs):
             # End the transaction the registration statement_timeout opened,
             # then re-open it with no tenant bound so no GUC is issued.
             await session.rollback()
@@ -518,7 +525,7 @@ class TestMaterializeStampsTenantAttribution:
                 await session.execute(sa.text("SELECT 1"))
             finally:
                 current_tenant_var.reset(token)
-            dataset = await real_register(session, request, user)
+            dataset = await real_register(session, request, user, **kwargs)
             row = (
                 await session.execute(
                     sa.text(

--- a/frontend/src/components/dataset/DatasetDeleteDialog.tsx
+++ b/frontend/src/components/dataset/DatasetDeleteDialog.tsx
@@ -51,6 +51,16 @@ function parseDependentVrts(error: Error): DependentVrt[] | null {
  * can act on this dialog.
  */
 export function deleteDetachesTable(dataset: DatasetResponse): boolean {
+  // fix(#1452 review round 3): the raster-family override comes FIRST, exactly
+  // as it does in geolens_owns_table. A raster or VRT row whose source_format
+  // is null derives origin 'postgis' — classify_origin reads a null format as
+  // registered-in-place — and without this the dialog would promise a
+  // PostgreSQL table survives a delete that reaps the dataset's storage
+  // artifacts and retires its name. Registration only ever creates vector
+  // datasets, so a raster-family record is GeoLens's by construction.
+  if (dataset.record_type === 'raster_dataset' || dataset.record_type === 'vrt_dataset') {
+    return false;
+  }
   if (dataset.origin !== 'postgis') return false;
   return dataset.origin_ref?.managed !== true;
 }

--- a/frontend/src/components/dataset/DatasetDeleteDialog.tsx
+++ b/frontend/src/components/dataset/DatasetDeleteDialog.tsx
@@ -32,6 +32,29 @@ function parseDependentVrts(error: Error): DependentVrt[] | null {
   return null;
 }
 
+/**
+ * Whether this delete leaves the operator's PostgreSQL table behind.
+ *
+ * fix(#1452): registering an existing table copies no data, so deleting the
+ * dataset detaches instead of dropping. Both served facts come from the
+ * server — `origin` is computed there (#1218) and `origin_ref.managed` is
+ * stamped at registration — and `geolens_owns_table` in the backend's
+ * platform/dataset_origin.py is the authority this mirrors for copy only.
+ *
+ * `managed` marks the one postgis-origin dataset GeoLens DID create: an
+ * analysis output, CTAS'd and then registered through the same helper. That
+ * table is dropped, so it must not get the reassuring wording.
+ *
+ * `origin_ref` is owner-or-admin only, which is exactly who can delete
+ * (`check_dataset_write_access` is the same predicate as
+ * `can_view_dataset_provenance`), so it is never redacted from a reader who
+ * can act on this dialog.
+ */
+export function deleteDetachesTable(dataset: DatasetResponse): boolean {
+  if (dataset.origin !== 'postgis') return false;
+  return dataset.origin_ref?.managed !== true;
+}
+
 interface DatasetDeleteDialogProps {
   dataset: DatasetResponse;
   open: boolean;
@@ -72,7 +95,12 @@ export function DatasetDeleteDialog({ dataset, open, onOpenChange }: DatasetDele
         <AlertDialogHeader>
           <AlertDialogTitle>{t('deleteDialog.title')}</AlertDialogTitle>
           <AlertDialogDescription>
-            {t('deleteDialog.description', { name: dataset.title })}
+            {t(
+              deleteDetachesTable(dataset)
+                ? 'deleteDialog.descriptionRegistered'
+                : 'deleteDialog.description',
+              { name: dataset.title },
+            )}
           </AlertDialogDescription>
         </AlertDialogHeader>
 

--- a/frontend/src/components/dataset/DatasetDeleteDialog.tsx
+++ b/frontend/src/components/dataset/DatasetDeleteDialog.tsx
@@ -55,6 +55,24 @@ export function deleteDetachesTable(dataset: DatasetResponse): boolean {
   return dataset.origin_ref?.managed !== true;
 }
 
+/**
+ * Which description this delete gets.
+ *
+ * fix(#1452 review round 2): a registered dataset whose table has already
+ * been dropped carries `source_health: 'missing'` — the PostGIS refresh maps
+ * SQLSTATE 42P01 to it — and the backend detects that absent relation and
+ * retires the name instead of preserving anything. Promising that its data
+ * stays intact would be the one wrong thing to tell someone in that state.
+ * The wording says "last saw" because the stored verdict is a past probe, not
+ * a live check: the operator may have recreated the table since.
+ */
+export function deleteDescriptionKey(dataset: DatasetResponse): string {
+  if (!deleteDetachesTable(dataset)) return 'deleteDialog.description';
+  return dataset.source_health === 'missing'
+    ? 'deleteDialog.descriptionRegisteredMissing'
+    : 'deleteDialog.descriptionRegistered';
+}
+
 interface DatasetDeleteDialogProps {
   dataset: DatasetResponse;
   open: boolean;
@@ -95,12 +113,7 @@ export function DatasetDeleteDialog({ dataset, open, onOpenChange }: DatasetDele
         <AlertDialogHeader>
           <AlertDialogTitle>{t('deleteDialog.title')}</AlertDialogTitle>
           <AlertDialogDescription>
-            {t(
-              deleteDetachesTable(dataset)
-                ? 'deleteDialog.descriptionRegistered'
-                : 'deleteDialog.description',
-              { name: dataset.title },
-            )}
+            {t(deleteDescriptionKey(dataset), { name: dataset.title })}
           </AlertDialogDescription>
         </AlertDialogHeader>
 

--- a/frontend/src/components/dataset/DatasetDeleteDialog.tsx
+++ b/frontend/src/components/dataset/DatasetDeleteDialog.tsx
@@ -80,13 +80,20 @@ export function deleteDetachesTable(dataset: DatasetResponse): boolean {
 /**
  * Which description this delete gets.
  *
- * fix(#1452 review round 2): a registered dataset whose table has already
- * been dropped carries `source_health: 'missing'` — the PostGIS refresh maps
- * SQLSTATE 42P01 to it — and the backend detects that absent relation and
- * retires the name instead of preserving anything. Promising that its data
- * stays intact would be the one wrong thing to tell someone in that state.
- * The wording says "last saw" because the stored verdict is a past probe, not
- * a live check: the operator may have recreated the table since.
+ * fix(#1452 review round 5): the registered copy states what GEOLENS will do
+ * — it will not drop the table — rather than what the world contains. Only
+ * the first is ours to promise. `source_health` is a past observation, so a
+ * table dropped since the last probe still reads `healthy`, and one never
+ * probed reads `unknown`; a copy that asserted the relation and its rows
+ * still exist would be wrong in both cases, and the backend's live
+ * `_relation_exists` probe would find nothing and retire the name.
+ *
+ * fix(#1452 review round 2): the `missing` variant remains, because when the
+ * refresh has actually seen the table gone (tasks_postgis_refresh maps
+ * SQLSTATE 42P01 to that verdict) "we will not drop it" is a strange thing to
+ * say about a table that is not there. It is now a courtesy rather than the
+ * thing standing between the reader and a false promise. Its wording says
+ * "last saw" for the same reason the main copy avoids world-state claims.
  */
 export function deleteDescriptionKey(dataset: DatasetResponse): string {
   if (!deleteDetachesTable(dataset)) return 'deleteDialog.description';

--- a/frontend/src/components/dataset/DatasetDeleteDialog.tsx
+++ b/frontend/src/components/dataset/DatasetDeleteDialog.tsx
@@ -88,6 +88,11 @@ export function deleteDetachesTable(dataset: DatasetResponse): boolean {
  * still exist would be wrong in both cases, and the backend's live
  * `_relation_exists` probe would find nothing and retire the name.
  *
+ * That is a contract on the STRING, in all four locales, and no gate can
+ * check it (round 6 caught the English being corrected while es/fr/de still
+ * said the contents remain intact). When editing `descriptionRegistered`,
+ * describe what GeoLens does to the table and never what the table holds.
+ *
  * fix(#1452 review round 2): the `missing` variant remains, because when the
  * refresh has actually seen the table gone (tasks_postgis_refresh maps
  * SQLSTATE 42P01 to that verdict) "we will not drop it" is a strange thing to

--- a/frontend/src/components/dataset/DatasetDeleteDialog.tsx
+++ b/frontend/src/components/dataset/DatasetDeleteDialog.tsx
@@ -89,9 +89,10 @@ export function deleteDetachesTable(dataset: DatasetResponse): boolean {
  * `_relation_exists` probe would find nothing and retire the name.
  *
  * That is a contract on the STRING, in all four locales, and no gate can
- * check it (round 6 caught the English being corrected while es/fr/de still
- * said the contents remain intact). When editing `descriptionRegistered`,
- * describe what GeoLens does to the table and never what the table holds.
+ * check it: fix(#1452 review round 6) caught the English being corrected
+ * while es/fr/de still said the contents remain intact. When editing
+ * `descriptionRegistered`, describe what GeoLens does to the table and never
+ * what the table holds.
  *
  * fix(#1452 review round 2): the `missing` variant remains, because when the
  * refresh has actually seen the table gone (tasks_postgis_refresh maps

--- a/frontend/src/components/dataset/DatasetDeleteDialog.tsx
+++ b/frontend/src/components/dataset/DatasetDeleteDialog.tsx
@@ -45,10 +45,20 @@ function parseDependentVrts(error: Error): DependentVrt[] | null {
  * analysis output, CTAS'd and then registered through the same helper. That
  * table is dropped, so it must not get the reassuring wording.
  *
- * `origin_ref` is owner-or-admin only, which is exactly who can delete
- * (`check_dataset_write_access` is the same predicate as
- * `can_view_dataset_provenance`), so it is never redacted from a reader who
- * can act on this dialog.
+ * fix(#1452 review round 4): a readable `origin_ref` is REQUIRED before this
+ * promises anything. `origin_ref` is owner-or-admin only, and while that is
+ * the same predicate as `check_dataset_write_access`, the response carrying
+ * it is cached under `['dataset', id]` with no identity in the key and a 60s
+ * staleTime, and login invalidates only the auth caches. So an owner can be
+ * handed the redacted response a non-owner or anonymous reader populated
+ * moments earlier, in which case `origin_ref` is null for a reason that has
+ * nothing to do with ownership. Null is also what migration 0036's backfill
+ * leaves on the rows it could not resolve. Reading either as "not managed"
+ * would promise that an analysis output's table survives a delete that drops
+ * it — the one direction this dialog must never be wrong in. Absent evidence
+ * therefore falls back to the copy that warns the data is destroyed: this
+ * over-warns for a registered table whose provenance we cannot read, and a
+ * spurious warning costs nothing that a false assurance does not cost more.
  */
 export function deleteDetachesTable(dataset: DatasetResponse): boolean {
   // fix(#1452 review round 3): the raster-family override comes FIRST, exactly
@@ -62,7 +72,9 @@ export function deleteDetachesTable(dataset: DatasetResponse): boolean {
     return false;
   }
   if (dataset.origin !== 'postgis') return false;
-  return dataset.origin_ref?.managed !== true;
+  const ref = dataset.origin_ref;
+  if (!ref || typeof ref !== 'object') return false;
+  return ref.managed !== true;
 }
 
 /**

--- a/frontend/src/components/dataset/__tests__/DatasetDeleteDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetDeleteDialog.test.tsx
@@ -16,9 +16,41 @@ function makeDataset(overrides: Partial<DatasetResponse> = {}): DatasetResponse 
   } as DatasetResponse;
 }
 
+/** A registered dataset whose provenance the caller can read. */
+function registeredDataset(overrides: Partial<DatasetResponse> = {}): DatasetResponse {
+  return makeDataset({
+    origin: 'postgis',
+    origin_ref: { kind: 'postgis', table_name: 'data.parcels' },
+    ...overrides,
+  });
+}
+
 describe('deleteDetachesTable', () => {
   it('detaches a registered PostGIS table', () => {
-    expect(deleteDetachesTable(makeDataset({ origin: 'postgis' }))).toBe(true);
+    const dataset = makeDataset({
+      origin: 'postgis',
+      origin_ref: { kind: 'postgis', table_name: 'data.parcels' },
+    });
+    expect(deleteDetachesTable(dataset)).toBe(true);
+  });
+
+  it.each([
+    ['redacted or absent', undefined],
+    ['explicitly null', null],
+    ['not an object', 'data.parcels'],
+  ] as const)('promises nothing when origin_ref is %s', (_label, origin_ref) => {
+    // fix(#1452 review round 4): `origin_ref` is owner-or-admin only, and the
+    // dataset response is cached under ['dataset', id] with no identity in the
+    // key, so an owner can be handed a non-owner's redacted copy. Null is also
+    // what migration 0036's backfill leaves on rows it could not resolve.
+    // Reading either as "not managed" would promise an analysis output's table
+    // survives a delete that drops it.
+    const dataset = makeDataset({
+      origin: 'postgis',
+      origin_ref: origin_ref as never,
+    });
+    expect(deleteDetachesTable(dataset)).toBe(false);
+    expect(deleteDescriptionKey(dataset)).toBe('deleteDialog.description');
   });
 
   it.each(['upload', 'service', 'stac', 'created'] as const)(
@@ -45,7 +77,7 @@ describe('deleteDetachesTable', () => {
       // 'postgis'. geolens_owns_table overrides on record type before it
       // consults the origin, and this must agree: the delete reaps that
       // dataset's storage and retires its name.
-      const dataset = makeDataset({ record_type, origin: 'postgis' });
+      const dataset = registeredDataset({ record_type });
       expect(deleteDetachesTable(dataset)).toBe(false);
       expect(deleteDescriptionKey(dataset)).toBe('deleteDialog.description');
     },
@@ -63,14 +95,14 @@ describe('deleteDetachesTable', () => {
 
 describe('deleteDescriptionKey', () => {
   it('promises survival for a healthy registered table', () => {
-    const dataset = makeDataset({ origin: 'postgis', source_health: 'healthy' });
+    const dataset = registeredDataset({ source_health: 'healthy' });
     expect(deleteDescriptionKey(dataset)).toBe('deleteDialog.descriptionRegistered');
   });
 
   it('drops the survival promise when the source table is missing', () => {
     // The backend detects the absent relation and retires the name instead
     // of preserving anything, so there is nothing to promise.
-    const dataset = makeDataset({ origin: 'postgis', source_health: 'missing' });
+    const dataset = registeredDataset({ source_health: 'missing' });
     expect(deleteDescriptionKey(dataset)).toBe(
       'deleteDialog.descriptionRegisteredMissing',
     );
@@ -80,7 +112,7 @@ describe('deleteDescriptionKey', () => {
     'keeps the survival promise when health is %s',
     (source_health) => {
       // Neither says the relation is gone; only `missing` does.
-      const dataset = makeDataset({ origin: 'postgis', source_health });
+      const dataset = registeredDataset({ source_health });
       expect(deleteDescriptionKey(dataset)).toBe('deleteDialog.descriptionRegistered');
     },
   );
@@ -95,7 +127,7 @@ describe('DatasetDeleteDialog copy', () => {
   it('promises the table survives for a registered dataset', () => {
     render(
       <DatasetDeleteDialog
-        dataset={makeDataset({ origin: 'postgis' })}
+        dataset={registeredDataset()}
         open
         onOpenChange={() => {}}
       />,
@@ -113,7 +145,7 @@ describe('DatasetDeleteDialog copy', () => {
     // owner cannot act on.
     render(
       <DatasetDeleteDialog
-        dataset={makeDataset({ origin: 'postgis' })}
+        dataset={registeredDataset()}
         open
         onOpenChange={() => {}}
       />,
@@ -126,7 +158,7 @@ describe('DatasetDeleteDialog copy', () => {
   it('does not promise intact data when the source table is missing', () => {
     render(
       <DatasetDeleteDialog
-        dataset={makeDataset({ origin: 'postgis', source_health: 'missing' })}
+        dataset={registeredDataset({ source_health: 'missing' })}
         open
         onOpenChange={() => {}}
       />,

--- a/frontend/src/components/dataset/__tests__/DatasetDeleteDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetDeleteDialog.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from '@/test/test-utils';
 import type { DatasetResponse } from '@/types/api';
-import { DatasetDeleteDialog, deleteDetachesTable } from '../DatasetDeleteDialog';
+import {
+  DatasetDeleteDialog,
+  deleteDescriptionKey,
+  deleteDetachesTable,
+} from '../DatasetDeleteDialog';
 
 function makeDataset(overrides: Partial<DatasetResponse> = {}): DatasetResponse {
   return {
@@ -43,6 +47,36 @@ describe('deleteDetachesTable', () => {
   });
 });
 
+describe('deleteDescriptionKey', () => {
+  it('promises survival for a healthy registered table', () => {
+    const dataset = makeDataset({ origin: 'postgis', source_health: 'healthy' });
+    expect(deleteDescriptionKey(dataset)).toBe('deleteDialog.descriptionRegistered');
+  });
+
+  it('drops the survival promise when the source table is missing', () => {
+    // The backend detects the absent relation and retires the name instead
+    // of preserving anything, so there is nothing to promise.
+    const dataset = makeDataset({ origin: 'postgis', source_health: 'missing' });
+    expect(deleteDescriptionKey(dataset)).toBe(
+      'deleteDialog.descriptionRegisteredMissing',
+    );
+  });
+
+  it.each(['unknown', 'inaccessible'] as const)(
+    'keeps the survival promise when health is %s',
+    (source_health) => {
+      // Neither says the relation is gone; only `missing` does.
+      const dataset = makeDataset({ origin: 'postgis', source_health });
+      expect(deleteDescriptionKey(dataset)).toBe('deleteDialog.descriptionRegistered');
+    },
+  );
+
+  it('ignores health entirely for a dataset GeoLens owns', () => {
+    const dataset = makeDataset({ origin: 'upload', source_health: 'missing' });
+    expect(deleteDescriptionKey(dataset)).toBe('deleteDialog.description');
+  });
+});
+
 describe('DatasetDeleteDialog copy', () => {
   it('promises the table survives for a registered dataset', () => {
     render(
@@ -55,6 +89,37 @@ describe('DatasetDeleteDialog copy', () => {
 
     expect(screen.getByText(/stays in the database/i)).toBeInTheDocument();
     expect(screen.queryByText(/including all spatial data/i)).not.toBeInTheDocument();
+  });
+
+  it('says the surviving table can be registered again', () => {
+    // fix(#1452 review round 2): a detached table goes back to being an
+    // unregistered table in the data schema, which /ingest/discover/ lists
+    // and any upload-permission user can register — the same exposure it had
+    // before its owner registered it. Silence about that is the part the
+    // owner cannot act on.
+    render(
+      <DatasetDeleteDialog
+        dataset={makeDataset({ origin: 'postgis' })}
+        open
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/register it again/i)).toBeInTheDocument();
+    expect(screen.getByText(/drop the table yourself/i)).toBeInTheDocument();
+  });
+
+  it('does not promise intact data when the source table is missing', () => {
+    render(
+      <DatasetDeleteDialog
+        dataset={makeDataset({ origin: 'postgis', source_health: 'missing' })}
+        open
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/nothing left to remove/i)).toBeInTheDocument();
+    expect(screen.queryByText(/data intact/i)).not.toBeInTheDocument();
   });
 
   it('still warns that the data goes for an uploaded dataset', () => {

--- a/frontend/src/components/dataset/__tests__/DatasetDeleteDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetDeleteDialog.test.tsx
@@ -10,6 +10,7 @@ function makeDataset(overrides: Partial<DatasetResponse> = {}): DatasetResponse 
   return {
     id: 'ds-1',
     title: 'Parcels',
+    record_type: 'vector_dataset',
     origin: 'upload',
     ...overrides,
   } as DatasetResponse;
@@ -36,6 +37,19 @@ describe('deleteDetachesTable', () => {
     });
     expect(deleteDetachesTable(dataset)).toBe(false);
   });
+
+  it.each(['raster_dataset', 'vrt_dataset'] as const)(
+    'never detaches a %s, even when its derived origin is postgis',
+    (record_type) => {
+      // A raster-family row with a null source_format derives origin
+      // 'postgis'. geolens_owns_table overrides on record type before it
+      // consults the origin, and this must agree: the delete reaps that
+      // dataset's storage and retires its name.
+      const dataset = makeDataset({ record_type, origin: 'postgis' });
+      expect(deleteDetachesTable(dataset)).toBe(false);
+      expect(deleteDescriptionKey(dataset)).toBe('deleteDialog.description');
+    },
+  );
 
   it('detaches when the ref carries no managed key', () => {
     // Registrations from before #1452 stored no key at all.

--- a/frontend/src/components/dataset/__tests__/DatasetDeleteDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetDeleteDialog.test.tsx
@@ -133,7 +133,7 @@ describe('DatasetDeleteDialog copy', () => {
       />,
     );
 
-    expect(screen.getByText(/stays in the database/i)).toBeInTheDocument();
+    expect(screen.getByText(/will not drop the postgresql table/i)).toBeInTheDocument();
     expect(screen.queryByText(/including all spatial data/i)).not.toBeInTheDocument();
   });
 
@@ -165,7 +165,9 @@ describe('DatasetDeleteDialog copy', () => {
     );
 
     expect(screen.getByText(/nothing left to remove/i)).toBeInTheDocument();
-    expect(screen.queryByText(/data intact/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/will not drop the postgresql table/i),
+    ).not.toBeInTheDocument();
   });
 
   it('still warns that the data goes for an uploaded dataset', () => {
@@ -178,6 +180,8 @@ describe('DatasetDeleteDialog copy', () => {
     );
 
     expect(screen.getByText(/including all spatial data/i)).toBeInTheDocument();
-    expect(screen.queryByText(/stays in the database/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/will not drop the postgresql table/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dataset/__tests__/DatasetDeleteDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetDeleteDialog.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@/test/test-utils';
+import type { DatasetResponse } from '@/types/api';
+import { DatasetDeleteDialog, deleteDetachesTable } from '../DatasetDeleteDialog';
+
+function makeDataset(overrides: Partial<DatasetResponse> = {}): DatasetResponse {
+  return {
+    id: 'ds-1',
+    title: 'Parcels',
+    origin: 'upload',
+    ...overrides,
+  } as DatasetResponse;
+}
+
+describe('deleteDetachesTable', () => {
+  it('detaches a registered PostGIS table', () => {
+    expect(deleteDetachesTable(makeDataset({ origin: 'postgis' }))).toBe(true);
+  });
+
+  it.each(['upload', 'service', 'stac', 'created'] as const)(
+    'drops a %s dataset — GeoLens created that table',
+    (origin) => {
+      expect(deleteDetachesTable(makeDataset({ origin }))).toBe(false);
+    },
+  );
+
+  it('drops a managed postgis table', () => {
+    // The analysis materialize path CTAS's its output and registers it, so it
+    // reads as postgis but is GeoLens's to drop.
+    const dataset = makeDataset({
+      origin: 'postgis',
+      origin_ref: { kind: 'postgis', table_name: 'data.buffer_out', managed: true },
+    });
+    expect(deleteDetachesTable(dataset)).toBe(false);
+  });
+
+  it('detaches when the ref carries no managed key', () => {
+    // Registrations from before #1452 stored no key at all.
+    const dataset = makeDataset({
+      origin: 'postgis',
+      origin_ref: { kind: 'postgis', table_name: 'data.parcels' },
+    });
+    expect(deleteDetachesTable(dataset)).toBe(true);
+  });
+});
+
+describe('DatasetDeleteDialog copy', () => {
+  it('promises the table survives for a registered dataset', () => {
+    render(
+      <DatasetDeleteDialog
+        dataset={makeDataset({ origin: 'postgis' })}
+        open
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/stays in the database/i)).toBeInTheDocument();
+    expect(screen.queryByText(/including all spatial data/i)).not.toBeInTheDocument();
+  });
+
+  it('still warns that the data goes for an uploaded dataset', () => {
+    render(
+      <DatasetDeleteDialog
+        dataset={makeDataset({ origin: 'upload' })}
+        open
+        onOpenChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/including all spatial data/i)).toBeInTheDocument();
+    expect(screen.queryByText(/stays in the database/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -288,7 +288,7 @@
   "deleteDialog": {
     "title": "Datensatz löschen",
     "description": "Der Datensatz \"{{name}}\" einschließlich aller Geodaten wird dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
-    "descriptionRegistered": "Der Katalogeintrag für \"{{name}}\" wird dauerhaft gelöscht. Die PostgreSQL-Tabelle, aus der er registriert wurde, bleibt mit ihren Daten in der Datenbank erhalten, und alle Personen mit Upload-Berechtigung können sie erneut registrieren. Löschen Sie die Tabelle selbst, wenn die Daten entfernt werden sollen. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "descriptionRegistered": "Der Katalogeintrag für \"{{name}}\" wird dauerhaft gelöscht. GeoLens löscht die PostgreSQL-Tabelle, aus der er registriert wurde, nicht. Ihr Inhalt bleibt unverändert, und alle Personen mit Upload-Berechtigung können sie erneut registrieren. Löschen Sie die Tabelle selbst, wenn die Daten entfernt werden sollen. Diese Aktion kann nicht rückgängig gemacht werden.",
     "descriptionRegisteredMissing": "Der Katalogeintrag für \"{{name}}\" wird dauerhaft gelöscht. Bei der letzten Prüfung war die Quelltabelle nicht auffindbar, daher ist möglicherweise nichts mehr zu entfernen. Diese Aktion kann nicht rückgängig gemacht werden.",
     "confirmPrompt": "Geben Sie den Datensatznamen zur Bestätigung ein:",
     "deleting": "Wird gelöscht...",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -288,6 +288,7 @@
   "deleteDialog": {
     "title": "Datensatz löschen",
     "description": "Der Datensatz \"{{name}}\" einschließlich aller Geodaten wird dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "descriptionRegistered": "Der Katalogeintrag für \"{{name}}\" wird dauerhaft gelöscht. Die PostgreSQL-Tabelle, aus der er registriert wurde, bleibt mit ihren Daten in der Datenbank erhalten. Diese Aktion kann nicht rückgängig gemacht werden.",
     "confirmPrompt": "Geben Sie den Datensatznamen zur Bestätigung ein:",
     "deleting": "Wird gelöscht...",
     "deleteDataset": "Datensatz löschen",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -288,7 +288,7 @@
   "deleteDialog": {
     "title": "Datensatz löschen",
     "description": "Der Datensatz \"{{name}}\" einschließlich aller Geodaten wird dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
-    "descriptionRegistered": "Der Katalogeintrag für \"{{name}}\" wird dauerhaft gelöscht. GeoLens löscht die PostgreSQL-Tabelle, aus der er registriert wurde, nicht. Ihr Inhalt bleibt unverändert, und alle Personen mit Upload-Berechtigung können sie erneut registrieren. Löschen Sie die Tabelle selbst, wenn die Daten entfernt werden sollen. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "descriptionRegistered": "Der Katalogeintrag für \"{{name}}\" wird dauerhaft gelöscht. GeoLens löscht die PostgreSQL-Tabelle, aus der er registriert wurde, nicht und lässt sie unangetastet. Alle Personen mit Upload-Berechtigung können sie erneut registrieren. Löschen Sie die Tabelle selbst, wenn die Daten entfernt werden sollen. Diese Aktion kann nicht rückgängig gemacht werden.",
     "descriptionRegisteredMissing": "Der Katalogeintrag für \"{{name}}\" wird dauerhaft gelöscht. Bei der letzten Prüfung war die Quelltabelle nicht auffindbar, daher ist möglicherweise nichts mehr zu entfernen. Diese Aktion kann nicht rückgängig gemacht werden.",
     "confirmPrompt": "Geben Sie den Datensatznamen zur Bestätigung ein:",
     "deleting": "Wird gelöscht...",

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -288,7 +288,8 @@
   "deleteDialog": {
     "title": "Datensatz löschen",
     "description": "Der Datensatz \"{{name}}\" einschließlich aller Geodaten wird dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
-    "descriptionRegistered": "Der Katalogeintrag für \"{{name}}\" wird dauerhaft gelöscht. Die PostgreSQL-Tabelle, aus der er registriert wurde, bleibt mit ihren Daten in der Datenbank erhalten. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "descriptionRegistered": "Der Katalogeintrag für \"{{name}}\" wird dauerhaft gelöscht. Die PostgreSQL-Tabelle, aus der er registriert wurde, bleibt mit ihren Daten in der Datenbank erhalten, und alle Personen mit Upload-Berechtigung können sie erneut registrieren. Löschen Sie die Tabelle selbst, wenn die Daten entfernt werden sollen. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "descriptionRegisteredMissing": "Der Katalogeintrag für \"{{name}}\" wird dauerhaft gelöscht. Bei der letzten Prüfung war die Quelltabelle nicht auffindbar, daher ist möglicherweise nichts mehr zu entfernen. Diese Aktion kann nicht rückgängig gemacht werden.",
     "confirmPrompt": "Geben Sie den Datensatznamen zur Bestätigung ein:",
     "deleting": "Wird gelöscht...",
     "deleteDataset": "Datensatz löschen",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -239,6 +239,7 @@
   "deleteDialog": {
     "title": "Delete Dataset",
     "description": "This will permanently delete dataset \"{{name}}\" including all spatial data. This action cannot be undone.",
+    "descriptionRegistered": "This will permanently delete the catalog entry for \"{{name}}\". The PostgreSQL table it was registered from stays in the database with its data intact. This action cannot be undone.",
     "confirmPrompt": "Type the dataset name to confirm:",
     "deleting": "Deleting...",
     "deleteDataset": "Delete Dataset",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -239,7 +239,7 @@
   "deleteDialog": {
     "title": "Delete Dataset",
     "description": "This will permanently delete dataset \"{{name}}\" including all spatial data. This action cannot be undone.",
-    "descriptionRegistered": "This will permanently delete the catalog entry for \"{{name}}\". The PostgreSQL table it was registered from stays in the database with its data intact, and anyone who can upload data can register it again. To remove the data, drop the table yourself. This action cannot be undone.",
+    "descriptionRegistered": "This will permanently delete the catalog entry for \"{{name}}\". GeoLens will not drop the PostgreSQL table it was registered from, so whatever it holds is left alone and anyone who can upload can register it again. To remove the data, drop the table yourself. This action cannot be undone.",
     "descriptionRegisteredMissing": "This will permanently delete the catalog entry for \"{{name}}\". GeoLens last saw its source table as missing, so there may be nothing left to remove. This action cannot be undone.",
     "confirmPrompt": "Type the dataset name to confirm:",
     "deleting": "Deleting...",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -239,7 +239,8 @@
   "deleteDialog": {
     "title": "Delete Dataset",
     "description": "This will permanently delete dataset \"{{name}}\" including all spatial data. This action cannot be undone.",
-    "descriptionRegistered": "This will permanently delete the catalog entry for \"{{name}}\". The PostgreSQL table it was registered from stays in the database with its data intact. This action cannot be undone.",
+    "descriptionRegistered": "This will permanently delete the catalog entry for \"{{name}}\". The PostgreSQL table it was registered from stays in the database with its data intact, and anyone who can upload data can register it again. To remove the data, drop the table yourself. This action cannot be undone.",
+    "descriptionRegisteredMissing": "This will permanently delete the catalog entry for \"{{name}}\". GeoLens last saw its source table as missing, so there may be nothing left to remove. This action cannot be undone.",
     "confirmPrompt": "Type the dataset name to confirm:",
     "deleting": "Deleting...",
     "deleteDataset": "Delete Dataset",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -288,7 +288,7 @@
   "deleteDialog": {
     "title": "Eliminar conjunto de datos",
     "description": "Se eliminará permanentemente el conjunto de datos \"{{name}}\" incluyendo todos los datos espaciales. Esta acción no se puede deshacer.",
-    "descriptionRegistered": "Se eliminará permanentemente la entrada del catálogo de \"{{name}}\". La tabla PostgreSQL desde la que se registró permanece en la base de datos con sus datos intactos, y cualquier persona que pueda subir datos puede volver a registrarla. Para eliminar los datos, borre la tabla usted mismo. Esta acción no se puede deshacer.",
+    "descriptionRegistered": "Se eliminará permanentemente la entrada del catálogo de \"{{name}}\". GeoLens no borrará la tabla PostgreSQL desde la que se registró, así que su contenido queda intacto y cualquier persona que pueda subir datos puede volver a registrarla. Para eliminar los datos, borre la tabla usted mismo. Esta acción no se puede deshacer.",
     "descriptionRegisteredMissing": "Se eliminará permanentemente la entrada del catálogo de \"{{name}}\". La última vez que GeoLens la consultó, su tabla de origen no existía, por lo que puede que no quede nada que eliminar. Esta acción no se puede deshacer.",
     "confirmPrompt": "Escriba el nombre del conjunto de datos para confirmar:",
     "deleting": "Eliminando...",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -288,7 +288,7 @@
   "deleteDialog": {
     "title": "Eliminar conjunto de datos",
     "description": "Se eliminará permanentemente el conjunto de datos \"{{name}}\" incluyendo todos los datos espaciales. Esta acción no se puede deshacer.",
-    "descriptionRegistered": "Se eliminará permanentemente la entrada del catálogo de \"{{name}}\". GeoLens no borrará la tabla PostgreSQL desde la que se registró, así que su contenido queda intacto y cualquier persona que pueda subir datos puede volver a registrarla. Para eliminar los datos, borre la tabla usted mismo. Esta acción no se puede deshacer.",
+    "descriptionRegistered": "Se eliminará permanentemente la entrada del catálogo de \"{{name}}\". GeoLens no borrará la tabla PostgreSQL desde la que se registró y la dejará tal como esté, y cualquier persona que pueda subir datos puede volver a registrarla. Para eliminar los datos, borre la tabla usted mismo. Esta acción no se puede deshacer.",
     "descriptionRegisteredMissing": "Se eliminará permanentemente la entrada del catálogo de \"{{name}}\". La última vez que GeoLens la consultó, su tabla de origen no existía, por lo que puede que no quede nada que eliminar. Esta acción no se puede deshacer.",
     "confirmPrompt": "Escriba el nombre del conjunto de datos para confirmar:",
     "deleting": "Eliminando...",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -288,6 +288,7 @@
   "deleteDialog": {
     "title": "Eliminar conjunto de datos",
     "description": "Se eliminará permanentemente el conjunto de datos \"{{name}}\" incluyendo todos los datos espaciales. Esta acción no se puede deshacer.",
+    "descriptionRegistered": "Se eliminará permanentemente la entrada del catálogo de \"{{name}}\". La tabla PostgreSQL desde la que se registró permanece en la base de datos con sus datos intactos. Esta acción no se puede deshacer.",
     "confirmPrompt": "Escriba el nombre del conjunto de datos para confirmar:",
     "deleting": "Eliminando...",
     "deleteDataset": "Eliminar conjunto de datos",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -288,7 +288,8 @@
   "deleteDialog": {
     "title": "Eliminar conjunto de datos",
     "description": "Se eliminará permanentemente el conjunto de datos \"{{name}}\" incluyendo todos los datos espaciales. Esta acción no se puede deshacer.",
-    "descriptionRegistered": "Se eliminará permanentemente la entrada del catálogo de \"{{name}}\". La tabla PostgreSQL desde la que se registró permanece en la base de datos con sus datos intactos. Esta acción no se puede deshacer.",
+    "descriptionRegistered": "Se eliminará permanentemente la entrada del catálogo de \"{{name}}\". La tabla PostgreSQL desde la que se registró permanece en la base de datos con sus datos intactos, y cualquier persona que pueda subir datos puede volver a registrarla. Para eliminar los datos, borre la tabla usted mismo. Esta acción no se puede deshacer.",
+    "descriptionRegisteredMissing": "Se eliminará permanentemente la entrada del catálogo de \"{{name}}\". La última vez que GeoLens la consultó, su tabla de origen no existía, por lo que puede que no quede nada que eliminar. Esta acción no se puede deshacer.",
     "confirmPrompt": "Escriba el nombre del conjunto de datos para confirmar:",
     "deleting": "Eliminando...",
     "deleteDataset": "Eliminar conjunto de datos",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -288,7 +288,7 @@
   "deleteDialog": {
     "title": "Supprimer le jeu de données",
     "description": "Cela supprimera définitivement le jeu de données \"{{name}}\" y compris toutes les données spatiales. Cette action est irréversible.",
-    "descriptionRegistered": "L'entrée du catalogue pour « {{name}} » sera définitivement supprimée. La table PostgreSQL à partir de laquelle il a été enregistré reste dans la base de données, avec ses données intactes, et toute personne autorisée à importer des données peut l'enregistrer à nouveau. Pour supprimer les données, supprimez la table vous-même. Cette action est irréversible.",
+    "descriptionRegistered": "L'entrée du catalogue pour « {{name}} » sera définitivement supprimée. GeoLens ne supprimera pas la table PostgreSQL à partir de laquelle il a été enregistré : son contenu reste intact et toute personne autorisée à importer des données peut l'enregistrer à nouveau. Pour supprimer les données, supprimez la table vous-même. Cette action est irréversible.",
     "descriptionRegisteredMissing": "L'entrée du catalogue pour « {{name}} » sera définitivement supprimée. Lors de la dernière vérification, GeoLens n'a pas trouvé sa table source : il ne reste peut-être rien à supprimer. Cette action est irréversible.",
     "confirmPrompt": "Saisissez le nom du jeu de données pour confirmer :",
     "deleting": "Suppression...",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -288,7 +288,8 @@
   "deleteDialog": {
     "title": "Supprimer le jeu de données",
     "description": "Cela supprimera définitivement le jeu de données \"{{name}}\" y compris toutes les données spatiales. Cette action est irréversible.",
-    "descriptionRegistered": "L'entrée du catalogue pour « {{name}} » sera définitivement supprimée. La table PostgreSQL à partir de laquelle il a été enregistré reste dans la base de données, avec ses données intactes. Cette action est irréversible.",
+    "descriptionRegistered": "L'entrée du catalogue pour « {{name}} » sera définitivement supprimée. La table PostgreSQL à partir de laquelle il a été enregistré reste dans la base de données, avec ses données intactes, et toute personne autorisée à importer des données peut l'enregistrer à nouveau. Pour supprimer les données, supprimez la table vous-même. Cette action est irréversible.",
+    "descriptionRegisteredMissing": "L'entrée du catalogue pour « {{name}} » sera définitivement supprimée. Lors de la dernière vérification, GeoLens n'a pas trouvé sa table source : il ne reste peut-être rien à supprimer. Cette action est irréversible.",
     "confirmPrompt": "Saisissez le nom du jeu de données pour confirmer :",
     "deleting": "Suppression...",
     "deleteDataset": "Supprimer le jeu de données",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -288,6 +288,7 @@
   "deleteDialog": {
     "title": "Supprimer le jeu de données",
     "description": "Cela supprimera définitivement le jeu de données \"{{name}}\" y compris toutes les données spatiales. Cette action est irréversible.",
+    "descriptionRegistered": "L'entrée du catalogue pour « {{name}} » sera définitivement supprimée. La table PostgreSQL à partir de laquelle il a été enregistré reste dans la base de données, avec ses données intactes. Cette action est irréversible.",
     "confirmPrompt": "Saisissez le nom du jeu de données pour confirmer :",
     "deleting": "Suppression...",
     "deleteDataset": "Supprimer le jeu de données",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -288,7 +288,7 @@
   "deleteDialog": {
     "title": "Supprimer le jeu de données",
     "description": "Cela supprimera définitivement le jeu de données \"{{name}}\" y compris toutes les données spatiales. Cette action est irréversible.",
-    "descriptionRegistered": "L'entrée du catalogue pour « {{name}} » sera définitivement supprimée. GeoLens ne supprimera pas la table PostgreSQL à partir de laquelle il a été enregistré : son contenu reste intact et toute personne autorisée à importer des données peut l'enregistrer à nouveau. Pour supprimer les données, supprimez la table vous-même. Cette action est irréversible.",
+    "descriptionRegistered": "L'entrée du catalogue pour « {{name}} » sera définitivement supprimée. GeoLens ne supprimera pas la table PostgreSQL à partir de laquelle il a été enregistré et n'y touchera pas, et toute personne autorisée à importer des données peut l'enregistrer à nouveau. Pour supprimer les données, supprimez la table vous-même. Cette action est irréversible.",
     "descriptionRegisteredMissing": "L'entrée du catalogue pour « {{name}} » sera définitivement supprimée. Lors de la dernière vérification, GeoLens n'a pas trouvé sa table source : il ne reste peut-être rien à supprimer. Cette action est irréversible.",
     "confirmPrompt": "Saisissez le nom du jeu de données pour confirmer :",
     "deleting": "Suppression...",


### PR DESCRIPTION
## What changed

Deleting a dataset that was registered from an existing PostGIS table now detaches instead of dropping. Registration copies no data, so the dataset row is a reference to a relation the operator built. `delete_dataset` dropped it unconditionally, which meant removing a catalog entry destroyed the original.

`geolens_owns_table` in `backend/app/platform/dataset_origin.py` is the single place that answers whether GeoLens created a dataset's table. Every origin but `postgis` did. `postgis` is the registered-in-place origin, where it did not. Raster and VRT rows are answered by record type before the origin rule is consulted, because registration only ever creates vector datasets, so a raster whose `source_format` were ever left NULL cannot read as registered-in-place.

One caller breaks the origin rule, and it is why this is more than an origin check. The analysis materialize path CTAS's its own output table and then registers it through the same `register_existing_table` an operator uses, producing an identical postgis origin with a null `source_format`. It now passes `managed=True`, which is stamped onto `origin_ref` at registration and is the only thing separating the two. The two register endpoints keep the default, `managed=False`.

An absent `managed` key reads as not managed, so every dataset registered before this change falls on the side that preserves the operator's table. That default leaks a table for analysis outputs registered before this ships. The other default would irreversibly destroy data GeoLens does not own, and that asymmetry decided it.

### Name retirement

The GH-1443 tombstone follows the **relation**, not the dataset's origin, because a name is freed only when nothing is left holding it. `delete_dataset` probes `pg_class` inside its own transaction and retires the name on every drop, plus on the detach of a table that had already vanished. It stays silent only for a detach that leaves a relation behind, which is the case that has to stay re-registerable: `register_existing_table` refuses a retired name by design, so tombstoning a surviving detached table would leave the operator permanently unable to re-adopt it.

The flag defaults to freed, so any path that does not lower it retires the name. The two mistakes are not symmetric: a missing tombstone is the GH-1443 disclosure, an extra one costs a rename.

### Delete dialog

The copy promised that all spatial data goes. It now has three cases, matching what the backend will actually do:

- GeoLens owns the table: unchanged warning that the data is destroyed.
- Registered: says GeoLens will not drop the PostgreSQL table it was registered from, that anyone who can upload can register it again, and that removing the data means dropping the table yourself.
- Registered with `source_health: 'missing'`: says GeoLens last saw the source table as missing, so there may be nothing left to remove.

Two properties of that wording are deliberate and cost several review rounds to get right. It states what **GeoLens does**, never what the table contains: `source_health` is a past observation, so a table dropped since its last probe still reads `healthy`, and a promise about the relation still existing would be wrong exactly when the backend's live `_relation_exists` check retires the name instead. And it is a contract on all four locale strings that no gate can check, since `test:i18n` verifies that keys exist, not what they say.

`deleteDetachesTable` mirrors `geolens_owns_table`, raster-family override included and in the same order. It also requires a readable `origin_ref` before promising anything, rather than reading an absent one as "not managed" — that field is redacted for non-owners, and the dataset response is cached under `['dataset', id]` with no identity in the key, so an owner can be handed a non-owner's redacted copy. Absent evidence falls back to the copy that warns the data is destroyed.

## Behavior impact

| Dataset | Before | After |
| --- | --- | --- |
| Registered, table survives | table dropped, name retired | table and rows untouched, name not retired, re-registration works |
| Registered, table already gone | name retired | name retired (unchanged) |
| Analysis output | dropped, name retired | unchanged (`managed=True`) |
| Uploaded / service / STAC / created / raster / VRT | dropped where applicable, name retired | unchanged |

Catalog-side deletion is unchanged in every case: the record, grants, tile-cache entries, and search and embedding rows all still go. Managed storage under `originals/{id}/` and `vectors/{id}/` is still reaped on a detach, since those are GeoLens artifacts keyed by dataset id, not the operator's table.

A detach leaves the table as *registration* left it, which is not the same as untouched. `register_existing_table` may add a `geom_4326` column and its GIST index, grant SELECT to the reader role, and linearize an existing `geom_4326` in place. None of that is undone, deliberately: each undo would be this path writing to a relation GeoLens does not own, and each is worse than the state it removes. Dropping the column rewrites the operator's table under a lock to delete a harmless one, revoking the grant removes a privilege that reaches nothing once the catalog row is gone, and the linearization is not reversible at all. Re-registering the table re-applies all three idempotently.

No schema change. No migration. No API surface change, so `backend/openapi.json` and the SDKs are untouched.

## Known residual, needs a decision

Three codex findings name work that is real and out of scope here. The first two converge on one missing capability and are documented at the call site rather than closed, because closing them needs a schema change this PR was scoped to avoid.

If the operator drops the relation **after** the delete transaction reads it, the name goes free with no tombstone, and a new ingest could draw it inside the metadata cache's 60-second window. Separately, a surviving detached table is listed by `/ingest/discover/` and can be registered by any user holding the editor `upload` permission.

Both want the same thing on `catalog.retired_table_names`: the relation's identity (`pg_class.oid`) and the previous owner's id. With those, registration could accept "the table I detached, re-adopted by its owner" and refuse "a new table wearing its name", while `generate_table_name` refused both. The owner's id in particular is unrecoverable after the fact, since the record row carrying `created_by` is deleted in the same transaction.

On the second finding specifically: the discovery exposure is the ambient property of a table sitting in the shared `data` schema, not something the detach introduces. The same relation was discoverable and registerable by the same users during the whole window before its owner registered it. Detach returns the table to the state the operator themselves put it in. What was cheap and worth doing was making the consequence explicit in the dialog rather than leaving it silent, which this PR does.

The third is older than this PR and belongs to the frontend cache: every identity-dependent dataset field is cached under an identity-independent key (`['dataset', id]`, 60s staleTime), while `use-auth.ts` clears only `['auth','me']` and `['auth','permissions']` on an identity change under BUG-021. Putting identity in the dataset key, or clearing `['dataset', *]` on login and logout, is the right fix and affects every consumer of a redaction-gated field. Not smuggled into a PR about dataset deletion; the dialog defends itself locally instead.

## Verification

```
# backend
cd backend && uv run ruff check .                  # clean
cd backend && uv run ruff format --check .         # clean
pytest tests/test_registered_delete_detach_1452.py -q          # 30 passed
pytest tests/test_layering.py -q                               # 47 passed
pytest <13 affected suites>                                    # 586 passed, 4 skipped
PYTHONPATH=. python scripts/dump_openapi.py --check             # no drift

# frontend
npm run lint                                       # clean
npm run typecheck                                  # clean
npm run test:i18n                                  # locale parity holds
npx vitest run src/components/dataset              # 329 passed
```

The new backend tests were confirmed non-vacuous by reverting each guard in turn and re-running: reverting the drop guard fails 4, reverting the retirement guard fails 2.

Two module LOC caps were raised with comments saying what the lines bought (`processing/ingest/service.py` 1199 to 1211, `processing/analysis/tasks.py` 1413 to 1420), and `datasets/domain/service_lifecycle.py` gained its first explicit cap, 350 to 415.

`_MockDataset` in `tests/test_raster_ingest.py` is the only hand-rolled Dataset double passed to `delete_dataset` (the two other delete-test files use `MagicMock`, which auto-supplies attributes). It gained `source_format` and `origin_ref`, defaulting to the ingested case those tests exercise.

Closes GH-1452

https://claude.ai/code/session_014tw9Frobcy3jR1ejkfjbCy
