### PR TITLE
chore(release): v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-08-13
+
+### Security
+
+- **Browser sessions now authenticate refresh with HttpOnly cookies and CSRF
+  protection.** Refresh tokens move out of localStorage into an HttpOnly
+  cookie scoped to the auth routes, with double-submit CSRF enforcement on
+  the two routes where the cookie authenticates. The cookie flow is an
+  explicit opt-in header, so CLI, SDK, and direct API consumers keep the
+  byte-identical body-token contract. Logout is now a real server-side
+  security event that revokes every refresh token and invalidates
+  outstanding access JWTs (#1446, #1302).
+- **Revocation gains a time-scoped horizon.** Refresh-token lookups and
+  access-JWT validation refuse any credential issued at or before the
+  user's last full revocation, an ordering-independent backstop layered on
+  the existing `token_version` machinery. Logout, password change, and
+  SAML-to-local conversion all stamp it (#1458, #1455).
+- **The login/revocation serialization the horizon backstops is pinned by a
+  deterministic test.** A login racing a logout either commits first and is
+  revoked or completes wholly after it as a clean successor; the test
+  forces the interleaving on observed lock state, never timers, so it
+  cannot pass vacuously (#1460, #1459).
+- **Tile serving refuses cached authorization for datasets that no longer
+  exist.** The tile path re-checks dataset liveness before honoring a
+  cached authorization decision (#1454, #1451).
+- **Ingest can no longer resurrect a deleted dataset's tile cache by name.**
+  Freed table names are retired in a persistent tombstone set consulted at
+  registration and name generation (#1444, #1443).
+
+### Changed
+
+- **Deleting a registered dataset detaches it instead of dropping the
+  table.** The catalog row, grants, tiles, and caches are removed while the
+  operator's physical table survives; datasets GeoLens ingested itself are
+  still dropped in full. The delete dialog says which will happen (#1453,
+  #1452).
+- **Tombstones now record what was freed.** Retirements carry the freed
+  relation's oid and the prior owner; detaches that leave the table
+  standing are recorded in a sibling `detached_relations` table, so future
+  ownership-aware re-registration has the identity it needs (#1457, #1456).
+- **The extension API version is now 7.** Overlay packages built against
+  earlier versions must be rebuilt before deploying this release (#1444).
+- **The admin data table is on react-table v9** (#1445, #1407).
+- Dependency updates across the backend and frontend (#1447, #1448, #1449,
+  #1450).
+
+### Fixed
+
+- **Raster tiles now send CORS headers.** External map clients that fetch
+  tiles (MapLibre GL, the ArcGIS Maps SDK for JavaScript, OpenLayers) can
+  consume GeoLens raster tiles cross-origin; out-of-extent empty tiles
+  carry the same header, and the value is a static wildcard so tile caches
+  can never replay a per-origin decision (#1465, #1464).
+- **Auto-generated vector-tile distributions no longer claim OGC:WMTS.**
+  The XYZ template is labeled `XYZ`, with payload semantics in `format`
+  and `media_type`; a migration relabels existing auto-generated rows and
+  leaves user-authored distributions untouched (#1466, #1463).
+
 ## [1.12.0] - 2026-08-12
 
 ### Added
@@ -2069,7 +2127,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.13.0...HEAD
+[1.13.0]: https://github.com/geolens-io/geolens/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/geolens-io/geolens/compare/v1.11.1...v1.12.0
 [1.11.1]: https://github.com/geolens-io/geolens/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/geolens-io/geolens/compare/v1.10.0...v1.11.0

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -687,7 +687,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.12.0"
+_FALLBACK_APP_VERSION = "1.13.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18439,7 +18439,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.12.0"
+    "version": "1.13.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.12.0"
+version = "1.13.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.12.0"
+version = "1.13.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.12.0"
+version = "1.13.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.13.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.12.0"
+version = "1.13.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.12.0
+package_version_override: 1.13.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.12.0"
+version = "1.13.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Version bump and changelog for v1.13.0. All 19 version sites rewritten by `make bump`; `make version-check` passes; the changelog section is the release body per release.yml.

Release span: everything since v1.12.0 — the auth work (#1446, #1458, #1460), catalog lifecycle (#1444, #1453, #1457), tile authz and CORS (#1454, #1465), the records relabel (#1466), react-table v9 (#1445), and the dependabot batch.

Note for overlay operators in the changelog: extension API version is now 7.