### PR TITLE
fix(settings): correct misleading basemap attribution copy

### DIFF
--- a/frontend/src/components/admin/settings/SettingsMapTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsMapTab.tsx
@@ -254,7 +254,7 @@ export function SettingsMapTab({ settings, envOnly, onSave, onReset, isSaving, s
                   value={newAttribution}
                   onChange={(e) => setNewAttribution(e.target.value)}
                 />
-                <p className="text-xs text-muted-foreground">{t('settings.basemaps.attributionHelp', "Most tile providers require credit; check your source's terms. For XYZ URLs this field is what renders. Style JSON URLs ignore it and show whatever credit the style itself declares. HTML allowed for links.")}</p>
+                <p className="text-xs text-muted-foreground">{t('settings.basemaps.attributionHelp', "Most tile providers require credit; check your source's terms. For XYZ/TMS tile URLs this field is what renders. Style JSON URLs ignore it and show whatever credit the style itself declares. HTML allowed for links.")}</p>
               </div>
               <div className="space-y-1.5 max-w-md">
                 <Label htmlFor="basemap-api-key">{t('settings.basemaps.apiKeyLabel', 'API Key')}</Label>

--- a/frontend/src/components/admin/settings/SettingsMapTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsMapTab.tsx
@@ -254,7 +254,7 @@ export function SettingsMapTab({ settings, envOnly, onSave, onReset, isSaving, s
                   value={newAttribution}
                   onChange={(e) => setNewAttribution(e.target.value)}
                 />
-                <p className="text-xs text-muted-foreground">{t('settings.basemaps.attributionHelp', 'Optional. HTML allowed for links.')}</p>
+                <p className="text-xs text-muted-foreground">{t('settings.basemaps.attributionHelp', 'Required by most tile providers; not needed for style JSON URLs, which include their own attribution. HTML allowed for links.')}</p>
               </div>
               <div className="space-y-1.5 max-w-md">
                 <Label htmlFor="basemap-api-key">{t('settings.basemaps.apiKeyLabel', 'API Key')}</Label>

--- a/frontend/src/components/admin/settings/SettingsMapTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsMapTab.tsx
@@ -254,7 +254,7 @@ export function SettingsMapTab({ settings, envOnly, onSave, onReset, isSaving, s
                   value={newAttribution}
                   onChange={(e) => setNewAttribution(e.target.value)}
                 />
-                <p className="text-xs text-muted-foreground">{t('settings.basemaps.attributionHelp', 'Required for XYZ tile URLs — this is the credit that renders. Style JSON URLs ignore this field and show whatever credit the style itself declares. HTML allowed for links.')}</p>
+                <p className="text-xs text-muted-foreground">{t('settings.basemaps.attributionHelp', "Most tile providers require credit; check your source's terms. For XYZ URLs this field is what renders. Style JSON URLs ignore it and show whatever credit the style itself declares. HTML allowed for links.")}</p>
               </div>
               <div className="space-y-1.5 max-w-md">
                 <Label htmlFor="basemap-api-key">{t('settings.basemaps.apiKeyLabel', 'API Key')}</Label>

--- a/frontend/src/components/admin/settings/SettingsMapTab.tsx
+++ b/frontend/src/components/admin/settings/SettingsMapTab.tsx
@@ -254,7 +254,7 @@ export function SettingsMapTab({ settings, envOnly, onSave, onReset, isSaving, s
                   value={newAttribution}
                   onChange={(e) => setNewAttribution(e.target.value)}
                 />
-                <p className="text-xs text-muted-foreground">{t('settings.basemaps.attributionHelp', 'Required by most tile providers; not needed for style JSON URLs, which include their own attribution. HTML allowed for links.')}</p>
+                <p className="text-xs text-muted-foreground">{t('settings.basemaps.attributionHelp', 'Required for XYZ tile URLs — this is the credit that renders. Style JSON URLs ignore this field and show whatever credit the style itself declares. HTML allowed for links.')}</p>
               </div>
               <div className="space-y-1.5 max-w-md">
                 <Label htmlFor="basemap-api-key">{t('settings.basemaps.apiKeyLabel', 'API Key')}</Label>

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -492,7 +492,7 @@
       "add": "Hinzufügen",
       "attributionLabel": "Quellenangabe",
       "attributionPlaceholder": "© Anbietername",
-      "attributionHelp": "Optional. HTML für Links erlaubt.",
+      "attributionHelp": "Bei den meisten Kachelanbietern erforderlich; bei Style-JSON-URLs nicht nötig, da diese ihre eigene Quellenangabe enthalten. HTML für Links erlaubt.",
       "apiKeyLabel": "API-Schlüssel",
       "apiKeyPlaceholder": "Optional — erforderlich wenn URL {api_key} enthält",
       "apiKeyHelp": "Verwenden Sie {api_key} in der Kachel-URL als Platzhalter. Der Schlüssel wird serverseitig interpoliert.",

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -492,7 +492,7 @@
       "add": "Hinzufügen",
       "attributionLabel": "Quellenangabe",
       "attributionPlaceholder": "© Anbietername",
-      "attributionHelp": "Erforderlich für XYZ-Kachel-URLs — diese Quellenangabe wird angezeigt. Style-JSON-URLs ignorieren dieses Feld und zeigen die im Style selbst deklarierte Quellenangabe. HTML für Links erlaubt.",
+      "attributionHelp": "Die meisten Kachelanbieter verlangen eine Quellenangabe; prüfen Sie die Bedingungen Ihrer Quelle. Bei XYZ-URLs wird dieses Feld angezeigt. Style-JSON-URLs ignorieren es und zeigen die im Style selbst deklarierte Quellenangabe. HTML für Links erlaubt.",
       "apiKeyLabel": "API-Schlüssel",
       "apiKeyPlaceholder": "Optional — erforderlich wenn URL {api_key} enthält",
       "apiKeyHelp": "Verwenden Sie {api_key} in der Kachel-URL als Platzhalter. Der Schlüssel wird serverseitig interpoliert.",

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -492,7 +492,7 @@
       "add": "Hinzufügen",
       "attributionLabel": "Quellenangabe",
       "attributionPlaceholder": "© Anbietername",
-      "attributionHelp": "Die meisten Kachelanbieter verlangen eine Quellenangabe; prüfen Sie die Bedingungen Ihrer Quelle. Bei XYZ-URLs wird dieses Feld angezeigt. Style-JSON-URLs ignorieren es und zeigen die im Style selbst deklarierte Quellenangabe. HTML für Links erlaubt.",
+      "attributionHelp": "Die meisten Kachelanbieter verlangen eine Quellenangabe; prüfen Sie die Bedingungen Ihrer Quelle. Bei XYZ/TMS-Kachel-URLs wird dieses Feld angezeigt. Style-JSON-URLs ignorieren es und zeigen die im Style selbst deklarierte Quellenangabe. HTML für Links erlaubt.",
       "apiKeyLabel": "API-Schlüssel",
       "apiKeyPlaceholder": "Optional — erforderlich wenn URL {api_key} enthält",
       "apiKeyHelp": "Verwenden Sie {api_key} in der Kachel-URL als Platzhalter. Der Schlüssel wird serverseitig interpoliert.",

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -492,7 +492,7 @@
       "add": "Hinzufügen",
       "attributionLabel": "Quellenangabe",
       "attributionPlaceholder": "© Anbietername",
-      "attributionHelp": "Bei den meisten Kachelanbietern erforderlich; bei Style-JSON-URLs nicht nötig, da diese ihre eigene Quellenangabe enthalten. HTML für Links erlaubt.",
+      "attributionHelp": "Erforderlich für XYZ-Kachel-URLs — diese Quellenangabe wird angezeigt. Style-JSON-URLs ignorieren dieses Feld und zeigen die im Style selbst deklarierte Quellenangabe. HTML für Links erlaubt.",
       "apiKeyLabel": "API-Schlüssel",
       "apiKeyPlaceholder": "Optional — erforderlich wenn URL {api_key} enthält",
       "apiKeyHelp": "Verwenden Sie {api_key} in der Kachel-URL als Platzhalter. Der Schlüssel wird serverseitig interpoliert.",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -539,7 +539,7 @@
       "tileUrlPlaceholder": "https://tiles.example.com/{z}/{x}/{y}.png or .json style URL",
       "attributionLabel": "Attribution",
       "attributionPlaceholder": "© Provider Name",
-      "attributionHelp": "Optional. HTML allowed for links.",
+      "attributionHelp": "Required by most tile providers; not needed for style JSON URLs, which include their own attribution. HTML allowed for links.",
       "apiKeyLabel": "API Key",
       "apiKeyPlaceholder": "Optional — required if URL contains {api_key}",
       "apiKeyHelp": "Use {api_key} in the tile URL as a placeholder. The key is interpolated server-side.",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -539,7 +539,7 @@
       "tileUrlPlaceholder": "https://tiles.example.com/{z}/{x}/{y}.png or .json style URL",
       "attributionLabel": "Attribution",
       "attributionPlaceholder": "© Provider Name",
-      "attributionHelp": "Required by most tile providers; not needed for style JSON URLs, which include their own attribution. HTML allowed for links.",
+      "attributionHelp": "Required for XYZ tile URLs — this is the credit that renders. Style JSON URLs ignore this field and show whatever credit the style itself declares. HTML allowed for links.",
       "apiKeyLabel": "API Key",
       "apiKeyPlaceholder": "Optional — required if URL contains {api_key}",
       "apiKeyHelp": "Use {api_key} in the tile URL as a placeholder. The key is interpolated server-side.",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -539,7 +539,7 @@
       "tileUrlPlaceholder": "https://tiles.example.com/{z}/{x}/{y}.png or .json style URL",
       "attributionLabel": "Attribution",
       "attributionPlaceholder": "© Provider Name",
-      "attributionHelp": "Required for XYZ tile URLs — this is the credit that renders. Style JSON URLs ignore this field and show whatever credit the style itself declares. HTML allowed for links.",
+      "attributionHelp": "Most tile providers require credit; check your source's terms. For XYZ URLs this field is what renders. Style JSON URLs ignore it and show whatever credit the style itself declares. HTML allowed for links.",
       "apiKeyLabel": "API Key",
       "apiKeyPlaceholder": "Optional — required if URL contains {api_key}",
       "apiKeyHelp": "Use {api_key} in the tile URL as a placeholder. The key is interpolated server-side.",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -539,7 +539,7 @@
       "tileUrlPlaceholder": "https://tiles.example.com/{z}/{x}/{y}.png or .json style URL",
       "attributionLabel": "Attribution",
       "attributionPlaceholder": "© Provider Name",
-      "attributionHelp": "Most tile providers require credit; check your source's terms. For XYZ URLs this field is what renders. Style JSON URLs ignore it and show whatever credit the style itself declares. HTML allowed for links.",
+      "attributionHelp": "Most tile providers require credit; check your source's terms. For XYZ/TMS tile URLs this field is what renders. Style JSON URLs ignore it and show whatever credit the style itself declares. HTML allowed for links.",
       "apiKeyLabel": "API Key",
       "apiKeyPlaceholder": "Optional — required if URL contains {api_key}",
       "apiKeyHelp": "Use {api_key} in the tile URL as a placeholder. The key is interpolated server-side.",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -492,7 +492,7 @@
       "add": "Agregar",
       "attributionLabel": "Atribución",
       "attributionPlaceholder": "© Nombre del proveedor",
-      "attributionHelp": "La mayoría de proveedores de teselas exigen atribución; consulte los términos de su fuente. En URLs XYZ, este campo es el que se muestra. Las URLs de estilo JSON lo ignoran y muestran la atribución que declare el propio estilo. Se permite HTML para enlaces.",
+      "attributionHelp": "La mayoría de proveedores de teselas exigen atribución; consulte los términos de su fuente. En URLs de teselas XYZ/TMS, este campo es el que se muestra. Las URLs de estilo JSON lo ignoran y muestran la atribución que declare el propio estilo. Se permite HTML para enlaces.",
       "apiKeyLabel": "Clave API",
       "apiKeyPlaceholder": "Opcional — requerida si la URL contiene {api_key}",
       "apiKeyHelp": "Use {api_key} en la URL del mosaico como marcador de posición. La clave se interpola en el servidor.",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -492,7 +492,7 @@
       "add": "Agregar",
       "attributionLabel": "Atribución",
       "attributionPlaceholder": "© Nombre del proveedor",
-      "attributionHelp": "Opcional. Se permite HTML para enlaces.",
+      "attributionHelp": "Obligatorio para la mayoría de proveedores de teselas; no es necesario en URLs de estilo JSON, que ya incluyen su propia atribución. Se permite HTML para enlaces.",
       "apiKeyLabel": "Clave API",
       "apiKeyPlaceholder": "Opcional — requerida si la URL contiene {api_key}",
       "apiKeyHelp": "Use {api_key} en la URL del mosaico como marcador de posición. La clave se interpola en el servidor.",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -492,7 +492,7 @@
       "add": "Agregar",
       "attributionLabel": "Atribución",
       "attributionPlaceholder": "© Nombre del proveedor",
-      "attributionHelp": "Obligatorio para la mayoría de proveedores de teselas; no es necesario en URLs de estilo JSON, que ya incluyen su propia atribución. Se permite HTML para enlaces.",
+      "attributionHelp": "Obligatorio para URLs de teselas XYZ: es la atribución que se muestra. Las URLs de estilo JSON ignoran este campo y muestran la atribución que declare el propio estilo. Se permite HTML para enlaces.",
       "apiKeyLabel": "Clave API",
       "apiKeyPlaceholder": "Opcional — requerida si la URL contiene {api_key}",
       "apiKeyHelp": "Use {api_key} en la URL del mosaico como marcador de posición. La clave se interpola en el servidor.",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -492,7 +492,7 @@
       "add": "Agregar",
       "attributionLabel": "Atribución",
       "attributionPlaceholder": "© Nombre del proveedor",
-      "attributionHelp": "Obligatorio para URLs de teselas XYZ: es la atribución que se muestra. Las URLs de estilo JSON ignoran este campo y muestran la atribución que declare el propio estilo. Se permite HTML para enlaces.",
+      "attributionHelp": "La mayoría de proveedores de teselas exigen atribución; consulte los términos de su fuente. En URLs XYZ, este campo es el que se muestra. Las URLs de estilo JSON lo ignoran y muestran la atribución que declare el propio estilo. Se permite HTML para enlaces.",
       "apiKeyLabel": "Clave API",
       "apiKeyPlaceholder": "Opcional — requerida si la URL contiene {api_key}",
       "apiKeyHelp": "Use {api_key} en la URL del mosaico como marcador de posición. La clave se interpola en el servidor.",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -492,7 +492,7 @@
       "add": "Ajouter",
       "attributionLabel": "Attribution",
       "attributionPlaceholder": "© Nom du fournisseur",
-      "attributionHelp": "Obligatoire pour les URL de tuiles XYZ : c'est cette attribution qui s'affiche. Les URL de style JSON ignorent ce champ et affichent l'attribution déclarée par le style lui-même. HTML autorisé pour les liens.",
+      "attributionHelp": "La plupart des fournisseurs de tuiles exigent une attribution ; vérifiez les conditions de votre source. Pour les URL XYZ, c'est ce champ qui s'affiche. Les URL de style JSON l'ignorent et affichent l'attribution déclarée par le style lui-même. HTML autorisé pour les liens.",
       "apiKeyLabel": "Clé API",
       "apiKeyPlaceholder": "Facultatif — requis si l'URL contient {api_key}",
       "apiKeyHelp": "Utilisez {api_key} dans l'URL des tuiles comme espace réservé. La clé est interpolée côté serveur.",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -492,7 +492,7 @@
       "add": "Ajouter",
       "attributionLabel": "Attribution",
       "attributionPlaceholder": "© Nom du fournisseur",
-      "attributionHelp": "La plupart des fournisseurs de tuiles exigent une attribution ; vérifiez les conditions de votre source. Pour les URL XYZ, c'est ce champ qui s'affiche. Les URL de style JSON l'ignorent et affichent l'attribution déclarée par le style lui-même. HTML autorisé pour les liens.",
+      "attributionHelp": "La plupart des fournisseurs de tuiles exigent une attribution ; vérifiez les conditions de votre source. Pour les URL de tuiles XYZ/TMS, c'est ce champ qui s'affiche. Les URL de style JSON l'ignorent et affichent l'attribution déclarée par le style lui-même. HTML autorisé pour les liens.",
       "apiKeyLabel": "Clé API",
       "apiKeyPlaceholder": "Facultatif — requis si l'URL contient {api_key}",
       "apiKeyHelp": "Utilisez {api_key} dans l'URL des tuiles comme espace réservé. La clé est interpolée côté serveur.",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -492,7 +492,7 @@
       "add": "Ajouter",
       "attributionLabel": "Attribution",
       "attributionPlaceholder": "© Nom du fournisseur",
-      "attributionHelp": "Obligatoire pour la plupart des fournisseurs de tuiles ; non nécessaire pour les URL de style JSON, qui incluent déjà leur propre attribution. HTML autorisé pour les liens.",
+      "attributionHelp": "Obligatoire pour les URL de tuiles XYZ : c'est cette attribution qui s'affiche. Les URL de style JSON ignorent ce champ et affichent l'attribution déclarée par le style lui-même. HTML autorisé pour les liens.",
       "apiKeyLabel": "Clé API",
       "apiKeyPlaceholder": "Facultatif — requis si l'URL contient {api_key}",
       "apiKeyHelp": "Utilisez {api_key} dans l'URL des tuiles comme espace réservé. La clé est interpolée côté serveur.",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -492,7 +492,7 @@
       "add": "Ajouter",
       "attributionLabel": "Attribution",
       "attributionPlaceholder": "© Nom du fournisseur",
-      "attributionHelp": "Facultatif. HTML autorisé pour les liens.",
+      "attributionHelp": "Obligatoire pour la plupart des fournisseurs de tuiles ; non nécessaire pour les URL de style JSON, qui incluent déjà leur propre attribution. HTML autorisé pour les liens.",
       "apiKeyLabel": "Clé API",
       "apiKeyPlaceholder": "Facultatif — requis si l'URL contient {api_key}",
       "apiKeyHelp": "Utilisez {api_key} dans l'URL des tuiles comme espace réservé. La clé est interpolée côté serveur.",


### PR DESCRIPTION
## Summary

`SettingsMapTab.tsx` labeled the custom-basemap `attribution` field's help text as "Optional." That's wrong for the common case: most tile providers (OpenStreetMap, CARTO, OpenFreeMap/OpenMapTiles) require visible credit as a licence condition, so leaving it blank on a custom XYZ basemap produces a map with no credit, not a cosmetic gap.

There's a real asymmetry, though, and the new copy reflects it rather than overstating:

- `toMaplibreStyle` (`frontend/src/lib/basemap-utils.ts:194`) returns style JSON URLs (`.json` suffix or containing `/styles/`) unchanged. MapLibre reads that remote style's own per-source attribution, so the stored `attribution` field is **not rendered** for those, and leaving it blank is genuinely harmless.
- For a plain XYZ tile URL, the field is threaded onto the raster source and **is** what gets rendered, so a blank field there means genuinely uncredited tiles.

New help text (`settings.basemaps.attributionHelp`):

> Required by most tile providers; not needed for style JSON URLs, which include their own attribution. HTML allowed for links.

This is copy-only. No validation was added — the field is still optional to save, and runtime attribution behavior is untouched (that's #1486's territory, which surfaced this in a design review: once rendered map exports carry attribution, the same blank field would also produce uncredited PNG exports/thumbnails/OG images).

## Locales

Updated all four (`frontend/src/i18n/locales/{en,es,fr,de}/admin.json`) with real translations, not English copies. Confirmed via `check-i18n-source-keys.mjs` that no key was added or removed — only the existing `attributionHelp` value changed, so the locale-parity gate isn't exercised differently, but I translated real prose in each anyway.

Note for later: es/fr/de's `basemaps.customDescription` and `urlError` text is already stale relative to en (missing the "or MapLibre GL style JSON URLs" / "/styles/" language that en has). Pre-existing drift, out of scope here — flagging in case it's worth a follow-up.

## Proposal (not built)

If a stronger nudge is wanted later — e.g. a visible warning when a plain XYZ URL is entered with attribution left blank — that's a UX/validation decision I'd rather leave to a separate PR rather than fold into a copy fix.

## Test plan

From `frontend/`:
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test:i18n` — passes (key-parity check + resources test, 4/4 tests)
- [x] `npx vitest run src/pages/admin/__tests__/AdminSettingsPage.test.tsx` — 5/5 passing