### PR TITLE
fix(auth): reject session credentials issued before their revocation horizon

### DIFF
--- a/backend/alembic/versions/0047_users_sessions_revoked_at.py
+++ b/backend/alembic/versions/0047_users_sessions_revoked_at.py
@@ -1,0 +1,47 @@
+"""Add the session revocation horizon to catalog.users.
+
+fix(#1455): logout revoked the refresh rows one statement's snapshot could see
+and bumped ``token_version``. Neither can express "everything issued up to
+now", so a refresh row inserted by a path that does not take the owner-row lock
+-- a login racing the logout -- can commit after that snapshot, survive the
+revocation, and rotate into a session that outlives the logout that ended it.
+
+``sessions_revoked_at`` is that missing statement, as a use-time predicate: any
+refresh row created at or before it, and any access JWT issued at or before it,
+is rejected on presentation regardless of its own state. Stamped from the DB
+clock, the same clock that stamps ``refresh_tokens.created_at``, so the refresh
+comparison has no skew axis.
+
+Nullable with no default and no backfill: NULL means "no horizon", which is the
+correct and behaviour-preserving value for every existing row -- none of those
+users has revoked anything, and inventing a timestamp would revoke live
+sessions on deploy. No index: the column is only ever read through a User row
+the request already loaded, or through the join the refresh lookups already
+make on the primary key.
+
+Revision ID: 0047_users_sessions_revoked_at
+Revises: 0046_detached_relations
+Create Date: 2026-08-13
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0047_users_sessions_revoked_at"
+down_revision: Union[str, None] = "0046_detached_relations"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("sessions_revoked_at", sa.DateTime(timezone=True), nullable=True),
+        schema="catalog",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "sessions_revoked_at", schema="catalog")

--- a/backend/app/modules/admin/service.py
+++ b/backend/app/modules/admin/service.py
@@ -13,9 +13,10 @@ from app.modules.admin.schemas import (
     EmbeddingStatsResponse,
     UserUpdate,
 )
-from app.modules.auth.models import ApiKey, RefreshToken, Role, User, UserRole
+from app.modules.auth.models import ApiKey, Role, User, UserRole
 from app.modules.auth.oauth.models import OAuthAccount, OAuthProvider
 from app.modules.auth.providers.local import hash_password
+from app.modules.auth.service import AuthService
 from app.core.text import escape_ilike
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -432,6 +433,9 @@ class AdminService:
              CHECK admits 'local').
           6. DELETE the SAML oauth_accounts row (clean break per D-04 -- the
              oauth_providers row stays; other users may still link to it).
+          7. revoke_all_tokens(commit=False, bump_key_epoch=True): revoke the
+             refresh rows, bump token_version and key_epoch, and stamp the
+             revocation horizon, so no SAML-era credential survives.
 
         Returns (user, provider_slug). The router uses provider_slug to populate
         the audit-log details field. The router (NOT this method) writes the
@@ -484,32 +488,20 @@ class AdminService:
             delete(OAuthAccount).where(OAuthAccount.id == saml_account.id)
         )
 
-        # 7. SEC-S15 (CR-02, Phase 1062 review): bump token_version so any
-        #    outstanding SAML access JWT is rejected on the next authenticated
-        #    request. The SAML JWT remains cryptographically valid until its
-        #    natural expiry otherwise, which violates the SEC-S15 requirement
-        #    that auth-provider conversion forces re-authentication.
-        #    fix(#821): also bump key_epoch — an auth-provider conversion is a
-        #    credential reset, so API keys minted before it stop resolving.
-        await self.db.execute(
-            update(User)
-            .where(User.id == user_id)
-            .values(
-                token_version=User.token_version + 1,
-                key_epoch=User.key_epoch + 1,
-            )
-        )
-
-        # 8. Belt-and-suspenders: also revoke any active refresh tokens so the
-        #    converted user cannot exchange a SAML-era refresh token for a new
-        #    access JWT after conversion.
-        await self.db.execute(
-            update(RefreshToken)
-            .where(
-                RefreshToken.user_id == user_id,
-                RefreshToken.revoked == False,  # noqa: E712
-            )
-            .values(revoked=True)
+        # 7. Revoke every session credential the SAML identity holds. Conversion
+        #    is a credential reset: SEC-S15 (CR-02, Phase 1062 review) requires
+        #    it to force re-authentication rather than let an outstanding SAML
+        #    access JWT stay cryptographically valid until its natural expiry,
+        #    and the SAML-era refresh tokens must not be exchangeable for a new
+        #    JWT afterwards. bump_key_epoch=True per fix(#821), so API keys
+        #    minted before the conversion also stop resolving.
+        #
+        #    fix(#1455): one call where two inline UPDATEs used to duplicate
+        #    revoke_all_tokens. The duplication is what let the sites drift —
+        #    the horizon added there would have silently missed this one. Same
+        #    session, so commit=False folds it into the caller's transaction.
+        await AuthService(self.db).revoke_all_tokens(
+            user_id, commit=False, bump_key_epoch=True
         )
 
         await self.db.flush()

--- a/backend/app/modules/auth/dependencies.py
+++ b/backend/app/modules/auth/dependencies.py
@@ -25,6 +25,47 @@ oauth2_scheme_optional = OAuth2PasswordBearer(tokenUrl="/auth/login", auto_error
 log = structlog.get_logger()
 
 
+def _predates_revocation_horizon(payload: Mapping, user: User) -> bool:
+    """True when this access JWT was certainly issued before the user's horizon.
+
+    fix(#1455): the companion to the ``token_version`` check at both call
+    sites. One helper rather than the pair of inline copies, so the two
+    dependencies cannot drift apart on a security predicate.
+
+    A missing (or non-numeric) ``iat`` is treated as 0, which precedes every
+    horizon and is therefore always rejected once one exists. That mirrors the
+    missing-``token_version``-is-0 convention at the call sites. Coercing
+    rather than comparing directly matters because PyJWT validates ``iat`` by
+    casting a COPY, leaving a numeric STRING in the payload, and ``"1" < 1``
+    raises rather than rejecting.
+
+    ``iat`` is whole seconds (PyJWT truncates), so it does not name an instant,
+    it names the interval ``[iat, iat+1)``. Rounding has to go one way or the
+    other, and this rejects only when that WHOLE interval precedes the horizon.
+    The other rounding kills any token minted in the same second as the
+    revocation, which is not a theoretical cost: it breaks logging out and
+    immediately logging back in, and it made
+    ``test_a_rotation_racing_logout_never_leaves_a_live_session`` fail
+    intermittently (observed: ``iat=1786618628`` against a horizon of
+    ``1786618628.02``, a token minted AFTER the revocation and refused).
+
+    Rounding this way gives up nothing, because the sub-second region is
+    already covered by the ``token_version`` bump that the same UPDATE makes.
+    A token minted before that UPDATE commits reads the pre-bump version under
+    READ COMMITTED and is rejected on the version check; one minted after it
+    commits genuinely postdates the horizon. The same composition is what
+    covers API-vs-DB clock skew, where an API clock running ahead could lift a
+    pre-revocation ``iat`` past the horizon: the bump still rejects it. This
+    check is therefore added ALONGSIDE the version check and never replaces it.
+    """
+    if user.sessions_revoked_at is None:
+        return False
+    issued_at = payload.get("iat", 0)
+    if not isinstance(issued_at, (int, float)):
+        issued_at = 0
+    return issued_at + 1 <= user.sessions_revoked_at.timestamp()
+
+
 # fix(#875): HTTP methods a read_only API key may authenticate. Enforcement is
 # method-based rather than capability-based on purpose: every read surface an
 # API-key client actually uses (OGC Features, STAC, tiles, search, dataset and
@@ -315,6 +356,13 @@ async def get_optional_user(
     if jwt_token_version < user.token_version:
         return None
 
+    # fix(#1455): a matching token_version is not proof the token postdates the
+    # last revocation — a rotation racing that revocation reads the pre-bump
+    # value and mints a token carrying it. The horizon is the check that does
+    # not depend on when the claim was read.
+    if _predates_revocation_horizon(payload, user):
+        return None
+
     return user
 
 
@@ -452,6 +500,13 @@ async def get_current_user(
     # version 0, which is always less than the minimum stored version of 1.
     jwt_token_version: int = payload.get("token_version", 0)
     if jwt_token_version < user.token_version:
+        raise credentials_exception
+
+    # fix(#1455): a matching token_version is not proof the token postdates the
+    # last revocation — a rotation racing that revocation reads the pre-bump
+    # value and mints a token carrying it. The horizon is the check that does
+    # not depend on when the claim was read.
+    if _predates_revocation_horizon(payload, user):
         raise credentials_exception
 
     return user

--- a/backend/app/modules/auth/dependencies.py
+++ b/backend/app/modules/auth/dependencies.py
@@ -32,31 +32,38 @@ def _predates_revocation_horizon(payload: Mapping, user: User) -> bool:
     sites. One helper rather than the pair of inline copies, so the two
     dependencies cannot drift apart on a security predicate.
 
+    CONSTRAINT: the rounding below is only safe while ``revoke_all_tokens``
+    bumps ``token_version`` in the SAME UPDATE that stamps the horizon. Anyone
+    who removes or weakens that bump must tighten this back to
+    ``issued_at <= int(...)`` in the same change.
+
+    Why the coupling exists. ``iat`` is whole seconds (PyJWT truncates), so it
+    names the interval ``[iat, iat+1)`` rather than an instant, and this
+    rejects only when that WHOLE interval precedes the horizon — which leaves
+    the same-second region covered by nothing on this line. The bump is what
+    covers it: the horizon is the revoking transaction's ``now()``, so a token
+    minted before that UPDATE commits necessarily read the pre-bump version
+    under READ COMMITTED and dies on the version check, while one minted after
+    it commits carries the new version and legitimately lives. The same
+    composition covers API-vs-DB clock skew, where an API clock running ahead
+    could lift a pre-revocation ``iat`` past the horizon: the bump still
+    rejects it. This check is therefore added ALONGSIDE the version check and
+    never replaces it.
+
+    Rounding the other way is not free, which is why the constraint is worth
+    keeping rather than pre-emptively tightening: it kills any token minted in
+    the same second as a revocation, which breaks logging out and immediately
+    logging back in, and it made
+    ``test_a_rotation_racing_logout_never_leaves_a_live_session`` fail
+    intermittently (``iat=1786618628`` against a horizon of ``1786618628.02``,
+    a token minted AFTER the revocation and refused).
+
     A missing (or non-numeric) ``iat`` is treated as 0, which precedes every
     horizon and is therefore always rejected once one exists. That mirrors the
     missing-``token_version``-is-0 convention at the call sites. Coercing
     rather than comparing directly matters because PyJWT validates ``iat`` by
     casting a COPY, leaving a numeric STRING in the payload, and ``"1" < 1``
     raises rather than rejecting.
-
-    ``iat`` is whole seconds (PyJWT truncates), so it does not name an instant,
-    it names the interval ``[iat, iat+1)``. Rounding has to go one way or the
-    other, and this rejects only when that WHOLE interval precedes the horizon.
-    The other rounding kills any token minted in the same second as the
-    revocation, which is not a theoretical cost: it breaks logging out and
-    immediately logging back in, and it made
-    ``test_a_rotation_racing_logout_never_leaves_a_live_session`` fail
-    intermittently (observed: ``iat=1786618628`` against a horizon of
-    ``1786618628.02``, a token minted AFTER the revocation and refused).
-
-    Rounding this way gives up nothing, because the sub-second region is
-    already covered by the ``token_version`` bump that the same UPDATE makes.
-    A token minted before that UPDATE commits reads the pre-bump version under
-    READ COMMITTED and is rejected on the version check; one minted after it
-    commits genuinely postdates the horizon. The same composition is what
-    covers API-vs-DB clock skew, where an API clock running ahead could lift a
-    pre-revocation ``iat`` past the horizon: the bump still rejects it. This
-    check is therefore added ALONGSIDE the version check and never replaces it.
     """
     if user.sessions_revoked_at is None:
         return False

--- a/backend/app/modules/auth/models.py
+++ b/backend/app/modules/auth/models.py
@@ -134,6 +134,17 @@ class User(Base):
     key_epoch: Mapped[int] = mapped_column(
         Integer, default=1, server_default="1", nullable=False
     )
+    # fix(#1455): revocation horizon — every session credential (refresh row or
+    # access JWT) issued at or before this instant is dead, whatever its own
+    # state says. token_version and the refresh-row UPDATE revoke the rows one
+    # statement's snapshot can see, which cannot express "everything issued up
+    # to now": a rotation committing just after that snapshot leaves a live
+    # refresh row behind. Read at use time by both refresh lookups and both JWT
+    # dependencies. NULL until the user's first revocation. Stamped from the DB
+    # clock, the same clock that stamps RefreshToken.created_at.
+    sessions_revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     auth_provider: Mapped[str] = mapped_column(
         String(20), server_default="local", nullable=False
     )

--- a/backend/app/modules/auth/service.py
+++ b/backend/app/modules/auth/service.py
@@ -400,12 +400,17 @@ class AuthService:
         #    happens to ignore NULLs, but the SQL standard propagates them, and
         #    this must not depend on which behavior we get.
         #
-        #    The token_version bump is retained, not replaced. iat comes from
+        #    The token_version bump below is retained, not replaced, and the
+        #    access-JWT half of #1455 DEPENDS on it in two ways. iat comes from
         #    the API process clock and the horizon from the DB clock, so an API
         #    clock running ahead could mint a pre-logout token whose iat clears
-        #    the horizon — the bump is what still kills it. That is what makes
-        #    this change purely additive: no credential rejected today becomes
-        #    acceptable.
+        #    the horizon — the bump is what still kills it. And because iat is
+        #    whole seconds, the same-second region is covered by the bump
+        #    ALONE: _predates_revocation_horizon in auth/dependencies.py rounds
+        #    toward accepting on exactly that basis. Removing or weakening this
+        #    bump requires tightening that rounding in the same change.
+        #    Together they are what makes this purely additive: no credential
+        #    rejected today becomes acceptable.
         values: dict = {
             "token_version": User.token_version + 1,
             "sessions_revoked_at": func.greatest(

--- a/backend/app/modules/auth/service.py
+++ b/backend/app/modules/auth/service.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import jwt
-from sqlalchemy import func, select, update
+from sqlalchemy import func, literal_column, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -176,6 +176,7 @@ class AuthService:
 
         Returns None when the token is missing, expired, or already revoked.
         Returns None when the linked user does not exist.
+        Returns None when the row predates the owner's revocation horizon.
         """
         token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
         result = await self.db.execute(
@@ -185,6 +186,15 @@ class AuthService:
                 RefreshToken.token_hash == token_hash,
                 RefreshToken.revoked == False,  # noqa: E712
                 RefreshToken.expires_at > datetime.now(UTC),
+                # fix(#1455): the revocation horizon, checked at use time so it
+                # covers rows revoke_all_tokens could not see when it ran.
+                # Both timestamps come from the DB clock, so the comparison is
+                # skew-free. A successor login's row is stamped after the
+                # horizon and passes without any client choreography.
+                or_(
+                    User.sessions_revoked_at.is_(None),
+                    RefreshToken.created_at > User.sessions_revoked_at,
+                ),
             )
         )
         stored = result.scalar_one_or_none()
@@ -223,6 +233,15 @@ class AuthService:
                 RefreshToken.token_hash == token_hash,
                 RefreshToken.revoked == False,  # noqa: E712
                 RefreshToken.expires_at > datetime.now(UTC),
+                # fix(#1455): the revocation horizon, checked at use time so it
+                # covers rows revoke_all_tokens could not see when it ran — the
+                # replacement a rotation commits just after the revoking
+                # statement took its snapshot is unrevoked and, without this,
+                # rotates into a fresh session that outlives its own logout.
+                or_(
+                    User.sessions_revoked_at.is_(None),
+                    RefreshToken.created_at > User.sessions_revoked_at,
+                ),
             )
         )
         stored = result.scalar_one_or_none()
@@ -368,7 +387,35 @@ class AuthService:
         # 2. Atomically increment token_version so prior access JWTs are
         #    rejected (and key_epoch in the same UPDATE when requested, so a
         #    security event revokes JWTs and API keys atomically).
-        values: dict = {"token_version": User.token_version + 1}
+        #
+        #    fix(#1455): stamp the revocation horizon in the same UPDATE. Step 1
+        #    can only revoke what its own snapshot sees, so a rotation that
+        #    commits its replacement row just after that snapshot survives this
+        #    revocation; the horizon is a predicate evaluated at USE time, which
+        #    is the only shape that covers a row this transaction cannot see
+        #    yet. func.now() is the transaction timestamp — the same clock that
+        #    stamps RefreshToken.created_at, so the refresh comparison has no
+        #    skew axis. GREATEST keeps the horizon monotonic if the DB clock
+        #    ever steps backwards. COALESCE is not redundant: Postgres GREATEST
+        #    happens to ignore NULLs, but the SQL standard propagates them, and
+        #    this must not depend on which behavior we get.
+        #
+        #    The token_version bump is retained, not replaced. iat comes from
+        #    the API process clock and the horizon from the DB clock, so an API
+        #    clock running ahead could mint a pre-logout token whose iat clears
+        #    the horizon — the bump is what still kills it. That is what makes
+        #    this change purely additive: no credential rejected today becomes
+        #    acceptable.
+        values: dict = {
+            "token_version": User.token_version + 1,
+            "sessions_revoked_at": func.greatest(
+                func.coalesce(
+                    User.sessions_revoked_at,
+                    literal_column("'-infinity'::timestamptz"),
+                ),
+                func.now(),
+            ),
+        }
         if bump_key_epoch:
             values["key_epoch"] = User.key_epoch + 1
         version_result = await self.db.execute(

--- a/backend/tests/test_auth_revocation_horizon_1455.py
+++ b/backend/tests/test_auth_revocation_horizon_1455.py
@@ -1,0 +1,570 @@
+"""GH-1455: the revocation horizon, so no session credential outlives its logout.
+
+``revoke_all_tokens`` revokes the refresh rows one statement's snapshot can see
+and bumps ``token_version``. Neither can express "everything issued up to now",
+so a refresh row inserted by a path that does not take the owner-row lock — a
+login racing the logout, the GH-1455 headline case — can commit after that
+snapshot and survive its own logout. ``users.sessions_revoked_at`` is the
+use-time predicate that covers it: every credential issued at or before the
+horizon is rejected on presentation, whatever its own row or claims say.
+
+Every test here asserts a REJECTION that did not happen before, or that a
+successor credential (issued after the horizon) still works. Nothing that was
+rejected before becomes acceptable — the change is purely additive.
+"""
+
+import hashlib
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import anyio
+import jwt
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request
+
+from app.core.config import settings
+from app.modules.auth.dependencies import get_current_user, get_optional_user
+from app.modules.auth.models import RefreshToken, User
+from app.modules.auth.service import AuthService
+
+PASSWORD = "TestPass1234!"  # SEC-S16: 12 chars, 3 character classes
+
+
+async def _create_user(client: AsyncClient, admin_headers: dict) -> tuple[str, str]:
+    """Create a throwaway local user; return (user_id, username).
+
+    A dedicated user per test rather than the seeded admin: stamping a horizon
+    on the shared admin row would reject any token another test on this worker
+    minted in the same second.
+    """
+    username = f"horizon_{uuid.uuid4().hex[:8]}"
+    resp = await client.post(
+        "/admin/users/",
+        json={"username": username, "password": PASSWORD, "role": "viewer"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"], username
+
+
+async def _login(client: AsyncClient, username: str) -> dict:
+    resp = await client.post(
+        "/auth/login", data={"username": username, "password": PASSWORD}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _load_user(session: AsyncSession, user_id) -> User:
+    """Re-read the user, defeating the identity map.
+
+    The test session is ``expire_on_commit=False``, so a plain ORM
+    ``select(User)`` hands back a cached instance still carrying
+    ``sessions_revoked_at = None`` after a Core UPDATE wrote one.
+    ``populate_existing`` refreshes THIS entity from the incoming row without
+    expiring the rest of the session, which a blanket ``expire_all()`` would
+    do: any other ORM instance the test still holds would then reload lazily
+    on next attribute access and raise ``MissingGreenlet`` under asyncio.
+    """
+    return (
+        await session.execute(
+            select(User)
+            .where(User.id == uuid.UUID(str(user_id)))
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+
+
+async def _set_horizon(session: AsyncSession, user_id, when: datetime | None) -> None:
+    """Write a horizon directly, then resync the cached User row.
+
+    The dependencies under test re-read the user with a plain ``select(User)``,
+    which returns the identity-mapped instance without overwriting attributes
+    already loaded on it. Without the resync they would keep observing the
+    pre-UPDATE horizon and the test would prove nothing.
+    """
+    await session.execute(
+        update(User)
+        .where(User.id == uuid.UUID(str(user_id)))
+        .values(sessions_revoked_at=when)
+    )
+    await session.commit()
+    await _load_user(session, user_id)
+
+
+async def _refresh_row(session: AsyncSession, raw_token: str) -> RefreshToken:
+    """Re-read the refresh row, defeating the identity map for the same reason
+    ``_load_user`` does: ``revoke_all_tokens`` revokes via a Core UPDATE, which
+    leaves a cached instance still claiming ``revoked=False``."""
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    return (
+        await session.execute(
+            select(RefreshToken)
+            .where(RefreshToken.token_hash == token_hash)
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+
+
+def _mint_access_token(*, user: User, iat: object, token_version: int | None = None):
+    """Encode an access JWT with a chosen ``iat``, otherwise shaped like a real one.
+
+    ``iat`` is passed through verbatim (including ``None``, which omits the
+    claim) so the missing-claim and non-numeric conventions are testable.
+    """
+    payload: dict = {
+        "sub": str(user.id),
+        "username": user.username,
+        "jti": uuid.uuid4().hex,
+        "token_version": (
+            user.token_version if token_version is None else token_version
+        ),
+        "exp": datetime.now(UTC) + timedelta(minutes=15),
+    }
+    if iat is not None:
+        payload["iat"] = iat
+    return jwt.encode(
+        payload,
+        settings.jwt_secret_key.get_secret_value(),
+        algorithm=settings.jwt_algorithm,
+    )
+
+
+def _bare_request() -> Request:
+    """A credential-free request, so the API-key lane resolves to None."""
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [],
+            "query_string": b"",
+        }
+    )
+
+
+async def _both_dependencies_reject(token: str, session: AsyncSession) -> None:
+    """Assert BOTH JWT enforcement sites refuse *token*.
+
+    The two dependencies duplicate their checks on purpose (the expired-token
+    UX in ``get_current_user`` is why they were never collapsed), so a horizon
+    check added to one and missed on the other is exactly the drift this
+    asserts against.
+    """
+    assert await get_optional_user(_bare_request(), token, session) is None
+    with pytest.raises(HTTPException) as excinfo:
+        await get_current_user(_bare_request(), token, session)
+    assert excinfo.value.status_code == 401
+
+
+class TestRefreshRowsAtOrBeforeTheHorizonAreRejected:
+    """The regression test for the race that motivates GH-1455.
+
+    An UNREVOKED refresh row whose ``created_at`` is at or before the horizon
+    is the survivor of the insert race: ``revoke_all_tokens`` never saw it, so
+    ``revoked`` is still false and every pre-existing check passes it.
+    """
+
+    async def test_get_user_from_refresh_token_rejects_it(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        user_id, username = await _create_user(client, admin_auth_header)
+        raw = (await _login(client, username))["refresh_token"]
+        row = await _refresh_row(test_db_session, raw)
+        assert not row.revoked, "the point of this test is an unrevoked row"
+
+        service = AuthService(test_db_session)
+        assert await service.get_user_from_refresh_token(raw) is not None
+
+        # Exactly the row's own timestamp: the boundary is "at or before".
+        await _set_horizon(test_db_session, user_id, row.created_at)
+
+        assert await service.get_user_from_refresh_token(raw) is None
+
+    async def test_rotate_refresh_token_rejects_it(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        user_id, username = await _create_user(client, admin_auth_header)
+        raw = (await _login(client, username))["refresh_token"]
+        row = await _refresh_row(test_db_session, raw)
+        await _set_horizon(test_db_session, user_id, row.created_at)
+
+        with pytest.raises(ValueError):
+            await AuthService(test_db_session).rotate_refresh_token(raw)
+
+        # And over HTTP, which is how the zombie session would actually present.
+        resp = await client.post("/auth/refresh/", json={"refresh_token": raw})
+        assert resp.status_code == 401, resp.text
+
+    async def test_the_row_is_still_unrevoked_so_only_the_horizon_rejected_it(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """Pins WHY it was rejected. If a future change revoked the row instead,
+        this test would pass for the wrong reason and stop guarding the race."""
+        user_id, username = await _create_user(client, admin_auth_header)
+        raw = (await _login(client, username))["refresh_token"]
+        row = await _refresh_row(test_db_session, raw)
+        await _set_horizon(test_db_session, user_id, row.created_at)
+
+        assert (
+            await AuthService(test_db_session).get_user_from_refresh_token(raw) is None
+        )
+        assert not (await _refresh_row(test_db_session, raw)).revoked
+
+
+class TestRefreshRowsAfterTheHorizonSurvive:
+    """Successor survival: a login that follows the revocation is outside the
+    revocation set by construction, with no client choreography involved."""
+
+    async def test_a_row_created_after_the_horizon_rotates(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        user_id, username = await _create_user(client, admin_auth_header)
+        first = (await _login(client, username))["refresh_token"]
+        row = await _refresh_row(test_db_session, first)
+        await _set_horizon(test_db_session, user_id, row.created_at)
+
+        successor = (await _login(client, username))["refresh_token"]
+        successor_row = await _refresh_row(test_db_session, successor)
+        horizon = (await _load_user(test_db_session, user_id)).sessions_revoked_at
+        assert successor_row.created_at > horizon
+
+        resp = await client.post("/auth/refresh/", json={"refresh_token": successor})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["access_token"]
+
+
+class TestAccessTokensAtOrBeforeTheHorizonAreRejected:
+    """The JWT half, at both enforcement sites.
+
+    ``token_version`` is deliberately held CURRENT in every rejection case
+    here: a rotation racing the revocation reads the pre-bump value and mints a
+    token carrying it, so a matching version is not evidence the token
+    postdates the revocation.
+    """
+
+    async def test_iat_before_the_horizon_is_rejected_at_both_sites(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        user_id, username = await _create_user(client, admin_auth_header)
+        await _login(client, username)
+        user = await _load_user(test_db_session, user_id)
+
+        horizon = datetime.now(UTC)
+        token = _mint_access_token(user=user, iat=int(horizon.timestamp()) - 60)
+        await _set_horizon(test_db_session, user_id, horizon)
+
+        await _both_dependencies_reject(token, test_db_session)
+
+    async def test_iat_after_the_horizon_is_accepted_at_both_sites(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        user_id, username = await _create_user(client, admin_auth_header)
+        await _login(client, username)
+        user = await _load_user(test_db_session, user_id)
+
+        horizon = datetime.now(UTC) - timedelta(minutes=5)
+        await _set_horizon(test_db_session, user_id, horizon)
+        token = _mint_access_token(user=user, iat=int(datetime.now(UTC).timestamp()))
+
+        assert (
+            await get_optional_user(_bare_request(), token, test_db_session)
+        ) is not None
+        assert await get_current_user(_bare_request(), token, test_db_session)
+
+    async def test_a_missing_iat_claim_is_rejected_once_a_horizon_exists(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """Mirrors the missing-``token_version``-is-0 convention: absent means
+        0, which is at or before every horizon."""
+        user_id, username = await _create_user(client, admin_auth_header)
+        await _login(client, username)
+        user = await _load_user(test_db_session, user_id)
+
+        token = _mint_access_token(user=user, iat=None)
+        assert "iat" not in jwt.decode(token, options={"verify_signature": False})
+
+        # No horizon yet: the same token authenticates, so the rejection below
+        # is attributable to the horizon and nothing else.
+        assert (
+            await get_optional_user(_bare_request(), token, test_db_session)
+        ) is not None
+
+        await _set_horizon(test_db_session, user_id, datetime.now(UTC))
+        await _both_dependencies_reject(token, test_db_session)
+
+    async def test_a_non_numeric_iat_is_rejected_rather_than_raising(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """PyJWT validates ``iat`` by casting a COPY, so a numeric string stays
+        a string in the payload and reaches the horizon comparison intact.
+
+        The horizon is deliberately in the PAST and the claim is NOT in the
+        future: PyJWT rejects a future ``iat`` itself (ImmatureSignatureError),
+        which would make this pass without ever reaching the code under test,
+        and a string that compares as later than the horizon is exactly the
+        input that would raise ``TypeError`` out of the dependency (a 500)
+        instead of refusing the token.
+        """
+        user_id, username = await _create_user(client, admin_auth_header)
+        await _login(client, username)
+        user = await _load_user(test_db_session, user_id)
+
+        await _set_horizon(
+            test_db_session, user_id, datetime.now(UTC) - timedelta(minutes=5)
+        )
+        token = _mint_access_token(
+            user=user, iat=str(int(datetime.now(UTC).timestamp()))
+        )
+
+        await _both_dependencies_reject(token, test_db_session)
+
+    async def test_the_same_second_as_the_horizon_is_accepted(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """Pins the rounding direction, which is a real decision, not a detail.
+
+        ``iat`` is whole seconds, so it names the interval ``[iat, iat+1)``
+        rather than an instant. Rejecting the whole second would kill a token
+        minted AFTER the revocation, which breaks logging out and immediately
+        logging back in. The sub-second region is covered by the
+        ``token_version`` bump instead: this same user's version is current
+        here precisely because no bump happened.
+        """
+        user_id, username = await _create_user(client, admin_auth_header)
+        await _login(client, username)
+        user = await _load_user(test_db_session, user_id)
+
+        second = int(datetime.now(UTC).timestamp())
+        token = _mint_access_token(user=user, iat=second)
+        # Horizon 20ms into the very second the token is stamped with, which is
+        # the shape observed in the failure this rounding fixes.
+        await _set_horizon(
+            test_db_session, user_id, datetime.fromtimestamp(second + 0.02, UTC)
+        )
+
+        assert (
+            await get_optional_user(_bare_request(), token, test_db_session)
+        ) is not None
+        assert await get_current_user(_bare_request(), token, test_db_session)
+
+        # One whole second earlier is unambiguously before the horizon.
+        stale = _mint_access_token(user=user, iat=second - 1)
+        await _both_dependencies_reject(stale, test_db_session)
+
+    async def test_no_horizon_means_no_new_rejection(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """NULL is correct for every pre-migration row, so a user who has never
+        revoked must see no behaviour change at all — including for the ancient
+        ``iat`` that the horizon check would otherwise refuse."""
+        user_id, username = await _create_user(client, admin_auth_header)
+        await _login(client, username)
+        user = await _load_user(test_db_session, user_id)
+        assert user.sessions_revoked_at is None
+
+        token = _mint_access_token(user=user, iat=1)
+        assert (
+            await get_optional_user(_bare_request(), token, test_db_session)
+        ) is not None
+        assert await get_current_user(_bare_request(), token, test_db_session)
+
+
+class TestLogoutStampsTheHorizonAndKeepsItMonotonic:
+    async def test_logout_sets_a_horizon_and_still_bumps_token_version(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        user_id, username = await _create_user(client, admin_auth_header)
+        before = await _load_user(test_db_session, user_id)
+        assert before.sessions_revoked_at is None
+        version_before = before.token_version
+
+        await AuthService(test_db_session).revoke_all_tokens(uuid.UUID(str(user_id)))
+
+        after = await _load_user(test_db_session, user_id)
+        assert after.sessions_revoked_at is not None, (
+            "the COALESCE fallback must let the first revocation stamp a NULL "
+            "horizon — a broken sentinel cast would leave it NULL"
+        )
+        assert abs((after.sessions_revoked_at - datetime.now(UTC)).total_seconds()) < 60
+        # The bump is RETAINED, not replaced: it is what still rejects a
+        # pre-revocation token whose iat clears the horizon under clock skew.
+        assert after.token_version == version_before + 1
+
+    async def test_a_later_revocation_cannot_regress_the_horizon(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """GREATEST, not assignment. A DB clock that steps backwards must not
+        resurrect credentials an earlier revocation already killed."""
+        user_id, username = await _create_user(client, admin_auth_header)
+        future = datetime.now(UTC) + timedelta(hours=1)
+        await _set_horizon(test_db_session, user_id, future)
+
+        await AuthService(test_db_session).revoke_all_tokens(uuid.UUID(str(user_id)))
+
+        after = await _load_user(test_db_session, user_id)
+        assert after.sessions_revoked_at == future
+
+    async def test_a_second_revocation_advances_it(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """The other half of GREATEST: monotonic must not mean frozen."""
+        user_id, username = await _create_user(client, admin_auth_header)
+        past = datetime.now(UTC) - timedelta(hours=1)
+        await _set_horizon(test_db_session, user_id, past)
+
+        await AuthService(test_db_session).revoke_all_tokens(uuid.UUID(str(user_id)))
+
+        after = await _load_user(test_db_session, user_id)
+        assert after.sessions_revoked_at > past
+
+
+class TestASuccessorLoginSurvivesTheLogoutEndToEnd:
+    """The whole point: logout must kill the old session without maiming the
+    next one. Runs entirely over HTTP, through the real handlers."""
+
+    async def test_logout_then_login_then_refresh(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        user_id, username = await _create_user(client, admin_auth_header)
+        first = await _login(client, username)
+
+        resp = await client.post(
+            "/auth/logout/",
+            json={"refresh_token": first["refresh_token"]},
+            headers={"Authorization": f"Bearer {first['access_token']}"},
+        )
+        assert resp.status_code == 204, resp.text
+
+        # The ended session is dead on both credentials.
+        assert (
+            await client.get(
+                "/auth/me/",
+                headers={"Authorization": f"Bearer {first['access_token']}"},
+            )
+        ).status_code == 401
+        assert (
+            await client.post(
+                "/auth/refresh/", json={"refresh_token": first["refresh_token"]}
+            )
+        ).status_code == 401
+
+        # iat is integer seconds, so a token minted in the same second as the
+        # horizon is rejected too (over-revocation bounded by one second, in
+        # the fail-safe direction). Wait that second out so the successor's
+        # acceptance is deterministic rather than clock-phase dependent.
+        horizon = (await _load_user(test_db_session, user_id)).sessions_revoked_at
+        assert horizon is not None
+        while int(datetime.now(UTC).timestamp()) <= int(horizon.timestamp()):
+            await anyio.sleep(0.05)
+
+        successor = await _login(client, username)
+        assert (
+            await client.get(
+                "/auth/me/",
+                headers={"Authorization": f"Bearer {successor['access_token']}"},
+            )
+        ).status_code == 200
+
+        rotated = await client.post(
+            "/auth/refresh/", json={"refresh_token": successor["refresh_token"]}
+        )
+        assert rotated.status_code == 200, rotated.text
+        assert (
+            await client.get(
+                "/auth/me/",
+                headers={"Authorization": f"Bearer {rotated.json()['access_token']}"},
+            )
+        ).status_code == 200
+
+
+class TestSamlConversionStampsTheHorizon:
+    """The conversion used to duplicate revoke_all_tokens' two UPDATEs inline,
+    which is precisely how it would have missed the horizon. Folding it onto
+    the shared method is what keeps the two revocation sites identical."""
+
+    async def test_conversion_revokes_refresh_rows_and_stamps_the_horizon(
+        self, client: AsyncClient, test_db_session
+    ):
+        from app.modules.admin.service import AdminService
+        from app.modules.auth.models import Role, UserRole
+        from app.modules.auth.oauth.encryption import encrypt_secret
+        from app.modules.auth.oauth.models import OAuthAccount, OAuthProvider
+        from app.modules.auth.providers.local import hash_password
+
+        suffix = uuid.uuid4().hex[:8]
+        provider = OAuthProvider(
+            slug=f"saml-horizon-{suffix}",
+            display_name="SAML Horizon Test",
+            provider_type="saml",
+            client_id="saml-no-client-id",
+            client_secret_encrypted=encrypt_secret("saml-no-client-secret"),
+            scopes="",
+            enabled=True,
+            default_role="viewer",
+        )
+        test_db_session.add(provider)
+        await test_db_session.flush()
+
+        saml_user = User(
+            username=f"samlhorizon-{suffix}",
+            password_hash=hash_password(PASSWORD),
+            is_active=True,
+            status="active",
+            auth_provider="oauth",
+        )
+        test_db_session.add(saml_user)
+        await test_db_session.flush()
+
+        viewer_role = (
+            await test_db_session.execute(select(Role).where(Role.name == "viewer"))
+        ).scalar_one()
+        test_db_session.add(UserRole(user_id=saml_user.id, role_id=viewer_role.id))
+        test_db_session.add(
+            OAuthAccount(
+                provider_id=provider.id,
+                user_id=saml_user.id,
+                subject=f"saml-sub-{suffix}",
+            )
+        )
+        # A live SAML-era refresh row, so the folded revocation has something
+        # to revoke — the half of the fold nothing else covers.
+        raw_refresh = AuthService(test_db_session).create_refresh_token(saml_user.id)
+        await test_db_session.commit()
+
+        assert (
+            await _load_user(test_db_session, saml_user.id)
+        ).sessions_revoked_at is None
+
+        await AdminService(test_db_session).convert_saml_user_to_local(
+            saml_user.id, "NewPass1234!"
+        )
+        await test_db_session.commit()
+
+        converted = await _load_user(test_db_session, saml_user.id)
+        assert converted.sessions_revoked_at is not None
+        assert (await _refresh_row(test_db_session, raw_refresh)).revoked
+
+
+class TestPathsThatMustNotStampTheHorizon:
+    async def test_a_role_change_does_not_stamp_the_horizon(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """The horizon means "log every session out", not "refresh your
+        claims". Role change bumps key_epoch only, and must keep doing so."""
+        user_id, _username = await _create_user(client, admin_auth_header)
+
+        resp = await client.patch(
+            f"/admin/users/{user_id}",
+            json={"role": "editor"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+
+        after = await _load_user(test_db_session, user_id)
+        assert after.sessions_revoked_at is None
+        assert after.key_epoch > 1


### PR DESCRIPTION
Closes #1455.

## The window this closes

Logout (`revoke_all_tokens`) does two things: it revokes the user's active refresh rows, then it bumps `token_version`. Both are row-set operations, "revoke what I can see right now", and that cannot express "revoke everything issued up to now".

A refresh row inserted by a path that does not take the owner-row lock, which in practice means a login, can commit after the revoking UPDATE has taken its snapshot. That row is never revoked. The bump kills the access JWT that login minted, but the refresh row is a live credential: the ended session presents it, rotation succeeds, and the replacement JWT carries the current `token_version`. The session has outlived the logout that ended it.

`fix(#1446)` serialized rotation against revocation on the owner row, which is why that path is safe. Login is not on that lock and cannot usefully be put on it, because you cannot lock a row that does not exist yet. The same window is open at every full-revocation site: logout, password change, and the SAML-to-local conversion.

**Scope of the fix, stated precisely.** This closes the window for every credential issued before the revoking transaction began. It does NOT close it for a login that begins *inside* that transaction: `now()` is the transaction timestamp on both sides, so such a login gets a `created_at` later than the horizon while still reading the pre-bump `token_version`. Codex review caught that on this PR and it reproduces, so it is filed as #1459 with the reproduction and a preferred fix (record the issuing `token_version` on the refresh row). That row survives on `main` today for the same reason, so this PR narrows the class without regressing anything, and #1459 is the follow-up that closes it.

## The change

One nullable column, `catalog.users.sessions_revoked_at`, the revocation horizon. Every session credential issued at or before it is dead, whatever its own row or claims say.

- `revoke_all_tokens` stamps it in the user UPDATE it already ran, as `GREATEST(COALESCE(sessions_revoked_at, '-infinity'::timestamptz), now())`. The refresh-row UPDATE and the `token_version` bump are untouched.
- Both refresh lookups (`get_user_from_refresh_token`, `rotate_refresh_token`) gain `sessions_revoked_at IS NULL OR refresh_tokens.created_at > sessions_revoked_at` on the join they already make.
- Both JWT dependencies reject a token whose `iat` is at or before the horizon, alongside the `token_version` check they already run.
- The SAML conversion's two inline UPDATEs, which duplicated `revoke_all_tokens`, are replaced by a call to it.

Every change is a new rejection layered on the existing ones. Nothing accepted today becomes acceptable, so the "precision done wrong under-revokes" failure mode cannot arise here. That property is what makes the residual in #1459 a narrowing rather than a regression.

## Review-risk notes

Both refresh lookups carry the predicate and both JWT dependencies carry the `iat` check. The JWT half goes through one shared helper, `_predates_revocation_horizon`, so the two dependencies cannot drift apart on it. They duplicate their other checks for an unrelated reason (the expired-token UX in `get_current_user`).

A missing `iat` is treated as 0, which is at or before every horizon, so such a token is rejected once a horizon exists. That mirrors the missing-`token_version`-is-0 convention already documented at both sites. A non-numeric `iat` gets the same treatment, which is not paranoia: PyJWT validates `iat` by casting a copy, so a numeric string survives into the payload, and comparing it directly would raise `TypeError` out of the dependency instead of refusing the token.

There are two clock sources. `iat` comes from the API process clock, the horizon from the DB clock. An API clock running ahead could lift a pre-logout token's `iat` past the horizon and slip this check. That token still dies on the `token_version` bump, which is why the bump is retained rather than replaced. On the refresh side there is no skew axis at all, because `refresh_tokens.created_at` and the horizon both come from `now()` on the same server.

`GREATEST` keeps the horizon monotonic: a DB clock that steps backwards must not resurrect credentials an earlier revocation already killed. `COALESCE` is not redundant next to it. Postgres `GREATEST` happens to ignore NULLs, but the SQL standard propagates them, and correctness here should not rest on which behaviour we get.

**The `iat` rounding rule, and the constraint it carries.** PyJWT writes `iat` as truncated integer seconds, so the claim does not name an instant, it names the interval `[iat, iat+1)`. The rounding has to go one way or the other, and this rejects only when that whole interval precedes the horizon: `iat + 1 <= horizon`.

That is a deliberate change from the design doc, which specified `iat <= int(horizon)`. Rounding the other way rejects any token minted in the *same second* as the revocation, and that is not a theoretical cost: it made `test_a_rotation_racing_logout_never_leaves_a_live_session` fail intermittently, with `iat=1786618628` against a horizon of `1786618628.02`, so a token minted after the revocation was refused. A control run on `origin/main` with the same file pairing is green, confirming the change caused it rather than a pre-existing flake. In product terms it meant logging out and immediately logging back in left a dead access token for up to a second.

Rounding this way gives up nothing, because the same-second region is covered by the `token_version` bump that the same UPDATE makes. The horizon is the revoking transaction's `now()`, so a token minted before that UPDATE commits necessarily read the pre-bump version under READ COMMITTED and dies on the version check, while one minted after it commits carries the new version and legitimately lives. That is the same composition the design already relies on for API-vs-DB clock skew.

The coupling is the part worth flagging, because it is invisible from the comparison itself: **the same-second region is covered by the bump alone, so removing or weakening that bump requires tightening this rounding back to `<=` in the same change.** It is written as a constraint at both ends, on `_predates_revocation_horizon` and on the bump in `revoke_all_tokens`, since a refactor would arrive at the latter. A test pins the rounding in both directions.

The post-lock re-check in `rotate_refresh_token` deliberately does not re-read the horizon. Any revocation that stamps a horizon also revokes every unrevoked row visible to it, so a rotation that loses the lock race finds `revoked=True` in the re-check it already performs. A third check would restructure a query the design says to leave alone, for a case the existing one covers.

All three revocation sites inherit the horizon through `revoke_all_tokens`: logout, password change, and now the SAML conversion. Role change deliberately does not, because it bumps `key_epoch` only. The horizon means "log every session out", not "refresh your claims", and a test pins that.

The download-token lane is untouched and out of scope. `?token=` downloads are verified by their own handler in `router_export.py`, which checks neither `token_version` nor the horizon. That is pre-existing behaviour, bounded by the 120s TTL cap on those tokens, and not what #1455 asks for.

The residual is #1459, restated here because it is the one thing a reader should not have to discover: a login whose transaction begins inside the revoking transaction is classified as a successor by a transaction-timestamp comparison, even though it read pre-revocation state. A timestamp cannot separate those two cases, which is why the follow-up proposes the `token_version` marker rather than a tighter clock.

Deliberate non-changes: no per-session or per-device revocation, because logout revoking everything as of its instant is what makes it a security event and what SEC-S15 builds on; no removal of the `token_version` bump; no frontend changes, so the #1446 client choreography stays as the availability layer with the horizon as the correctness layer under it; and no API surface change, so no OpenAPI or SDK impact.

## Migration

`0047_users_sessions_revoked_at` adds one nullable column, with no default, no backfill and no index. NULL means "no horizon", which is the correct and behaviour-preserving value for every existing row; backfilling a timestamp would revoke live sessions on deploy. No index, because the column is only ever read through a `User` row the request already loaded, or through the primary-key join the refresh lookups already make.

## Verification

```
cd backend
uv run ruff check . && uv run ruff format --check .
uv run alembic upgrade head
uv run alembic check
uv run pytest tests/test_auth_revocation_horizon_1455.py \
              tests/test_auth_refresh_cookies_1302.py \
              tests/test_admin_invariants_regression.py -q
uv run pytest tests/test_layering.py -q
```



## Post-merge correction (2026-08-13)

The residual described above was refuted after merge: #1459 is closed as invalid, with the measurement and mechanism in its closing comment. A login racing the revoking transaction is serialized on the user row before it ever reads `token_version` (rotation explicitly via the #1446 lock; both login paths via the `last_login_at` write that autoflushes ahead of the version re-SELECT), so it completes either as a revoked row or as a clean successor. There is no third ordering, and the codex finding's premise (a pre-bump version read) does not occur.

This correction narrows this PR's claim, not its content: the horizon and predicates stand as an additive structural backstop that holds independently of that serialization, half of which is accidental. Nothing in this PR relies on the refuted premise.
