### PR TITLE
fix(audit): serialize audit details through JSON mode so date fields cannot 500 the mutation

### DIFF
--- a/backend/app/modules/catalog/collections/router.py
+++ b/backend/app/modules/catalog/collections/router.py
@@ -253,7 +253,9 @@ async def update_collection_endpoint(
             action="collection.update",
             resource_type="collection",
             resource_id=collection_id,
-            details=body.model_dump(exclude_none=True),
+            # fix(#1484): mode="json" so a future non-JSON scalar on
+            # CollectionUpdate cannot reach the JSONB column as a raw object.
+            details=body.model_dump(mode="json", exclude_none=True),
             ip_address=request.client.host if request.client else None,
         ),
     )

--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -377,7 +377,11 @@ async def update_dataset_metadata(
             resource_id=dataset_id,
             # exclude_unset, not exclude_none: an explicit null clear
             # (#458 E-04) must appear in the audit/history details.
-            details=meta.model_dump(exclude_unset=True),
+            # fix(#1484): mode="json" — details lands in a JSONB column that
+            # serializes with stdlib json.dumps, and data_vintage_start/end are
+            # real date objects. A python-mode dump raised at flush time and
+            # rolled back the record UPDATE staged above it.
+            details=meta.model_dump(mode="json", exclude_unset=True),
             ip_address=request.client.host if request.client else None,
         ),
     )

--- a/backend/tests/test_audit_details_json_1484.py
+++ b/backend/tests/test_audit_details_json_1484.py
@@ -1,0 +1,286 @@
+"""Audit ``details`` payloads must be JSON-safe before they reach JSONB (#1484).
+
+``audit_logs.details`` is a JSONB column and the engine configures no
+``json_serializer``, so SQLAlchemy serializes it with stdlib ``json.dumps``.
+A python-mode ``model_dump()`` leaves ``date``/``datetime``/``UUID``/``Decimal``
+objects intact, and stdlib json cannot encode any of them.
+
+Why that is worse than a broken audit row: the ``TypeError`` surfaces at FLUSH
+time, not at ``audit_emit()`` time. ``audit_emit`` isolates sink failures
+(AUDIT-03), but the sink only calls ``session.add()`` — the INSERT is emitted
+later, inside the caller's commit, outside that try/except. So the failure
+rolls back the whole request transaction and takes the user's already-staged
+mutation with it. On the live demo a
+``PATCH /datasets/{id} {"data_vintage_start": "1950-01-01"}`` 500'd and silently
+discarded the license/keyword edits sent in the same body.
+
+Two regression tests pin the observable behaviour, and one structural test
+pins the class so a new call site cannot reintroduce it.
+"""
+
+import ast
+import pathlib
+import uuid
+from datetime import date
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.modules.audit.models import AuditLog
+from tests.factories import create_collection_via_api, create_dataset, get_user_id
+
+pytestmark = pytest.mark.anyio
+
+
+async def _latest_details(session, action: str, resource_id: uuid.UUID) -> dict:
+    """Return the newest audit row's details for one action/resource."""
+    # The handler committed on its own connection; drop any snapshot this
+    # session is holding so the SELECT below sees that commit.
+    await session.rollback()
+    row = (
+        await session.execute(
+            select(AuditLog.details)
+            .where(AuditLog.action == action, AuditLog.resource_id == resource_id)
+            .order_by(AuditLog.created_at.desc(), AuditLog.id.desc())
+            .limit(1)
+        )
+    ).scalar_one()
+    return row
+
+
+async def test_patch_dataset_vintage_dates_succeed_and_audit_iso_strings(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """The live 500 from #1484, end to end.
+
+    Sends the vintage dates together with a plain-string field so the test also
+    proves the co-staged record UPDATE survives: before the fix the audit INSERT
+    rolled back the whole transaction, and ``license`` was lost with it.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    ds = await create_dataset(
+        session, created_by=admin_id, name=f"Vintage {uuid.uuid4().hex[:6]}"
+    )
+
+    resp = await client.patch(
+        f"/datasets/{ds.id}",
+        json={
+            "data_vintage_start": "1950-01-01",
+            "data_vintage_end": "1999-12-31",
+            "license": "https://creativecommons.org/licenses/by/4.0/",
+        },
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # The mutation itself is durable, including the field that used to be
+    # collateral damage.
+    got = (await client.get(f"/datasets/{ds.id}", headers=admin_auth_header)).json()
+    assert got["data_vintage_start"] == "1950-01-01"
+    assert got["data_vintage_end"] == "1999-12-31"
+    assert got["license"] == "https://creativecommons.org/licenses/by/4.0/"
+
+    # And the audit row records the edit as ISO strings rather than failing to
+    # serialize. Asserting the stored value (not just a 200) is the point: an
+    # engine-level ``default=str`` would also return 200 here while silently
+    # stringifying every other type.
+    details = await _latest_details(session, "metadata.edit", ds.id)
+    assert details["data_vintage_start"] == "1950-01-01"
+    assert details["data_vintage_end"] == "1999-12-31"
+    assert details["license"] == "https://creativecommons.org/licenses/by/4.0/"
+
+
+async def test_patch_dataset_vintage_null_clear_still_audits(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """``exclude_unset`` semantics survive the mode switch.
+
+    ``mode="json"`` must not turn an explicit null-clear into an absent key —
+    that distinction is load-bearing for the history feed (#458 E-04).
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    ds = await create_dataset(
+        session,
+        created_by=admin_id,
+        name=f"VintageClear {uuid.uuid4().hex[:6]}",
+        temporal_start=date(1950, 1, 1),
+        temporal_end=date(1999, 12, 31),
+    )
+
+    resp = await client.patch(
+        f"/datasets/{ds.id}",
+        json={"data_vintage_start": None},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+
+    details = await _latest_details(session, "metadata.edit", ds.id)
+    assert "data_vintage_start" in details
+    assert details["data_vintage_start"] is None
+    # Unset fields stay out of the payload.
+    assert "data_vintage_end" not in details
+
+
+async def test_collection_update_audit_details_round_trip(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+):
+    """The sibling ``model_dump`` site keeps recording what changed.
+
+    ``CollectionUpdate`` carries only ``str | None`` fields today, so this site
+    could not 500 — the ``mode="json"`` there is preventive. What this test pins
+    is that making it preventive did not change the payload it records.
+    """
+    session = test_db_session
+    coll = await create_collection_via_api(client, admin_auth_header)
+    coll_id = uuid.UUID(coll["id"])
+
+    resp = await client.patch(
+        f"/catalog/collections/{coll_id}",
+        json={"name": "Renamed collection", "description": "Edited description"},
+        headers=admin_auth_header,
+    )
+    assert resp.status_code == 200, resp.text
+
+    details = await _latest_details(session, "collection.update", coll_id)
+    assert details == {
+        "name": "Renamed collection",
+        "description": "Edited description",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Structural guard
+# ---------------------------------------------------------------------------
+
+_APP_ROOT = pathlib.Path(__file__).resolve().parents[1] / "app"
+
+
+def _is_model_dump(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "model_dump"
+    )
+
+
+def _dumps_json(call: ast.Call) -> bool:
+    """True only when ``mode`` is provably the literal ``"json"``.
+
+    ``mode`` is ``model_dump``'s first positional parameter, so both spellings
+    count. A non-literal (``mode=some_var``) is NOT provable and is reported —
+    this guard fails loudly rather than assuming.
+    """
+    if call.args and isinstance(call.args[0], ast.Constant):
+        return call.args[0].value == "json"
+    for kw in call.keywords:
+        if kw.arg == "mode":
+            return isinstance(kw.value, ast.Constant) and kw.value.value == "json"
+    return False
+
+
+def _model_dumps_in(node: ast.AST) -> list[ast.Call]:
+    return [child for child in ast.walk(node) if _is_model_dump(child)]
+
+
+def _python_mode_details_dumps(tree: ast.AST) -> list[int]:
+    """Return the line of every ``details=`` payload built by a python-mode dump.
+
+    Scope is every ``details=`` keyword argument, not just the ones passed
+    straight to ``AuditEvent``/``log_action``: forwarding helpers
+    (``_propagate_record_write``, ``record_map_history_event``) take the same
+    kwarg and hand it to the same columns, and a rule that only matched the
+    direct calls would miss them.
+
+    Resolution is lexical, within one enclosing function: a dump written inline
+    (``details=body.model_dump(...)``), spread into a literal
+    (``details={**body.model_dump(...), "x": 1}``), or assigned to the name that
+    is then passed (``payload = body.model_dump(...)`` ... ``details=payload``).
+    """
+    # A function plus the module body: enough to resolve `x = ...dump()`
+    # followed by `details=x`. Nested functions get walked by their parent too,
+    # which only ever widens what this sees.
+    scopes: list[ast.AST] = [tree] + [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    ]
+    lines: set[int] = set()
+    for scope in scopes:
+        assigned: dict[str, list[ast.Call]] = {}
+        for node in ast.walk(scope):
+            if not isinstance(node, ast.Assign):
+                continue
+            dumps = _model_dumps_in(node.value)
+            if not dumps:
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assigned.setdefault(target.id, []).extend(dumps)
+
+        for node in ast.walk(scope):
+            if not isinstance(node, ast.Call):
+                continue
+            for kw in node.keywords:
+                if kw.arg != "details":
+                    continue
+                dumps = list(_model_dumps_in(kw.value))
+                if isinstance(kw.value, ast.Name):
+                    dumps.extend(assigned.get(kw.value.id, []))
+                lines.update(d.lineno for d in dumps if not _dumps_json(d))
+    return sorted(lines)
+
+
+def test_audit_details_payloads_never_use_a_python_mode_model_dump():
+    """No ``details=`` payload under app/ is built by a python-mode model dump.
+
+    Known limit, stated rather than implied: a dump that reaches a ``details=``
+    site with no lexical trace in the same function — built in another module,
+    pulled from a container, arriving as a parameter — is not recognizable to
+    any AST rule and this guard does not claim it. Every payload that reaches
+    audit today is either one of the shapes above or a hand-built literal of
+    strings, ints, and bools.
+    """
+    violations = [
+        f"{path.relative_to(_APP_ROOT.parent)}:{line}"
+        for path in sorted(_APP_ROOT.rglob("*.py"))
+        for line in _python_mode_details_dumps(ast.parse(path.read_text()))
+    ]
+
+    assert not violations, (
+        'audit `details=` payloads must be built with model_dump(mode="json") '
+        "— a python-mode dump puts date/datetime/UUID/Decimal objects into a "
+        "JSONB column that serializes with stdlib json.dumps, which raises at "
+        "flush time and rolls back the caller's mutation (#1484). "
+        f"Offending sites: {violations}"
+    )
+
+
+def test_structural_guard_detects_a_python_mode_dump():
+    """The guard above asserts an absence; this proves it can still see one.
+
+    Without this, gutting ``_python_mode_details_dumps`` would leave a
+    permanently green test. Exercises the real resolver, not a copy of it.
+    """
+    sample = ast.parse(
+        "def handler(body, other, chosen):\n"
+        "    payload = body.model_dump(exclude_unset=True)\n"
+        "    emit(details=payload)\n"  # line 3: via variable
+        "    emit(details=other.model_dump())\n"  # line 4: inline
+        "    emit(details={**other.model_dump(), 'k': 1})\n"  # line 5: spread
+        "    emit(details=other.model_dump(mode=chosen))\n"  # line 6: unprovable
+        "    emit(details=other.model_dump(mode='json'))\n"  # clean
+        "    emit(details=other.model_dump('json'))\n"  # clean (positional)
+        "    emit(details={'k': 1})\n"  # clean (no dump)
+    )
+    # Line 2 is where the via-variable dump is written, so that is the line
+    # reported for the line-3 call site.
+    assert _python_mode_details_dumps(sample) == [2, 4, 5, 6]


### PR DESCRIPTION
## Problem

`PATCH /api/datasets/{id}` with `{"data_vintage_start": "1950-01-01"}` returned 500 and silently discarded every other field sent in the same body. Reported in #1484, found live on the demo at 1.13.0.

## Chain

1. Pydantic parses `data_vintage_start` into a real `datetime.date` (`DatasetMeta`).
2. The PATCH handler built its audit payload with a python-mode `model_dump`, so the `date` object survived into the details dict.
3. `audit_logs.details` is JSONB and the engine configures no `json_serializer`, so SQLAlchemy encodes it with stdlib `json.dumps` — which cannot encode a `date`.
4. The `TypeError` surfaces at **flush** time, not at `audit_emit` time. `audit_emit` isolates sink failures per AUDIT-03, but the sink only calls `session.add()`; the INSERT is emitted later inside the caller's commit, outside that `try/except`. The exception therefore rolls back the whole request transaction and takes the already-staged record UPDATE with it — license, keywords, and theme sent in the same PATCH are lost too.

## Sweep

`details` is typed `dict | None` and nothing checks JSON-safety at the boundary, so this is a class, not an instance. I walked the AST of every module under `backend/app/` and enumerated all 126 `details=` keyword arguments (97 passed directly to `AuditEvent`/`log_action`, 29 through forwarding helpers). Disposition:

| Shape | Count | Disposition |
|---|---|---|
| `meta.model_dump(exclude_unset=True)` — `datasets/api/router.py` | 1 | **Fixed.** `DatasetMeta.data_vintage_start`/`_end` are `date`. This is the live 500. |
| `body.model_dump(exclude_none=True)` — `collections/router.py` | 1 | **Fixed, preventive.** `CollectionUpdate` is `name`/`description`, both `str \| None`, so this site could not 500 today. Changed so a future field addition cannot make it. |
| Literal dicts of `str`/`int`/`bool` | 89 | No change needed. UUIDs are already `str(...)`-converted and datetimes already `.isoformat()`-converted at the call site (e.g. the audit-export `filters` dict, `router_operations.py`'s `expires_at`). |
| `details` bound to a literal dict in the same function (`admin/router.py`, `audit/router.py`, `records/router.py`, `refresh/service.py`, `jobs/router.py`) | 12 | No change needed. Traced each to its assignment; all are literal dicts of scalars. |
| `{**spread, ...}` from an internal result dict | 6 | No change needed. Traced each source: `StaleJobSweepOutcome.as_dict()` is annotated `dict[str, int]`, the rest are counts and fixed strings. |
| Reads out of the column, not writes into it (`AuditLogResponse(details=log.details)`) | 4 | Out of scope — these render a value the DB already returned as JSON. |
| `MapEditHistoryEvent` via `record_map_history_event` | 13 | Already safe. `service_history.py:47` runs its payload through `jsonable_encoder`, so the sibling history table never had this bug. |

`Visibility` is a `Literal` of strings, not an `Enum`, so no enum member reaches a details payload.

## Why per-site `mode="json"` and not an engine-level serializer

An engine-level `json_serializer=partial(json.dumps, default=str)` would also make the 500 go away, and it is the wrong fix: it silently stringifies *every* type in *every* JSON column, so a future mistake gets a plausible-looking `"2026-08-14 00:00:00+00:00"` in the audit trail instead of a loud failure. Per-site `mode="json"` produces the ISO-8601 form Pydantic already uses everywhere else in the API, and leaves unexpected types loud.

## Preventing the class

`tests/test_audit_details_json_1484.py::test_audit_details_payloads_never_use_a_python_mode_model_dump` walks every `details=` keyword argument under `backend/app/` and fails any whose value resolves to a `model_dump` without `mode="json"`. It resolves three shapes lexically within one enclosing function: inline, spread into a literal (`{**body.model_dump(), ...}`), and assigned-then-passed. `mode=<variable>` is not provable and is reported rather than assumed.

It covers `details=` on *any* callee, not just `AuditEvent`/`log_action`, because the forwarding helpers (`_propagate_record_write`, `record_map_history_event`) take the same kwarg into the same columns.

Known limit, stated rather than implied: a dump reaching a `details=` site with no lexical trace in the same function is not recognizable to any AST rule and the guard does not claim it. A companion test (`test_structural_guard_detects_a_python_mode_dump`) calls the real resolver against a synthetic sample, so gutting the detection logic cannot leave a permanently green assertion-of-absence.

## Verification

Both directions checked, not just the green one. Against `origin/main`'s version of the two files the guard reports exactly `router.py:380` and `collections/router.py:256` and nothing else. With the fix reverted in place, the regression test fails with the same error the issue's live traceback shows:

```
sqlalchemy.exc.StatementError: (builtins.TypeError) Object of type date is not JSON serializable
```

Commands run from `backend/` with `.env.test` sourced:

```
uv run pytest tests/test_audit_details_json_1484.py -q                      # 5 passed
uv run pytest tests/test_collections.py tests/test_metadata_roundtrip.py \
              tests/test_audit.py -q                                        # 60 passed (incl. the new file)
uv run pytest tests/test_datasets.py tests/test_dataset_history_redaction.py \
              tests/test_audit_sink.py tests/test_audit_column_ddl_feed.py \
              tests/test_dataset_attribution.py -q                          # 114 passed
uv run pytest tests/test_layering.py -q                                     # 47 passed
uv run ruff check . && uv run ruff format --check .                         # clean
```

The null-clear test pins that `mode="json"` did not disturb `exclude_unset` semantics — an explicit `null` still appears in the details payload, which the history feed depends on (#458 E-04).

## Out of scope, worth a follow-up

AUDIT-03 says audit sinks must not break callers, and `audit_emit` implements that with a `try/except` around each sink. That guarantee is only half-real: the sink stages an ORM object, so any error in *writing* it lands at the caller's flush, outside the isolation. This PR removes the known way to trigger it, but the structural gap — an audit-row defect can still destroy a user's mutation — remains. Worth deciding deliberately whether audit failures should fail closed (reject the mutation) or be dropped with a loud log, rather than inheriting whichever one flush ordering produces.

Fixes #1484