### PR TITLE
fix(records): stop labeling XYZ vector-tile distributions as OGC:WMTS

### DIFF
--- a/backend/alembic/versions/0048_vector_tiles_protocol_xyz.py
+++ b/backend/alembic/versions/0048_vector_tiles_protocol_xyz.py
@@ -28,8 +28,16 @@ The WHERE clause is deliberately four-way:
   re-run is a no-op and an auto-generated row already corrected by hand is left
   as it is.
 
-Downgrade restores the old value under the mirror-image scope, so the data
-matches whatever the template says at that revision.
+Downgrade is a no-op, like the other data-only normalizations here (0003,
+0028, 0034). The mirror-image UPDATE looks symmetric and is not: ``XYZ`` is
+also what an operator who corrected a row by hand before this deploy already
+has, and the upgrade deliberately leaves those alone, so a reverse statement
+scoped to ``protocol = 'XYZ'`` would rewrite rows this migration never touched
+and hand them a value that was wrong when they fixed it. Recording the row ids
+to make the reverse exact is not worth it either, because no revision needs
+``OGC:WMTS`` back: ``protocol`` is metadata, nothing reads it for behaviour at
+any version (not the frontend, not the DCAT/GeoDCAT-AP/DCAT-US serializers,
+not STAC), so leaving the honest label in place downgrades cleanly.
 
 Revision ID: 0048_vector_tiles_protocol_xyz
 Revises: 0047_users_sessions_revoked_at
@@ -60,13 +68,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        """
-        UPDATE catalog.record_distributions
-        SET protocol = 'OGC:WMTS'
-        WHERE auto_generated = true
-          AND distribution_type = 'vector_tiles'
-          AND format = 'pbf'
-          AND protocol = 'XYZ'
-        """
-    )
+    # fix(#1463, codex round 1): data-only relabel, intentionally not reversed.
+    # See the module docstring — the reverse statement cannot tell a row this
+    # migration rewrote from one an operator had already corrected, and no
+    # revision needs the WMTS label back.
+    pass

--- a/backend/alembic/versions/0048_vector_tiles_protocol_xyz.py
+++ b/backend/alembic/versions/0048_vector_tiles_protocol_xyz.py
@@ -1,0 +1,72 @@
+"""Relabel auto-generated vector-tile distributions from OGC:WMTS to XYZ.
+
+fix(#1463): the generated "Vector Tiles" row advertised ``protocol='OGC:WMTS'``
+against ``/tiles/data.{table}/{z}/{x}/{y}.pbf`` — a plain XYZ template with no
+capabilities document and no TileMatrixSet negotiation. A client that believed
+the label failed against a healthy instance, which reads as a broken deployment
+rather than a wrong string. ``records/service.py`` now stamps ``XYZ`` on new
+rows; this rewrites the ones already in the database.
+
+A migration is required rather than a reconcile-side correction, because
+neither generated-distribution write path ever updates a surviving row.
+``generate_distributions`` probes ``(distribution_type, format)`` pairs and
+SKIPS one it already owns, and ``reconcile_distributions`` only deletes pairs
+the record's new modality excludes and normalizes ``is_primary``. Nothing
+rewrites ``protocol``, so without this statement every record created before
+the deploy keeps the wrong value for good.
+
+The WHERE clause is deliberately four-way:
+
+- ``auto_generated = true`` — rows a user authored through
+  ``create_distribution`` are their text in a free-text field. Someone who
+  typed ``OGC:WMTS`` for their own WMTS service is correct, and a migration has
+  no standing to overwrite it.
+- ``distribution_type = 'vector_tiles' AND format = 'pbf'`` — the exact pair
+  ``generate_distributions`` owns. The raster and VRT ingest tails write their
+  own auto-generated ``download`` rows, which this must not touch.
+- ``protocol = 'OGC:WMTS'`` — only rows still carrying the wrong value, so a
+  re-run is a no-op and an auto-generated row already corrected by hand is left
+  as it is.
+
+Downgrade restores the old value under the mirror-image scope, so the data
+matches whatever the template says at that revision.
+
+Revision ID: 0048_vector_tiles_protocol_xyz
+Revises: 0047_users_sessions_revoked_at
+Create Date: 2026-08-13
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0048_vector_tiles_protocol_xyz"
+down_revision: Union[str, None] = "0047_users_sessions_revoked_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE catalog.record_distributions
+        SET protocol = 'XYZ'
+        WHERE auto_generated = true
+          AND distribution_type = 'vector_tiles'
+          AND format = 'pbf'
+          AND protocol = 'OGC:WMTS'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE catalog.record_distributions
+        SET protocol = 'OGC:WMTS'
+        WHERE auto_generated = true
+          AND distribution_type = 'vector_tiles'
+          AND format = 'pbf'
+          AND protocol = 'XYZ'
+        """
+    )

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -737,15 +737,21 @@ async def generate_distributions(
     existing_set = {(row[0], row[1]) for row in existing_result.all()}
 
     # fix(#1463, codex round 2): repair a surviving row the OLD template wrote.
-    # Migration 0048 is one-shot and `scripts/upgrade.sh` migrates while the
-    # previous app containers still serve (step 6 migrates, step 7 replaces the
-    # app), so a dataset created in that window is stamped `OGC:WMTS` after the
-    # UPDATE commits — and the pair-existence skip below means the template
+    # Migration 0048 is one-shot and the scripted upgrade migrates while the
+    # previous app containers still serve (it migrates first, replaces the app
+    # after), so a dataset created in that window is stamped `OGC:WMTS` after
+    # the UPDATE commits — and the pair-existence skip below means the template
     # never rewrites it. Scoped like the migration's WHERE plus this record;
-    # a user's own row is not visible to this function at all. Reaches anything
-    # later refreshed, reuploaded or reconciled. A dataset created in the window
-    # and never touched again keeps the wrong label: the general ordering
-    # problem is #1467.
+    # a user's own row is not visible to this function at all.
+    #
+    # fix(#1463, codex round 4): this is a partial mitigation, not a closer, and
+    # the earlier comment here overstated it. Both refresh callers gate
+    # `reconcile_distributions` on a modality FLIP (`tasks_postgis_refresh` and
+    # `tasks_common`, each deliberately, so an unchanged refresh cannot
+    # renormalize `is_primary`), and creation cannot meet a stale row. So the
+    # reach is: a dataset that gains or loses geometry, plus any future caller
+    # that regenerates. Everything else created in the window keeps the wrong
+    # label until #1467 removes the window itself, which is the actual fix.
     if _VECTOR_TILES_PAIR in existing_set:
         await session.execute(
             update(RecordDistribution)

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -628,6 +628,21 @@ _DISTRIBUTION_TEMPLATES = [
 # generated set, so reconcile has to see it.
 _VECTOR_TILES_PAIR = ("vector_tiles", "pbf")
 
+# fix(#1463): this used to read ``OGC:WMTS``, which the endpoint below does not
+# speak — ``/tiles/data.{table}/{z}/{x}/{y}.pbf`` is a plain XYZ template with
+# no capabilities document and no TileMatrixSet negotiation, so a client that
+# believed the label failed against a working instance. ``XYZ`` is what the
+# scheme is actually called everywhere it is consumed (QGIS's connection type,
+# GDAL's driver, MapLibre's source), and it claims no OGC standard, because
+# there is none to claim. The payload semantics are carried precisely by
+# ``format='pbf'`` and ``media_type='application/vnd.mapbox-vector-tile'``.
+# Bare rather than prefixed to match ``HTTP`` in the templates above, which is
+# this vocabulary's form for a transport that is not an OGC service.
+#
+# Migration 0048 rewrites the rows generated before this change; the WHERE
+# there matches this exact value, so the two have to move together.
+_VECTOR_TILES_PROTOCOL = "XYZ"
+
 # The four-column unique constraint on ``record_distributions``
 # (record_id, distribution_type, format, url) — see RecordDistribution's
 # ``__table_args__``. Named here because the generated-row insert has to be
@@ -791,7 +806,7 @@ async def generate_distributions(
                 "format": "pbf",
                 "url": f"/tiles/data.{table_name}/{{z}}/{{x}}/{{y}}.pbf",
                 "title": "Vector Tiles",
-                "protocol": "OGC:WMTS",
+                "protocol": _VECTOR_TILES_PROTOCOL,
                 "media_type": "application/vnd.mapbox-vector-tile",
                 "is_primary": False,
                 "auto_generated": True,

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -628,20 +628,14 @@ _DISTRIBUTION_TEMPLATES = [
 # generated set, so reconcile has to see it.
 _VECTOR_TILES_PAIR = ("vector_tiles", "pbf")
 
-# fix(#1463): this used to read ``OGC:WMTS``, which the endpoint below does not
-# speak — ``/tiles/data.{table}/{z}/{x}/{y}.pbf`` is a plain XYZ template with
-# no capabilities document and no TileMatrixSet negotiation, so a client that
-# believed the label failed against a working instance. ``XYZ`` is what the
-# scheme is actually called everywhere it is consumed (QGIS's connection type,
-# GDAL's driver, MapLibre's source), and it claims no OGC standard, because
-# there is none to claim. The payload semantics are carried precisely by
-# ``format='pbf'`` and ``media_type='application/vnd.mapbox-vector-tile'``.
-# Bare rather than prefixed to match ``HTTP`` in the templates above, which is
-# this vocabulary's form for a transport that is not an OGC service.
-#
-# Migration 0048 rewrites the rows generated before this change; the WHERE
-# there matches this exact value, so the two have to move together.
+# fix(#1463): this read ``OGC:WMTS``, which the tile URL does not speak — it is
+# a plain XYZ template, no capabilities document and no TileMatrixSet. Bare, to
+# match ``HTTP`` above: this vocabulary prefixes ``OGC:`` only for real OGC
+# services, and there is no OGC XYZ standard to claim. Payload semantics stay
+# in ``format`` and ``media_type``. Migration 0048's WHERE matches both values
+# below, so the three move together.
 _VECTOR_TILES_PROTOCOL = "XYZ"
+_STALE_VECTOR_TILES_PROTOCOL = "OGC:WMTS"
 
 # The four-column unique constraint on ``record_distributions``
 # (record_id, distribution_type, format, url) — see RecordDistribution's
@@ -741,6 +735,29 @@ async def generate_distributions(
         )
     )
     existing_set = {(row[0], row[1]) for row in existing_result.all()}
+
+    # fix(#1463, codex round 2): repair a surviving row the OLD template wrote.
+    # Migration 0048 is one-shot and `scripts/upgrade.sh` migrates while the
+    # previous app containers still serve (step 6 migrates, step 7 replaces the
+    # app), so a dataset created in that window is stamped `OGC:WMTS` after the
+    # UPDATE commits — and the pair-existence skip below means the template
+    # never rewrites it. Scoped like the migration's WHERE plus this record;
+    # a user's own row is not visible to this function at all. Reaches anything
+    # later refreshed, reuploaded or reconciled. A dataset created in the window
+    # and never touched again keeps the wrong label: the general ordering
+    # problem is #1467.
+    if _VECTOR_TILES_PAIR in existing_set:
+        await session.execute(
+            update(RecordDistribution)
+            .where(
+                RecordDistribution.record_id == record_id,
+                RecordDistribution.auto_generated.is_(True),
+                RecordDistribution.distribution_type == _VECTOR_TILES_PAIR[0],
+                RecordDistribution.format == _VECTOR_TILES_PAIR[1],
+                RecordDistribution.protocol == _STALE_VECTOR_TILES_PROTOCOL,
+            )
+            .values(protocol=_VECTOR_TILES_PROTOCOL)
+        )
 
     # fix(#1383): the template's primary flag yields to whoever already holds
     # it. At dataset creation nothing does and the GeoPackage (or CSV) row

--- a/backend/tests/test_distribution_reconcile_1314.py
+++ b/backend/tests/test_distribution_reconcile_1314.py
@@ -820,8 +820,13 @@ class TestTheStaleProtocolRepair:
     in ``generate_distributions`` means the template never rewrites a pair it
     already owns, so without the repair below the row stays wrong for good.
 
-    The general upgrade-ordering problem is #1467; this covers the one row
-    class that ships in the same release as the migration.
+    fix(#1463, codex round 4): what this does NOT do. Both refresh callers gate
+    ``reconcile_distributions`` on a modality flip, so an ordinary refresh of an
+    unchanged dataset never arrives here and the repair is a partial mitigation
+    rather than a closer. The reach is a dataset that gains or loses geometry,
+    plus any future caller that regenerates. Removing the window itself is
+    #1467. These tests pin the repair's behaviour where it does run; they are
+    not evidence that every stranded row gets fixed.
     """
 
     async def _stale(self, session: AsyncSession, record_id: uuid.UUID) -> None:
@@ -854,7 +859,7 @@ class TestTheStaleProtocolRepair:
     async def test_reconcile_repairs_it_too(
         self, test_db_session: AsyncSession
     ) -> None:
-        """Refresh, reupload and modality changes all arrive through here."""
+        """The modality-flip path, which is the one that reaches this in prod."""
         dataset = await _spatial_dataset(test_db_session)
         await self._stale(test_db_session, dataset.record_id)
 

--- a/backend/tests/test_distribution_reconcile_1314.py
+++ b/backend/tests/test_distribution_reconcile_1314.py
@@ -813,8 +813,8 @@ class TestTheStaleProtocolRepair:
     """fix(#1463, codex round 2): the pair-existence skip can strand a bad row.
 
     Migration 0048 relabels the auto-generated vector-tile rows from
-    ``OGC:WMTS`` to ``XYZ``. It runs once, and ``scripts/upgrade.sh`` applies
-    migrations while the previous app containers are still serving, so a
+    ``OGC:WMTS`` to ``XYZ``. It runs once, and the scripted upgrade path
+    applies migrations while the previous app containers are still serving, so a
     dataset created in that window is written by the OLD template AFTER the
     UPDATE has committed. Alembic will not repeat the revision, and the skip
     in ``generate_distributions`` means the template never rewrites a pair it

--- a/backend/tests/test_distribution_reconcile_1314.py
+++ b/backend/tests/test_distribution_reconcile_1314.py
@@ -807,3 +807,132 @@ class TestTwoRowsForOneFormat:
         assert not any(
             key for key in item["assets"] if "mine.gpkg" in str(item["assets"][key])
         )
+
+
+class TestTheStaleProtocolRepair:
+    """fix(#1463, codex round 2): the pair-existence skip can strand a bad row.
+
+    Migration 0048 relabels the auto-generated vector-tile rows from
+    ``OGC:WMTS`` to ``XYZ``. It runs once, and ``scripts/upgrade.sh`` applies
+    migrations while the previous app containers are still serving, so a
+    dataset created in that window is written by the OLD template AFTER the
+    UPDATE has committed. Alembic will not repeat the revision, and the skip
+    in ``generate_distributions`` means the template never rewrites a pair it
+    already owns, so without the repair below the row stays wrong for good.
+
+    The general upgrade-ordering problem is #1467; this covers the one row
+    class that ships in the same release as the migration.
+    """
+
+    async def _stale(self, session: AsyncSession, record_id: uuid.UUID) -> None:
+        """Put a record's generated vector-tile row back to the old label."""
+        row = await _row(session, record_id, "vector_tiles", "pbf")
+        assert row is not None
+        row.protocol = "OGC:WMTS"
+        await session.commit()
+
+    async def test_generate_repairs_a_surviving_stale_row(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        dataset = await _spatial_dataset(test_db_session)
+        await self._stale(test_db_session, dataset.record_id)
+
+        await generate_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        row = await _row(test_db_session, dataset.record_id, "vector_tiles", "pbf")
+        assert row is not None
+        await test_db_session.refresh(row)
+        assert row.protocol == "XYZ"
+
+    async def test_reconcile_repairs_it_too(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Refresh, reupload and modality changes all arrive through here."""
+        dataset = await _spatial_dataset(test_db_session)
+        await self._stale(test_db_session, dataset.record_id)
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        row = await _row(test_db_session, dataset.record_id, "vector_tiles", "pbf")
+        assert row is not None
+        await test_db_session.refresh(row)
+        assert row.protocol == "XYZ"
+
+    async def test_a_user_authored_row_keeps_its_own_protocol(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """Same rule as the migration's WHERE: user rows are not ours to edit.
+
+        Somebody pointing their own distribution at a real WMTS service is
+        correct, and the repair must not reach it just because the type and
+        the value match.
+        """
+        dataset = await _spatial_dataset(test_db_session)
+        await self._stale(test_db_session, dataset.record_id)
+        mine = await create_distribution(
+            test_db_session,
+            dataset.record_id,
+            distribution_type="vector_tiles",
+            format="pbf",
+            url="https://example.org/wmts/1.0.0/WMTSCapabilities.xml",
+            title="My own WMTS",
+            protocol="OGC:WMTS",
+        )
+        await test_db_session.commit()
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        theirs = await test_db_session.get(RecordDistribution, mine.id)
+        assert theirs is not None
+        await test_db_session.refresh(theirs)
+        assert theirs.protocol == "OGC:WMTS"
+
+    async def test_a_healthy_row_is_left_alone(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """The repair matches the stale value, not the pair.
+
+        An auto-generated row an operator already corrected by hand to
+        something else is not stale, and rewriting it would be the same
+        overreach the migration's downgrade was dropped for.
+        """
+        dataset = await _spatial_dataset(test_db_session)
+        row = await _row(test_db_session, dataset.record_id, "vector_tiles", "pbf")
+        assert row is not None
+        row.protocol = "WWW:LINK"
+        await test_db_session.commit()
+
+        await reconcile_distributions(
+            test_db_session,
+            dataset.id,
+            dataset.record_id,
+            dataset.table_name,
+            geometry_type="POLYGON",
+        )
+        await test_db_session.commit()
+
+        row = await _row(test_db_session, dataset.record_id, "vector_tiles", "pbf")
+        assert row is not None
+        await test_db_session.refresh(row)
+        assert row.protocol == "WWW:LINK"

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3187,6 +3187,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # PostgreSQL-valid reference is not false-404'd. Most of the added lines are
     # that rationale. Cap at the exact size.
     "backend/app/platform/sandbox/validator.py": 1871,
+    # fix(#1463): crossed the inclusion threshold at 1001. The growth is the
+    # vector-tile protocol constants and the stale-label repair in
+    # generate_distributions, plus the comment recording why the repair has to
+    # exist at all: migration 0048 is one-shot and scripts/upgrade.sh runs it
+    # while the previous release is still writing rows (#1467), so the template
+    # is not the only place that has to know the old value. Cap at the exact
+    # size; the module is otherwise a stable set of CRUD helpers over the
+    # record's related tables and is not where new domains should land.
+    "backend/app/modules/catalog/records/service.py": 1001,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3187,15 +3187,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # PostgreSQL-valid reference is not false-404'd. Most of the added lines are
     # that rationale. Cap at the exact size.
     "backend/app/platform/sandbox/validator.py": 1871,
-    # fix(#1463): crossed the inclusion threshold at 1001. The growth is the
-    # vector-tile protocol constants and the stale-label repair in
-    # generate_distributions, plus the comment recording why the repair has to
-    # exist at all: migration 0048 is one-shot and the scripted upgrade runs it
-    # while the previous release is still writing rows (#1467), so the template
-    # is not the only place that has to know the old value. Cap at the exact
-    # size; the module is otherwise a stable set of CRUD helpers over the
-    # record's related tables and is not where new domains should land.
-    "backend/app/modules/catalog/records/service.py": 1001,
+    # fix(#1463): crossed the inclusion threshold. The growth is the vector-tile
+    # protocol constants and the stale-label repair in generate_distributions,
+    # plus the comment recording why the repair has to exist at all: migration
+    # 0048 is one-shot and the scripted upgrade runs it while the previous
+    # release is still writing rows (#1467), so the template is not the only
+    # place that has to know the old value.
+    # fix(#1463 codex r4): +6 — the same comment recording what the repair does
+    # NOT reach. Both refresh callers gate reconcile on a modality flip, so
+    # naming it a closer for the deploy window was wrong; the correction is
+    # worth more than the six lines. Cap at the exact size; the module is
+    # otherwise a stable set of CRUD helpers over the record's related tables
+    # and is not where new domains should land.
+    "backend/app/modules/catalog/records/service.py": 1007,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3190,7 +3190,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1463): crossed the inclusion threshold at 1001. The growth is the
     # vector-tile protocol constants and the stale-label repair in
     # generate_distributions, plus the comment recording why the repair has to
-    # exist at all: migration 0048 is one-shot and scripts/upgrade.sh runs it
+    # exist at all: migration 0048 is one-shot and the scripted upgrade runs it
     # while the previous release is still writing rows (#1467), so the template
     # is not the only place that has to know the old value. Cap at the exact
     # size; the module is otherwise a stable set of CRUD helpers over the

--- a/backend/tests/test_records_related.py
+++ b/backend/tests/test_records_related.py
@@ -766,6 +766,43 @@ class TestDistributions:
                 f"Distribution URL should contain dataset_id {dataset_id_str}: {d['url']}"
             )
 
+    async def test_vector_tiles_distribution_is_labeled_xyz(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session: AsyncSession,
+    ):
+        """fix(#1463): the tile template is XYZ, and says so.
+
+        The URL is ``/tiles/data.{table}/{z}/{x}/{y}.pbf`` — no capabilities
+        document, no TileMatrixSet negotiation. It carried ``OGC:WMTS``, which
+        sent a conforming client down a path the endpoint cannot serve, so the
+        assertion that matters is the negative one: whatever the value is, it
+        must not name a service GeoLens does not speak.
+        """
+        admin_id = await get_user_id(test_db_session, "admin")
+        ds = await _create_dataset_with_distributions(
+            test_db_session, created_by=admin_id
+        )
+        resp = await client.get(
+            f"/records/{ds.record_id}/distributions/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200
+        tiles = [
+            d
+            for d in resp.json()["distributions"]
+            if d["distribution_type"] == "vector_tiles"
+        ]
+        assert len(tiles) == 1
+        assert tiles[0]["protocol"] == "XYZ"
+        assert tiles[0]["media_type"] == "application/vnd.mapbox-vector-tile"
+
+        # No generated row may advertise a service with no server behind it.
+        # GeoLens serves neither WMTS nor WMS anywhere (#1461 is where real
+        # WMTS would land, with its own capabilities distribution).
+        for d in resp.json()["distributions"]:
+            assert d["protocol"] not in ("OGC:WMTS", "OGC:WMS"), d
+
     async def test_create_manual_distribution(
         self,
         client: AsyncClient,

--- a/frontend/src/components/dataset/__tests__/ConnectDropdown.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ConnectDropdown.test.tsx
@@ -107,7 +107,7 @@ describe('ConnectDropdown', () => {
             url: '/tiles/data.public_parks/{z}/{x}/{y}.pbf',
             title: 'Vector Tiles',
             description: null,
-            protocol: 'OGC:WMTS',
+            protocol: 'XYZ',
             media_type: 'application/vnd.mapbox-vector-tile',
             is_primary: false,
             auto_generated: true,

--- a/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DistributionsList.test.tsx
@@ -155,7 +155,7 @@ describe('DistributionsList', () => {
             url: '/tiles/data.example/{z}/{x}/{y}.pbf',
             title: 'Vector Tiles',
             description: null,
-            protocol: 'OGC:WMTS',
+            protocol: 'XYZ',
             media_type: 'application/vnd.mapbox-vector-tile',
             is_primary: false,
             auto_generated: true,


### PR DESCRIPTION
## What this fixes

The auto-generated "Vector Tiles" distribution stamped `protocol: "OGC:WMTS"` onto `/tiles/data.{table}/{z}/{x}/{y}.pbf`. That endpoint is a plain XYZ template: no capabilities document, no TileMatrixSet negotiation, and GeoLens serves WMTS nowhere. A client that trusted the label failed against a healthy instance, which reads as a broken deployment rather than a wrong string.

Closes #1463

## The value, and why it is honest

The new value is `XYZ`.

The requirement is only that the distribution must not name a protocol the endpoint does not speak, and `XYZ` satisfies it by claiming no standard at all. There is no OGC XYZ specification to fall short of. It is also the name the scheme goes by everywhere it is consumed: QGIS's connection type, GDAL's driver, MapLibre's source. The precise payload semantics were never carried by `protocol` anyway. `format: "pbf"` and `media_type: "application/vnd.mapbox-vector-tile"` already say exactly what comes back.

Bare rather than prefixed, to match `HTTP` on the five download templates. This vocabulary uses an `OGC:` prefix for real OGC services (`OGC:OAFeat`) and a bare short name for a transport that is not one, so `OGC:XYZ` would have restated the original problem in a new spelling.

## Consumer inventory

Every site that carried the old value, and what happens to it:

| Site | Reads `protocol`? | Effect |
|---|---|---|
| `records/service.py` (the template) | writes it | now writes `XYZ`, and repairs a stale surviving row (see below) |
| `ConnectDropdown.tsx` | no | unaffected. The copy-URL item resolves through `getDatasetAccessEndpoints`, which matches on `distribution_type === 'vector_tiles'` |
| `DistributionsList.tsx` | no | unaffected. Grouping keys off `distribution_type` via `DISTRIBUTION_GROUPS`, and the badge renders `format` |
| `ConnectDropdown.test.tsx`, `DistributionsList.test.tsx` | fixture only | updated, so the fixtures keep mirroring real backend output |
| DCAT / GeoDCAT-AP / DCAT-US serializers | no | `protocol` is not serialized into any feed. Those emit `dcat:mediaType` and `dcterms:format` |
| STAC / search assets | no | assets carry `type` and `roles`, never `protocol` |

No behavior keys off the value anywhere. It is metadata a harvester or a human reads, which is what made the wrong value costly and the fix small. No i18n strings are involved.

## The migration

`0048_vector_tiles_protocol_xyz`, parent `0047_users_sessions_revoked_at`.

This needs a migration rather than a reconcile-side correction, and I checked that against how `existing_set` matching actually works. `generate_distributions` probes `(distribution_type, format)` pairs and skips one it already owns, so it never updates a surviving row's columns. `reconcile_distributions` only deletes pairs the record's new modality excludes and normalizes `is_primary`. Neither path rewrites `protocol`, so a template change on its own would leave every pre-existing record mislabeled indefinitely.

WHERE scope:

```sql
WHERE auto_generated = true
  AND distribution_type = 'vector_tiles'
  AND format = 'pbf'
  AND protocol = 'OGC:WMTS'
```

`auto_generated = true` is what keeps user rows untouchable. A row authored through `create_distribution` is the user's own text in a free-text field, and someone who typed `OGC:WMTS` for their own WMTS service is correct. A migration has no standing to overwrite that.

The pair clause narrows to the one `generate_distributions` owns. The raster and VRT ingest tails write their own auto-generated `download` rows (geotiff, vrt), which this must not touch.

Matching on the old value makes a re-run a no-op and leaves alone any auto-generated row somebody already corrected by hand.

Verified live against the test DB by seeding four cases in a rolled-back transaction. Exactly one of the four was updated, the stale auto-generated row. A user-authored `vector_tiles` row keeping `OGC:WMTS`, a user's real WMTS `api` row, and an auto-generated row already hand-fixed to `WWW:LINK` all came through unchanged.

The downgrade is a no-op (codex round 1). A mirror-image reverse looks symmetric and is not: after the fact, a row this migration rewrote and a row an operator had already corrected to `XYZ` by hand are indistinguishable, so the reverse would hand someone back a value that was wrong when they fixed it. Nothing reads `protocol` for behaviour at any revision, so no revision needs `OGC:WMTS` back. Matches 0003, 0028 and 0034.

## The deploy window (codex round 2)

`scripts/upgrade.sh` migrates at step 6 and only replaces the app containers at step 7, so the previous release keeps serving writes after the UPDATE commits. A dataset created in that window is stamped `OGC:WMTS` by the old template, Alembic will not repeat the revision, and the pair-existence skip means the template never rewrites it either.

`generate_distributions` now repairs a surviving auto-generated vector-tile row carrying the old value, scoped exactly like the migration's WHERE plus the record id and gated on the pair already existing, so dataset creation does not pay for a statement that cannot match. `TestTheStaleProtocolRepair` covers both entry points plus the two rows the repair must not touch: a user-authored row holding its own `OGC:WMTS`, and an auto-generated row already hand-corrected to something else.

**How far it actually reaches** (corrected in codex round 4, which caught me overstating this). Both refresh callers gate `reconcile_distributions` on a modality FLIP: `tasks_postgis_refresh.py` checks `(stored_geometry_type is None) != (effective_geometry_type is None)` and `tasks_common.py` checks `was_spatial != is_spatial`, each deliberately, so an unchanged refresh cannot renormalize `is_primary`. Dataset creation is the only other caller and cannot meet a stale row. So the repair reaches a dataset that gains or loses geometry, plus any future caller that regenerates. An ordinary refresh does not reach it.

That makes this a partial mitigation, not a closer, and the code comment and test docstring now say so. Closing the window properly means stopping writers before data migrations, which applies to every data-only backfill in the tree (0013, 0028, 0034, 0036) and turns the upgrade into a real outage window. That is filed as #1467 rather than decided here. Reviewers who want the repair to reach every refresh should say so: it needs a new `ProcessingPort` method plus unconditional calls at both sites, which is a wider diff than a relabel PR should carry on its own authority.

`records/service.py` crosses the 1000-line inclusion threshold at 1007 as a result, and is registered in `_MODULE_LOC_CAPS` with the reason.

## Scope note

If real WMTS serving ever ships (#1461), the right home for an `OGC:WMTS` protocol entry is that feature's capabilities-document distribution, not this URL.

## Verification

- `uv run ruff check .` passed; `uv run ruff format --check .` reports 996 files already formatted
- `uv run python -m alembic upgrade head` against the test DB at `localhost:5434` rewrote 30 auto-generated rows; downgrade moves 0048 to 0047 leaving all 30 as `XYZ`, and the re-upgrade is a no-op on them
- `uv run python -m alembic check`: no new upgrade operations detected
- `uv run pytest tests/test_records_related.py -k distribution`: 15 passed, including the new `test_vector_tiles_distribution_is_labeled_xyz`, which I confirmed fails on the old value before the fix
- `uv run pytest tests/test_distribution_reconcile_1314.py tests/test_distribution_primary_1383.py tests/test_records_related.py`: 95 passed, including the four new `TestTheStaleProtocolRepair` cases; the two positive ones fail with the repair disabled
- `uv run pytest tests/test_layering.py -q`: 47 passed
- `npx vitest run` on both dataset test files: 14 passed
- `npm run typecheck`: clean
- `backend/openapi.json`, `api.generated.ts` and the SDKs are untouched. This is a value change, not a shape change.
