### PR TITLE
fix(ogc): serve HEAD wherever the standards preflight advertises it

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -956,6 +956,54 @@ def _iter_api_routes(target_app: FastAPI) -> list:
     ]
 
 
+def _clone_api_route(
+    target_app: FastAPI,
+    route,
+    *,
+    path: str,
+    methods: list[str],
+    name_suffix: str,
+) -> None:
+    """Re-register an existing APIRoute at *path* for *methods*.
+
+    Both derived-route passes below register a copy of a canonical route
+    rather than editing it, so every attribute a handler's behaviour depends
+    on has to be carried across. Spelled once here: a kwarg dropped from this
+    list is a silent behaviour difference between the canonical route and its
+    copy, and that is not a difference either caller wants.
+
+    Hidden from OpenAPI. A derived route documents nothing the canonical one
+    does not, and publishing it would churn every generated SDK.
+    """
+    target_app.add_api_route(
+        path=path,
+        endpoint=route.endpoint,
+        response_model=route.response_model,
+        status_code=route.status_code,
+        tags=route.tags,
+        dependencies=route.dependencies,
+        summary=route.summary,
+        description=route.description,
+        response_description=route.response_description,
+        responses=route.responses,
+        deprecated=route.deprecated,
+        methods=methods,
+        operation_id=None,  # MUST differ from canonical for uniqueness;
+        # FastAPI auto-generates when None.
+        response_model_include=route.response_model_include,
+        response_model_exclude=route.response_model_exclude,
+        response_model_by_alias=route.response_model_by_alias,
+        response_model_exclude_unset=route.response_model_exclude_unset,
+        response_model_exclude_defaults=route.response_model_exclude_defaults,
+        response_model_exclude_none=route.response_model_exclude_none,
+        include_in_schema=False,
+        response_class=route.response_class,
+        name=f"{route.name}__{name_suffix}" if route.name else None,
+        openapi_extra=route.openapi_extra,
+        generate_unique_id_function=route.generate_unique_id_function,
+    )
+
+
 def _add_trailing_slash_aliases(target_app: FastAPI) -> None:
     """ROUTE-01 (Phase 1092 review CR-01): register a hidden no-slash alias
     for every trailing-slash route in the app.
@@ -1013,33 +1061,12 @@ def _add_trailing_slash_aliases(target_app: FastAPI) -> None:
             # Register the alias. Inherit response_model, dependencies,
             # status_code, etc. from the canonical route — APIRoute
             # exposes these directly.
-            target_app.add_api_route(
+            _clone_api_route(
+                target_app,
+                route,
                 path=no_slash,
-                endpoint=route.endpoint,
-                response_model=route.response_model,
-                status_code=route.status_code,
-                tags=route.tags,
-                dependencies=route.dependencies,
-                summary=route.summary,
-                description=route.description,
-                response_description=route.response_description,
-                responses=route.responses,
-                deprecated=route.deprecated,
                 methods=[method],
-                operation_id=None,  # MUST differ from canonical for
-                # uniqueness; FastAPI auto-generates
-                # when None.
-                response_model_include=route.response_model_include,
-                response_model_exclude=route.response_model_exclude,
-                response_model_by_alias=route.response_model_by_alias,
-                response_model_exclude_unset=route.response_model_exclude_unset,
-                response_model_exclude_defaults=route.response_model_exclude_defaults,
-                response_model_exclude_none=route.response_model_exclude_none,
-                include_in_schema=False,  # ROUTE-01: hide aliases from OpenAPI
-                response_class=route.response_class,
-                name=f"{route.name}__no_slash_alias" if route.name else None,
-                openapi_extra=route.openapi_extra,
-                generate_unique_id_function=route.generate_unique_id_function,
+                name_suffix="no_slash_alias",
             )
             existing_paths.add((method, no_slash))
             added += 1
@@ -1051,7 +1078,57 @@ def _add_trailing_slash_aliases(target_app: FastAPI) -> None:
         target_app.openapi_schema = None
 
 
+def _register_standards_head_routes(target_app: FastAPI) -> None:
+    """fix(#1470): serve HEAD wherever the CORS preflight says we do.
+
+    ``DynamicCORSMiddleware._set_public_standards_cors_headers`` answers a
+    preflight on the anonymous standards surface with
+    ``Access-Control-Allow-Methods: GET, HEAD, POST, OPTIONS``, and
+    ``_is_anonymous_standards_request`` accepts ``HEAD`` as a requested
+    method — but FastAPI's ``APIRoute`` does not add HEAD alongside GET the
+    way starlette's plain ``Route`` does, so every one of these routes
+    answered ``405 allow: GET``. A browser client that trusts the preflight
+    was told HEAD was fine and then refused. HEAD-probing a landing page or a
+    collection before fetching it is ordinary OGC client behaviour.
+
+    Derived here rather than by editing ~48 decorators across five routers.
+    Both surfaces read the same ``standards_api_path`` classifier, so the set
+    that answers HEAD and the set advertised as answering it cannot drift —
+    which is the actual bug, not the missing routes.
+
+    Runs after ``_add_trailing_slash_aliases`` so the no-slash aliases are
+    covered too. Registering a route rather than adding to
+    ``route.methods``: fastapi 0.140 keeps included-router routes nested and
+    matches through ``RouteContext``, whose ``methods`` is a COPY of the
+    route's, so an in-place mutation would leave the matcher answering 405.
+    """
+    existing: set[tuple[str, str]] = set()
+    for ctx in _iter_api_routes(target_app):
+        for method in ctx.route.methods:
+            existing.add((method, ctx.path))
+
+    added = 0
+    for ctx in _iter_api_routes(target_app):
+        if "GET" not in ctx.route.methods or ("HEAD", ctx.path) in existing:
+            continue
+        if standards_api_path(ctx.path) is None:
+            continue
+        _clone_api_route(
+            target_app,
+            ctx.route,
+            path=ctx.path,
+            methods=["HEAD"],
+            name_suffix="head",
+        )
+        existing.add(("HEAD", ctx.path))
+        added += 1
+
+    if added > 0:
+        target_app.openapi_schema = None
+
+
 _add_trailing_slash_aliases(app)
+_register_standards_head_routes(app)
 
 
 # OGC API Common requires malformed standards-path parameters to use 400.  The

--- a/backend/app/standards/ogc/errors.py
+++ b/backend/app/standards/ogc/errors.py
@@ -4,10 +4,14 @@ import json
 from typing import Any
 
 import structlog
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.exception_handlers import (
+    http_exception_handler as default_http_exception_handler,
+)
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.core.url_redaction import redact_query_credentials
 from app.standards.ogc.utils import standards_api_path
@@ -185,6 +189,40 @@ def _is_standards_path(request: Request) -> bool:
     )
 
 
+def _allow_header_with_head(headers: dict[str, str] | None) -> dict[str, str] | None:
+    """Add HEAD to a 405's ``Allow`` header when GET is already listed.
+
+    fix(#1470): ``_register_standards_head_routes`` serves HEAD beside every
+    standards GET, but as a SEPARATE route. It has to be separate — FastAPI
+    derives a route's operation id from its name and path rather than its
+    method, so one route carrying ``{GET, HEAD}`` emits duplicate operation
+    ids and 48 phantom operations into ``openapi.json`` (measured, not
+    assumed). The cost of that separation is that starlette builds a 405's
+    ``Allow`` from the FIRST partial match, which is the GET-only canonical
+    route, so the header understated what the surface answers.
+
+    Restated here rather than in the route table because this is where the
+    standards error contract already lives, and because the rule is an
+    invariant of that surface rather than of any one route: HEAD is
+    registered for every standards GET, so GET being allowed means HEAD is
+    too. Keyed off GET for exactly that reason — a standards route that
+    allows only POST (``/stac/search``) gains nothing here.
+    """
+    if not headers:
+        return headers
+    allow_key = next((key for key in headers if key.lower() == "allow"), None)
+    if allow_key is None:
+        return headers
+    methods = [
+        value.strip() for value in headers[allow_key].split(",") if value.strip()
+    ]
+    if "GET" not in methods or "HEAD" in methods:
+        return headers
+    updated = dict(headers)
+    updated[allow_key] = ", ".join([*methods, "HEAD"])
+    return updated
+
+
 def register_error_handlers(app: FastAPI) -> None:
     @app.exception_handler(HTTPException)
     async def http_exception_handler(
@@ -207,6 +245,27 @@ def register_error_handlers(app: FastAPI) -> None:
             media_type="application/problem+json",
             headers=exc.headers,
         )
+
+    @app.exception_handler(StarletteHTTPException)
+    async def framework_http_exception_handler(
+        request: Request, exc: StarletteHTTPException
+    ) -> Response:
+        """Correct the ``Allow`` header on a framework-raised standards 405.
+
+        Registered on starlette's base class specifically: the handler above
+        is bound to fastapi's SUBCLASS, which routers raise explicitly, while
+        the 405 comes from ``fastapi.routing`` (which imports HTTPException
+        from ``starlette.exceptions``) and so never reached it. Handler
+        lookup walks the MRO and prefers the most specific registration, so
+        the problem-detail contract for router-raised errors is untouched.
+
+        Everything else is delegated to fastapi's own default, unchanged --
+        this deliberately does NOT convert framework 405/404 bodies to
+        problem+json, which would be a separate contract change.
+        """
+        if exc.status_code == 405 and _is_standards_path(request):
+            exc.headers = _allow_header_with_head(exc.headers)
+        return await default_http_exception_handler(request, exc)
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2174,7 +2174,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # boot-time callers deliberately stay synchronous, so a future review
     # round reads the asymmetry as intentional rather than a missed sibling.
     # Cap 1386 -> 1389, exact.
-    "backend/app/api/main.py": 1389,
+    # fix(#1470): +77 — _register_standards_head_routes, the derived-route pass
+    # that makes HEAD answer wherever the CORS preflight advertises it, and
+    # _clone_api_route, the ~25-kwarg route copy it now shares with
+    # _add_trailing_slash_aliases (which previously spelled that list inline).
+    # HEAD was 405 on all 48 standards GET routes; deriving both surfaces from
+    # standards_api_path is what stops them drifting again, and is why this is
+    # one pass here rather than 48 decorator edits across five routers.
+    # Cap 1389 -> 1466, exact.
+    "backend/app/api/main.py": 1466,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_ogc_discovery.py
+++ b/backend/tests/test_ogc_discovery.py
@@ -210,6 +210,42 @@ async def test_anonymous_standards_cors_default_is_read_only(client, monkeypatch
     assert "access-control-allow-origin" not in credentialed.headers
 
 
+async def test_head_is_served_wherever_the_preflight_advertises_it(client):
+    """fix(#1470): the preflight said HEAD was allowed; the route said 405.
+
+    ``_set_public_standards_cors_headers`` answers a standards preflight with
+    ``GET, HEAD, POST, OPTIONS``, so a browser client that trusts it sent HEAD
+    and got ``405 allow: GET``. Both surfaces are now derived from
+    ``standards_api_path``.
+    """
+    preflight = await client.options(
+        "/collections",
+        headers={
+            "Origin": "https://client.example",
+            "Access-Control-Request-Method": "HEAD",
+            "Access-Control-Request-Headers": "Accept",
+        },
+    )
+    assert preflight.status_code == 200
+    assert "HEAD" in preflight.headers["access-control-allow-methods"]
+
+    for path in ("/collections", "/", "/conformance", "/stac", "/datasets/dcat/"):
+        head = await client.head(path)
+        get = await client.get(path)
+        assert head.status_code == 200, path
+        assert head.status_code == get.status_code, path
+        assert head.headers.get("content-type") == get.headers.get("content-type"), path
+        assert head.content == b"", path
+        assert get.content, path
+
+
+async def test_head_stays_off_non_standards_routes(client):
+    """The pass is scoped by the same classifier, not applied app-wide."""
+    response = await client.head("/datasets/")
+    assert response.status_code == 405
+    assert "HEAD" not in response.headers.get("allow", "")
+
+
 # --- Conformance endpoint tests ---
 
 

--- a/backend/tests/test_ogc_discovery.py
+++ b/backend/tests/test_ogc_discovery.py
@@ -246,6 +246,38 @@ async def test_head_stays_off_non_standards_routes(client):
     assert "HEAD" not in response.headers.get("allow", "")
 
 
+async def test_standards_405_allow_header_reports_head(client):
+    """A 405 must enumerate what the surface answers, HEAD included.
+
+    HEAD is registered as a separate route (see
+    ``_register_standards_head_routes``), and starlette builds ``Allow`` from
+    the first partial match — the GET-only canonical route — so the header
+    understated the surface until the standards error handler restated it.
+    """
+    for path in ("/conformance", "/collections", "/stac"):
+        response = await client.request("PUT", path)
+        assert response.status_code == 405, path
+        methods = {m.strip() for m in response.headers["allow"].split(",")}
+        assert methods == {"GET", "HEAD"}, path
+
+    # Scoped: a native route's 405 keeps the methods it actually serves.
+    native = await client.request("PUT", "/datasets/")
+    assert native.status_code == 405
+    assert "HEAD" not in native.headers.get("allow", "")
+
+
+async def test_standards_router_errors_keep_problem_details(client):
+    """The 405 handler binds starlette's base class, not fastapi's subclass.
+
+    Routers raise fastapi's ``HTTPException``, which must keep resolving to
+    the problem+json handler — registering a base-class handler beside it
+    would be a silent contract change if MRO lookup preferred the general one.
+    """
+    response = await client.get("/collections/00000000-0000-0000-0000-000000000000")
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/problem+json")
+
+
 # --- Conformance endpoint tests ---
 
 

--- a/backend/tests/test_ogc_discovery.py
+++ b/backend/tests/test_ogc_discovery.py
@@ -210,14 +210,31 @@ async def test_anonymous_standards_cors_default_is_read_only(client, monkeypatch
     assert "access-control-allow-origin" not in credentialed.headers
 
 
-async def test_head_is_served_wherever_the_preflight_advertises_it(client):
+async def test_head_is_served_wherever_the_preflight_advertises_it(client, monkeypatch):
     """fix(#1470): the preflight said HEAD was allowed; the route said 405.
 
     ``_set_public_standards_cors_headers`` answers a standards preflight with
     ``GET, HEAD, POST, OPTIONS``, so a browser client that trusts it sent HEAD
     and got ``405 allow: GET``. Both surfaces are now derived from
     ``standards_api_path``.
+
+    ``_is_origin_allowed`` is stubbed for the same reason the sibling CORS
+    test above stubs it, and it is load-bearing rather than tidy: a real
+    lookup populates ``cors._origins_cache``, a module global with a 30s TTL
+    and no invalidation on settings write. Under ``pytest -n 4`` that cache
+    outlives this test and makes ``test_persistent_config.py::
+    test_cors_preflight_returns_200`` read a stale origin set and 405 — which
+    is exactly how it failed on this PR's first CI run.
     """
+
+    async def _deny_origin(_self, _origin):
+        return False
+
+    monkeypatch.setattr(
+        "app.api.middleware.cors.DynamicCORSMiddleware._is_origin_allowed",
+        _deny_origin,
+    )
+
     preflight = await client.options(
         "/collections",
         headers={

--- a/backend/tests/test_persistent_config.py
+++ b/backend/tests/test_persistent_config.py
@@ -773,12 +773,19 @@ async def test_cors_matching_origin_gets_headers(
     client: AsyncClient, admin_auth_header: dict
 ):
     """Request with matching origin gets CORS headers in response."""
+    from app.api.middleware import cors as cors_middleware
+
     # Set CORS origins to allow http://example.com
     await client.put(
         "/settings/",
         json={"settings": {"cors_allowed_origins": "http://example.com"}},
         headers=admin_auth_header,
     )
+    # Same guard, same reason, as test_cors_preflight_returns_200 below: any
+    # request in the previous 30s left an allowlist in the module-global cache,
+    # and the PUT above does not invalidate it, so this positive assertion would
+    # be read against a neighbour's origins rather than the one just written.
+    cors_middleware._origins_cache = (0.0, set())
 
     resp = await client.get("/health", headers={"Origin": "http://example.com"})
     assert resp.status_code == 200
@@ -791,11 +798,18 @@ async def test_cors_non_matching_origin_no_headers(
     client: AsyncClient, admin_auth_header: dict
 ):
     """Request with non-matching origin gets no CORS headers."""
+    from app.api.middleware import cors as cors_middleware
+
     await client.put(
         "/settings/",
         json={"settings": {"cors_allowed_origins": "http://example.com"}},
         headers=admin_auth_header,
     )
+    # Same guard as test_cors_preflight_returns_200 below, and here it is what
+    # gives the assertion teeth rather than what keeps it passing: a stale-empty
+    # cache denies every origin, so the deny path would look correct without the
+    # written allowlist ever being consulted.
+    cors_middleware._origins_cache = (0.0, set())
 
     resp = await client.get("/health", headers={"Origin": "http://evil.com"})
     assert resp.status_code == 200

--- a/backend/tests/test_persistent_config.py
+++ b/backend/tests/test_persistent_config.py
@@ -805,11 +805,19 @@ async def test_cors_non_matching_origin_no_headers(
 @pytest.mark.anyio
 async def test_cors_preflight_returns_200(client: AsyncClient, admin_auth_header: dict):
     """OPTIONS preflight with matching origin returns 200 with CORS headers."""
+    from app.api.middleware import cors as cors_middleware
+
     await client.put(
         "/settings/",
         json={"settings": {"cors_allowed_origins": "http://example.com"}},
         headers=admin_auth_header,
     )
+    # Same guard as test_cors_wildcard_from_env_is_rejected below, for the same
+    # reason: the allowlist cache is a module global with a 30s TTL and no
+    # write-through invalidation, so the origin this test just saved is invisible
+    # while an earlier test's entry is still warm. Under `pytest -n 4` that made
+    # this test 405 on a sibling's cache (#1470 CI run 1).
+    cors_middleware._origins_cache = (0.0, set())
 
     resp = await client.options(
         "/health",


### PR DESCRIPTION
Closes #1470

## Problem

```
$ curl -sI https://<instance>/api/collections
HTTP/2 405
allow: GET
```

while the CORS preflight on the same path answers `access-control-allow-methods: GET, HEAD, POST, OPTIONS`. A browser client that preflights a HEAD is told it is allowed, then refused.

The mismatch is not an oversight in the CORS layer — that layer means it. `DynamicCORSMiddleware._is_anonymous_standards_request` (`backend/app/api/middleware/cors.py:130`) explicitly admits `HEAD` into the anonymous standards allowlist, and `_set_public_standards_cors_headers` advertises it. What is missing is on the route side: FastAPI's `APIRoute` does not add HEAD alongside GET the way starlette's plain `Route` does. That is why `/openapi.json` and `/docs` (plain Routes) answer HEAD and every standards route does not. All 48 GET routes on that surface were GET-only.

## Fix

Register HEAD by deriving it, in one pass after the routers are included, from the same `standards_api_path` classifier the CORS middleware already uses to decide what to advertise. That is the point of doing it this way: the advertised set and the served set now come from one function and can no longer disagree. Editing ~48 decorators across five routers would fix today's mismatch and leave the next route free to reintroduce it.

There is already precedent for this shape — `_add_trailing_slash_aliases` is the same kind of derived-route pass in the same file, added for the same reason (a mechanical property that should hold across a whole surface, not per-decorator).

Two details worth calling out:

- **Registering a route, not mutating `route.methods`.** fastapi 0.140 keeps included-router routes nested and matches through `RouteContext`, whose `.methods` is a *copy* of the route's (verified: `ctx.methods is ctx.route.methods` -> `False`). An in-place `route.methods.add("HEAD")` would leave the matcher answering 405 while the route object claimed otherwise.
- **`include_in_schema=False`.** A HEAD operation documents nothing its GET does not, and publishing 48 of them would churn `openapi.json` and every generated SDK. Confirmed: no OpenAPI drift.

The ~25-kwarg route copy both passes need is factored into `_clone_api_route`; `_add_trailing_slash_aliases` previously spelled that list inline and now shares it. A kwarg dropped from that list is a silent behaviour difference between a canonical route and its copy, so it is worth having exactly one copy of it.

### Why register rather than narrow the advertisement

The issue offered both. Narrowing is the wrong direction here: the middleware's own allowlist already treats HEAD as a first-class standards method, HEAD-probing a landing page or collection before fetching it is ordinary OGC client behaviour, and the same static header also advertises POST (true only for `/stac/search`), so "make the header exact" is a larger change than "make the routes match" and leaves clients worse off.

## Verification

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_ogc_discovery.py tests/test_ogc_features.py tests/test_ogc_pagination.py \
  tests/test_ogc_public_access.py tests/test_ogc_queryables.py tests/test_ogc_records_conformance.py \
  tests/test_ogc_collection_metadata.py tests/test_stac*.py tests/test_dcat.py tests/test_geodcat_ap.py \
  tests/test_middleware.py tests/test_redirect_slashes.py tests/test_layering.py -q
# 515 passed

uv run ruff check . && uv run ruff format --check .
PYTHONPATH=. uv run python scripts/dump_openapi.py --check   # no drift
```

Route-table check after the pass: 48 standards GET paths, 48 standards HEAD paths, zero GET-without-HEAD, and zero HEAD routes outside the standards surface.

New tests in `tests/test_ogc_discovery.py`:
- `test_head_is_served_wherever_the_preflight_advertises_it` — the preflight advertises HEAD, and HEAD on `/collections`, `/`, `/conformance`, `/stac`, `/datasets/dcat/` returns 200 with the same content-type as GET and an empty body.
- `test_head_stays_off_non_standards_routes` — `HEAD /datasets/` still 405s, so the pass is scoped by the classifier rather than applied app-wide.

## Impact

No schema or API-contract change; no OpenAPI drift, no SDK regeneration. `_MODULE_LOC_CAPS` for `api/main.py` goes 1389 -> 1466 (the new pass plus the shared route-copy helper), recorded with the reason in the same commit.


---

## Review round 1: the `Allow` header

Review pointed out that HEAD answering is only half of it — a 405 for some *other* method still reported `Allow: GET`, which understates what the surface serves.

The suggested "register GET and HEAD on the same effective route" is not available in FastAPI. `get_openapi_path` derives a route's operation id from its name and path rather than its method, so one route carrying `{GET, HEAD}` produces a duplicate operation id per route plus 48 phantom `head:` operations. Measured both ways with `scripts/dump_openapi.py --check`:

| approach | duplicate operation ids | snapshot |
| --- | --- | --- |
| separate HEAD route (this PR) | 0 | clean |
| `{GET, HEAD}` on canonical route | 5 | out of date |

That is the same reason FastAPI does not auto-add HEAD the way starlette's plain `Route` does.

So the header is restated instead, in `backend/app/standards/ogc/errors.py` where the standards error contract already lives. Two things surfaced while doing it:

- `fastapi/routing.py:96` imports `HTTPException` from `starlette.exceptions` and raises **that** for the 405. The existing problem-detail handler is bound to fastapi's subclass, so it never saw this exception — the standards 405 was being served by fastapi's default JSON handler all along.
- Handler lookup walks `type(exc).__mro__` and prefers the most specific registration, so binding the base class beside the subclass leaves router-raised errors on their problem+json contract. Pinned by `test_standards_router_errors_keep_problem_details`.

The new handler only rewrites `Allow` and delegates everything else to fastapi's default. It deliberately does **not** convert framework 405/404 bodies to problem+json — that is a real pre-existing inconsistency, but a separate contract change.

Keyed off GET, since HEAD is registered for every standards GET: a standards route allowing only POST gains nothing, and `PUT /datasets/` still reports `Allow: GET`.

Added `test_standards_405_allow_header_reports_head` and `test_standards_router_errors_keep_problem_details`. Full re-run: 550 passed across the OGC/STAC/DCAT/middleware/layering suites, `dump_openapi.py --check` clean.
