### PR TITLE
test(auth): pin the serialization that keeps a racing login out of a revocation

### DIFF
--- a/backend/tests/test_login_revocation_serialization.py
+++ b/backend/tests/test_login_revocation_serialization.py
@@ -94,7 +94,7 @@ class TestLoginIsSerializedAgainstRevocation:
     async def test_a_login_racing_a_logout_is_revoked_or_a_clean_successor(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
     ):
-        """Force the widest possible window and assert there is no third outcome.
+        """Force the interleaving deterministically, then assert the outcome.
 
         The logout handler runs ``revoke_all_tokens(commit=False)`` and then
         ``audit_emit`` before its single commit, so stalling ``audit_emit``
@@ -108,8 +108,20 @@ class TestLoginIsSerializedAgainstRevocation:
         first = await _login(client, username)
         original_emit = audit_mod.audit_emit
 
+        # fix(#1460 codex): synchronize on the lock actually being held, not on
+        # elapsed time. A sleep long enough on a warm machine is not long
+        # enough under CI connection contention, and a login that slips in
+        # BEFORE the logout takes its lock gets revoked normally, which used to
+        # satisfy this test through an early return. That made the guard pass
+        # vacuously in exactly the conditions where it is hardest to notice,
+        # including with the serialization removed. audit_emit runs after
+        # revoke_all_tokens and before the commit, so entering it proves the
+        # lock is held and the revocation is staged but not yet durable.
+        lock_held = anyio.Event()
+
         async def _stalled_emit(*args, **kwargs):
             result = await original_emit(*args, **kwargs)
+            lock_held.set()
             await anyio.sleep(1.5)
             return result
 
@@ -124,9 +136,10 @@ class TestLoginIsSerializedAgainstRevocation:
             results["logout"] = resp.status_code
 
         async def _login_racing():
-            # Begin after the logout has taken its lock, which is what puts
-            # this login inside the revoking transaction's lifetime.
-            await anyio.sleep(0.5)
+            # Fail loudly rather than hang if the logout never reaches the
+            # stall (e.g. it 401s), which would otherwise look like a timeout.
+            with anyio.fail_after(30):
+                await lock_held.wait()
             resp = await client.post(
                 "/auth/login", data={"username": username, "password": PASSWORD}
             )
@@ -141,14 +154,20 @@ class TestLoginIsSerializedAgainstRevocation:
         assert results["logout"] == 204
         racing = await _newest_refresh_row(test_db_session, user_id)
 
-        if racing.revoked:
-            # Ordering one: the login committed before the revocation's UPDATE
-            # took its snapshot, so the revocation saw and killed its row.
-            return
+        # The login provably began after the lock was taken, so the revocation's
+        # UPDATE had already run and cannot have seen this row. Asserting that,
+        # rather than tolerating it, is what stops a mis-ordered run from
+        # passing without exercising anything. The other ordering has its own
+        # test below.
+        assert not racing.revoked, (
+            "the racing login's row was revoked, so it committed before the "
+            "revocation's UPDATE despite starting after the lock was held; the "
+            "interleaving this test needs did not happen and nothing was proven"
+        )
 
-        # Ordering two: the login completed after the revocation committed, so
-        # it read post-revocation state and is an ordinary successor. Both of
-        # its credentials must work. A failure here means the login minted from
+        # It therefore completed after the revocation committed, read
+        # post-revocation state, and is an ordinary successor. Both of its
+        # credentials must work. A failure here means it minted from
         # pre-revocation state and kept a live credential, which is the
         # zombie-session shape #1459 described.
         tokens = results["tokens"]

--- a/backend/tests/test_login_revocation_serialization.py
+++ b/backend/tests/test_login_revocation_serialization.py
@@ -45,6 +45,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.auth.models import RefreshToken
+from app.modules.auth.service import AuthService
 
 PASSWORD = "TestPass1234!"  # SEC-S16: 12 chars, 3 character classes
 
@@ -108,24 +109,49 @@ class TestLoginIsSerializedAgainstRevocation:
         first = await _login(client, username)
         original_emit = audit_mod.audit_emit
 
-        # fix(#1460 codex): synchronize on the lock actually being held, not on
-        # elapsed time. A sleep long enough on a warm machine is not long
-        # enough under CI connection contention, and a login that slips in
-        # BEFORE the logout takes its lock gets revoked normally, which used to
-        # satisfy this test through an early return. That made the guard pass
-        # vacuously in exactly the conditions where it is hardest to notice,
-        # including with the serialization removed. audit_emit runs after
-        # revoke_all_tokens and before the commit, so entering it proves the
-        # lock is held and the revocation is staged but not yet durable.
+        # fix(#1460 codex): both ends of the window are synchronized on events,
+        # not on elapsed time. Neither side may drift out of the interleaving.
+        #
+        # Start: audit_emit runs after revoke_all_tokens and before the commit,
+        # so entering it proves the lock is held and the revocation is staged
+        # but not durable. A login released by a timer instead could slip in
+        # BEFORE the lock was taken, get revoked normally, and satisfy the test
+        # without exercising anything.
+        #
+        # End: the stall must not expire on a timer either, or a login delayed
+        # past it (CI contention) arrives after the commit, legitimately reads
+        # post-revocation state, and passes for the wrong reason. So the
+        # revocation is held uncommitted until the login has actually reached
+        # issuance.
         lock_held = anyio.Event()
+        login_reached_issuance = anyio.Event()
+        original_create_access_token = AuthService.create_access_token
+
+        async def _signalling_create_access_token(self, *args, **kwargs):
+            # Signal BEFORE delegating. The original's version re-SELECT is the
+            # query that autoflushes the pending last_login_at write into the
+            # revocation's lock queue, so this call is about to block until the
+            # logout commits. Signalling after it would deadlock the pair.
+            login_reached_issuance.set()
+            return await original_create_access_token(self, *args, **kwargs)
 
         async def _stalled_emit(*args, **kwargs):
             result = await original_emit(*args, **kwargs)
             lock_held.set()
-            await anyio.sleep(1.5)
+            with anyio.fail_after(30):
+                await login_reached_issuance.wait()
+            # A margin AFTER a deterministic sync point, not a substitute for
+            # one. Its only job is to let a login that is NOT serialized finish
+            # its version read while the revocation is still uncommitted, so
+            # removing the serialization fails this test loudly instead of
+            # racing the commit. The serialized path does not depend on it.
+            await anyio.sleep(0.25)
             return result
 
         monkeypatch.setattr(audit_mod, "audit_emit", _stalled_emit)
+        monkeypatch.setattr(
+            AuthService, "create_access_token", _signalling_create_access_token
+        )
         results: dict = {}
 
         async def _logout():
@@ -227,14 +253,24 @@ class TestTheSerializationPointsStillExist:
         ):
             source = (Path(__file__).resolve().parents[1] / rel).read_text()
             assign = source.find("last_login_at = func.now()")
-            mint = source.find("create_refresh_token(")
+            # fix(#1460 codex): compare against create_access_token, NOT
+            # create_refresh_token. The boundary that matters is the version
+            # re-SELECT, because that is the query the pending write
+            # autoflushes into. Measuring against the refresh mint leaves a gap
+            # exactly the width of the two calls: an assignment moved BETWEEN
+            # them still precedes create_refresh_token and passes, while the
+            # access token has already been minted from pre-revocation state.
+            # The behavioural test above only drives /auth/login, so an OAuth
+            # reorder into that gap would be caught by nothing.
+            mint = source.find("create_access_token(")
             assert assign != -1, f"{rel}: last_login_at assignment not found"
-            assert mint != -1, f"{rel}: create_refresh_token call not found"
+            assert mint != -1, f"{rel}: create_access_token call not found"
             assert assign < mint, (
-                f"{rel}: the pending last_login_at write must precede token "
-                "issuance. It is what queues this login behind a concurrent "
-                "revocation's owner-row lock (fix(#1459)); minting first lets "
-                "the login read a token_version the revocation is about to bump."
+                f"{rel}: the pending last_login_at write must precede "
+                "create_access_token. Its version re-SELECT is what flushes "
+                "that write into a concurrent revocation's owner-row lock "
+                "queue (fix(#1459)); minting first lets the login read a "
+                "token_version the revocation is about to bump."
             )
 
     def test_create_access_token_still_queries_the_database(self):

--- a/backend/tests/test_login_revocation_serialization.py
+++ b/backend/tests/test_login_revocation_serialization.py
@@ -1,0 +1,242 @@
+"""Credential issuance is serialized against revocation. Nothing else pins it.
+
+fix(#1459): that issue was filed on the belief that a login whose transaction
+BEGINS inside a revoking transaction reads the pre-bump ``token_version``,
+mints from that stale state, and lands an unrevoked refresh row that rotates
+into a session outliving its own logout. It was closed as not planned: the
+interleaving does not occur, because every path that issues a refresh token
+writes the user row before minting and therefore queues behind
+``revoke_all_tokens``'s ``SELECT ... FOR UPDATE``.
+
+  - password login: ``user.last_login_at = func.now()`` (auth/router.py)
+    before ``create_access_token`` / ``create_refresh_token``
+  - OAuth login: the same assignment, same ordering (auth/oauth/router.py)
+  - rotation: an explicit ``SELECT ... FOR UPDATE`` on the owner row, added
+    deliberately by fix(#1446)
+
+Only two orderings exist and both are correct: the login finishes first and
+the revocation's UPDATE sees and revokes its row, or the login blocks and
+completes wholly after the commit, as a successor whose credentials all carry
+the new epoch.
+
+WHY THIS TEST EXISTS. On the rotation path the serialization is deliberate and
+commented as such. On the login paths it is ACCIDENTAL, and it is load-bearing
+anyway. It rests on two things that look like implementation detail:
+
+  1. ``last_login_at`` being assigned before the tokens are minted, so there is
+     a pending write to autoflush at all. Moving that assignment after the
+     mint, or writing it in a separate transaction, removes the lock entirely.
+  2. ``create_access_token`` re-SELECTing ``token_version`` instead of reading
+     it off the User row the caller already loaded. That query is what the
+     pending write autoflushes into. Its own comment calls it "a safe extra
+     query - correctness over micro-optimisation", which names it as an
+     optimisation target: deleting it is exactly the change a reviewer would
+     wave through, and it would move the version read in front of the lock.
+
+Either edit silently opens the window #1459 imagined, with no test failing and
+no reviewer prompted to think about revocation. This test fails instead.
+"""
+
+import uuid
+
+import anyio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.auth.models import RefreshToken
+
+PASSWORD = "TestPass1234!"  # SEC-S16: 12 chars, 3 character classes
+
+
+async def _create_user(client: AsyncClient, admin_headers: dict) -> tuple[str, str]:
+    """Create a throwaway local user; return (user_id, username)."""
+    username = f"serial_{uuid.uuid4().hex[:8]}"
+    resp = await client.post(
+        "/admin/users/",
+        json={"username": username, "password": PASSWORD, "role": "viewer"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"], username
+
+
+async def _login(client: AsyncClient, username: str) -> dict:
+    resp = await client.post(
+        "/auth/login", data={"username": username, "password": PASSWORD}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _newest_refresh_row(session: AsyncSession, user_id) -> RefreshToken:
+    """Re-read with ``populate_existing`` so a Core UPDATE elsewhere in the
+    request cannot be masked by a cached instance, and without expiring the
+    rest of the session (a blanket ``expire_all()`` makes any other ORM object
+    the test holds reload lazily and raise ``MissingGreenlet`` under asyncio).
+    """
+    rows = (
+        (
+            await session.execute(
+                select(RefreshToken)
+                .where(RefreshToken.user_id == uuid.UUID(str(user_id)))
+                .order_by(RefreshToken.created_at)
+                .execution_options(populate_existing=True)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return rows[-1]
+
+
+class TestLoginIsSerializedAgainstRevocation:
+    async def test_a_login_racing_a_logout_is_revoked_or_a_clean_successor(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+    ):
+        """Force the widest possible window and assert there is no third outcome.
+
+        The logout handler runs ``revoke_all_tokens(commit=False)`` and then
+        ``audit_emit`` before its single commit, so stalling ``audit_emit``
+        holds the owner-row lock and the uncommitted revocation open while a
+        login is fired underneath it. Without the serialization this test
+        guards, that login reads the pre-bump version and lands a live row.
+        """
+        import app.modules.audit.service as audit_mod
+
+        user_id, username = await _create_user(client, admin_auth_header)
+        first = await _login(client, username)
+        original_emit = audit_mod.audit_emit
+
+        async def _stalled_emit(*args, **kwargs):
+            result = await original_emit(*args, **kwargs)
+            await anyio.sleep(1.5)
+            return result
+
+        monkeypatch.setattr(audit_mod, "audit_emit", _stalled_emit)
+        results: dict = {}
+
+        async def _logout():
+            resp = await client.post(
+                "/auth/logout/",
+                headers={"Authorization": f"Bearer {first['access_token']}"},
+            )
+            results["logout"] = resp.status_code
+
+        async def _login_racing():
+            # Begin after the logout has taken its lock, which is what puts
+            # this login inside the revoking transaction's lifetime.
+            await anyio.sleep(0.5)
+            resp = await client.post(
+                "/auth/login", data={"username": username, "password": PASSWORD}
+            )
+            results["login"] = resp.status_code
+            results["tokens"] = resp.json() if resp.status_code == 200 else None
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_logout)
+            tg.start_soon(_login_racing)
+        monkeypatch.undo()
+
+        assert results["logout"] == 204
+        racing = await _newest_refresh_row(test_db_session, user_id)
+
+        if racing.revoked:
+            # Ordering one: the login committed before the revocation's UPDATE
+            # took its snapshot, so the revocation saw and killed its row.
+            return
+
+        # Ordering two: the login completed after the revocation committed, so
+        # it read post-revocation state and is an ordinary successor. Both of
+        # its credentials must work. A failure here means the login minted from
+        # pre-revocation state and kept a live credential, which is the
+        # zombie-session shape #1459 described.
+        tokens = results["tokens"]
+        assert tokens is not None, "an unrevoked row implies the login succeeded"
+
+        me = await client.get(
+            "/auth/me/",
+            headers={"Authorization": f"Bearer {tokens['access_token']}"},
+        )
+        assert me.status_code == 200, (
+            "the racing login's own access token must authenticate; a 401 here "
+            "means it read the pre-bump token_version, so issuance is no longer "
+            "serialized against revocation - see this module's docstring"
+        )
+
+        rotated = await client.post(
+            "/auth/refresh/", json={"refresh_token": tokens["refresh_token"]}
+        )
+        assert rotated.status_code == 200, rotated.text
+
+    async def test_a_login_that_finishes_first_is_revoked_by_the_logout(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """The other ordering, without any stall: a login that commits before
+        the revocation runs is inside the set the revocation can see."""
+        user_id, username = await _create_user(client, admin_auth_header)
+        first = await _login(client, username)
+        second = await _login(client, username)
+
+        resp = await client.post(
+            "/auth/logout/",
+            headers={"Authorization": f"Bearer {second['access_token']}"},
+        )
+        assert resp.status_code == 204, resp.text
+
+        assert (await _newest_refresh_row(test_db_session, user_id)).revoked
+        for token in (first["refresh_token"], second["refresh_token"]):
+            assert (
+                await client.post("/auth/refresh/", json={"refresh_token": token})
+            ).status_code == 401
+
+
+class TestTheSerializationPointsStillExist:
+    """Structural guards on the two incidental mechanisms above.
+
+    The behavioural test needs a forced interleaving to fail, which makes it
+    the slower and less obvious signal. These name the exact edits that would
+    break it, so the failure arrives with its cause attached.
+    """
+
+    def test_login_assigns_last_login_at_before_minting_tokens(self):
+        from pathlib import Path
+
+        for rel in (
+            "app/modules/auth/router.py",
+            "app/modules/auth/oauth/router.py",
+        ):
+            source = (Path(__file__).resolve().parents[1] / rel).read_text()
+            assign = source.find("last_login_at = func.now()")
+            mint = source.find("create_refresh_token(")
+            assert assign != -1, f"{rel}: last_login_at assignment not found"
+            assert mint != -1, f"{rel}: create_refresh_token call not found"
+            assert assign < mint, (
+                f"{rel}: the pending last_login_at write must precede token "
+                "issuance. It is what queues this login behind a concurrent "
+                "revocation's owner-row lock (fix(#1459)); minting first lets "
+                "the login read a token_version the revocation is about to bump."
+            )
+
+    def test_create_access_token_still_queries_the_database(self):
+        """The autoflush trigger, asserted as the mechanism rather than as a
+        literal: any query will flush the pending write, so a rewrite of the
+        SELECT is fine and only its REMOVAL breaks the invariant."""
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[1] / "app/modules/auth/service.py"
+        ).read_text()
+        start = source.find("async def create_access_token")
+        end = source.find("def create_download_token")
+        assert start != -1 and end > start
+        body = source[start:end]
+        assert "self.db.execute(" in body and "token_version" in body, (
+            "create_access_token must read token_version through a database "
+            "query rather than off an already-loaded User row. That query is "
+            "what the pending last_login_at write autoflushes into, and the "
+            "autoflush is what puts a login behind a concurrent revocation's "
+            "owner-row lock (fix(#1459)). The comment on it calls it 'a safe "
+            "extra query', which marks it as an optimisation target; it is "
+            "not one, and removing it opens a revocation-bypass window."
+        )

--- a/backend/tests/test_login_revocation_serialization.py
+++ b/backend/tests/test_login_revocation_serialization.py
@@ -41,7 +41,7 @@ import uuid
 
 import anyio
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.auth.models import RefreshToken
@@ -121,8 +121,12 @@ class TestLoginIsSerializedAgainstRevocation:
         # End: the stall must not expire on a timer either, or a login delayed
         # past it (CI contention) arrives after the commit, legitimately reads
         # post-revocation state, and passes for the wrong reason. So the
-        # revocation is held uncommitted until the login has actually reached
-        # issuance.
+        # revocation is held uncommitted until the login's write is OBSERVED
+        # waiting on the lock, in pg_stat_activity, over a third connection.
+        # Entering issuance is not sufficient evidence on its own: it proves
+        # the version read was about to happen, not that it is blocked, and any
+        # fixed margin bridging that gap fails under pool contention in exactly
+        # the case the margin exists to catch.
         lock_held = anyio.Event()
         login_reached_issuance = anyio.Event()
         original_create_access_token = AuthService.create_access_token
@@ -135,17 +139,40 @@ class TestLoginIsSerializedAgainstRevocation:
             login_reached_issuance.set()
             return await original_create_access_token(self, *args, **kwargs)
 
-        async def _stalled_emit(*args, **kwargs):
-            result = await original_emit(*args, **kwargs)
+        async def _login_write_is_waiting_on_the_lock() -> bool:
+            """True once a backend is blocked on a lock running the flushed UPDATE.
+
+            Read over ``test_db_session``, a connection belonging to neither
+            transaction in the race, because both of theirs are occupied.
+            ``pg_stat_activity`` reports live shared state rather than an MVCC
+            snapshot, so an open transaction here does not hide the waiter.
+            """
+            waiting = await test_db_session.execute(
+                text(
+                    "SELECT count(*) FROM pg_stat_activity "
+                    "WHERE datname = current_database() "
+                    "AND pid <> pg_backend_pid() "
+                    "AND state = 'active' "
+                    "AND wait_event_type = 'Lock' "
+                    "AND query ILIKE '%last_login_at%'"
+                )
+            )
+            return waiting.scalar_one() > 0
+
+        async def _stalled_emit(db, event, *args, **kwargs):
+            result = await original_emit(db, event, *args, **kwargs)
+            # Only the logout's call holds the lock. The racing login emits its
+            # own user.login.success audit through this same patched symbol,
+            # and stalling that one waits for a lock waiter that has already
+            # come and gone, so the login hangs until fail_after fires. A
+            # sleep-based stall hid this by merely delaying the login.
+            if getattr(event, "action", None) != "user.logout":
+                return result
             lock_held.set()
             with anyio.fail_after(30):
                 await login_reached_issuance.wait()
-            # A margin AFTER a deterministic sync point, not a substitute for
-            # one. Its only job is to let a login that is NOT serialized finish
-            # its version read while the revocation is still uncommitted, so
-            # removing the serialization fails this test loudly instead of
-            # racing the commit. The serialized path does not depend on it.
-            await anyio.sleep(0.25)
+                while not await _login_write_is_waiting_on_the_lock():
+                    await anyio.sleep(0.05)
             return result
 
         monkeypatch.setattr(audit_mod, "audit_emit", _stalled_emit)


### PR DESCRIPTION
Test only. No app-code change, no migration.

## The invariant

Credential issuance is serialized against revocation. Every path that creates a refresh row writes the user row before minting, so the pending write queues behind `revoke_all_tokens`'s `SELECT ... FOR UPDATE`:

- password login assigns `last_login_at` before `create_access_token` / `create_refresh_token`
- OAuth login does the same, in the same order
- rotation takes the owner-row lock explicitly, added by #1446

That pending ORM write autoflushes at the next query, and the query it flushes into is `create_access_token`'s re-SELECT of `token_version`. So the UPDATE joins the revocation's lock queue before the version is ever read. Only two orderings exist and both are correct: the login commits first and the revocation's UPDATE sees and revokes its row, or the login blocks and completes wholly after the commit, as a successor whose credentials all carry the new epoch.

## Why it needs pinning

This is what makes #1459 a non-issue, and #1459 was filed because the property is invisible. It is closed as not planned with the full analysis: https://github.com/geolens-io/geolens/issues/1459

On the rotation path the serialization is deliberate and commented. On the login paths it is incidental, and it rests on two things that read as implementation detail:

1. `last_login_at` being assigned before the mint, so there is a pending write to autoflush at all.
2. `create_access_token` querying the database for `token_version` instead of reading it off the User row the caller already loaded. Its own comment calls it "a safe extra query", which names it as an optimisation target. It is not one.

Either edit silently reopens the window, with nothing failing and no reviewer prompted to think about revocation. Nothing in the suite covers it today.

## What the tests do

`TestLoginIsSerializedAgainstRevocation` forces the widest window, stalling the logout handler inside `audit_emit` (which runs after `revoke_all_tokens(commit=False)` and before the single commit, so the lock and the uncommitted revocation stay open) and firing a login underneath it. It then asserts there is no third outcome: the racing row is revoked, or the login is a clean successor whose own access token authenticates and whose refresh token rotates. A second test covers the unstalled ordering.

`TestTheSerializationPointsStillExist` names the two mechanisms structurally, so the failure arrives with its cause attached rather than as a mysterious race. The second one asserts that `create_access_token` queries the database at all, rather than matching a literal, so rewriting the SELECT is fine and only removing it fails.

## Synchronization discipline

Review found the same defect three times in this file, in three different places: a timer standing in for a synchronization primitive. Each one made the test capable of passing without exercising the race, which is the only failure mode a regression guard must not have. Enumerated so the class is closed rather than whack-a-moled:

1. The login was released by `sleep(0.5)`. A logout slow to reach `revoke_all_tokens` let the login commit before the lock was taken, get revoked normally, and satisfy an early return. Replaced by an event set on entering `audit_emit`, which runs after `revoke_all_tokens` and before the commit, so entering it proves the lock is held and the revocation is staged but not durable. The early return is now an assertion, since that ordering is no longer reachable here and has its own test.
2. The stall ended on `sleep(1.5)`. A login delayed past it arrived after the commit, legitimately read post-revocation state, and passed for the wrong reason. Replaced by an event set on entering `create_access_token`, before it delegates, since its version re-SELECT is the call that blocks.
3. A `sleep(0.25)` margin bridged "issuance entered" to "version read done". Under pool contention the mutant's read landed after the commit and read legitimate state. Replaced by polling `pg_stat_activity` over a third connection until the login's flushed `UPDATE ... last_login_at` is observed with `wait_event_type = 'Lock'`.

The invariant that closes the class: every synchronization point on the pass path gates on observed state, never on elapsed time. Two gates observe program state that each prove a database fact (the lock is held; the version read is imminent), and the third observes the database directly. Two sleeps remain and neither orders anything: the 0.05s poll interval paces a loop whose exit condition is the observation above, and `fail_after(30)` bounds the failure path so a waiter that never appears fails loudly instead of hanging.

Fixing (3) also surfaced a latent flaw the sleeps had been hiding: the racing login emits its own `user.login.success` audit through the same patched symbol, so it entered the stall too. Against a sleep that was an invisible delay; against a poll it waited for a lock waiter that had already come and gone. The stall is now scoped to the logout's own audit event.

## Verified by mutation

Every shape the invariant can break in dies, and each dies for the right reason:

- **`last_login_at` moved after minting** fails the behavioural assertion in 5s, with the racing login's own access token returning 401. That is a genuine surviving session, not a tripwire: exactly the zombie shape #1459 described.
- **`last_login_at` removed entirely** produces no lock waiter at all, so `fail_after(30)` fires and the logout 500s. Deterministic, and loud.
- **The OAuth assignment moved between `create_access_token` and `create_refresh_token`** fails the ordering guard. Asserted in both directions: the previous comparison against `create_refresh_token` accepts that edit, the one at head rejects it. The behavioural test only drives `/auth/login`, so nothing else would have caught it.
- **`create_access_token`'s query removed** fails the second structural guard.

Restored and re-verified green after each, three consecutive clean runs.

## Verification

```
cd backend
uv run ruff check . && uv run ruff format --check .
uv run pytest tests/test_login_revocation_serialization.py tests/test_layering.py -q
```

51 passed.
