### PR TITLE
ci(readme): gate the committed README screenshot dimensions

### DIFF
--- a/.github/assets/README.md
+++ b/.github/assets/README.md
@@ -69,9 +69,29 @@ The three content shots (Find / Inspect / Ask AI panel) are deterministic — th
 are the ones that drift with catalog data, which is exactly what the automated
 recipe keeps in parity with the marketing site.
 
+## Keeping the committed files intact
+
+`npm run check:readme-assets` (from the repo root) pins every image in this
+folder to an exact pixel size and fails if one moves. CI runs it on every PR, and
+there is a pre-commit hook for it.
+
+It exists because these files get silently downscaled. The `image-sanitizer`
+Claude Code plugin hooks the **Read** tool and runs `magick -resize` in place on
+anything wider than 1200px, so a committed image loses resolution the moment
+somebody opens it to look at it — long after whatever produced it exited. Never
+open a master with an image-previewing tool. Measure with `sips -g pixelWidth -g
+pixelHeight`, and copy to a throwaway path first if you want to see one.
+
+Adding an image here means adding it to `scripts/check-readme-assets.mjs` too;
+the gate fails on an unpinned file rather than ignoring it.
+
 ## Capture notes
 
-- Sources are captured at 1600×900; the README renders them at `width="900"`.
+- The recipe captures at 1600×900 and the README renders at `width="900"`.
+  The five `capture:readme` shots currently committed are **not** at that size —
+  they are 1200×750 (1200×800 for `geolens-ai-labels.png`), predating the
+  automated recipe and downscaled on top of it. `check-readme-assets.mjs` records
+  the gap and pins them where they are; recapturing is a separate change.
   Optionally strip/optimize before committing (e.g. `magick in.png -strip out.png`;
   JPG at quality ~88 for terrain).
 - These images are public. Keep them free of private/draft dataset titles,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -885,6 +885,35 @@ jobs:
       - name: Surface gate regression tests
         run: python -m unittest tests.test_check_public_surface tests.test_check_deployed_surface
 
+  # ---------- README assets ----------
+  # Gate over the committed README screenshots in .github/assets/.
+  #
+  # The image-sanitizer Claude Code plugin resizes images IN PLACE from a
+  # PreToolUse hook on the Read tool (shrink-only, 1200px cap), so any committed
+  # image wider than that silently loses resolution the first time someone opens
+  # it to look at it. docs and marketing (both in getgeolens.com) each grew a gate
+  # against this; the README shots did not, because they are produced in that repo
+  # and committed in THIS one, so neither side owned the check. Three of the
+  # source-panel crops are 1232px wide and were live-vulnerable.
+  #
+  # No path filter on purpose: the corruption edits the images, so a filtered job
+  # would still fire, but this also catches a manifest edit that quietly unpins a
+  # file. Pure stdlib Node — no DB, browser, or network. Runs on every push/PR.
+  readme-assets:
+    name: README Assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: 22
+
+      # No `npm ci` — the script is dependency-free stdlib Node, so the job stays
+      # a few seconds.
+      - name: Check committed README image dimensions
+        run: npm run check:readme-assets
+
   # ---------- CLI ----------
   # Structural enforcement that the CLI never grows
   # a direct httpx/requests dependency. Runs on cli/** OR sdks/python/**
@@ -1519,6 +1548,7 @@ jobs:
       - pre-commit
       - version-coherence
       - docs-contract
+      - readme-assets
       # fix(#825): PR-only browser gate; skipped (non-stack PRs, push, cron)
       # counts as pass below, failed blocks the merge.
       - e2e-smoke

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,6 +129,20 @@ repos:
         types_or: [python, pyi]
         files: '^backend/.*\.py$'
 
+      # --- Committed README images ---
+      # The image-sanitizer plugin resizes images in place from a PreToolUse hook
+      # on the Read tool, so the damage happens on a developer's machine between
+      # checkout and commit. Catching it here is strictly earlier than CI; the
+      # readme-assets job in ci.yml is the backstop for anyone not running hooks.
+      # pass_filenames is off because the script checks the whole folder,
+      # including the "an image landed here unpinned" case.
+      - id: readme-assets
+        name: "README image dimensions (.github/assets)"
+        language: system
+        entry: node scripts/check-readme-assets.mjs
+        pass_filenames: false
+        files: '^(\.github/assets/|scripts/check-readme-assets\.mjs$)'
+
   # --- Generic hygiene + secret scanning ---
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "e2e:export": "npx playwright test e2e/export-runtime.spec.ts --project=api --workers=1 --retries=0",
     "e2e:ui": "npx playwright test --ui",
     "check:readme-locales": "node scripts/check-readme-locales.mjs",
+    "check:readme-assets": "node scripts/check-readme-assets.mjs",
     "check:public-surface": "make public-surface-check",
     "check:deployed-surface": "make deployed-surface-check"
   },

--- a/scripts/check-readme-assets.mjs
+++ b/scripts/check-readme-assets.mjs
@@ -157,8 +157,29 @@ for (const [filename, expected] of Object.entries(README_ASSETS)) {
 
 // A new image that nobody pinned is a new unguarded surface — which is the exact
 // hole this gate exists to close. Fail rather than ignore it.
-const onDisk = fs
-  .readdirSync(assetDir)
+//
+// fix(#1500 review): `readdirSync` returns immediate children only, so an image
+// at `.github/assets/<subdir>/shot.png` was seen as a directory name, matched no
+// image extension, and slipped through unpinned — the gate reporting success on
+// precisely the file it was meant to cover. The manifest is keyed by bare
+// filename, so rather than recurse (which would make two files of the same name
+// in different directories collide on one key), reject subdirectories outright.
+// AGENTS.md puts README images in `.github/assets/`, flat, so this enforces the
+// documented layout instead of quietly supporting a second one.
+const entries = fs.readdirSync(assetDir, { withFileTypes: true });
+
+for (const entry of entries) {
+  if (entry.isDirectory()) {
+    failures.push(
+      `${entry.name}/: .github/assets/ must stay flat — README images live directly in it ` +
+        '(AGENTS.md), and a nested image would not be covered by this gate',
+    );
+  }
+}
+
+const onDisk = entries
+  .filter((entry) => !entry.isDirectory())
+  .map((entry) => entry.name)
   .filter((name) => IMAGE_EXTENSIONS.has(path.extname(name).toLowerCase()));
 for (const name of onDisk) {
   if (!(name in README_ASSETS)) {

--- a/scripts/check-readme-assets.mjs
+++ b/scripts/check-readme-assets.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// check-readme-assets.mjs — gate over the committed README images in .github/assets/.
+//
+// Run: npm run check:readme-assets
+//
+// Asserts every committed README image is present and still exactly the size
+// this file pins for it, and that no image sits in .github/assets/ unpinned.
+// Needs no database, browser, or network — pure stdlib, safe anywhere.
+//
+// WHY A GATE OVER THE COMMITTED FILES
+//
+// The `image-sanitizer` Claude Code plugin registers a PreToolUse hook on the
+// Read TOOL. Before a read is served it runs, in place:
+//     magick <file> -resize "${CLAUDE_IMAGE_MAX_DIMENSION:-1200}x...>"
+// on any path with an image extension. Shrink-only, aspect preserved, 1200px
+// cap. So the rewrite is synchronous and deterministic — not a race — and it is
+// triggered by somebody choosing to eyeball a committed image, which usually
+// happens long after whatever produced it exited. Only a check you can run at
+// commit time sees that.
+//
+// This is the third such gate. docs (getgeolens.com/docs) has verify-build.sh
+// QUICK-03; marketing (getgeolens.com) has scripts/verify-screenshots.mjs. The
+// README shots were the one unguarded surface, because they are produced in one
+// repo (getgeolens.com/scripts/capture-readme.ts) and committed in another
+// (here). The gate belongs where the files are committed and where CI can run it
+// on every PR — so, here.
+//
+// Note this is a VERIFICATION script, not a capture script: .github/assets/README.md
+// asks that capture tooling stay out of this public repo, and it does. Nothing
+// here launches a browser or talks to a GeoLens.
+//
+// The operator rule this enforces: never open a master with an image-previewing
+// tool. Measure with `sips -g pixelWidth -g pixelHeight`, and copy to a throwaway
+// path first if you want to look at one.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const assetDir = path.join(repoRoot, '.github/assets');
+
+// Every image committed under .github/assets/, with the size it must be on disk.
+//
+// `capturedAt` records the size the upstream capture recipe DECLARES for a shot,
+// when that differs from what is committed. It is documentation of a known
+// deficit, not a second assertion: the gate pins `width`/`height` so nothing can
+// degrade further, and reports the gap so it stays visible instead of being
+// silently blessed. Clear a `capturedAt` by recapturing and updating
+// `width`/`height` to match it in the same commit.
+const README_ASSETS = {
+  // --- The five targets of getgeolens.com/scripts/capture-readme.ts ---------
+  // That script declares `const VP = { width: 1600, height: 900 }` for all five,
+  // and .github/assets/README.md documents "Sources are captured at 1600x900".
+  // What is committed is neither: 1200x750 is a 1.6 aspect, and 1200x800 is 1.5,
+  // while 1600x900 is 1.778. A sanitizer pass over a 1600x900 master lands at
+  // 1200x675 (measured), so these are not downscales of the current recipe —
+  // they are downscales of an older, differently-shaped hand capture. Git agrees:
+  // at #205 (2026-06-07) four of them were 1200x675, i.e. genuinely 1600x900
+  // shrunk; they became 1200x750 at #407 (2026-07-06) and have not moved since.
+  //
+  // They are pinned here at their committed size rather than at 1600x900 so this
+  // gate lands green and starts protecting the other ten images immediately. See
+  // the PR for why the recapture is a separate change.
+  'geolens-manhattan-3d-hero.jpg': { width: 1200, height: 750, capturedAt: { width: 1600, height: 900 } },
+  'geolens-search.png': { width: 1200, height: 750, capturedAt: { width: 1600, height: 900 } },
+  'geolens-dataset.png': { width: 1200, height: 750, capturedAt: { width: 1600, height: 900 } },
+  'geolens-matterhorn-terrain.jpg': { width: 1200, height: 750, capturedAt: { width: 1600, height: 900 } },
+  'geolens-ai-labels.png': { width: 1200, height: 800, capturedAt: { width: 1600, height: 900 } },
+
+  // --- Hand-captured, added 2026-07-23 (#659) ------------------------------
+  // Not part of capture-readme.ts's target list; .github/assets/README.md
+  // documents them at 1200x750, which is what is on disk. 1200 is exactly the
+  // sanitizer's cap, so they are already immune to it — pinned here to catch
+  // replacement and deletion.
+  'geolens-dataset-chat.png': { width: 1200, height: 750 },
+  'geolens-dataset-chat-dark.png': { width: 1200, height: 750 },
+  'geolens-admin-overview.png': { width: 1200, height: 750 },
+  'geolens-admin-overview-dark.png': { width: 1200, height: 750 },
+  'geolens-admin-users.png': { width: 1200, height: 750 },
+  'geolens-admin-users-dark.png': { width: 1200, height: 750 },
+
+  // --- Source-panel crops, added 2026-08-08 (#1279, #1280) -----------------
+  // These are the ones currently AT RISK: 1232 > 1200, so a single Read on any
+  // of the three would shrink it to 1200 wide. That is the immediate value of
+  // this gate.
+  'source-panel-service.png': { width: 1232, height: 522 },
+  'source-panel-vrt.png': { width: 1232, height: 619 },
+  'source-state-dataset-header.png': { width: 1232, height: 116 },
+  'source-state-search-chips.png': { width: 760, height: 176 },
+};
+
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.avif']);
+
+// PNG + JPEG header parse. Deliberately dependency-free: this gate has to run in
+// a bare CI job with nothing installed, and shelling out to sips would tie it to
+// macOS. Mirrors readImageDimensions() in getgeolens.com/scripts/lib/capture-core.mjs.
+function readImageDimensions(file) {
+  const buf = fs.readFileSync(file);
+  if (buf.length > 24 && buf.toString('ascii', 1, 4) === 'PNG') {
+    return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+  }
+  if (buf.length > 4 && buf[0] === 0xff && buf[1] === 0xd8) {
+    // Scan JPEG segments for the first SOF marker (0xC0-0xCF minus DHT/JPG/DAC).
+    let off = 2;
+    while (off + 9 < buf.length) {
+      if (buf[off] !== 0xff) { off++; continue; }
+      const marker = buf[off + 1];
+      if (marker === 0xff) { off++; continue; }
+      if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+        return { height: buf.readUInt16BE(off + 5), width: buf.readUInt16BE(off + 7) };
+      }
+      off += 2 + buf.readUInt16BE(off + 2);
+    }
+    throw new Error('no JPEG SOF marker found');
+  }
+  throw new Error('not a PNG or JPEG');
+}
+
+const failures = [];
+const rows = [];
+const deficits = [];
+
+for (const [filename, expected] of Object.entries(README_ASSETS)) {
+  const file = path.join(assetDir, filename);
+
+  if (!fs.existsSync(file)) {
+    failures.push(`${filename}: missing from .github/assets/`);
+    continue;
+  }
+
+  let actual;
+  try {
+    actual = readImageDimensions(file);
+  } catch (err) {
+    failures.push(`${filename}: ${err instanceof Error ? err.message : String(err)}`);
+    continue;
+  }
+
+  const ok = actual.width === expected.width && actual.height === expected.height;
+  rows.push(
+    `  ${ok ? 'ok  ' : 'FAIL'} ${filename.padEnd(34)} ${actual.width}x${actual.height}` +
+      (ok ? '' : `  (expected ${expected.width}x${expected.height})`),
+  );
+  if (!ok) {
+    failures.push(
+      `${filename} is ${actual.width}x${actual.height} on disk; expected ${expected.width}x${expected.height}`,
+    );
+  } else if (expected.capturedAt) {
+    deficits.push(
+      `${filename}: pinned at ${expected.width}x${expected.height}, but the capture recipe ` +
+        `declares ${expected.capturedAt.width}x${expected.capturedAt.height}`,
+    );
+  }
+}
+
+// A new image that nobody pinned is a new unguarded surface — which is the exact
+// hole this gate exists to close. Fail rather than ignore it.
+const onDisk = fs
+  .readdirSync(assetDir)
+  .filter((name) => IMAGE_EXTENSIONS.has(path.extname(name).toLowerCase()));
+for (const name of onDisk) {
+  if (!(name in README_ASSETS)) {
+    failures.push(
+      `${name}: committed in .github/assets/ but not pinned in ${path.basename(fileURLToPath(import.meta.url))} — ` +
+        'add it with its dimensions so it is covered too',
+    );
+  }
+}
+
+console.log(`Verifying ${Object.keys(README_ASSETS).length} committed README images in .github/assets`);
+for (const row of rows) console.log(row);
+
+if (failures.length > 0) {
+  console.error(`\nFAIL: ${failures.length} problem(s) with the committed README images:`);
+  for (const line of failures) console.error(`  ${line}`);
+  console.error(
+    '\n  An image at exactly 1200px on its long edge was almost certainly resized in\n' +
+      '  place by the image-sanitizer plugin, which hooks the Read tool. Restore it with\n' +
+      '  `git checkout -- .github/assets/<file>` if it is committed correctly. Never open\n' +
+      '  a master with an image-previewing tool — measure with\n' +
+      '  `sips -g pixelWidth -g pixelHeight`, and copy to a throwaway path first if you\n' +
+      '  want to look at it. The capture recipe lives in the getgeolens.com repo\n' +
+      '  (`npm run capture:readme`); see .github/assets/README.md.',
+  );
+  process.exit(1);
+}
+
+if (deficits.length > 0) {
+  console.log(`\n${deficits.length} image(s) are pinned below their declared capture size:`);
+  for (const line of deficits) console.log(`  - ${line}`);
+  console.log('  Recapture with `npm run capture:readme` from the getgeolens.com repo, then');
+  console.log('  update width/height here and drop the capturedAt entry in the same commit.');
+}
+
+console.log(`\nOK: all ${rows.length} README images are at their pinned size.`);


### PR DESCRIPTION
## What

Adds `scripts/check-readme-assets.mjs`, a gate over the 15 committed images in
`.github/assets/`. It pins each one to an exact pixel size, fails if a size moves,
and fails if an image is committed without being pinned. Wired into `ci.yml` as an
always-run job feeding `ci-ok`, plus a pre-commit hook.

The `image-sanitizer` editor plugin hooks the **Read** tool and runs
`magick <file> -resize "${CLAUDE_IMAGE_MAX_DIMENSION:-1200}x...>"` in place. Shrink
only, aspect preserved, 1200px cap. So a committed image loses resolution the moment
somebody opens it to look at it, usually long after whatever produced it exited. It is
synchronous and agent-triggered, not a race.

Docs (`verify-build.sh` QUICK-03) and marketing (`scripts/verify-screenshots.mjs`) both
have a gate for this. The README shots did not, because they are captured in
getgeolens.com (`scripts/capture-readme.ts`) and committed here, so neither repo owned
the check. The gate belongs where the files are committed and where CI sees every PR.

Three of the source-panel crops are 1232px wide, so they were live-vulnerable to a
single `Read` right now. That is the immediate value.

## What the assets' history actually is

`capture-readme.ts` declares `const VP = { width: 1600, height: 900 }` for all five
targets and runs with `enforceDimensions: true`. `.github/assets/README.md` line 74
also documented 1600x900. Neither matches what is committed.

Measured with `sips`, the committed five are 1200x750 (1200x800 for `ai-labels`).
Those are 1.6 and 1.5 aspect; 1600x900 is 1.778. The sanitizer preserves aspect, so a
1600x900 master lands at 1200x**675**, never 750. These are therefore not downscales of
the current recipe.

Walking the blobs back through git confirms it:

| commit | date | search/dataset/matterhorn/ai-labels |
| --- | --- | --- |
| `47b13549` (#198) | 2026-06-06 | hand-captured, inconsistent (hero 1200x750, dataset 1280x800) |
| `4f983f81` (#205) | 2026-06-07 | **1200x675**, i.e. genuinely 1600x900 sanitized |
| `683c4cd7` (#404) | 2026-07-05 | matterhorn moves to 1200x750 |
| `ee99ba93` (#407) | 2026-07-06 | all 1200x750, ai-labels 1200x800; unchanged since |

So #205 is direct evidence of the sanitizer operating on 16:9 masters, and the current
set came later from a differently shaped capture that was then downscaled on top. They
predate the automated recipe and were shrunk as well, which is what @team-lead
suspected.

## Which path I chose

I recaptured, verified the output, and then did **not** commit it.

`npm run capture:readme` against the local stack produced all five at a clean 1600x900.
I QA'd them through throwaway copies (never `Read` on a master) and three were not
publishable:

- `geolens-dataset.png` captured a **page error**: `The requested module
  '/node_modules/.vite/deps/@tanstack_react-table.js' does not provide an export named
  'columnVisibilityFeature'`.
- `geolens-search.png` showed 9 results with "Significant Volcanic Eruptions" listed
  twice.
- The hero opened the layer editor on a junk `buildings - selected` layer with an
  unconfigured style panel, instead of the era-colored 3D buildings layer.

The cause is the dev stack's state, not the recipe, and it is two separate things.

**The dataset route is broken by a stale dependency install.** `frontend/node_modules`
is a named Docker volume, not the bind mount, and it still has
`@tanstack/react-table@8.21.3` while `frontend/package.json` declares `^9.1.2` and the
lockfile pins `9.1.2`. #1445 did that v8 to v9 migration on 2026-08-12; the volume was
populated before it and has never been reinstalled. `columnVisibilityFeature` is a v9
export, so the optimized dep cannot provide it. Reproducible across two page loads.
Source code is unaffected and current: the bind mount serves `layer-icons.tsx`
containing `gradientUnits="userSpaceOnUse"`, which #1494 introduced and which is absent
from its parent commit.

**The local catalog has duplicate seed data.** Three copies each of four datasets,
including "Significant Volcanic Eruptions", which is the duplicated row visible in the
search shot.

Both need changes to a stack other agents are actively using, so neither is mine to
make. This PR is the gate only, and it lands green:

- the five `capture:readme` targets are pinned at their committed size, with a
  `capturedAt: { width: 1600, height: 900 }` field recording the declared size
- the gate prints that gap on every run instead of silently blessing 1200x750
- recapture becomes an unblocked follow-up: update `width`/`height`, drop `capturedAt`

Pinning them at 1600x900 today would have gone red on `main` and blocked every PR. The
sequencing also happens to be right: at 1200 wide the five are currently below the
sanitizer's cap and cannot be shrunk further, so it is the recapture back to 1600x900
that makes them vulnerable again. The gate should exist before that, not after.

## Scope

All 15 images, not just the 5 script targets, and an unpinned image is a failure. The
six admin/dataset-chat shots from #659 have no capture script and are pinned at the
1200x750 that `.github/assets/README.md` documents for them. The four source-panel crops
from #1279/#1280 are the ones currently at risk.

## Non-vacuity proof

Five deliberate failures, each restored afterward. Proof 1 uses the plugin's actual
resize command on a genuinely at-risk file.

| # | Fault injected | Result |
| --- | --- | --- |
| 1 | `magick source-panel-service.png -resize "1200x1200>"` (1232x522 -> 1200x508) | exit 1, `source-panel-service.png is 1200x508 on disk; expected 1232x522` |
| 2 | `geolens-ai-labels.png` moved away | exit 1, `missing from .github/assets/` |
| 3 | new `geolens-brand-new-shot.png` added | exit 1, `committed ... but not pinned` |
| 4 | a real 1600x900 recapture dropped in without a manifest update | exit 1, `is 1600x900 on disk; expected 1200x750` |
| 5 | proof 1 repeated through `pre-commit run readme-assets` | hook fails |

Green on the correct set: `OK: all 15 README images are at their pinned size.` (exit 0).

Proof 4 matters because it makes the pin bidirectional: an unreviewed recapture cannot
land silently either.

`git diff --stat origin/main -- .github/assets/` shows only `README.md`, so no image
byte changed despite the resize experiments.

## Verification

```
npm run check:readme-assets                    # exit 0, 15 pinned
pre-commit run readme-assets --all-files       # Passed
cd backend && uv run pytest tests/test_ci_merge_queue.py -q   # 22 passed
```

`test_ci_merge_queue.py` is the one that matters for the CI wiring: `readme-assets` has
no `if:`, so it runs in the merge queue and satisfies
`test_every_required_gate_runs_in_the_queue`.

The script is stdlib-only Node with its own PNG/JPEG header parser, so the job needs no
`npm ci`, no database, no browser, and no network.

## Follow-ups, not in this PR

1. Recapture the five once the stack can produce publishable shots, then update the pins
   to 1600x900 and drop `capturedAt`.
2. The dataset detail route is broken on the shared dev stack for everyone, not just for
   screenshots, until the frontend `node_modules` volume is reinstalled against the
   current lockfile.
3. The footer version is stamped from `package.json` at Vite config load, so it reports
   whatever the version was when the container started (v1.11.1 here, from a
   2026-08-12T02:49Z start). It is not a signal for what code is being served, and it
   misled me before I checked the served module directly.
4. `npm run check:readme-locales` exists but is not wired into any workflow. Same class
   of gap, out of scope here.
