### PR TITLE
chore(make): add env-test target for the gitignored host test env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ The React/Vite frontend is in `frontend/src/`: `components/`, `pages/`, `hooks/`
 - Frontend: `cd frontend && npx vitest run src/path/foo.test.ts`.
 - E2E: `npx playwright test e2e/foo.spec.ts --project=chromium` (stack must be running).
 
-A focused selection is blind to the module-size gates. `backend/tests/test_layering.py` caps the size of the largest backend modules, and CI runs it on every PR that triggers `backend-test`, so a change that adds lines to a ratcheted file passes locally and fails there. If you touched anything under `backend/app/`, finish with `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q`; it needs no database, but it does boot `app.core.config`, so a bare run dies on missing env vars with a non-zero exit before collecting anything — which reads exactly like a gate failure and is not one. In a fresh clone `.env.test` does not exist yet (it is gitignored); create it once with `cp .env.test.example .env.test` from the repo root. Growth is allowed — raise the file's cap in `_MODULE_LOC_CAPS` in the same commit, with a comment saying what the lines bought.
+A focused selection is blind to the module-size gates. `backend/tests/test_layering.py` caps the size of the largest backend modules, and CI runs it on every PR that triggers `backend-test`, so a change that adds lines to a ratcheted file passes locally and fails there. If you touched anything under `backend/app/`, finish with `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q`; it needs no database, but it does boot `app.core.config`, so a bare run dies on missing env vars with a non-zero exit before collecting anything — which reads exactly like a gate failure and is not one. In a fresh clone `.env.test` does not exist yet (it is gitignored); create it once with `make env-test` from the repo root. Growth is allowed — raise the file's cap in `_MODULE_LOC_CAPS` in the same commit, with a comment saying what the lines bought.
 
 ### Working from a git worktree
 
@@ -33,7 +33,7 @@ The dev stack bind-mounts the MAIN checkout (`./frontend` → `/app`, and `backe
 
 One exception: a spec-only change (editing `e2e/*.spec.ts` with no app-code change) is validly testable from a worktree, because Playwright reads the specs from your worktree while the app code stays byte-identical to `main`.
 
-The host backend recipe above is also unrunnable verbatim from a worktree — the sandbox refuses `source` on a path outside the worktree and denies reading `.env*`. Copy `.env.test` into the worktree instead (it is gitignored; delete it when you are done) and run pytest from a wrapper script.
+The host backend recipe above is also unrunnable verbatim from a worktree — the sandbox refuses `source` on a path outside the worktree and denies reading `.env*`. Run `make env-test` inside the worktree instead (it is gitignored; delete it when you are done) and run pytest from a wrapper script.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -c
 
-.PHONY: dev dev-init down reset-db migrate migration alembic-check overlay-migration-check test test-sequential test-cov ai-evals e2e logs logs-db logs-api status doctor preflight openapi openapi-check sdks sdks-check sdks-test manifest-contract-check publish-sdks-py publish-sdks-ts cli-build cli-test cli-check publish-cli mcp-build mcp-test mcp-live-test publish-mcp audit-sink-discipline billing-extraction-discipline catalog-domain-discipline bump version-check public-surface-check deployed-surface-check
+.PHONY: dev dev-init down reset-db migrate migration alembic-check overlay-migration-check test test-sequential test-cov env-test ai-evals e2e logs logs-db logs-api status doctor preflight openapi openapi-check sdks sdks-check sdks-test manifest-contract-check publish-sdks-py publish-sdks-ts cli-build cli-test cli-check publish-cli mcp-build mcp-test mcp-live-test publish-mcp audit-sink-discipline billing-extraction-discipline catalog-domain-discipline bump version-check public-surface-check deployed-surface-check
 
 # Pre-flight: verify boot-required env vars are non-empty in .env before any
 # `docker compose` build (which takes 5-10 minutes on a cold cache only to crash
@@ -84,11 +84,27 @@ test-sequential:
 test-cov:
 	docker compose exec api env UV_CACHE_DIR=/app/staging/uv-cache UV_PROJECT_ENVIRONMENT=/app/staging/geolens-api-test-venv COVERAGE_FILE=/app/staging/.coverage uv run pytest -o cache_dir=/app/staging/.pytest_cache -v --tb=short --cov=app --cov-report=term-missing
 
+# Bootstrap the host-side test env file. `.env.test` is gitignored, so a fresh
+# clone starts without it and so does every new worktree. The documented host
+# pytest recipe then dies on missing env vars before collecting anything, with
+# a non-zero exit that reads exactly like a gate failure and is not one.
+# Idempotent: an existing .env.test is left alone, never overwritten.
+env-test:
+	@if [ -f .env.test ]; then \
+		echo ".env.test already exists, leaving it alone"; \
+	else \
+		cp .env.test.example .env.test; \
+		echo "created .env.test from .env.test.example"; \
+	fi
+
 # Live-provider AI evals (assertion-based NL->SQL regression suite). Skipped
 # in normal test runs; costs real provider tokens. Needs the dev DB up and
 # ANTHROPIC_API_KEY (or the configured provider's key) in the environment.
-ai-evals:
-	cd backend && set -a && if [ -f ../.env.test ]; then . ../.env.test; fi && set +a && RUN_AI_EVALS=1 uv run pytest tests/evals/ -v
+# Depends on env-test so the source is unconditional: the old `if [ -f ... ]`
+# guard let a missing .env.test run the evals against whatever happened to be
+# in the environment instead of failing.
+ai-evals: env-test
+	cd backend && set -a && . ../.env.test && set +a && RUN_AI_EVALS=1 uv run pytest tests/evals/ -v
 
 e2e:
 	npx playwright test

--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,16 @@ env-test:
 # Live-provider AI evals (assertion-based NL->SQL regression suite). Skipped
 # in normal test runs; costs real provider tokens. Needs the dev DB up and
 # ANTHROPIC_API_KEY (or the configured provider's key) in the environment.
-# Depends on env-test so the source is unconditional: the old `if [ -f ... ]`
-# guard let a missing .env.test run the evals against whatever happened to be
-# in the environment instead of failing.
-ai-evals: env-test
-	cd backend && set -a && . ../.env.test && set +a && RUN_AI_EVALS=1 uv run pytest tests/evals/ -v
+#
+# fix(#1481): the `if [ -f ... ]` guard below is load-bearing. Do NOT make this
+# target depend on env-test, and do not source the file unconditionally.
+# .env.test.example ships POSTGRES_PASSWORD=geolens, while `make dev-init`
+# generates a RANDOM one into .env (SEC-010). Sourcing the template under
+# `set -a` exports the public default over the real password, and the evals can
+# no longer authenticate against the dev DB. With no .env.test present,
+# Settings loads .env directly and the credentials match.
+ai-evals:
+	cd backend && set -a && if [ -f ../.env.test ]; then . ../.env.test; fi && set +a && RUN_AI_EVALS=1 uv run pytest tests/evals/ -v
 
 e2e:
 	npx playwright test


### PR DESCRIPTION
## What

`make env-test` creates the gitignored `.env.test` from `.env.test.example`. That is the whole change.

## Why

`.env.test` is gitignored, so a fresh clone starts without it and so does every new worktree. The host pytest recipe documented in `AGENTS.md` then dies on missing env vars while booting `app.core.config`, before collecting a single test. The non-zero exit reads exactly like a gate failure, which is the part that costs time.

`AGENTS.md` already said to fix it with `cp .env.test.example .env.test`. Replacing that instruction with a target matters most in worktrees, where `AGENTS.md` separately tells you to copy `.env.test` in from outside the checkout. `make env-test` does it without reaching across checkouts.

## Scope reduced after review

The first revision also made `ai-evals` depend on `env-test` so its recipe could source `.env.test` unconditionally, on the theory that the `if [ -f ... ]` guard was hiding a silent-wrong path. Codex showed that backwards, and it was right:

- `.env.test.example` ships `POSTGRES_PASSWORD=geolens`.
- `make dev-init` generates a *random* `POSTGRES_PASSWORD` into `.env`, specifically because `geolens` is the known-public default (SEC-010, `scripts/install.sh`).
- Sourcing the template under `set -a` exports the public default over the real password, so the evals can no longer authenticate against the dev DB on a default install.
- With no `.env.test` present, `Settings` loads `.env` directly (`backend/app/core/config.py`) and the credentials match.

The guard was preserving a working path. `ai-evals` is now restored byte-for-byte against `main`, with a comment recording why it must stay that way so the next person does not repeat the same "cleanup".

## Verification

- `make env-test` in a clean worktree creates the file.
- A second run reports the file exists and leaves it untouched, confirmed by appending a sentinel line between runs and checking it survived.
- `git check-ignore` confirms `.env.test` still matches `.gitignore:3`, so it cannot be committed by accident.
- The `ai-evals` recipe is diffed byte-for-byte against `origin/main`: identical.
- pre-commit passed.

Not run: the backend suite and every docker target. Another session was mid `pytest -n 4` against the shared DB, and starting a second run would have collided with its cluster-global DDL.

## Related

#1480 covers the worktree e2e trap, a larger version of the same class of problem.
