### PR TITLE
feat(builder): render a space background behind the globe

### DIFF
--- a/frontend/src/components/builder/__tests__/map-composition-sync.test.ts
+++ b/frontend/src/components/builder/__tests__/map-composition-sync.test.ts
@@ -71,6 +71,21 @@ function skyMap(initialSky?: Sky) {
   };
 }
 
+// A map holding a real container element, so the space backdrop can be read
+// back the way the stylesheet selects it (feat(#1479)).
+function containerMap() {
+  const container = document.createElement('div');
+  container.className = 'maplibregl-map';
+  return {
+    map: {
+      isStyleLoaded: vi.fn(() => true),
+      setProjection: vi.fn(),
+      getContainer: vi.fn(() => container),
+    } as unknown as MaplibreMap,
+    container,
+  };
+}
+
 function layer(id = 'layer-1'): SyncLayerInput {
   return {
     id,
@@ -355,6 +370,99 @@ describe('map composition sync', () => {
     expect(throwingSky).toHaveBeenCalledWith(
       expect.objectContaining({ 'atmosphere-blend': expect.anything() }),
     );
+  });
+
+  it('marks the container for globe and unmarks it on mercator (feat(#1479))', () => {
+    const target = containerMap();
+
+    applyMapBasemapAppearance({
+      map: target.map,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+    });
+    expect(target.container.getAttribute('data-globe-space')).toBe('true');
+
+    // Both ways of saying mercator have to strip it: an explicit projection and
+    // a config that never mentioned one.
+    applyMapBasemapAppearance({
+      map: target.map,
+      basemapConfig: { projection: 'mercator' } as MapBasemapConfig,
+    });
+    expect(target.container.hasAttribute('data-globe-space')).toBe(false);
+
+    applyMapBasemapAppearance({
+      map: target.map,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+    });
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: null });
+    expect(target.container.hasAttribute('data-globe-space')).toBe(false);
+  });
+
+  it('leaves the marker off a container it never set (feat(#1479))', () => {
+    // Reverting a map that was never a globe must not invent the attribute,
+    // and removeAttribute on an absent attribute must stay silent.
+    const target = containerMap();
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: null });
+    expect(target.container.hasAttribute('data-globe-space')).toBe(false);
+  });
+
+  it('keeps one surface\'s backdrop out of the other (feat(#1479))', () => {
+    const builder = containerMap();
+    const viewer = containerMap();
+
+    applyMapBasemapAppearance({
+      map: builder.map,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+    });
+    applyMapBasemapAppearance({
+      map: viewer.map,
+      basemapConfig: null,
+      idPrefix: 'viewer-',
+    });
+
+    expect(builder.container.getAttribute('data-globe-space')).toBe('true');
+    expect(viewer.container.hasAttribute('data-globe-space')).toBe(false);
+
+    // And the reverse, so neither surface is merely winning by ordering.
+    applyMapBasemapAppearance({ map: builder.map, basemapConfig: null });
+    applyMapBasemapAppearance({
+      map: viewer.map,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+      idPrefix: 'viewer-',
+    });
+    expect(builder.container.hasAttribute('data-globe-space')).toBe(false);
+    expect(viewer.container.getAttribute('data-globe-space')).toBe('true');
+  });
+
+  it('does not wait for a parsed style to update the backdrop (feat(#1479))', () => {
+    // The backdrop is DOM, not style state. Riding the projection's retry
+    // would strand it behind any setProjection throw — the whole style.load
+    // window on the way in, and forever if the throw had another cause.
+    const container = document.createElement('div');
+    const unparsed = {
+      isStyleLoaded: vi.fn(() => false),
+      setProjection: vi.fn(() => { throw new Error('Style is not done loading'); }),
+      getContainer: vi.fn(() => container),
+      once: vi.fn(),
+      off: vi.fn(),
+    } as unknown as MaplibreMap;
+
+    applyMapBasemapAppearance({
+      map: unparsed,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+    });
+    expect(container.getAttribute('data-globe-space')).toBe('true');
+
+    applyMapBasemapAppearance({ map: unparsed, basemapConfig: null });
+    expect(container.hasAttribute('data-globe-space')).toBe(false);
+  });
+
+  it('tolerates a map with no container (feat(#1479))', () => {
+    expect(() =>
+      applyMapBasemapAppearance({
+        map: map(),
+        basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+      }),
+    ).not.toThrow();
   });
 
   it('lets sublayer override retry logic handle unloaded styles', () => {

--- a/frontend/src/components/builder/__tests__/map-composition-sync.test.ts
+++ b/frontend/src/components/builder/__tests__/map-composition-sync.test.ts
@@ -9,7 +9,7 @@ import {
   syncLayersToMap,
   type SyncLayerInput,
 } from '../map-sync';
-import { applyMapBasemapAppearance, syncMapComposition } from '../map-composition-sync';
+import { applyMapBasemapAppearance, hasGlobeSpaceBackdrop, syncMapComposition } from '../map-composition-sync';
 
 vi.mock('../map-sync', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../map-sync')>();
@@ -454,6 +454,24 @@ describe('map composition sync', () => {
 
     applyMapBasemapAppearance({ map: unparsed, basemapConfig: null });
     expect(container.hasAttribute('data-globe-space')).toBe(false);
+  });
+
+  it('reports the backdrop to capture paths through hasGlobeSpaceBackdrop (fix(#1479))', () => {
+    // Image captures read this instead of re-deriving globeness, so it has to
+    // track the marker exactly — including for a map that cannot be marked.
+    const target = containerMap();
+    expect(hasGlobeSpaceBackdrop(target.map)).toBe(false);
+
+    applyMapBasemapAppearance({
+      map: target.map,
+      basemapConfig: { projection: 'globe' } as MapBasemapConfig,
+    });
+    expect(hasGlobeSpaceBackdrop(target.map)).toBe(true);
+
+    applyMapBasemapAppearance({ map: target.map, basemapConfig: null });
+    expect(hasGlobeSpaceBackdrop(target.map)).toBe(false);
+
+    expect(hasGlobeSpaceBackdrop(map())).toBe(false);
   });
 
   it('tolerates a map with no container (feat(#1479))', () => {

--- a/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/use-builder-save.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createElement, type ReactNode } from 'react';
+import { MAP_COLORS } from '@/lib/map-colors';
 import { act } from '@testing-library/react';
 import { renderHook as baseRenderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -87,17 +88,42 @@ vi.mock('@/hooks/use-edition', () => ({
 /* ── Helpers ───────────────────────────────────────── */
 
 function createMockCanvas() {
+  // fix(#1479): the 2D context records its fills so the globe space backdrop
+  // painted under a capture can be asserted, along with the order — a fill
+  // after drawImage would erase the map instead of backing it.
+  const fills: { style: string; rect: number[] }[] = [];
+  const ctx = {
+    drawImage: vi.fn(),
+    fillStyle: '',
+    font: '',
+    textBaseline: '',
+    fillText: vi.fn(),
+    fillRect: vi.fn((...rect: number[]) => { fills.push({ style: ctx.fillStyle, rect }); }),
+    strokeRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+  };
   return {
     width: 800,
     height: 600,
     toBlob: vi.fn((cb: (b: Blob | null) => void) => cb(new Blob(['png'], { type: 'image/png' }))),
     toDataURL: vi.fn(() => 'data:image/jpeg;base64,abc'),
-    getContext: vi.fn(() => ({ drawImage: vi.fn() })),
+    getContext: vi.fn(() => ctx),
+    ctx,
+    fills,
   };
 }
 
-function createMockMap(overrides: { loaded?: boolean } = {}) {
+function createMockMap(overrides: { loaded?: boolean; globeSpace?: boolean } = {}) {
+  // fix(#1479): capture paths ask the container whether the space backdrop is
+  // on screen. Every mock map has one; only an opted-in map is marked.
+  const container = document.createElement('div');
+  if (overrides.globeSpace) container.setAttribute('data-globe-space', 'true');
   return {
+    getContainer: vi.fn(() => container),
     getCenter: vi.fn(() => ({ lng: -73.9, lat: 40.7 })),
     getZoom: vi.fn(() => 10),
     getBearing: vi.fn(() => 0),
@@ -1533,6 +1559,64 @@ describe('useBuilderSave', () => {
       vi.useRealTimers();
     });
 
+    it('backs thumbnail and OG crops with the globe space color (fix(#1479))', async () => {
+      // The WebGL canvas is transparent where a ray missed the planet, so a
+      // crop with nothing under it hands the encoder alpha and the sphere
+      // lands on whatever it substitutes — white for PNG, black for JPEG.
+      vi.useFakeTimers();
+      const canvases: ReturnType<typeof createMockCanvas>[] = [];
+      createElementSpy.mockImplementation((tag: string, options?: ElementCreationOptions) => {
+        if (tag !== 'canvas') return origCreateElement(tag, options);
+        const canvas = createMockCanvas();
+        canvases.push(canvas);
+        return canvas as unknown as HTMLCanvasElement;
+      });
+
+      const mockMap = createMockMap({ loaded: true, globeSpace: true });
+      await triggerSaveSuccess(mockMap);
+      act(() => { vi.advanceTimersByTime(500); });
+      await act(async () => { fireRenderCallback(mockMap); await Promise.resolve(); });
+
+      // Two crops: the 400x250 thumbnail and the 1200x630 OG image.
+      const crops = canvases.filter((c) => c.fills.length > 0);
+      expect(crops).toHaveLength(2);
+      expect(crops.map((c) => c.fills[0])).toEqual([
+        { style: MAP_COLORS.exportImage.globeBackground, rect: [0, 0, 400, 250] },
+        { style: MAP_COLORS.exportImage.globeBackground, rect: [0, 0, 1200, 630] },
+      ]);
+
+      // Under the map, not over it.
+      for (const crop of crops) {
+        expect(crop.ctx.fillRect.mock.invocationCallOrder[0])
+          .toBeLessThan(crop.ctx.drawImage.mock.invocationCallOrder[0]);
+      }
+
+      vi.useRealTimers();
+    });
+
+    it('leaves mercator crops unpainted (fix(#1479))', async () => {
+      // A mercator map fills its own canvas edge to edge, so a backdrop would
+      // be dead paint and any color drift behind it would be invisible.
+      vi.useFakeTimers();
+      const canvases: ReturnType<typeof createMockCanvas>[] = [];
+      createElementSpy.mockImplementation((tag: string, options?: ElementCreationOptions) => {
+        if (tag !== 'canvas') return origCreateElement(tag, options);
+        const canvas = createMockCanvas();
+        canvases.push(canvas);
+        return canvas as unknown as HTMLCanvasElement;
+      });
+
+      const mockMap = createMockMap({ loaded: true });
+      await triggerSaveSuccess(mockMap);
+      act(() => { vi.advanceTimersByTime(500); });
+      await act(async () => { fireRenderCallback(mockMap); await Promise.resolve(); });
+
+      expect(canvases.some((c) => c.fills.length > 0)).toBe(false);
+      expect(canvases.some((c) => c.ctx.drawImage.mock.calls.length > 0)).toBe(true);
+
+      vi.useRealTimers();
+    });
+
     it('idle event clears timeout to prevent double-capture', async () => {
       vi.useFakeTimers();
       const mockMap = createMockMap({ loaded: false });
@@ -1648,6 +1732,27 @@ describe('useBuilderSave', () => {
   });
 
   describe('handleExportPNG (idle handling)', () => {
+    // fix(#1479): the spy is installed and restored by the hooks rather than
+    // inline, so a failing assertion cannot leave it in place — a leaked spy
+    // becomes the next test's `origCreateElement` and recurses forever.
+    const origCreateElement = document.createElement.bind(document);
+    let createElementSpy: ReturnType<typeof vi.spyOn>;
+    let canvases: ReturnType<typeof createMockCanvas>[] = [];
+
+    beforeEach(() => {
+      canvases = [];
+      createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string, options?: ElementCreationOptions) => {
+        if (tag !== 'canvas') return origCreateElement(tag, options);
+        const canvas = createMockCanvas();
+        canvases.push(canvas);
+        return canvas as unknown as HTMLCanvasElement;
+      });
+    });
+
+    afterEach(() => {
+      createElementSpy.mockRestore();
+    });
+
     it('defers export via idle event when map is not loaded', () => {
       const mockMap = createMockMap({ loaded: false });
       const state = makeSaveState({ mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'] });
@@ -1656,6 +1761,52 @@ describe('useBuilderSave', () => {
       act(() => { result.current.handleExportPNG(); });
 
       expect(mockMap.once).toHaveBeenCalledWith('idle', expect.any(Function));
+    });
+
+    it('paints the space color under the map band only (fix(#1479))', () => {
+      // The chrome bands keep the white fill: exportImage.text is #0a0a0a, so
+      // darkening the whole sheet would take the title and legend with it.
+      const mockMap = createMockMap({ loaded: true, globeSpace: true });
+      const state = makeSaveState({
+        mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+        localName: 'Globe',
+        localDescription: '',
+      });
+      const { result } = renderHook(() => useBuilderSave(state));
+      act(() => { result.current.handleExportPNG(); });
+      act(() => { fireRenderCallback(mockMap); });
+
+      const sheet = canvases.find((c) => c.fills.length > 0);
+      expect(sheet).toBeDefined();
+      const [chrome, mapBand] = sheet!.fills;
+
+      // Whole sheet white first, then the map band alone in space color. The
+      // source canvas is 800x600 and a title with no description adds 56px.
+      expect(chrome.style).toBe(MAP_COLORS.exportImage.background);
+      expect(mapBand).toEqual({
+        style: MAP_COLORS.exportImage.globeBackground,
+        rect: [0, 56, 800, 600],
+      });
+      expect(sheet!.ctx.drawImage).toHaveBeenCalledWith(expect.anything(), 0, 56);
+      expect(sheet!.ctx.fillRect.mock.invocationCallOrder[1])
+        .toBeLessThan(sheet!.ctx.drawImage.mock.invocationCallOrder[0]);
+    });
+
+    it('leaves a mercator export sheet white (fix(#1479))', () => {
+      const mockMap = createMockMap({ loaded: true });
+      const state = makeSaveState({
+        mapInstanceRef: { current: mockMap } as unknown as SaveState['mapInstanceRef'],
+        localName: 'Flat',
+      });
+      const { result } = renderHook(() => useBuilderSave(state));
+      act(() => { result.current.handleExportPNG(); });
+      act(() => { fireRenderCallback(mockMap); });
+
+      const sheet = canvases.find((c) => c.fills.length > 0);
+      expect(sheet).toBeDefined();
+      expect(sheet!.fills.map((f) => f.style)).not.toContain(
+        MAP_COLORS.exportImage.globeBackground,
+      );
     });
   });
 

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import { getSourceIdForLayer } from '@/components/builder/map-sync';
+import { hasGlobeSpaceBackdrop } from '@/components/builder/map-composition-sync';
 import { ApiError } from '@/api/client';
 import { useUpdateMap, useDuplicateMap, usePatchMapLayers } from '@/hooks/use-maps';
 import { useEnabledPlugins } from '@/hooks/use-settings';
@@ -34,8 +35,19 @@ import { getLayerCapabilities, isFolderGroupLayer } from '@/lib/layer-capabiliti
  *
  *  SHARE-08 (Phase 1142): extracted from the former inline doCapture crop block
  *  to allow two crops (400×250 thumbnail, 1200×630 OG image) to share one
- *  render event with a single triggerRepaint(). */
-function cropResize(srcCanvas: HTMLCanvasElement, targetW: number, targetH: number): HTMLCanvasElement {
+ *  render event with a single triggerRepaint().
+ *
+ *  fix(#1479 Codex P2 round 1): `backdrop` is painted under the crop when the
+ *  globe space backdrop is on screen. The WebGL canvas is transparent wherever
+ *  a ray missed the planet, so without it the sphere lands on whatever the
+ *  encoder substitutes for alpha — white once composited, black for JPEG,
+ *  neither of them the space color the map is actually showing. */
+function cropResize(
+  srcCanvas: HTMLCanvasElement,
+  targetW: number,
+  targetH: number,
+  backdrop?: string,
+): HTMLCanvasElement {
   const targetRatio = targetW / targetH;
   const srcW = srcCanvas.width;
   const srcH = srcCanvas.height;
@@ -55,6 +67,10 @@ function cropResize(srcCanvas: HTMLCanvasElement, targetW: number, targetH: numb
   offscreen.height = targetH;
   const ctx = offscreen.getContext('2d');
   if (ctx) {
+    if (backdrop) {
+      ctx.fillStyle = backdrop;
+      ctx.fillRect(0, 0, targetW, targetH);
+    }
     ctx.drawImage(srcCanvas, cropX, cropY, cropW, cropH, 0, 0, targetW, targetH);
   }
   return offscreen;
@@ -77,9 +93,15 @@ function doCapture(map: MaplibreMap, mapId: string, queryClient: ReturnType<type
   const onRender = () => {
     try {
       const srcCanvas = map.getCanvas();
+      // fix(#1479 Codex P2 round 1): both crops carry the space backdrop when
+      // the map is showing one, so a globe map's thumbnail and OG card match
+      // the builder instead of putting the sphere back on a flat background.
+      const backdrop = hasGlobeSpaceBackdrop(map)
+        ? MAP_COLORS.exportImage.globeBackground
+        : undefined;
 
       // 400×250 thumbnail — unchanged behavior
-      const thumb = cropResize(srcCanvas, 400, 250);
+      const thumb = cropResize(srcCanvas, 400, 250, backdrop);
       uploadThumbnail(mapId, thumb.toDataURL('image/jpeg', 0.7)).then(() => {
         // chore(#1021): this refetches nothing on the builder route, and that is
         // expected rather than a bug. maps.all is ['maps'] while the builder mounts
@@ -97,7 +119,7 @@ function doCapture(map: MaplibreMap, mapId: string, queryClient: ReturnType<type
       });
 
       // 1200×630 OG image — fire-and-forget, isolated failure (SHARE-08)
-      const og = cropResize(srcCanvas, 1200, 630);
+      const og = cropResize(srcCanvas, 1200, 630, backdrop);
       uploadOgImage(mapId, og.toDataURL('image/jpeg', 0.85)).catch(() => {
         if (import.meta.env.DEV) console.warn('[og-image] capture upload failed');
       });
@@ -896,6 +918,15 @@ export function useBuilderSave(state: SaveState) {
             cursorY += titleBlockH;
           }
 
+          // fix(#1479 Codex P2 round 1): the map band, and only the map band,
+          // gets the space color under the canvas — the globe's void is
+          // transparent, so it would otherwise composite onto the white fill
+          // above and export as a sphere on white. The title/legend/footer
+          // bands stay white because their text is #0a0a0a on white by design.
+          if (hasGlobeSpaceBackdrop(map)) {
+            ctx.fillStyle = MAP_COLORS.exportImage.globeBackground;
+            ctx.fillRect(0, cursorY, totalW, mapHeight);
+          }
           ctx.drawImage(srcCanvas, 0, cursorY);
           cursorY += mapHeight;
 

--- a/frontend/src/components/builder/map-composition-sync.ts
+++ b/frontend/src/components/builder/map-composition-sync.ts
@@ -82,6 +82,28 @@ function applySky(map: MaplibreMap, isGlobe: boolean) {
   skyStates.set(map, { applied: map.getSky?.(), base });
 }
 
+// feat(#1479): the void behind the sphere, which no sky value can reach — the
+// atmosphere pass returns alpha 0 for rays that miss the planet, the canvas
+// clears transparent, and the style's `background` layer is drawn per tile so
+// it stays clipped to the sphere. What shows through the miss is the page
+// behind the canvas, so the treatment is a background on the map container and
+// the color lives in `index.css` against this marker.
+//
+// A dedicated attribute rather than writing container.style.backgroundColor
+// keeps the value out of the component (DESIGN-GUIDE) and gives the mercator
+// path the discipline #1474 needed for sky: we add and remove exactly the one
+// attribute we own, so reverting cannot clobber a background that belongs to
+// someone else.
+const GLOBE_SPACE_ATTR = 'data-globe-space';
+
+function applySpaceBackdrop(map: MaplibreMap, isGlobe: boolean) {
+  // Partial map mocks in tests lack `getContainer`, hence the optional call.
+  const container = map.getContainer?.();
+  if (!container) return;
+  if (isGlobe) container.setAttribute(GLOBE_SPACE_ATTR, 'true');
+  else container.removeAttribute(GLOBE_SPACE_ATTR);
+}
+
 function sourcePrefixFor(idPrefix: string | undefined) {
   return idPrefix ? `${idPrefix}source-` : 'source-';
 }
@@ -136,6 +158,12 @@ export function applyMapBasemapAppearance({
     pendingRootStyleRetries.delete(map);
   }
   const projection = basemapConfig?.projection ?? 'mercator';
+  // feat(#1479): the backdrop is DOM state, not style state, so it does not
+  // share setProjection's parsed-style precondition and is applied outside the
+  // retry below. Inside it, a throw from either maplibre call would strand the
+  // backdrop out of step with the projection until `style.load` — permanently
+  // if the throw came from anything other than an unparsed style.
+  applySpaceBackdrop(map, projection === 'globe');
   const applyRootStyle = () => {
     pendingRootStyleRetries.delete(map);
     try {

--- a/frontend/src/components/builder/map-composition-sync.ts
+++ b/frontend/src/components/builder/map-composition-sync.ts
@@ -104,6 +104,19 @@ function applySpaceBackdrop(map: MaplibreMap, isGlobe: boolean) {
   else container.removeAttribute(GLOBE_SPACE_ATTR);
 }
 
+/**
+ * Whether `map` is currently showing the globe space backdrop.
+ *
+ * fix(#1479 Codex P2 round 1): image captures have to paint the same void the
+ * screen does, and this is the one predicate that answers "is space showing
+ * right now" — asking the container what it was marked with, rather than
+ * re-deriving globeness from projection state, is what keeps a capture from
+ * ever disagreeing with the pixels it is capturing.
+ */
+export function hasGlobeSpaceBackdrop(map: MaplibreMap): boolean {
+  return map.getContainer?.()?.hasAttribute(GLOBE_SPACE_ATTR) ?? false;
+}
+
 function sourcePrefixFor(idPrefix: string | undefined) {
   return idPrefix ? `${idPrefix}source-` : 'source-';
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -93,6 +93,16 @@
   --map-street: oklch(0.82 0.004 85);
   --map-water:  oklch(0.85 0.02 220);
 
+  /* ─ Globe space ─
+     feat(#1479): the void behind the sphere on globe-projection maps. Has no
+     dark-mode counterpart on purpose — space is the same dark in both themes,
+     and a light value is exactly what makes the globe read as a sticker on
+     white. Sits a little below the dark theme's --background (0.145) so the
+     void reads as deeper than the chrome around it instead of continuous with
+     it, and carries enough chroma to stay a night sky rather than a black
+     rectangle. */
+  --map-space: oklch(0.13 0.03 265);
+
   /* ─ Shadow tokens (light mode) ─ */
   --elevation-xs: 0 1px 1px oklch(0 0 0 / 4%);
   --elevation-sm: 0 1px 2px oklch(0 0 0 / 5%);
@@ -577,6 +587,24 @@
  */
 [data-builder-canvas="true"] [data-coord-readout="true"] {
   top: 3rem; /* 48px — below the centered MapToolbar band */
+}
+
+/* ── Globe projection: the space behind the sphere ─────────────────────────
+ * feat(#1479): nothing inside a MapLibre style can paint the void a globe
+ * leaves around itself. The atmosphere pass added in #1473/#1474 returns
+ * alpha 0 for rays that miss the planet, the canvas clears transparent, and
+ * the style's `background` layer is drawn per tile so it stays clipped to the
+ * sphere. What shows through is whatever is behind the canvas — the page — so
+ * the treatment has to live on the map container.
+ *
+ * The marker is set by `applyMapBasemapAppearance` in `map-composition-sync`
+ * whenever basemap_config.projection is `globe` and removed on mercator, so
+ * the builder and the viewer both inherit it from the one place that already
+ * owns projection state. Scoped to `.maplibregl-map` so the attribute can only
+ * ever paint a map container.
+ */
+.maplibregl-map[data-globe-space="true"] {
+  background-color: var(--map-space);
 }
 
 /* ── MapLibre Popup Styling ─────────────────────────── */

--- a/frontend/src/lib/__tests__/map-colors.test.ts
+++ b/frontend/src/lib/__tests__/map-colors.test.ts
@@ -85,6 +85,14 @@ describe('MAP_COLORS design-token parity', () => {
     expect(MAP_COLORS.default.stroke).toBe(oklchToSrgbHex(readOklchToken(root, '--primary-700')));
   });
 
+  it('keeps the globe export backdrop synchronized with --map-space (fix(#1479))', () => {
+    // Captures composite the WebGL canvas onto a 2D context, which cannot read
+    // a CSS token, so the globe void's color exists twice. This pins the copy.
+    expect(MAP_COLORS.exportImage.globeBackground).toBe(
+      oklchToSrgbHex(readOklchToken(root, '--map-space')),
+    );
+  });
+
   it('keeps non-frozen categorical colors synchronized with light --viz-2..8', () => {
     const tokenColors = Array.from({ length: 7 }, (_, index) =>
       oklchToSrgbHex(readOklchToken(root, `--viz-${index + 2}`)),

--- a/frontend/src/lib/map-colors.ts
+++ b/frontend/src/lib/map-colors.ts
@@ -100,6 +100,13 @@ export const MAP_COLORS = {
     text: '#0a0a0a',
     mutedText: '#666666',
     attribution: '#999999',
+    /** fix(#1479 Codex P2 round 1): the void a globe leaves around itself is
+     *  transparent in the WebGL canvas, so a capture composited over
+     *  `background` puts the sphere back on white — the exact problem #1479
+     *  fixes on screen. Captures fill the map region with this instead
+     *  whenever the on-screen space backdrop is active. It is the sRGB form of
+     *  the `--map-space` token, held to it by map-colors.test.ts. */
+    globeBackground: '#030713',
   },
   /** Transparent MapLibre paint value. */
   transparent: 'rgba(0,0,0,0)',


### PR DESCRIPTION
## What

Globe-projection maps now paint a deep-space tone behind the sphere. `applyMapBasemapAppearance` marks the MapLibre container with `data-globe-space="true"` while `basemap_config.projection` is `globe`, and strips the marker on mercator; `index.css` hangs a new `--map-space` token off that marker, scoped to `.maplibregl-map`.

The builder and the viewer already route projection through `applyMapBasemapAppearance`, so both pick this up from one place and neither needs its own copy of the keying. No schema change, and no new translation keys.

## Why

Fixes #1479. The atmosphere from #1473/#1474 gave the sphere its limb halo, but the void around it kept rendering as the page background, so on the light theme a globe map read as a sticker on white.

No sky value can reach that region, which is what makes this DOM work rather than another `setSky` change. The atmosphere pass returns alpha 0 for rays that miss the planet, the canvas clears transparent, and the style's `background` layer is drawn per tile so it stays clipped to the sphere. What shows through is the element behind the canvas.

## Relationship to #1474

Additive, and it touches no part of the sky handling. The halo now has a dark backdrop to sit against instead of white.

It does follow #1474's restore discipline, adapted to the DOM. There, handing back a sky spec that never mentioned `atmosphere-blend` failed to remove the override, because MapLibre's diff only walks the keys you pass; the fix was to name the property explicitly. The DOM equivalent is to own a dedicated attribute rather than write `container.style.backgroundColor`, so reverting removes exactly what we set and cannot clobber a background belonging to something else.

One deliberate difference: the marker is applied *outside* the parsed-style retry that projection and sky share. It is DOM state with no such precondition, and riding the retry would strand it behind any `setProjection` throw, for the whole `style.load` window on the way in and permanently if the throw had another cause. `map-composition-sync.test.ts` pins that with an always-throwing `setProjection`.

## Theme

The token is defined in `:root` only, with no `.dark` counterpart. Space is the same dark in both themes, and a light-mode variant would reintroduce the bug. The value sits a little below the dark theme's `--background` so the void reads as deeper than the chrome around it rather than continuous with it.

## Verification

- `npx vitest run src/components/builder/__tests__/map-composition-sync.test.ts`: 14 passed, 5 new covering the projection-toggle lifecycle. Applies on globe; reverts on both `projection: 'mercator'` and a config that never named one; stays off a container it never marked; no leak between two map surfaces, asserted in both orders; applies without a parsed style; tolerates a map with no container.
- `npx vitest run src/components/builder/__tests__/`: 98 files, 1707 passed.
- `npx vitest run src/components/viewer/__tests__/`: 17 files, 107 passed.
- `npx vitest run src/lib/__tests__/map-colors.test.ts src/lib/__tests__/warning-foreground-usage.test.ts`: the two suites that parse `index.css`; passed.
- `npm run typecheck`, `npm run lint`: clean.
- `npm run build`, then grepped the emitted CSS, since jsdom applies no stylesheets and the unit tests can only assert the attribute. The rule survives minification with its scope intact: `.maplibregl-map[data-globe-space=true]{background-color:var(--map-space)}`, with `--map-space:oklch(13% .03 265)`.

## Screenshots

N/A from here. Live visual QA is pending the orchestrator, since Playwright MCP is orchestrator-only.

Fixes #1479
