### PR TITLE
feat(builder): render the globe atmosphere on globe projection

### DIFF
--- a/frontend/src/components/builder/__tests__/map-composition-sync.test.ts
+++ b/frontend/src/components/builder/__tests__/map-composition-sync.test.ts
@@ -40,6 +40,37 @@ function map(styleLoaded = true) {
   } as unknown as MaplibreMap;
 }
 
+const ATMOSPHERE = ['interpolate', ['linear'], ['zoom'], 0, 1, 5, 1, 7, 0];
+
+type Sky = Record<string, unknown> | undefined;
+
+// Mirrors maplibre's Style.setSky closely enough to be worth testing against:
+// the update check walks only the keys of the spec you hand it, and a write
+// that changes none of them is dropped without touching the stored sky.
+function skyMap(initialSky?: Sky) {
+  let stored: Sky = initialSky;
+  const setSky = vi.fn((sky: Sky) => {
+    if (sky && stored) {
+      const changed = Object.keys(sky).some(
+        (key) => JSON.stringify(sky[key]) !== JSON.stringify(stored?.[key]),
+      );
+      if (!changed) return;
+    }
+    stored = sky;
+  });
+  return {
+    map: {
+      isStyleLoaded: vi.fn(() => true),
+      setProjection: vi.fn(),
+      setSky,
+      getSky: vi.fn(() => stored),
+    } as unknown as MaplibreMap,
+    setSky,
+    sky: () => stored,
+    reload: (next: Sky) => { stored = next; },
+  };
+}
+
 function layer(id = 'layer-1'): SyncLayerInput {
   return {
     id,
@@ -223,53 +254,53 @@ describe('map composition sync', () => {
 
   it('layers the atmosphere over a style-provided sky and restores it (fix(#1474))', () => {
     const styleSky = { 'sky-color': '#0b1026', 'horizon-color': '#7ba0c0' };
-    let stored: unknown = styleSky;
-    const setSky = vi.fn((sky: unknown) => { stored = sky; });
-    const getSky = vi.fn(() => stored);
-    const target = {
-      isStyleLoaded: vi.fn(() => true), setProjection: vi.fn(), setSky, getSky,
-    } as unknown as MaplibreMap;
+    const target = skyMap(styleSky);
     const globe = { projection: 'globe' } as MapBasemapConfig;
-    const atmosphere = ['interpolate', ['linear'], ['zoom'], 0, 1, 5, 1, 7, 0];
 
-    applyMapBasemapAppearance({ map: target, basemapConfig: globe });
-    expect(setSky).toHaveBeenLastCalledWith({ ...styleSky, 'atmosphere-blend': atmosphere });
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: globe });
+    expect(target.setSky).toHaveBeenLastCalledWith({ ...styleSky, 'atmosphere-blend': ATMOSPHERE });
 
-    // Mercator hands the basemap its own sky back instead of clearing it.
-    applyMapBasemapAppearance({ map: target, basemapConfig: null });
-    expect(setSky).toHaveBeenLastCalledWith(styleSky);
+    // Mercator hands the basemap its own sky back instead of clearing it, and
+    // names atmosphere-blend so maplibre cannot drop the write as a no-op. 0.8
+    // is the spec default, which is what this style already evaluated it to.
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: null });
+    expect(target.setSky).toHaveBeenLastCalledWith({ ...styleSky, 'atmosphere-blend': 0.8 });
+    expect(target.sky()).toEqual({ ...styleSky, 'atmosphere-blend': 0.8 });
 
     // A basemap swap brings a different sky; that one becomes what we preserve.
-    stored = { 'sky-color': '#222222' };
-    applyMapBasemapAppearance({ map: target, basemapConfig: globe });
-    expect(setSky).toHaveBeenLastCalledWith({ 'sky-color': '#222222', 'atmosphere-blend': atmosphere });
-    applyMapBasemapAppearance({ map: target, basemapConfig: null });
-    expect(setSky).toHaveBeenLastCalledWith({ 'sky-color': '#222222' });
+    target.reload({ 'sky-color': '#222222' });
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: globe });
+    expect(target.setSky).toHaveBeenLastCalledWith({ 'sky-color': '#222222', 'atmosphere-blend': ATMOSPHERE });
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: null });
+    expect(target.sky()).toEqual({ 'sky-color': '#222222', 'atmosphere-blend': 0.8 });
+  });
+
+  it('restores a style-provided atmosphere-blend verbatim (fix(#1474))', () => {
+    const styleSky = { 'sky-color': '#000000', 'atmosphere-blend': 0.3 };
+    const target = skyMap(styleSky);
+
+    applyMapBasemapAppearance({
+      map: target.map,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+    });
+    expect(target.sky()).toEqual({ 'sky-color': '#000000', 'atmosphere-blend': ATMOSPHERE });
+
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: null });
+    expect(target.sky()).toEqual(styleSky);
   });
 
   it('still resets after maplibre drops a no-op sky write (fix(#1474))', () => {
-    // maplibre skips the assignment when the spec you pass changes nothing, so
-    // what we believe is on the map has to be read back rather than assumed.
-    let stored: Record<string, unknown> | undefined;
-    const setSky = vi.fn((sky?: Record<string, unknown>) => {
-      const unchanged = sky && stored
-        && Object.keys(sky).every((k) => JSON.stringify(sky[k]) === JSON.stringify(stored?.[k]));
-      if (!unchanged) stored = sky;
-    });
-    const target = {
-      isStyleLoaded: vi.fn(() => true),
-      setProjection: vi.fn(),
-      setSky,
-      getSky: vi.fn(() => stored),
-    } as unknown as MaplibreMap;
+    // maplibre skips the assignment when the spec changes nothing, so what we
+    // believe is on the map has to be read back rather than assumed.
+    const target = skyMap();
     const globe = { projection: 'globe' } as MapBasemapConfig;
 
-    applyMapBasemapAppearance({ map: target, basemapConfig: globe });
-    applyMapBasemapAppearance({ map: target, basemapConfig: globe });
-    applyMapBasemapAppearance({ map: target, basemapConfig: null });
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: globe });
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: globe });
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: null });
 
-    expect(setSky).toHaveBeenLastCalledWith(undefined);
-    expect(stored).toBeUndefined();
+    expect(target.setSky).toHaveBeenLastCalledWith(undefined);
+    expect(target.sky()).toBeUndefined();
   });
 
   it('retries the globe sky on style.load with the projection (feat(#1473))', () => {

--- a/frontend/src/components/builder/__tests__/map-composition-sync.test.ts
+++ b/frontend/src/components/builder/__tests__/map-composition-sync.test.ts
@@ -191,6 +191,90 @@ describe('map composition sync', () => {
     expect(setProjection).toHaveBeenCalledWith({ type: 'mercator' });
   });
 
+  it('applies the globe atmosphere with the projection and resets it on mercator (feat(#1473))', () => {
+    const setProjection = vi.fn();
+    const setSky = vi.fn();
+    const target = { isStyleLoaded: vi.fn(() => true), setProjection, setSky } as unknown as MaplibreMap;
+
+    applyMapBasemapAppearance({
+      map: target,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+      idPrefix: 'viewer-',
+    });
+    expect(setSky).toHaveBeenCalledWith({
+      'atmosphere-blend': ['interpolate', ['linear'], ['zoom'], 0, 1, 5, 1, 7, 0],
+    });
+
+    // Mercator resets with `undefined`, the branch maplibre reads as "no sky".
+    // An empty object is a silent no-op there and would strand the globe sky.
+    applyMapBasemapAppearance({ map: target, basemapConfig: null, idPrefix: 'viewer-' });
+    expect(setSky).toHaveBeenLastCalledWith(undefined);
+
+    // Sky is attempted on the same not-yet-idle path as the projection.
+    setSky.mockClear();
+    applyMapBasemapAppearance({
+      map: { isStyleLoaded: vi.fn(() => false), setProjection, setSky } as unknown as MaplibreMap,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+    });
+    expect(setSky).toHaveBeenCalledWith(
+      expect.objectContaining({ 'atmosphere-blend': expect.anything() }),
+    );
+  });
+
+  it('retries the globe sky on style.load with the projection (feat(#1473))', () => {
+    // The projection throws first on an unparsed style, so the sky never runs
+    // until the retry — proving it rides the same deferral.
+    let styleParsed = false;
+    const setProjection = vi.fn(() => {
+      if (!styleParsed) throw new Error('Style is not done loading');
+    });
+    const setSky = vi.fn();
+    const once = vi.fn();
+    const off = vi.fn();
+    const loading = {
+      isStyleLoaded: vi.fn(() => false), setProjection, setSky, once, off,
+    } as unknown as MaplibreMap;
+
+    applyMapBasemapAppearance({
+      map: loading,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+    });
+    expect(setSky).not.toHaveBeenCalled();
+
+    styleParsed = true;
+    (once.mock.calls[0][1] as () => void)();
+    expect(setSky).toHaveBeenCalledWith(
+      expect.objectContaining({ 'atmosphere-blend': expect.anything() }),
+    );
+
+    // A sky call that is itself the one to throw defers the same way.
+    let skyParsed = false;
+    const throwingSky = vi.fn(() => {
+      if (!skyParsed) throw new Error('Style is not done loading');
+    });
+    const skyOnce = vi.fn();
+    const skyLoading = {
+      isStyleLoaded: vi.fn(() => false),
+      setProjection: vi.fn(),
+      setSky: throwingSky,
+      once: skyOnce,
+      off: vi.fn(),
+    } as unknown as MaplibreMap;
+
+    applyMapBasemapAppearance({
+      map: skyLoading,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+    });
+    expect(skyOnce).toHaveBeenCalledWith('style.load', expect.any(Function));
+
+    skyParsed = true;
+    throwingSky.mockClear();
+    (skyOnce.mock.calls[0][1] as () => void)();
+    expect(throwingSky).toHaveBeenCalledWith(
+      expect.objectContaining({ 'atmosphere-blend': expect.anything() }),
+    );
+  });
+
   it('lets sublayer override retry logic handle unloaded styles', () => {
     const basemapConfig: MapBasemapConfig = {
       label_mode: 'full',

--- a/frontend/src/components/builder/__tests__/map-composition-sync.test.ts
+++ b/frontend/src/components/builder/__tests__/map-composition-sync.test.ts
@@ -221,6 +221,57 @@ describe('map composition sync', () => {
     );
   });
 
+  it('layers the atmosphere over a style-provided sky and restores it (fix(#1474))', () => {
+    const styleSky = { 'sky-color': '#0b1026', 'horizon-color': '#7ba0c0' };
+    let stored: unknown = styleSky;
+    const setSky = vi.fn((sky: unknown) => { stored = sky; });
+    const getSky = vi.fn(() => stored);
+    const target = {
+      isStyleLoaded: vi.fn(() => true), setProjection: vi.fn(), setSky, getSky,
+    } as unknown as MaplibreMap;
+    const globe = { projection: 'globe' } as MapBasemapConfig;
+    const atmosphere = ['interpolate', ['linear'], ['zoom'], 0, 1, 5, 1, 7, 0];
+
+    applyMapBasemapAppearance({ map: target, basemapConfig: globe });
+    expect(setSky).toHaveBeenLastCalledWith({ ...styleSky, 'atmosphere-blend': atmosphere });
+
+    // Mercator hands the basemap its own sky back instead of clearing it.
+    applyMapBasemapAppearance({ map: target, basemapConfig: null });
+    expect(setSky).toHaveBeenLastCalledWith(styleSky);
+
+    // A basemap swap brings a different sky; that one becomes what we preserve.
+    stored = { 'sky-color': '#222222' };
+    applyMapBasemapAppearance({ map: target, basemapConfig: globe });
+    expect(setSky).toHaveBeenLastCalledWith({ 'sky-color': '#222222', 'atmosphere-blend': atmosphere });
+    applyMapBasemapAppearance({ map: target, basemapConfig: null });
+    expect(setSky).toHaveBeenLastCalledWith({ 'sky-color': '#222222' });
+  });
+
+  it('still resets after maplibre drops a no-op sky write (fix(#1474))', () => {
+    // maplibre skips the assignment when the spec you pass changes nothing, so
+    // what we believe is on the map has to be read back rather than assumed.
+    let stored: Record<string, unknown> | undefined;
+    const setSky = vi.fn((sky?: Record<string, unknown>) => {
+      const unchanged = sky && stored
+        && Object.keys(sky).every((k) => JSON.stringify(sky[k]) === JSON.stringify(stored?.[k]));
+      if (!unchanged) stored = sky;
+    });
+    const target = {
+      isStyleLoaded: vi.fn(() => true),
+      setProjection: vi.fn(),
+      setSky,
+      getSky: vi.fn(() => stored),
+    } as unknown as MaplibreMap;
+    const globe = { projection: 'globe' } as MapBasemapConfig;
+
+    applyMapBasemapAppearance({ map: target, basemapConfig: globe });
+    applyMapBasemapAppearance({ map: target, basemapConfig: globe });
+    applyMapBasemapAppearance({ map: target, basemapConfig: null });
+
+    expect(setSky).toHaveBeenLastCalledWith(undefined);
+    expect(stored).toBeUndefined();
+  });
+
   it('retries the globe sky on style.load with the projection (feat(#1473))', () => {
     // The projection throws first on an unparsed style, so the sky never runs
     // until the retry — proving it rides the same deferral.

--- a/frontend/src/components/builder/map-composition-sync.ts
+++ b/frontend/src/components/builder/map-composition-sync.ts
@@ -1,4 +1,4 @@
-import type { Map as MaplibreMap } from 'maplibre-gl';
+import type { Map as MaplibreMap, SkySpecification } from 'maplibre-gl';
 import type { TileToken } from '@/api/tiles';
 import type { MapBasemapConfig } from '@/types/api';
 import { applySublayerOverrides } from '@/lib/builder/basemap-style-mutation';
@@ -14,9 +14,31 @@ import {
 
 type RefBox<T> = { current: T };
 
-// feat(#845): one pending projection idle-retry per map instance, so a newer
-// appearance application can cancel a stale one (Codex P2 on #848).
-const pendingProjectionRetries = new WeakMap<MaplibreMap, () => void>();
+// feat(#845): one pending root-style idle-retry per map instance, so a newer
+// appearance application can cancel a stale one (Codex P2 on #848). Covers
+// projection and, since feat(#1473), sky — both are root style state with the
+// same "needs a parsed style" precondition.
+const pendingRootStyleRetries = new WeakMap<MaplibreMap, () => void>();
+
+// feat(#1473): atmosphere for globe maps, so the sphere reads as a planet
+// instead of a flat disc. `atmosphere-blend` is the only sky property a globe
+// actually shows: MapLibre draws the limb halo in a separate atmosphere pass
+// scaled by this value, while the sky pass that consumes sky-color /
+// horizon-color / sky-horizon-blend is multiplied out to fully transparent for
+// as long as the projection is a globe.
+//
+// So the colors stay at their MapLibre defaults on purpose. A globe map zoomed
+// past MapLibre's automatic globe-to-mercator handoff turns the sky pass back
+// on, and a near-black sky-color would land there as a black band above the
+// horizon on pitched views — the one place it is visible is the one place it
+// would look wrong.
+//
+// The zoom ramp is upstream's own curve from their globe-with-atmosphere
+// example: a full halo at world view, held through continental zoom, gone by
+// the time the limb has left the frame.
+const GLOBE_SKY: SkySpecification = {
+  'atmosphere-blend': ['interpolate', ['linear'], ['zoom'], 0, 1, 5, 1, 7, 0],
+};
 
 function sourcePrefixFor(idPrefix: string | undefined) {
   return idPrefix ? `${idPrefix}source-` : 'source-';
@@ -66,23 +88,32 @@ export function applyMapBasemapAppearance({
   // is not parsed yet the call throws; retry once on `style.load`, and
   // cancel any stale retry first so a projection change during the load
   // window can't be reverted by an old callback (Codex P2 round 1 on #848).
-  const staleRetry = pendingProjectionRetries.get(map);
+  const staleRetry = pendingRootStyleRetries.get(map);
   if (staleRetry) {
     map.off?.('style.load', staleRetry);
-    pendingProjectionRetries.delete(map);
+    pendingRootStyleRetries.delete(map);
   }
-  const applyProjection = () => {
-    pendingProjectionRetries.delete(map);
+  const projection = basemapConfig?.projection ?? 'mercator';
+  const applyRootStyle = () => {
+    pendingRootStyleRetries.delete(map);
     try {
-      map.setProjection?.({ type: basemapConfig?.projection ?? 'mercator' });
+      map.setProjection?.({ type: projection });
+      // feat(#1473): sky shares setProjection's parsed-style precondition, so
+      // it rides the same retry and survives style/basemap reloads. Resetting
+      // means passing `undefined` — that is the branch MapLibre reads as "no
+      // sky", restoring the untouched default. An empty object instead is a
+      // silent no-op that would strand the globe sky on a mercator map.
+      // Map.setSky types the argument as required even though the Style method
+      // it forwards to declares it optional, hence the cast.
+      map.setSky?.((projection === 'globe' ? GLOBE_SKY : undefined) as SkySpecification);
     } catch {
       // Style not parsed yet — re-attempt as soon as it is. Partial map
       // mocks in tests lack `once`, hence the optional call.
-      pendingProjectionRetries.set(map, applyProjection);
-      map.once?.('style.load', applyProjection);
+      pendingRootStyleRetries.set(map, applyRootStyle);
+      map.once?.('style.load', applyRootStyle);
     }
   };
-  applyProjection();
+  applyRootStyle();
 
   if (!map.isStyleLoaded()) {
     applySublayerOverrides(map, basemapConfig?.sublayer_overrides ?? null, sourcePrefix, masterOpacity);

--- a/frontend/src/components/builder/map-composition-sync.ts
+++ b/frontend/src/components/builder/map-composition-sync.ts
@@ -40,6 +40,34 @@ const GLOBE_SKY: SkySpecification = {
   'atmosphere-blend': ['interpolate', ['linear'], ['zoom'], 0, 1, 5, 1, 7, 0],
 };
 
+// fix(#1474 Codex P2 round 1): a remote basemap style may ship its own `sky`
+// block, and sanitizeMaplibreStyle() passes root properties through untouched.
+// So the atmosphere is layered OVER whatever sky the style brought rather than
+// replacing it, and mercator restores that sky instead of clearing it.
+//
+// `base` is the style's own sky and `applied` is what we last handed to
+// setSky, read back from the map because maplibre skips the assignment when
+// the new spec makes no difference. If the map is no longer holding `applied`,
+// the style was reloaded underneath us and whatever it holds now is the new
+// base to preserve.
+type SkyState = { applied: SkySpecification | undefined; base: SkySpecification | undefined };
+const skyStates = new WeakMap<MaplibreMap, SkyState>();
+
+function applySky(map: MaplibreMap, isGlobe: boolean) {
+  if (!map.setSky) return;
+  const current = map.getSky?.();
+  const tracked = skyStates.get(map);
+  const base = tracked && current === tracked.applied ? tracked.base : current;
+  const next = isGlobe ? { ...base, ...GLOBE_SKY } : base;
+  // Passing `undefined` is the branch maplibre reads as "no sky at all", which
+  // is the correct reset for a style that never had one. An empty object is a
+  // silent no-op instead, because the diff it runs only walks the keys of the
+  // spec you hand it. Map.setSky types the argument as required even though
+  // the Style method behind it declares it optional, hence the cast.
+  map.setSky(next as SkySpecification);
+  skyStates.set(map, { applied: map.getSky?.(), base });
+}
+
 function sourcePrefixFor(idPrefix: string | undefined) {
   return idPrefix ? `${idPrefix}source-` : 'source-';
 }
@@ -99,13 +127,8 @@ export function applyMapBasemapAppearance({
     try {
       map.setProjection?.({ type: projection });
       // feat(#1473): sky shares setProjection's parsed-style precondition, so
-      // it rides the same retry and survives style/basemap reloads. Resetting
-      // means passing `undefined` — that is the branch MapLibre reads as "no
-      // sky", restoring the untouched default. An empty object instead is a
-      // silent no-op that would strand the globe sky on a mercator map.
-      // Map.setSky types the argument as required even though the Style method
-      // it forwards to declares it optional, hence the cast.
-      map.setSky?.((projection === 'globe' ? GLOBE_SKY : undefined) as SkySpecification);
+      // it rides the same retry and survives style/basemap reloads.
+      applySky(map, projection === 'globe');
     } catch {
       // Style not parsed yet — re-attempt as soon as it is. Partial map
       // mocks in tests lack `once`, hence the optional call.

--- a/frontend/src/components/builder/map-composition-sync.ts
+++ b/frontend/src/components/builder/map-composition-sync.ts
@@ -1,3 +1,4 @@
+import { latest as styleSpec } from '@maplibre/maplibre-gl-style-spec';
 import type { Map as MaplibreMap, SkySpecification } from 'maplibre-gl';
 import type { TileToken } from '@/api/tiles';
 import type { MapBasemapConfig } from '@/types/api';
@@ -53,12 +54,25 @@ const GLOBE_SKY: SkySpecification = {
 type SkyState = { applied: SkySpecification | undefined; base: SkySpecification | undefined };
 const skyStates = new WeakMap<MaplibreMap, SkyState>();
 
+// fix(#1474 Codex P2 round 2): handing back a `base` that never mentioned
+// atmosphere-blend does not remove ours. setSky's diff walks only the keys of
+// the spec you pass, so every key would compare equal and the write would be
+// dropped with our override still in the live style. Naming the property
+// explicitly forces the write. The value is what a fresh load of `base` would
+// evaluate the property to, read off the style spec so it cannot drift.
+const DEFAULT_ATMOSPHERE_BLEND = styleSpec.sky['atmosphere-blend'].default as number;
+
+function restoreSky(base: SkySpecification | undefined) {
+  if (!base || base['atmosphere-blend'] !== undefined) return base;
+  return { ...base, 'atmosphere-blend': DEFAULT_ATMOSPHERE_BLEND };
+}
+
 function applySky(map: MaplibreMap, isGlobe: boolean) {
   if (!map.setSky) return;
   const current = map.getSky?.();
   const tracked = skyStates.get(map);
   const base = tracked && current === tracked.applied ? tracked.base : current;
-  const next = isGlobe ? { ...base, ...GLOBE_SKY } : base;
+  const next = isGlobe ? { ...base, ...GLOBE_SKY } : restoreSky(base);
   // Passing `undefined` is the branch maplibre reads as "no sky at all", which
   // is the correct reset for a style that never had one. An empty object is a
   // silent no-op instead, because the diff it runs only walks the keys of the


### PR DESCRIPTION
`applyMapBasemapAppearance` now calls `map.setSky()` next to the existing `setProjection` call. A saved `basemap_config.projection` of `globe` gets MapLibre's atmosphere, and mercator resets back to no sky at all. Both the builder and the viewer already route through this function, so neither surface needed its own change, and there is no new schema field, no API change, and nothing to configure.

The sky call sits inside the same `style.load` idle-retry closure as `setProjection`. `Style.setSky` and `Style.setProjection` share a `_checkLoaded()` precondition, so one deferral covers both and the sky survives style and basemap reloads.

## The values

```js
{ 'atmosphere-blend': ['interpolate', ['linear'], ['zoom'], 0, 1, 5, 1, 7, 0] }
```

Full halo out at world view, held through zoom 5, gone by zoom 7 once the limb has left the frame. The curve is taken from MapLibre's own `display-a-globe-with-an-atmosphere` example rather than invented.

The colors are left at their defaults on purpose, which departs from the issue's proposed near-black `sky-color`. In the bundled maplibre-gl 5.24.0, the sky fragment shader ends with:

```glsl
fragColor = mix(fragColor, vec4(vec3(0.0), 0.0), u_sky_blend);
```

`u_sky_blend` is `projectionTransition`, which is 1 for as long as the projection is a globe. So `sky-color`, `horizon-color` and `sky-horizon-blend` are multiplied to fully transparent exactly when you are looking at a globe. They switch back on when a globe map zooms past MapLibre's automatic handoff to mercator, and that is the one place a near-black sky would be visible: as a black band above the horizon on a pitched view. Setting it can only hurt. `atmosphere-blend` is the property that survives, because the halo is a separate render pass scaled by that same `projectionTransition` instead of zeroed by it. Both of MapLibre's globe examples set `atmosphere-blend` and nothing else.

## What this does not fix

The void behind the sphere is still the page background. Rays that miss the atmosphere leave the shader at alpha 0, the canvas is cleared transparent, and the style's background layer is drawn per tile so it stays clipped to the sphere. No value in the sky spec can paint it. Darkening space means putting a background color on the map container, which is a different mechanism and worth its own change if we want it.

## Reset

Most basemaps ship no sky. For those, mercator passes `undefined`, the branch `Style.setSky` reads as "no sky at all". `setSky({})` looks equivalent and is not: the diff it runs only walks the keys of the spec you hand it, so an empty object never registers as a change and the call returns early with the globe sky still in place. `Map.setSky` types its argument as required even though the `Style` method it forwards to declares it optional, which is the one cast at the call site.

A style that does bring its own `sky` block gets that back instead (Codex P2, round 1). `sanitizeMaplibreStyle()` passes root properties through untouched, so a custom basemap URL can carry a sky, and clearing it on every mercator apply would quietly drop the gradient its author wrote. On globe the atmosphere is layered over that sky rather than replacing it. What we last wrote is read back off the map rather than remembered, because maplibre skips the assignment entirely when the new spec changes nothing, and assuming otherwise leaves the tracked value one apply out of date.

That same key-scoped diff bites the restore itself (Codex P2, round 2): handing back a sky that never mentioned `atmosphere-blend` compares equal on every key it does mention, so the write is dropped and our override stays live. The restore names the property explicitly when the style omitted it. The value is `styleSpec.sky['atmosphere-blend'].default` rather than a literal, so it tracks upstream. Clearing the sky first would have been the other option and is worse: `setSky(undefined)` drops the Sky object to its transparent fallback, so everything the style did not spell out would come back transparent instead of defaulted, which is visible on pitched mercator.

## Verification

```
cd frontend
npx vitest run src/components/builder/__tests__/map-composition-sync.test.ts   # 9 passed
npx vitest run src/components/builder src/components/viewer src/components/map # 178 files, 2625 passed
npm run lint                                                                   # clean
npm run typecheck                                                              # clean
```

Five unit tests cover the change: values applied on globe with `undefined` on mercator, a style-provided sky preserved through both directions, a style-provided `atmosphere-blend` restored verbatim, the dropped-write case, and the retry path. The fake map mirrors maplibre's key-scoped diff including the dropped write, and drives the same style-load states the file's existing projection tests use.

No Playwright here. The dev stack bind-mounts the main checkout, so e2e from this worktree would exercise code that is not in this branch. Live visual QA happens on the orchestrator's side after merge.

Closes #1473
