### PR TITLE
fix(standards): publish real raster access surfaces in the DCAT feeds

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -59,7 +59,7 @@ from app.modules.catalog.datasets.domain.service import get_dataset
 from app.core.dependencies import get_db
 from app.core.db.tenant_session import current_tenant_var
 from app.core.tenancy import is_multi_tenant
-from app.core.public_urls import get_public_api_url
+from app.core.public_urls import get_public_urls
 from app.platform.extensions import get_catalog_port
 from app.platform.storage import get_storage
 from app.platform.storage.titiler_url import resolve_storage_key
@@ -307,11 +307,12 @@ async def get_dcat_catalog(
     """DCAT 3 JSON-LD catalog feed. Respects dataset visibility."""
     datasets = await _get_visible_dcat_datasets(db, user, limit=limit, offset=offset)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     preferred_languages = parse_accept_languages(request)
     catalog = catalog_to_dcat(
         datasets,
         base_url,
+        app_base_url=app_base_url,
         preferred_languages=preferred_languages,
         lineage_by_record_id=await _visible_lineage(db, datasets, user),
     )
@@ -345,10 +346,11 @@ async def validate_dcat3_catalog(
     """Validate the visible W3C DCAT 3 catalog feed."""
     datasets = await _get_visible_dcat_datasets(db, user)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     catalog = catalog_to_dcat(
         datasets,
         base_url,
+        app_base_url=app_base_url,
         lineage_by_record_id=await _visible_lineage(db, datasets, user),
     )
     report = validate_dcat3(catalog, "Catalog")
@@ -380,10 +382,11 @@ async def get_dcat_us3_catalog(
     """DCAT-US Schema v3.0 catalog feed. Respects dataset visibility."""
     datasets = await _get_visible_dcat_datasets(db, user, limit=limit, offset=offset)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     catalog = catalog_to_dcat_us3(
         datasets,
         base_url,
+        app_base_url=app_base_url,
         catalog_contact_email=settings.dcat_contact_email,
         lineage_by_record_id=await _visible_lineage(db, datasets, user),
     )
@@ -418,10 +421,11 @@ async def validate_dcat_us3_catalog(
     """Validate the visible DCAT-US Schema v3.0 catalog feed."""
     datasets = await _get_visible_dcat_datasets(db, user)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     catalog = catalog_to_dcat_us3(
         datasets,
         base_url,
+        app_base_url=app_base_url,
         catalog_contact_email=settings.dcat_contact_email,
         lineage_by_record_id=await _visible_lineage(db, datasets, user),
     )
@@ -447,10 +451,11 @@ async def get_geodcat_ap_catalog(
     """GeoDCAT-AP 2.0.0 catalog feed. Respects dataset visibility."""
     datasets = await _get_visible_dcat_datasets(db, user, limit=limit, offset=offset)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     catalog = catalog_to_geodcat_ap(
         datasets,
         base_url,
+        app_base_url=app_base_url,
         lineage_by_record_id=await _visible_lineage(db, datasets, user),
     )
     completeness = _catalog_completeness(
@@ -481,10 +486,11 @@ async def validate_geodcat_ap_catalog(
     """Validate the visible GeoDCAT-AP 2.0.0 catalog feed."""
     datasets = await _get_visible_dcat_datasets(db, user)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     catalog = catalog_to_geodcat_ap(
         datasets,
         base_url,
+        app_base_url=app_base_url,
         lineage_by_record_id=await _visible_lineage(db, datasets, user),
     )
     report = validate_geodcat_ap(catalog, "Catalog")
@@ -515,10 +521,11 @@ async def validate_dcat3_record(
     """Validate a single dataset as W3C DCAT 3."""
     dataset = await _get_dcat_dataset_for_export(db, dataset_id, user)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     dcat = record_to_dcat(
         dataset,
         base_url,
+        app_base_url=app_base_url,
         lineage_summary=await _visible_record_lineage(db, dataset, user),
     )
     report = validate_dcat3(dcat, "Dataset")
@@ -543,11 +550,12 @@ async def get_dcat_record(
     """DCAT 3 JSON-LD for a single dataset."""
     dataset = await _get_dcat_dataset_for_export(db, dataset_id, user)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     preferred_languages = parse_accept_languages(request)
     dcat = record_to_dcat(
         dataset,
         base_url,
+        app_base_url=app_base_url,
         preferred_languages=preferred_languages,
         lineage_summary=await _visible_record_lineage(db, dataset, user),
     )
@@ -577,10 +585,11 @@ async def validate_dcat_us3_record(
     """Validate a single dataset as DCAT-US Schema v3.0."""
     dataset = await _get_dcat_dataset_for_export(db, dataset_id, user)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     dcat = record_to_dcat_us3(
         dataset,
         base_url,
+        app_base_url=app_base_url,
         catalog_contact_email=settings.dcat_contact_email,
         lineage_summary=await _visible_record_lineage(db, dataset, user),
     )
@@ -613,10 +622,11 @@ async def get_dcat_us3_record(
     """DCAT-US Schema v3.0 JSON-LD for a single dataset."""
     dataset = await _get_dcat_dataset_for_export(db, dataset_id, user)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     dcat = record_to_dcat_us3(
         dataset,
         base_url,
+        app_base_url=app_base_url,
         catalog_contact_email=settings.dcat_contact_email,
         lineage_summary=await _visible_record_lineage(db, dataset, user),
     )
@@ -648,10 +658,11 @@ async def validate_geodcat_ap_record(
     """Validate a single dataset as GeoDCAT-AP 2.0.0."""
     dataset = await _get_dcat_dataset_for_export(db, dataset_id, user)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     geodcat = record_to_geodcat_ap(
         dataset,
         base_url,
+        app_base_url=app_base_url,
         lineage_summary=await _visible_record_lineage(db, dataset, user),
     )
     report = validate_geodcat_ap(geodcat, "Dataset")
@@ -679,10 +690,11 @@ async def get_geodcat_ap_record(
     """GeoDCAT-AP 2.0.0 JSON-LD for a single dataset."""
     dataset = await _get_dcat_dataset_for_export(db, dataset_id, user)
 
-    base_url = await get_public_api_url(db, request=request)
+    app_base_url, base_url = await get_public_urls(db, request=request)
     geodcat = record_to_geodcat_ap(
         dataset,
         base_url,
+        app_base_url=app_base_url,
         lineage_summary=await _visible_record_lineage(db, dataset, user),
     )
     fallback_fields = geodcat_ap_fallback_fields(dataset)

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -28,6 +28,7 @@ from app.modules.catalog.search.record_metadata import (
 )
 from app.modules.catalog.sources.provenance import derive_last_edited
 from app.platform.dataset_origin import classify_origin, project_unknown
+from app.standards.distributions import is_publishable_url
 from app.standards.ogc.utils import build_url
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -412,7 +413,12 @@ def dataset_to_ogc_record(
                 if record.usage_constraints or record.access_constraints
                 else None
             ),
-            # Distributions from record_distributions table (API-01)
+            # Distributions from record_distributions table (API-01).
+            # fix(#1469): the raster/VRT ingest tails write a row whose url is
+            # the COG's object-storage KEY — unresolvable by a consumer, and it
+            # exposes the storage layout. Dropped rather than replaced: this
+            # profile already publishes the raster access surface above, as
+            # build_assets' raster_tiles asset.
             "distributions": [
                 {
                     "type": d.distribution_type,
@@ -426,10 +432,9 @@ def dataset_to_ogc_record(
                     "media_type": d.media_type,
                     "is_primary": d.is_primary,
                 }
-                for d in record.distributions
-            ]
-            if record.distributions
-            else [],
+                for d in (record.distributions or ())
+                if is_publishable_url(d.url)
+            ],
         },
         "links": [
             {

--- a/backend/app/standards/dcat/service.py
+++ b/backend/app/standards/dcat/service.py
@@ -13,6 +13,10 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from app.modules.catalog.records.localization import select_localized_record_text
+from app.standards.distributions import (
+    PublishedDistribution,
+    published_distributions,
+)
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -21,7 +25,6 @@ if TYPE_CHECKING:
     from app.modules.catalog.datasets.domain.models import (
         Dataset,
         RecordContact,
-        RecordDistribution,
     )
 _LANG_URI_BASE = "http://publications.europa.eu/resource/authority/language/"
 
@@ -246,6 +249,7 @@ def record_to_dcat(
     dataset: Dataset,
     base_url: str,
     *,
+    app_base_url: str,
     include_context: bool = True,
     preferred_languages: Sequence[str] | None = None,
     lineage_summary: str | None = None,
@@ -255,6 +259,9 @@ def record_to_dcat(
     Args:
         dataset: Dataset ORM object with record relationship eager-loaded.
         base_url: Absolute base URL (e.g. ``http://localhost:8000``).
+        app_base_url: Absolute public APP base URL. fix(#1469): the raster
+            tile template is served there, not under the API base — see
+            ``app.standards.distributions``.
         include_context: Include ``@context`` in output. Set to False for
             individual entries within a catalog feed to avoid duplication.
         lineage_summary: ``dcterms:provenance``, already access-checked by the
@@ -343,10 +350,11 @@ def record_to_dcat(
     if record.contacts:
         result["dcat:contactPoint"] = [_contact_to_dcat(c) for c in record.contacts]
 
-    if record.distributions:
-        result["dcat:distribution"] = [
-            _distribution_to_dcat(d, base_url) for d in record.distributions
-        ]
+    distributions = published_distributions(
+        dataset, api_base_url=base_url, app_base_url=app_base_url
+    )
+    if distributions:
+        result["dcat:distribution"] = [_distribution_to_dcat(d) for d in distributions]
 
     # Temporal extent
     if record.temporal_start or record.temporal_end:
@@ -411,17 +419,12 @@ def _contact_to_dcat(contact: RecordContact) -> dict:
     return {k: v for k, v in result.items() if v is not None}
 
 
-def _distribution_to_dcat(dist: RecordDistribution, base_url: str) -> dict:
-    """Serialize a RecordDistribution to a dcat:Distribution dict."""
-    # Resolve relative URLs to absolute
-    url = dist.url
-    if url.startswith("/"):
-        url = base_url + url
-
+def _distribution_to_dcat(dist: PublishedDistribution) -> dict:
+    """Serialize a published distribution to a dcat:Distribution dict."""
     result: dict = {"@type": "dcat:Distribution"}
     if dist.title is not None:
         result["dcterms:title"] = dist.title
-    result["dcat:accessURL"] = url
+    result["dcat:accessURL"] = dist.url
     if dist.media_type is not None:
         result["dcat:mediaType"] = dist.media_type
     if dist.format is not None:
@@ -433,6 +436,7 @@ def catalog_to_dcat(
     datasets: list[Dataset],
     base_url: str,
     *,
+    app_base_url: str,
     preferred_languages: Sequence[str] | None = None,
     lineage_by_record_id: Mapping[uuid.UUID, str | None] | None = None,
 ) -> dict:
@@ -454,6 +458,7 @@ def catalog_to_dcat(
         record_to_dcat(
             ds,
             base_url,
+            app_base_url=app_base_url,
             include_context=False,
             preferred_languages=preferred_languages,
             lineage_summary=lineage.get(ds.record_id),

--- a/backend/app/standards/dcat_us/service.py
+++ b/backend/app/standards/dcat_us/service.py
@@ -10,18 +10,29 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from app.standards.distributions import (
+    RASTER_TILES_DISTRIBUTION_TYPE,
+    PublishedDistribution,
+    published_distributions,
+)
+
 if TYPE_CHECKING:
     from app.modules.catalog.datasets.domain.models import (
         Dataset,
         Record,
         RecordContact,
-        RecordDistribution,
     )
 
 logger = structlog.stdlib.get_logger(__name__)
 
 DCAT_US_CONTEXT = "https://resources.data.gov/dcat-us/3.0.0"
-SERVICE_DISTRIBUTION_TYPES = {"api", "ogcService", "ogc_features", "vector_tiles"}
+SERVICE_DISTRIBUTION_TYPES = {
+    "api",
+    "ogcService",
+    "ogc_features",
+    "vector_tiles",
+    RASTER_TILES_DISTRIBUTION_TYPE,
+}
 _EMAIL_PATTERN = re.compile(r"^mailto:[\w_~!$&'()*+,;=:.-]+@[\w.-]+\.[\w.-]+$")
 
 
@@ -29,6 +40,7 @@ def record_to_dcat_us3(
     dataset: Dataset,
     base_url: str,
     *,
+    app_base_url: str,
     include_context: bool = True,
     catalog_contact_email: str | None = None,
     lineage_summary: str | None = None,
@@ -39,6 +51,9 @@ def record_to_dcat_us3(
     (``visible_lineage_summary``) rather than off the record — fix(#1103): an
     analysis output's lineage names the titles of the datasets it was derived
     from, and this feed is served to anonymous requesters.
+
+    ``app_base_url`` is the public APP base URL, where the raster tile
+    template is served — fix(#1469), see ``app.standards.distributions``.
     """
     record = dataset.record
     result: dict = {}
@@ -104,16 +119,18 @@ def record_to_dcat_us3(
     if record.theme_category:
         result["theme"] = [_concept(theme) for theme in record.theme_category]
 
-    if record.distributions:
+    distributions = published_distributions(
+        dataset, api_base_url=base_url, app_base_url=app_base_url
+    )
+    if distributions:
         result["distribution"] = [
             _distribution_to_dcat_us3(
                 distribution,
-                base_url,
                 publisher=result["publisher"],
                 contacts=contacts,
                 license_value=record.license,
             )
-            for distribution in record.distributions
+            for distribution in distributions
         ]
 
     return _strip_empty(result)
@@ -123,6 +140,7 @@ def catalog_to_dcat_us3(
     datasets: list[Dataset],
     base_url: str,
     *,
+    app_base_url: str,
     catalog_contact_email: str | None = None,
     lineage_by_record_id: Mapping[uuid.UUID, str | None] | None = None,
 ) -> dict:
@@ -139,6 +157,7 @@ def catalog_to_dcat_us3(
         record_to_dcat_us3(
             ds,
             base_url,
+            app_base_url=app_base_url,
             include_context=False,
             catalog_contact_email=catalog_contact_email,
             lineage_summary=lineage.get(ds.record_id),
@@ -235,14 +254,13 @@ def _has_text(value: str | None) -> bool:
 
 
 def _distribution_to_dcat_us3(
-    distribution: RecordDistribution,
-    base_url: str,
+    distribution: PublishedDistribution,
     *,
     publisher: dict,
     contacts: list[dict],
     license_value: str | None,
 ) -> dict:
-    url = _absolute_url(distribution.url, base_url)
+    url = distribution.url
     result: dict = {
         "@type": "Distribution",
         "accessURL": url,
@@ -339,14 +357,6 @@ def _mailto(value: str) -> str:
     if value.startswith("mailto:"):
         return value
     return f"mailto:{value}"
-
-
-def _absolute_url(value: str, base_url: str) -> str:
-    if value.startswith(("http://", "https://")):
-        return value
-    if value.startswith("/"):
-        return f"{base_url}{value}"
-    return f"{base_url}/{value}"
 
 
 def _strip_empty(value: dict) -> dict:

--- a/backend/app/standards/distributions.py
+++ b/backend/app/standards/distributions.py
@@ -16,14 +16,14 @@ This module is the one place that decides what a feed may publish:
   can author goes through ``DistributionCreate``, whose validator requires
   an http(s) URL, and everything ``generate_distributions`` writes is a
   root-relative API path — so the rule drops storage keys and nothing else.
-- ``published_distributions`` adds, for the raster family, the access
-  surfaces the product actually serves. Those are derived per request rather
-  than stored, because both depend on values a row cannot hold: the tile
-  template lives at the APP origin (``/raster-tiles/...`` is nginx-rewritten
-  to the tile proxy; the API origin has no such route) and carries the
-  dataset's current ``tile_cache_version``.
+- ``published_distributions`` adds, for the raster family, the tile template
+  the product actually serves anonymously. It is derived per request rather
+  than stored, because it depends on values a row cannot hold: it lives at
+  the APP origin (``/raster-tiles/...`` is nginx-rewritten to the tile proxy;
+  the API origin has no such route) and carries the dataset's current
+  ``tile_cache_version``.
 
-The raster entries deliberately mirror ``build_assets`` in
+The raster entry deliberately mirrors ``build_assets`` in
 ``modules/catalog/search/service_records.py``, which is what STAC advertises
 for the same datasets. The two surfaces describing one dataset differently
 is the discrepancy #1469 reported.
@@ -48,7 +48,6 @@ if TYPE_CHECKING:
 RASTER_TILES_DISTRIBUTION_TYPE = "raster_tiles"
 
 _RASTER_TILES_MEDIA_TYPE = "image/png"
-_COG_MEDIA_TYPE = "image/tiff; application=geotiff; profile=cloud-optimized"
 
 _PUBLISHABLE_SCHEMES = frozenset({"http", "https"})
 
@@ -99,41 +98,33 @@ def raster_tiles_path(dataset: Dataset) -> str:
     return f"{path}?v={version}" if version else path
 
 
-def _raster_distributions(
-    dataset: Dataset,
-    *,
-    api_base_url: str,
-    app_base_url: str,
-) -> list[PublishedDistribution]:
-    """Access surfaces for a raster-family dataset, best first."""
-    entries = [
-        PublishedDistribution(
-            distribution_type=RASTER_TILES_DISTRIBUTION_TYPE,
-            format="png",
-            url=app_base_url + raster_tiles_path(dataset),
-            title="Raster Tiles",
-            description=None,
-            media_type=_RASTER_TILES_MEDIA_TYPE,
-        )
-    ]
+def _raster_tiles_distribution(
+    dataset: Dataset, *, app_base_url: str
+) -> PublishedDistribution:
+    """The one raster access surface these feeds can honestly advertise.
 
-    # ``download_cog`` (datasets/api/router_export.py) rejects anything that
-    # is not a ``raster_dataset``, so a VRT gets the tile template alone --
-    # a mosaic is composed from other datasets and has no single COG to hand
-    # out. Advertised for STAC-origin rasters too: their asset lives on a
-    # remote host and the endpoint redirects to it.
-    if dataset.record.record_type == "raster_dataset":
-        entries.append(
-            PublishedDistribution(
-                distribution_type="download",
-                format="cog",
-                url=f"{api_base_url}/datasets/{dataset.id}/download/cog",
-                title="Cloud-Optimized GeoTIFF Download",
-                description=None,
-                media_type=_COG_MEDIA_TYPE,
-            )
-        )
-    return entries
+    Deliberately NOT joined by a ``/datasets/{id}/download/cog`` entry
+    (#1469, review round 1). That route exists, but ``_resolve_download_user``
+    401s a caller carrying neither credentials nor a download-scoped
+    ``?token=``, and minting one is a separate POST to
+    ``/auth/download-token/{id}`` that no generic DCAT client will make. These
+    feeds are served to anonymous harvesters, so publishing it — as
+    ``dcat:downloadURL``, no less — would advertise a link that fails for the
+    audience it is written for. The tile template has no such gate: a public,
+    published raster serves tiles to an anonymous caller (see
+    ``TestRasterAuthCheck::test_auth_check_returns_open_path_for_public_raster``).
+
+    This also keeps the surface exactly equal to ``build_assets``, which
+    advertises ``raster_tiles`` and no COG download for the same datasets.
+    """
+    return PublishedDistribution(
+        distribution_type=RASTER_TILES_DISTRIBUTION_TYPE,
+        format="png",
+        url=app_base_url + raster_tiles_path(dataset),
+        title="Raster Tiles",
+        description=None,
+        media_type=_RASTER_TILES_MEDIA_TYPE,
+    )
 
 
 def published_distributions(
@@ -145,17 +136,13 @@ def published_distributions(
     """Every distribution a catalog feed should publish for *dataset*.
 
     Stored rows that resolve for a consumer, plus the derived raster access
-    surfaces. Requires ``dataset.record.distributions`` to be loaded.
+    surface. Requires ``dataset.record.distributions`` to be loaded.
     """
     record = dataset.record
     entries: list[PublishedDistribution] = []
 
     if is_raster_family(record.record_type):
-        entries.extend(
-            _raster_distributions(
-                dataset, api_base_url=api_base_url, app_base_url=app_base_url
-            )
-        )
+        entries.append(_raster_tiles_distribution(dataset, app_base_url=app_base_url))
 
     for row in record.distributions or ():
         if not is_publishable_url(row.url):

--- a/backend/app/standards/distributions.py
+++ b/backend/app/standards/distributions.py
@@ -1,0 +1,174 @@
+"""The access surfaces a catalog feed publishes for a dataset.
+
+fix(#1469): the DCAT-family serializers used to map ``record.distributions``
+straight onto ``dcat:Distribution`` nodes. That works for vector datasets,
+whose rows are written by ``generate_distributions`` and hold root-relative
+API paths, but the raster and VRT ingest tails write a row whose ``url`` is
+the object-storage KEY of the COG (``rasters/<id>/<hash>/source.cog.tif``).
+A storage key is not an access URL: it has no scheme and no host, so no
+consumer can resolve it, and publishing it exposes the internal storage
+layout. STAC-imported rasters have no distribution row at all, so they
+appeared in the feeds as datasets with no access method whatsoever.
+
+This module is the one place that decides what a feed may publish:
+
+- ``is_publishable_url`` rejects the internal pointers. Everything a user
+  can author goes through ``DistributionCreate``, whose validator requires
+  an http(s) URL, and everything ``generate_distributions`` writes is a
+  root-relative API path — so the rule drops storage keys and nothing else.
+- ``published_distributions`` adds, for the raster family, the access
+  surfaces the product actually serves. Those are derived per request rather
+  than stored, because both depend on values a row cannot hold: the tile
+  template lives at the APP origin (``/raster-tiles/...`` is nginx-rewritten
+  to the tile proxy; the API origin has no such route) and carries the
+  dataset's current ``tile_cache_version``.
+
+The raster entries deliberately mirror ``build_assets`` in
+``modules/catalog/search/service_records.py``, which is what STAC advertises
+for the same datasets. The two surfaces describing one dataset differently
+is the discrepancy #1469 reported.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+from app.core.record_types import is_raster_family
+
+if TYPE_CHECKING:
+    from app.modules.catalog.datasets.domain.models import Dataset
+
+# The tile template's distribution type. Not in ``chk_distribution_type``
+# because these entries are synthesized per request and never persisted --
+# see the module docstring for why they cannot be. It is listed in each
+# profile's ``SERVICE_DISTRIBUTION_TYPES`` beside ``vector_tiles``, so the
+# two tile surfaces serialize alike.
+RASTER_TILES_DISTRIBUTION_TYPE = "raster_tiles"
+
+_RASTER_TILES_MEDIA_TYPE = "image/png"
+_COG_MEDIA_TYPE = "image/tiff; application=geotiff; profile=cloud-optimized"
+
+_PUBLISHABLE_SCHEMES = frozenset({"http", "https"})
+
+
+@dataclass(frozen=True)
+class PublishedDistribution:
+    """One access surface, with its URL already resolved to absolute form.
+
+    Field-compatible with the ``RecordDistribution`` attributes the profile
+    serializers read, so each of them maps over this type instead of the ORM
+    rows and no longer resolves URLs itself.
+    """
+
+    distribution_type: str
+    format: str | None
+    url: str
+    title: str | None
+    description: str | None
+    media_type: str | None
+
+
+def is_publishable_url(url: str) -> bool:
+    """Whether a stored distribution URL may be handed to a consumer.
+
+    Root-relative paths (what ``generate_distributions`` writes) and absolute
+    http(s) URLs (all ``DistributionCreate`` accepts) qualify. A bare
+    object-storage key does not.
+    """
+    if url.startswith("/"):
+        return True
+    return urlsplit(url).scheme in _PUBLISHABLE_SCHEMES
+
+
+def _absolute(url: str, base_url: str) -> str:
+    return base_url + url if url.startswith("/") else url
+
+
+def raster_tiles_path(dataset: Dataset) -> str:
+    """The XYZ template for a raster dataset, versioned like every renderer.
+
+    fix(#1372) versions the template so a replace that bumps
+    ``tile_cache_version`` rolls the shared tile cache. Kept identical to
+    ``build_assets``: a client that reads both the STAC asset and the DCAT
+    distribution must get the same URL.
+    """
+    path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
+    version = getattr(dataset, "tile_cache_version", None)
+    return f"{path}?v={version}" if version else path
+
+
+def _raster_distributions(
+    dataset: Dataset,
+    *,
+    api_base_url: str,
+    app_base_url: str,
+) -> list[PublishedDistribution]:
+    """Access surfaces for a raster-family dataset, best first."""
+    entries = [
+        PublishedDistribution(
+            distribution_type=RASTER_TILES_DISTRIBUTION_TYPE,
+            format="png",
+            url=app_base_url + raster_tiles_path(dataset),
+            title="Raster Tiles",
+            description=None,
+            media_type=_RASTER_TILES_MEDIA_TYPE,
+        )
+    ]
+
+    # ``download_cog`` (datasets/api/router_export.py) rejects anything that
+    # is not a ``raster_dataset``, so a VRT gets the tile template alone --
+    # a mosaic is composed from other datasets and has no single COG to hand
+    # out. Advertised for STAC-origin rasters too: their asset lives on a
+    # remote host and the endpoint redirects to it.
+    if dataset.record.record_type == "raster_dataset":
+        entries.append(
+            PublishedDistribution(
+                distribution_type="download",
+                format="cog",
+                url=f"{api_base_url}/datasets/{dataset.id}/download/cog",
+                title="Cloud-Optimized GeoTIFF Download",
+                description=None,
+                media_type=_COG_MEDIA_TYPE,
+            )
+        )
+    return entries
+
+
+def published_distributions(
+    dataset: Dataset,
+    *,
+    api_base_url: str,
+    app_base_url: str,
+) -> list[PublishedDistribution]:
+    """Every distribution a catalog feed should publish for *dataset*.
+
+    Stored rows that resolve for a consumer, plus the derived raster access
+    surfaces. Requires ``dataset.record.distributions`` to be loaded.
+    """
+    record = dataset.record
+    entries: list[PublishedDistribution] = []
+
+    if is_raster_family(record.record_type):
+        entries.extend(
+            _raster_distributions(
+                dataset, api_base_url=api_base_url, app_base_url=app_base_url
+            )
+        )
+
+    for row in record.distributions or ():
+        if not is_publishable_url(row.url):
+            continue
+        entries.append(
+            PublishedDistribution(
+                distribution_type=row.distribution_type,
+                format=row.format,
+                url=_absolute(row.url, api_base_url),
+                title=row.title,
+                description=row.description,
+                media_type=row.media_type,
+            )
+        )
+
+    return entries

--- a/backend/app/standards/geodcat_ap/service.py
+++ b/backend/app/standards/geodcat_ap/service.py
@@ -24,6 +24,11 @@ from app.standards.dcat.service import (
     DCAT_CONTEXT,
     _lang_to_uri,
 )
+from app.standards.distributions import (
+    RASTER_TILES_DISTRIBUTION_TYPE,
+    PublishedDistribution,
+    published_distributions,
+)
 from app.standards.ogc.utils import normalize_language_tag
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -33,7 +38,6 @@ if TYPE_CHECKING:
         Dataset,
         Record,
         RecordContact,
-        RecordDistribution,
     )
 # GeoDCAT-AP extends the DCAT 3 context with the geospatial / EU namespaces it
 # relies on (GeoSPARQL for geometry/CRS, ADMS for status, locn, prov, geodcat
@@ -72,13 +76,20 @@ _ROLE_TO_PROPERTY: dict[str, str] = {
     "contributor": "dcterms:contributor",
 }
 
-SERVICE_DISTRIBUTION_TYPES = {"api", "ogcService", "ogc_features", "vector_tiles"}
+SERVICE_DISTRIBUTION_TYPES = {
+    "api",
+    "ogcService",
+    "ogc_features",
+    "vector_tiles",
+    RASTER_TILES_DISTRIBUTION_TYPE,
+}
 
 
 def record_to_geodcat_ap(
     dataset: Dataset,
     base_url: str,
     *,
+    app_base_url: str,
     include_context: bool = True,
     lineage_summary: str | None = None,
 ) -> dict:
@@ -88,6 +99,9 @@ def record_to_geodcat_ap(
         dataset: Dataset ORM object with the ``record`` relationship and its
             keywords/contacts/distributions eager-loaded.
         base_url: Absolute base URL (e.g. ``http://localhost:8000``).
+        app_base_url: Absolute public APP base URL, where the raster tile
+            template is served — fix(#1469), see
+            ``app.standards.distributions``.
         include_context: Include ``@context``. Set to False for entries nested
             inside a catalog feed to avoid duplicating the context.
         lineage_summary: ``dcterms:provenance``, already access-checked by the
@@ -167,10 +181,12 @@ def record_to_geodcat_ap(
     # Responsible parties by CI_RoleCode (does NOT fabricate missing contacts).
     _apply_responsible_parties(result, record.contacts)
 
-    if record.distributions:
+    distributions = published_distributions(
+        dataset, api_base_url=base_url, app_base_url=app_base_url
+    )
+    if distributions:
         result["dcat:distribution"] = [
-            _distribution_to_geodcat_ap(d, base_url, record=record)
-            for d in record.distributions
+            _distribution_to_geodcat_ap(d, record=record) for d in distributions
         ]
 
     # Temporal extent.
@@ -205,6 +221,7 @@ def catalog_to_geodcat_ap(
     datasets: list[Dataset],
     base_url: str,
     *,
+    app_base_url: str,
     lineage_by_record_id: Mapping[uuid.UUID, str | None] | None = None,
 ) -> dict:
     """Serialize a list of visible datasets to a GeoDCAT-AP Catalog JSON-LD dict.
@@ -226,6 +243,7 @@ def catalog_to_geodcat_ap(
         record_to_geodcat_ap(
             ds,
             base_url,
+            app_base_url=app_base_url,
             include_context=False,
             lineage_summary=lineage.get(ds.record_id),
         )
@@ -324,13 +342,12 @@ def _to_vcard(agent: dict) -> dict:
 
 
 def _distribution_to_geodcat_ap(
-    dist: RecordDistribution,
-    base_url: str,
+    dist: PublishedDistribution,
     *,
     record: Record,
 ) -> dict:
-    """Serialize a RecordDistribution to a dcat:Distribution dict."""
-    url = _absolute_url(dist.url, base_url)
+    """Serialize a published distribution to a dcat:Distribution dict."""
+    url = dist.url
     result: dict = {"@type": "dcat:Distribution", "dcat:accessURL": {"@id": url}}
 
     if dist.title is not None:
@@ -404,11 +421,3 @@ def _mailto(value: str) -> str:
     if value.startswith("mailto:"):
         return value
     return f"mailto:{value}"
-
-
-def _absolute_url(value: str, base_url: str) -> str:
-    if value.startswith(("http://", "https://")):
-        return value
-    if value.startswith("/"):
-        return f"{base_url}{value}"
-    return f"{base_url}/{value}"

--- a/backend/tests/test_dcat.py
+++ b/backend/tests/test_dcat.py
@@ -1024,44 +1024,28 @@ async def test_dcat_raster_advertises_the_tile_template(
 
 
 @pytest.mark.anyio
-async def test_dcat_cog_raster_advertises_the_download_endpoint(
+@pytest.mark.parametrize("record_type", ["raster_dataset", "vrt_dataset"])
+async def test_dcat_raster_does_not_advertise_the_token_gated_cog_download(
     client: AsyncClient,
     admin_auth_header: dict,
     test_db_session,
+    record_type: str,
 ):
-    """The COG download route replaces the storage key it used to publish."""
-    session = test_db_session
-    admin_id = await get_user_id(session, "admin")
-    ds = await _create_dcat_raster_dataset(
-        session, created_by=admin_id, storage_key=_STORAGE_KEY
-    )
+    """``/download/cog`` 401s an anonymous caller, and this feed serves those.
 
-    resp = await client.get(f"/datasets/{ds.id}/dcat/", headers=admin_auth_header)
-    downloads = [
-        d
-        for d in resp.json()["dcat:distribution"]
-        if d["dcat:accessURL"].endswith(f"/datasets/{ds.id}/download/cog")
-    ]
-    assert len(downloads) == 1
-    assert downloads[0]["dcterms:title"] == "Cloud-Optimized GeoTIFF Download"
-    assert downloads[0]["dcat:mediaType"].startswith("image/tiff")
-
-
-@pytest.mark.anyio
-async def test_dcat_vrt_advertises_tiles_but_no_cog_download(
-    client: AsyncClient,
-    admin_auth_header: dict,
-    test_db_session,
-):
-    """``download_cog`` rejects a VRT, so the feed must not point at it."""
+    Reaching it needs a download-scoped token minted by a separate POST to
+    ``/auth/download-token/{id}``, which no generic DCAT client will make, so
+    advertising it — as ``downloadURL`` in two of the three profiles — would
+    publish a link that fails for the feed's audience.
+    """
     session = test_db_session
     admin_id = await get_user_id(session, "admin")
     ds = await _create_dcat_raster_dataset(
         session,
         created_by=admin_id,
-        name="VRT Mosaic",
-        record_type="vrt_dataset",
-        storage_key="vrt/3d1b/mosaic.vrt",
+        name=f"Raster {record_type}",
+        record_type=record_type,
+        storage_key=_STORAGE_KEY,
     )
 
     resp = await client.get(f"/datasets/{ds.id}/dcat/", headers=admin_auth_header)

--- a/backend/tests/test_dcat.py
+++ b/backend/tests/test_dcat.py
@@ -971,22 +971,36 @@ async def test_dcat_feed_gives_every_dataset_a_distribution(
     admin_auth_header: dict,
     test_db_session,
 ):
-    """Including STAC-origin rasters, which carry no distribution row."""
+    """Including STAC-origin rasters, which carry no distribution row.
+
+    Scoped to the datasets this test creates rather than asserted over the
+    whole feed. "Every dataset has a distribution" is a property of datasets
+    created through the real creation paths (which call
+    ``generate_distributions``), not of the table: under ``pytest -n 4`` the
+    shared per-worker DB carries public datasets that sibling tests inserted
+    as bare ORM rows, and a feed-wide assertion fails on those instead — 56
+    of them, on the first CI run of this test.
+    """
     session = test_db_session
     admin_id = await get_user_id(session, "admin")
-    await _create_dcat_dataset(session, created_by=admin_id, name="Vector")
-    await _create_dcat_raster_dataset(
-        session, created_by=admin_id, name="COG Raster", storage_key=_STORAGE_KEY
-    )
-    await _create_dcat_raster_dataset(
-        session, created_by=admin_id, name="Sentinel-2 Scene", source_format="stac"
-    )
+    created = {
+        "vector": await _create_dcat_dataset(
+            session, created_by=admin_id, name="Vector"
+        ),
+        "COG-backed raster": await _create_dcat_raster_dataset(
+            session, created_by=admin_id, name="COG Raster", storage_key=_STORAGE_KEY
+        ),
+        "STAC-origin raster": await _create_dcat_raster_dataset(
+            session, created_by=admin_id, name="Sentinel-2 Scene", source_format="stac"
+        ),
+    }
 
     resp = await client.get("/datasets/dcat/", headers=admin_auth_header)
-    entries = resp.json()["dcat:dataset"]
-    assert entries
-    without = [e["@id"] for e in entries if not e.get("dcat:distribution")]
-    assert without == [], f"datasets with no access method: {without}"
+    entries = {e["dcterms:identifier"]: e for e in resp.json()["dcat:dataset"]}
+    for label, dataset in created.items():
+        entry = entries.get(str(dataset.id))
+        assert entry is not None, f"{label} missing from the feed"
+        assert entry.get("dcat:distribution"), f"{label} has no access method"
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_dcat.py
+++ b/backend/tests/test_dcat.py
@@ -128,6 +128,88 @@ async def _create_dcat_dataset(
     return dataset
 
 
+async def _create_dcat_raster_dataset(
+    session,
+    *,
+    created_by: uuid.UUID,
+    name: str = "DCAT Raster Dataset",
+    record_type: str = "raster_dataset",
+    source_format: str = "geotiff",
+    storage_key: str | None = None,
+) -> Dataset:
+    """Insert a raster-family Record + Dataset shaped like the ingest tails.
+
+    ``storage_key`` models the row ``tasks_raster``/``tasks_vrt``/the swap
+    write: ``url`` is the object-storage KEY of the COG, with no title and no
+    media type. Left None for the STAC-import shape, which writes no
+    distribution row at all.
+    """
+    record = Record(
+        title=name,
+        summary=f"Description for {name}",
+        record_type=record_type,
+        visibility="public",
+        record_status="published",
+        created_by=created_by,
+        license="CC-BY-4.0",
+        spatial_extent=WKTElement(_NYC_EXTENT, srid=4326),
+    )
+    session.add(record)
+    await session.flush()
+
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"ras_{uuid.uuid4().hex[:12]}",
+        srid=4326,
+        geometry_type=None,
+        source_format=source_format,
+        source_filename=f"{name}.tif",
+    )
+    session.add(dataset)
+    await session.flush()
+
+    if storage_key is not None:
+        session.add(
+            RecordDistribution(
+                record_id=record.id,
+                distribution_type="download",
+                format="vrt" if record_type == "vrt_dataset" else "geotiff",
+                url=storage_key,
+            )
+        )
+
+    await session.commit()
+    await session.refresh(dataset)
+    return dataset
+
+
+def _access_urls(document: object, key: str = "dcat:accessURL") -> list[str]:
+    """Every access URL anywhere in a JSON-LD document.
+
+    Handles both spellings the profiles use: a bare string (DCAT 3, DCAT-US)
+    and a ``{"@id": ...}`` node reference (GeoDCAT-AP).
+    """
+    found: list[str] = []
+
+    def walk(value: object) -> None:
+        if isinstance(value, dict):
+            for found_key, nested in value.items():
+                if found_key == key:
+                    if isinstance(nested, str):
+                        found.append(nested)
+                    elif isinstance(nested, dict) and isinstance(
+                        nested.get("@id"), str
+                    ):
+                        found.append(nested["@id"])
+                walk(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                walk(nested)
+
+    walk(document)
+    return found
+
+
 # ---------------------------------------------------------------------------
 # Single record DCAT tests
 # ---------------------------------------------------------------------------
@@ -824,3 +906,165 @@ async def test_single_record_dcat_404_for_missing(
     random_id = uuid.uuid4()
     resp = await client.get(f"/datasets/{random_id}/dcat/", headers=admin_auth_header)
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Raster distributions (#1469)
+# ---------------------------------------------------------------------------
+
+_STORAGE_KEY = (
+    "rasters/6e9ca821-3345-4c30-bcf8-935bc6dbd61f/1954d0c080b1/source.cog.tif"
+)
+
+
+def _raster_tile_distributions(entry: dict, dataset_id: uuid.UUID) -> list[dict]:
+    return [
+        d
+        for d in entry.get("dcat:distribution", [])
+        if f"/raster-tiles/{dataset_id}/tiles/" in d.get("dcat:accessURL", "")
+    ]
+
+
+@pytest.mark.anyio
+async def test_dcat_feed_never_exposes_a_storage_key(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """No accessURL in the feed is an object-storage key.
+
+    The COG-backed and VRT ingest tails write a distribution row whose url is
+    the storage key. DCAT 3 emitted it verbatim; the DCAT-US and GeoDCAT-AP
+    profiles glued it onto the API origin, which resolves to nothing and
+    exposes the same layout. All three now drop it.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    await _create_dcat_raster_dataset(
+        session, created_by=admin_id, name="COG Raster", storage_key=_STORAGE_KEY
+    )
+    await _create_dcat_raster_dataset(
+        session,
+        created_by=admin_id,
+        name="VRT Mosaic",
+        record_type="vrt_dataset",
+        storage_key="vrt/3d1b/mosaic.vrt",
+    )
+
+    for path, key in (
+        ("/datasets/dcat/", "dcat:accessURL"),
+        ("/datasets/dcat-us/3.0/", "accessURL"),
+        ("/datasets/geodcat-ap/", "dcat:accessURL"),
+    ):
+        resp = await client.get(path, headers=admin_auth_header)
+        assert resp.status_code == 200, path
+        urls = _access_urls(resp.json(), key)
+        assert urls, f"{path} published no access URLs at all"
+        assert not [u for u in urls if u.startswith("rasters/")], path
+        assert not [u for u in urls if "source.cog.tif" in u], path
+        assert all(u.startswith("http") for u in urls), path
+
+
+@pytest.mark.anyio
+async def test_dcat_feed_gives_every_dataset_a_distribution(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """Including STAC-origin rasters, which carry no distribution row."""
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    await _create_dcat_dataset(session, created_by=admin_id, name="Vector")
+    await _create_dcat_raster_dataset(
+        session, created_by=admin_id, name="COG Raster", storage_key=_STORAGE_KEY
+    )
+    await _create_dcat_raster_dataset(
+        session, created_by=admin_id, name="Sentinel-2 Scene", source_format="stac"
+    )
+
+    resp = await client.get("/datasets/dcat/", headers=admin_auth_header)
+    entries = resp.json()["dcat:dataset"]
+    assert entries
+    without = [e["@id"] for e in entries if not e.get("dcat:distribution")]
+    assert without == [], f"datasets with no access method: {without}"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("source_format", ["geotiff", "stac"])
+async def test_dcat_raster_advertises_the_tile_template(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    source_format: str,
+):
+    """Both raster origins advertise the template STAC already publishes.
+
+    The COG-backed case has a storage-key row to replace; the STAC-origin
+    case has no row at all and no local COG to point at, so the template is
+    the only access surface it can offer.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    ds = await _create_dcat_raster_dataset(
+        session,
+        created_by=admin_id,
+        name=f"Raster {source_format}",
+        source_format=source_format,
+        storage_key=_STORAGE_KEY if source_format == "geotiff" else None,
+    )
+
+    resp = await client.get(f"/datasets/{ds.id}/dcat/", headers=admin_auth_header)
+    assert resp.status_code == 200
+    tiles = _raster_tile_distributions(resp.json(), ds.id)
+    assert len(tiles) == 1, resp.json().get("dcat:distribution")
+    assert tiles[0]["dcterms:title"] == "Raster Tiles"
+    assert tiles[0]["dcat:mediaType"] == "image/png"
+    assert tiles[0]["dcat:accessURL"].startswith("http")
+    assert "{z}/{x}/{y}.png" in tiles[0]["dcat:accessURL"]
+
+
+@pytest.mark.anyio
+async def test_dcat_cog_raster_advertises_the_download_endpoint(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """The COG download route replaces the storage key it used to publish."""
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    ds = await _create_dcat_raster_dataset(
+        session, created_by=admin_id, storage_key=_STORAGE_KEY
+    )
+
+    resp = await client.get(f"/datasets/{ds.id}/dcat/", headers=admin_auth_header)
+    downloads = [
+        d
+        for d in resp.json()["dcat:distribution"]
+        if d["dcat:accessURL"].endswith(f"/datasets/{ds.id}/download/cog")
+    ]
+    assert len(downloads) == 1
+    assert downloads[0]["dcterms:title"] == "Cloud-Optimized GeoTIFF Download"
+    assert downloads[0]["dcat:mediaType"].startswith("image/tiff")
+
+
+@pytest.mark.anyio
+async def test_dcat_vrt_advertises_tiles_but_no_cog_download(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """``download_cog`` rejects a VRT, so the feed must not point at it."""
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    ds = await _create_dcat_raster_dataset(
+        session,
+        created_by=admin_id,
+        name="VRT Mosaic",
+        record_type="vrt_dataset",
+        storage_key="vrt/3d1b/mosaic.vrt",
+    )
+
+    resp = await client.get(f"/datasets/{ds.id}/dcat/", headers=admin_auth_header)
+    dists = resp.json()["dcat:distribution"]
+    assert len(_raster_tile_distributions(resp.json(), ds.id)) == 1
+    assert not [d for d in dists if "/download/cog" in d["dcat:accessURL"]]

--- a/backend/tests/test_distribution_reconcile_1314.py
+++ b/backend/tests/test_distribution_reconcile_1314.py
@@ -760,7 +760,9 @@ class TestTwoRowsForOneFormat:
         from app.standards.dcat.service import record_to_dcat
 
         dataset = await self._record_with_two_gpkg_rows(test_db_session)
-        doc = record_to_dcat(dataset, "https://example.test")
+        doc = record_to_dcat(
+            dataset, "https://example.test", app_base_url="https://app.example.test"
+        )
 
         gpkg = [
             d for d in doc["dcat:distribution"] if d.get("dcterms:format") == "gpkg"

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1664,7 +1664,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # Cap 505 -> 512, exact.
         # fix(#1372 codex r2): +7 — the advertised raster_tiles asset carries
         # ?v=<tile_cache_version> like every rendered raster template.
-        "backend/app/modules/catalog/search/service_records.py": 519,
+        # fix(#1469): +5 — properties.distributions no longer republishes the
+        # raster/VRT ingest tails' object-storage-key row (unresolvable, and it
+        # exposes the storage layout). One is_publishable_url guard plus the
+        # comment saying why this profile drops the row instead of replacing it
+        # — build_assets already advertises raster access here. Cap 519 -> 524.
+        "backend/app/modules/catalog/search/service_records.py": 524,
         # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
         # wrapper) + the gated/approximated vector-only match COUNT in
         # _run_rrf_merge (perf audit 2026-07-10 §2d). Cap 350 → 390
@@ -4820,6 +4825,13 @@ def test_platform_never_imports_processing_routers() -> None:
 # surface cannot grow silently; shrinking (migrating an edge through
 # CatalogPort) is welcome but not required.
 _STANDARDS_MODULE_IMPORT_SURFACE: dict[str, set[str]] = {
+    # fix(#1469): the shared "what may a feed publish" helper the three
+    # DCAT-family serializers now share. Same catalog-ORM edge each of them
+    # already carries, in one file instead of three, and TYPE_CHECKING-only —
+    # it is duck-typed on the Dataset instance at runtime.
+    "distributions.py": {
+        "app.modules.catalog.datasets.domain.models",
+    },
     "dcat/service.py": {
         "app.modules.catalog.datasets.domain.models",
         "app.modules.catalog.records.localization",


### PR DESCRIPTION
Closes #1469

## Problem

The DCAT-family serializers mapped `record_distributions` rows straight onto distribution nodes. That works for vector datasets, whose rows are written by `generate_distributions` and hold root-relative API paths. Raster datasets have three separate defects:

1. **COG-backed rasters published a storage key.** The raster/VRT ingest tails write `RecordDistribution(url=cog_key)` — a bare object-storage key like `rasters/<id>/<hash>/source.cog.tif`, with no title and no media type. DCAT 3 emitted it verbatim (`_distribution_to_dcat` only prefixed urls starting with `/`). DCAT-US and GeoDCAT-AP were worse in a quieter way: their `_absolute_url` had a third branch that glued the key onto the API origin, producing `https://host/api/rasters/<id>/<hash>/source.cog.tif`. Neither form resolves for a consumer, and both expose the internal storage layout plus a content hash.

2. **STAC-origin rasters published nothing.** `stac_router.py` creates the Record and Dataset but writes no distribution row, so those datasets appeared in every feed as `dcat:Dataset` entries with no access method at all.

3. **The raster tile template appeared nowhere**, even though `build_assets` advertises exactly that template as the STAC `raster_tiles` asset for the same datasets. The two surfaces described one dataset differently.

## Fix

New `backend/app/standards/distributions.py` is the one place that decides what a feed may publish:

- `is_publishable_url` drops stored urls that are neither root-relative nor absolute http(s). The rule cannot drop a legitimate row: everything a user authors goes through `DistributionCreate`, whose validator requires an http(s) url, and everything `generate_distributions` writes is a root-relative API path. Storage keys are the only thing left.
- `published_distributions` adds the raster family's real access surfaces — the tile template (title, `image/png`), plus `/datasets/{id}/download/cog` for `raster_dataset` only, since `download_cog` rejects a VRT with 400. STAC-origin rasters get both: their raster asset lives on a remote host and the download endpoint redirects to it.

Both raster entries are derived per request rather than stored, because they depend on values a row cannot hold: the tile template is served at the **app** origin (`/raster-tiles/...` is nginx-rewritten to the tile proxy; the API origin has no such route) and carries the dataset's current `tile_cache_version`. That is why `app_base_url` is threaded into the six serializer entry points and resolved with `get_public_urls` at the 12 handlers in `router_export.py`, replacing `get_public_api_url` (which is literally `get_public_urls(...)[1]`, so the API half is unchanged).

`raster_tiles` joins `vector_tiles` in each profile's `SERVICE_DISTRIBUTION_TYPES`, so the two tile surfaces serialize alike.

The OGC Records profile (`properties.distributions`) republished the same storage key. It gets the drop half only — `build_assets` already publishes its raster access surface as the `raster_tiles` asset, so synthesizing a second copy there would duplicate it.

## Verification

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_dcat.py tests/test_geodcat_ap.py tests/test_distribution_reconcile_1314.py \
  tests/test_metadata_roundtrip.py tests/test_ogc_discovery.py tests/test_layering.py tests/test_datasets.py -q
# 214 passed

uv run pytest tests/test_ogc_record_properties.py tests/test_ogc_record_enrichment.py \
  tests/test_ogc_records_conformance.py tests/test_ogc_collection_metadata.py \
  tests/test_distribution_primary_1383.py tests/test_raster_tile_url_version_1372.py \
  tests/test_record_subresource_edits.py tests/test_stac*.py -q
# 381 passed

uv run ruff check . && uv run ruff format --check .
PYTHONPATH=. uv run python scripts/dump_openapi.py --check   # no drift
```

New tests in `tests/test_dcat.py` cover the issue's acceptance criteria across all three profiles: no accessURL matches `^rasters/`, every dataset carries at least one distribution (including a STAC-origin raster), and the tile template appears for both a COG-backed and a STAC-origin dataset. `test_dcat_feed_never_exposes_a_storage_key` was confirmed non-vacuous by stubbing `is_publishable_url` to return True — it fails.

## Impact

No schema or API-contract change; no OpenAPI drift. `_MODULE_LOC_CAPS` for `search/service_records.py` goes 519 -> 524 (the filter plus its comment), and `_STANDARDS_MODULE_IMPORT_SURFACE` gains the new module's TYPE_CHECKING-only catalog-ORM edge — the same edge the three serializers already carry, now in one file instead of three.