### PR TITLE
docs(agents): break the module-size-gate paragraph into steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,18 @@ The React/Vite frontend is in `frontend/src/`: `components/`, `pages/`, `hooks/`
 - Frontend: `cd frontend && npx vitest run src/path/foo.test.ts`.
 - E2E: `npx playwright test e2e/foo.spec.ts --project=chromium` (stack must be running).
 
-A focused selection is blind to the module-size gates. `backend/tests/test_layering.py` caps the size of the largest backend modules, and CI runs it on every PR that triggers `backend-test`, so a change that adds lines to a ratcheted file passes locally and fails there. If you touched anything under `backend/app/`, finish with `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q`; it needs no database, but it does boot `app.core.config`, so a bare run dies on missing env vars with a non-zero exit before collecting anything — which reads exactly like a gate failure and is not one. In a fresh clone `.env.test` does not exist yet (it is gitignored); create it once with `make env-test` from the repo root. Growth is allowed — raise the file's cap in `_MODULE_LOC_CAPS` in the same commit, with a comment saying what the lines bought.
+A focused selection is blind to the module-size gates. `backend/tests/test_layering.py` caps the size of the largest backend modules, and CI runs it on every PR that triggers `backend-test`, so a change that adds lines to a ratcheted file passes locally and fails there.
+
+If you touched anything under `backend/app/`, finish with:
+
+```bash
+cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q
+```
+
+- It needs no database.
+- It does boot `app.core.config`, so a bare run dies on missing env vars with a non-zero exit before collecting anything. That reads exactly like a gate failure and is not one.
+- In a fresh clone `.env.test` does not exist yet (it is gitignored). Create it once with `make env-test` from the repo root.
+- Growth is allowed. Raise the file's cap in `_MODULE_LOC_CAPS` in the same commit, with a comment saying what the lines bought.
 
 ### Working from a git worktree
 


### PR DESCRIPTION
## What

The paragraph under `### Running a single test` becomes a lead sentence, a fenced command block, and four bullets. No content changes.

## Why

It packed nine separate facts into 887 characters:

1. A focused selection is blind to the module-size gates.
2. `backend/tests/test_layering.py` caps the largest backend modules.
3. CI runs it on every PR that triggers `backend-test`.
4. So a change adding lines to a ratcheted file passes locally and fails there.
5. The command to run if you touched `backend/app/`.
6. It needs no database.
7. It boots `app.core.config`, so a bare run dies on missing env vars before collecting anything, which mimics a gate failure.
8. A fresh clone has no `.env.test` (now `make env-test`, added in #1481).
9. Raising a cap in `_MODULE_LOC_CAPS` belongs in the same commit with a comment.

Facts 5 through 9 are things you act on, and they were buried mid-sentence. The command in particular was inline backticks inside a longer clause, which is awkward to copy.

## Verification

- The command text is byte-identical, just moved from inline backticks to a fenced `bash` block. Confirmed with an exact-string grep.
- Every other backticked identifier in the file is unchanged. Confirmed with `comm` over the sorted sets; the only delta is the command itself moving into the fence.
- Code fences balanced (4, two pairs).
- Longest prose block in the file: 887 to 659 characters. Long non-list prose blocks: 3 to 2.
- Diff is one file, 12 insertions, 1 deletion.
- pre-commit passed.

## Related

Follows #1482, which did the same for the security section. Completes the pass I deferred there to avoid tangling with #1481.