### PR TITLE
chore(release): v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-08-14
+
+### Added
+
+- **Dataset attribution is persisted and displayed.** Attribution supplied
+  at manifest ingest used to stop in the job metadata; it now lands on the
+  record, comes back through the catalog API, and renders in the map's
+  attribution control wherever the dataset is drawn (#1477, #1472).
+- **Globe projection gets an atmosphere and a space background.** Maps
+  saved with the globe projection render MapLibre's sky atmosphere and a
+  deep-space backdrop behind the sphere, in both the builder and the
+  viewer; mercator maps are unchanged (#1474, #1488).
+
+### Fixed
+
+- **Multi-color line symbology icons render again.** The layer list,
+  sidebar, and legends drew a blank icon for every line layer with banded
+  or graduated colors, because a zero-height bounding box disables the
+  icon's gradient under the SVG default units. The gradient now uses
+  user-space coordinates (#1494).
+- **A logged exception can no longer pin the API event loop.** Production
+  tracebacks are logged plain instead of through the rich renderer, which
+  could spend minutes rendering a single traceback while the loop served
+  nothing else (#1490).
+- **Date fields in a dataset PATCH no longer 500 the request.** Audit
+  details are serialized in JSON mode, so date-typed metadata fields
+  write cleanly instead of failing the whole mutation (#1489, #1484).
+- **Standards endpoints serve HEAD wherever the preflight advertises it.**
+  A browser client that preflights a HEAD against a standards path was
+  told it is allowed and then got a 405 (#1478, #1470).
+- **DCAT feeds publish real raster access surfaces.** COG-backed rasters
+  published a bare object-storage key as their distribution URL; raster
+  and VRT datasets now list working access URLs (#1475, #1469).
+- **Upgrades pull new images before stopping the app, and restore it if
+  the upgrade fails.** The outage window no longer includes image
+  download time, and a failed upgrade brings the previous release back
+  up (#1476, #1467).
+
 ## [1.13.0] - 2026-08-13
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2165,7 +2165,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.13.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.13.1...HEAD
+[1.13.1]: https://github.com/geolens-io/geolens/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/geolens-io/geolens/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/geolens-io/geolens/compare/v1.11.1...v1.12.0
 [1.11.1]: https://github.com/geolens-io/geolens/compare/v1.11.0...v1.11.1

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -691,7 +691,7 @@ _is_production = settings.is_production
 # no metadata to read. We fall back to the current published line so import never
 # crashes. Keep this fallback in lockstep with backend/pyproject.toml — it is one
 # of the sites `make bump` rewrites.
-_FALLBACK_APP_VERSION = "1.13.0"
+_FALLBACK_APP_VERSION = "1.13.1"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18486,7 +18486,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.13.0"
+    "version": "1.13.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.13.0"
+version = "1.13.1"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.13.0"
+version = "1.13.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.13.0"
+version = "1.13.1"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.13.0"
+version = "1.13.1"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.13.0"
+version = "1.13.1"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.13.0"
+version = "1.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.13.0
+package_version_override: 1.13.1
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.13.0"
+version = "1.13.1"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
Patch release: everything merged since the v1.13.0 tag.

## Ships

**Added**
- Dataset attribution persisted end-to-end and rendered in the map attribution control (#1477)
- Globe atmosphere + space background on globe projection (#1474, #1488)

**Fixed**
- Blank multi-color line symbology icons in layer lists and legends (#1494)
- Rich traceback rendering pinning the API event loop (#1490)
- Date-typed metadata fields 500ing dataset PATCH via the audit serializer (#1489)
- HEAD support on standards endpoints that advertise it in preflight (#1478)
- DCAT raster distributions publishing storage keys instead of access URLs (#1475)
- Upgrade script pulls images before the outage window and restores on failure (#1476)

Also rides: demo seeder fixes (#1471, #1487, #1493), docs (#1482, #1483), `make env-test` (#1481).

## Impacts

- One new migration: `0049_records_attribution` (additive).
- OpenAPI/SDKs: attribution fields added in #1477; snapshots were regenerated there. This PR only stamps versions.
- Extension API version unchanged (7) — enterprise v0.4.0 overlays remain compatible.

## Verification

- `make version-check`: all 19 sites agree on 1.13.1, changelog section present.