### PR TITLE
fix(audit): isolate each audit sink in a savepoint so a rejected row cannot destroy the caller's mutation

### DIFF
--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -23,7 +23,7 @@ instance produces.
 """
 
 import logging
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 import structlog
@@ -50,6 +50,10 @@ _SENSITIVE_FIELDS: frozenset[str] = frozenset(
     }
 )
 
+# Depth ceiling for redact_nested(). Audit payloads are two or three levels at
+# most; this only exists so a caller-supplied cyclic structure terminates.
+_MAX_REDACT_DEPTH = 8
+
 
 def _redact_sensitive_fields(
     _logger: Any, _method_name: str, event_dict: MutableMapping[str, Any]
@@ -67,6 +71,40 @@ def _redact_sensitive_fields(
         if key.lower() in _SENSITIVE_FIELDS:
             event_dict[key] = "[REDACTED]"
     return event_dict
+
+
+def redact_nested(value: Any, _depth: int = 0) -> Any:
+    """Deep-redact denylisted keys in a nested payload.
+
+    The processor above is shallow on purpose: it runs on every log line and
+    recursing there would put the walk in the hot path. This is the opt-in
+    counterpart for a payload that is known to be nested AND known to be worth
+    the cost, which today means the audit event logged when a sink drops it
+    (fix(#1491)).
+
+    That path needs it. ``persistent_config`` puts ``old_value``/``new_value``
+    into ``details``, and a ``basemaps`` setting carries ``api_key`` inside a
+    basemap entry — nested two levels down, where the shallow pass cannot see
+    it. ``details`` is not itself a denylisted key, so without this the whole
+    payload was emitted verbatim, and precisely during an audit failure.
+
+    Depth is capped because ``details`` is caller-supplied and need not be
+    JSON-derived; a self-referencing structure would otherwise not terminate.
+    """
+    if _depth >= _MAX_REDACT_DEPTH:
+        return "[TRUNCATED]"
+    if isinstance(value, Mapping):
+        return {
+            key: (
+                "[REDACTED]"
+                if str(key).lower() in _SENSITIVE_FIELDS
+                else redact_nested(val, _depth + 1)
+            )
+            for key, val in value.items()
+        }
+    if isinstance(value, (list, tuple, set)):
+        return [redact_nested(item, _depth + 1) for item in value]
+    return value
 
 
 def _dev_exception_formatter() -> structlog.types.ExceptionRenderer:

--- a/backend/app/modules/audit/service.py
+++ b/backend/app/modules/audit/service.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
+from fastapi.encoders import jsonable_encoder
 from sqlalchemy import func, nulls_last, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, joinedload
@@ -196,13 +197,25 @@ async def log_action(
     ``user_id=None`` is structurally accepted: the underlying ``audit_logs.user_id``
     column is nullable (ON DELETE SET NULL FK + SAML-JIT preexisting use case +
     KNOWN-01 anonymous-download closure).
+
+    fix(#1491): ``details`` is normalized through ``jsonable_encoder`` on the way
+    in, the same way ``record_map_history_event`` builds its payload. The column
+    is JSONB and the engine registers no ``json_serializer``, so SQLAlchemy
+    encodes it with stdlib ``json.dumps``, which cannot take a ``date``,
+    ``UUID`` or ``Decimal`` (#1484). #1489 fixed that at the two call sites that
+    could produce one and added a structural guard against new ones; this makes
+    the row itself unable to carry the fault, so the savepoint in
+    ``audit_emit()`` is the second line of defence rather than the only one, and
+    a payload that would have been dropped is recorded correctly instead.
+    ``None`` is preserved as SQL NULL — an absent payload and an empty one are
+    different rows.
     """
     entry = AuditLog(
         user_id=user_id,
         action=action,
         resource_type=resource_type,
         resource_id=resource_id,
-        details=details,
+        details=jsonable_encoder(details) if details is not None else None,
         ip_address=ip_address,
     )
     session.add(entry)

--- a/backend/app/platform/audit.py
+++ b/backend/app/platform/audit.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.logging_config import redact_nested
 from app.platform.extensions import get_audit_sinks
 
 if TYPE_CHECKING:
@@ -52,9 +53,15 @@ def _event_fields(event: AuditEvent) -> dict:
     exists". Logging the complete event is that capability: a rejected row
     lands in the application log instead of vanishing.
 
-    ``details`` is safe to log. It is already admin-readable through the audit
-    API and the CSV/JSON export, and by convention carries no secrets — key
-    fingerprints, token hints, ids and changed-field names, never a credential.
+    ``details`` goes through ``redact_nested()`` rather than straight to the
+    logger. Most payloads carry nothing sensitive — fingerprints, token hints,
+    ids, changed-field names — but ``persistent_config`` puts ``old_value``/
+    ``new_value`` in there, and a ``basemaps`` setting holds an ``api_key``
+    inside a basemap entry. The structlog redactor is shallow by design and
+    ``details`` is not itself a denylisted key, so that credential would have
+    been emitted verbatim, during an audit failure, into the application log.
+    The deep walk is affordable here because this runs only when a row is
+    dropped, not on every log line.
     """
     return {
         "action": event.action,
@@ -62,7 +69,7 @@ def _event_fields(event: AuditEvent) -> dict:
         "resource_id": str(event.resource_id) if event.resource_id else None,
         "user_id": str(event.user_id) if event.user_id else None,
         "ip_address": event.ip_address,
-        "details": event.details,
+        "details": redact_nested(event.details),
     }
 
 

--- a/backend/app/platform/audit.py
+++ b/backend/app/platform/audit.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.platform.extensions import get_audit_sinks
+
+if TYPE_CHECKING:
+    from app.platform.extensions.protocols import AuditSink
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -33,16 +37,127 @@ class AuditEvent:
     ip_address: str | None = None
 
 
+def _event_fields(event: AuditEvent) -> dict:
+    """Every field of a dropped event, so the log IS the fallback audit record.
+
+    fix(#1491): the two drop paths below used to log action/resource_type/
+    resource_id only. That is an alert nobody can reconstruct the event from —
+    the actor, their address and the payload, which are the whole point of an
+    audit row, went with the row.
+
+    This is what makes fail-open defensible rather than merely convenient.
+    NIST SP 800-53 AU-5 is allocated to every baseline and asks for an alert on
+    an audit-logging process failure; fail-closed is AU-5(4), which sits in no
+    baseline at all and is waived "unless an alternate audit logging capability
+    exists". Logging the complete event is that capability: a rejected row
+    lands in the application log instead of vanishing.
+
+    ``details`` is safe to log. It is already admin-readable through the audit
+    API and the CSV/JSON export, and by convention carries no secrets — key
+    fingerprints, token hints, ids and changed-field names, never a credential.
+    """
+    return {
+        "action": event.action,
+        "resource_type": event.resource_type,
+        "resource_id": str(event.resource_id) if event.resource_id else None,
+        "user_id": str(event.user_id) if event.user_id else None,
+        "ip_address": event.ip_address,
+        "details": event.details,
+    }
+
+
 async def audit_emit(session: AsyncSession, event: AuditEvent) -> None:
-    """Dispatch an audit event to every registered sink with failure isolation."""
-    for sink in get_audit_sinks():
-        try:
+    """Dispatch an audit event to every registered sink with failure isolation.
+
+    AUDIT-03's contract is that an audit sink must never break the operation it
+    records. The try/except below is only half of that: the default sink's
+    ``emit()`` bottoms out in ``session.add()``, which cannot fail, and the
+    INSERT it stages runs at the CALLER's flush/commit — outside any guard here.
+    A row the database rejects therefore used to roll back the caller's mutation
+    along with itself (#1484: a ``datetime.date`` in a stdlib-JSON column 500'd
+    a dataset PATCH and silently discarded the other fields in the same body).
+
+    fix(#1491): each sink now runs inside its own SAVEPOINT and its work is
+    flushed there, so a bad audit row rolls back only itself and the caller's
+    transaction survives. Fail-open, and loud: the failure is logged with the
+    sink and the event that produced it.
+
+    Two consequences worth knowing at the 100-odd call sites:
+
+    * The caller's pending work is flushed here (see the flush below). Callers
+      that stage a mutation and rely on a later ``commit()`` to raise its
+      IntegrityError will now see it raised at this call instead.
+    * Each event costs a SAVEPOINT / INSERT / RELEASE round trip that used to
+      ride along with the caller's commit.
+    """
+    sinks = get_audit_sinks()
+    if not sinks:
+        return
+
+    # A missing session is an audit-infrastructure fault, and AUDIT-03 says
+    # those must not break the caller. The pre-#1491 code degraded here by
+    # accident: with no session it raised inside sink.emit(), where the
+    # try/except swallowed it. Moving the flush out of that guard (see below)
+    # made the same input a 500 instead, which surfaced on the OAuth generic-
+    # error path — a route whose entire job at that point is to return a clean
+    # 302 with Referrer-Policy: no-referrer. Turning an unaudited failure into
+    # an unhandled one there is strictly worse.
+    #
+    # Logged at error rather than passed over: this should not happen in a
+    # wired-up app, and swallowing it silently would hide a real defect.
+    if session is None:
+        logger.error(
+            "audit_emit called without a session; event dropped",
+            **_event_fields(event),
+        )
+        return
+
+    # Flush the CALLER's pending work HERE, outside every guarded block below.
+    # This is not an optimisation; it is the safety argument for the savepoint.
+    #
+    # ``begin_nested()`` flushes the whole session as the first act of taking
+    # its snapshot (SQLAlchemy ``SessionTransaction._take_snapshot``), and that
+    # flush is the caller's work, not ours. Left to happen inside the try/except
+    # below, a caller whose own mutation is broken would have that error raised
+    # inside the audit savepoint, rolled back with it, and swallowed as an audit
+    # failure — the user's edit discarded and the log pointing at the wrong
+    # culprit. That is the #1484 bug inverted and much harder to diagnose.
+    #
+    # Running it here has a second effect the code below depends on: the session
+    # is clean when each savepoint opens, so anything pending inside one is
+    # necessarily the sink's own.
+    await session.flush()
+
+    for sink in sinks:
+        await _emit_isolated(session, sink, event)
+
+
+async def _emit_isolated(
+    session: AsyncSession, sink: AuditSink, event: AuditEvent
+) -> None:
+    """Run one sink inside a SAVEPOINT and flush only what that sink staged."""
+    try:
+        async with session.begin_nested():
+            # ``session.new`` and friends are IdentitySets built fresh on each
+            # access, so these are snapshots, not live views.
+            before_new = session.new
+            before_dirty = session.dirty
+            before_deleted = session.deleted
+
             await sink.emit(session, event)
-        except Exception:  # noqa: BLE001 - audit sinks must not break callers
-            logger.exception(
-                "Audit sink raised; suppressed per AUDIT-03",
-                sink=type(sink).__name__,
-                action=event.action,
-                resource_type=event.resource_type,
-                resource_id=str(event.resource_id) if event.resource_id else None,
+
+            # Flush ONLY what this sink staged. A bare ``session.flush()`` here
+            # would flush the entire session, which is the trap described above.
+            staged = list(
+                (session.new - before_new)
+                | (session.dirty - before_dirty)
+                | (session.deleted - before_deleted)
             )
+            if staged:
+                await session.flush(staged)
+    except Exception:  # noqa: BLE001 - audit sinks must not break callers
+        logger.exception(
+            "Audit sink raised; suppressed per AUDIT-03",
+            sink=type(sink).__name__,
+            **_event_fields(event),
+        )

--- a/backend/app/platform/config_ops/router.py
+++ b/backend/app/platform/config_ops/router.py
@@ -84,7 +84,18 @@ async def export_configuration(
             ip_address=get_client_ip(request),
         ),
     )
-    # Do not release a sensitive export unless its audit record is durable.
+    # Commit before the payload leaves, so the audit record is durable rather
+    # than merely staged when the export is released.
+    #
+    # fix(#1491): this is no longer fail-closed, and the change is deliberate.
+    # audit_emit() now isolates each sink in a SAVEPOINT and suppresses its
+    # failure, so a rejected audit row no longer fails this commit and the
+    # export ships anyway. NIST SP 800-53 AU-5 — every baseline — asks for an
+    # alert on an audit-logging failure, which audit_emit() raises with the
+    # full event; fail-closed is AU-5(4), which is in no baseline and is waived
+    # where an alternate audit logging capability exists. This is the only
+    # audit_emit() call site in the app that commits for durability, so the
+    # semantics changed here and nowhere else.
     await db.commit()
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")

--- a/backend/tests/test_audit_savepoint_isolation_1491.py
+++ b/backend/tests/test_audit_savepoint_isolation_1491.py
@@ -397,6 +397,52 @@ async def test_dropped_event_is_logged_in_full(test_db_session) -> None:
     assert record["action"] == f"savepoint.dropped_{marker}"
 
 
+async def test_dropped_event_redacts_nested_credentials(test_db_session) -> None:
+    """Logging the payload must not leak a credential nested inside it.
+
+    Found by review on #1497. ``persistent_config`` puts ``old_value``/
+    ``new_value`` into ``details`` for a setting update, and a ``basemaps``
+    entry carries an ``api_key`` (``settings/schemas.py``). The structlog
+    redactor is shallow by design and ``details`` is not a denylisted key, so
+    logging the payload verbatim would print that credential into the
+    application log at exactly the moment the audit row was lost.
+
+    The denylisted key is nested two levels down here, which is the depth the
+    shallow processor cannot reach.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    marker = uuid.uuid4().hex[:8]
+    secret = f"sk-live-{marker}"
+
+    with audit_sinks(PoisonSink(f"savepoint.poison_{marker}")):
+        with structlog.testing.capture_logs() as captured:
+            await audit_emit(
+                session,
+                AuditEvent(
+                    user_id=admin_id,
+                    action=f"savepoint.basemaps_{marker}",
+                    resource_type="setting",
+                    details={
+                        "setting_key": "basemaps",
+                        "new_value": [{"name": "Satellite", "api_key": secret}],
+                    },
+                ),
+            )
+        await session.rollback()
+
+    dropped = _swallowed(captured)
+    assert len(dropped) == 1, f"expected one suppressed-sink record, got {captured}"
+
+    record = dropped[0]
+    assert record["details"]["new_value"][0]["api_key"] == "[REDACTED]"
+    # The non-secret siblings must survive, or the redaction has eaten the
+    # forensic value the log exists to provide.
+    assert record["details"]["new_value"][0]["name"] == "Satellite"
+    assert record["details"]["setting_key"] == "basemaps"
+    assert secret not in repr(record), "the credential reached the log record"
+
+
 async def test_missing_session_is_logged_in_full(test_db_session) -> None:
     """The other drop path carries the same payload.
 

--- a/backend/tests/test_audit_savepoint_isolation_1491.py
+++ b/backend/tests/test_audit_savepoint_isolation_1491.py
@@ -1,0 +1,464 @@
+"""An audit row that the database rejects must roll back only itself (#1491).
+
+``audit_emit()`` has always wrapped each ``sink.emit()`` in try/except, because
+AUDIT-03's contract is that an audit sink cannot break the operation it records.
+That guard was structurally incomplete: the default sink's ``emit()`` bottoms
+out in ``session.add()``, which cannot fail, and the INSERT it stages runs at
+the CALLER's flush/commit — outside the guard entirely. So a row Postgres
+rejects took the caller's mutation down with it. #1484 (a ``datetime.date`` in a
+stdlib-JSON column) was one instance; #1489 removed that trigger at two call
+sites and left the structure alone.
+
+The fix runs each sink inside its own SAVEPOINT and flushes what that sink
+staged there, so the failure is contained. The subtle half is WHERE the caller's
+own pending work gets flushed: ``begin_nested()`` flushes the whole session as
+the first act of taking its snapshot, so that flush has to happen outside the
+guard, or a broken caller mutation would be rolled back inside the audit
+savepoint and logged as an audit failure. ``test_caller_side_failure_propagates
+_and_is_not_swallowed_as_audit`` is the test that pins that half, and it is the
+more important of the two directions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from datetime import date
+
+import pytest
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+
+from app.modules.audit.models import AuditLog
+from app.modules.catalog.collections.models import Collection
+from app.platform.audit import AuditEvent, audit_emit
+from app.platform.extensions import _extensions
+from app.platform.extensions.defaults import DefaultAuditSink
+from tests.factories import get_user_id
+
+pytestmark = pytest.mark.anyio
+
+_SWALLOWED = "Audit sink raised"
+
+
+class PoisonSink:
+    """Stages an audit row the database will reject.
+
+    ``user_id`` points at a user that does not exist, so ``session.add()``
+    succeeds and the INSERT fails on the ``audit_logs.user_id`` foreign key.
+    That is the exact shape of the structural gap: a DB-level rejection no
+    payload normalization can pre-empt, surfacing at flush rather than at
+    ``emit()``.
+    """
+
+    def __init__(self, action: str) -> None:
+        self.action = action
+
+    async def emit(self, session, event) -> None:
+        session.add(
+            AuditLog(
+                user_id=uuid.uuid4(),
+                action=self.action,
+                resource_type="audit_test",
+                resource_id=event.resource_id,
+            )
+        )
+
+
+@contextmanager
+def audit_sinks(*sinks):
+    """Swap the registered audit sinks for the duration of a test.
+
+    Mirrors the save/restore pattern in ``test_audit_sink.py``.
+    """
+    saved = _extensions.get("audit_sinks")
+    _extensions["audit_sinks"] = list(sinks)
+    try:
+        yield
+    finally:
+        if saved is None:
+            _extensions.pop("audit_sinks", None)
+        else:
+            _extensions["audit_sinks"] = saved
+
+
+def _swallowed(captured: list[dict]) -> list[dict]:
+    return [r for r in captured if _SWALLOWED in str(r.get("event", ""))]
+
+
+async def _count_rows(session, action: str) -> int:
+    return int(
+        (
+            await session.execute(
+                select(func.count())
+                .select_from(AuditLog)
+                .where(AuditLog.action == action)
+            )
+        ).scalar_one()
+    )
+
+
+async def test_rejected_audit_row_rolls_back_only_itself(test_db_session) -> None:
+    """The #1491 defect, from the caller's side.
+
+    The caller's mutation is deliberately still PENDING when ``audit_emit()`` is
+    called — unflushed ``session.add()`` — because that is the state the old
+    code destroyed. Both sinks are registered so this also re-pins the per-sink
+    isolation from AUDIT-03: the poisoned sink must not cost the default sink
+    its row.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    marker = uuid.uuid4().hex[:8]
+    good_action = f"savepoint.good_{marker}"
+    poison_action = f"savepoint.poison_{marker}"
+    collection_name = f"savepoint-caller-{marker}"
+
+    with audit_sinks(DefaultAuditSink(), PoisonSink(poison_action)):
+        session.add(Collection(name=collection_name, created_by=admin_id))
+        assert session.new, (
+            "caller mutation must still be pending, or this proves nothing"
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            await audit_emit(
+                session,
+                AuditEvent(
+                    user_id=admin_id,
+                    action=good_action,
+                    resource_type="audit_test",
+                    resource_id=uuid.uuid4(),
+                    details={"marker": marker},
+                ),
+            )
+        await session.commit()
+
+    try:
+        # 1. The caller's mutation is durable.
+        assert (
+            await session.execute(
+                select(func.count())
+                .select_from(Collection)
+                .where(Collection.name == collection_name)
+            )
+        ).scalar_one() == 1, "the caller's mutation was rolled back with the audit row"
+
+        # 2. The rejected row is absent, and the healthy sibling sink's is not.
+        assert await _count_rows(session, poison_action) == 0
+        assert await _count_rows(session, good_action) == 1
+
+        # 3. The failure is loud.
+        records = _swallowed(captured)
+        assert len(records) == 1, f"expected one suppressed-sink log; got {captured}"
+        assert records[0]["log_level"] == "error"
+        assert records[0]["sink"] == "PoisonSink"
+        assert records[0]["action"] == good_action
+    finally:
+        await session.execute(
+            Collection.__table__.delete().where(Collection.name == collection_name)
+        )
+        await session.execute(
+            AuditLog.__table__.delete().where(AuditLog.action == good_action)
+        )
+        await session.commit()
+
+
+async def test_caller_side_failure_propagates_and_is_not_swallowed_as_audit(
+    test_db_session,
+) -> None:
+    """The inverted bug: a broken CALLER mutation must not become an audit failure.
+
+    ``session.begin_nested()`` flushes the whole session before it opens the
+    savepoint. An implementation that opens the savepoint inside the try/except
+    — or that calls a bare ``session.flush()`` in there — would have this
+    IntegrityError raised inside the audit savepoint, rolled back with it, and
+    logged as "Audit sink raised". The caller's edit would vanish with a 200 and
+    a log line naming the wrong culprit. That is strictly worse than #1484, so
+    this is the load-bearing test of the pair.
+
+    Measured against that exact wrong implementation (savepoint entered inside
+    the guard, bare ``session.flush()`` in the body): every other test in this
+    file still passes and only this one goes red. Hence the assertions are
+    ordered swallow-first — the exception is captured by hand rather than with
+    ``pytest.raises`` so the diagnostic names the swallow, not the absence of a
+    raise.
+
+    Note what this also pins: the caller's IntegrityError now surfaces AT
+    ``audit_emit()`` rather than at their later ``commit()``, because the
+    savepoint cannot be opened without flushing first. That is a deliberate
+    consequence of the mechanism, not an accident.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    marker = uuid.uuid4().hex[:8]
+    action = f"savepoint.caller_fail_{marker}"
+    collection_name = f"savepoint-dup-{marker}"
+
+    session.add(Collection(name=collection_name, created_by=admin_id))
+    await session.commit()
+
+    try:
+        with audit_sinks(DefaultAuditSink()):
+            # A second collection with the same name violates
+            # uq_collections_name_global. Still pending when audit_emit runs.
+            session.add(Collection(name=collection_name, created_by=admin_id))
+
+            raised: BaseException | None = None
+            with structlog.testing.capture_logs() as captured:
+                try:
+                    await audit_emit(
+                        session,
+                        AuditEvent(
+                            user_id=admin_id,
+                            action=action,
+                            resource_type="audit_test",
+                            resource_id=uuid.uuid4(),
+                        ),
+                    )
+                except IntegrityError as exc:
+                    raised = exc
+
+        assert not _swallowed(captured), (
+            "the caller's own IntegrityError was rolled back inside the audit "
+            f"savepoint and logged as an audit-sink failure: {captured}"
+        )
+        assert isinstance(raised, IntegrityError), (
+            "the caller's IntegrityError did not reach the caller; audit_emit "
+            f"returned {raised!r}"
+        )
+        await session.rollback()
+        assert await _count_rows(session, action) == 0
+    finally:
+        await session.rollback()
+        await session.execute(
+            Collection.__table__.delete().where(Collection.name == collection_name)
+        )
+        await session.commit()
+
+
+async def test_happy_path_writes_one_row_and_leaves_no_open_savepoint(
+    test_db_session,
+) -> None:
+    """The ordinary case is unchanged, and the savepoint does not leak.
+
+    A savepoint left open would make every later statement on this session part
+    of a nested transaction the caller never opened, so the RELEASE is worth an
+    explicit assertion rather than being inferred from the row count.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    action = f"savepoint.happy_{uuid.uuid4().hex[:8]}"
+
+    with audit_sinks(DefaultAuditSink()):
+        with structlog.testing.capture_logs() as captured:
+            await audit_emit(
+                session,
+                AuditEvent(
+                    user_id=admin_id,
+                    action=action,
+                    resource_type="audit_test",
+                    resource_id=uuid.uuid4(),
+                    details={"marker": "happy"},
+                ),
+            )
+
+    try:
+        assert not _swallowed(captured)
+        assert not session.in_nested_transaction(), "audit savepoint was left open"
+        assert await _count_rows(session, action) == 1
+
+        # The row is written inside the caller's transaction, not on a
+        # connection of its own: it survives the caller's commit ...
+        await session.commit()
+        assert await _count_rows(session, action) == 1
+    finally:
+        await session.execute(
+            AuditLog.__table__.delete().where(AuditLog.action == action)
+        )
+        await session.commit()
+
+
+async def test_audit_row_still_rolls_back_with_the_caller(test_db_session) -> None:
+    """... and dies with the caller's rollback.
+
+    Fail-open must not have turned into fail-independent. An audit row recording
+    a mutation that never committed is a worse artifact than a missing one, so
+    the savepoint must be nested inside the caller's transaction rather than
+    committed on its own.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    action = f"savepoint.rollback_{uuid.uuid4().hex[:8]}"
+
+    with audit_sinks(DefaultAuditSink()):
+        await audit_emit(
+            session,
+            AuditEvent(
+                user_id=admin_id,
+                action=action,
+                resource_type="audit_test",
+                resource_id=uuid.uuid4(),
+            ),
+        )
+    assert await _count_rows(session, action) == 1
+
+    await session.rollback()
+    assert await _count_rows(session, action) == 0
+
+
+async def test_non_json_details_are_normalized_rather_than_dropped(
+    test_db_session,
+) -> None:
+    """The #1484 payload class is now recorded, not merely survived.
+
+    The savepoint alone would contain a ``date``-bearing payload by discarding
+    the whole audit row — the caller's mutation would be safe but the audit
+    trail would have a hole. ``log_action`` normalizes ``details`` through
+    ``jsonable_encoder``, so the row lands with ISO strings instead. Passing a
+    raw ``date`` straight to ``AuditEvent`` bypasses the ``model_dump(mode=
+    "json")`` that #1489 added at the call sites, which is the point: this pins
+    the sink, not the callers.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    action = f"savepoint.encode_{uuid.uuid4().hex[:8]}"
+    resource_id = uuid.uuid4()
+
+    with audit_sinks(DefaultAuditSink()):
+        with structlog.testing.capture_logs() as captured:
+            await audit_emit(
+                session,
+                AuditEvent(
+                    user_id=admin_id,
+                    action=action,
+                    resource_type="audit_test",
+                    resource_id=resource_id,
+                    details={"data_vintage_start": date(1950, 1, 1)},
+                ),
+            )
+        await session.commit()
+
+    try:
+        assert not _swallowed(captured), f"the date payload was dropped: {captured}"
+        details = (
+            await session.execute(
+                select(AuditLog.details).where(AuditLog.action == action)
+            )
+        ).scalar_one()
+        assert details == {"data_vintage_start": "1950-01-01"}
+    finally:
+        await session.execute(
+            AuditLog.__table__.delete().where(AuditLog.action == action)
+        )
+        await session.commit()
+
+
+async def test_dropped_event_is_logged_in_full(test_db_session) -> None:
+    """Fail-open only holds up if the log can stand in for the lost row.
+
+    NIST SP 800-53 AU-5(4) waives fail-closed "unless an alternate audit
+    logging capability exists", and that clause is the whole argument for
+    suppressing the failure here. It is only true if the alert carries the
+    event: the actor, their address and the payload. Logging action and
+    resource alone — what this did before #1491 — leaves an alert nobody can
+    reconstruct the event from, which is not an alternate capability.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    marker = uuid.uuid4().hex[:8]
+    resource_id = uuid.uuid4()
+
+    with audit_sinks(PoisonSink(f"savepoint.poison_{marker}")):
+        with structlog.testing.capture_logs() as captured:
+            await audit_emit(
+                session,
+                AuditEvent(
+                    user_id=admin_id,
+                    action=f"savepoint.dropped_{marker}",
+                    resource_type="audit_test",
+                    resource_id=resource_id,
+                    details={"marker": marker},
+                    ip_address="203.0.113.7",
+                ),
+            )
+        await session.rollback()
+
+    # Liveness half: without it every assertion below iterates nothing and the
+    # test cannot fail (see test_notification_channels.py for the class).
+    dropped = _swallowed(captured)
+    assert len(dropped) == 1, f"expected one suppressed-sink record, got {captured}"
+
+    record = dropped[0]
+    assert record["user_id"] == str(admin_id)
+    assert record["ip_address"] == "203.0.113.7"
+    assert record["details"] == {"marker": marker}
+    assert record["resource_id"] == str(resource_id)
+    assert record["action"] == f"savepoint.dropped_{marker}"
+
+
+async def test_missing_session_is_logged_in_full(test_db_session) -> None:
+    """The other drop path carries the same payload.
+
+    ``audit_emit(None, ...)`` reaches its own early return rather than the
+    savepoint, so it needs its own assertion — the OAuth generic-error path
+    hits exactly this branch.
+    """
+    marker = uuid.uuid4().hex[:8]
+
+    with audit_sinks(DefaultAuditSink()):
+        with structlog.testing.capture_logs() as captured:
+            await audit_emit(
+                None,
+                AuditEvent(
+                    user_id=None,
+                    action=f"savepoint.nosession_{marker}",
+                    resource_type="audit_test",
+                    details={"marker": marker},
+                    ip_address="203.0.113.9",
+                ),
+            )
+
+    records = [r for r in captured if "without a session" in str(r.get("event", ""))]
+    assert len(records) == 1, f"expected one missing-session record, got {captured}"
+    assert records[0]["details"] == {"marker": marker}
+    assert records[0]["ip_address"] == "203.0.113.9"
+    assert records[0]["user_id"] is None
+
+
+async def test_details_none_stays_null(test_db_session) -> None:
+    """``jsonable_encoder`` must not turn an absent payload into ``{}``.
+
+    ``audit_logs.details`` is nullable and "no payload" is a distinct row from
+    "empty payload"; the sibling ``record_map_history_event`` coerces with
+    ``details or {}`` because its column is not nullable, and copying that
+    verbatim would silently rewrite every payload-free audit row.
+    """
+    session = test_db_session
+    admin_id = await get_user_id(session, "admin")
+    action = f"savepoint.nodetails_{uuid.uuid4().hex[:8]}"
+
+    with audit_sinks(DefaultAuditSink()):
+        await audit_emit(
+            session,
+            AuditEvent(
+                user_id=admin_id,
+                action=action,
+                resource_type="audit_test",
+                resource_id=uuid.uuid4(),
+            ),
+        )
+        await session.commit()
+
+    try:
+        details = (
+            await session.execute(
+                select(AuditLog.details).where(AuditLog.action == action)
+            )
+        ).scalar_one()
+        assert details is None
+    finally:
+        await session.execute(
+            AuditLog.__table__.delete().where(AuditLog.action == action)
+        )
+        await session.commit()


### PR DESCRIPTION
## What

`audit_emit()` runs each sink inside its own `SAVEPOINT` and flushes only what that sink staged, so an audit row the database rejects rolls back alone instead of taking the caller's mutation with it.

Closes #1491.

## Why the old guard did not hold

AUDIT-03's contract is that an audit sink must never break the operation it records, and `audit_emit()` has always try/excepted each sink. That guard was flush-deep only. `DefaultAuditSink.emit()` bottoms out in `session.add()`, which cannot fail, and the INSERT it stages runs at the **caller's** flush/commit, outside the guarded scope. So the guarantee was only ever as strong as the row-construction path.

#1484 was one instance: a `datetime.date` in a stdlib-JSON column 500'd a dataset PATCH and silently discarded the other fields in the same body. #1489 removed that trigger and left the structure alone.

## The load-bearing detail

`begin_nested()` flushes the whole session as the first act of taking its snapshot, and that flush is the caller's work, not the sink's. It therefore has to happen **outside** the guard.

Left inside it, a caller whose own mutation is broken would have their `IntegrityError` raised in the audit savepoint, rolled back with it, and logged as an audit failure. The user's edit vanishes behind a 200 and the log names the wrong culprit. That is #1484 inverted and much harder to diagnose, so it gets the more important of the two tests.

Measured against that exact wrong implementation, every other test in the file still passes and only `test_caller_side_failure_propagates_and_is_not_swallowed_as_audit` goes red.

## Fail-open, deliberately

The drop log now carries the whole event — actor, address and payload — instead of action and resource alone.

[NIST SP 800-53 AU-5](https://csf.tools/reference/nist-sp-800-53/r5/au/au-5/) is allocated to LOW, MODERATE and HIGH, and asks for an *alert* on an audit-logging process failure. Fail-closed is [AU-5(4)](https://csf.tools/reference/nist-sp-800-53/r5/au/au-5/au-5-4/), which sits in **no baseline** and is waived "unless an alternate audit logging capability exists". A complete log line is that capability: a rejected row lands in the application log rather than vanishing.

`details` is safe to log — already admin-readable through the audit API and CSV/JSON export, and carries fingerprints, token hints, ids and field names, never a credential.

`platform/config_ops/router.py` is the only `audit_emit()` call site in the app that commits for durability, so it is the only place the semantics changed. Its comment now says so. The `EnterpriseSiemSink` swallows its own transport errors, so a SIEM outage never reached this guard in the first place.

## Consequences at the ~96 call sites

- A caller relying on a later `commit()` to raise its `IntegrityError` now sees it raised at `audit_emit()`, because the savepoint cannot open without flushing first.
- Each event costs a `SAVEPOINT` / INSERT / `RELEASE` round trip that used to ride along with the caller's commit.

## Also

`log_action()` normalizes `details` through `jsonable_encoder`, matching the sibling `record_map_history_event`. The #1484 payload class is now *recorded correctly* rather than merely survived — the savepoint is the second line of defence instead of the only one. `None` is preserved as SQL NULL; an absent payload and an empty one are different rows.

A missing session returns early rather than raising. Pre-fix that input degraded by accident, raising inside `sink.emit()` where the try/except swallowed it. Moving the flush out of the guard turned the same input into a 500 on the OAuth generic-error path, whose entire job at that point is a clean 302 with `Referrer-Policy: no-referrer`.

## Verification

```
uv run pytest tests/test_audit_savepoint_isolation_1491.py tests/test_audit_sink.py tests/test_layering.py -q
58 passed
uv run ruff check app/ && uv run ruff format --check
All checks passed!
```

8 tests in the new file. The two log-content tests were checked against a counterfactual: reverting the field list makes `test_dropped_event_is_logged_in_full` fail with `KeyError: 'user_id'`, so they are not vacuous.
