### PR TITLE
fix(observability): log production tracebacks plain so an exception cannot pin the event loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,10 +157,13 @@ GEOLENS_ADMIN_PASSWORD=
 # PUBLIC_BASE_URL=
 
 # --- Deployment environment ---
-# Controls security-sensitive behavior: API docs exposure (/docs, /redoc) and
-# the Secure flag on the OAuth session cookie.
+# Controls security-sensitive behavior: API docs exposure (/docs, /redoc), the
+# Secure flag on the OAuth session cookie, and how tracebacks are rendered.
 #   development -> docs enabled, session cookie WITHOUT Secure (safe for HTTP)
 #   production  -> docs disabled, session cookie WITH Secure (HTTPS only)
+# Production also formats tracebacks with the stdlib traceback module instead
+# of rich, so logging an exception cannot spend minutes rendering frame locals
+# on the event loop (#1485).
 # Set this to "production" on every public-facing, TLS-terminated deployment.
 # If unset, the app falls back to using LOG_JSON as the production indicator
 # (backward compatibility with deployments configured before this setting).

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -65,7 +65,11 @@ from slowapi.middleware import SlowAPIMiddleware
 import slowapi.middleware as slowapi_middleware_module
 
 # Configure structured logging before app creation so lifespan logs are structured
-setup_logging(json_logs=settings.log_json, log_level=settings.log_level)
+setup_logging(
+    json_logs=settings.log_json,
+    log_level=settings.log_level,
+    production=settings.is_production,
+)
 structlog.contextvars.bind_contextvars(service="api")
 
 logger = structlog.stdlib.get_logger(__name__)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -175,7 +175,10 @@ class Settings(BaseSettings):
     # behaviors — API docs exposure (/docs, /redoc) and the Secure flag on the
     # OAuth session cookie (SessionMiddleware https_only). Previously these were
     # keyed off LOG_JSON, an innocuously-documented log-format flag.
-    #   "production"  -> hardened posture (docs hidden, Secure cookie)
+    # fix(#1485): also selects plain traceback rendering, because rich's
+    # frame-locals tables made one exception a multi-minute event-loop stall.
+    #   "production"  -> hardened posture (docs hidden, Secure cookie,
+    #                    plain tracebacks)
     #   "development" -> open posture (docs shown, no Secure cookie)
     #   unset (None)  -> fall back to LOG_JSON for backward compatibility
     # Set ENVIRONMENT=production on any public, TLS-terminated deployment.
@@ -860,8 +863,8 @@ class Settings(BaseSettings):
 
     @property
     def is_production(self) -> bool:
-        """Whether to enforce the production security posture (API docs hidden,
-        Secure session cookie).
+        """Whether to enforce the production posture (API docs hidden, Secure
+        session cookie, plain tracebacks).
 
         SEC-005: driven by the explicit ENVIRONMENT setting. When ENVIRONMENT is
         unset, fall back to LOG_JSON (the de-facto production switch before this

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -5,6 +5,21 @@ structlog chain so JWT / API-key / password values are replaced with
 `[REDACTED]` before reaching stdout / log aggregators. Even if a developer
 accidentally logs `logger.info("attempt", token=jwt)`, the token is
 redacted at the structlog layer.
+
+fix(#1485): exception rendering is never handed to rich in production.
+`structlog.dev.ConsoleRenderer` defaults its `exception_formatter` to
+`RichTracebackFormatter(show_locals=True)` whenever rich is importable, and
+rich is in the backend's transitive dependency set. Rendering per-frame
+locals costs time proportional to the `repr()` of every local in every frame,
+and rich's line splitting is quadratic in the length of a single long line —
+so one exception raised with ORM objects in scope burned minutes of
+synchronous CPU inside the logging call, on the event loop, in the request
+path. With `--workers 1` that is the whole API.
+
+`RichTracebackFormatter`'s `locals_max_length` / `locals_max_string` do not
+bound it: they truncate containers and `str` values, not the `repr()` of an
+arbitrary object, which is exactly what a SQLAlchemy session or model
+instance produces.
 """
 
 import logging
@@ -54,8 +69,30 @@ def _redact_sensitive_fields(
     return event_dict
 
 
-def setup_logging(json_logs: bool = False, log_level: str = "INFO") -> None:
-    """Configure structlog + stdlib logging with shared processor chain."""
+def _dev_exception_formatter() -> structlog.types.ExceptionRenderer:
+    """The console exception formatter for non-production deployments.
+
+    Keeps rich's syntax-highlighted frames, which are the reason the pretty
+    renderer is worth having, and drops only the per-frame locals tables — the
+    part whose cost is unbounded (see the module docstring). Deployments
+    without rich installed keep whatever structlog picked for them.
+    """
+    formatter = structlog.dev.default_exception_formatter
+    if isinstance(formatter, structlog.dev.RichTracebackFormatter):
+        return structlog.dev.RichTracebackFormatter(show_locals=False)
+    return formatter
+
+
+def setup_logging(
+    json_logs: bool = False, log_level: str = "INFO", *, production: bool = False
+) -> None:
+    """Configure structlog + stdlib logging with shared processor chain.
+
+    `production` selects the exception-rendering posture rather than the log
+    format: when set, tracebacks are formatted by the stdlib `traceback`
+    module and rich is never reached, at a cost that does not depend on the
+    size of any frame's local variables.
+    """
     shared_processors: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_logger_name,
@@ -71,7 +108,12 @@ def setup_logging(json_logs: bool = False, log_level: str = "INFO") -> None:
         structlog.processors.StackInfoRenderer(),
     ]
 
-    if json_logs:
+    # fix(#1485): resolve `exc_info` into a plain `exception` string inside the
+    # processor chain, so no renderer is ever handed a traceback object to
+    # pretty-print. This chain is also the ProcessorFormatter's
+    # `foreign_pre_chain` below, so it covers stdlib records (uvicorn.error and
+    # friends) as well as structlog's own.
+    if json_logs or production:
         shared_processors.append(structlog.processors.format_exc_info)
 
     structlog.configure(
@@ -85,8 +127,19 @@ def setup_logging(json_logs: bool = False, log_level: str = "INFO") -> None:
     log_renderer: structlog.types.Processor
     if json_logs:
         log_renderer = structlog.processors.JSONRenderer()
+    elif production:
+        # `plain_traceback` is the second half of the #1485 fix, not a
+        # redundant one: ConsoleRenderer warns on every exception when a
+        # non-plain formatter meets an already-rendered `exception` field
+        # ("Remove `format_exc_info` from your processor chain..."), and it
+        # still owns any exc_info that reaches it by another route.
+        log_renderer = structlog.dev.ConsoleRenderer(
+            exception_formatter=structlog.dev.plain_traceback
+        )
     else:
-        log_renderer = structlog.dev.ConsoleRenderer()
+        log_renderer = structlog.dev.ConsoleRenderer(
+            exception_formatter=_dev_exception_formatter()
+        )
 
     formatter = structlog.stdlib.ProcessorFormatter(
         foreign_pre_chain=shared_processors,

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -37,7 +37,11 @@ redirect_tempfile_to_staging(settings.upload_staging_dir)
 configure_gdal_s3_env(settings)
 
 # Configure structured logging with service label
-setup_logging(json_logs=settings.log_json, log_level=settings.log_level)
+setup_logging(
+    json_logs=settings.log_json,
+    log_level=settings.log_level,
+    production=settings.is_production,
+)
 structlog.contextvars.bind_contextvars(service="worker")
 log = structlog.get_logger()
 

--- a/backend/tests/_logging_state.py
+++ b/backend/tests/_logging_state.py
@@ -69,7 +69,7 @@ def preserved_logging_state() -> Iterator[None]:
 
 @contextlib.contextmanager
 def configured_logging(
-    *, json_logs: bool = True, log_level: str = "DEBUG"
+    *, json_logs: bool = True, log_level: str = "DEBUG", production: bool = False
 ) -> Iterator[None]:
     """``setup_logging()`` inside a preserved window, with the freeze disarmed.
 
@@ -98,6 +98,6 @@ def configured_logging(
     fails with ``--- Logging error ---`` instead of landing anywhere assertable.
     """
     with preserved_logging_state():
-        setup_logging(json_logs=json_logs, log_level=log_level)
+        setup_logging(json_logs=json_logs, log_level=log_level, production=production)
         structlog.configure(cache_logger_on_first_use=False)
         yield

--- a/backend/tests/test_exception_log_rendering.py
+++ b/backend/tests/test_exception_log_rendering.py
@@ -1,0 +1,256 @@
+"""fix(#1485): production exception logging must never reach rich.
+
+`structlog.dev.ConsoleRenderer` picks `RichTracebackFormatter(show_locals=True)`
+as its exception formatter whenever rich is importable, and rich is in the
+backend's transitive dependency set. Rendering a frame's locals costs time
+proportional to the `repr()` of each one, and rich's line splitting is
+quadratic in the length of a single long line — so an exception raised with
+SQLAlchemy objects in scope spent minutes of synchronous CPU inside the
+logging call. That call happens on the event loop in the request path, and
+the production compose default is one uvicorn worker, so the whole API was
+unavailable for the duration.
+
+These tests pin both halves of the fix: the production configuration cannot
+route an exception through rich, and what it emits for an exception does not
+depend on the size of any local variable. Measured on the middleware case
+below, the same request went from 83,062 bytes of log output to 3,675.
+
+Nothing here asserts on elapsed time. The property under test is that the
+work is not proportional to local size, which the emitted record shows
+directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from io import StringIO
+
+import pytest
+import structlog
+
+import app.api.middleware.logging as logging_mw
+from tests._logging_state import configured_logging
+
+# Appears only inside the repr of a frame local — never in an exception
+# message, a source line, or a field name — so finding it in log output means
+# locals were rendered.
+_LOCALS_SENTINEL = "LOCALS_SHOULD_NOT_BE_RENDERED"
+
+# Rich draws its traceback frames inside a box; the plain formatter cannot
+# produce any of these.
+_BOX_DRAWING = "╭╮╰╯│─"
+
+
+class _FatRepr:
+    """Stands in for a session or ORM instance: one enormous non-str repr.
+
+    Deliberately neither a `str` nor a container, because those are the only
+    two things `RichTracebackFormatter`'s `locals_max_string` and
+    `locals_max_length` truncate. An arbitrary object's `repr()` is emitted
+    whole, which is why those knobs are not a fix for this.
+    """
+
+    def __init__(self, repeats: int) -> None:
+        self._repeats = repeats
+
+    def __repr__(self) -> str:
+        return f"<_FatRepr {_LOCALS_SENTINEL * self._repeats}>"
+
+
+def _raise_with_fat_local(repeats: int = 200) -> None:
+    _orm_ish = _FatRepr(repeats)
+    raise ValueError("audit_details.date is not a date")
+
+
+def _current_formatter() -> structlog.stdlib.ProcessorFormatter:
+    """The ProcessorFormatter `setup_logging()` installed on the root handler."""
+    formatter = logging.getLogger().handlers[0].formatter
+    assert isinstance(formatter, structlog.stdlib.ProcessorFormatter)
+    return formatter
+
+
+def _processors_in_play() -> list[object]:
+    """Every processor a record can pass through under the running config.
+
+    Structlog's own chain, plus both halves of the ProcessorFormatter — its
+    `foreign_pre_chain` (stdlib records, e.g. uvicorn.error) and its render
+    chain (structlog's own records).
+    """
+    formatter = _current_formatter()
+    return [
+        *structlog.get_config()["processors"],
+        *(formatter.foreign_pre_chain or ()),
+        *formatter.processors,
+    ]
+
+
+def _rich_formatters_in_play() -> list[object]:
+    """Anything in the running config that would render a traceback with rich."""
+    found: list[object] = []
+    for processor in _processors_in_play():
+        if isinstance(processor, structlog.dev.RichTracebackFormatter):
+            found.append(processor)
+        exception_formatter = getattr(processor, "exception_formatter", None)
+        if isinstance(exception_formatter, structlog.dev.RichTracebackFormatter):
+            found.append(exception_formatter)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Structural: what the production configuration is built out of
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("json_logs", [False, True])
+def test_production_config_has_no_rich_traceback_renderer(json_logs: bool) -> None:
+    """No production log format may route an exception through rich.
+
+    Both formats are covered because ENVIRONMENT and LOG_JSON are independent
+    settings. The reported incident ran with ENVIRONMENT=production and the
+    compose default LOG_JSON=false, which is the console branch.
+    """
+    with configured_logging(json_logs=json_logs, production=True):
+        assert _rich_formatters_in_play() == []
+
+
+def test_production_console_renderer_uses_plain_traceback() -> None:
+    """The console renderer's exception formatter is structlog's plain one.
+
+    `plain_traceback` defers to the stdlib `traceback` module, which prints
+    source lines and no locals, so its cost tracks stack depth rather than the
+    size of anything the frames happen to hold.
+    """
+    with configured_logging(json_logs=False, production=True):
+        renderer = _current_formatter().processors[-1]
+
+        assert isinstance(renderer, structlog.dev.ConsoleRenderer)
+        assert renderer.exception_formatter is structlog.dev.plain_traceback
+
+
+@pytest.mark.parametrize("json_logs", [False, True])
+def test_production_resolves_exc_info_before_the_renderer(json_logs: bool) -> None:
+    """`format_exc_info` runs in the chain, so no renderer is handed a traceback.
+
+    This is the structural half of the fix. It also covers stdlib records,
+    because the same list is the ProcessorFormatter's `foreign_pre_chain`.
+    """
+    with configured_logging(json_logs=json_logs, production=True):
+        chain = structlog.get_config()["processors"]
+        foreign_chain = _current_formatter().foreign_pre_chain
+
+        assert structlog.processors.format_exc_info in chain
+        assert structlog.processors.format_exc_info in foreign_chain
+
+
+def test_development_console_renderer_does_not_render_locals() -> None:
+    """Dev keeps rich's highlighted frames but not the unbounded part.
+
+    Turning locals off is what makes the render cost independent of local
+    size; no setting bounds an arbitrary object's `repr()`.
+    """
+    with configured_logging(json_logs=False, production=False):
+        renderer = _current_formatter().processors[-1]
+        exception_formatter = renderer.exception_formatter
+
+        if isinstance(exception_formatter, structlog.dev.RichTracebackFormatter):
+            assert exception_formatter.show_locals is False
+        else:
+            assert exception_formatter is structlog.dev.plain_traceback
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: what a request-path exception actually emits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_middleware_exception_logs_plain_traceback(capsys) -> None:
+    """An unhandled exception logs type, message and frames — and no locals.
+
+    The sentinel is reachable only through a frame local's `repr()`, so its
+    absence is what makes the emitted record independent of local size.
+    """
+    from httpx import ASGITransport, AsyncClient
+    from starlette.applications import Starlette
+    from starlette.routing import Route
+
+    async def boom(_request):
+        _raise_with_fat_local()
+
+    app = Starlette(routes=[Route("/boom", boom)])
+    app.add_middleware(logging_mw.RequestLoggingMiddleware)
+
+    with configured_logging(json_logs=False, log_level="INFO", production=True):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as http:
+            with pytest.raises(ValueError):
+                await http.get("/boom")
+
+        captured = capsys.readouterr()
+
+    out = captured.out + captured.err
+
+    # The exception stays debuggable: type, message, and the raising frame.
+    assert "Unhandled exception" in out
+    assert "Traceback (most recent call last)" in out
+    assert "ValueError" in out
+    assert "audit_details.date is not a date" in out
+    assert "_raise_with_fat_local" in out
+
+    # ...but nothing whose cost is a frame local's repr was rendered.
+    assert _LOCALS_SENTINEL not in out
+    assert "_FatRepr" not in out
+    assert not any(char in out for char in _BOX_DRAWING)
+
+
+def test_emitted_traceback_is_independent_of_local_size() -> None:
+    """The same exception with a 500x larger local emits an identical traceback.
+
+    This is the incident's property stated directly, and without a stopwatch:
+    both runs go through the real production handler, the only difference
+    between them is the size of one frame local, and what lands in the log is
+    byte-for-byte the same.
+    """
+
+    def render_traceback(repeats: int) -> str:
+        stream = StringIO()
+        with configured_logging(json_logs=False, log_level="INFO", production=True):
+            logging.getLogger().handlers[0].setStream(stream)
+            try:
+                _raise_with_fat_local(repeats)
+            except ValueError:
+                structlog.stdlib.get_logger("api.error").exception(
+                    "Unhandled exception"
+                )
+        emitted = stream.getvalue()
+        assert _LOCALS_SENTINEL not in emitted
+        # Drop the key/value prefix: its timestamp is the one field that
+        # legitimately differs between the two runs.
+        return emitted[emitted.index("Traceback (most recent call last)") :]
+
+    assert render_traceback(1) == render_traceback(500)
+
+
+def test_rich_formatter_would_have_rendered_the_locals() -> None:
+    """Pins the premise the two tests above rest on.
+
+    Without this, `_LOCALS_SENTINEL not in out` could pass because the
+    sentinel never reaches any formatter at all, and both regression tests
+    would be vacuous. structlog's stock rich formatter does emit it.
+    """
+    if not isinstance(
+        structlog.dev.default_exception_formatter, structlog.dev.RichTracebackFormatter
+    ):
+        pytest.skip("rich is not installed, so the rich default is not in play")
+
+    try:
+        _raise_with_fat_local()
+    except ValueError:
+        exc_info = sys.exc_info()
+
+    sio = StringIO()
+    structlog.dev.RichTracebackFormatter(width=200)(sio, exc_info)
+
+    assert _LOCALS_SENTINEL in sio.getvalue()

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2634,7 +2634,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # estimate of how long an upload takes — the tracking-row check is what
     # decides ownership), so nobody later "tunes" it as if it were a transfer
     # margin. Cap 1091 -> 1104, exact.
-    "backend/app/core/config.py": 1104,
+    # fix(#1485): +3 — ENVIRONMENT gained a third behavior (plain traceback
+    # rendering), so the field comment and the `is_production` docstring that
+    # enumerate what the setting controls say so. This setting exists because
+    # security posture was once keyed off a flag documented as log-format only;
+    # an under-documented coupling is the same mistake. Cap 1104 -> 1107, exact.
+    "backend/app/core/config.py": 1107,
     # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
     # the inclusion rule's own comment predicted for this file ("watched by
     # nothing until they cross 1000. The threshold catches them then"). The

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2201,7 +2201,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # standards_api_path is what stops them drifting again, and is why this is
     # one pass here rather than 48 decorator edits across five routers.
     # Cap 1389 -> 1466, exact.
-    "backend/app/api/main.py": 1466,
+    # fix(#1485): +4 — the boot-time setup_logging() call gains
+    # production=settings.is_production, which selects the plain traceback
+    # formatter so an exception cannot pin the event loop rendering frame
+    # locals with rich. Over 88 columns as one line, hence four.
+    # Cap 1466 -> 1470, exact.
+    "backend/app/api/main.py": 1470,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative


### PR DESCRIPTION
## The incident

A dataset-metadata PATCH that raised pinned the demo's api container at 100% CPU for over three minutes (1.13.0, single uvicorn worker). py-spy against the worker mid-hang showed the loop inside rich, not application code:

```
split_and_crop_lines (rich/segment.py:344)
render_lines (rich/console.py:1386)
_render (rich/table.py:838)
...
_proxy_to_logger (structlog/stdlib.py:280)
exception (structlog/stdlib.py:252)
dispatch (app/api/middleware/logging.py:40)
```

Any reproducible unhandled exception was a multi-minute denial-of-service primitive against a single-worker deployment. The victim request never reaches `request_completed`, so the outage did not appear in the access log either.

## The chain

`setup_logging()` picked `structlog.dev.ConsoleRenderer()` whenever `LOG_JSON` was false — and `docker-compose.prod.yml` defaults it to `false`. That renderer takes its `exception_formatter` from `structlog.dev.default_exception_formatter`, which is `RichTracebackFormatter(show_locals=True, max_frames=100)` whenever rich is importable. rich is in the backend's transitive dependency set, so production had it.

Rendering a frame's locals costs `repr()` of every local in every frame, and rich's segment splitting is quadratic in the length of a single long line. A handler that raises with a session, a record and a dataset in scope hands rich a hundred frames of enormous single-line reprs. That is synchronous CPU on the event loop in the request path, so client disconnects cannot cancel it and health checks queue behind it.

`RichTracebackFormatter`'s `locals_max_length` and `locals_max_string` are not a fix: they truncate containers and `str` values, not the `repr()` of an arbitrary object, which is exactly what a SQLAlchemy session or model instance produces.

## What renders where now

`setup_logging()` takes a keyword-only `production` flag, wired at both entrypoints (`api/main.py`, `platform/jobs/worker.py`) to `settings.is_production`.

| ENVIRONMENT | LOG_JSON | renderer | exception path |
|---|---|---|---|
| production | false | `ConsoleRenderer` | `format_exc_info` in the chain + `plain_traceback` |
| production | true | `JSONRenderer` | `format_exc_info` in the chain |
| unset / development | true | `JSONRenderer` | `format_exc_info` in the chain |
| unset / development | false | `ConsoleRenderer` | rich, `show_locals=False` |

Production gets two independent guards, and the second is not decoration. `format_exc_info` resolves `exc_info` into a plain `exception` string inside the processor chain, so no renderer is ever handed a traceback object — and because that same list is the `ProcessorFormatter`'s `foreign_pre_chain`, it covers stdlib records (`uvicorn.error` and friends) as well as structlog's own. Pairing it with a non-plain `exception_formatter` would then make `ConsoleRenderer` emit a `warnings.warn` on every single exception, so `plain_traceback` is required alongside it; it also still owns any `exc_info` that reaches the renderer by another route.

Development keeps rich's syntax-highlighted frames, which are the reason the pretty renderer is worth having, and loses only the locals tables. There is no setting that bounds an arbitrary object's `repr()`, so the cap has to be `show_locals=False`.

Nothing is lost for debugging: exception type, message, and every stack frame with its source line still land in the log.

## Verification

Before writing the tests I reverted the fix in-place and confirmed each new assertion fails against the old code — five of the eight fail pre-fix, the other three are the JSON path (already plain) and the counterfactual below.

Measured through `RequestLoggingMiddleware` with one 5.8 KB frame local, same request both times:

| | log output | locals sentinel | box drawing |
|---|---|---|---|
| before | 83,062 bytes | present (2x) | yes |
| after | 3,675 bytes | absent | no |

New `backend/tests/test_exception_log_rendering.py`:

- **Structural** — builds the production config and walks every processor it can route a record through (structlog's chain, the `foreign_pre_chain`, and the render chain), asserting none is a `RichTracebackFormatter` and none carries one as its `exception_formatter`. Parameterized over both log formats, since `ENVIRONMENT` and `LOG_JSON` are independent settings. Separate tests pin `plain_traceback` on the console renderer, `format_exc_info` in both chains, and `show_locals=False` on the development formatter.
- **Behavioral** — an exception through the middleware must still log its type, message, raising frame and `Traceback (most recent call last)`, and must contain neither the sentinel that only a frame local's `repr()` can produce nor any of rich's box-drawing characters.
- **Cost independence, without a stopwatch** — the same exception raised with a 500x larger frame local emits a byte-identical traceback.
- **Counterfactual** — asserts structlog's stock rich formatter *does* render the sentinel, so the two absence assertions above cannot pass vacuously.

`caplog` sees no structlog records in this codebase, so capture is via the configured handler's stream and `capsys`, through the existing `tests/_logging_state.py` helper (extended to pass `production` through).

Commands run from the worktree backend with `.env.test` sourced:

- `uv run pytest tests/test_exception_log_rendering.py tests/test_phase_273_log_redaction.py tests/test_access_log_path_redaction.py tests/test_logging_conftest_guard.py tests/test_notification_channels.py tests/test_layering.py -q` — 109 passed (random ordering).
- `uv run ruff check .` — passed. `uv run ruff format --check .` — passed.

## Schema / API / config impact

None. No new environment variable: the flag is derived from the existing `ENVIRONMENT` setting via `settings.is_production`, which already falls back to `LOG_JSON` when `ENVIRONMENT` is unset.

A second commit documents the consequence. `ENVIRONMENT=production` now controls three things rather than two, so the field comment in `config.py`, the `is_production` docstring, and `.env.example` all enumerate traceback rendering alongside docs exposure and the Secure cookie. This setting exists in the first place because security posture used to be keyed off `LOG_JSON`, a flag documented as controlling log format only (SEC-005); leaving a third behavior undocumented on the setting that replaced it would repeat that.

Two `_MODULE_LOC_CAPS` ratchets move, each in the commit that causes it: `backend/app/api/main.py` 1466 -> 1470 (the boot call exceeds 88 columns as one line) and `backend/app/core/config.py` 1104 -> 1107 (the comment and docstring above).

Fixes #1485
