### PR TITLE
fix(installer): pull before the upgrade outage and restore the app if it fails

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -2200,7 +2200,7 @@ otherwise the largest part of an upgrade.
 | Release-file sync or image pull | Nothing stopped, nothing migrated, `.env` unchanged. Fix and re-run. |
 | Cannot stop `api`/`worker` | Aborts before the dump instead of dumping under live writers, and restarts whatever it managed to stop. Database untouched. |
 | Dump fails, is empty, or does not read back | Discards the unusable dump, restarts `api`/`worker` on the previous version, aborts. Database untouched. |
-| Migrations fail | Restarts `api`/`worker` on the previous version, prints the rollback recipe, exits non-zero. |
+| Migrations fail | Restarts `api`/`worker` on the previous version, waits to see whether they stay up, prints the rollback recipe, exits non-zero. |
 | New version starts but never becomes healthy | Leaves the new version running and prints the rollback recipe. It does not put the old containers back. |
 
 Two consequences are worth knowing before you meet them.
@@ -2212,6 +2212,12 @@ old code, but old code on a partly-migrated schema is not a state to settle
 into. Read `docker compose logs migrate`, then either fix the cause and re-run
 the upgrade, or restore the pre-upgrade dump the script just took. Its path is
 in the rollback recipe the script prints.
+
+That restart can also fail to hold, and the script says so when it does rather
+than reporting a recovery it did not get. The api image runs
+`alembic upgrade heads` on boot, so if the failed migration committed a revision
+the previous image has never seen, that image refuses to start and the restart
+policy loops it. When you see that message, the dump is the way back.
 
 **The `GEOLENS_VERSION` pin in `.env` moves only after the migrations succeed.**
 A failed upgrade leaves the file naming the version you are still running, so
@@ -2246,9 +2252,9 @@ docker compose -f docker-compose.prod.yml logs --tail 50 migrate
 
 Then take the case that matches.
 
-**`api`/`worker` are stopped and migrate never ran, or exited non-zero.**
-Nothing irreversible happened. Start the previous release again and re-run the
-upgrade when you are ready:
+**`api`/`worker` are stopped and migrate never ran.** Nothing irreversible
+happened. Start the previous release again and re-run the upgrade when you are
+ready:
 
 ```bash
 docker compose -f docker-compose.prod.yml up -d --no-deps api worker
@@ -2257,6 +2263,29 @@ docker compose -f docker-compose.prod.yml up -d --no-deps api worker
 `--no-deps` is not optional here. `api` declares a dependency on the `migrate`
 one-shot completing successfully, so a plain `up -d` re-runs the migration you
 may be trying to stay clear of.
+
+**`api`/`worker` are stopped and migrate exited non-zero.** Do not assume the
+database is untouched. Alembic runs the batch in a transaction, but a revision
+that does its own commits (anything creating an index `CONCURRENTLY`, for
+instance) can leave both schema changes and an advanced `alembic_version` behind
+when a later revision fails. Read the migrate logs and decide which way to go:
+
+- If the cause is fixable (a full disk, a lock timeout), fix it and re-run
+  `scripts/upgrade.sh`. `alembic upgrade heads` is idempotent, so it resumes.
+- Otherwise restore the pre-upgrade dump, below. Starting the previous release
+  is not a safe substitute: the api image runs `alembic upgrade heads` on boot,
+  so if the failed migration committed a revision the old image does not know,
+  it refuses to start and the restart policy loops it. A stopped instance is the
+  visible symptom; old code silently reading a half-migrated schema is the worse
+  one.
+
+```bash
+docker compose -f docker-compose.prod.yml exec -T db \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c 'SELECT * FROM alembic_version'
+```
+
+If that revision is not in the release you were running, the dump is the only
+way back.
 
 **`api`/`worker` are stopped and migrate exited 0.** The schema is already on
 the new release, so finish the upgrade rather than reverting it. Edit the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -22,6 +22,7 @@ documentation.
 7. [Schema rollback](#7-schema-rollback)
 8. [Audit log retention](#8-audit-log-retention)
 9. [Uploaded source-file retention](#9-uploaded-source-file-retention)
+10. [Routine version upgrade: outage and rollback](#10-routine-version-upgrade-outage-and-rollback)
 
 ---
 
@@ -2142,3 +2143,138 @@ case where the COG carries the same samples anyway. Retained originals are
 recoverable on a local install, so if you are restoring one and need the
 pre-conversion files back, extract the staging archive as §2 describes and the
 `originals/` tree comes with it.
+
+---
+
+## 10. Routine version upgrade: outage and rollback
+
+[UPGRADING.md](UPGRADING.md) has the command. This section is the operator
+reference for the part that matters on a running instance: `scripts/upgrade.sh`
+takes the app down for a stretch of its run, and what it does when something
+fails depends on where it failed.
+
+### What stops, and for how long
+
+The upgrade stops `api` and `worker` before it dumps the database, and starts
+them again on the new version at the end. Between those two points the instance
+takes no writes and answers no API traffic.
+
+That outage is deliberate. Data migrations backfill and rewrite existing rows,
+and a one-shot backfill that runs while the previous release is still accepting
+writes silently misses every row written behind it. Alembic will not re-run the
+revision, so nothing repairs those rows later (#1467). Stopping the writers is
+also what makes the pre-upgrade dump a snapshot with no lost writes: `pg_dump`
+does not block writers, so anything acknowledged while it runs would be missing
+from the file you would restore from.
+
+Three services stay up for the whole upgrade:
+
+| Service | During the outage |
+| --- | --- |
+| `db` | Up. The dump and the migrations both need it. |
+| `frontend` | Up, still serving the previous release's UI shell. |
+| `titiler` | Up, but it is only reachable through `api`, so raster tiles stop with it. |
+
+In practice, a browser pointed at the instance still loads the page, and every
+request behind that page fails until the new `api` is healthy.
+
+The window is dump, then migrations, then the container swap:
+
+- The **dump** dominates on a large catalog. It is a `pg_dump -Fc` of the whole
+  database followed by a full read-back verification, so it takes longer than a
+  plain `pg_dump`. If you need a number before announcing a maintenance window,
+  time a `pg_dump -Fc` against a quiet instance and roughly double it.
+- **Migrations** are usually seconds. A release that backfills a large table is
+  the exception, and the release notes call those out.
+- The **container swap** plus the health gate is seconds to a couple of minutes.
+
+The image download is not in the window. The script syncs the release files and
+runs `docker compose pull` while the previous release is still serving, and
+stops the app only once the images are on disk. On a slow link that download is
+otherwise the largest part of an upgrade.
+
+### What it does when it fails
+
+| Failure | State it leaves behind |
+| --- | --- |
+| Release-file sync or image pull | Nothing stopped, nothing migrated, `.env` unchanged. Fix and re-run. |
+| Cannot stop `api`/`worker` | Aborts before the dump instead of dumping under live writers, and restarts whatever it managed to stop. Database untouched. |
+| Dump fails, is empty, or does not read back | Discards the unusable dump, restarts `api`/`worker` on the previous version, aborts. Database untouched. |
+| Migrations fail | Restarts `api`/`worker` on the previous version, prints the rollback recipe, exits non-zero. |
+| New version starts but never becomes healthy | Leaves the new version running and prints the rollback recipe. It does not put the old containers back. |
+
+Two consequences are worth knowing before you meet them.
+
+**A failed migration leaves the previous release running against a database that
+may already hold part of the new release's schema.** The script restarts the old
+`api` and `worker` because an instance that is down is worse than one running
+old code, but old code on a partly-migrated schema is not a state to settle
+into. Read `docker compose logs migrate`, then either fix the cause and re-run
+the upgrade, or restore the pre-upgrade dump the script just took. Its path is
+in the rollback recipe the script prints.
+
+**The `GEOLENS_VERSION` pin in `.env` moves only after the migrations succeed.**
+A failed upgrade leaves the file naming the version you are still running, so
+re-running `scripts/upgrade.sh` retries the upgrade rather than deciding there
+is nothing to do.
+
+The last row of the table is the one case where the script deliberately does not
+act. Once migrations have committed, starting the previous release's containers
+is not a rollback; it is old code on a new schema. Rolling back from there means
+restoring the dump (§2) and then re-pinning the previous version.
+
+### If the script itself dies mid-way
+
+A closed terminal, a dropped SSH session, or a host reboot can leave the upgrade
+half-finished. The automatic restore lives in the script's own shell, so when
+that shell is gone, put the instance back by hand.
+
+Find out where it got to first:
+
+```bash
+# Which containers are running, and on which image tag?
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml images api worker
+
+# What does .env still pin? It only moves once migrations have committed.
+grep '^GEOLENS_VERSION=' .env
+
+# Did the migrate one-shot run, and how did it end?
+docker compose -f docker-compose.prod.yml ps -a migrate
+docker compose -f docker-compose.prod.yml logs --tail 50 migrate
+```
+
+Then take the case that matches.
+
+**`api`/`worker` are stopped and migrate never ran, or exited non-zero.**
+Nothing irreversible happened. Start the previous release again and re-run the
+upgrade when you are ready:
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --no-deps api worker
+```
+
+`--no-deps` is not optional here. `api` declares a dependency on the `migrate`
+one-shot completing successfully, so a plain `up -d` re-runs the migration you
+may be trying to stay clear of.
+
+**`api`/`worker` are stopped and migrate exited 0.** The schema is already on
+the new release, so finish the upgrade rather than reverting it. Edit the
+`GEOLENS_VERSION=` line in `.env` to the version you were upgrading to, then:
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.prod.yml ps
+```
+
+**You want out.** Restore the pre-upgrade dump. The script writes it to
+`./backups/pre-upgrade/<db>_pre_<old>_to_<new>_<timestamp>.dump` and nothing
+prunes that directory, so the newest file there belongs to this attempt:
+
+```bash
+ls -t ./backups/pre-upgrade/*.dump | head -1
+```
+
+Re-pin the previous `GEOLENS_VERSION` in `.env`, restore that dump with
+`scripts/restore.sh` (§2), and bring the stack up. `alembic downgrade` is not a
+supported rollback; see §7 for why.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -86,8 +86,8 @@ dies mid-way.
 On success it prints the rollback recipe for reference and keeps the
 pre-upgrade dump. On **any** failure it stops, leaves your data in the dump, and
 prints the same rollback recipe. If it fails while the app is stopped for the
-migration, it brings the **previous** version back up first, so a failed upgrade
-never leaves the instance down.
+migration, it brings the **previous** version back up first and checks that it
+stayed up, so a failed upgrade does not quietly leave the instance down.
 
 > Re-running `scripts/install.sh` in an existing install also **detects** a newer
 > release: it prints a notice (non-interactive) or offers to upgrade

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -62,18 +62,32 @@ From your install directory:
 
 `scripts/upgrade.sh` performs, in order:
 
-1. **Pre-upgrade backup** — `pg_dump -Fc` to
-   `backups/pre-upgrade/<db>_pre_<old>_to_<new>_<timestamp>.dump`. The upgrade
-   **aborts** if the dump is missing or empty (nothing else is touched).
-2. **Pins** the new `GEOLENS_VERSION` in `.env`.
-3. **Pulls** the prebuilt images (`docker compose pull --ignore-buildable`).
-4. **Runs migrations** — the one-shot `migrate` service (fail-closed). A failed
-   migration **aborts before the app is started**.
+1. **Syncs and pulls** — checks the release files out at the target tag and
+   pulls the prebuilt images (`docker compose pull --ignore-buildable`). The app
+   keeps serving throughout, so the download costs no downtime.
+2. **Stops `api` and `worker`**, then takes the **pre-upgrade backup** —
+   `pg_dump -Fc` to
+   `backups/pre-upgrade/<db>_pre_<old>_to_<new>_<timestamp>.dump`, verified by
+   reading it back end to end. The upgrade **aborts** and restarts the previous
+   version if the dump is missing, empty, or unreadable.
+3. **Runs migrations** — the one-shot `migrate` service (fail-closed). With the
+   app stopped, a data migration sees the final state of the old data instead of
+   racing writes from the release being replaced.
+4. **Pins** the new `GEOLENS_VERSION` in `.env`, once the migrations have
+   committed.
 5. **Starts** the stack and waits for every service to report healthy.
+
+Steps 2 through 5 are an **outage**: the instance takes no writes and answers no
+API traffic until the new version is healthy.
+[RUNBOOK.md § 10](RUNBOOK.md#10-routine-version-upgrade-outage-and-rollback)
+covers how long that lasts, what keeps serving, and what to do if the script
+dies mid-way.
 
 On success it prints the rollback recipe for reference and keeps the
 pre-upgrade dump. On **any** failure it stops, leaves your data in the dump, and
-prints the same rollback recipe.
+prints the same rollback recipe. If it fails while the app is stopped for the
+migration, it brings the **previous** version back up first, so a failed upgrade
+never leaves the instance down.
 
 > Re-running `scripts/install.sh` in an existing install also **detects** a newer
 > release: it prints a notice (non-interactive) or offers to upgrade
@@ -85,26 +99,42 @@ prints the same rollback recipe.
 If you prefer to drive it by hand (same steps as the script):
 
 ```bash
-# 1. Back up first (custom-format dump — the format restore.sh expects).
+# 1. Pull the new images first. The app keeps serving while this runs. Select
+#    the target for compose without editing .env yet (replace 1.2.4).
+export GEOLENS_VERSION=1.2.4
+docker compose -f docker-compose.prod.yml pull --ignore-buildable
+
+# 2. Stop the writers, THEN back up (custom-format dump — the format restore.sh
+#    expects). Stopping api+worker first is what makes the dump a snapshot with
+#    no lost writes, and what keeps step 3's migrations from racing writes from
+#    the release you are replacing. The outage starts here.
+docker compose -f docker-compose.prod.yml stop api worker
 mkdir -p backups/pre-upgrade
 docker compose -f docker-compose.prod.yml exec -T db \
   pg_dump -U geolens -d geolens -Fc --no-owner --no-acl \
   > "backups/pre-upgrade/geolens_$(date +%Y%m%d_%H%M%S).dump"
 
-# 2. Pin the new version in .env (replace 1.2.4 with your target).
-#    Edit the GEOLENS_VERSION= line, e.g.:
-#    GEOLENS_VERSION=1.2.4
-
-# 3. Pull the new prebuilt images.
-docker compose -f docker-compose.prod.yml pull --ignore-buildable
-
-# 4. Run migrations (fail-closed one-shot) BEFORE starting the app.
+# 3. Run migrations (fail-closed one-shot) BEFORE starting the app.
 docker compose -f docker-compose.prod.yml up -d --no-deps migrate
 docker compose -f docker-compose.prod.yml logs migrate   # confirm it exited 0
 
-# 5. Bring the stack up and verify health.
+# 4. Pin the new version in .env now that the migrations have committed.
+#    Edit the GEOLENS_VERSION= line, e.g.:
+#    GEOLENS_VERSION=1.2.4
+
+# 5. Bring the stack up and verify health. The outage ends here.
 docker compose -f docker-compose.prod.yml up -d
 docker compose -f docker-compose.prod.yml ps
+```
+
+If step 3 fails, put the previous release back rather than leaving the instance
+down. `--no-deps` is required here: `api` depends on the `migrate` one-shot
+completing successfully, so a plain `up -d` re-runs the migration that just
+failed.
+
+```bash
+GEOLENS_VERSION=1.2.3 docker compose -f docker-compose.prod.yml \
+  up -d --no-deps api worker      # replace 1.2.3 with the version you were on
 ```
 
 ---
@@ -117,24 +147,30 @@ running — it does **not** modify a source install. Upgrade by updating the
 checkout and rebuilding:
 
 ```bash
-# 1. Back up first.
+# 1. Stop the writers FIRST. The outage starts here. Unlike the prebuilt flow,
+#    the build cannot happen while the app serves: this compose file
+#    bind-mounts ./backend/app into the api container, so checking out the new
+#    tag in step 3 swaps the running app's code the moment it lands.
+docker compose -f docker-compose.yml stop api worker
+
+# 2. Back up (custom-format dump — the format restore.sh expects). With the
+#    writers stopped, the dump loses no acknowledged writes and step 4's
+#    migrations cannot race the release you are replacing.
 mkdir -p backups/pre-upgrade
 docker compose -f docker-compose.yml exec -T db \
   pg_dump -U geolens -d geolens -Fc --no-owner --no-acl \
   > "backups/pre-upgrade/geolens_$(date +%Y%m%d_%H%M%S).dump"
 
-# 2. Update the checkout to the new release tag.
+# 3. Update the checkout to the new release tag and rebuild.
 git fetch --tags origin
 git checkout v1.2.4            # replace with your target tag
-
-# 3. Rebuild the images from the new source.
 docker compose -f docker-compose.yml build
 
 # 4. Run migrations (fail-closed) BEFORE starting the app.
-docker compose -f docker-compose.yml up -d migrate
+docker compose -f docker-compose.yml up -d --no-deps migrate
 docker compose -f docker-compose.yml logs migrate   # confirm it exited 0
 
-# 5. Bring the stack up and verify health.
+# 5. Bring the stack up and verify health. The outage ends here.
 docker compose -f docker-compose.yml up -d
 docker compose -f docker-compose.yml ps
 ```

--- a/scripts/tests/test-upgrade-order.sh
+++ b/scripts/tests/test-upgrade-order.sh
@@ -4,9 +4,15 @@
 # ORDER to a log; no real stack, no DB, no network.
 #
 # Asserts:
-#   - backup (pg_dump) runs BEFORE the image pull
+#   - fix(#1467): the image pull runs BEFORE api/worker are stopped, so the
+#     outage window does not include the download
+#   - fix(#1467): api/worker stay stopped across the whole migrate step, so a
+#     data migration cannot race the previous release's writes
+#   - backup (pg_dump) runs after the stop and before migrate
 #   - migrate runs BEFORE the app `up -d` and BEFORE the health gate
-#   - a NON-ZERO migrate aborts BEFORE `up -d` and prints the rollback recipe
+#   - the .env version pin moves only AFTER migrations succeed
+#   - a NON-ZERO migrate aborts BEFORE `up -d`, restarts the PREVIOUS release's
+#     api/worker, leaves the pin alone, and prints the rollback recipe
 #   - a source-build install (COMPOSE_FILE=docker-compose.yml) exits 0 with the
 #     source-build instructions and makes NO compose/pg_dump calls
 #   - test(#826) wait_for_healthy edge cases: a still-starting service passes
@@ -111,15 +117,25 @@ if [ "$1" = "compose" ]; then
       printf 'PGDMP-fake-custom-format-dump-bytes\n'
       exit 0 ;;
     up)
-      # detect the migrate one-shot vs the db-only config recreate vs the app up
+      # detect the migrate one-shot vs the db-only config recreate vs the
+      # previous-release restore vs the app up
       for a in "$@"; do
         if [ "$a" = "migrate" ]; then echo "migrate_up" >> "$LOG"; exit 0; fi
       done
       # fix(#959): `up -d --force-recreate --no-deps --wait db` applies a synced
       # db/postgresql.conf. It is NOT an app up — logging it as one would make
       # the ordering assertions read a config bounce as bringing the app back.
+      #
+      # fix(#1467): `up -d --no-deps api worker` is the failure-path restore of
+      # the PREVIOUS release. Matching on --no-deps is deliberate: the prod
+      # compose gives api a `depends_on: migrate:
+      # service_completed_successfully` edge, so a restore that dropped
+      # --no-deps would re-run the one-shot that just failed. Such a call falls
+      # through to app_up here, and the "no app_up on the failure path"
+      # assertions below catch it.
       case "$*" in
         *--no-deps*\ db|*--no-deps*\ db\ *) echo "db_recreate" >> "$LOG"; exit 0 ;;
+        *--no-deps*api\ worker*)            echo "restore_app" >> "$LOG"; exit 0 ;;
       esac
       echo "app_up" >> "$LOG"; exit 0 ;;
     ps)
@@ -293,10 +309,14 @@ else
 fi
 
 b="$(pos_of backup)"; p="$(pos_of pull)"; m="$(pos_of migrate_up)"; a="$(pos_of app_up)"
-if [ -n "$b" ] && [ -n "$p" ] && [ "$b" -lt "$p" ]; then
-  ok "backup (pg_dump) runs BEFORE the image pull ($b < $p)"
+s="$(pos_of stop_app)"
+# fix(#1467): the download must not be charged to the operator as downtime. The
+# pull happens while the previous release is still serving; only stop -> dump ->
+# migrate -> start is the outage.
+if [ -n "$p" ] && [ -n "$s" ] && [ "$p" -lt "$s" ]; then
+  ok "image pull runs BEFORE the app is stopped ($p < $s)"
 else
-  bad "backup did not precede pull (backup=$b pull=$p)"
+  bad "pull did not precede the stop (pull=$p stop=$s)"
 fi
 if [ -n "$m" ] && [ -n "$a" ] && [ "$m" -lt "$a" ]; then
   ok "migrate runs BEFORE the app up -d ($m < $a)"
@@ -314,46 +334,66 @@ else
   bad "success path did not print rollback recipe"
 fi
 
-# Full expected order: probe_pg, stop_app, backup, verify_backup, pull,
+# Full expected order: probe_pg, pull, stop_app, backup, verify_backup,
 # db_recreate, migrate_up, app_up. The PG-major probe runs first — it must
-# decide before anything is changed. db_recreate appears because the git stub
-# reports a db/postgresql.conf that differs from the target tag (fix(#959));
-# it lands after the pull and before migrate, so migrations already run under
-# the release's Postgres settings.
+# decide before anything is changed. fix(#1467): the pull sits before the stop,
+# so the outage is stop -> dump -> migrate -> start and nothing else.
+# db_recreate appears because the git stub reports a db/postgresql.conf that
+# differs from the target tag (fix(#959)); it lands after the dump and before
+# migrate, so migrations already run under the release's Postgres settings.
 order="$(tr '\n' ',' < "$WORK/calls.log")"
-expected="probe_pg,stop_app,backup,verify_backup,pull,db_recreate,migrate_up,app_up,"
+expected="probe_pg,pull,stop_app,backup,verify_backup,db_recreate,migrate_up,app_up,"
 if [ "$order" = "$expected" ]; then
-  ok "full call order is probe pg major -> stop api/worker -> backup -> verify -> pull -> db conf recreate -> migrate -> app_up"
+  ok "full call order is probe pg major -> pull -> stop api/worker -> backup -> verify -> db conf recreate -> migrate -> app_up"
 else
   bad "unexpected call order: $order"
 fi
 
 # fix(#959): the config bounce must not straddle the migrate step or the app up.
+# It also belongs inside the outage — bouncing the database under a running old
+# app would break its connections for nothing.
 d="$(pos_of db_recreate)"
-if [ -n "$d" ] && [ -n "$p" ] && [ -n "$m" ] && [ "$p" -lt "$d" ] && [ "$d" -lt "$m" ]; then
-  ok "synced db/postgresql.conf is applied between the pull and migrate ($p < $d < $m)"
+if [ -n "$d" ] && [ -n "$b" ] && [ -n "$m" ] && [ "$b" -lt "$d" ] && [ "$d" -lt "$m" ]; then
+  ok "synced db/postgresql.conf is applied between the backup and migrate ($b < $d < $m)"
 else
-  bad "db config recreate out of place (pull=$p db_recreate=$d migrate=$m)"
+  bad "db config recreate out of place (backup=$b db_recreate=$d migrate=$m)"
 fi
 
 # fix(#714): the rollback dump is read back end-to-end BEFORE the first
-# irreversible step. A dump truncated by a full disk is non-empty and passes
-# `--list`, so `-s` alone would let the upgrade migrate the schema behind an
-# unrestorable rollback artifact.
+# irreversible step, which is the migrate (the pull only downloads images, and
+# since fix(#1467) the .env pin does not move until migrations have committed).
+# A dump truncated by a full disk is non-empty and passes `--list`, so `-s`
+# alone would let the upgrade migrate the schema behind an unrestorable
+# rollback artifact.
 v="$(pos_of verify_backup)"
-if [ -n "$v" ] && [ -n "$b" ] && [ -n "$p" ] && [ "$b" -lt "$v" ] && [ "$v" -lt "$p" ]; then
-  ok "rollback dump verified between the dump and the first irreversible step ($b < $v < $p)"
+if [ -n "$v" ] && [ -n "$b" ] && [ -n "$m" ] && [ "$b" -lt "$v" ] && [ "$v" -lt "$m" ]; then
+  ok "rollback dump verified between the dump and the first irreversible step ($b < $v < $m)"
 else
-  bad "backup not verified before the pull (backup=$b verify=$v pull=$p)"
+  bad "backup not verified before the migrate (backup=$b verify=$v migrate=$m)"
 fi
 
 # Writers quiesced BEFORE the dump (so the snapshot loses no acknowledged writes on
-# rollback) and before migrate (Codex P1).
-s="$(pos_of stop_app)"
+# rollback) and before migrate (Codex P1, and the policy decision in #1467).
 if [ -n "$s" ] && [ -n "$b" ] && [ -n "$m" ] && [ "$s" -lt "$b" ] && [ "$b" -lt "$m" ]; then
   ok "api/worker stopped before the backup dump and before migrate ($s < $b < $m)"
 else
   bad "writers not quiesced before the dump (stop=$s backup=$b migrate=$m)"
+fi
+
+# fix(#1467): nothing restarts api/worker between the stop and the final app up,
+# so the whole migrate step runs with no application writer alive. A restore_app
+# in the happy path would mean something brought the OLD release back mid-upgrade.
+if [ -z "$(pos_of restore_app)" ]; then
+  ok "no writer restart between the stop and the app up (migrate sees no app writes)"
+else
+  bad "the previous release was restarted mid-upgrade: $(tr '\n' ',' < "$WORK/calls.log")"
+fi
+
+# A successful upgrade is what moves the .env pin.
+if grep -q '^GEOLENS_VERSION=1.2.4$' "$FAKE/.env"; then
+  ok "successful upgrade pins GEOLENS_VERSION=1.2.4 in .env"
+else
+  bad "successful upgrade did not pin the new version: $(grep GEOLENS_VERSION "$FAKE/.env")"
 fi
 
 # UPG release-file sync (Codex P2): the prebuilt flow fetches the target tag and
@@ -399,6 +439,44 @@ if [ -n "$(pos_of backup)" ] && [ -z "$(pos_of app_up)" ]; then
   ok "backup was taken before the failed migrate (data safe)"
 else
   bad "backup ordering wrong on the failure path"
+fi
+# fix(#1467): the app was stopped for the migration, so a failed migration must
+# put the PREVIOUS release back. Leaving it stopped turns a failed upgrade into
+# an outage that lasts until the operator notices.
+if [ -n "$(pos_of restore_app)" ]; then
+  ok "failed migrate restarts the previous release's api/worker (instance not left down)"
+else
+  bad "failed migrate left the app stopped: $(tr '\n' ',' < "$WORK/calls.log")"
+fi
+if grep -q 'Restored GeoLens 1.2.3' "$WORK/out.txt"; then
+  ok "failed migrate says which version it restored"
+else
+  bad "failed migrate did not report the restored version"
+  sed 's/^/    # /' "$WORK/out.txt"
+fi
+if grep -q 'may already hold part' "$WORK/out.txt"; then
+  ok "failed migrate warns the database may hold part of the release's migrations"
+else
+  bad "failed migrate did not warn about a partially applied migration"
+  sed 's/^/    # /' "$WORK/out.txt"
+fi
+# fix(#1467): the pin must NOT have moved. It used to move before the migrate,
+# so a re-run read the new version as installed, decided there was nothing to
+# upgrade, and exited 0 with the app still down and the schema unmigrated.
+if grep -q '^GEOLENS_VERSION=1.2.3$' "$FAKE/.env"; then
+  ok "failed migrate leaves GEOLENS_VERSION at the installed version"
+else
+  bad "failed migrate moved the version pin: $(grep GEOLENS_VERSION "$FAKE/.env")"
+fi
+
+# ...and because the pin did not move, re-running the upgrade actually retries
+# instead of reporting "nothing to upgrade".
+run_upgrade ok 1.2.4
+if [ "$(cat "$WORK/code.txt")" = "0" ] && [ -n "$(pos_of migrate_up)" ] && [ -n "$(pos_of app_up)" ]; then
+  ok "re-running after a failed migrate retries the upgrade (not a no-op)"
+else
+  bad "re-run after a failed migrate did not retry (exit=$(cat "$WORK/code.txt"), calls=$(tr '\n' ',' < "$WORK/calls.log"))"
+  sed 's/^/    # /' "$WORK/out.txt"
 fi
 
 # ============================================================================
@@ -528,10 +606,15 @@ if [ "$(cat "$WORK/code.txt")" != "0" ] && [ -z "$(pos_of backup)" ]; then
 else
   bad "failed quiesce did not abort before backup (exit=$(cat "$WORK/code.txt"), calls=$(tr '\n' ',' < "$WORK/calls.log"))"
 fi
-if [ -n "$(pos_of app_up)" ]; then
-  ok "failed quiesce restarts api/worker (restart_writers ran)"
+if [ -n "$(pos_of restore_app)" ] && [ -z "$(pos_of app_up)" ]; then
+  ok "failed quiesce restarts api/worker on the previous release"
 else
-  bad "failed quiesce did not restart api/worker"
+  bad "failed quiesce did not restart api/worker: $(tr '\n' ',' < "$WORK/calls.log")"
+fi
+if grep -q '^GEOLENS_VERSION=1.2.3$' "$FAKE/.env"; then
+  ok "failed quiesce leaves the version pin at the installed version"
+else
+  bad "failed quiesce moved the version pin: $(grep GEOLENS_VERSION "$FAKE/.env")"
 fi
 
 # ============================================================================
@@ -547,20 +630,27 @@ rm -rf "$FAKE/backups/pre-upgrade"
 VERIFY_MODE=fail
 run_upgrade ok 1.2.4
 VERIFY_MODE=ok
-if [ "$(cat "$WORK/code.txt")" != "0" ] && [ -z "$(pos_of pull)" ]; then
-  ok "unreadable rollback dump aborts BEFORE the pull (nothing irreversible ran)"
+# The first IRREVERSIBLE step is the migrate; since fix(#1467) the pull happens
+# earlier, outside the outage, and downloading images changes nothing.
+if [ "$(cat "$WORK/code.txt")" != "0" ] && [ -z "$(pos_of migrate_up)" ]; then
+  ok "unreadable rollback dump aborts BEFORE the migrate (nothing irreversible ran)"
 else
-  bad "corrupt dump did not abort before pull (exit=$(cat "$WORK/code.txt"), calls=$(tr '\n' ',' < "$WORK/calls.log"))"
+  bad "corrupt dump did not abort before migrate (exit=$(cat "$WORK/code.txt"), calls=$(tr '\n' ',' < "$WORK/calls.log"))"
 fi
 if [ -z "$(find "$FAKE/backups/pre-upgrade" -name '*.dump' 2>/dev/null)" ]; then
   ok "unreadable rollback dump is discarded, not left to look like a backup"
 else
   bad "corrupt dump was left on disk: $(find "$FAKE/backups/pre-upgrade" -name '*.dump')"
 fi
-if [ -n "$(pos_of app_up)" ]; then
-  ok "failed verification restarts api/worker (app is not left down)"
+if [ -n "$(pos_of restore_app)" ] && [ -z "$(pos_of app_up)" ]; then
+  ok "failed verification restarts api/worker on the previous release (app not left down)"
 else
-  bad "failed verification did not restart api/worker"
+  bad "failed verification did not restart api/worker: $(tr '\n' ',' < "$WORK/calls.log")"
+fi
+if grep -q '^GEOLENS_VERSION=1.2.3$' "$FAKE/.env"; then
+  ok "failed verification leaves the version pin at the installed version"
+else
+  bad "failed verification moved the version pin: $(grep GEOLENS_VERSION "$FAKE/.env")"
 fi
 
 # ============================================================================
@@ -832,6 +922,16 @@ if grep -q 'ROLLBACK' "$WORK/out.txt"; then
   ok "stuck service failure prints the rollback recipe"
 else
   bad "stuck service failure did not print the rollback recipe"
+fi
+# fix(#1467): the automatic restore stops at the migrate boundary. Once
+# migrations have committed and the pin has moved, starting the PREVIOUS
+# release's containers on top of the new schema is not a rollback — restoring
+# the dump and then re-pinning is, and that stays the operator's call.
+if [ -z "$(pos_of restore_app)" ]; then
+  ok "a health-gate failure does not put old containers back on a migrated schema"
+else
+  bad "the previous release was restarted after migrations had committed"
+  sed 's/^/    # /' "$WORK/out.txt"
 fi
 
 # Mixed: one straggler within its tolerance, one past it — the overdue one

--- a/scripts/tests/test-upgrade-order.sh
+++ b/scripts/tests/test-upgrade-order.sh
@@ -162,6 +162,13 @@ if [ "$1" = "compose" ]; then
 fi
 if [ "$1" = "wait" ]; then
   # docker wait <cid> -> block-then-print the migrate one-shot's exit code (0|3).
+  #
+  # codex P1 on #1476: this call is the last thing before upgrade.sh pins .env,
+  # so it is where the test makes that pin fail for real. Dropping write
+  # permission on the install directory means `update_env_value`'s
+  # `mv .env.tmp.$$ .env` cannot rename, which is the fallible step that used to
+  # reach the EXIT trap with the auto-restore still armed.
+  [ -n "${DOCKER_SEAL_DIR:-}" ] && chmod a-w "$DOCKER_SEAL_DIR" 2>/dev/null
   [ "$MIGRATE_MODE" = "fail" ] && echo 3 || echo 0
   exit 0
 fi
@@ -277,6 +284,7 @@ run_upgrade() {  # $1=migrate mode, rest=args to upgrade.sh
       DOCKER_STARTED_backup="${STARTED_BACKUP:-}" \
       DOCKER_STARTED_api="${STARTED_API:-}" \
       DOCKER_STARTED_frontend="${STARTED_FRONTEND:-}" \
+      DOCKER_SEAL_DIR="${SEAL_DIR:-}" \
       DOCKER_PG_NUM="${PG_NUM:-170005}" GIT_TARGET_PG="${TARGET_PG:-17}" \
       DOCKER_DB_RUNNING_CONF="${DB_RUNNING_CONF-temp_file_limit = 0}" \
       sh "$FAKE/scripts/upgrade.sh" "$@" </dev/null > "$WORK/out.txt" 2>&1 )
@@ -476,6 +484,39 @@ if [ "$(cat "$WORK/code.txt")" = "0" ] && [ -n "$(pos_of migrate_up)" ] && [ -n 
   ok "re-running after a failed migrate retries the upgrade (not a no-op)"
 else
   bad "re-run after a failed migrate did not retry (exit=$(cat "$WORK/code.txt"), calls=$(tr '\n' ',' < "$WORK/calls.log"))"
+  sed 's/^/    # /' "$WORK/out.txt"
+fi
+
+# ============================================================================
+# CASE 2d — codex P1 on #1476: migrations commit, then pinning .env fails. The
+# automatic restore must already be disarmed, because starting the PREVIOUS
+# release against a fully migrated schema is the state the flag exists to
+# prevent. The docker stub drops write permission on the install directory
+# during `docker wait`, so `update_env_value`'s rename genuinely fails and
+# `set -e` carries the abort into the EXIT trap.
+# ============================================================================
+seed_prod_env
+SEAL_DIR="$FAKE"
+run_upgrade ok 1.2.4
+SEAL_DIR=""
+chmod u+w "$FAKE" 2>/dev/null
+
+if [ "$(cat "$WORK/code.txt")" != "0" ]; then
+  ok "an unwritable .env after a successful migration fails the upgrade"
+else
+  bad "unwritable .env did not fail the upgrade (exit=$(cat "$WORK/code.txt"))"
+  sed 's/^/    # /' "$WORK/out.txt"
+fi
+if [ -z "$(pos_of restore_app)" ]; then
+  ok "a failed pin after committed migrations does NOT restart the previous release"
+else
+  bad "the previous release was restarted onto a migrated schema: $(tr '\n' ',' < "$WORK/calls.log")"
+  sed 's/^/    # /' "$WORK/out.txt"
+fi
+if grep -q 'ROLLBACK' "$WORK/out.txt"; then
+  ok "a failed pin prints the rollback recipe"
+else
+  bad "a failed pin did not print the rollback recipe"
   sed 's/^/    # /' "$WORK/out.txt"
 fi
 

--- a/scripts/tests/test-upgrade-order.sh
+++ b/scripts/tests/test-upgrade-order.sh
@@ -190,7 +190,16 @@ if [ "$1" = "inspect" ]; then
       eval "st=\${DOCKER_STARTED_${svc}:-}"
       [ -n "$hc" ] && echo "${st:-unset-started} $hc"
       exit 0 ;;
-    *State.Status*)   echo "exited" ; exit 0 ;;
+    *State.Status*)
+      # The migrate one-shot is `exited` by design. The restored api answers
+      # DOCKER_API_STATE (running by default) so the post-restore settle probe
+      # can be driven both ways (codex P1 round 2 on #1476).
+      for a in "$@"; do cid="$a"; done
+      case "$cid" in
+        cid-api) printf '%s\n' "${DOCKER_API_STATE:-running}" ;;
+        *)       echo "exited" ;;
+      esac
+      exit 0 ;;
     *State.ExitCode*) [ "$MIGRATE_MODE" = "fail" ] && echo 3 || echo 0 ; exit 0 ;;
   esac
   exit 0
@@ -284,7 +293,7 @@ run_upgrade() {  # $1=migrate mode, rest=args to upgrade.sh
       DOCKER_STARTED_backup="${STARTED_BACKUP:-}" \
       DOCKER_STARTED_api="${STARTED_API:-}" \
       DOCKER_STARTED_frontend="${STARTED_FRONTEND:-}" \
-      DOCKER_SEAL_DIR="${SEAL_DIR:-}" \
+      DOCKER_SEAL_DIR="${SEAL_DIR:-}" DOCKER_API_STATE="${API_STATE:-running}" \
       DOCKER_PG_NUM="${PG_NUM:-170005}" GIT_TARGET_PG="${TARGET_PG:-17}" \
       DOCKER_DB_RUNNING_CONF="${DB_RUNNING_CONF-temp_file_limit = 0}" \
       sh "$FAKE/scripts/upgrade.sh" "$@" </dev/null > "$WORK/out.txt" 2>&1 )
@@ -484,6 +493,37 @@ if [ "$(cat "$WORK/code.txt")" = "0" ] && [ -n "$(pos_of migrate_up)" ] && [ -n 
   ok "re-running after a failed migrate retries the upgrade (not a no-op)"
 else
   bad "re-run after a failed migrate did not retry (exit=$(cat "$WORK/code.txt"), calls=$(tr '\n' ',' < "$WORK/calls.log"))"
+  sed 's/^/    # /' "$WORK/out.txt"
+fi
+
+# ============================================================================
+# CASE 2c — codex P1 round 2 on #1476: the restored api does not stay up. The
+# api image runs `alembic upgrade heads` on boot, so a failed migration that
+# already committed a revision leaves the OLD image unable to start, and
+# `compose up -d` still exits 0 because the container was created. The script
+# must not claim a restore that did not hold.
+# ============================================================================
+seed_prod_env
+API_STATE=restarting
+run_upgrade fail 1.2.4
+API_STATE=running
+
+if [ -n "$(pos_of restore_app)" ]; then
+  ok "a crash-looping previous release is still attempted"
+else
+  bad "no restore was attempted: $(tr '\n' ',' < "$WORK/calls.log")"
+fi
+if grep -q 'did not stay up' "$WORK/out.txt" \
+   && ! grep -q 'api + worker are running again' "$WORK/out.txt"; then
+  ok "a restored api that does not stay up is reported DOWN, not restored"
+else
+  bad "the script claimed a restore that did not hold"
+  sed 's/^/    # /' "$WORK/out.txt"
+fi
+if grep -q 'restoring the pre-upgrade dump' "$WORK/out.txt"; then
+  ok "an unbootable previous release points at the dump restore, not a restart"
+else
+  bad "no dump-restore fallback for an unbootable previous release"
   sed 's/^/    # /' "$WORK/out.txt"
 fi
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -377,13 +377,49 @@ restore_previous_app() {
   export GEOLENS_VERSION="$PREVIOUS_VERSION"
   compose up -d --no-deps api worker >/dev/null 2>&1
 }
+
+# `compose up -d` returns as soon as the containers are CREATED, which is not
+# the same as the previous release serving again (codex P1 round 2 on #1476).
+# The api image runs `alembic upgrade heads` on boot unless
+# GEOLENS_API_RUN_MIGRATIONS=false, and refuses to start when it fails. So if a
+# failed migration already committed a revision the OLD graph has never heard
+# of, the restored api exits and the restart policy loops it. Watch it settle
+# instead of reporting a restore that did not happen. An unreadable state fails
+# open, like this script's other best-effort probes.
+previous_app_settled() {
+  _cid="$(compose ps -q api 2>/dev/null | head -n 1)"
+  [ -n "$_cid" ] || return 1
+  _i=0
+  _state=""
+  while [ "$_i" -lt 6 ]; do
+    _i=$((_i + 1))
+    _state="$(docker inspect --format '{{.State.Status}}' "$_cid" 2>/dev/null || printf '')"
+    case "$_state" in
+      restarting|exited|dead) return 1 ;;
+      "") return 0 ;;
+    esac
+    sleep 5
+  done
+  [ "$_state" = "running" ]
+}
+
 report_restore() {
-  if restore_previous_app; then
-    say "Restored GeoLens ${PREVIOUS_VERSION}: api + worker are running again."
-  else
-    warn "Could not restart api + worker — this instance is DOWN. Start it with:"
-    warn "  docker compose -f $COMPOSE_FILE up -d"
+  if ! restore_previous_app; then
+    warn "Could not start api + worker on GeoLens ${PREVIOUS_VERSION} — this instance is DOWN."
+    warn "  docker compose -f $COMPOSE_FILE logs api"
+    return 0
   fi
+  if previous_app_settled; then
+    say "Restored GeoLens ${PREVIOUS_VERSION}: api + worker are running again."
+    return 0
+  fi
+  warn "GeoLens ${PREVIOUS_VERSION}'s api did not stay up — this instance is DOWN."
+  warn "If the migration got far enough to commit a revision, the previous release"
+  warn "cannot start against it: its own boot-time 'alembic upgrade heads' does not"
+  warn "know that revision. Check with:"
+  warn "  docker compose -f $COMPOSE_FILE logs api"
+  warn "If that is what happened, going back means restoring the pre-upgrade dump"
+  warn "(step 2 below), not restarting containers."
 }
 
 say "Step 2/5: stopping api + worker — the upgrade outage starts here"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -498,6 +498,18 @@ if [ -n "$migrate_cid" ]; then
   fi
 fi
 say "  migrations applied."
+# Committed forward. The schema is the new release's, so the trap must not put
+# the previous release's containers back on top of it, and the rollback recipe
+# (restore the dump, then re-pin) becomes the only correct answer.
+#
+# This has to be the FIRST thing after the migration succeeds, ahead of anything
+# that can fail (codex P1 on #1476). Pinning .env below is fallible — an
+# unwritable file, a full disk — and under `set -e` that abort reaches the EXIT
+# trap. With the flag still armed, the trap would start ${PREVIOUS_VERSION}
+# against a fully migrated schema, which is the state this flag exists to
+# prevent. The app is then left stopped, which the printed rollback recipe
+# covers; old code on a new schema is the worse of the two.
+APP_DOWN=0
 say ""
 
 # --- Step 8: pin the new version, bring the app up, health gate --------------
@@ -510,12 +522,6 @@ say "Step 4/5: pinning GEOLENS_VERSION=$TARGET_VERSION in .env"
 export GEOLENS_VERSION="$TARGET_VERSION"
 update_env_value GEOLENS_VERSION "$TARGET_VERSION"
 say ""
-
-# Committed forward: the schema is migrated and the pin has moved, so the trap
-# must not put the previous release's containers back on top of them. From here
-# a failure is a stack that is up but unhealthy, and the rollback recipe (restore
-# the dump, then re-pin) is the only correct answer.
-APP_DOWN=0
 
 say "Step 5/5: starting GeoLens $TARGET_VERSION — the outage ends here"
 compose up -d || fail "compose up failed for $TARGET_VERSION."

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -13,15 +13,23 @@ set -eu
 #   2. Determine the TARGET version (arg $1, else newest remote release tag).
 #   2.5 Refuse to cross a PostgreSQL major (chore(#704)) — abort before any
 #      change with a pointer to RUNBOOK section 6.
-#   3. PRE-UPGRADE BACKUP — pg_dump -Fc to a timestamped file. Abort if it is
-#      missing/empty. (Backup BEFORE we touch images or schema.)
-#   4. Bump GEOLENS_VERSION (export + persist via update_env_value).
+#   3. Export GEOLENS_VERSION=<target> for compose (NOT written to .env yet).
+#   4. Sync the on-disk release files to the target tag.
 #   5. compose pull --ignore-buildable.
-#   6. Run the one-shot migrate (fail-closed since phase 1216) — abort on non-zero
+#   6. OUTAGE STARTS — stop api + worker, then PRE-UPGRADE BACKUP (pg_dump -Fc
+#      to a timestamped file). Abort if it is missing/empty/unreadable.
+#   7. Run the one-shot migrate (fail-closed since phase 1216) — abort on non-zero
 #      BEFORE bringing the app up.
-#   7. compose up -d, then wait_for_healthy.
-#   8. Success: print the ROLLBACK recipe for reference. Any failure: stop, print
-#      the same rollback recipe, exit non-zero.
+#   8. Persist GEOLENS_VERSION to .env, compose up -d, wait_for_healthy — OUTAGE
+#      ENDS.
+#   9. Success: print the ROLLBACK recipe for reference. Any failure: print the
+#      same rollback recipe and exit non-zero — and while the app is still
+#      deliberately stopped, put the PREVIOUS release back first.
+#
+# fix(#1467): steps 3-5 all run before the stop, so the outage is stop -> dump ->
+# migrate -> start and never includes the download. Everything from step 6 on
+# runs with no application writers, so a data migration may assume it sees the
+# final state of the old data.
 #
 # Shared helpers (compose / wait_for_healthy / update_env_value / tag resolution)
 # live in scripts/lib/common.sh. install.sh inlines its own copies (curl|sh
@@ -65,17 +73,28 @@ if [ "$COMPOSE_FILE" != "docker-compose.prod.yml" ]; then
   say "scripts/upgrade.sh upgrades PREBUILT-IMAGE installs only. To upgrade a"
   say "source-build install, update the checkout and rebuild:"
   say ""
+  say "  docker compose -f docker-compose.yml stop api worker          # outage starts"
   say "  git fetch --tags origin"
   say "  git checkout <new-tag>          # e.g. v1.2.4"
   say "  docker compose -f docker-compose.yml build"
-  say "  docker compose -f docker-compose.yml up -d migrate   # run migrations"
-  say "  docker compose -f docker-compose.yml up -d"
+  say "  docker compose -f docker-compose.yml up -d --no-deps migrate  # run migrations"
+  say "  docker compose -f docker-compose.yml up -d                    # outage ends"
   say ""
-  say "Take a backup first (see UPGRADING.md). No changes were made."
+  # fix(#1467): the stop leads, and it is part of the recipe rather than an
+  # optimisation. Migrations that backfill existing rows must not run while the
+  # old release is still writing, and this compose file bind-mounts
+  # ./backend/app into the api container, so checking out the new tag under a
+  # running app swaps its code immediately.
+  say "Take the backup with api + worker already stopped (see UPGRADING.md)."
+  say "No changes were made."
   exit 0
 fi
 
 export GEOLENS_VERSION="${CURRENT_VERSION:-latest}"
+# What every failure path rolls back TO. An install with no GEOLENS_VERSION line
+# is already running whatever `latest` resolved to, which is also what compose
+# falls back to, so the two spellings are the same instance.
+PREVIOUS_VERSION="${CURRENT_VERSION:-latest}"
 
 # --- Step 2: determine target version ---------------------------------------
 if [ "$#" -ge 1 ] && [ -n "${1:-}" ]; then
@@ -210,93 +229,15 @@ if [ -n "$target_pg_major" ] && [ -n "$current_pg_major" ] \
 fi
 say ""
 
-# --- Step 3: pre-upgrade backup ---------------------------------------------
-
-BACKUP_DIR="$PROJECT_ROOT/backups/pre-upgrade"
-mkdir -p "$BACKUP_DIR"
-STAMP="$(date '+%Y%m%d_%H%M%S')"
-BACKUP_FILE="$BACKUP_DIR/${POSTGRES_DB}_pre_${CURRENT_VERSION:-unknown}_to_${TARGET_VERSION}_${STAMP}.dump"
-
-# Quiesce the app's DB writers (api + worker) BEFORE the dump (Codex P1). pg_dump
-# is a snapshot taken when it BEGINS and does NOT block writers, so an acknowledged
-# write during/after the dump would be absent from the backup and lost if a failed
-# migration later triggers the restore recipe. Stopping api/worker first makes the
-# dump a consistent, no-lost-writes snapshot, and keeps the schema migration below
-# from running concurrently with old-version handling. db stays up (the dump +
-# migrate need it). If we abort before the app is brought back up, restart_writers
-# brings them back so a failure never leaves the app down; the success path's final
-# `compose up -d` (and a failed upgrade's rollback recipe) restart them too.
-restart_writers() { compose up -d api worker >/dev/null 2>&1 || true; }
-say "Stopping api + worker to quiesce writers before the backup + migration"
-# Hard precondition (Codex P1): if the stop fails, a writer may still be running,
-# so the no-writers guarantee is NOT established — taking the rollback dump now
-# could miss acknowledged writes. Restart whatever we stopped and abort BEFORE the
-# backup (nothing irreversible has happened yet; this is before the rollback trap).
-if ! compose stop api worker >/dev/null 2>&1; then
-  restart_writers
-  fail "Could not stop api/worker to quiesce writers. Aborting before any changes were made (refusing to dump under active writers)."
-fi
-
-say "Step 1/5: pre-upgrade database backup -> $BACKUP_FILE"
-# -Fc custom-format dump (the format restore.sh expects via pg_restore). Stream
-# to the host file via `exec -T` so the dump lands outside the container.
-if ! compose exec -T db pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
-    -Fc --no-owner --no-acl > "$BACKUP_FILE"; then
-  rm -f "$BACKUP_FILE"
-  restart_writers
-  fail "Pre-upgrade backup failed (pg_dump). Aborting before any changes were made."
-fi
-if [ ! -s "$BACKUP_FILE" ]; then
-  rm -f "$BACKUP_FILE"
-  restart_writers
-  fail "Pre-upgrade backup is empty. Aborting before any changes were made."
-fi
-# Read the archive back end-to-end before trusting it as the rollback artifact
-# (fix(#714), same check backup.sh got in #710). A dump truncated by a disk that
-# filled mid-write is non-empty and still passes `--list`, because the -Fc table
-# of contents sits at the front — the damage is only visible once every data
-# block is read. Do it here, while the pre-upgrade cluster is still intact and
-# a re-dump is free; the next steps migrate the schema, after which this file is
-# the only way back.
-if ! compose exec -T db pg_restore -f /dev/null < "$BACKUP_FILE" >/dev/null 2>&1; then
-  rm -f "$BACKUP_FILE"
-  restart_writers
-  fail "Pre-upgrade backup did not read back cleanly (truncated or corrupt). Aborting before any changes were made."
-fi
-say "  backup OK ($(du -h "$BACKUP_FILE" 2>/dev/null | cut -f1) ) — restore with: scripts/restore.sh \"$BACKUP_FILE\""
-say ""
-
-# From here on, a failure has (potentially) changed images/schema, so every
-# failure path must print the rollback recipe.
-print_rollback() {
-  say ""
-  say "=============================== ROLLBACK ==============================="
-  say "1. Re-pin the previous version in .env:"
-  say "     GEOLENS_VERSION=${CURRENT_VERSION:-<previous-version>}"
-  say "2. Restore the pre-upgrade database dump:"
-  say "     scripts/restore.sh \"$BACKUP_FILE\""
-  say "3. Bring the previous version back up:"
-  say "     docker compose -f $COMPOSE_FILE up -d"
-  say ""
-  say "Note: 'alembic downgrade' is NOT a supported rollback — restore the dump."
-  say "======================================================================="
-}
-rollback_trap() {
-  rc=$?
-  if [ "$rc" -ne 0 ]; then
-    warn "Upgrade FAILED (exit $rc). Your data is safe in $BACKUP_FILE."
-    print_rollback
-  fi
-}
-trap rollback_trap EXIT
-
-# --- Step 4: bump the version pin -------------------------------------------
-say "Step 2/5: pinning GEOLENS_VERSION=$TARGET_VERSION in .env"
+# --- Step 3: select the target version for compose ---------------------------
+# Export only — the .env pin is deliberately NOT written yet. Compose reads the
+# environment ahead of .env, so this is all the sync, pull and migrate steps
+# below need in order to resolve the target release's images, while .env keeps
+# naming the version that is actually installed until Step 8 says otherwise
+# (fix(#1467)).
 export GEOLENS_VERSION="$TARGET_VERSION"
-update_env_value GEOLENS_VERSION "$TARGET_VERSION"
-say ""
 
-# --- Step 4.5: sync the on-disk release files to the target tag --------------
+# --- Step 4: sync the on-disk release files to the target tag ----------------
 # UPG (Codex P2): `compose pull` refreshes IMAGES only. Without this, the operator
 # would keep the OLD checkout's compose file + container-mounted helper scripts, so
 # a release that changed compose (a new service, mount, or env wiring) would boot
@@ -307,7 +248,7 @@ say ""
 # (gitignored). Best-effort: a non-git install or any git failure warns and
 # continues with the current files (the pre-v1043 pull-only behaviour) rather than
 # aborting the upgrade. Local edits to the tracked files above are replaced.
-say "Step 3/5: syncing release files to ${TARGET_TAG}, then pulling prebuilt images"
+say "Step 1/5: syncing release files to ${TARGET_TAG}, then pulling prebuilt images"
 DB_CONF="db/postgresql.conf"
 DB_CONF_CHANGED=0
 DB_CONF_AT_TARGET=0
@@ -394,15 +335,134 @@ if [ "$DB_CONF_AT_TARGET" = "1" ] && [ -f "$DB_CONF" ]; then
 fi
 say ""
 
-# --- Step 5: pull the new images --------------------------------------------
-compose pull --ignore-buildable || fail "Could not pull prebuilt images for $TARGET_VERSION."
+# --- Step 5: pull the new images (the last step before any downtime) ---------
+compose pull --ignore-buildable \
+  || fail "Could not pull prebuilt images for $TARGET_VERSION. Nothing was stopped, .env still pins ${PREVIOUS_VERSION}, and the database is untouched."
 say ""
+
+# --- Step 6: stop the app, then take the pre-upgrade backup ------------------
+# fix(#1467): this line is the boundary. Everything ABOVE it — the release-file
+# sync and the image pull — runs with the previous release still serving, which
+# is where the download belongs: on a self-hosted link it is the longest part of
+# an upgrade and it does not need the app to be down. Everything BELOW it runs
+# with api + worker stopped, so a data migration may assume it sees the final
+# state of the old data with no concurrent application writes behind it. A
+# one-shot backfill that ran while the old code was still accepting writes would
+# silently miss every row written in the window, and Alembic never re-runs the
+# revision to repair them (#1467).
+#
+# Stopping the writers is also what makes the dump a consistent, no-lost-writes
+# snapshot (Codex P1): pg_dump snapshots when it BEGINS and does NOT block
+# writers, so a write acknowledged during the dump would be absent from the
+# backup and lost if a failed migration later triggered the restore recipe.
+#
+# api and worker are the only services that write the catalog schema. db stays
+# up (the dump and the migration both need it); frontend and titiler stay up and
+# keep answering, though the frontend can only return errors for API calls until
+# the new api is running.
+BACKUP_DIR="$PROJECT_ROOT/backups/pre-upgrade"
+mkdir -p "$BACKUP_DIR"
+STAMP="$(date '+%Y%m%d_%H%M%S')"
+BACKUP_FILE="$BACKUP_DIR/${POSTGRES_DB}_pre_${CURRENT_VERSION:-unknown}_to_${TARGET_VERSION}_${STAMP}.dump"
+
+# Put the instance back the way we found it. `--no-deps` is load-bearing: the
+# prod compose gives api a `depends_on: migrate: service_completed_successfully`
+# edge, so a plain `up -d api worker` re-runs the one-shot — which on the
+# migrate-failure path is the very thing that just failed, so the app would stay
+# down. db is up throughout, so skipping deps costs nothing. GEOLENS_VERSION goes
+# back to the previous release in the environment, which is what selects the old
+# images; .env still names it (the pin does not move until Step 8).
+APP_DOWN=0
+restore_previous_app() {
+  export GEOLENS_VERSION="$PREVIOUS_VERSION"
+  compose up -d --no-deps api worker >/dev/null 2>&1
+}
+report_restore() {
+  if restore_previous_app; then
+    say "Restored GeoLens ${PREVIOUS_VERSION}: api + worker are running again."
+  else
+    warn "Could not restart api + worker — this instance is DOWN. Start it with:"
+    warn "  docker compose -f $COMPOSE_FILE up -d"
+  fi
+}
+
+say "Step 2/5: stopping api + worker — the upgrade outage starts here"
+# Hard precondition (Codex P1): if the stop fails, a writer may still be running,
+# so the no-writers guarantee is NOT established — taking the rollback dump now
+# could miss acknowledged writes, and the migration below could run underneath a
+# live old app. Restart whatever we stopped and abort BEFORE the backup (the
+# database is still untouched; this is before the rollback trap).
+if ! compose stop api worker >/dev/null 2>&1; then
+  report_restore
+  fail "Could not stop api/worker to quiesce writers. The database was not touched (refusing to dump or migrate under active writers)."
+fi
+APP_DOWN=1
+
+say "  pre-upgrade database backup -> $BACKUP_FILE"
+# -Fc custom-format dump (the format restore.sh expects via pg_restore). Stream
+# to the host file via `exec -T` so the dump lands outside the container.
+if ! compose exec -T db pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+    -Fc --no-owner --no-acl > "$BACKUP_FILE"; then
+  rm -f "$BACKUP_FILE"
+  report_restore
+  fail "Pre-upgrade backup failed (pg_dump). Aborting before the database was changed."
+fi
+if [ ! -s "$BACKUP_FILE" ]; then
+  rm -f "$BACKUP_FILE"
+  report_restore
+  fail "Pre-upgrade backup is empty. Aborting before the database was changed."
+fi
+# Read the archive back end-to-end before trusting it as the rollback artifact
+# (fix(#714), same check backup.sh got in #710). A dump truncated by a disk that
+# filled mid-write is non-empty and still passes `--list`, because the -Fc table
+# of contents sits at the front — the damage is only visible once every data
+# block is read. Do it here, while the pre-upgrade cluster is still intact and
+# a re-dump is free; the next steps migrate the schema, after which this file is
+# the only way back.
+if ! compose exec -T db pg_restore -f /dev/null < "$BACKUP_FILE" >/dev/null 2>&1; then
+  rm -f "$BACKUP_FILE"
+  report_restore
+  fail "Pre-upgrade backup did not read back cleanly (truncated or corrupt). Aborting before the database was changed."
+fi
+say "  backup OK ($(du -h "$BACKUP_FILE" 2>/dev/null | cut -f1) ) — restore with: scripts/restore.sh \"$BACKUP_FILE\""
+say ""
+
+# From here on, a failure has (potentially) changed the schema, so every failure
+# path must print the rollback recipe. fix(#1467): while the app is still
+# deliberately stopped, it must also put the previous release back — a failed
+# upgrade never leaves the instance down. Doing it in the trap covers every way
+# out, including a `set -e` abort nobody wrote a message for.
+print_rollback() {
+  say ""
+  say "=============================== ROLLBACK ==============================="
+  say "1. Re-pin the previous version in .env:"
+  say "     GEOLENS_VERSION=${CURRENT_VERSION:-<previous-version>}"
+  say "2. Restore the pre-upgrade database dump:"
+  say "     scripts/restore.sh \"$BACKUP_FILE\""
+  say "3. Bring the previous version back up:"
+  say "     docker compose -f $COMPOSE_FILE up -d"
+  say ""
+  say "Note: 'alembic downgrade' is NOT a supported rollback — restore the dump."
+  say "======================================================================="
+}
+rollback_trap() {
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    warn "Upgrade FAILED (exit $rc). Your data is safe in $BACKUP_FILE."
+    if [ "$APP_DOWN" = "1" ]; then
+      warn "Bringing the previous version back up so the app is not left stopped."
+      report_restore
+    fi
+    print_rollback
+  fi
+}
+trap rollback_trap EXIT
 
 # fix(#959): the release's db/postgresql.conf needs the container RECREATED,
 # not restarted or reloaded — `git checkout` writes a new inode and a
 # single-file bind mount keeps resolving the one the container started with.
-# Do it before the migrate step, while the old app containers are still the
-# ones about to be replaced anyway, and wait for the healthcheck.
+# Do it before the migrate step, while the app is already stopped and the dump
+# is already taken, and wait for the healthcheck.
 if [ "$DB_CONF_CHANGED" = "1" ]; then
   say "Applying ${DB_CONF} (recreating the db container)"
   compose up -d --force-recreate --no-deps --wait db \
@@ -410,13 +470,16 @@ if [ "$DB_CONF_CHANGED" = "1" ]; then
   say ""
 fi
 
-# --- Step 6: run migrations (fail-closed) BEFORE bringing the app up ---------
-say "Step 4/5: running database migrations (fail-closed)"
+# --- Step 7: run migrations (fail-closed) BEFORE bringing the app up ---------
+say "Step 3/5: running database migrations (fail-closed)"
 # The prod compose migrate service is a one-shot. `up -d migrate` waits on db
 # health and runs alembic upgrade heads; since phase 1216 it is fail-closed, so
 # we trust its exit code. Use --exit-code-from to surface the migrate result.
+# fix(#1467): api + worker are stopped for the whole of this step, so a data
+# migration here sees the final state of the old data — no application write can
+# land behind a one-shot backfill that has already passed the row.
 if ! compose up -d --no-deps migrate; then
-  fail "Migration step failed to start. App was NOT brought up to $TARGET_VERSION."
+  fail "Migration step failed to start. $TARGET_VERSION was NOT started and the version pin in .env still reads ${PREVIOUS_VERSION}."
 fi
 # Confirm the one-shot exited 0 before proceeding to the app.
 migrate_cid="$(compose ps -aq migrate 2>/dev/null | head -n 1)"
@@ -431,14 +494,30 @@ if [ -n "$migrate_cid" ]; then
   if [ "$m_exit" != "0" ]; then
     warn "migrate one-shot exit=$m_exit. Last 30 log lines:"
     compose logs --tail 30 migrate 2>&1 | sed 's/^/  /' >&2
-    fail "Migrations did NOT complete. App was NOT brought up to $TARGET_VERSION."
+    fail "Migrations did NOT complete. The database may already hold part of ${TARGET_VERSION}'s migrations, and $TARGET_VERSION was NOT started. The version pin in .env still reads ${PREVIOUS_VERSION}."
   fi
 fi
 say "  migrations applied."
 say ""
 
-# --- Step 7: bring the app up + health gate ---------------------------------
-say "Step 5/5: starting GeoLens $TARGET_VERSION"
+# --- Step 8: pin the new version, bring the app up, health gate --------------
+# fix(#1467): the .env pin moves HERE, once the migrations have committed, not
+# before them. While it moved first, a failed upgrade left .env naming a version
+# whose migrations had not run — and re-running this script then read that pin as
+# the installed version, decided there was nothing to upgrade, and exited 0 with
+# the app still stopped.
+say "Step 4/5: pinning GEOLENS_VERSION=$TARGET_VERSION in .env"
+export GEOLENS_VERSION="$TARGET_VERSION"
+update_env_value GEOLENS_VERSION "$TARGET_VERSION"
+say ""
+
+# Committed forward: the schema is migrated and the pin has moved, so the trap
+# must not put the previous release's containers back on top of them. From here
+# a failure is a stack that is up but unhealthy, and the rollback recipe (restore
+# the dump, then re-pin) is the only correct answer.
+APP_DOWN=0
+
+say "Step 5/5: starting GeoLens $TARGET_VERSION — the outage ends here"
 compose up -d || fail "compose up failed for $TARGET_VERSION."
 if ! wait_for_healthy; then
   fail "GeoLens $TARGET_VERSION did not come up cleanly. See the failing service output above."


### PR DESCRIPTION
Closes #1467.

## What #1467 asked, and what was actually there

The issue describes a window where migrations run while the previous release is still serving writes. Checking the script first: that window does not exist. `scripts/upgrade.sh` has stopped `api` and `worker` before the dump since f1183a645, and nothing restarts them until the final `compose up -d` (the two intermediate `up` calls both pass `--no-deps`). The migrate step already runs with no application writer alive.

What was missing is that the property was incidental. The stop landed as a pg_dump consistency fix, no comment claimed the migration-safety guarantee, and no test pinned it, so any future edit could have reintroduced the window silently. Two adjacent things were genuinely broken.

## The outage included the download

The release-file sync and `compose pull` ran *after* the stop, so every operator paid the image download as downtime. On a self-hosted link that is usually the largest part of an upgrade, and it has no reason to be inside the window. Both now run before the stop. The outage is stop, dump, migrate, start.

New order: PG-major probe, sync, pull, **stop api+worker**, dump, verify, db config bounce, migrate, pin `.env`, **up -d**.

## A failed migration left the instance down

The migrate-failure path printed the rollback recipe and exited with `api` and `worker` still stopped. The instance stayed down until someone noticed.

It now restores the previous release first. Two details are load-bearing:

- `--no-deps` on the restore. The prod compose gives `api` a `depends_on: migrate: service_completed_successfully` edge, so a plain `up -d api worker` re-runs the one-shot that just failed and the app stays down.
- The restore lives in the `EXIT` trap, gated on a flag, so it covers every abort while the app is deliberately stopped, not only the paths someone wrote a message for.

The gate closes once migrations commit. Starting old containers on a new schema is not a rollback, so a health-gate failure keeps printing the recipe and leaves the new version running.

## The version pin moved too early

`update_env_value GEOLENS_VERSION` ran before the migrate step. After a failed migration `.env` named a version whose migrations had not run, so re-running the script compared the target against that pin, decided `same`, printed "Already on X, nothing to upgrade" and exited 0 with the app still stopped and the schema unmigrated.

The pin now moves after migrations succeed. Compose reads the environment ahead of `.env`, so the exported `GEOLENS_VERSION` is all the sync, pull and migrate steps need. A re-run after a failure now actually retries (covered by a new test).

## Docs

`RUNBOOK.md` gets section 10: what stops and for how long, what keeps serving (`db`, `frontend` and `titiler` stay up, but `titiler` is only reachable through `api`, so raster tiles stop with it), a per-failure table of end states, and the manual recovery for when the script's own shell dies mid-run.

`UPGRADING.md`'s step list described the old order and never mentioned that the upgrade is an outage. Both manual recipes are updated to match the script. The source-build recipe now stops `api` and `worker` **before** `git checkout`: `docker-compose.yml` bind-mounts `./backend/app` into the api container, so checking out the new tag under a running app swaps its code immediately. That is the same defect #1467 describes, in the hand-driven path.

## Verification

- `sh -n scripts/upgrade.sh` clean. `shellcheck -x -s sh scripts/upgrade.sh` (via `koalaman/shellcheck:stable`) reports zero findings, same as the base revision.
- `scripts/tests/test-upgrade-order.sh`: 70/70 (was 55). New assertions cover pull-before-stop, no writer restart between the stop and the app up, the pin moving only on success, the migrate-failure restore, the pin surviving a failed migrate, a re-run after a failed migrate actually retrying, and no restore after migrations commit. The stub logs `restore_app` only for `--no-deps ... api worker`, so a restore that dropped `--no-deps` falls through to `app_up` and fails the failure-path assertions.
- `scripts/tests/test-upgrading-doc-consistency.sh` 15/15, `scripts/check_env_doc_drift.py` OK, plus the other four `installer-test` job scripts and `pre-commit` on the changed files.
- Independent PATH shim logging full argv, to confirm ordering and the restore's image tag:

```
SUCCESS                                              MIGRATE FAILURE (exit 1)
compose exec -T db psql ... server_version_num       compose exec -T db psql ...
compose exec -T db cat /etc/postgresql/custom.conf   compose exec -T db cat ...
compose pull --ignore-buildable                      compose pull --ignore-buildable
compose stop api worker         <- outage starts     compose stop api worker
compose exec -T db pg_dump ...                       compose exec -T db pg_dump ...
compose exec -T db pg_restore -f /dev/null           compose exec -T db pg_restore -f /dev/null
compose up -d --no-deps migrate                      compose up -d --no-deps migrate
compose ps -aq migrate ; docker wait                 compose ps -aq migrate ; docker wait
compose up -d                   <- outage ends       compose logs --tail 30 migrate
compose ps --format ...                              compose up -d --no-deps api worker
.env => GEOLENS_VERSION=1.2.4                        .env => GEOLENS_VERSION=1.2.3
```

The restore call carries `GEOLENS_VERSION=1.2.3` in its environment, so it starts the previous release's images. No real stack was touched.

## Scope notes

Beyond `scripts/upgrade.sh` and `RUNBOOK.md` I had to touch two more in-repo files, both made wrong by the change: `scripts/tests/test-upgrade-order.sh` pins the exact call order in CI's `installer-test` job, and `UPGRADING.md` documents the script's steps and the hand-driven equivalents.

Not edited, for follow-up:

- The public installer repo, which syncs `scripts/upgrade.sh` at release time.
- `getgeolens.com` `docs/.../upgrade.mdx`, the user-facing upgrade guide. UPGRADING.md already carries a maintainer note flagging it as a cross-repo follow-up, and the doc-consistency test enforces that note.

One behavior change worth calling out for review: because the release-file sync now runs before the stop, `compose stop api worker` executes against the newly synced compose file rather than the installed one. Compose resolves running containers by project and service label, so this is fine unless a release renames or removes those services, in which case the stop fails and the script aborts before touching the database. That failure is safe, and arguably the right outcome.