### PR TITLE
sec(tiles): refuse cached authorization for a dataset row that no longer exists

### DIFF
--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1781,13 +1781,34 @@ async def _assert_dataset_still_registered(
     LRU, so a delete only evicts in the worker that served it. No process-local
     cache can answer for the others, so the check has to reach the database.
 
-    The cost is bounded by WHERE this runs. The caller is ``_acquire_and_serve_tile``,
-    which reaches this only after both tile caches have missed and before it takes
-    any capacity. A served-from-cache tile still costs zero round-trips, which is
-    the whole point of ``_dataset_cache`` (PERF-006 / PERF-002); a tile the pool
-    has to build pays one indexed primary-key lookup that is over, connection and
-    all, before the FAIR-01 permit is requested. The call site records why every
-    later position inverts an acquisition order against some other path.
+    WHERE this runs is the rest of the design, and four review rounds narrowed it
+    to one line in each endpoint: the first statement past the tile-byte-cache
+    short-circuit. Both bounds are tight.
+
+    No earlier, or the hot path pays for it. A tile answered from the byte cache
+    returns above this and still costs zero round-trips, which is the whole point
+    of ``_dataset_cache`` (PERF-006 / PERF-002).
+
+    No later, for two independent reasons. Everything below acts on the cached
+    authorization, starting with the COLD-02 seam, which would enqueue a restore
+    and hand back a 202 for a dataset the catalog no longer has. And a tile
+    request takes three bounded resources in sequence — this API-pool connection,
+    the FAIR-01 permit, then the tile-pool connection — so the check has to
+    complete and roll back before the first of them is requested. Every later
+    position inverts a pair against a metadata-cache MISS, which carries
+    ``_resolve_dataset_meta``'s connection into both waits: inside the tile
+    transaction it asks the API pool while holding a tile connection; after the
+    permit it holds a permit while asking the API pool. Both stall under ordinary
+    mixed load with no attacker involved.
+
+    Asking on the tile connection instead would need neither pool twice, but it
+    would need ``geolens_reader`` to hold SELECT on ``catalog.datasets``: a
+    runtime-role contract change for every deployment, and a widening of the one
+    role whose narrowness is why this path binds it at all.
+
+    ``test_both_tile_endpoints_ask_before_they_act`` pins the position, because a
+    third endpoint that resolved cached metadata and forgot this call would be a
+    silent regression.
 
     Pinning id AND table_name together is what makes it a liveness check rather
     than an existence check: a surviving row that has since been repointed at a
@@ -1976,8 +1997,6 @@ def _cluster_cache_table_key(
 async def _acquire_and_serve_tile(
     *,
     request: Request,
-    db: AsyncSession,
-    dataset_id: uuid.UUID,
     table_name: str,
     z: int,
     x: int,
@@ -2010,35 +2029,6 @@ async def _acquire_and_serve_tile(
     Callers keep their own cache-hit short-circuit and COLD-02 cold-rehydrate seam,
     which differ between the two paths.
     """
-    # fix(#1451): the catalog check, and the release that comes with it, run here
-    # — before any capacity is taken. Three resources are in play on this path and
-    # they are now acquired in one order by every request: the API-pool connection
-    # first, then the FAIR-01 permit, then the tile connection. Each is released
-    # before the next is requested, so no two paths can hold them in opposite
-    # orders (codex P1, rounds 1-3, which found one edge of that graph per round).
-    #
-    # `_assert_dataset_still_registered` ends by rolling back, which is what makes
-    # this position safe rather than merely early. The round-1 objection was
-    # retention, not placement: `db.execute` opens a transaction `get_db` would
-    # otherwise hold until the response is written, pinning an API connection
-    # through the 10s permit wait, the tile-pool wait, the PostGIS query and the
-    # gzip. Handing it back here also retires the PRE-EXISTING half of the same
-    # problem, since a metadata-cache miss already carried `_resolve_dataset_meta`'s
-    # connection into the permit wait, and an authenticated request carried the
-    # user lookup's.
-    #
-    # The two later positions both invert something. Inside the tile transaction
-    # it asks the API pool while holding a tile connection; after the permit it
-    # holds a permit while asking the API pool. Either one stalls against a
-    # metadata-cache miss taking the same pair the other way, under ordinary mixed
-    # load and with no attacker involved. Asking on the tile connection instead
-    # would need `geolens_reader` to hold SELECT on catalog.datasets: a
-    # runtime-role contract change for every deployment, and a widening of the one
-    # role whose narrowness is why this path binds it at all.
-    await _assert_dataset_still_registered(
-        db, dataset_id=dataset_id, table_name=table_name, tid=tid
-    )
-
     try:
         pool = get_tile_pool()
     except RuntimeError as exc:
@@ -2231,6 +2221,14 @@ async def cluster_tile_endpoint(
                 _serving_tile_headers(cache_scope, cache_ttl, _cluster_cache_control),
             )
 
+    # fix(#1451): first thing past the byte-cache short-circuit, because
+    # everything past it acts on the cached authorization — the cold seam below
+    # would enqueue a restore for a dataset the catalog no longer has. See the
+    # helper for why it cannot sit any later than this.
+    await _assert_dataset_still_registered(
+        db, dataset_id=meta.dataset_id, table_name=table_name, tid=_cluster_tid
+    )
+
     # COLD-02 (Phase 1214-04): cold-rehydrate seam — BEFORE cluster tile query.
     # Mirrors the tile_endpoint seam: uses cached meta.record_status (T-1214-18);
     # failure is broad-except-swallowed (T-1214-17).
@@ -2266,8 +2264,6 @@ async def cluster_tile_endpoint(
     # The same tenant concurrency budget governs vector and cluster DB reads.
     return await _acquire_and_serve_tile(
         request=request,
-        db=db,
-        dataset_id=meta.dataset_id,
         table_name=table_name,
         z=z,
         x=x,
@@ -2390,6 +2386,14 @@ async def tile_endpoint(
                 _serving_tile_headers(cache_scope, cache_ttl, _tile_cache_control),
             )
 
+    # fix(#1451): first thing past the byte-cache short-circuit, because
+    # everything past it acts on the cached authorization — the cold seam below
+    # would enqueue a restore for a dataset the catalog no longer has. See the
+    # helper for why it cannot sit any later than this.
+    await _assert_dataset_still_registered(
+        db, dataset_id=meta.dataset_id, table_name=table_name, tid=_tile_tid
+    )
+
     # COLD-02 (Phase 1214-04): cold-rehydrate seam — BEFORE tile query.
     # Uses the cached meta.record_status (no extra DB round-trip on the hot path,
     # T-1214-18). Returns a 202 Response for over-gate warming or None to continue.
@@ -2442,8 +2446,6 @@ async def tile_endpoint(
     # FAIR-01 per-tenant semaphore (cloud only) is threaded through tenant_sem.
     return await _acquire_and_serve_tile(
         request=request,
-        db=db,
-        dataset_id=meta.dataset_id,
         table_name=table_name,
         z=z,
         x=x,

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1782,12 +1782,12 @@ async def _assert_dataset_still_registered(
     cache can answer for the others, so the check has to reach the database.
 
     The cost is bounded by WHERE this runs. The caller is ``_acquire_and_serve_tile``,
-    which reaches this only after both tile caches have missed, after the FAIR-01
-    permit and the tile connection are already in hand, and with the relation read
-    as the very next statement. A served-from-cache tile still costs zero
-    round-trips, which is the whole point of ``_dataset_cache`` (PERF-006 /
-    PERF-002); a tile the pool has to build pays one indexed primary-key lookup
-    that ends before the PostGIS query begins.
+    which reaches this only after both tile caches have missed and after the
+    FAIR-01 permit is in hand, and which acquires its tile connection on the next
+    line. A served-from-cache tile still costs zero round-trips, which is the whole
+    point of ``_dataset_cache`` (PERF-006 / PERF-002); a tile the pool has to build
+    pays one indexed primary-key lookup that is over before the PostGIS query
+    begins. The call site records why no earlier or later position works.
 
     Pinning id AND table_name together is what makes it a liveness check rather
     than an existence check: a surviving row that has since been repointed at a
@@ -2042,22 +2042,37 @@ async def _acquire_and_serve_tile(
     # SET LOCAL ROLE + SET LOCAL search_path survive for the tile query
     # (PgBouncer transaction-mode: SET LOCAL is valid within one txn; T-1209-10).
     try:
+        # fix(#1451): the catalog check sits between the FAIR-01 permit and the
+        # tile connection, and it returns its own connection before the next
+        # line asks for one. That position is pinned from three sides.
+        #
+        # Ahead of the permit (codex P1, round 1) it held an API-pool connection
+        # through the whole 10s wait, so a burst of uncached coordinates could
+        # starve CRUD of the connections the separate tile pool exists to
+        # protect.
+        #
+        # Inside the tile transaction (codex P1, round 2) it asked the API pool
+        # while holding a tile connection, the reverse of the order a metadata
+        # cache MISS takes, and two bounded pools acquired in opposite orders
+        # stall each other under a mixed load with no attacker involved.
+        #
+        # On the tile connection itself, which would need neither pool twice,
+        # geolens_reader would need SELECT on catalog.datasets — a runtime-role
+        # contract change for every deployment, and a widening of the role whose
+        # narrowness is what makes SET ROLE worth doing on this path.
+        #
+        # Releasing before the acquire also retires the pre-existing half of that
+        # inversion: on a metadata-cache miss the session was already holding an
+        # API connection into the tile-pool wait, and now hands it back first.
+        await _assert_dataset_still_registered(
+            db, dataset_id=dataset_id, table_name=table_name, tid=tid
+        )
+
         async with pool.acquire() as tile_conn:
             async with tile_conn.transaction():
                 # Bind per-tenant role + search_path BEFORE the tile query.
                 # No-op in single_tenant or when tid is None.
                 await set_tenant_role_for_tile_request(tile_conn, tid)
-                # fix(#1451 codex P1/P2): the catalog check sits here, between
-                # capacity acquisition and the relation read, and nowhere
-                # earlier. Ahead of the semaphore it pinned an API-pool
-                # connection for the whole 10s wait plus the query, so a burst
-                # of uncached coordinates could starve CRUD of the connections
-                # the dedicated tile pool exists to protect; and every await
-                # between the check and the read is a window in which the
-                # delete-plus-recreate this guards against could still land.
-                await _assert_dataset_still_registered(
-                    db, dataset_id=dataset_id, table_name=table_name, tid=tid
-                )
                 tile_data = await query_callable(pool, tile_conn)
     except HTTPException:
         # A refusal is an answer, not a tile-service failure. Without this the

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1756,6 +1756,82 @@ async def _resolve_dataset_meta(table_name: str, db: AsyncSession) -> _DatasetMe
     return meta
 
 
+async def _assert_dataset_still_registered(
+    db: AsyncSession,
+    *,
+    dataset_id: uuid.UUID,
+    table_name: str,
+    tid: Any,
+) -> None:
+    """Refuse a cached authorization the catalog no longer backs (#1451).
+
+    ``_resolve_dataset_meta`` answers a cache hit without touching the database,
+    so for up to ``_DATASET_CACHE_TTL`` seconds a worker keeps authorizing
+    against a dataset row that may already be deleted. GH-1443 stopped the
+    product from redrawing a freed table name, but nothing stops someone holding
+    a database session from running ``CREATE TABLE data.roads`` directly, and
+    ``ALTER DEFAULT PRIVILEGES IN SCHEMA data GRANT SELECT ON TABLES TO
+    geolens_reader`` (scripts/lib/configure-runtime-db-role.sh) makes that
+    relation readable by the role the tile path binds without
+    ``grant_reader_access`` ever running. The deleted dataset's cached ``public``
+    visibility would then carry a stranger's rows to anonymous callers.
+
+    The ``_evict_dataset_meta`` listener (#1441) cannot close this alone: it is
+    process-local, and with REDIS_URL unset every uvicorn worker holds a private
+    LRU, so a delete only evicts in the worker that served it. No process-local
+    cache can answer for the others, so the check has to reach the database.
+
+    The cost is bounded by WHERE this runs: the caller is the pool path, reached
+    only after both tile caches have missed and immediately before the relation
+    is read. A served-from-cache tile still costs zero round-trips, which is the
+    whole point of ``_dataset_cache`` (PERF-006 / PERF-002).
+
+    Pinning id AND table_name together is what makes it a liveness check rather
+    than an existence check: a surviving row that has since been repointed at a
+    different relation must not authorize a read of the old name either.
+
+    It runs unconditionally, including right after a ``_dataset_cache`` MISS has
+    just read the same row. Skipping it there would mean threading "was this a
+    cache hit" out of the resolver and into a security check, which buys one PK
+    lookup on the path that already pays a joinedload, in exchange for a caller
+    that can silently skip the check by getting the flag wrong.
+
+    Scope is every caller that reads a ``data``-schema relation off cached
+    authorization, which is the vector and cluster endpoints — one call site,
+    since both reach the relation through ``_acquire_and_serve_tile``. The raster
+    proxy caches authorization the same way (``_raster_meta_cache``) and is
+    deliberately NOT covered: it is addressed by dataset id rather than by table
+    name, and it resolves to an object-storage asset, so there is no relation for
+    an out-of-band ``CREATE TABLE`` to substitute. Its bounded staleness is the
+    tradeoff written down at ``_RASTER_META_CACHE_TTL``, not this bug.
+    """
+    from app.modules.catalog.datasets.domain.models import Dataset as DatasetORM
+
+    stmt = select(DatasetORM.id).where(
+        DatasetORM.id == dataset_id,
+        DatasetORM.table_name == table_name,
+    )
+    if is_multi_tenant() and tid is not None:
+        # Mirrors the _resolve_dataset_meta filter so the probe cannot be
+        # satisfied by another tenant's row carrying the same table_name.
+        stmt = stmt.where(DatasetORM.tenant_id == tid)
+
+    if (await db.execute(stmt)).scalar_one_or_none() is not None:
+        return
+
+    # Drop the entry that got us here so the next request re-resolves and 404s
+    # in _resolve_dataset_meta, rather than re-paying this probe for the TTL.
+    _evict_dataset_meta(table_name)
+    logger.warning(
+        "Tile refused: cached dataset metadata outlived its catalog row",
+        table_name=table_name,
+        dataset_id=str(dataset_id),
+    )
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
+    )
+
+
 async def _authorize_vector_tile_request(
     request: Request,
     meta: _DatasetMeta,
@@ -1886,6 +1962,8 @@ def _cluster_cache_table_key(
 async def _acquire_and_serve_tile(
     *,
     request: Request,
+    db: AsyncSession,
+    dataset_id: uuid.UUID,
     table_name: str,
     z: int,
     x: int,
@@ -1918,6 +1996,21 @@ async def _acquire_and_serve_tile(
     Callers keep their own cache-hit short-circuit and COLD-02 cold-rehydrate seam,
     which differ between the two paths.
     """
+    # fix(#1451): every read of a `data`-schema relation off cached authorization
+    # funnels through here, so this is the one place the catalog has to agree
+    # before the relation is queried. Both tile caches have already missed by the
+    # time control reaches this line — a cache hit returns in the caller and pays
+    # nothing, which is the round-trip `_dataset_cache` exists to avoid.
+    #
+    # Ordered ahead of the FAIR-01 semaphore rather than behind it: a dead dataset
+    # then costs no permit and no pool slot, and the refusal needs no release path
+    # of its own. The cost of that choice is one indexed lookup on a request the
+    # limiter is about to reject — which is not a new class, since a metadata
+    # cache miss and an embed-token check both already query before this point.
+    await _assert_dataset_still_registered(
+        db, dataset_id=dataset_id, table_name=table_name, tid=tid
+    )
+
     try:
         pool = get_tile_pool()
     except RuntimeError as exc:
@@ -2145,6 +2238,8 @@ async def cluster_tile_endpoint(
     # The same tenant concurrency budget governs vector and cluster DB reads.
     return await _acquire_and_serve_tile(
         request=request,
+        db=db,
+        dataset_id=meta.dataset_id,
         table_name=table_name,
         z=z,
         x=x,
@@ -2319,6 +2414,8 @@ async def tile_endpoint(
     # FAIR-01 per-tenant semaphore (cloud only) is threaded through tenant_sem.
     return await _acquire_and_serve_tile(
         request=request,
+        db=db,
+        dataset_id=meta.dataset_id,
         table_name=table_name,
         z=z,
         x=x,

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1781,10 +1781,13 @@ async def _assert_dataset_still_registered(
     LRU, so a delete only evicts in the worker that served it. No process-local
     cache can answer for the others, so the check has to reach the database.
 
-    The cost is bounded by WHERE this runs: the caller is the pool path, reached
-    only after both tile caches have missed and immediately before the relation
-    is read. A served-from-cache tile still costs zero round-trips, which is the
-    whole point of ``_dataset_cache`` (PERF-006 / PERF-002).
+    The cost is bounded by WHERE this runs. The caller is ``_acquire_and_serve_tile``,
+    which reaches this only after both tile caches have missed, after the FAIR-01
+    permit and the tile connection are already in hand, and with the relation read
+    as the very next statement. A served-from-cache tile still costs zero
+    round-trips, which is the whole point of ``_dataset_cache`` (PERF-006 /
+    PERF-002); a tile the pool has to build pays one indexed primary-key lookup
+    that ends before the PostGIS query begins.
 
     Pinning id AND table_name together is what makes it a liveness check rather
     than an existence check: a surviving row that has since been repointed at a
@@ -1816,7 +1819,18 @@ async def _assert_dataset_still_registered(
         # satisfied by another tenant's row carrying the same table_name.
         stmt = stmt.where(DatasetORM.tenant_id == tid)
 
-    if (await db.execute(stmt)).scalar_one_or_none() is not None:
+    registered = (await db.execute(stmt)).scalar_one_or_none()
+
+    # fix(#1451 codex P1): hand the API-pool connection back before returning.
+    # `db.execute` opens a transaction that `get_db` would otherwise hold open
+    # until the response is written, so without this every tile the pool has to
+    # build would occupy one of the API's connections for the length of its
+    # PostGIS query and gzip. The probe is read-only, so the rollback discards
+    # nothing; it is here rather than at the call site because the caller cannot
+    # release what it did not know was taken.
+    await db.rollback()
+
+    if registered is not None:
         return
 
     # Drop the entry that got us here so the next request re-resolves and 404s
@@ -1996,21 +2010,6 @@ async def _acquire_and_serve_tile(
     Callers keep their own cache-hit short-circuit and COLD-02 cold-rehydrate seam,
     which differ between the two paths.
     """
-    # fix(#1451): every read of a `data`-schema relation off cached authorization
-    # funnels through here, so this is the one place the catalog has to agree
-    # before the relation is queried. Both tile caches have already missed by the
-    # time control reaches this line — a cache hit returns in the caller and pays
-    # nothing, which is the round-trip `_dataset_cache` exists to avoid.
-    #
-    # Ordered ahead of the FAIR-01 semaphore rather than behind it: a dead dataset
-    # then costs no permit and no pool slot, and the refusal needs no release path
-    # of its own. The cost of that choice is one indexed lookup on a request the
-    # limiter is about to reject — which is not a new class, since a metadata
-    # cache miss and an embed-token check both already query before this point.
-    await _assert_dataset_still_registered(
-        db, dataset_id=dataset_id, table_name=table_name, tid=tid
-    )
-
     try:
         pool = get_tile_pool()
     except RuntimeError as exc:
@@ -2048,7 +2047,22 @@ async def _acquire_and_serve_tile(
                 # Bind per-tenant role + search_path BEFORE the tile query.
                 # No-op in single_tenant or when tid is None.
                 await set_tenant_role_for_tile_request(tile_conn, tid)
+                # fix(#1451 codex P1/P2): the catalog check sits here, between
+                # capacity acquisition and the relation read, and nowhere
+                # earlier. Ahead of the semaphore it pinned an API-pool
+                # connection for the whole 10s wait plus the query, so a burst
+                # of uncached coordinates could starve CRUD of the connections
+                # the dedicated tile pool exists to protect; and every await
+                # between the check and the read is a window in which the
+                # delete-plus-recreate this guards against could still land.
+                await _assert_dataset_still_registered(
+                    db, dataset_id=dataset_id, table_name=table_name, tid=tid
+                )
                 tile_data = await query_callable(pool, tile_conn)
+    except HTTPException:
+        # A refusal is an answer, not a tile-service failure. Without this the
+        # broad handler below would relabel the 404 as a 503.
+        raise
     except asyncio.TimeoutError:
         logger.warning(
             "Tile pool acquire timeout",

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1782,12 +1782,12 @@ async def _assert_dataset_still_registered(
     cache can answer for the others, so the check has to reach the database.
 
     The cost is bounded by WHERE this runs. The caller is ``_acquire_and_serve_tile``,
-    which reaches this only after both tile caches have missed and after the
-    FAIR-01 permit is in hand, and which acquires its tile connection on the next
-    line. A served-from-cache tile still costs zero round-trips, which is the whole
-    point of ``_dataset_cache`` (PERF-006 / PERF-002); a tile the pool has to build
-    pays one indexed primary-key lookup that is over before the PostGIS query
-    begins. The call site records why no earlier or later position works.
+    which reaches this only after both tile caches have missed and before it takes
+    any capacity. A served-from-cache tile still costs zero round-trips, which is
+    the whole point of ``_dataset_cache`` (PERF-006 / PERF-002); a tile the pool
+    has to build pays one indexed primary-key lookup that is over, connection and
+    all, before the FAIR-01 permit is requested. The call site records why every
+    later position inverts an acquisition order against some other path.
 
     Pinning id AND table_name together is what makes it a liveness check rather
     than an existence check: a surviving row that has since been repointed at a
@@ -2010,6 +2010,35 @@ async def _acquire_and_serve_tile(
     Callers keep their own cache-hit short-circuit and COLD-02 cold-rehydrate seam,
     which differ between the two paths.
     """
+    # fix(#1451): the catalog check, and the release that comes with it, run here
+    # — before any capacity is taken. Three resources are in play on this path and
+    # they are now acquired in one order by every request: the API-pool connection
+    # first, then the FAIR-01 permit, then the tile connection. Each is released
+    # before the next is requested, so no two paths can hold them in opposite
+    # orders (codex P1, rounds 1-3, which found one edge of that graph per round).
+    #
+    # `_assert_dataset_still_registered` ends by rolling back, which is what makes
+    # this position safe rather than merely early. The round-1 objection was
+    # retention, not placement: `db.execute` opens a transaction `get_db` would
+    # otherwise hold until the response is written, pinning an API connection
+    # through the 10s permit wait, the tile-pool wait, the PostGIS query and the
+    # gzip. Handing it back here also retires the PRE-EXISTING half of the same
+    # problem, since a metadata-cache miss already carried `_resolve_dataset_meta`'s
+    # connection into the permit wait, and an authenticated request carried the
+    # user lookup's.
+    #
+    # The two later positions both invert something. Inside the tile transaction
+    # it asks the API pool while holding a tile connection; after the permit it
+    # holds a permit while asking the API pool. Either one stalls against a
+    # metadata-cache miss taking the same pair the other way, under ordinary mixed
+    # load and with no attacker involved. Asking on the tile connection instead
+    # would need `geolens_reader` to hold SELECT on catalog.datasets: a
+    # runtime-role contract change for every deployment, and a widening of the one
+    # role whose narrowness is why this path binds it at all.
+    await _assert_dataset_still_registered(
+        db, dataset_id=dataset_id, table_name=table_name, tid=tid
+    )
+
     try:
         pool = get_tile_pool()
     except RuntimeError as exc:
@@ -2042,42 +2071,12 @@ async def _acquire_and_serve_tile(
     # SET LOCAL ROLE + SET LOCAL search_path survive for the tile query
     # (PgBouncer transaction-mode: SET LOCAL is valid within one txn; T-1209-10).
     try:
-        # fix(#1451): the catalog check sits between the FAIR-01 permit and the
-        # tile connection, and it returns its own connection before the next
-        # line asks for one. That position is pinned from three sides.
-        #
-        # Ahead of the permit (codex P1, round 1) it held an API-pool connection
-        # through the whole 10s wait, so a burst of uncached coordinates could
-        # starve CRUD of the connections the separate tile pool exists to
-        # protect.
-        #
-        # Inside the tile transaction (codex P1, round 2) it asked the API pool
-        # while holding a tile connection, the reverse of the order a metadata
-        # cache MISS takes, and two bounded pools acquired in opposite orders
-        # stall each other under a mixed load with no attacker involved.
-        #
-        # On the tile connection itself, which would need neither pool twice,
-        # geolens_reader would need SELECT on catalog.datasets — a runtime-role
-        # contract change for every deployment, and a widening of the role whose
-        # narrowness is what makes SET ROLE worth doing on this path.
-        #
-        # Releasing before the acquire also retires the pre-existing half of that
-        # inversion: on a metadata-cache miss the session was already holding an
-        # API connection into the tile-pool wait, and now hands it back first.
-        await _assert_dataset_still_registered(
-            db, dataset_id=dataset_id, table_name=table_name, tid=tid
-        )
-
         async with pool.acquire() as tile_conn:
             async with tile_conn.transaction():
                 # Bind per-tenant role + search_path BEFORE the tile query.
                 # No-op in single_tenant or when tid is None.
                 await set_tenant_role_for_tile_request(tile_conn, tid)
                 tile_data = await query_callable(pool, tile_conn)
-    except HTTPException:
-        # A refusal is an answer, not a tile-service failure. Without this the
-        # broad handler below would relabel the 404 as a 503.
-        raise
     except asyncio.TimeoutError:
         logger.warning(
             "Tile pool acquire timeout",

--- a/backend/tests/test_data_serving_extension.py
+++ b/backend/tests/test_data_serving_extension.py
@@ -6,7 +6,7 @@ import gzip
 import json
 import uuid
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -21,6 +21,21 @@ def _clean_registry():
     _reset_registry()
     yield
     _reset_registry()
+
+
+def _session_answering_liveness_probe() -> AsyncMock:
+    """A session double whose only job is the #1451 catalog liveness probe.
+
+    The DB-miss tile path re-checks that the cached authorization still has a
+    catalog row behind it before reading the relation. These tests are about the
+    hosted serving contract for datasets that ARE registered, so the double
+    answers with a row rather than the probe being patched out.
+    """
+    db = AsyncMock()
+    db.execute.return_value = MagicMock(
+        scalar_one_or_none=MagicMock(return_value=uuid.uuid4())
+    )
+    return db
 
 
 @pytest.mark.asyncio
@@ -218,6 +233,11 @@ async def test_rejected_tile_limiter_never_queries_or_releases(
     with pytest.raises(HTTPException) as exc_info:
         await tile_router._acquire_and_serve_tile(
             request=request,
+            # fix(#1451): the liveness probe runs ahead of the limiter so a dead
+            # dataset takes no permit. Answering it with a row keeps this test
+            # about the rejection path it is named for.
+            db=_session_answering_liveness_probe(),
+            dataset_id=uuid.uuid4(),
             table_name="roads",
             z=0,
             x=0,
@@ -305,7 +325,10 @@ async def test_hosted_tile_endpoints_share_cache_policy_and_limit_only_db_misses
 
     app = FastAPI()
     app.include_router(tile_router.router)
-    app.dependency_overrides[get_db] = lambda: None
+    # fix(#1451): the DB-miss path now re-checks the catalog before reading the
+    # relation, so `None` no longer stands in for a session the endpoint never
+    # touched.
+    app.dependency_overrides[get_db] = lambda: _session_answering_liveness_probe()
     app.dependency_overrides[get_optional_user] = lambda: None
     transport = ASGITransport(app=app)
     path = (

--- a/backend/tests/test_data_serving_extension.py
+++ b/backend/tests/test_data_serving_extension.py
@@ -216,11 +216,6 @@ async def test_rejected_tile_limiter_never_queries_or_releases(
     limiter = _RejectingLimiter()
     pool = _FakeTilePool()
     query = AsyncMock(return_value=b"unreachable")
-    # fix(#1451): the DB-miss path asks the catalog before requesting a permit,
-    # so a request the limiter is about to reject does pay one indexed lookup.
-    # What it must NOT do is still be holding that connection when it waits, and
-    # a rejected request must not take a permit it never releases.
-    catalog_session = _session_answering_liveness_probe()
     monkeypatch.setattr(tile_router, "get_tile_pool", lambda: pool)
 
     request = Request(
@@ -238,8 +233,6 @@ async def test_rejected_tile_limiter_never_queries_or_releases(
     with pytest.raises(HTTPException) as exc_info:
         await tile_router._acquire_and_serve_tile(
             request=request,
-            db=catalog_session,
-            dataset_id=uuid.uuid4(),
             table_name="roads",
             z=0,
             x=0,
@@ -259,7 +252,6 @@ async def test_rejected_tile_limiter_never_queries_or_releases(
     assert limiter.released == 0
     assert pool.acquire_count == 0
     query.assert_not_awaited()
-    catalog_session.rollback.assert_awaited()
 
 
 @pytest.mark.asyncio
@@ -328,9 +320,8 @@ async def test_hosted_tile_endpoints_share_cache_policy_and_limit_only_db_misses
 
     app = FastAPI()
     app.include_router(tile_router.router)
-    # fix(#1451): the DB-miss path now re-checks the catalog before reading the
-    # relation, so `None` no longer stands in for a session the endpoint never
-    # touched.
+    # fix(#1451): the endpoints re-check the catalog before acting on cached
+    # metadata, so `None` no longer stands in for a session they never touched.
     app.dependency_overrides[get_db] = lambda: _session_answering_liveness_probe()
     app.dependency_overrides[get_optional_user] = lambda: None
     transport = ASGITransport(app=app)

--- a/backend/tests/test_data_serving_extension.py
+++ b/backend/tests/test_data_serving_extension.py
@@ -216,6 +216,11 @@ async def test_rejected_tile_limiter_never_queries_or_releases(
     limiter = _RejectingLimiter()
     pool = _FakeTilePool()
     query = AsyncMock(return_value=b"unreachable")
+    # fix(#1451): the catalog liveness probe is required by the DB-miss path now.
+    # A rejected request must not reach it, which is why the probe sits after
+    # capacity acquisition: ahead of the limiter it would have checked out an
+    # API-pool connection for every request the limiter was about to turn away.
+    catalog_session = _session_answering_liveness_probe()
     monkeypatch.setattr(tile_router, "get_tile_pool", lambda: pool)
 
     request = Request(
@@ -233,10 +238,7 @@ async def test_rejected_tile_limiter_never_queries_or_releases(
     with pytest.raises(HTTPException) as exc_info:
         await tile_router._acquire_and_serve_tile(
             request=request,
-            # fix(#1451): the liveness probe runs ahead of the limiter so a dead
-            # dataset takes no permit. Answering it with a row keeps this test
-            # about the rejection path it is named for.
-            db=_session_answering_liveness_probe(),
+            db=catalog_session,
             dataset_id=uuid.uuid4(),
             table_name="roads",
             z=0,
@@ -257,6 +259,7 @@ async def test_rejected_tile_limiter_never_queries_or_releases(
     assert limiter.released == 0
     assert pool.acquire_count == 0
     query.assert_not_awaited()
+    catalog_session.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_data_serving_extension.py
+++ b/backend/tests/test_data_serving_extension.py
@@ -216,10 +216,10 @@ async def test_rejected_tile_limiter_never_queries_or_releases(
     limiter = _RejectingLimiter()
     pool = _FakeTilePool()
     query = AsyncMock(return_value=b"unreachable")
-    # fix(#1451): the catalog liveness probe is required by the DB-miss path now.
-    # A rejected request must not reach it, which is why the probe sits after
-    # capacity acquisition: ahead of the limiter it would have checked out an
-    # API-pool connection for every request the limiter was about to turn away.
+    # fix(#1451): the DB-miss path asks the catalog before requesting a permit,
+    # so a request the limiter is about to reject does pay one indexed lookup.
+    # What it must NOT do is still be holding that connection when it waits, and
+    # a rejected request must not take a permit it never releases.
     catalog_session = _session_answering_liveness_probe()
     monkeypatch.setattr(tile_router, "get_tile_pool", lambda: pool)
 
@@ -259,7 +259,7 @@ async def test_rejected_tile_limiter_never_queries_or_releases(
     assert limiter.released == 0
     assert pool.acquire_count == 0
     query.assert_not_awaited()
-    catalog_session.execute.assert_not_awaited()
+    catalog_session.rollback.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2028,7 +2028,7 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     empty-tile Cache-Control (#430 V-03). NOTE: `_check_cold_rehydrate` is pinned to
 #     this module by the overlay's 1214-05 static AST proof, so the tile_seams.py split
 #     must update the overlay in lockstep.
-#   tiles/router.py 2341 -> 2466. fix(#1451): +125 for `_assert_dataset_still_registered`
+#   tiles/router.py 2341 -> 2468. fix(#1451): +127 for `_assert_dataset_still_registered`
 #     and its single call site in `_acquire_and_serve_tile`. GH-1443 closed the
 #     half a caller could reach; direct DDL on the `data` schema can still put a
 #     relation under a deleted dataset's name, and the schema-wide default
@@ -2039,14 +2039,15 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     exists to avoid. Most of the lines are the docstring recording why the check
 #     sits on the pool path and not in _resolve_dataset_meta, since that placement
 #     is the whole difference between this and the option #1451 ruled out. The
-#     codex rounds added the placement itself, which took three and is now the bulk
-#     of the lines. A tile request takes an API-pool connection, a FAIR-01 permit
-#     and a tile-pool connection; each round found one more pair being taken in
-#     opposite orders by two paths, which stalls both under ordinary mixed load.
-#     The probe runs before all three and rolls back before the first is requested,
-#     which also retires the pre-existing half — a metadata-cache miss used to
-#     carry its connection into the permit wait. The rejected positions are written
-#     down at the call site so the next reader does not re-derive them.
+#     codex rounds added the placement itself, which took four and is now the bulk
+#     of the lines. The check sits in each endpoint on the first line past the
+#     byte-cache short-circuit: earlier and the hot path pays for it, later and it
+#     is below the COLD-02 seam (which would wake storage for a deleted dataset)
+#     and below the three bounded resources a tile request takes in order — an
+#     API-pool connection, a FAIR-01 permit, a tile-pool connection — where every
+#     position inverts a pair against a metadata-cache miss and stalls both paths.
+#     Every rejected position is recorded in the docstring, since re-deriving them
+#     is what the four rounds were.
 #   tiles/router.py 2329 -> 2341. fix(#1444): +12 of comment, no code. Both
 #     docstrings that GH-1429 left stating "a freed table name is immediately
 #     redrawable" as a live precondition now say GH-1443 removed it, and each
@@ -3096,7 +3097,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # writes and a predictable future `v` can no longer park a pre-swap
     # snapshot on the key the swap is about to make legitimate.
     # Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2466,
+    "backend/app/processing/tiles/router.py": 2468,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2028,6 +2028,17 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     empty-tile Cache-Control (#430 V-03). NOTE: `_check_cold_rehydrate` is pinned to
 #     this module by the overlay's 1214-05 static AST proof, so the tile_seams.py split
 #     must update the overlay in lockstep.
+#   tiles/router.py 2341 -> 2438. fix(#1451): +97 for `_assert_dataset_still_registered`
+#     and its single call site in `_acquire_and_serve_tile`. GH-1443 closed the
+#     half a caller could reach; direct DDL on the `data` schema can still put a
+#     relation under a deleted dataset's name, and the schema-wide default
+#     privilege makes it readable by the tile role with no grant of its own. The
+#     cached authorization is what would carry it, and the #1441 eviction is
+#     process-local, so the catalog gets asked once per tile the pool actually has
+#     to build — never on a cache hit, which is the round-trip _dataset_cache
+#     exists to avoid. Most of the lines are the docstring recording why the check
+#     sits on the pool path and not in _resolve_dataset_meta, since that placement
+#     is the whole difference between this and the option #1451 ruled out.
 #   tiles/router.py 2329 -> 2341. fix(#1444): +12 of comment, no code. Both
 #     docstrings that GH-1429 left stating "a freed table name is immediately
 #     redrawable" as a live precondition now say GH-1443 removed it, and each
@@ -3077,7 +3088,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # writes and a predictable future `v` can no longer park a pre-swap
     # snapshot on the key the swap is about to make legitimate.
     # Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2341,
+    "backend/app/processing/tiles/router.py": 2438,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2028,7 +2028,7 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     empty-tile Cache-Control (#430 V-03). NOTE: `_check_cold_rehydrate` is pinned to
 #     this module by the overlay's 1214-05 static AST proof, so the tile_seams.py split
 #     must update the overlay in lockstep.
-#   tiles/router.py 2341 -> 2452. fix(#1451): +111 for `_assert_dataset_still_registered`
+#   tiles/router.py 2341 -> 2467. fix(#1451): +126 for `_assert_dataset_still_registered`
 #     and its single call site in `_acquire_and_serve_tile`. GH-1443 closed the
 #     half a caller could reach; direct DDL on the `data` schema can still put a
 #     relation under a deleted dataset's name, and the schema-wide default
@@ -2039,10 +2039,13 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     exists to avoid. Most of the lines are the docstring recording why the check
 #     sits on the pool path and not in _resolve_dataset_meta, since that placement
 #     is the whole difference between this and the option #1451 ruled out. The
-#     codex round added the placement itself: the probe moved inside the tile
-#     transaction, after the FAIR-01 permit and the pool connection, so it neither
-#     pins an API-pool connection across the 10s capacity wait nor leaves an await
-#     between the check and the read for a delete-plus-recreate to land in. The
+#     codex rounds added the placement itself, which took two tries and is now the
+#     bulk of the lines. The probe sits after the FAIR-01 permit and before the
+#     tile connection, releasing its own API connection in between: ahead of the
+#     permit it pinned an API connection across a 10s wait, and inside the tile
+#     transaction it asked the API pool while holding a tile connection, the
+#     reverse of the order a metadata-cache miss takes. Both neighbours are written
+#     down at the call site so the next reader does not re-derive them. The
 #     HTTPException re-raise beside it keeps a refusal a 404 instead of letting the
 #     broad handler relabel it 503.
 #   tiles/router.py 2329 -> 2341. fix(#1444): +12 of comment, no code. Both
@@ -3094,7 +3097,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # writes and a predictable future `v` can no longer park a pre-swap
     # snapshot on the key the swap is about to make legitimate.
     # Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2452,
+    "backend/app/processing/tiles/router.py": 2467,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2028,7 +2028,7 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     empty-tile Cache-Control (#430 V-03). NOTE: `_check_cold_rehydrate` is pinned to
 #     this module by the overlay's 1214-05 static AST proof, so the tile_seams.py split
 #     must update the overlay in lockstep.
-#   tiles/router.py 2341 -> 2438. fix(#1451): +97 for `_assert_dataset_still_registered`
+#   tiles/router.py 2341 -> 2452. fix(#1451): +111 for `_assert_dataset_still_registered`
 #     and its single call site in `_acquire_and_serve_tile`. GH-1443 closed the
 #     half a caller could reach; direct DDL on the `data` schema can still put a
 #     relation under a deleted dataset's name, and the schema-wide default
@@ -2038,7 +2038,13 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     to build — never on a cache hit, which is the round-trip _dataset_cache
 #     exists to avoid. Most of the lines are the docstring recording why the check
 #     sits on the pool path and not in _resolve_dataset_meta, since that placement
-#     is the whole difference between this and the option #1451 ruled out.
+#     is the whole difference between this and the option #1451 ruled out. The
+#     codex round added the placement itself: the probe moved inside the tile
+#     transaction, after the FAIR-01 permit and the pool connection, so it neither
+#     pins an API-pool connection across the 10s capacity wait nor leaves an await
+#     between the check and the read for a delete-plus-recreate to land in. The
+#     HTTPException re-raise beside it keeps a refusal a 404 instead of letting the
+#     broad handler relabel it 503.
 #   tiles/router.py 2329 -> 2341. fix(#1444): +12 of comment, no code. Both
 #     docstrings that GH-1429 left stating "a freed table name is immediately
 #     redrawable" as a live precondition now say GH-1443 removed it, and each
@@ -3088,7 +3094,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # writes and a predictable future `v` can no longer park a pre-swap
     # snapshot on the key the swap is about to make legitimate.
     # Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2438,
+    "backend/app/processing/tiles/router.py": 2452,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2028,7 +2028,7 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     empty-tile Cache-Control (#430 V-03). NOTE: `_check_cold_rehydrate` is pinned to
 #     this module by the overlay's 1214-05 static AST proof, so the tile_seams.py split
 #     must update the overlay in lockstep.
-#   tiles/router.py 2341 -> 2467. fix(#1451): +126 for `_assert_dataset_still_registered`
+#   tiles/router.py 2341 -> 2466. fix(#1451): +125 for `_assert_dataset_still_registered`
 #     and its single call site in `_acquire_and_serve_tile`. GH-1443 closed the
 #     half a caller could reach; direct DDL on the `data` schema can still put a
 #     relation under a deleted dataset's name, and the schema-wide default
@@ -2039,15 +2039,14 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 #     exists to avoid. Most of the lines are the docstring recording why the check
 #     sits on the pool path and not in _resolve_dataset_meta, since that placement
 #     is the whole difference between this and the option #1451 ruled out. The
-#     codex rounds added the placement itself, which took two tries and is now the
-#     bulk of the lines. The probe sits after the FAIR-01 permit and before the
-#     tile connection, releasing its own API connection in between: ahead of the
-#     permit it pinned an API connection across a 10s wait, and inside the tile
-#     transaction it asked the API pool while holding a tile connection, the
-#     reverse of the order a metadata-cache miss takes. Both neighbours are written
-#     down at the call site so the next reader does not re-derive them. The
-#     HTTPException re-raise beside it keeps a refusal a 404 instead of letting the
-#     broad handler relabel it 503.
+#     codex rounds added the placement itself, which took three and is now the bulk
+#     of the lines. A tile request takes an API-pool connection, a FAIR-01 permit
+#     and a tile-pool connection; each round found one more pair being taken in
+#     opposite orders by two paths, which stalls both under ordinary mixed load.
+#     The probe runs before all three and rolls back before the first is requested,
+#     which also retires the pre-existing half — a metadata-cache miss used to
+#     carry its connection into the permit wait. The rejected positions are written
+#     down at the call site so the next reader does not re-derive them.
 #   tiles/router.py 2329 -> 2341. fix(#1444): +12 of comment, no code. Both
 #     docstrings that GH-1429 left stating "a freed table name is immediately
 #     redrawable" as a live precondition now say GH-1443 removed it, and each
@@ -3097,7 +3096,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # writes and a predictable future `v` can no longer park a pre-swap
     # snapshot on the key the swap is about to make legitimate.
     # Ratchet stays exact.
-    "backend/app/processing/tiles/router.py": 2467,
+    "backend/app/processing/tiles/router.py": 2466,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_tile_cached_authz_liveness_1451.py
+++ b/backend/tests/test_tile_cached_authz_liveness_1451.py
@@ -1,0 +1,343 @@
+"""Cached tile authorization must not outlive the catalog row it came from (#1451).
+
+``_resolve_dataset_meta`` answers a cache hit without touching the database, so
+for up to ``_DATASET_CACHE_TTL`` seconds a worker keeps authorizing against a
+dataset row that may already be gone. GH-1443 retired freed table names, which
+closed the half a caller could reach through the API. Direct DDL on the ``data``
+schema is not that half: ``CREATE TABLE data.roads`` needs no registration, and
+``ALTER DEFAULT PRIVILEGES IN SCHEMA data GRANT SELECT ON TABLES TO
+geolens_reader`` (scripts/lib/configure-runtime-db-role.sh) hands the tile role
+read access to it without ``grant_reader_access`` ever running. Inside the TTL an
+anonymous tile request would be authorized against the deleted dataset's
+``public`` visibility and answered from a relation nobody registered.
+
+The #1441 eviction listener is process-local and REDIS_URL is unset by default,
+so a delete only ever evicts in the worker that served it — which is why these
+tests warm the cache and then delete WITHOUT evicting: that is not a contrived
+state, it is what every other uvicorn worker holds.
+
+The fix asks the catalog once per tile the pool actually has to build. The last
+test here is the other half of the bargain: a tile answered from the byte cache
+must still reach the database zero times.
+"""
+
+import gzip
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.processing.tiles import router as tile_router
+from tests.factories import get_user_id
+
+pytestmark = pytest.mark.usefixtures("_init_tile_pool_for_tests")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _restore_dataset_cache():
+    """The meta cache is a process global — hand it back exactly as found.
+
+    These tests deliberately leave warm entries pointing at deleted datasets;
+    leaking one into the rest of the session would decide another test's
+    authorization.
+    """
+    with tile_router._dataset_cache_lock:
+        before = dict(tile_router._dataset_cache)
+    yield
+    with tile_router._dataset_cache_lock:
+        tile_router._dataset_cache.clear()
+        tile_router._dataset_cache.update(before)
+
+
+@pytest.fixture
+async def drop_tables(test_db_session: AsyncSession):
+    """Drop relations the test created out-of-band.
+
+    A recreated relation is by definition unregistered, so no delete path will
+    ever reap it.
+    """
+    created: list[str] = []
+
+    def _register(table_name: str) -> str:
+        created.append(table_name)
+        return table_name
+
+    yield _register
+
+    for table_name in created:
+        await test_db_session.execute(text(f'DROP TABLE IF EXISTS data."{table_name}"'))
+    await test_db_session.commit()
+
+
+async def _create_point_relation(session: AsyncSession, table_name: str, label: str):
+    """The shape ``column_info`` describes, holding one point inside tile 0/0/0.
+
+    Column compatibility is a precondition of the disclosure — a restore from
+    backup satisfies it, and without it the cached ``column_info`` would make the
+    tile query fail on its own rather than return the recreated rows.
+    """
+    await session.execute(
+        text(
+            f'CREATE TABLE data."{table_name}" ('
+            "  gid SERIAL PRIMARY KEY,"
+            "  name TEXT,"
+            "  value INTEGER,"
+            "  geom GEOMETRY(Point, 3857),"
+            "  geom_4326 GEOMETRY(Point, 4326)"
+            ")"
+        )
+    )
+    await session.execute(
+        text(
+            f'INSERT INTO data."{table_name}" (name, value, geom, geom_4326) VALUES ('
+            "  :label, 42,"
+            "  ST_Transform(ST_SetSRID(ST_MakePoint(0, 0), 4326), 3857),"
+            "  ST_SetSRID(ST_MakePoint(0, 0), 4326)"
+            ")"
+        ),
+        {"label": label},
+    )
+    await session.commit()
+
+
+async def _make_public_dataset(session: AsyncSession, table_name: str, title: str):
+    """A published public dataset over ``table_name`` — anonymously tileable."""
+    from tests.factories import create_dataset
+
+    admin_id = await get_user_id(session, "admin")
+    return await create_dataset(
+        session,
+        created_by=admin_id,
+        name=title,
+        table_name=table_name,
+        record_type="vector_dataset",
+        visibility="public",
+        record_status="published",
+        geometry_type="Point",
+        column_info=[
+            {"name": "gid", "type": "integer"},
+            {"name": "name", "type": "text"},
+            {"name": "value", "type": "integer"},
+            {"name": "geom", "type": "geometry"},
+            {"name": "geom_4326", "type": "geometry"},
+        ],
+    )
+
+
+async def _delete_dataset(session: AsyncSession, dataset_id: uuid.UUID, title: str):
+    """Delete through the real service, then commit — and evict nothing.
+
+    #1441 moved the meta eviction out of ``delete_dataset`` and into the two
+    delete ENDPOINTS, after their commit. Driving the service directly therefore
+    reproduces a real worker's state rather than simulating it: the row is gone,
+    the table is dropped, the name is retired, and this process's metadata map is
+    untouched — exactly what every worker that did not serve the delete holds.
+    """
+    from app.modules.catalog.datasets.domain.service import delete_dataset
+
+    class _NoStagedObjects:
+        async def list(self, prefix: str) -> list[str]:
+            return []
+
+        async def delete(self, key: str) -> None:  # pragma: no cover - none listed
+            raise AssertionError("no keys were listed")
+
+    with patch(
+        "app.platform.storage.provider.get_storage", return_value=_NoStagedObjects()
+    ):
+        await delete_dataset(session, dataset_id, title)
+    await session.commit()
+
+
+def _cached_meta(table_name: str):
+    with tile_router._dataset_cache_lock:
+        entry = tile_router._dataset_cache.get(table_name)
+    return None if entry is None else entry[1]
+
+
+# ---------------------------------------------------------------------------
+# The scenario the issue describes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url_template",
+    [
+        "/tiles/data.{table}/0/0/0.pbf",
+        "/tiles/clusters/data.{table}/0/0/0.pbf",
+    ],
+    ids=["vector", "cluster"],
+)
+async def test_recreated_relation_is_not_served_under_a_deleted_datasets_authorization(
+    client: AsyncClient,
+    test_db_session: AsyncSession,
+    drop_tables,
+    url_template: str,
+):
+    """The four steps from GH-1451, end to end, on both tile endpoints.
+
+    Both endpoints reach the physical relation through ``_acquire_and_serve_tile``,
+    so both are the same call site — but only one of them was exercised when the
+    check was written, and a future third endpoint that skips the funnel would
+    pass a vector-only test.
+    """
+    table_name = f"roads_{uuid.uuid4().hex[:12]}"
+    title = f"Roads {uuid.uuid4().hex[:6]}"
+    drop_tables(table_name)
+
+    # 1. Public dataset A occupies `roads`. A tile worker caches meta(A).
+    dataset_a = await _make_public_dataset(test_db_session, table_name, title)
+    await _create_point_relation(test_db_session, table_name, "public_row")
+    await tile_router._resolve_dataset_meta(table_name, test_db_session)
+    assert _cached_meta(table_name).visibility == "public"
+
+    # 2. A is deleted. The table is dropped and the name retired; this process
+    #    never hears about it.
+    await _delete_dataset(test_db_session, dataset_a.id, title)
+
+    # 3. Someone with a database session recreates `roads` and does NOT register
+    #    it. Nothing in the product can do this — that is the point.
+    await _create_point_relation(test_db_session, table_name, "unregistered_row")
+
+    assert _cached_meta(table_name) is not None, (
+        "the warm entry is the whole premise: without it this request would "
+        "404 in _resolve_dataset_meta and prove nothing"
+    )
+
+    # 4. An anonymous tile request inside the TTL.
+    response = await client.get(url_template.format(table=table_name))
+
+    assert response.status_code == 404, (
+        "an unregistered relation was served under a deleted dataset's cached "
+        f"authorization (got {response.status_code})"
+    )
+    # An MVT names its source layer `data.{table}`; a 404 body cannot.
+    assert f"data.{table_name}".encode() not in response.content
+
+
+async def test_refusal_evicts_the_stale_entry_it_refused(
+    client: AsyncClient,
+    test_db_session: AsyncSession,
+    drop_tables,
+):
+    """One refusal, not a refusal per request for the rest of the TTL.
+
+    Leaving the entry in place would keep every later request paying the probe to
+    reach the same answer, and would leave a metadata map that disagrees with the
+    catalog for a minute after the disagreement was detected.
+    """
+    table_name = f"trails_{uuid.uuid4().hex[:12]}"
+    title = f"Trails {uuid.uuid4().hex[:6]}"
+    drop_tables(table_name)
+
+    dataset = await _make_public_dataset(test_db_session, table_name, title)
+    await _create_point_relation(test_db_session, table_name, "public_row")
+    await tile_router._resolve_dataset_meta(table_name, test_db_session)
+
+    await _delete_dataset(test_db_session, dataset.id, title)
+    await _create_point_relation(test_db_session, table_name, "unregistered_row")
+
+    assert (await client.get(f"/tiles/data.{table_name}/0/0/0.pbf")).status_code == 404
+    assert _cached_meta(table_name) is None, (
+        "the entry that authorized the refused request survived it"
+    )
+
+
+async def test_a_live_dataset_still_serves_its_own_tiles(
+    client: AsyncClient,
+    test_db_session: AsyncSession,
+    drop_tables,
+):
+    """The control: the probe must not turn normal serving into a 404.
+
+    A liveness check that fails closed on live datasets is worse than the leak it
+    prevents, and this is the case a mocked probe would never catch.
+    """
+    table_name = f"parks_{uuid.uuid4().hex[:12]}"
+    title = f"Parks {uuid.uuid4().hex[:6]}"
+    drop_tables(table_name)
+
+    await _make_public_dataset(test_db_session, table_name, title)
+    await _create_point_relation(test_db_session, table_name, "public_row")
+    await tile_router._resolve_dataset_meta(table_name, test_db_session)
+
+    response = await client.get(f"/tiles/data.{table_name}/0/0/0.pbf")
+
+    # httpx decodes Content-Encoding: gzip, so .content is the MVT itself. The
+    # tile carries no `name` property — columns are opt-in — so the layer name
+    # is what identifies the relation the tile was built from.
+    assert response.status_code == 200, response.text
+    assert f"data.{table_name}".encode() in response.content
+
+
+# ---------------------------------------------------------------------------
+# The cost bound the check has to respect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tile_kind", ["vector", "cluster"])
+async def test_a_cached_tile_still_reaches_the_database_zero_times(tile_kind: str):
+    """A byte-cache hit must cost no round-trip — PERF-006 / PERF-002.
+
+    ``_dataset_cache`` exists to keep the hot path off the database, so a
+    liveness check placed in ``_resolve_dataset_meta`` would be paid on every
+    tile ever served. This pins where the check lives, not only what it does:
+    the probe belongs on the path that is about to read the relation.
+    """
+    from fastapi import FastAPI
+
+    from app.core.dependencies import get_db
+    from app.modules.auth.dependencies import get_optional_user
+
+    table_name = f"cached_{tile_kind}"
+    meta = tile_router._DatasetMeta(
+        dataset_id=uuid.uuid4(),
+        record_id=uuid.uuid4(),
+        table_name=table_name,
+        visibility="public",
+        record_status="published",
+        created_by=uuid.uuid4(),
+        record_type="vector_dataset",
+        geometry_type="Point",
+        column_info=[],
+        tile_cache_ttl=30,
+        tile_columns=None,
+    )
+    db = AsyncMock()
+    cache = SimpleNamespace(
+        get=AsyncMock(return_value=gzip.compress(b"cached-mvt")),
+        set=AsyncMock(),
+    )
+
+    app = FastAPI()
+    app.include_router(tile_router.router)
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[get_optional_user] = lambda: None
+
+    path = (
+        f"/tiles/data.{table_name}/0/0/0.pbf"
+        if tile_kind == "vector"
+        else f"/tiles/clusters/data.{table_name}/0/0/0.pbf"
+    )
+
+    with (
+        patch.object(
+            tile_router, "_resolve_dataset_meta", AsyncMock(return_value=meta)
+        ),
+        patch.object(tile_router, "get_tile_cache", lambda: cache),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            response = await c.get(path)
+
+    assert response.status_code == 200
+    db.execute.assert_not_awaited()

--- a/backend/tests/test_tile_cached_authz_liveness_1451.py
+++ b/backend/tests/test_tile_cached_authz_liveness_1451.py
@@ -16,23 +16,30 @@ so a delete only ever evicts in the worker that served it — which is why these
 tests warm the cache and then delete WITHOUT evicting: that is not a contrived
 state, it is what every other uvicorn worker holds.
 
-The fix asks the catalog once per tile the pool actually has to build. The last
-test here is the other half of the bargain: a tile answered from the byte cache
-must still reach the database zero times.
+The fix asks the catalog once per tile the pool actually has to build. Two of
+these tests cover the other half of that bargain, because where the question is
+asked matters as much as asking it: a tile answered from the byte cache must
+still reach the database zero times, and the check must sit after the FAIR-01
+permit and immediately before the relation read, holding no API-pool connection
+across the wait and leaving no await for a delete to slip through.
 """
 
 import gzip
 import uuid
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request
 
 from app.processing.tiles import router as tile_router
 from tests.factories import get_user_id
+
 
 pytestmark = pytest.mark.usefixtures("_init_tile_pool_for_tests")
 
@@ -40,6 +47,22 @@ pytestmark = pytest.mark.usefixtures("_init_tile_pool_for_tests")
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _bare_request() -> Request:
+    """The minimum scope ``_acquire_and_serve_tile`` reads off a request."""
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/tiles/data.roads/0/0/0.pbf",
+            "headers": [],
+            "query_string": b"",
+            "server": ("test", 80),
+            "client": ("test", 1234),
+            "scheme": "http",
+        }
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -341,3 +364,134 @@ async def test_a_cached_tile_still_reaches_the_database_zero_times(tile_kind: st
 
     assert response.status_code == 200
     db.execute.assert_not_awaited()
+
+
+class _RecordingSession:
+    """A session that logs when it is queried and when it lets its connection go."""
+
+    def __init__(self, events: list[str], *, registered: bool = True) -> None:
+        self._events = events
+        self._registered = registered
+
+    async def execute(self, _stmt):
+        self._events.append("db.execute")
+        value = uuid.uuid4() if self._registered else None
+        return SimpleNamespace(scalar_one_or_none=lambda: value)
+
+    async def rollback(self) -> None:
+        self._events.append("db.rollback")
+
+
+class _RecordingTileConnection:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    def transaction(self):
+        return _null_async_context(self._events, "txn")
+
+
+class _RecordingTilePool:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+        self.connection = _RecordingTileConnection(events)
+
+    def acquire(self):
+        return _null_async_context(self._events, "pool.acquire", self.connection)
+
+
+@asynccontextmanager
+async def _null_async_context(events: list[str], label: str, value=None):
+    events.append(label)
+    yield value
+
+
+async def test_the_catalog_is_asked_between_capacity_and_the_relation_read():
+    """Order is the fix, so order is what this pins (codex P1/P2 on #1454).
+
+    Ahead of the tile pool the probe held an API-pool connection for the whole
+    FAIR-01 wait, which is how a burst of uncached coordinates starves the CRUD
+    traffic the separate tile pool exists to protect. Any await between the check
+    and the read reopens the window the check closes. Both failure modes are
+    invisible to a test that only asserts the 404, so this one asserts where.
+    """
+    events: list[str] = []
+    pool = _RecordingTilePool(events)
+    dataset_id = uuid.uuid4()
+
+    async def _query(_pool, _conn):
+        events.append("tile_query")
+        return b"mvt"
+
+    async def _record_role_bind(_conn, _tid):
+        events.append("set_role")
+
+    with (
+        patch.object(tile_router, "get_tile_pool", lambda: pool),
+        patch.object(
+            tile_router, "set_tenant_role_for_tile_request", _record_role_bind
+        ),
+    ):
+        response = await tile_router._acquire_and_serve_tile(
+            request=_bare_request(),
+            db=_RecordingSession(events),
+            dataset_id=dataset_id,
+            table_name="roads",
+            z=0,
+            x=0,
+            y=0,
+            tid=None,
+            schema="data",
+            query_callable=_query,
+            tile_cache=None,
+            cache_key="roads",
+            cache_ttl=60,
+            base_headers={},
+        )
+
+    assert response.status_code == 200
+    assert events == [
+        "pool.acquire",
+        "txn",
+        "set_role",
+        "db.execute",
+        "db.rollback",
+        "tile_query",
+    ], events
+
+
+async def test_a_refused_tile_is_a_404_not_a_service_error():
+    """The pool block maps a broad exception to 503; a refusal must escape that.
+
+    Moving the check inside that block put it under a handler that would have
+    reported the deleted dataset as a tile-service outage, which reads as
+    something to page about and hides the reason the tile was withheld.
+    """
+    events: list[str] = []
+    pool = _RecordingTilePool(events)
+
+    async def _query(_pool, _conn):  # pragma: no cover - must never run
+        raise AssertionError("the relation was read after the catalog refused")
+
+    with (
+        patch.object(tile_router, "get_tile_pool", lambda: pool),
+        patch.object(tile_router, "set_tenant_role_for_tile_request", AsyncMock()),
+        pytest.raises(HTTPException) as excinfo,
+    ):
+        await tile_router._acquire_and_serve_tile(
+            request=_bare_request(),
+            db=_RecordingSession(events, registered=False),
+            dataset_id=uuid.uuid4(),
+            table_name="roads",
+            z=0,
+            x=0,
+            y=0,
+            tid=None,
+            schema="data",
+            query_callable=_query,
+            tile_cache=None,
+            cache_key="roads",
+            cache_ttl=60,
+            base_headers={},
+        )
+
+    assert excinfo.value.status_code == 404

--- a/backend/tests/test_tile_cached_authz_liveness_1451.py
+++ b/backend/tests/test_tile_cached_authz_liveness_1451.py
@@ -16,12 +16,13 @@ so a delete only ever evicts in the worker that served it — which is why these
 tests warm the cache and then delete WITHOUT evicting: that is not a contrived
 state, it is what every other uvicorn worker holds.
 
-The fix asks the catalog once per tile the pool actually has to build. Two of
+The fix asks the catalog once per tile the pool actually has to build. Three of
 these tests cover the other half of that bargain, because where the question is
-asked matters as much as asking it: a tile answered from the byte cache must
-still reach the database zero times, and the check must sit after the FAIR-01
-permit and immediately before the relation read, holding no API-pool connection
-across the wait and leaving no await for a delete to slip through.
+asked matters as much as asking it. A tile answered from the byte cache must
+still reach the database zero times. And a tile request takes three bounded
+resources — an API-pool connection, a FAIR-01 permit, a tile-pool connection —
+so the check has to run before any of them and give its connection back before
+the first is requested, or two paths end up holding a pair in opposite orders.
 """
 
 import gzip
@@ -405,24 +406,38 @@ async def _null_async_context(events: list[str], label: str, value=None):
     yield value
 
 
-async def test_the_catalog_is_asked_between_capacity_and_the_tile_connection():
-    """Order is the fix, so order is what this pins (codex P1 rounds 1 and 2).
+class _RecordingLimiter:
+    """A FAIR-01 permit that logs when it is taken."""
 
-    Two failure modes bracket the one safe position, and a 404 assertion sees
-    neither. Ahead of the FAIR-01 permit, the probe held an API-pool connection
-    through a 10-second wait, starving the CRUD traffic the separate tile pool
-    exists to protect. Inside the tile transaction, it asked the API pool while
-    holding a tile connection, which is the reverse of the order a metadata cache
-    miss takes: two bounded pools acquired in opposite orders stall each other
-    under ordinary mixed load.
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+        self.released = 0
 
-    So the release has to land BETWEEN the catalog read and the tile acquire,
-    which is what the expected sequence below says and what neither neighbouring
-    placement can satisfy.
+    async def acquire(self) -> bool:
+        self._events.append("permit")
+        return True
+
+    def release(self) -> None:
+        self.released += 1
+
+
+async def test_the_catalog_is_asked_before_any_capacity_is_taken():
+    """Order is the fix, so order is what this pins (codex P1, rounds 1-3).
+
+    A tile request takes three bounded resources: an API-pool connection, a
+    FAIR-01 permit, and a tile-pool connection. Each round of review found one
+    more pair being taken in opposite orders by two paths, which is a stall under
+    ordinary mixed load and needs no attacker. The probe now runs first and hands
+    its connection back before the permit is requested, so all three are acquired
+    in one order by every request.
+
+    A 404 assertion cannot see any of that, so this asserts the sequence: the
+    release lands between the catalog read and the first capacity request, which
+    is what no later placement can produce.
     """
     events: list[str] = []
     pool = _RecordingTilePool(events)
-    dataset_id = uuid.uuid4()
+    limiter = _RecordingLimiter(events)
 
     async def _query(_pool, _conn):
         events.append("tile_query")
@@ -440,7 +455,7 @@ async def test_the_catalog_is_asked_between_capacity_and_the_tile_connection():
         response = await tile_router._acquire_and_serve_tile(
             request=_bare_request(),
             db=_RecordingSession(events),
-            dataset_id=dataset_id,
+            dataset_id=uuid.uuid4(),
             table_name="roads",
             z=0,
             x=0,
@@ -452,28 +467,33 @@ async def test_the_catalog_is_asked_between_capacity_and_the_tile_connection():
             cache_key="roads",
             cache_ttl=60,
             base_headers={},
+            tenant_sem=limiter,
         )
 
     assert response.status_code == 200
     assert events == [
         "db.execute",
         "db.rollback",
+        "permit",
         "pool.acquire",
         "txn",
         "set_role",
         "tile_query",
     ], events
+    assert limiter.released == 1
 
 
-async def test_a_refused_tile_is_a_404_not_a_service_error():
-    """The pool block maps a broad exception to 503; a refusal must escape that.
+async def test_a_refusal_costs_no_capacity_and_stays_a_404():
+    """A refused tile takes no permit, no pool slot, and is not reported as a 503.
 
-    Moving the check inside that block put it under a handler that would have
-    reported the deleted dataset as a tile-service outage, which reads as
-    something to page about and hides the reason the tile was withheld.
+    Both properties come from the same placement. Sitting ahead of the capacity
+    block, the refusal needs no release path of its own; sitting outside the
+    ``except Exception`` that maps tile failures to 503, it stays the answer it
+    is rather than reading as a tile-service outage worth paging about.
     """
     events: list[str] = []
     pool = _RecordingTilePool(events)
+    limiter = _RecordingLimiter(events)
 
     async def _query(_pool, _conn):  # pragma: no cover - must never run
         raise AssertionError("the relation was read after the catalog refused")
@@ -498,6 +518,9 @@ async def test_a_refused_tile_is_a_404_not_a_service_error():
             cache_key="roads",
             cache_ttl=60,
             base_headers={},
+            tenant_sem=limiter,
         )
 
     assert excinfo.value.status_code == 404
+    assert events == ["db.execute", "db.rollback"], events
+    assert limiter.released == 0

--- a/backend/tests/test_tile_cached_authz_liveness_1451.py
+++ b/backend/tests/test_tile_cached_authz_liveness_1451.py
@@ -16,13 +16,15 @@ so a delete only ever evicts in the worker that served it — which is why these
 tests warm the cache and then delete WITHOUT evicting: that is not a contrived
 state, it is what every other uvicorn worker holds.
 
-The fix asks the catalog once per tile the pool actually has to build. Three of
-these tests cover the other half of that bargain, because where the question is
-asked matters as much as asking it. A tile answered from the byte cache must
-still reach the database zero times. And a tile request takes three bounded
-resources — an API-pool connection, a FAIR-01 permit, a tile-pool connection —
-so the check has to run before any of them and give its connection back before
-the first is requested, or two paths end up holding a pair in opposite orders.
+The fix asks the catalog once per tile the pool actually has to build, and half
+these tests are about WHERE it asks, which took four review rounds to settle. It
+cannot be earlier: a tile answered from the byte cache must still reach the
+database zero times, which is what `_dataset_cache` is for. It cannot be later:
+everything past that point acts on the cached authorization, starting with the
+COLD-02 seam that would wake storage for a deleted dataset, and a tile request
+then takes an API-pool connection, a FAIR-01 permit and a tile-pool connection in
+that order — so the check must finish and hand its connection back before the
+first of them, or two paths hold a pair in opposite orders and stall.
 """
 
 import gzip
@@ -32,11 +34,9 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette.requests import Request
 
 from app.processing.tiles import router as tile_router
 from tests.factories import get_user_id
@@ -48,22 +48,6 @@ pytestmark = pytest.mark.usefixtures("_init_tile_pool_for_tests")
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _bare_request() -> Request:
-    """The minimum scope ``_acquire_and_serve_tile`` reads off a request."""
-    return Request(
-        {
-            "type": "http",
-            "method": "GET",
-            "path": "/tiles/data.roads/0/0/0.pbf",
-            "headers": [],
-            "query_string": b"",
-            "server": ("test", 80),
-            "client": ("test", 1234),
-            "scheme": "http",
-        }
-    )
 
 
 @pytest.fixture(autouse=True)
@@ -180,6 +164,23 @@ async def _delete_dataset(session: AsyncSession, dataset_id: uuid.UUID, title: s
     ):
         await delete_dataset(session, dataset_id, title)
     await session.commit()
+
+
+def _fake_meta(table_name: str):
+    """A published public meta, as a warm cache entry would hand one back."""
+    return tile_router._DatasetMeta(
+        dataset_id=uuid.uuid4(),
+        record_id=uuid.uuid4(),
+        table_name=table_name,
+        visibility="public",
+        record_status="published",
+        created_by=uuid.uuid4(),
+        record_type="vector_dataset",
+        geometry_type="Point",
+        column_info=[],
+        tile_cache_ttl=30,
+        tile_columns=None,
+    )
 
 
 def _cached_meta(table_name: str):
@@ -314,8 +315,8 @@ async def test_a_cached_tile_still_reaches_the_database_zero_times(tile_kind: st
 
     ``_dataset_cache`` exists to keep the hot path off the database, so a
     liveness check placed in ``_resolve_dataset_meta`` would be paid on every
-    tile ever served. This pins where the check lives, not only what it does:
-    the probe belongs on the path that is about to read the relation.
+    tile ever served. This is the lower bound on how early the check may sit;
+    the ordering test below is the upper bound.
     """
     from fastapi import FastAPI
 
@@ -323,19 +324,7 @@ async def test_a_cached_tile_still_reaches_the_database_zero_times(tile_kind: st
     from app.modules.auth.dependencies import get_optional_user
 
     table_name = f"cached_{tile_kind}"
-    meta = tile_router._DatasetMeta(
-        dataset_id=uuid.uuid4(),
-        record_id=uuid.uuid4(),
-        table_name=table_name,
-        visibility="public",
-        record_status="published",
-        created_by=uuid.uuid4(),
-        record_type="vector_dataset",
-        geometry_type="Point",
-        column_info=[],
-        tile_cache_ttl=30,
-        tile_columns=None,
-    )
+    meta = _fake_meta(table_name)
     db = AsyncMock()
     cache = SimpleNamespace(
         get=AsyncMock(return_value=gzip.compress(b"cached-mvt")),
@@ -394,9 +383,11 @@ class _RecordingTileConnection:
 class _RecordingTilePool:
     def __init__(self, events: list[str]) -> None:
         self._events = events
+        self.acquired = 0
         self.connection = _RecordingTileConnection(events)
 
     def acquire(self):
+        self.acquired += 1
         return _null_async_context(self._events, "pool.acquire", self.connection)
 
 
@@ -406,121 +397,177 @@ async def _null_async_context(events: list[str], label: str, value=None):
     yield value
 
 
-class _RecordingLimiter:
-    """A FAIR-01 permit that logs when it is taken."""
+@pytest.mark.parametrize("tile_kind", ["vector", "cluster"])
+async def test_the_catalog_is_asked_before_anything_acts_on_the_cached_meta(
+    tile_kind: str,
+):
+    """Order is the fix, so order is what this pins (codex, rounds 1-4).
 
-    def __init__(self, events: list[str]) -> None:
-        self._events = events
-        self.released = 0
+    Past the byte-cache short-circuit a tile request touches four things in
+    sequence: the COLD-02 seam, an API-pool connection, a FAIR-01 permit, and a
+    tile-pool connection. Each review round found the check sitting after one
+    more of them.
 
-    async def acquire(self) -> bool:
-        self._events.append("permit")
-        return True
+    The seam is a correctness problem — it enqueues a restore for the dataset the
+    cached metadata names, so a deleted one buys storage work and a 202. The
+    other three are a lock-order problem: `get_db` holds its connection until the
+    response is written, so a metadata-cache MISS carries it into both later
+    waits, and any position that takes one of those while asking for the API pool
+    inverts a pair against it. Two bounded resources acquired in opposite orders
+    stall under ordinary mixed load, no attacker involved.
 
-    def release(self) -> None:
-        self.released += 1
-
-
-async def test_the_catalog_is_asked_before_any_capacity_is_taken():
-    """Order is the fix, so order is what this pins (codex P1, rounds 1-3).
-
-    A tile request takes three bounded resources: an API-pool connection, a
-    FAIR-01 permit, and a tile-pool connection. Each round of review found one
-    more pair being taken in opposite orders by two paths, which is a stall under
-    ordinary mixed load and needs no attacker. The probe now runs first and hands
-    its connection back before the permit is requested, so all three are acquired
-    in one order by every request.
-
-    A 404 assertion cannot see any of that, so this asserts the sequence: the
-    release lands between the catalog read and the first capacity request, which
-    is what no later placement can produce.
+    A 404 assertion sees none of this, so this asserts the sequence.
     """
-    events: list[str] = []
-    pool = _RecordingTilePool(events)
-    limiter = _RecordingLimiter(events)
+    from fastapi import FastAPI
 
-    async def _query(_pool, _conn):
+    from app.core.dependencies import get_db
+    from app.modules.auth.dependencies import get_optional_user
+
+    events: list[str] = []
+    table_name = f"ordered_{tile_kind}"
+    meta = _fake_meta(table_name)
+    pool = _RecordingTilePool(events)
+    session = _RecordingSession(events)
+
+    async def _query(*_args, **_kwargs):
         events.append("tile_query")
         return b"mvt"
+
+    async def _record_cold_seam(*_args, **_kwargs):
+        events.append("cold_seam")
+        return None
 
     async def _record_role_bind(_conn, _tid):
         events.append("set_role")
 
+    app = FastAPI()
+    app.include_router(tile_router.router)
+    app.dependency_overrides[get_db] = lambda: session
+    app.dependency_overrides[get_optional_user] = lambda: None
+
+    path = (
+        f"/tiles/data.{table_name}/0/0/0.pbf"
+        if tile_kind == "vector"
+        else f"/tiles/clusters/data.{table_name}/0/0/0.pbf"
+    )
+
     with (
+        patch.object(
+            tile_router, "_resolve_dataset_meta", AsyncMock(return_value=meta)
+        ),
+        patch.object(tile_router, "get_tile_cache", lambda: None),
         patch.object(tile_router, "get_tile_pool", lambda: pool),
+        patch.object(tile_router, "_check_cold_rehydrate", _record_cold_seam),
         patch.object(
             tile_router, "set_tenant_role_for_tile_request", _record_role_bind
         ),
+        patch.object(tile_router, "get_tile", _query),
+        patch.object(tile_router, "get_cluster_tile", _query),
     ):
-        response = await tile_router._acquire_and_serve_tile(
-            request=_bare_request(),
-            db=_RecordingSession(events),
-            dataset_id=uuid.uuid4(),
-            table_name="roads",
-            z=0,
-            x=0,
-            y=0,
-            tid=None,
-            schema="data",
-            query_callable=_query,
-            tile_cache=None,
-            cache_key="roads",
-            cache_ttl=60,
-            base_headers={},
-            tenant_sem=limiter,
-        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            response = await c.get(path)
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     assert events == [
         "db.execute",
         "db.rollback",
-        "permit",
+        "cold_seam",
         "pool.acquire",
         "txn",
         "set_role",
         "tile_query",
     ], events
-    assert limiter.released == 1
 
 
-async def test_a_refusal_costs_no_capacity_and_stays_a_404():
-    """A refused tile takes no permit, no pool slot, and is not reported as a 503.
+async def test_both_tile_endpoints_ask_before_they_act():
+    """The check lives in two endpoints, so nothing structural funnels it.
 
-    Both properties come from the same placement. Sitting ahead of the capacity
-    block, the refusal needs no release path of its own; sitting outside the
-    ``except Exception`` that maps tile failures to 503, it stays the answer it
-    is rather than reading as a tile-service outage worth paging about.
+    It used to sit in `_acquire_and_serve_tile`, which both endpoints reach, but
+    that is below the COLD-02 seam and below the capacity acquisitions, and both
+    of those turned out to matter. Moving it up traded a funnel for a convention,
+    so the convention is enforced here instead: a third tile route that resolves
+    cached metadata and forgets this call would otherwise be a silent regression.
     """
-    events: list[str] = []
-    pool = _RecordingTilePool(events)
-    limiter = _RecordingLimiter(events)
+    import ast
+    import inspect
+    import textwrap
 
-    async def _query(_pool, _conn):  # pragma: no cover - must never run
+    for endpoint in (tile_router.tile_endpoint, tile_router.cluster_tile_endpoint):
+        source = textwrap.dedent(inspect.getsource(endpoint))
+        calls = [
+            node.func.id
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        ]
+        name = endpoint.__name__
+
+        assert "_assert_dataset_still_registered" in calls, (
+            f"{name} reads a data-schema relation off cached authorization "
+            "without re-checking the catalog (#1451)"
+        )
+        probe_at = calls.index("_assert_dataset_still_registered")
+        for later in ("_check_cold_rehydrate", "_acquire_and_serve_tile"):
+            assert probe_at < calls.index(later), (
+                f"{name} calls {later} before the #1451 catalog check, so it "
+                "acts on cached authorization the catalog may no longer back"
+            )
+
+
+@pytest.mark.parametrize("tile_kind", ["vector", "cluster"])
+async def test_a_refusal_costs_no_capacity_and_no_storage_work(tile_kind: str):
+    """A refused tile takes no permit, no pool slot, and wakes no cold storage.
+
+    All three follow from the check sitting above them. The COLD-02 seam is the
+    one that bites hardest: it acts on the same cached ``record_status``, so a
+    deleted dataset left cold in the map would have bought a restore job and a
+    202 for a row the catalog no longer has.
+    """
+    from fastapi import FastAPI
+
+    from app.core.dependencies import get_db
+    from app.modules.auth.dependencies import get_optional_user
+
+    events: list[str] = []
+    table_name = f"refused_{tile_kind}"
+    pool = _RecordingTilePool(events)
+
+    async def _query(*_args, **_kwargs):  # pragma: no cover - must never run
         raise AssertionError("the relation was read after the catalog refused")
 
-    with (
-        patch.object(tile_router, "get_tile_pool", lambda: pool),
-        patch.object(tile_router, "set_tenant_role_for_tile_request", AsyncMock()),
-        pytest.raises(HTTPException) as excinfo,
-    ):
-        await tile_router._acquire_and_serve_tile(
-            request=_bare_request(),
-            db=_RecordingSession(events, registered=False),
-            dataset_id=uuid.uuid4(),
-            table_name="roads",
-            z=0,
-            x=0,
-            y=0,
-            tid=None,
-            schema="data",
-            query_callable=_query,
-            tile_cache=None,
-            cache_key="roads",
-            cache_ttl=60,
-            base_headers={},
-            tenant_sem=limiter,
-        )
+    async def _cold_seam(*_args, **_kwargs):  # pragma: no cover - must never run
+        raise AssertionError("cold rehydrate ran for a dataset that was deleted")
 
-    assert excinfo.value.status_code == 404
+    app = FastAPI()
+    app.include_router(tile_router.router)
+    app.dependency_overrides[get_db] = lambda: _RecordingSession(
+        events, registered=False
+    )
+    app.dependency_overrides[get_optional_user] = lambda: None
+
+    path = (
+        f"/tiles/data.{table_name}/0/0/0.pbf"
+        if tile_kind == "vector"
+        else f"/tiles/clusters/data.{table_name}/0/0/0.pbf"
+    )
+
+    with (
+        patch.object(
+            tile_router,
+            "_resolve_dataset_meta",
+            AsyncMock(return_value=_fake_meta(table_name)),
+        ),
+        patch.object(tile_router, "get_tile_cache", lambda: None),
+        patch.object(tile_router, "get_tile_pool", lambda: pool),
+        patch.object(tile_router, "_check_cold_rehydrate", _cold_seam),
+        patch.object(tile_router, "set_tenant_role_for_tile_request", AsyncMock()),
+        patch.object(tile_router, "get_tile", _query),
+        patch.object(tile_router, "get_cluster_tile", _query),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            response = await c.get(path)
+
+    assert response.status_code == 404
     assert events == ["db.execute", "db.rollback"], events
-    assert limiter.released == 0
+    assert pool.acquired == 0

--- a/backend/tests/test_tile_cached_authz_liveness_1451.py
+++ b/backend/tests/test_tile_cached_authz_liveness_1451.py
@@ -405,14 +405,20 @@ async def _null_async_context(events: list[str], label: str, value=None):
     yield value
 
 
-async def test_the_catalog_is_asked_between_capacity_and_the_relation_read():
-    """Order is the fix, so order is what this pins (codex P1/P2 on #1454).
+async def test_the_catalog_is_asked_between_capacity_and_the_tile_connection():
+    """Order is the fix, so order is what this pins (codex P1 rounds 1 and 2).
 
-    Ahead of the tile pool the probe held an API-pool connection for the whole
-    FAIR-01 wait, which is how a burst of uncached coordinates starves the CRUD
-    traffic the separate tile pool exists to protect. Any await between the check
-    and the read reopens the window the check closes. Both failure modes are
-    invisible to a test that only asserts the 404, so this one asserts where.
+    Two failure modes bracket the one safe position, and a 404 assertion sees
+    neither. Ahead of the FAIR-01 permit, the probe held an API-pool connection
+    through a 10-second wait, starving the CRUD traffic the separate tile pool
+    exists to protect. Inside the tile transaction, it asked the API pool while
+    holding a tile connection, which is the reverse of the order a metadata cache
+    miss takes: two bounded pools acquired in opposite orders stall each other
+    under ordinary mixed load.
+
+    So the release has to land BETWEEN the catalog read and the tile acquire,
+    which is what the expected sequence below says and what neither neighbouring
+    placement can satisfy.
     """
     events: list[str] = []
     pool = _RecordingTilePool(events)
@@ -450,11 +456,11 @@ async def test_the_catalog_is_asked_between_capacity_and_the_relation_read():
 
     assert response.status_code == 200
     assert events == [
+        "db.execute",
+        "db.rollback",
         "pool.acquire",
         "txn",
         "set_role",
-        "db.execute",
-        "db.rollback",
         "tile_query",
     ], events
 


### PR DESCRIPTION
## What changed

`_resolve_dataset_meta` answers a cache hit without touching the database, so for up to 60 seconds (`_DATASET_CACHE_TTL`) a tile worker keeps authorizing against a dataset row that may already be deleted. GH-1443 retired freed table names, which closed the half a caller could reach through the API. Direct DDL on the `data` schema is not that half: `CREATE TABLE data.roads` needs no registration, and the schema-wide `ALTER DEFAULT PRIVILEGES ... GRANT SELECT ON TABLES TO geolens_reader` in `scripts/lib/configure-runtime-db-role.sh` hands the tile role read access to it without `grant_reader_access` ever running. Inside the TTL an anonymous request for `/tiles/data.roads/...` is authorized against the deleted dataset's `public` visibility and answered from a relation nobody registered.

New `_assert_dataset_still_registered()` in `backend/app/processing/tiles/router.py` asks the catalog whether the cached authorization still has a row behind it. Both tile endpoints call it on the first line past their byte-cache short-circuit.

## Which option this is

GH-1451 costed two remedies. This is neither verbatim.

**Option 1** (verify relation identity with a per-request `pg_class` lookup) was ruled out because it costs the round-trip `_dataset_cache` exists to avoid. That objection is about the hot path, not about consulting the database at all — a tile served from the byte cache returns above this check and still costs zero round-trips. Asking the catalog is also stronger than checking relation identity: it validates the authorization premise rather than a proxy for it, and it does not break after a `pg_dump`/restore the way a cached OID would.

**Option 2** (drop the schema-wide default privilege) changes the operator-facing runtime-role contract for every deployment and needs its own review, an upgrade note, and ACL reconciliation for restores. It remains worth doing on its own terms and nothing here blocks it.

Propagating the eviction was not available: the GH-1429 listener is process-local, `REDIS_URL` is unset in the checked-in default, and a delete therefore only evicts in the worker that served it.

## Where the check sits, and why it took four review rounds

Placement turned out to be most of this change, so it is written down at the call site rather than left to be re-derived.

The position is bounded on both sides. **No earlier**, or a byte-cache hit pays for a check that only matters when the relation is about to be read. **No later**, for two independent reasons:

- Everything past that line acts on the cached authorization, starting with the COLD-02 seam, which would enqueue a restore and return a 202 for a dataset the catalog no longer has.
- A tile request then takes three bounded resources in sequence: an API-pool connection, a FAIR-01 permit, a tile-pool connection. `get_db` holds the first until the response is written, so a metadata-cache miss carries `_resolve_dataset_meta`'s connection into both later waits. Any position that takes a permit or a tile connection *before* asking the API pool inverts a pair against that path, and two bounded resources acquired in opposite orders stall under ordinary mixed load with no attacker involved.

The check therefore runs before all of it and rolls back before the first acquisition. That release also retires the pre-existing half of the same problem, where a metadata-cache miss and an authenticated user lookup both carried their connection into the permit wait.

Asking on the tile connection instead would need neither pool twice, but it would need `geolens_reader` to hold SELECT on `catalog.datasets` — a runtime-role contract change for every deployment, and a widening of the one role whose narrowness is why this path binds it.

One finding was refuted rather than fixed: holding a row lock (`FOR KEY SHARE`) through the relation read. Reasoning is in a PR comment. Short version: it needs the same catalog grant, it makes ordinary tile traffic block dataset deletes, and the race it closes is microseconds wide against an actor who by GH-1451's own analysis already has full read access to the schema.

## Behavior impact

- A tile request whose cached authorization no longer has a catalog row behind it returns 404 instead of serving, and no longer wakes cold storage. The refusal evicts the entry that produced it, so the next request 404s in the resolver.
- No change for any registered dataset, and no change to byte-cache-hit latency.
- A request the FAIR-01 limiter is about to reject now pays one indexed primary-key lookup. That is the cost of a single consistent acquisition order; the connection is back in the pool before any wait begins.
- The probe pins id and table_name together, so a surviving row repointed at a different relation cannot authorize a read of the old name, and it mirrors the resolver's tenant filter.
- No migration, no config change, no API surface change.
- The raster proxy caches authorization the same way and is deliberately not covered: it is addressed by dataset id and resolves to an object-storage asset, so there is no relation an out-of-band `CREATE TABLE` could substitute. Its bounded staleness is the tradeoff already documented at `_RASTER_META_CACHE_TTL`.

## Tests

`backend/tests/test_tile_cached_authz_liveness_1451.py` (11 tests).

The scenario, on both endpoints: seed a public dataset over a real physical table, warm the metadata cache, delete through the real `delete_dataset` service without evicting, recreate the relation out of band, then issue an anonymous tile request. Driving the service rather than the endpoint is deliberate — GH-1429 moved the eviction to the delete endpoints after their commit, so this is the state every worker that did not serve the delete actually holds.

**I confirmed the tests fail without the fix.** With the check removed, both scenario cases return **200** and serve the unregistered relation.

The rest pin what a 404 assertion cannot see: a live dataset still serves its own tiles; a byte-cache hit reaches the database zero times; the recorded call order puts the catalog read and its rollback ahead of the cold seam and both pool acquisitions; a refusal takes no pool slot and wakes no storage; and an AST walk of both endpoints fails if the check is missing or falls after the cold seam or the serve helper. That last one replaces the structural funnel the check gave up by moving out of `_acquire_and_serve_tile`.

`test_data_serving_extension.py` needed its `get_db` override changed from `None` to a session double, since the endpoints now use the session they previously never touched. The double answers the probe with a row rather than patching the check out.

`tiles/router.py` grew 127 lines, so its `_MODULE_LOC_CAPS` entry moves 2341 to 2468 with the carve-out written beside it.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_tile_cached_authz_liveness_1451.py -q            # 11 passed
uv run pytest tests/test_layering.py tests/test_rule1_structural.py \
              tests/test_rule2_structural.py -q
```

Plus every suite in the tree that touches a tile endpoint, found by grepping the
test tree for `/tiles/`, `_acquire_and_serve_tile` and the two endpoint names —
33 files including `test_tiles`, `test_vector_tile_auth`, `test_tile_signing`,
`test_raster_tiles`, `test_embed_tokens`, `test_dp02_read_path_binding`,
`test_dp03_cross_tenant_privilege_gate`, `test_tenant_session_guc` and
`test_retired_table_names_1443`: **885 passed, 2 skipped**.

No e2e or alembic-check: this touches no schema and no frontend.

Closes GH-1451

https://claude.ai/code/session_014tw9Frobcy3jR1ejkfjbCy
