### PR TITLE
fix(tiles): emit CORS headers on raster tile responses

### DIFF
--- a/backend/tests/test_nginx_raster_cors_1464.py
+++ b/backend/tests/test_nginx_raster_cors_1464.py
@@ -77,9 +77,18 @@ def test_empty_tile_fallback_repeats_the_cors_header():
 
 
 def test_raster_cors_header_is_static_never_reflected():
-    """A reflected origin is cache-poisonous behind raster_cache and the CDN."""
+    """A reflected origin is cache-poisonous behind raster_cache and the CDN.
+
+    Scoped to the two raster locations on purpose. The cache-safety invariant
+    belongs to this cached route, and an uncached location elsewhere may have
+    good reason to answer a specific origin.
+    """
     conf = _without_comments(NGINX_CONF.read_text())
-    values = _ANY_ACAO_VALUE.findall(conf)
+    values = [
+        value
+        for pattern in (RASTER_TILES_LOCATION, EMPTY_TILE_LOCATION)
+        for value in _ANY_ACAO_VALUE.findall(_location_block(conf, pattern))
+    ]
 
     assert values, "expected at least one Access-Control-Allow-Origin header"
     for value in values:
@@ -87,6 +96,26 @@ def test_raster_cors_header_is_static_never_reflected():
             f'Access-Control-Allow-Origin must be the static "*", got {value!r}; '
             "a per-origin value would be cached and replayed to other origins"
         )
+
+
+def test_empty_tile_keeps_its_security_headers():
+    """The CORS header must not cost @empty_tile its inherited security headers.
+
+    add_header disables inheritance from the server scope, so the three headers
+    this 204 carried before #1464 have to be re-declared alongside the new one.
+    """
+    conf = _without_comments(NGINX_CONF.read_text())
+    block = _location_block(conf, EMPTY_TILE_LOCATION)
+
+    for header, value in (
+        ("X-Frame-Options", "SAMEORIGIN"),
+        ("X-Content-Type-Options", "nosniff"),
+        ("Referrer-Policy", "strict-origin-when-cross-origin"),
+    ):
+        assert re.search(
+            rf'add_header\s+{re.escape(header)}\s+"{re.escape(value)}"\s+always\s*;',
+            block,
+        ), f"@empty_tile must re-declare {header}; add_header disables inheritance"
 
 
 def test_raster_tiles_hides_upstream_cors_header():

--- a/backend/tests/test_nginx_raster_cors_1464.py
+++ b/backend/tests/test_nginx_raster_cors_1464.py
@@ -1,0 +1,100 @@
+"""Regression coverage for CORS headers on the nginx raster-tile route (#1464).
+
+Raster tiles are served from the app origin at ``/raster-tiles/...`` and never
+pass through the api's CORS handling, so the header has to come from nginx.
+Two properties matter and neither is visible from a single grep:
+
+* the header must reach the ``@empty_tile`` fallback as well, because
+  ``error_page 404 = @empty_tile`` internal-redirects and nginx then emits only
+  the FINAL location's ``add_header`` set; and
+* the value must stay the static ``*``, because the route sits behind the
+  ``raster_cache`` proxy cache (and a CDN tile cache in the demo), where a
+  reflected ``$http_origin`` would be replayed to the wrong origin.
+"""
+
+import re
+
+from tests.repo_paths import repo_root
+
+NGINX_CONF = repo_root(__file__) / "frontend" / "nginx.conf"
+
+RASTER_TILES_LOCATION = r"location\s+~\s+\^/raster-tiles/"
+EMPTY_TILE_LOCATION = r"location\s+@empty_tile\b"
+
+_ACAO_DIRECTIVE = re.compile(
+    r'add_header\s+Access-Control-Allow-Origin\s+"\*"\s+always\s*;'
+)
+_ANY_ACAO_VALUE = re.compile(r"add_header\s+Access-Control-Allow-Origin\s+(\S+)")
+
+
+def _without_comments(text: str) -> str:
+    """Drop nginx comment lines so prose can never satisfy an assertion."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _location_block(text: str, header_pattern: str) -> str:
+    """Return the body of the first location block whose header matches."""
+    match = re.search(header_pattern, text)
+    assert match, f"expected a location block matching {header_pattern!r}"
+    start = text.index("{", match.start())
+    depth = 0
+    for index in range(start, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start + 1 : index]
+    raise AssertionError(f"unbalanced braces after {header_pattern!r}")
+
+
+def test_raster_tiles_location_emits_cors_header():
+    conf = _without_comments(NGINX_CONF.read_text())
+    block = _location_block(conf, RASTER_TILES_LOCATION)
+
+    assert _ACAO_DIRECTIVE.search(block), (
+        "the /raster-tiles/ location must emit "
+        'add_header Access-Control-Allow-Origin "*" always'
+    )
+
+
+def test_empty_tile_fallback_repeats_the_cors_header():
+    """Out-of-extent tiles 404 upstream and are served from @empty_tile.
+
+    nginx emits the add_header set of the location that finally handles the
+    request, so the header on the /raster-tiles/ block does not survive the
+    internal redirect. Without this, sparse rasters fail CORS on every edge tile.
+    """
+    conf = _without_comments(NGINX_CONF.read_text())
+    block = _location_block(conf, EMPTY_TILE_LOCATION)
+
+    assert _ACAO_DIRECTIVE.search(block), (
+        "@empty_tile must repeat the CORS header; add_header sets are not "
+        "inherited across the error_page internal redirect"
+    )
+
+
+def test_raster_cors_header_is_static_never_reflected():
+    """A reflected origin is cache-poisonous behind raster_cache and the CDN."""
+    conf = _without_comments(NGINX_CONF.read_text())
+    values = _ANY_ACAO_VALUE.findall(conf)
+
+    assert values, "expected at least one Access-Control-Allow-Origin header"
+    for value in values:
+        assert value == '"*"', (
+            f'Access-Control-Allow-Origin must be the static "*", got {value!r}; '
+            "a per-origin value would be cached and replayed to other origins"
+        )
+
+
+def test_raster_tiles_hides_upstream_cors_header():
+    """add_header appends, so a duplicate wildcard would break CORS outright."""
+    conf = _without_comments(NGINX_CONF.read_text())
+    block = _location_block(conf, RASTER_TILES_LOCATION)
+
+    assert re.search(r"proxy_hide_header\s+Access-Control-Allow-Origin\s*;", block), (
+        "the /raster-tiles/ location must hide any upstream "
+        "Access-Control-Allow-Origin so exactly one value is emitted"
+    )

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -158,9 +158,36 @@ server {
         proxy_ignore_headers Set-Cookie;
 
         add_header X-Cache-Status $upstream_cache_status always;
+
+        # fix(#1464): canvas/WebGL map clients FETCH raster tiles, so they need
+        # CORS, and this route never reaches the api's CORS handling — it is
+        # rewritten to /tiles/raster-proxy/, whose handler returns only
+        # Cache-Control. (The MVT handlers emit their own wildcard in
+        # processing/tiles/responses.py, which is why vector tiles already work.)
+        # Three constraints hold this shape:
+        #   - STATIC "*", never a reflected $http_origin. The response is stored
+        #     by raster_cache above and, on the demo, a Cloudflare tile cache
+        #     rule, so a per-origin value would be replayed to other origins.
+        #   - `always`, so the limit_req 503s above carry it and rate limiting
+        #     stays readable instead of surfacing as an opaque CORS error.
+        #   - proxy_hide_header, because add_header APPENDS: if the upstream ever
+        #     starts emitting its own wildcard the client would see two values,
+        #     which browsers reject outright.
+        # Tile auth rides query params rather than cookies, so no
+        # Allow-Credentials is involved.
+        proxy_hide_header Access-Control-Allow-Origin;
+        add_header Access-Control-Allow-Origin "*" always;
     }
 
+    # fix(#1464): a tile outside the raster's extent 404s upstream and arrives
+    # here through `error_page 404 = @empty_tile`. That internal redirect makes
+    # THIS the final location, so nginx emits this block's add_header set and
+    # discards the /raster-tiles/ block's entirely (same semantics documented at
+    # `location ~ ^/m/` below; verified against nginx 1.31.3). Repeat the header
+    # or every edge tile of a sparse raster still fails CORS in the browser while
+    # the covered tiles succeed.
     location @empty_tile {
+        add_header Access-Control-Allow-Origin "*" always;
         return 204;
     }
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -188,6 +188,12 @@ server {
     # the covered tiles succeed.
     location @empty_tile {
         add_header Access-Control-Allow-Origin "*" always;
+        # Adding any add_header here disables inheritance, so re-declare the
+        # server-scope security headers this 204 carried before #1464 rather
+        # than dropping them as a side effect of the CORS fix.
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         return 204;
     }
 


### PR DESCRIPTION
Closes #1464

`/raster-tiles/{dataset_id}/tiles/{z}/{x}/{y}.png` responses carried no CORS headers, so every fetch-based map client was blocked from consuming GeoLens raster tiles cross-origin.

## Evidence

The issue confirmed this at the origin, not just at the CDN edge: a cache-busting request returned `cf-cache-status: MISS` and still had no `access-control-*` headers, so the origin chain (nginx, then the api's `/tiles/raster-proxy/` route, then Titiler) never emitted one. In a browser, a MapLibre `raster` source failed every tile with `No 'Access-Control-Allow-Origin' header is present` (108 console errors) while `/api/` examples on the same page origin rendered fine.

I reproduced the defect locally against the rendered `nginx.conf` from `origin/main` with a stub upstream, and confirmed the fix through the identical harness. Details under Verification.

Two things kept this hidden. Vector tiles were never affected, because the MVT handlers set `Access-Control-Allow-Origin: *` themselves in `backend/app/processing/tiles/responses.py`. That is worth stating precisely, since it is the tile handlers rather than the CORS middleware doing the work there. And Leaflet, the client most likely to have surfaced it, loads raster tiles through `<img>` tags, which bypass CORS for display. Only canvas and WebGL clients (MapLibre, ArcGIS `WebTileLayer`, OpenLayers) fetch tiles and fail.

## The fix

The header is added in nginx rather than in the api handler, because nginx also generates responses on this route that the api never sees: the `limit_req` 503, and the `@empty_tile` 204. Four properties, each load-bearing.

Static `*`, never a reflected `Origin`. The route sits behind two caches, the `raster_cache` proxy cache in this file and, on the demo, a Cloudflare tile cache rule. A reflected per-origin value would be cached under one origin and replayed to others. `*` is not a loosening: it matches the wildcard the MVT tile handlers already emit, and tile auth rides query parameters rather than cookies, so no `Access-Control-Allow-Credentials` is involved and cookie-credentialed cross-origin access remains impossible by design.

`always`, so rate-limited and error responses carry it too. Verified: the `limit_req` 503 emits the header, which keeps rate limiting visible to clients as a readable 503 instead of an opaque CORS failure.

`proxy_hide_header Access-Control-Allow-Origin`, because `add_header` appends. I confirmed against nginx 1.31.3 that when an upstream also emits the wildcard, the client receives two `Access-Control-Allow-Origin: *` headers, which browsers reject outright. The api's raster handler emits none today, so this changes nothing now. It stops a future change to `raster_tile_proxy` (the natural "make it match the MVT handlers" edit) from silently breaking CORS behind the cache.

The header is repeated on `@empty_tile`. This is the one addition beyond the issue's stated scope, and the reason is a non-obvious nginx semantic. An out-of-extent tile 404s upstream and reaches `@empty_tile` through `error_page 404 = @empty_tile`. That internal redirect makes `@empty_tile` the *final* location, so nginx emits its `add_header` set and discards the `/raster-tiles/` block's entirely. I verified this directly: without the repeat, the 204 carries the server-scope headers and no CORS header. It is the same semantic already documented in the `location ~ ^/m/` block. Left unfixed, sparse or non-rectangular rasters would still fail CORS on every edge tile while the covered tiles succeeded, a partial fix that would have looked like a flake.

Adding an `add_header` to `@empty_tile` disables inheritance, which would have dropped the three server-scope security headers that 204 previously carried (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`). They are re-declared there, so the only behavioral change on that response is the added CORS header. The covered-tile 200 never carried them, because its own `X-Cache-Status` header already disabled inheritance before this PR.

No preflight handling is needed. Tile `GET`s with no custom request headers are CORS *simple* requests, so browsers never send an `OPTIONS` preflight for them.

## Sibling-location survey

I checked every location in `nginx.conf` for the same gap, meaning public read content served outside `/api/` that bypasses the api's CORS handling:

- `location /api/`: proxies to FastAPI, which applies `DynamicCORSMiddleware`. Not changed.
- `location ~ ^/raster-tiles/`: the defect. Fixed.
- `location @empty_tile`: its 404 fallback, same gap by internal-redirect semantics. Fixed.
- `location /assets/`, `location = /env-config.js`, `location /`: static SPA assets and HTML, loaded same-origin by the app itself.
- `location ~ ^/m/`: the embed HTML shell, loaded as a document or iframe, where CORS does not apply. Its cross-origin story is the per-token `frame-ancestors` CSP.
- `location = /_embed_frame_policy`: `internal;`, unreachable from outside.
- `location = /api/metrics`: deliberately `return 404`.

So the raster-tile route and its own 404 fallback are the only such surfaces.

One scope note. The api-side `/tiles/raster-proxy/` route also emits no CORS header, and it is documented as the fallback for deployments without nginx. I left it alone. Every raster tile URL the api advertises (STAC assets, OGC, search, saved-map style JSON, dataset helpers) is the app-origin `/raster-tiles/...` path, so the nginx route is the public contract, and adding the header in both places without the `proxy_hide_header` above would produce the duplicate-header break described earlier.

## Verification

Backend gates, from the branch:

- `uv run ruff check tests/test_nginx_raster_cors_1464.py`: passed
- `uv run ruff format --check tests/test_nginx_raster_cors_1464.py`: passed
- `uv run pytest tests/test_nginx_raster_cors_1464.py tests/test_nginx_apikey_log_scrub_sec006.py -q`: 8 passed
- pre-commit (Rule 1 and Rule 2 hooks, ruff, secret detection): passed

`nginx -t` was runnable rather than skipped. The config is an `envsubst` template, so I rendered it with the four substitutions and the defaults `frontend/docker-entrypoint.sh` applies, then validated it inside the production base image (`nginxinc/nginx-unprivileged:1.31.3-alpine`): *syntax is ok / test is successful*. The only warning is the pre-existing duplicate `wasm` MIME extension.

Behavioral check against nginx 1.31.3, running the rendered config with a stub upstream that mimics `raster_tile_proxy` (200 with only `Cache-Control`, 404 for an out-of-extent tile):

| case | result |
| --- | --- |
| covered tile, cache MISS | 200, header present |
| same tile, cache HIT | 200, header present |
| out-of-extent tile via `@empty_tile` | 204, header present |
| upstream also emitting a wildcard | exactly 1 header |
| same request against the `origin/main` config | **no** `access-control-*` header (defect reproduced) |
| out-of-extent 204, security headers | `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy` preserved |

The new tests are guards, not decoration. All four of the original ones fail against the `origin/main` config, and three of them, including the dedicated static-value test, fail against a reflected `$http_origin` variant of the fixed config. The fifth fails when the security headers are stripped from `@empty_tile`. The scoped static-value test still passes when an origin-specific header is injected into the `/api/` block, which is the behavior codex asked for.

Not run, and why: no migration is involved, so no `alembic-check`. No `backend/app/` source changed, so `test_layering.py` is not implicated. No frontend app code changed, so no e2e.
