### PR TITLE
fix(catalog): record freed relation oid and prior owner on tombstones

### DIFF
--- a/backend/alembic/versions/0045_retired_table_names_identity.py
+++ b/backend/alembic/versions/0045_retired_table_names_identity.py
@@ -1,0 +1,72 @@
+"""Record the freed relation's identity and its prior owner on a tombstone.
+
+fix(#1456). ``catalog.retired_table_names`` recorded only the freed NAME. Two
+review findings on #1453 converge on the same gap: a tombstone cannot tell
+"the table I detached" from "a new table wearing its name", and it cannot say
+who owned the dataset that freed it. Both answers have to be captured inside
+the delete transaction, because both sources die in it — the relation is
+dropped, and the ``catalog.records`` row carrying ``created_by`` is deleted.
+
+This migration only makes the data exist. Nothing reads the new columns yet;
+the tombstone-vs-not decision is unchanged and still keyed on whether the
+delete freed the name.
+
+``relation_oid`` is BIGINT, not INTEGER: a pg_class oid is an unsigned 32-bit
+value, so int4 overflows on any oid past 2^31 and a cluster that has churned
+enough objects hands those out. It is forensic identity within ONE cluster
+lifetime and nothing more — oids are not preserved by pg_dump/pg_restore, so
+every row here reads as a stale oid on the far side of the RUNBOOK's backup
+and restore path. The durable half of the identity is ``previous_owner_id``.
+
+``previous_owner_id`` is deliberately NOT a foreign key to ``catalog.users``.
+This table is retain-forever, and an FK gives only bad options: ON DELETE
+CASCADE would erase tombstones when a user is deleted (silently re-arming
+GH-1443 for every name that user's datasets freed), RESTRICT would let a
+tombstone block a user deletion, and SET NULL would quietly discard the one
+durable half of the identity. The same reasoning already governs the
+``dataset_id`` column beside it, whose referent is deleted in the very
+transaction that writes the row.
+
+Both columns are nullable and no backfill is attempted, because none is
+possible by construction. Every pre-existing tombstone was written after its
+relation was dropped and its record row deleted, so neither value survives
+anywhere to be recovered. NULL means "not recorded", not "no owner" — a
+consumer must treat a NULL as unknown, never as a match.
+
+Revision ID: 0045_retired_table_names_identity
+Revises: 0044_retired_table_names
+Create Date: 2026-08-13
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0045_retired_table_names_identity"
+down_revision: Union[str, None] = "0044_retired_table_names"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "retired_table_names",
+        sa.Column("relation_oid", sa.BigInteger(), nullable=True),
+        schema="catalog",
+    )
+    op.add_column(
+        "retired_table_names",
+        sa.Column("previous_owner_id", postgresql.UUID(as_uuid=True), nullable=True),
+        schema="catalog",
+    )
+    # No index on either column. Nothing queries them yet, and the probe this
+    # table exists to serve is still the name lookup that
+    # ix_retired_table_names_table_name backs. A reader that later matches on
+    # identity reaches these columns through that same name row.
+
+
+def downgrade() -> None:
+    op.drop_column("retired_table_names", "previous_owner_id", schema="catalog")
+    op.drop_column("retired_table_names", "relation_oid", schema="catalog")

--- a/backend/alembic/versions/0046_detached_relations.py
+++ b/backend/alembic/versions/0046_detached_relations.py
@@ -1,0 +1,108 @@
+"""Record a relation GeoLens released a claim on while it was still standing.
+
+fix(#1456 review round 1). 0045 stamped the freed relation's identity onto the
+tombstone, which covers every delete that RELEASES a name. It does not cover
+the case #1456's window 1 is actually about: a detach that leaves the
+operator's table standing writes no tombstone at all, so the oid and the prior
+owner were probed and then discarded. If the operator drops that relation after
+the delete commits, the name goes free with nothing recorded anywhere, which is
+precisely the window the identity was collected to let a later change close.
+
+Both values are as unrecoverable here as they are on the freed paths: the
+record row carrying ``created_by`` dies in the delete transaction, and the oid
+dies with the relation whenever the operator gets around to dropping it.
+
+A SIBLING TABLE, not a flag on ``catalog.retired_table_names``. That table's
+entire API is set membership: ``generate_table_name`` asks "is this name
+retired?" and ``register_existing_table`` refuses any name that answers yes.
+A row recording a relation that still holds its name is not a prohibition, and
+putting one in that set would either burn the operator's own table name (if the
+readers ignore the discriminator) or make every future reader responsible for
+remembering a predicate whose failure direction is silent. GH-1456 sanctioned
+either shape; this is the one that cannot be read wrong. Nothing reads this
+table yet.
+
+Shape mirrors 0044 deliberately, including its reasoning:
+
+* Retention is FOREVER. A detach is rarer than a delete and the row is one name
+  plus three ids.
+* No unique constraint. The same table can be registered and detached any
+  number of times, and a duplicate must never be able to fail a delete.
+* ``tenant_id`` is the dormant TSEAM-01 shape: nullable, no FK, no RLS policy,
+  written from the deleted dataset's own column.
+* ``dataset_id`` and ``previous_owner_id`` carry no foreign keys. The dataset is
+  deleted in the transaction that writes this row, and an FK to
+  ``catalog.users`` would let a retain-forever row block a user deletion or be
+  cascaded away by one. See 0045 for the full argument.
+* ``relation_oid`` is BIGINT (a pg_class oid is unsigned 32-bit) and identifies
+  the relation for one cluster lifetime only, since pg_dump/pg_restore does not
+  preserve oids. It is nullable even though the only write site reaches it with
+  a non-null oid, because a NOT NULL here could turn a surprise into a FAILED
+  DELETE, and no record is worth that.
+
+The index on ``table_name`` matches 0044's. Nothing queries this table today,
+but every plausible consumer arrives by name, the write happens at most once
+per dataset delete, and adding the index later means migrating a table that has
+been accumulating since this deploy.
+
+Revision ID: 0046_detached_relations
+Revises: 0045_retired_table_names_identity
+Create Date: 2026-08-13
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0046_detached_relations"
+down_revision: Union[str, None] = "0045_retired_table_names_identity"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "detached_relations",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        # Same width as catalog.datasets.table_name, which is what this copies.
+        sa.Column("table_name", sa.String(length=255), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("dataset_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("relation_oid", sa.BigInteger(), nullable=True),
+        sa.Column("previous_owner_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "detached_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="detached_relations_pkey"),
+        schema="catalog",
+    )
+    op.create_index(
+        "ix_detached_relations_table_name",
+        "detached_relations",
+        ["table_name"],
+        schema="catalog",
+    )
+
+    # No backfill, and none is possible. Every detach before this migration
+    # left the relation standing and recorded nothing, so its oid is knowable
+    # only while that relation survives and its owner is already gone with the
+    # record row. Relations detached before this deploy stay unidentified.
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_detached_relations_table_name",
+        table_name="detached_relations",
+        schema="catalog",
+    )
+    op.drop_table("detached_relations", schema="catalog")

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -934,3 +934,53 @@ class RetiredTableName(Base):
     retired_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+
+
+class DetachedRelation(Base):
+    """A relation GeoLens released its claim on while it was still standing.
+
+    fix(#1456 review round 1). :class:`RetiredTableName` covers every delete
+    that FREES a name. The case GH-1456's window 1 is about is the one that
+    frees nothing: a detach that leaves the operator's table standing writes no
+    tombstone, so the relation's identity and its owner were probed and thrown
+    away. If the operator drops that relation after the delete commits, the
+    name goes free with nothing recorded anywhere.
+
+    A separate table rather than a flagged row on ``retired_table_names``,
+    because that table's whole API is set membership — a name in it is never
+    handed out again. A relation still holding its name is not a prohibition,
+    and mixing the two would make every future reader responsible for a
+    predicate whose failure direction is silent. Nothing reads this table yet;
+    it exists so a later change can tell "the table I detached" from "a new
+    table wearing its name" without having to invent history it cannot have.
+    """
+
+    __tablename__ = "detached_relations"
+    __table_args__ = (
+        Index("ix_detached_relations_table_name", "table_name"),
+        {"schema": "catalog"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, server_default=func.gen_random_uuid()
+    )
+    table_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # TSEAM-01 (Phase 1207): dormant tenant_id — nullable, no FK enforcement.
+    tenant_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    # Neither id is a foreign key, for the reasons the sibling table gives: the
+    # dataset is deleted in the transaction that writes this row, and an FK to
+    # catalog.users would let a retain-forever row block a user deletion.
+    dataset_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    # Nullable although the only write site reaches it with a non-null oid: a
+    # NOT NULL here could turn a surprise into a failed DELETE.
+    relation_oid: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    previous_owner_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    detached_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -913,6 +913,24 @@ class RetiredTableName(Base):
     dataset_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
+    # fix(#1456): the identity of the relation whose name this row freed, and
+    # the id of the user who owned the dataset that held it. Both are captured
+    # inside the delete transaction because both sources die in it. Nothing
+    # READS them yet — they exist so a later ownership-aware re-registration
+    # can tell "the table I detached" from "a new table wearing its name".
+    #
+    # BIGINT because a pg_class oid is unsigned 32-bit. It identifies the
+    # relation only within one cluster lifetime: pg_dump/pg_restore does not
+    # preserve oids, so a restored catalog carries oids that match nothing.
+    # previous_owner_id is the durable half.
+    relation_oid: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # Not a foreign key, for the reason dataset_id above is not one plus a
+    # sharper one: this table is retain-forever, so a CASCADE would erase
+    # tombstones when a user is deleted and re-arm GH-1443 for every name
+    # their datasets freed.
+    previous_owner_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
     retired_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -61,10 +61,10 @@ async def _reap_managed_storage(prefixes: list[str], tenant_id: str | None) -> N
             await asyncio.gather(*(storage.delete(key) for key in keys))
 
 
-async def _relation_exists(
+async def _relation_oid(
     session: AsyncSession, table_name: str, *, schema: str
-) -> bool:
-    """Whether a relation of this name currently exists in ``schema``.
+) -> int | None:
+    """The oid of the relation holding this name in ``schema``, or None.
 
     pg_catalog rather than information_schema, for the reason
     ``generate_table_name``'s collision probe gives: the SQL standard filters
@@ -72,16 +72,22 @@ async def _relation_exists(
     a role that does not own the relation can be blind to exactly the one
     being asked about. pg_class is visible to every role and covers every
     relation kind that can hold the name.
+
+    fix(#1456): returns the oid rather than a bare bool so ONE probe answers
+    both questions the delete asks — whether anything still occupies the name,
+    and which relation occupies it. `relname` is unique within a namespace, so
+    there is at most one row. None is the only "absent" answer; an oid is
+    never 0, but callers ask `is None` because that is the actual question.
     """
     result = await session.execute(
         text(
-            "SELECT EXISTS ("
-            " SELECT 1 FROM pg_catalog.pg_class c"
+            "SELECT c.oid FROM pg_catalog.pg_class c"
             " JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace"
-            " WHERE n.nspname = :schema AND c.relname = :table_name)"
+            " WHERE n.nspname = :schema AND c.relname = :table_name"
         ).bindparams(schema=schema, table_name=table_name)
     )
-    return bool(result.scalar())
+    oid = result.scalar()
+    return None if oid is None else int(oid)
 
 
 class DependentVrtError(Exception):
@@ -156,6 +162,14 @@ async def delete_dataset(
     # disclosure GH-1443 exists to prevent, while an extra one costs an
     # operator a rename before they can re-register.
     name_is_freed = True
+
+    # fix(#1456): the identity of the relation this delete frees, read while it
+    # is still there to read. Stays None wherever no relation held the name —
+    # the raster/VRT branch (whose table_name is the synthetic `raster_<hex>`
+    # and names nothing in the data schema) and a detach whose table the
+    # operator had already dropped. NULL therefore means "nothing to identify",
+    # never "no owner"; see the tombstone insert below.
+    relation_oid: int | None = None
 
     if record_type in RASTER_FAMILY_RECORD_TYPES:
         if record_type == "raster_dataset":
@@ -235,7 +249,17 @@ async def delete_dataset(
                 "Dataset deletion is missing tenant context in multi-tenant mode"
             )
         data_schema = tenant_data_schema(tenant_id)
+        # fix(#1456): probe ahead of the branch, not inside the detach arm.
+        # After the DROP below the pg_class row is gone within this
+        # transaction, so this is the last moment the dropped relation can be
+        # identified at all — and the detach arm needs the same read it was
+        # already making. One probe, both answers.
+        relation_oid = await _relation_oid(session, table_name, schema=data_schema)
         if owns_table:
+            # Deliberately does NOT feed `name_is_freed`. A missing relation
+            # here means the DROP IF EXISTS is a no-op, not that the name stays
+            # taken: the catalog row going is what frees it. The fail-safe
+            # direction is unchanged — this path always retires.
             await session.execute(
                 text(
                     f"DROP TABLE IF EXISTS "
@@ -245,12 +269,10 @@ async def delete_dataset(
         else:
             # The name stays taken only if the relation is still there. Asked
             # inside this transaction, so a concurrent DROP either committed
-            # before this read (answers False, name retired) or lands after
+            # before this read (answers None, name retired) or lands after
             # it. The latter is the residual noted in the retirement comment
             # below.
-            name_is_freed = not await _relation_exists(
-                session, table_name, schema=data_schema
-            )
+            name_is_freed = relation_oid is None
         # The storage reap below runs either way: `originals/` and `vectors/`
         # hold GeoLens-produced artifacts keyed by dataset id (an archived
         # source, a quicklook), never the operator's table. A detached dataset
@@ -311,20 +333,34 @@ async def delete_dataset(
     # processing/tiles/router.py already documents for any visibility change,
     # not a predecessor's visibility over a different dataset's rows.
     #
-    # ONE residual remains, and closing it needs a schema change this fix does
-    # not make: if the operator drops that relation AFTER this transaction
-    # reads it, the name goes free with no tombstone. Telling "the table I
-    # detached" from "a new table wearing its name" needs the relation's
-    # identity stored on the tombstone (pg_class.oid), so registration could
-    # accept the first and refuse the second while generate_table_name refuses
-    # both. Until then the exposure is an operator dropping their own table
-    # inside the same 60s window in which a new ingest must also draw the name.
+    # ONE residual remains: if the operator drops that relation AFTER this
+    # transaction reads it, the name goes free with no tombstone. Telling "the
+    # table I detached" from "a new table wearing its name" needs the
+    # relation's identity, so registration could accept the first and refuse
+    # the second while generate_table_name refuses both.
+    #
+    # fix(#1456) records that identity but does NOT act on it. The decision
+    # above is unchanged and still keyed on `name_is_freed`; nothing reads
+    # `relation_oid` or `previous_owner_id` yet. The exposure is still an
+    # operator dropping their own table inside the same 60s window in which a
+    # new ingest must also draw the name — what changed is that the data a
+    # future closure needs now exists, and it could not be reconstructed later
+    # because both of its sources die in this transaction.
     if name_is_freed:
         session.add(
             RetiredTableName(
                 table_name=table_name,
                 tenant_id=dataset.tenant_id,
                 dataset_id=dataset_id,
+                # fix(#1456): captured while their sources are alive — the oid
+                # before the DROP above, created_by before the record delete
+                # below. The oid identifies the relation for ONE cluster
+                # lifetime only: pg_dump/pg_restore does not preserve oids, so
+                # after a RUNBOOK restore every stored oid matches nothing and
+                # a consumer must treat it as unknown rather than as a
+                # mismatch. The owner id is the durable half.
+                relation_oid=relation_oid,
+                previous_owner_id=dataset.record.created_by,
             )
         )
 

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -14,7 +14,10 @@ from app.modules.catalog.datasets.domain._sql_safety import (
     SAFE_TABLE_NAME_RE,
     _safe_table_ref,
 )
-from app.modules.catalog.datasets.domain.models import RetiredTableName
+from app.modules.catalog.datasets.domain.models import (
+    DetachedRelation,
+    RetiredTableName,
+)
 from app.core.db.tenant_session import current_tenant_var
 from app.core.db.tenant_schema import tenant_data_schema
 from app.core.tenancy import is_multi_tenant
@@ -343,22 +346,51 @@ async def delete_dataset(
     # above is unchanged and still keyed on `name_is_freed`; nothing reads
     # `relation_oid` or `previous_owner_id` yet. The exposure is still an
     # operator dropping their own table inside the same 60s window in which a
-    # new ingest must also draw the name — what changed is that the data a
+    # new ingest must also draw the name. What changed is that the data a
     # future closure needs now exists, and it could not be reconstructed later
     # because both of its sources die in this transaction.
+    #
+    # fix(#1456 codex round 1): which is why the ELSE branch below exists. The
+    # residual above lives on the path that writes NO tombstone, so recording
+    # identity only alongside a retirement would collect it for every case but
+    # the one it was collected for.
     if name_is_freed:
         session.add(
             RetiredTableName(
                 table_name=table_name,
                 tenant_id=dataset.tenant_id,
                 dataset_id=dataset_id,
-                # fix(#1456): captured while their sources are alive — the oid
-                # before the DROP above, created_by before the record delete
-                # below. The oid identifies the relation for ONE cluster
+                # fix(#1456): captured while their sources are alive. The oid
+                # was read before the DROP above, created_by before the record
+                # delete below. The oid identifies the relation for ONE cluster
                 # lifetime only: pg_dump/pg_restore does not preserve oids, so
                 # after a RUNBOOK restore every stored oid matches nothing and
                 # a consumer must treat it as unknown rather than as a
                 # mismatch. The owner id is the durable half.
+                relation_oid=relation_oid,
+                previous_owner_id=dataset.record.created_by,
+            )
+        )
+    elif relation_oid is not None:
+        # fix(#1456 codex round 1): the detach left the operator's table
+        # standing, so no name was released and nothing may go in the
+        # retirement set — a name in there is never handed out again, and this
+        # one is still the operator's to re-register. The identity still has to
+        # be recorded HERE or never: created_by dies with the record row three
+        # lines down, and the oid dies with the relation whenever the operator
+        # drops it, which is the exact event this row exists to make detectable.
+        #
+        # A sibling table rather than a flagged tombstone, so no reader of the
+        # retirement set has to remember a predicate to stay correct. Nothing
+        # reads this one yet. The `is not None` guard is belt-and-braces: on
+        # this branch name_is_freed is False precisely because the probe found
+        # a relation, so a None here would mean the two answers disagreed, and
+        # a row asserting an identity nothing verified is worse than no row.
+        session.add(
+            DetachedRelation(
+                table_name=table_name,
+                tenant_id=dataset.tenant_id,
+                dataset_id=dataset_id,
                 relation_oid=relation_oid,
                 previous_owner_id=dataset.record.created_by,
             )

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1780,7 +1780,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # the reasoning for why they are captured here and nowhere else
         # (both sources die in this transaction) plus the oid's
         # one-cluster-lifetime caveat. Cap 415 -> 451, exact.
-        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 451,
+        # fix(#1456 codex round 1): +32 — the identity was being collected
+        # everywhere EXCEPT the surviving-detach path, which is the one
+        # GH-1456's window 1 is about. That path now writes a DetachedRelation
+        # instead of discarding what it probed, in a sibling table rather than
+        # the retirement set (whose whole API is set membership), with the
+        # reasoning for the split and for the belt-and-braces oid guard.
+        # Cap 451 -> 483, exact.
+        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 483,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1772,7 +1772,15 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # makes with the reasoning behind them: drop-vs-detach, and the
         # GH-1443 retirement that follows the relation rather than the
         # dataset. Cap 350 -> 415, exact.
-        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 415,
+        # fix(#1456): +36 — the tombstone now carries the freed relation's oid
+        # and the dataset's prior owner. _relation_exists became _relation_oid
+        # (same one probe, now returning the identity), the probe moved ahead
+        # of the drop-vs-detach branch so the DROP path can capture an oid
+        # before the relation is gone, and the two new tombstone fields carry
+        # the reasoning for why they are captured here and nowhere else
+        # (both sources die in this transaction) plus the oid's
+        # one-cluster-lifetime caveat. Cap 415 -> 451, exact.
+        "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 451,
         # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
         # default (largest is chat_actions.py at ~245 LOC). No explicit
         # per-file overrides needed; default applies.

--- a/backend/tests/test_raster_ingest.py
+++ b/backend/tests/test_raster_ingest.py
@@ -438,6 +438,11 @@ class _MockRecord:
     def __init__(self, title: str, record_type: str):
         self.title = title
         self.record_type = record_type
+        # fix(#1456): delete_dataset copies this onto the retired-name row as
+        # previous_owner_id, reading it before the record is deleted. A real
+        # record's created_by is nullable, and None is the honest value for a
+        # double that never had an owner.
+        self.created_by = None
         self._deleted = False
 
 
@@ -631,6 +636,15 @@ class TestRasterDeleteCascadeRemovesStorage:
 
         async def _capture_execute(stmt, *args, **kwargs):
             executed_sqls.append(str(stmt))
+            # fix(#1456): the vector branch now probes pg_class for the
+            # relation's oid before the DROP, and reads .scalar() off the
+            # result. Returning None here answered every execute with None and
+            # broke on that read. A scalar of None is the honest answer for a
+            # session with no database behind it — no relation is found, so the
+            # tombstone records no identity, which this test does not assert on.
+            result = mock.MagicMock()
+            result.scalar.return_value = None
+            return result
 
         session.execute.side_effect = _capture_execute
 

--- a/backend/tests/test_retired_table_names_1443.py
+++ b/backend/tests/test_retired_table_names_1443.py
@@ -520,6 +520,12 @@ class TestSchema:
             "tenant_id": "YES",
             "dataset_id": "YES",
             "retired_at": "NO",
+            # fix(#1456): the freed relation's oid and the prior owner's id.
+            # Nullable, and not optionally so: every row written before that
+            # migration carries NULL in both and no backfill is possible, since
+            # both sources were already gone when those rows were written.
+            "relation_oid": "YES",
+            "previous_owner_id": "YES",
         }
 
         index_names = (

--- a/backend/tests/test_tombstone_identity_1456.py
+++ b/backend/tests/test_tombstone_identity_1456.py
@@ -14,17 +14,24 @@ here as hard as the new fields, because the whole claim of the change is that
 it altered no behaviour on the way in.
 """
 
+import ast
 import uuid
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.modules.catalog.datasets.domain.models import RetiredTableName
+from app.modules.catalog.datasets.domain.models import (
+    DetachedRelation,
+    RetiredTableName,
+)
 from app.processing.ingest.schemas import RegisterRequest
 from app.processing.ingest.service import register_existing_table
 from tests.factories import create_dataset
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
 
 
 class _MockStorage:
@@ -57,6 +64,15 @@ async def _one_tombstone(session: AsyncSession, table_name: str) -> RetiredTable
     rows = await _tombstones(session, table_name)
     assert len(rows) == 1, f"expected exactly one tombstone for {table_name}: {rows}"
     return rows[0]
+
+
+async def _detach_records(
+    session: AsyncSession, table_name: str
+) -> list[DetachedRelation]:
+    result = await session.execute(
+        select(DetachedRelation).where(DetachedRelation.table_name == table_name)
+    )
+    return list(result.scalars().all())
 
 
 async def _live_oid(session: AsyncSession, table_name: str) -> int | None:
@@ -218,6 +234,129 @@ class TestADetachWhoseTableAlreadyVanished:
             "an oid was recorded for a relation that was already gone — the "
             "column would then be asserting an identity nothing verified"
         )
+
+    async def test_no_detach_record_is_written_when_nothing_survived(
+        self, test_db_session: AsyncSession
+    ):
+        """A detach record claims a relation is still standing. None is."""
+        owner = await _make_user(test_db_session)
+        table_name = await _operator_table(test_db_session)
+        title = f"Vanished {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title, owner)
+
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert await _detach_records(test_db_session, table_name) == []
+
+
+class TestASurvivingDetachRecordsWhatItReleased:
+    """fix(#1456 codex round 1): the path GH-1456's window 1 actually lives on.
+
+    A detach that leaves the operator's table standing frees no name, so it
+    writes no tombstone. Before this, that meant the probed oid and the owner
+    were read and thrown away on the one path where the residual exists: if the
+    operator drops that relation after the delete commits, the name goes free
+    with nothing recorded anywhere, and neither value can be recovered.
+    """
+
+    async def test_the_released_relation_is_recorded_with_its_live_oid(
+        self, test_db_session: AsyncSession
+    ):
+        owner = await _make_user(test_db_session)
+        table_name = await _operator_table(test_db_session)
+        title = f"Released {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title, owner)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        records = await _detach_records(test_db_session, table_name)
+        assert len(records) == 1
+        assert records[0].relation_oid == await _live_oid(test_db_session, table_name)
+        assert records[0].previous_owner_id == owner
+        assert records[0].dataset_id == dataset.id
+
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+    async def test_the_record_does_not_retire_the_name(
+        self, test_db_session: AsyncSession
+    ):
+        """The reason it is a sibling table and not a flag on the tombstone.
+
+        The retirement set's whole API is membership: a name in it is never
+        handed out again, and ``register_existing_table`` refuses it outright.
+        The operator's table is still theirs to re-register, so this record has
+        to be invisible to both of those readers, which it is by construction
+        rather than by anyone remembering a predicate.
+        """
+        from app.processing.ingest.service import generate_table_name
+
+        owner = await _make_user(test_db_session)
+        table_name = await _operator_table(test_db_session)
+        title = f"Readopt {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title, owner)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+        assert len(await _detach_records(test_db_session, table_name)) == 1
+
+        # Registration must still accept the operator's own surviving table.
+        readopted = await _register(
+            test_db_session, table_name, f"Readopted {uuid.uuid4().hex[:6]}", owner
+        )
+        assert readopted.table_name == table_name
+
+        # And the collision walk must refuse it for the reason it always did —
+        # a live relation occupies it — not because a record retired it.
+        redrawn, _ = await generate_table_name(table_name, test_db_session)
+        assert redrawn == f"{table_name}_2"
+
+        await _delete(test_db_session, readopted.id, readopted.record.title)
+        await test_db_session.commit()
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+    async def test_a_dropped_table_writes_no_detach_record(
+        self, test_db_session: AsyncSession
+    ):
+        """The owning path releases nothing: it destroys the relation."""
+        owner = await _make_user(test_db_session)
+        title = f"Ingested {uuid.uuid4().hex[:6]}"
+        dataset, table_name = await _ingested_dataset(test_db_session, title, owner)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert await _detach_records(test_db_session, table_name) == []
+        assert len(await _tombstones(test_db_session, table_name)) == 1
+
+    def test_only_delete_dataset_constructs_a_detach_record(self):
+        """One write site, matching the tombstone's own enumeration.
+
+        A second one would mean something other than a dataset delete claims
+        GeoLens released a relation, which is not a claim any other path is in
+        a position to make.
+        """
+        sites: list[str] = []
+        for path in sorted((BACKEND_ROOT / "app").rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "DetachedRelation"
+                ):
+                    sites.append(f"{path.relative_to(BACKEND_ROOT)}:{node.lineno}")
+
+        assert len(sites) == 1, sites
+        assert sites[0].startswith(
+            "app/modules/catalog/datasets/domain/service_lifecycle.py"
+        ), sites
 
 
 class TestNothingElseChanged:

--- a/backend/tests/test_tombstone_identity_1456.py
+++ b/backend/tests/test_tombstone_identity_1456.py
@@ -1,0 +1,372 @@
+"""A tombstone must carry the identity of the relation whose name it freed.
+
+fix(#1456). ``catalog.retired_table_names`` recorded only the freed NAME. That
+cannot tell "the table I detached" from "a new table wearing its name", and it
+says nothing about who owned the dataset that held it. Both answers have to be
+read inside the delete transaction, because both of their sources die in it:
+the relation is dropped, and the ``catalog.records`` row carrying ``created_by``
+is deleted. Neither can be reconstructed afterwards, which is why the recording
+lands before anything reads it.
+
+This is a data-carrying change only. Nothing consumes the two columns yet and
+the tombstone-vs-not decision is untouched — the unchanged paths are pinned
+here as hard as the new fields, because the whole claim of the change is that
+it altered no behaviour on the way in.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.catalog.datasets.domain.models import RetiredTableName
+from app.processing.ingest.schemas import RegisterRequest
+from app.processing.ingest.service import register_existing_table
+from tests.factories import create_dataset
+
+
+class _MockStorage:
+    """delete_dataset reaps originals/ and vectors/; nothing is staged here."""
+
+    async def list(self, prefix: str) -> list[str]:
+        return []
+
+    async def delete(self, key: str) -> None:  # pragma: no cover - nothing listed
+        raise AssertionError("no keys were listed")
+
+
+async def _delete(session: AsyncSession, dataset_id: uuid.UUID, title: str) -> str:
+    from app.modules.catalog.datasets.domain.service import delete_dataset
+
+    with patch(
+        "app.platform.storage.provider.get_storage", return_value=_MockStorage()
+    ):
+        return await delete_dataset(session, dataset_id, title)
+
+
+async def _tombstones(session: AsyncSession, table_name: str) -> list[RetiredTableName]:
+    result = await session.execute(
+        select(RetiredTableName).where(RetiredTableName.table_name == table_name)
+    )
+    return list(result.scalars().all())
+
+
+async def _one_tombstone(session: AsyncSession, table_name: str) -> RetiredTableName:
+    rows = await _tombstones(session, table_name)
+    assert len(rows) == 1, f"expected exactly one tombstone for {table_name}: {rows}"
+    return rows[0]
+
+
+async def _live_oid(session: AsyncSession, table_name: str) -> int | None:
+    """The oid pg_class currently holds for this name, read independently.
+
+    Deliberately not the production probe — comparing delete_dataset's answer
+    against its own helper would pass whatever that helper returned.
+    """
+    result = await session.execute(
+        text(
+            "SELECT c.oid FROM pg_catalog.pg_class c"
+            " JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace"
+            " WHERE n.nspname = 'data' AND c.relname = :t"
+        ).bindparams(t=table_name)
+    )
+    oid = result.scalar()
+    return None if oid is None else int(oid)
+
+
+async def _make_user(session: AsyncSession) -> uuid.UUID:
+    """A fresh owner, so the recorded id can only have come from the record."""
+    from app.modules.auth.models import User
+
+    user = User(id=uuid.uuid4(), username=f"owner_{uuid.uuid4().hex[:10]}")
+    session.add(user)
+    await session.commit()
+    return user.id
+
+
+async def _ingested_dataset(session: AsyncSession, title: str, owner: uuid.UUID):
+    """A dataset plus the physical table a real vector ingest would leave."""
+    from app.processing.ingest.service import generate_table_name
+
+    table_name, _ = await generate_table_name(title, session)
+    dataset = await create_dataset(
+        session,
+        created_by=owner,
+        name=title,
+        table_name=table_name,
+        record_type="vector_dataset",
+        source_format="geojson",
+    )
+    await session.execute(text(f'CREATE TABLE data."{table_name}" (marker integer)'))
+    await session.commit()
+    return dataset, table_name
+
+
+async def _operator_table(session: AsyncSession) -> str:
+    """A table the OPERATOR created, which registration only points at."""
+    table_name = f"operator_{uuid.uuid4().hex[:12]}"
+    await session.execute(
+        text(f'CREATE TABLE data."{table_name}" (gid serial primary key, note text)')
+    )
+    await session.commit()
+    return table_name
+
+
+async def _register(session: AsyncSession, table_name: str, title: str, owner):
+    dataset = await register_existing_table(
+        session,
+        RegisterRequest(table_name=table_name, title=title),
+        SimpleNamespace(id=owner),
+    )
+    await session.commit()
+    return dataset
+
+
+class TestTheDroppedRelationIsIdentified:
+    """The DROP path is the one that frees a relation GeoLens can still see."""
+
+    async def test_the_recorded_oid_is_the_relation_the_delete_dropped(
+        self, test_db_session: AsyncSession
+    ):
+        """Also pins the probe's POSITION, not just its result.
+
+        The oid is only readable before the DROP: afterwards the pg_class row
+        is gone inside the same transaction. A probe moved below the DROP
+        would record NULL here and the delete would still succeed, so this
+        equality is the only thing standing between the ordering and a silent
+        regression to a column full of nulls.
+        """
+        owner = await _make_user(test_db_session)
+        title = f"Parcels {uuid.uuid4().hex[:6]}"
+        dataset, table_name = await _ingested_dataset(test_db_session, title, owner)
+
+        oid_before = await _live_oid(test_db_session, table_name)
+        assert oid_before is not None, "the fixture never created the table"
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert await _live_oid(test_db_session, table_name) is None, (
+            "the table survived a delete that owns it — this test is measuring "
+            "the wrong path"
+        )
+        row = await _one_tombstone(test_db_session, table_name)
+        assert row.relation_oid == oid_before
+
+    async def test_the_recorded_owner_is_the_datasets_creator(
+        self, test_db_session: AsyncSession
+    ):
+        """A fresh user, so a stray admin id could not pass by coincidence."""
+        owner = await _make_user(test_db_session)
+        title = f"Owned {uuid.uuid4().hex[:6]}"
+        dataset, table_name = await _ingested_dataset(test_db_session, title, owner)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        row = await _one_tombstone(test_db_session, table_name)
+        assert row.previous_owner_id == owner
+        assert row.dataset_id == dataset.id
+
+    async def test_an_ownerless_dataset_records_a_null_owner(
+        self, test_db_session: AsyncSession
+    ):
+        """``records.created_by`` is nullable and NULL survives as NULL.
+
+        Nothing substitutes a caller or an admin for a missing owner: the
+        column answers "who owned it", and inventing an answer would be worse
+        than not having one.
+        """
+        title = f"Ownerless {uuid.uuid4().hex[:6]}"
+        dataset, table_name = await _ingested_dataset(test_db_session, title, None)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        row = await _one_tombstone(test_db_session, table_name)
+        assert row.previous_owner_id is None
+
+
+class TestADetachWhoseTableAlreadyVanished:
+    """The registered path that still frees the name (fix(#1452) round 1).
+
+    The relation is already gone when the delete runs, so there is no identity
+    left to record — the honest oid is NULL. The owner is not lost with it,
+    and that is the half the issue called unrecoverable after the fact.
+    """
+
+    async def test_the_owner_is_recorded_although_no_relation_survives(
+        self, test_db_session: AsyncSession
+    ):
+        owner = await _make_user(test_db_session)
+        table_name = await _operator_table(test_db_session)
+        title = f"Vanished {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title, owner)
+
+        # The operator drops their own table behind GeoLens's back.
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        row = await _one_tombstone(test_db_session, table_name)
+        assert row.previous_owner_id == owner
+        assert row.relation_oid is None, (
+            "an oid was recorded for a relation that was already gone — the "
+            "column would then be asserting an identity nothing verified"
+        )
+
+
+class TestNothingElseChanged:
+    """The tombstone-vs-not decision is exactly what it was before #1456."""
+
+    async def test_a_surviving_detached_table_still_writes_no_tombstone(
+        self, test_db_session: AsyncSession
+    ):
+        """The probe now also reads an oid on this path, and must not use it.
+
+        Recording a tombstone here would make the operator's own table
+        permanently unregisterable, which is the whole reason fix(#1452) reads
+        the relation rather than the origin.
+        """
+        owner = await _make_user(test_db_session)
+        table_name = await _operator_table(test_db_session)
+        title = f"Surviving {uuid.uuid4().hex[:6]}"
+        dataset = await _register(test_db_session, table_name, title, owner)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert await _tombstones(test_db_session, table_name) == []
+        assert await _live_oid(test_db_session, table_name) is not None
+
+        await test_db_session.execute(text(f'DROP TABLE data."{table_name}"'))
+        await test_db_session.commit()
+
+    async def test_an_ingested_delete_still_drops_and_still_retires(
+        self, test_db_session: AsyncSession
+    ):
+        owner = await _make_user(test_db_session)
+        title = f"Ingested {uuid.uuid4().hex[:6]}"
+        dataset, table_name = await _ingested_dataset(test_db_session, title, owner)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        assert await _live_oid(test_db_session, table_name) is None
+        assert len(await _tombstones(test_db_session, table_name)) == 1
+
+    async def test_a_raster_delete_records_no_relation_identity(
+        self, test_db_session: AsyncSession
+    ):
+        """The raster branch never had a relation to identify.
+
+        A raster dataset's table_name is the synthetic ``raster_<hex>`` and
+        names nothing in the data schema, so that branch is not probed at all.
+        Its name is still freed by the delete, so the tombstone is still
+        written — with the owner, and with a NULL oid.
+        """
+        owner = await _make_user(test_db_session)
+        title = f"Imagery {uuid.uuid4().hex[:6]}"
+        table_name = f"raster_{uuid.uuid4().hex[:16]}"
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=owner,
+            name=title,
+            table_name=table_name,
+            record_type="raster_dataset",
+        )
+        await test_db_session.commit()
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        row = await _one_tombstone(test_db_session, table_name)
+        assert row.relation_oid is None
+        assert row.previous_owner_id == owner
+
+
+class TestTheColumnsCannotBreakADelete:
+    """Both are nullable and neither carries a foreign key, deliberately.
+
+    This table's one hard rule is that it must never be the reason a delete
+    fails, and every tombstone written before #1456 has to stay valid — no
+    backfill is possible, since both sources were already gone when those rows
+    were written.
+    """
+
+    async def test_a_tombstone_with_neither_identity_column_is_accepted(
+        self, test_db_session: AsyncSession
+    ):
+        """The shape of every pre-existing row, and of an operator insert."""
+        table_name = f"legacy_{uuid.uuid4().hex[:12]}"
+        test_db_session.add(RetiredTableName(table_name=table_name))
+        await test_db_session.commit()
+
+        row = await _one_tombstone(test_db_session, table_name)
+        assert row.relation_oid is None
+        assert row.previous_owner_id is None
+
+    async def test_no_foreign_key_reaches_out_of_this_table(
+        self, test_db_session: AsyncSession
+    ):
+        """An FK on previous_owner_id gives only bad options.
+
+        CASCADE erases tombstones when a user is deleted, re-arming GH-1443
+        for every name their datasets freed; RESTRICT lets a retain-forever
+        row block a user deletion; SET NULL silently discards the durable half
+        of the identity.
+        """
+        fks = (
+            (
+                await test_db_session.execute(
+                    text(
+                        "SELECT conname FROM pg_constraint"
+                        " WHERE conrelid = 'catalog.retired_table_names'::regclass"
+                        "   AND contype = 'f'"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert list(fks) == []
+
+    async def test_deleting_the_prior_owner_leaves_the_tombstone_intact(
+        self, test_db_session: AsyncSession
+    ):
+        """The property the missing FK buys, asked of the database itself."""
+        from app.modules.auth.models import User
+
+        owner = await _make_user(test_db_session)
+        title = f"Departing {uuid.uuid4().hex[:6]}"
+        dataset, table_name = await _ingested_dataset(test_db_session, title, owner)
+
+        await _delete(test_db_session, dataset.id, title)
+        await test_db_session.commit()
+
+        await test_db_session.execute(
+            text("DELETE FROM catalog.users WHERE id = :id").bindparams(id=owner)
+        )
+        await test_db_session.commit()
+
+        survivors = (
+            await test_db_session.execute(
+                select(func.count())
+                .select_from(RetiredTableName)
+                .where(RetiredTableName.table_name == table_name)
+                .where(RetiredTableName.previous_owner_id == owner)
+            )
+        ).scalar_one()
+        assert survivors == 1, (
+            "the tombstone followed its owner out — the name is redrawable "
+            "again and GH-1443 is re-armed"
+        )
+        assert (
+            await test_db_session.execute(
+                select(func.count()).select_from(User).where(User.id == owner)
+            )
+        ).scalar_one() == 0, "the tombstone blocked the user deletion"


### PR DESCRIPTION
## What changed

Every dataset delete now records the identity of the relation it released, and who owned the dataset that held it.

`catalog.retired_table_names` gains two nullable columns, `relation_oid` (the pg_class oid of the relation whose name the delete freed) and `previous_owner_id` (the `created_by` of the dataset that held it), for the deletes that free a name. A sibling table `catalog.detached_relations` takes the same two values plus the name, tenant and dataset ids for the delete that frees nothing: a detach that leaves the operator's table standing.

Nothing reads any of it. The tombstone-vs-not decision is exactly the one #1453 shipped, and the retirement set contains exactly the rows it would have contained before.

It is a PR of its own because none of these values can be recovered afterwards. The `catalog.records` row carrying `created_by` is deleted inside the delete transaction. The oid dies with its relation, either in the same transaction (a drop) or whenever the operator gets round to it (a detach). A closure written later would find both sources gone and would have to start collecting from its own deploy date.

## The two windows from #1456

Window 1 is the post-transaction drop. Detach decides tombstone-vs-not by probing pg_class inside the delete transaction, so an operator who drops the relation *after* that read frees the name with no tombstone, reopening GH-1443's ingest window for it. Closing that needs registration to accept "the table I detached" and refuse "a new table wearing its name" while `generate_table_name` refuses both, and telling those two apart is what the recorded identity is for. This is the window the data enables closing later. The closure itself is not here.

Window 1 lives entirely on the path that writes no tombstone, which is why `detached_relations` exists. The first version of this PR recorded identity alongside retirements only, which collected it for every case except the one it was collected for. Codex caught that; the `elif` branch in `delete_dataset` is the answer.

Window 2 is the surviving detached table, discoverable and re-registerable by any editor holding `upload`. #1453 partially refuted it: that is the ambient property of any table sitting in the shared `data` schema, identical to the window before its owner first registered it. `previous_owner_id` is what a later ownership-aware re-registration would key on, but no such flow exists and this PR does not propose one.

Neither window is closed here. Both stay as wide as they were.

## Why a sibling table and not a flag on the tombstone

`retired_table_names` has one API, and it is set membership. `generate_table_name` asks "is this name retired?" and `register_existing_table` refuses any name that answers yes. A row describing a relation that still holds its name is not a prohibition. Putting one in that set either burns the operator's own table name, if the readers ignore the discriminator, or makes every future reader of a security-load-bearing probe responsible for remembering a predicate whose failure direction is silent.

GH-1456 sanctioned either shape ("the tombstone or a sibling record"). This is the one that cannot be read wrong, and it needs no change to either consumer. `test_the_record_does_not_retire_the_name` asks both of them directly: after a detach, registration still accepts the operator's surviving table, and the collision walk still refuses the name for the reason it always did, because a live relation occupies it.

`detached_relations` mirrors 0044's shape and its reasoning: retain-forever, no unique constraint, dormant nullable `tenant_id`, no foreign keys, and an index on `table_name` because every plausible consumer arrives by name.

## What deliberately does not change

`name_is_freed` is computed from the same probe, in the same transaction, with the same fail-safe default of retiring. Nothing was added to or removed from the retirement set.

The DROP path does not consult the probe. A missing relation there means `DROP TABLE IF EXISTS` is a no-op, not that the name stays taken: the catalog row going is what frees it. Reading the oid on that path only records what was dropped.

A detach that leaves the relation standing still writes no tombstone. Retiring it would leave the operator holding a table their own catalog can never accept again, which is why #1453 keys on the relation rather than the origin.

No API surface changes. `backend/openapi.json` is untouched and `scripts/dump_openapi.py --check` agrees.

The one cost is a second pg_catalog lookup on the ingested-vector delete, which previously probed nothing. It is an indexed single-row read inside a transaction that is already dropping a table.

## Why neither owner column carries a foreign key

Both tables are retain-forever, and an FK to `catalog.users` gives only bad options. CASCADE erases the record when a user is deleted, silently re-arming GH-1443 for every name that user's datasets freed. RESTRICT lets a retain-forever row block a user deletion. SET NULL discards the durable half of the identity to preserve referential tidiness nothing reads.

The same reasoning already governs the `dataset_id` column beside it, whose referent dies in the transaction that writes the row. `test_deleting_the_prior_owner_leaves_the_tombstone_intact` asks the database directly: delete the owner, and the tombstone is still there with the uuid intact.

## The oid does not survive a restore

`pg_dump`/`pg_restore` does not preserve oids. Every row written before a RUNBOOK restore carries an oid that matches nothing on the far side, so a consumer has to read that as unknown rather than as a mismatch. Refusing a re-registration because a restored oid disagrees would be exactly backwards. `previous_owner_id` is the durable half and survives the restore intact. The caveat is repeated in both migration docstrings, on both models, and at the capture site, because each is a place where someone will decide what a stored oid means.

`BIGINT` rather than `INTEGER`: a pg_class oid is unsigned 32-bit, so int4 overflows past 2^31, and a cluster that has churned enough objects hands those out.

## Sibling findings preempted

Nullability of every new column. NOT NULL would make pre-#1456 tombstones unrepresentable and could fail a delete, which is the one outcome these tables must never cause. On the tombstone, `relation_oid` is legitimately NULL wherever no relation held the name: the raster/VRT branch, whose `table_name` is the synthetic `raster_<hex>` and names nothing in the data schema, and a detach whose table the operator had already dropped. NULL means "not recorded", never "no owner" and never "no relation". On `detached_relations`, `relation_oid` is nullable even though the only write site reaches it with a non-null oid, guarded by an explicit `is not None` so a row can never assert an identity nothing verified.

FK absence on both owner columns, covered above. `test_no_foreign_key_reaches_out_of_this_table` pins it against `pg_constraint`, so re-adding one fails a test rather than passing review.

Backfill impossibility. Every tombstone written before 0045 was written after its relation was dropped and its record row deleted, so neither value survives anywhere. Every relation detached before 0046 recorded nothing and its owner is already gone with the record row. Both migrations say so instead of pretending, the way 0044 handled names freed before it existed.

oid transience across dump and restore, covered above.

Write-site count. `test_only_delete_dataset_constructs_a_detach_record` walks the `backend/app/` ASTs and requires exactly one `DetachedRelation` construction, mirroring the enumeration #1444 already applies to `RetiredTableName`.

## Verification

```
cd backend && uv run ruff check .                       # clean
cd backend && uv run ruff format --check .              # 991 files already formatted
PYTHONPATH=. python scripts/dump_openapi.py --check     # exit 0, no drift

alembic upgrade head                                    # 0044 -> 0045 -> 0046, test DB
alembic downgrade -1 && alembic upgrade head            # both round-trip clean

pytest tests/test_tombstone_identity_1456.py -q         # 15 passed (new)
pytest tests/test_retired_table_names_1443.py \
       tests/test_registered_delete_detach_1452.py \
       tests/test_raster_ingest.py \
       tests/test_vrt_delete_guard_174.py \
       tests/test_dataset_delete_tile_cache_purge.py \
       tests/test_layering.py \
       tests/test_migration_discovery.py \
       tests/test_dormant_tenancy_schema.py \
       tests/test_alembic_helpers.py -q                 # 173 passed
pytest tests/test_datasets.py tests/test_raster_replace_1221.py \
       tests/test_dataset_metadata_idor.py tests/test_attribute_metadata.py \
       tests/test_tile_cache_generation_key_1429.py \
       tests/test_tile_cached_authz_liveness_1451.py \
       tests/test_raster_ingest_orphan_cleanup_gap017.py -q  # 255 passed
```

The tests were confirmed non-vacuous by breaking the implementation and re-running. Moving the probe below the DROP fails 1: the recorded oid becomes NULL while the delete still succeeds, which is the failure mode that equality exists to catch. Stamping `previous_owner_id=None` fails 4.

Two test doubles needed the new read. `_MockRecord` in `test_raster_ingest.py` gained `created_by`, and one mocked session in that file returned `None` from every `execute`, which the new `.scalar()` read tripped over. It now returns a result whose scalar is None, the honest answer for a session with no database behind it.

`service_lifecycle.py`'s LOC cap went from 415 to 483 across the two rounds, with a comment for each saying what the lines bought. `domain/models.py` is at 986, still under the 1000-line ratchet inclusion threshold.

Refs #1456

Closes #1456