### PR TITLE
feat(auth): declare the cookie-mode headers as OpenAPI parameters

### DIFF
--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -3,12 +3,26 @@
 import secrets
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.auth.cookies import (
+    AUTH_MODE_HEADER,
+    COOKIE_AUTH_MODE,
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    REFRESH_COOKIE_NAME,
     clear_browser_session,
     enforce_csrf,
     issue_browser_session,
@@ -66,6 +80,43 @@ def _login_rate_limit(_request: Request | None = None) -> str:
     return f"{get_cached_login_rate_limit()}/minute"
 
 
+# fix(#1496): the browser cookie flow is negotiated and CSRF-protected with two
+# request headers, and the spec named them only in prose — so the three
+# session-lifecycle operations published ZERO parameters, and neither a
+# generated SDK nor the docs "try it" form could express the inputs needed to
+# establish, refresh, or revoke a cookie session.
+#
+# The parameters below are DECLARED, not consumed. Every cookie and CSRF
+# decision stays in app/modules/auth/cookies.py, which reads the headers off the
+# Request because it needs that same Request to reach the paired cookies;
+# FastAPI has no "document a header without binding it" primitive, so an
+# optional unread parameter is the declaration. Two things stop it rotting away
+# from the enforcement: each ``alias`` IS the cookies.py constant, so renaming
+# the header cannot leave a stale spec behind, and
+# tests/test_api_contract_openapi.py derives the expected header set per
+# operation from the helper calls each handler actually makes.
+#
+# Optional is the entire compatibility argument. Neither header carries a
+# default value, a pattern, or a required flag, so a caller that sends neither
+# gets the pre-GH-1302 token-in-body contract byte for byte — which is exactly
+# what the CLI, both generated SDKs, Postman, and CI logins send.
+_AUTH_MODE_PARAM_DESCRIPTION = (
+    f"Browser session-transport negotiation. Send `{COOKIE_AUTH_MODE}` to carry "
+    f"the refresh token in an httpOnly `{REFRESH_COOKIE_NAME}` cookie, paired "
+    f"with a script-readable `{CSRF_COOKIE_NAME}` cookie, and receive a null "
+    "`refresh_token` in the response body. When the header is absent (the "
+    "default) the refresh token is returned in the response body, which is the "
+    "contract every non-browser caller uses."
+)
+
+_CSRF_PARAM_DESCRIPTION = (
+    "Double-submit CSRF token, enforced only when the refresh cookie is what "
+    f"authenticates the call. Echo the value of the `{CSRF_COOKIE_NAME}` cookie "
+    "issued alongside the refresh cookie. Callers presenting a refresh token in "
+    "the request body do not send it."
+)
+
+
 # SP-11 (v1009.1) superseded by ROUTE-01 (Phase 1092): both slash and
 # no-slash variants register the same handler directly. Canonical
 # OpenAPI-published form is /login; /login/ is a hidden alias for callers
@@ -85,6 +136,12 @@ async def login(
     response: Response,
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: AsyncSession = Depends(get_db),
+    # fix(#1496): declared for the contract, read via wants_cookie_auth below.
+    auth_mode: str | None = Header(
+        default=None,
+        alias=AUTH_MODE_HEADER,
+        description=_AUTH_MODE_PARAM_DESCRIPTION,
+    ),
 ) -> TokenResponse:
     """Authenticate with username and password, receive a JWT token.
 
@@ -237,6 +294,18 @@ async def refresh(
     response: Response,
     body: RefreshRequest | None = None,
     db: AsyncSession = Depends(get_db),
+    # fix(#1496): declared for the contract, read via wants_cookie_auth /
+    # enforce_csrf below.
+    auth_mode: str | None = Header(
+        default=None,
+        alias=AUTH_MODE_HEADER,
+        description=_AUTH_MODE_PARAM_DESCRIPTION,
+    ),
+    csrf_token: str | None = Header(
+        default=None,
+        alias=CSRF_HEADER_NAME,
+        description=_CSRF_PARAM_DESCRIPTION,
+    ),
 ) -> TokenResponse:
     """Exchange a valid refresh token for a new access + refresh token pair.
 
@@ -694,6 +763,16 @@ async def logout(
     identity: Identity | None = Depends(get_optional_user),
     body: RefreshRequest | None = None,
     db: AsyncSession = Depends(get_db),
+    # fix(#1496): declared for the contract, read via enforce_csrf below. No
+    # auth-mode parameter here on purpose: unlike login and refresh, logout
+    # never calls wants_cookie_auth. It accepts the refresh cookie and clears
+    # both cookies unconditionally, so publishing a negotiation header this
+    # handler ignores would document an input that does nothing.
+    csrf_token: str | None = Header(
+        default=None,
+        alias=CSRF_HEADER_NAME,
+        description=_CSRF_PARAM_DESCRIPTION,
+    ),
 ) -> Response:
     """Revoke all refresh tokens and bump token_version for the current user.
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -25088,6 +25088,26 @@
       "post": {
         "description": "Authenticate with username and password, receive a JWT token.\n\nGH-1302: a caller sending ``X-GeoLens-Auth-Mode: cookie`` receives the\nrefresh token as an httpOnly cookie and a null ``refresh_token`` in the\nbody. Without that header the response is unchanged, which is what keeps\nthe CLI, the generated SDKs, Postman, and CI logins working.",
         "operationId": "login_auth_login_post",
+        "parameters": [
+          {
+            "description": "Browser session-transport negotiation. Send `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response body. When the header is absent (the default) the refresh token is returned in the response body, which is the contract every non-browser caller uses.",
+            "in": "header",
+            "name": "X-GeoLens-Auth-Mode",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Browser session-transport negotiation. Send `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response body. When the header is absent (the default) the refresh token is returned in the response body, which is the contract every non-browser caller uses.",
+              "title": "X-Geolens-Auth-Mode"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/x-www-form-urlencoded": {
@@ -25209,6 +25229,26 @@
       "post": {
         "description": "Revoke all refresh tokens and bump token_version for the current user.\n\nSEC-S15 (Phase 1062-01): revoke_all_tokens bumps User.token_version so the\naccess JWT used for this logout call (and any other outstanding access JWTs)\nare rejected on the next authenticated request \u2014 closing the\n\"logout doesn't invalidate the access JWT\" gap.\n\nfix(#821): logout deliberately does NOT bump key_epoch \u2014 API keys exist to\noutlive browser sessions (CI, MCP servers, tile URLs), so session hygiene\nmust not revoke them. Security events (password change, role change) do.\n\nfix(#1446): the refresh COOKIE can authenticate this call when the access\ntoken has aged out. Requiring a live bearer token meant a user returning\nafter their 15-minute access token expired got a 401 here while their\nmulti-day refresh cookie stayed valid \u2014 the UI reported a clean logout and\nthe session survived it. CSRF is enforced on that path exactly as it is for\n/auth/refresh, since the cookie is then the credential.",
         "operationId": "logout_auth_logout__post",
+        "parameters": [
+          {
+            "description": "Double-submit CSRF token, enforced only when the refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie issued alongside the refresh cookie. Callers presenting a refresh token in the request body do not send it.",
+            "in": "header",
+            "name": "X-CSRF-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Double-submit CSRF token, enforced only when the refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie issued alongside the refresh cookie. Callers presenting a refresh token in the request body do not send it.",
+              "title": "X-Csrf-Token"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -26053,6 +26093,44 @@
       "post": {
         "description": "Exchange a valid refresh token for a new access + refresh token pair.\n\nMulti-tenant clients must call this endpoint on their tenant host. Refresh\ntokens are opaque and carry no bearer ``tid`` claim, so tenant middleware\nbinds the database transaction from that same-origin host before the user\nrow is resolved and the next tenant-bound access token is minted.\n\nGH-1302: with ``X-GeoLens-Auth-Mode: cookie`` the presented token is read\nfrom the httpOnly cookie (falling back to the body once, so a session\nestablished before the cookie flow shipped migrates on its next refresh\ninstead of being logged out), the double-submit CSRF token is enforced, and\nthe rotated token goes back out as a cookie with a null body\n``refresh_token``. Without the header this endpoint behaves exactly as\nbefore.",
         "operationId": "refresh_auth_refresh__post",
+        "parameters": [
+          {
+            "description": "Browser session-transport negotiation. Send `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response body. When the header is absent (the default) the refresh token is returned in the response body, which is the contract every non-browser caller uses.",
+            "in": "header",
+            "name": "X-GeoLens-Auth-Mode",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Browser session-transport negotiation. Send `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response body. When the header is absent (the default) the refresh token is returned in the response body, which is the contract every non-browser caller uses.",
+              "title": "X-Geolens-Auth-Mode"
+            }
+          },
+          {
+            "description": "Double-submit CSRF token, enforced only when the refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie issued alongside the refresh cookie. Callers presenting a refresh token in the request body do not send it.",
+            "in": "header",
+            "name": "X-CSRF-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Double-submit CSRF token, enforced only when the refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie issued alongside the refresh cookie. Callers presenting a refresh token in the request body do not send it.",
+              "title": "X-Csrf-Token"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/backend/tests/test_api_contract_openapi.py
+++ b/backend/tests/test_api_contract_openapi.py
@@ -9,7 +9,7 @@ import textwrap
 
 from fastapi.routing import APIRoute
 
-from app.api.main import app
+from app.api.main import _iter_api_routes, app
 
 
 def _openapi() -> dict:
@@ -439,6 +439,95 @@ def test_config_ops_and_source_health_tags_are_title_case() -> None:
     health_op = spec["paths"]["/datasets/{dataset_id}/source-health/"]["post"]
     assert "Datasets - Source health" not in health_op["tags"]
     assert "Datasets - Source Health" in health_op["tags"]
+
+
+def _published_post_endpoint(path: str):
+    """The handler behind the schema-visible POST operation at *path*.
+
+    Two traps here. The auth routes register twice (ROUTE-01 dual-shape), so
+    ``include_in_schema`` picks the half that reaches the spec. And routes
+    included from a router stay NESTED under fastapi 0.140 — a plain scan of
+    ``app.routes`` sees almost none of the API — so this walks the flattened
+    route contexts, whose ``path_format`` carries the effective full path.
+    """
+    for ctx in _iter_api_routes(app):
+        if (
+            ctx.path_format == path
+            and "POST" in (ctx.route.methods or ())
+            and ctx.route.include_in_schema
+        ):
+            return ctx.route.endpoint
+    raise AssertionError(f"no published POST route at {path}")
+
+
+def _called_helper_names(endpoint, candidates: set[str]) -> set[str]:
+    """Which of *candidates* the handler calls directly."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(endpoint)))
+    return {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in candidates
+    }
+
+
+def test_cookie_session_operations_declare_their_negotiation_headers() -> None:
+    """fix(#1496): the cookie-mode headers are published parameters, not prose.
+
+    Before this, the three session-lifecycle operations declared zero
+    parameters, so a generated SDK or the docs request form could not express
+    the inputs that establish, refresh, or revoke a browser cookie session.
+
+    The expectation is derived from each handler's own body — which cookies.py
+    helper it calls decides which header is an input — so the declaration
+    cannot drift away from the enforcement in either direction: start
+    enforcing CSRF somewhere new without declaring it, or declare a header no
+    handler reads, and this fails.
+    """
+    from app.modules.auth.cookies import AUTH_MODE_HEADER, CSRF_HEADER_NAME
+
+    spec = _openapi()
+    helper_header = {
+        "wants_cookie_auth": AUTH_MODE_HEADER,
+        "enforce_csrf": CSRF_HEADER_NAME,
+    }
+    # Pinned as well as derived: logout deliberately never negotiates (it
+    # accepts the cookie and clears it unconditionally), and a change to that
+    # should have to edit this table rather than pass silently.
+    expected_helpers = {
+        "/auth/login": {"wants_cookie_auth"},
+        "/auth/refresh/": {"wants_cookie_auth", "enforce_csrf"},
+        "/auth/logout/": {"enforce_csrf"},
+    }
+
+    for path, helpers in expected_helpers.items():
+        endpoint = _published_post_endpoint(path)
+        assert _called_helper_names(endpoint, set(helper_header)) == helpers, (
+            f"{path} no longer calls the helpers this test was written against"
+        )
+
+        # .get: an operation with no parameters at all omits the key entirely,
+        # which is the exact state this test exists to catch — read it as an
+        # empty set so the failure is the set comparison, not a KeyError.
+        published = {
+            param["name"]: param
+            for param in spec["paths"][path]["post"].get("parameters", [])
+        }
+        assert set(published) == {helper_header[helper] for helper in helpers}, path
+
+        for name, param in published.items():
+            assert param["in"] == "header", (path, name)
+            # Optional, nullable, and defaultless is the compatibility
+            # contract: a caller that sends neither header gets the
+            # pre-GH-1302 token-in-body response byte for byte.
+            assert param["required"] is False, (path, name)
+            assert param["schema"]["anyOf"] == [{"type": "string"}, {"type": "null"}], (
+                path,
+                name,
+            )
+            assert "default" not in param["schema"], (path, name)
+            assert param["description"], (path, name)
 
 
 def test_inline_json_schema_rejects_recursive_model() -> None:

--- a/backend/tests/test_auth_refresh_cookies_1302.py
+++ b/backend/tests/test_auth_refresh_cookies_1302.py
@@ -129,6 +129,79 @@ class TestProgrammaticCallersUnchanged:
         assert resp.status_code == 200
 
 
+class TestDeclaredHeadersStayInert:
+    """fix(#1496): both headers are published OpenAPI parameters now.
+
+    Declaring them is a documentation change and has to stay one. FastAPI
+    validates declared parameters, so the risk the class covers is a parameter
+    that grows a required flag, a pattern, or a default and starts rejecting or
+    reshaping calls that used to succeed. Every case below sends a header value
+    the handler does not act on and expects the pre-GH-1302 behaviour.
+    """
+
+    async def test_an_unrecognised_auth_mode_still_returns_the_body_token(
+        self, client: AsyncClient
+    ):
+        """Only the exact opt-in value switches transport; anything else is
+        not an error, it is simply not the opt-in."""
+        resp = await client.post(
+            "/auth/login",
+            data={"username": ADMIN_USER, "password": ADMIN_PASS},
+            headers={"X-GeoLens-Auth-Mode": "bearer"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["refresh_token"]
+        assert not resp.headers.get_list("set-cookie")
+
+    async def test_an_empty_auth_mode_is_not_a_validation_error(
+        self, client: AsyncClient
+    ):
+        resp = await client.post(
+            "/auth/login",
+            data={"username": ADMIN_USER, "password": ADMIN_PASS},
+            headers={"X-GeoLens-Auth-Mode": ""},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["refresh_token"]
+
+    async def test_a_stray_csrf_header_does_not_disturb_a_body_token_refresh(
+        self, client: AsyncClient
+    ):
+        """No cookie authenticates this call, so the CSRF value is irrelevant
+        and must be neither validated nor enforced."""
+        refresh_token = (await _login(client, cookie_mode=False)).json()[
+            "refresh_token"
+        ]
+        client.cookies.clear()
+
+        resp = await client.post(
+            "/auth/refresh/",
+            json={"refresh_token": refresh_token},
+            headers={"X-CSRF-Token": "not-a-real-token"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["refresh_token"]
+
+    async def test_a_stray_csrf_header_does_not_disturb_a_body_token_logout(
+        self, client: AsyncClient
+    ):
+        refresh_token = (await _login(client, cookie_mode=False)).json()[
+            "refresh_token"
+        ]
+        client.cookies.clear()
+
+        resp = await client.post(
+            "/auth/logout/",
+            json={"refresh_token": refresh_token},
+            headers={"X-CSRF-Token": "not-a-real-token"},
+        )
+
+        assert resp.status_code == 204, resp.text
+
+
 class TestBrowserCookieFlow:
     async def test_login_sets_httponly_refresh_cookie_and_nulls_body_token(
         self, client: AsyncClient

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -17716,7 +17716,10 @@ export interface operations {
     login_auth_login_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Browser session-transport negotiation. Send `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response body. When the header is absent (the default) the refresh token is returned in the response body, which is the contract every non-browser caller uses. */
+                "X-GeoLens-Auth-Mode"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -17814,7 +17817,10 @@ export interface operations {
     logout_auth_logout__post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Double-submit CSRF token, enforced only when the refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie issued alongside the refresh cookie. Callers presenting a refresh token in the request body do not send it. */
+                "X-CSRF-Token"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -18474,7 +18480,12 @@ export interface operations {
     refresh_auth_refresh__post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Browser session-transport negotiation. Send `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response body. When the header is absent (the default) the refresh token is returned in the response body, which is the contract every non-browser caller uses. */
+                "X-GeoLens-Auth-Mode"?: string | null;
+                /** @description Double-submit CSRF token, enforced only when the refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie issued alongside the refresh cookie. Callers presenting a refresh token in the request body do not send it. */
+                "X-CSRF-Token"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };

--- a/sdks/python/geolens/api/auth/login_auth_login_post.py
+++ b/sdks/python/geolens/api/auth/login_auth_login_post.py
@@ -4,19 +4,23 @@ from typing import Any
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, UNSET
 from ... import errors
 
 from ...models.body_login_auth_login_post import BodyLoginAuthLoginPost
 from ...models.problem_detail import ProblemDetail
 from ...models.token_response import TokenResponse
+from ...types import Unset
 
 
 def _get_kwargs(
     *,
     body: BodyLoginAuthLoginPost,
+    x_geo_lens_auth_mode: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_geo_lens_auth_mode, Unset):
+        headers["X-GeoLens-Auth-Mode"] = x_geo_lens_auth_mode
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -100,6 +104,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: BodyLoginAuthLoginPost,
+    x_geo_lens_auth_mode: None | str | Unset = UNSET,
 ) -> Response[ProblemDetail | TokenResponse]:
     """Login
 
@@ -111,6 +116,11 @@ def sync_detailed(
     the CLI, the generated SDKs, Postman, and CI logins working.
 
     Args:
+        x_geo_lens_auth_mode (None | str | Unset): Browser session-transport negotiation. Send
+            `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a
+            script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response
+            body. When the header is absent (the default) the refresh token is returned in the
+            response body, which is the contract every non-browser caller uses.
         body (BodyLoginAuthLoginPost):
 
     Raises:
@@ -123,6 +133,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_geo_lens_auth_mode=x_geo_lens_auth_mode,
     )
 
     response = client.get_httpx_client().request(
@@ -136,6 +147,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: BodyLoginAuthLoginPost,
+    x_geo_lens_auth_mode: None | str | Unset = UNSET,
 ) -> ProblemDetail | TokenResponse | None:
     """Login
 
@@ -147,6 +159,11 @@ def sync(
     the CLI, the generated SDKs, Postman, and CI logins working.
 
     Args:
+        x_geo_lens_auth_mode (None | str | Unset): Browser session-transport negotiation. Send
+            `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a
+            script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response
+            body. When the header is absent (the default) the refresh token is returned in the
+            response body, which is the contract every non-browser caller uses.
         body (BodyLoginAuthLoginPost):
 
     Raises:
@@ -160,6 +177,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_geo_lens_auth_mode=x_geo_lens_auth_mode,
     ).parsed
 
 
@@ -167,6 +185,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: BodyLoginAuthLoginPost,
+    x_geo_lens_auth_mode: None | str | Unset = UNSET,
 ) -> Response[ProblemDetail | TokenResponse]:
     """Login
 
@@ -178,6 +197,11 @@ async def asyncio_detailed(
     the CLI, the generated SDKs, Postman, and CI logins working.
 
     Args:
+        x_geo_lens_auth_mode (None | str | Unset): Browser session-transport negotiation. Send
+            `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a
+            script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response
+            body. When the header is absent (the default) the refresh token is returned in the
+            response body, which is the contract every non-browser caller uses.
         body (BodyLoginAuthLoginPost):
 
     Raises:
@@ -190,6 +214,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_geo_lens_auth_mode=x_geo_lens_auth_mode,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -201,6 +226,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: BodyLoginAuthLoginPost,
+    x_geo_lens_auth_mode: None | str | Unset = UNSET,
 ) -> ProblemDetail | TokenResponse | None:
     """Login
 
@@ -212,6 +238,11 @@ async def asyncio(
     the CLI, the generated SDKs, Postman, and CI logins working.
 
     Args:
+        x_geo_lens_auth_mode (None | str | Unset): Browser session-transport negotiation. Send
+            `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a
+            script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response
+            body. When the header is absent (the default) the refresh token is returned in the
+            response body, which is the contract every non-browser caller uses.
         body (BodyLoginAuthLoginPost):
 
     Raises:
@@ -226,5 +257,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_geo_lens_auth_mode=x_geo_lens_auth_mode,
         )
     ).parsed

--- a/sdks/python/geolens/api/auth/logout_auth_logout_post.py
+++ b/sdks/python/geolens/api/auth/logout_auth_logout_post.py
@@ -15,8 +15,11 @@ from ...types import Unset
 def _get_kwargs(
     *,
     body: None | RefreshRequest | Unset = UNSET,
+    x_csrf_token: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_csrf_token, Unset):
+        headers["X-CSRF-Token"] = x_csrf_token
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -102,6 +105,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: None | RefreshRequest | Unset = UNSET,
+    x_csrf_token: None | str | Unset = UNSET,
 ) -> Response[Any | ProblemDetail]:
     r"""Logout
 
@@ -124,6 +128,10 @@ def sync_detailed(
     /auth/refresh, since the cookie is then the credential.
 
     Args:
+        x_csrf_token (None | str | Unset): Double-submit CSRF token, enforced only when the
+            refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie
+            issued alongside the refresh cookie. Callers presenting a refresh token in the request
+            body do not send it.
         body (None | RefreshRequest | Unset):
 
     Raises:
@@ -136,6 +144,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_csrf_token=x_csrf_token,
     )
 
     response = client.get_httpx_client().request(
@@ -149,6 +158,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: None | RefreshRequest | Unset = UNSET,
+    x_csrf_token: None | str | Unset = UNSET,
 ) -> Any | ProblemDetail | None:
     r"""Logout
 
@@ -171,6 +181,10 @@ def sync(
     /auth/refresh, since the cookie is then the credential.
 
     Args:
+        x_csrf_token (None | str | Unset): Double-submit CSRF token, enforced only when the
+            refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie
+            issued alongside the refresh cookie. Callers presenting a refresh token in the request
+            body do not send it.
         body (None | RefreshRequest | Unset):
 
     Raises:
@@ -184,6 +198,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_csrf_token=x_csrf_token,
     ).parsed
 
 
@@ -191,6 +206,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: None | RefreshRequest | Unset = UNSET,
+    x_csrf_token: None | str | Unset = UNSET,
 ) -> Response[Any | ProblemDetail]:
     r"""Logout
 
@@ -213,6 +229,10 @@ async def asyncio_detailed(
     /auth/refresh, since the cookie is then the credential.
 
     Args:
+        x_csrf_token (None | str | Unset): Double-submit CSRF token, enforced only when the
+            refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie
+            issued alongside the refresh cookie. Callers presenting a refresh token in the request
+            body do not send it.
         body (None | RefreshRequest | Unset):
 
     Raises:
@@ -225,6 +245,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_csrf_token=x_csrf_token,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -236,6 +257,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: None | RefreshRequest | Unset = UNSET,
+    x_csrf_token: None | str | Unset = UNSET,
 ) -> Any | ProblemDetail | None:
     r"""Logout
 
@@ -258,6 +280,10 @@ async def asyncio(
     /auth/refresh, since the cookie is then the credential.
 
     Args:
+        x_csrf_token (None | str | Unset): Double-submit CSRF token, enforced only when the
+            refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie
+            issued alongside the refresh cookie. Callers presenting a refresh token in the request
+            body do not send it.
         body (None | RefreshRequest | Unset):
 
     Raises:
@@ -272,5 +298,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_csrf_token=x_csrf_token,
         )
     ).parsed

--- a/sdks/python/geolens/api/auth/refresh_auth_refresh_post.py
+++ b/sdks/python/geolens/api/auth/refresh_auth_refresh_post.py
@@ -16,8 +16,15 @@ from ...types import Unset
 def _get_kwargs(
     *,
     body: None | RefreshRequest | Unset = UNSET,
+    x_geo_lens_auth_mode: None | str | Unset = UNSET,
+    x_csrf_token: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_geo_lens_auth_mode, Unset):
+        headers["X-GeoLens-Auth-Mode"] = x_geo_lens_auth_mode
+
+    if not isinstance(x_csrf_token, Unset):
+        headers["X-CSRF-Token"] = x_csrf_token
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -104,6 +111,8 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: None | RefreshRequest | Unset = UNSET,
+    x_geo_lens_auth_mode: None | str | Unset = UNSET,
+    x_csrf_token: None | str | Unset = UNSET,
 ) -> Response[ProblemDetail | TokenResponse]:
     """Refresh
 
@@ -123,6 +132,15 @@ def sync_detailed(
     before.
 
     Args:
+        x_geo_lens_auth_mode (None | str | Unset): Browser session-transport negotiation. Send
+            `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a
+            script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response
+            body. When the header is absent (the default) the refresh token is returned in the
+            response body, which is the contract every non-browser caller uses.
+        x_csrf_token (None | str | Unset): Double-submit CSRF token, enforced only when the
+            refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie
+            issued alongside the refresh cookie. Callers presenting a refresh token in the request
+            body do not send it.
         body (None | RefreshRequest | Unset):
 
     Raises:
@@ -135,6 +153,8 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_geo_lens_auth_mode=x_geo_lens_auth_mode,
+        x_csrf_token=x_csrf_token,
     )
 
     response = client.get_httpx_client().request(
@@ -148,6 +168,8 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: None | RefreshRequest | Unset = UNSET,
+    x_geo_lens_auth_mode: None | str | Unset = UNSET,
+    x_csrf_token: None | str | Unset = UNSET,
 ) -> ProblemDetail | TokenResponse | None:
     """Refresh
 
@@ -167,6 +189,15 @@ def sync(
     before.
 
     Args:
+        x_geo_lens_auth_mode (None | str | Unset): Browser session-transport negotiation. Send
+            `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a
+            script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response
+            body. When the header is absent (the default) the refresh token is returned in the
+            response body, which is the contract every non-browser caller uses.
+        x_csrf_token (None | str | Unset): Double-submit CSRF token, enforced only when the
+            refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie
+            issued alongside the refresh cookie. Callers presenting a refresh token in the request
+            body do not send it.
         body (None | RefreshRequest | Unset):
 
     Raises:
@@ -180,6 +211,8 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_geo_lens_auth_mode=x_geo_lens_auth_mode,
+        x_csrf_token=x_csrf_token,
     ).parsed
 
 
@@ -187,6 +220,8 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: None | RefreshRequest | Unset = UNSET,
+    x_geo_lens_auth_mode: None | str | Unset = UNSET,
+    x_csrf_token: None | str | Unset = UNSET,
 ) -> Response[ProblemDetail | TokenResponse]:
     """Refresh
 
@@ -206,6 +241,15 @@ async def asyncio_detailed(
     before.
 
     Args:
+        x_geo_lens_auth_mode (None | str | Unset): Browser session-transport negotiation. Send
+            `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a
+            script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response
+            body. When the header is absent (the default) the refresh token is returned in the
+            response body, which is the contract every non-browser caller uses.
+        x_csrf_token (None | str | Unset): Double-submit CSRF token, enforced only when the
+            refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie
+            issued alongside the refresh cookie. Callers presenting a refresh token in the request
+            body do not send it.
         body (None | RefreshRequest | Unset):
 
     Raises:
@@ -218,6 +262,8 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_geo_lens_auth_mode=x_geo_lens_auth_mode,
+        x_csrf_token=x_csrf_token,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -229,6 +275,8 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: None | RefreshRequest | Unset = UNSET,
+    x_geo_lens_auth_mode: None | str | Unset = UNSET,
+    x_csrf_token: None | str | Unset = UNSET,
 ) -> ProblemDetail | TokenResponse | None:
     """Refresh
 
@@ -248,6 +296,15 @@ async def asyncio(
     before.
 
     Args:
+        x_geo_lens_auth_mode (None | str | Unset): Browser session-transport negotiation. Send
+            `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a
+            script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response
+            body. When the header is absent (the default) the refresh token is returned in the
+            response body, which is the contract every non-browser caller uses.
+        x_csrf_token (None | str | Unset): Double-submit CSRF token, enforced only when the
+            refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie
+            issued alongside the refresh cookie. Callers presenting a refresh token in the request
+            body do not send it.
         body (None | RefreshRequest | Unset):
 
     Raises:
@@ -262,5 +319,7 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_geo_lens_auth_mode=x_geo_lens_auth_mode,
+            x_csrf_token=x_csrf_token,
         )
     ).parsed

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -13656,6 +13656,14 @@ export type CreateDownloadTokenEndpointAuthDownloadTokenDatasetIdPostResponse = 
 
 export type LoginAuthLoginPostData = {
     body: BodyLoginAuthLoginPost;
+    headers?: {
+        /**
+         * X-Geolens-Auth-Mode
+         *
+         * Browser session-transport negotiation. Send `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response body. When the header is absent (the default) the refresh token is returned in the response body, which is the contract every non-browser caller uses.
+         */
+        'X-GeoLens-Auth-Mode'?: string | null;
+    };
     path?: never;
     query?: never;
     url: '/auth/login';
@@ -13712,6 +13720,14 @@ export type LogoutAuthLogoutPostData = {
      * Body
      */
     body?: RefreshRequest | null;
+    headers?: {
+        /**
+         * X-Csrf-Token
+         *
+         * Double-submit CSRF token, enforced only when the refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie issued alongside the refresh cookie. Callers presenting a refresh token in the request body do not send it.
+         */
+        'X-CSRF-Token'?: string | null;
+    };
     path?: never;
     query?: never;
     url: '/auth/logout/';
@@ -14087,6 +14103,20 @@ export type RefreshAuthRefreshPostData = {
      * Body
      */
     body?: RefreshRequest | null;
+    headers?: {
+        /**
+         * X-Geolens-Auth-Mode
+         *
+         * Browser session-transport negotiation. Send `cookie` to carry the refresh token in an httpOnly `geolens_refresh` cookie, paired with a script-readable `geolens_csrf` cookie, and receive a null `refresh_token` in the response body. When the header is absent (the default) the refresh token is returned in the response body, which is the contract every non-browser caller uses.
+         */
+        'X-GeoLens-Auth-Mode'?: string | null;
+        /**
+         * X-Csrf-Token
+         *
+         * Double-submit CSRF token, enforced only when the refresh cookie is what authenticates the call. Echo the value of the `geolens_csrf` cookie issued alongside the refresh cookie. Callers presenting a refresh token in the request body do not send it.
+         */
+        'X-CSRF-Token'?: string | null;
+    };
     path?: never;
     query?: never;
     url: '/auth/refresh/';


### PR DESCRIPTION
## What

The cookie-mode browser flow (#1446, v1.13.0) negotiates with `X-GeoLens-Auth-Mode` and enforces double-submit CSRF with `X-CSRF-Token`, but the spec named both only in prose. `/auth/login`, `/auth/refresh/` and `/auth/logout/` published zero operation parameters, so generated SDKs and the docs reference's request UI had no way to express the inputs that establish, refresh, or revoke a cookie session.

This declares the headers as optional `Header(...)` parameters and regenerates every artifact derived from the spec.

## Header map, which differs from the issue

The issue asked for "the headers" on all three routes. I followed the handlers instead:

| Operation | `X-GeoLens-Auth-Mode` | `X-CSRF-Token` |
| --- | --- | --- |
| `POST /auth/login` | yes, `wants_cookie_auth` | no, it issues the CSRF cookie rather than reading one |
| `POST /auth/refresh/` | yes, `wants_cookie_auth` | yes, `enforce_csrf` |
| `POST /auth/logout/` | no | yes, `enforce_csrf` |

Logout never calls `wants_cookie_auth`. It accepts the refresh cookie and clears both cookies unconditionally, so an auth-mode parameter there would document an input the handler ignores.

Two smaller drifts from the issue text, both cosmetic: the published login path is `/auth/login` with no trailing slash (the slash form is a hidden ROUTE-01 alias), and the header constants sit at `backend/app/modules/auth/cookies.py:29-31` rather than 29-30.

## Compatibility

Optional is the whole argument. Neither parameter carries a default, a pattern, or a required flag, so a caller that omits both gets what it got before:

- the `backend/openapi.json` diff is 78 insertions with zero deletions
- `openapi-python-client` emits them as keyword-only arguments defaulting to `UNSET`, and sends no header when unset
- the frontend types move from `header?: never` to an optional `header?: { ... }`

`TestProgrammaticCallersUnchanged` in `backend/tests/test_auth_refresh_cookies_1302.py` is the existing behavioral guard for the no-header path, and it still passes. Four new cases in the same file cover the risk this PR introduces, which is a declared parameter that starts validating: an unrecognised auth mode, an empty auth mode, and a stray CSRF header on the body-token refresh and logout paths all behave as they did before.

## Enforcement does not move

The handlers still do not read these values. Every cookie and CSRF decision stays in `cookies.py`, which needs the `Request` anyway to reach the paired cookies. FastAPI has no way to document a header without binding it, so an optional unread parameter is the declaration. Two things keep it from drifting away from the enforcement:

- each `alias` is the `cookies.py` constant itself, so renaming a header cannot leave the spec stale
- `test_cookie_session_operations_declare_their_negotiation_headers` derives the expected header set per operation from the helper calls each handler actually makes, by AST. Declare a header no handler reads, or start enforcing CSRF somewhere without declaring it, and it fails.

I checked that test is not vacuous: with the logout declaration removed it fails with `assert set() == {'X-CSRF-Token'}`.

## Regenerated in lockstep (REL-04)

- `backend/openapi.json`
- `sdks/python/geolens/api/auth/{login,logout,refresh}_*.py`
- `sdks/typescript/src/client/types.gen.ts`
- `frontend/src/types/api.generated.ts`

The vendored snapshot in getgeolens.com is untouched, per the issue: it syncs at release time and has to byte-match a shipped release.

No schema, database, or config impact. The only runtime surface is three additional optional request parameters.

## Verification

| Command | Result |
| --- | --- |
| `pytest tests/test_api_contract_openapi.py tests/test_auth_refresh_cookies_1302.py tests/test_layering.py` | 106 passed |
| `pytest tests/test_auth.py tests/test_auth_refresh_logout.py tests/test_auth_revocation_horizon_1455.py tests/test_api_key_auth.py tests/test_openapi_property_order.py tests/test_openapi_overlay_boundary.py` | 98 passed, 1 skipped |
| `ruff check .` / `ruff format --check .` | passed, 1001 files already formatted |
| `make openapi-check` | exit 0 |
| `make sdks-check` | exit 0 |
| `make cli-test` | exit 0 (318 CLI + 8 round-trip) |
| `npm run typecheck` / `npm run types:check` | exit 0 |
| `npx vitest run src/lib/__tests__/auth-transport.test.ts src/api/__tests__/refresh-cookie-1302.test.ts` | 27 passed |

## Unrelated finding, left alone

The new test resolves routes through `_iter_api_routes(app)` rather than `app.routes`, because fastapi 0.140 keeps routes included from a router nested: a plain `app.routes` scan sees 133 of the app's 486 API routes and none of the 32 under `/auth`. `test_direct_route_http_exceptions_are_documented`, already in the same file, still scans `app.routes` and so silently covers about a quarter of the API. Out of scope here, worth its own issue.

Closes #1496
