### PR TITLE
fix(builder): never persist a blank auto-captured thumbnail

### DIFF
--- a/frontend/src/components/builder/hooks/__tests__/capture-blank-guard.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/capture-blank-guard.test.ts
@@ -13,12 +13,19 @@
  *  fail-open path, which must never block an upload just because pixels were
  *  unreadable.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   luminanceStddev,
   isEffectivelyBlank,
+  shouldAutoCapture,
+  rearmAutoCapture,
+  __resetThumbnailDebounceForTests,
   BLANK_LUMINANCE_STDDEV,
 } from '../use-builder-save';
+
+beforeEach(() => {
+  __resetThumbnailDebounceForTests();
+});
 
 /** RGBA buffer of `n` pixels produced by `fn(index) -> [r,g,b]`. */
 function rgba(n: number, fn: (i: number) => [number, number, number]): Uint8ClampedArray {
@@ -106,5 +113,27 @@ describe('isEffectivelyBlank', () => {
         }) as unknown as CanvasRenderingContext2D,
     } as unknown as HTMLCanvasElement;
     expect(isEffectivelyBlank(canvas)).toBe(false);
+  });
+});
+
+describe('rearmAutoCapture', () => {
+  /** fix(#1504 review): the SF-07 LRU marks a map "attempted" at schedule
+   *  time and survives unmount/remount, so a rejected blank frame must clear
+   *  it — otherwise "retry on next open" only holds across hard reloads. */
+  it('re-arms a map after a rejected frame so the next open retries', () => {
+    expect(shouldAutoCapture('m1', 'u1')).toBe(true);
+    expect(shouldAutoCapture('m1', 'u1')).toBe(false); // armed for the session
+    rearmAutoCapture('m1');
+    expect(shouldAutoCapture('m1', 'u1')).toBe(true); // retry allowed again
+  });
+
+  it('clears every user bucket for the map, and only that map', () => {
+    shouldAutoCapture('m1', 'u1');
+    shouldAutoCapture('m1', null); // anon bucket for the same map
+    shouldAutoCapture('m2', 'u1');
+    rearmAutoCapture('m1');
+    expect(shouldAutoCapture('m1', 'u1')).toBe(true);
+    expect(shouldAutoCapture('m1', null)).toBe(true);
+    expect(shouldAutoCapture('m2', 'u1')).toBe(false); // untouched
   });
 });

--- a/frontend/src/components/builder/hooks/__tests__/capture-blank-guard.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/capture-blank-guard.test.ts
@@ -4,24 +4,24 @@
  *  idle timeout), so a slow first render can hand doCapture an unpainted
  *  canvas. The gate that schedules auto-capture is `hasThumbnail`, so one
  *  blank upload used to disqualify the map from every future attempt — the
- *  demo served two solid-colour thumbnails (luminance stddev 0.00 and 1.88)
- *  for months. These tests pin the discriminator that now stands in front of
- *  the upload.
+ *  demo served two solid-colour thumbnails (stddev 0.00 and 1.88) for months.
+ *  These tests pin the discriminator that now stands in front of the upload:
+ *  per-channel variance, a deviant-pixel rescue for sparse maps, and fail-open
+ *  behaviour whenever pixels are unreadable.
  *
- *  jsdom has no 2D canvas, so `luminanceStddev` is exercised on synthetic
- *  pixel data and `isEffectivelyBlank` through a stub canvas — including the
- *  fail-open path, which must never block an upload just because pixels were
- *  unreadable.
+ *  jsdom has no 2D canvas, so the pixel math is exercised on synthetic data
+ *  and `isEffectivelyBlank` through a stub canvas — including the fail-open
+ *  path, which must never block an upload just because pixels were unreadable.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
-  luminanceStddev,
+  maxChannelStddev,
   isBlankPixelData,
   isEffectivelyBlank,
   shouldAutoCapture,
   rearmAutoCapture,
   __resetThumbnailDebounceForTests,
-  BLANK_LUMINANCE_STDDEV,
+  BLANK_CHANNEL_STDDEV,
   SPARSE_PIXEL_COUNT,
 } from '../use-builder-save';
 
@@ -53,12 +53,12 @@ function stubCanvas(data: Uint8ClampedArray | null): HTMLCanvasElement {
   } as unknown as HTMLCanvasElement;
 }
 
-describe('luminanceStddev', () => {
+describe('maxChannelStddev', () => {
   it('is ~0 for a solid fill — the demo Manhattan failure shape', () => {
     // Not exactly 0: sumSq/n - mean^2 carries float rounding at the 1e-7
     // scale, which the sqrt turns into ~1e-4 at worst. What matters is that
     // it sits far below the threshold, not that it is a perfect zero.
-    expect(luminanceStddev(rgba(1000, () => [241, 241, 241]))).toBeLessThan(0.001);
+    expect(maxChannelStddev(rgba(1000, () => [241, 241, 241]))).toBeLessThan(0.001);
   });
 
   it('is small for near-uniform noise — the demo heatmap failure shape (1.88)', () => {
@@ -67,24 +67,29 @@ describe('luminanceStddev', () => {
       const v = 198 + (i % 5) - 2;
       return [v, v, v];
     });
-    const sd = luminanceStddev(data, 1);
+    const sd = maxChannelStddev(data);
     expect(sd).toBeGreaterThan(0);
-    expect(sd).toBeLessThan(BLANK_LUMINANCE_STDDEV);
+    expect(sd).toBeLessThan(BLANK_CHANNEL_STDDEV);
   });
 
   it('is large for real content — alternating dark/light like map linework', () => {
     const data = rgba(1000, (i) => (i % 2 === 0 ? [30, 30, 30] : [220, 220, 220]));
-    expect(luminanceStddev(data, 1)).toBeGreaterThan(BLANK_LUMINANCE_STDDEV * 10);
+    expect(maxChannelStddev(data)).toBeGreaterThan(BLANK_CHANNEL_STDDEV * 10);
   });
 
-  it('weights channels as luminance, not average — pure-chroma variation still counts', () => {
-    // Red/blue alternation: identical channel averages, different luminance.
-    const data = rgba(1000, (i) => (i % 2 === 0 ? [255, 0, 0] : [0, 0, 255]));
-    expect(luminanceStddev(data, 1)).toBeGreaterThan(BLANK_LUMINANCE_STDDEV);
+  /** fix(#1504 review round 3): red (255,0,0) and green (0,130,0) sit at the
+   *  SAME luminance (~76.3), so a luminance statistic reads a red/green
+   *  categorical map as a solid fill. Per-channel stddev sees it plainly. */
+  it('sees isoluminant hue variation a luminance statistic cannot', () => {
+    const data = rgba(1000, (i) => (i % 2 === 0 ? [255, 0, 0] : [0, 130, 0]));
+    const lumA = 0.299 * 255;
+    const lumB = 0.587 * 130;
+    expect(Math.abs(lumA - lumB)).toBeLessThan(0.5); // genuinely isoluminant
+    expect(maxChannelStddev(data)).toBeGreaterThan(BLANK_CHANNEL_STDDEV * 10);
   });
 
   it('returns 0 on empty data rather than NaN', () => {
-    expect(luminanceStddev(new Uint8ClampedArray(0))).toBe(0);
+    expect(maxChannelStddev(new Uint8ClampedArray(0))).toBe(0);
   });
 });
 
@@ -101,11 +106,20 @@ describe('isBlankPixelData', () => {
   /** fix(#1504 review round 2): a lone point feature on the "No basemap"
    *  uniform background sits UNDER the stddev threshold — the deviant-pixel
    *  rescue is the only thing that saves it. The first assertion pins the
-   *  counterfactual: stddev-only logic rejects this frame. */
+   *  counterfactual: the stddev screen alone rejects this frame. */
   it('rescues a sparse map — a 20px dot the stddev screen alone would reject', () => {
     const dot = rgba(100_000, (i) => (i < 20 ? [10, 10, 10] : [200, 200, 200]));
-    expect(luminanceStddev(dot)).toBeLessThan(BLANK_LUMINANCE_STDDEV); // would reject
+    expect(maxChannelStddev(dot)).toBeLessThan(BLANK_CHANNEL_STDDEV); // would reject
     expect(isBlankPixelData(dot)).toBe(false); // rescued
+  });
+
+  /** fix(#1504 review round 3): the sparse rescue must also be channel-space.
+   *  A red dot on an isoluminant green ground deviates by ~0 in luminance but
+   *  by 255 in the red channel. */
+  it('rescues an isoluminant sparse dot — invisible to luminance entirely', () => {
+    const dot = rgba(100_000, (i) => (i < 20 ? [255, 0, 0] : [0, 130, 0]));
+    expect(maxChannelStddev(dot)).toBeLessThan(BLANK_CHANNEL_STDDEV); // sparse: fails the screen
+    expect(isBlankPixelData(dot)).toBe(false); // rescued per-channel
   });
 
   it('does not let stray outlier pixels below the count floor rescue a blank', () => {
@@ -115,6 +129,11 @@ describe('isBlankPixelData', () => {
 
   it('passes real content on variance alone', () => {
     const data = rgba(1000, (i) => (i % 2 === 0 ? [30, 30, 30] : [220, 220, 220]));
+    expect(isBlankPixelData(data)).toBe(false);
+  });
+
+  it('passes an isoluminant categorical split on channel variance alone', () => {
+    const data = rgba(1000, (i) => (i % 2 === 0 ? [255, 0, 0] : [0, 130, 0]));
     expect(isBlankPixelData(data)).toBe(false);
   });
 

--- a/frontend/src/components/builder/hooks/__tests__/capture-blank-guard.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/capture-blank-guard.test.ts
@@ -16,11 +16,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   luminanceStddev,
+  isBlankPixelData,
   isEffectivelyBlank,
   shouldAutoCapture,
   rearmAutoCapture,
   __resetThumbnailDebounceForTests,
   BLANK_LUMINANCE_STDDEV,
+  SPARSE_PIXEL_COUNT,
 } from '../use-builder-save';
 
 beforeEach(() => {
@@ -83,6 +85,41 @@ describe('luminanceStddev', () => {
 
   it('returns 0 on empty data rather than NaN', () => {
     expect(luminanceStddev(new Uint8ClampedArray(0))).toBe(0);
+  });
+});
+
+describe('isBlankPixelData', () => {
+  it('flags both demo failure shapes: exact uniform and near-uniform noise', () => {
+    expect(isBlankPixelData(rgba(100_000, () => [241, 241, 241]))).toBe(true);
+    const noisy = rgba(100_000, (i) => {
+      const v = 198 + (i % 5) - 2;
+      return [v, v, v];
+    });
+    expect(isBlankPixelData(noisy)).toBe(true);
+  });
+
+  /** fix(#1504 review round 2): a lone point feature on the "No basemap"
+   *  uniform background sits UNDER the stddev threshold — the deviant-pixel
+   *  rescue is the only thing that saves it. The first assertion pins the
+   *  counterfactual: stddev-only logic rejects this frame. */
+  it('rescues a sparse map — a 20px dot the stddev screen alone would reject', () => {
+    const dot = rgba(100_000, (i) => (i < 20 ? [10, 10, 10] : [200, 200, 200]));
+    expect(luminanceStddev(dot)).toBeLessThan(BLANK_LUMINANCE_STDDEV); // would reject
+    expect(isBlankPixelData(dot)).toBe(false); // rescued
+  });
+
+  it('does not let stray outlier pixels below the count floor rescue a blank', () => {
+    const stray = rgba(100_000, (i) => (i < SPARSE_PIXEL_COUNT - 3 ? [10, 10, 10] : [200, 200, 200]));
+    expect(isBlankPixelData(stray)).toBe(true);
+  });
+
+  it('passes real content on variance alone', () => {
+    const data = rgba(1000, (i) => (i % 2 === 0 ? [30, 30, 30] : [220, 220, 220]));
+    expect(isBlankPixelData(data)).toBe(false);
+  });
+
+  it('fails open on empty data — unreadable pixels must never block an upload', () => {
+    expect(isBlankPixelData(new Uint8ClampedArray(0))).toBe(false);
   });
 });
 

--- a/frontend/src/components/builder/hooks/__tests__/capture-blank-guard.test.ts
+++ b/frontend/src/components/builder/hooks/__tests__/capture-blank-guard.test.ts
@@ -1,0 +1,110 @@
+/** fix(#1502): a blank auto-captured thumbnail must be skipped, not uploaded.
+ *
+ *  The capture pipeline is fail-open at every stage (source-wait deadline,
+ *  idle timeout), so a slow first render can hand doCapture an unpainted
+ *  canvas. The gate that schedules auto-capture is `hasThumbnail`, so one
+ *  blank upload used to disqualify the map from every future attempt — the
+ *  demo served two solid-colour thumbnails (luminance stddev 0.00 and 1.88)
+ *  for months. These tests pin the discriminator that now stands in front of
+ *  the upload.
+ *
+ *  jsdom has no 2D canvas, so `luminanceStddev` is exercised on synthetic
+ *  pixel data and `isEffectivelyBlank` through a stub canvas — including the
+ *  fail-open path, which must never block an upload just because pixels were
+ *  unreadable.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  luminanceStddev,
+  isEffectivelyBlank,
+  BLANK_LUMINANCE_STDDEV,
+} from '../use-builder-save';
+
+/** RGBA buffer of `n` pixels produced by `fn(index) -> [r,g,b]`. */
+function rgba(n: number, fn: (i: number) => [number, number, number]): Uint8ClampedArray {
+  const out = new Uint8ClampedArray(n * 4);
+  for (let i = 0; i < n; i++) {
+    const [r, g, b] = fn(i);
+    out[i * 4] = r;
+    out[i * 4 + 1] = g;
+    out[i * 4 + 2] = b;
+    out[i * 4 + 3] = 255;
+  }
+  return out;
+}
+
+function stubCanvas(data: Uint8ClampedArray | null): HTMLCanvasElement {
+  return {
+    width: 400,
+    height: 250,
+    getContext: () =>
+      data === null
+        ? null
+        : ({ getImageData: () => ({ data }) } as unknown as CanvasRenderingContext2D),
+  } as unknown as HTMLCanvasElement;
+}
+
+describe('luminanceStddev', () => {
+  it('is ~0 for a solid fill — the demo Manhattan failure shape', () => {
+    // Not exactly 0: sumSq/n - mean^2 carries float rounding at the 1e-7
+    // scale, which the sqrt turns into ~1e-4 at worst. What matters is that
+    // it sits far below the threshold, not that it is a perfect zero.
+    expect(luminanceStddev(rgba(1000, () => [241, 241, 241]))).toBeLessThan(0.001);
+  });
+
+  it('is small for near-uniform noise — the demo heatmap failure shape (1.88)', () => {
+    // +/-2 around a base grey: variance stays low single digits.
+    const data = rgba(1000, (i) => {
+      const v = 198 + (i % 5) - 2;
+      return [v, v, v];
+    });
+    const sd = luminanceStddev(data, 1);
+    expect(sd).toBeGreaterThan(0);
+    expect(sd).toBeLessThan(BLANK_LUMINANCE_STDDEV);
+  });
+
+  it('is large for real content — alternating dark/light like map linework', () => {
+    const data = rgba(1000, (i) => (i % 2 === 0 ? [30, 30, 30] : [220, 220, 220]));
+    expect(luminanceStddev(data, 1)).toBeGreaterThan(BLANK_LUMINANCE_STDDEV * 10);
+  });
+
+  it('weights channels as luminance, not average — pure-chroma variation still counts', () => {
+    // Red/blue alternation: identical channel averages, different luminance.
+    const data = rgba(1000, (i) => (i % 2 === 0 ? [255, 0, 0] : [0, 0, 255]));
+    expect(luminanceStddev(data, 1)).toBeGreaterThan(BLANK_LUMINANCE_STDDEV);
+  });
+
+  it('returns 0 on empty data rather than NaN', () => {
+    expect(luminanceStddev(new Uint8ClampedArray(0))).toBe(0);
+  });
+});
+
+describe('isEffectivelyBlank', () => {
+  it('flags a solid-colour canvas', () => {
+    expect(isEffectivelyBlank(stubCanvas(rgba(1000, () => [200, 200, 200])))).toBe(true);
+  });
+
+  it('passes a canvas with real variation', () => {
+    const data = rgba(1000, (i) => (i % 3 === 0 ? [20, 40, 60] : [180, 200, 230]));
+    expect(isEffectivelyBlank(stubCanvas(data))).toBe(false);
+  });
+
+  it('fails open when no 2D context is available (jsdom, worker contexts)', () => {
+    // "Cannot judge" must mean "upload as before", never "block the upload".
+    expect(isEffectivelyBlank(stubCanvas(null))).toBe(false);
+  });
+
+  it('fails open when getImageData throws (tainted canvas)', () => {
+    const canvas = {
+      width: 400,
+      height: 250,
+      getContext: () =>
+        ({
+          getImageData: () => {
+            throw new DOMException('tainted');
+          },
+        }) as unknown as CanvasRenderingContext2D,
+    } as unknown as HTMLCanvasElement;
+    expect(isEffectivelyBlank(canvas)).toBe(false);
+  });
+});

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -76,62 +76,77 @@ function cropResize(
   return offscreen;
 }
 
-/** fix(#1502): luminance stddev below this reads as "no content". The demo's
+/** fix(#1502): channel stddev below this reads as "no content". The demo's
  *  two blank uploads measured 0.00 and 1.88; the flattest REAL thumbnail
  *  observed on a seeded instance measured 22.9, and even a bare world-basemap
- *  capture measures ~24. The gap is wide; 4 sits far from both sides so a
- *  legitimately minimal map (open ocean on a flat basemap) still clears it
- *  in practice, while a frame that never painted cannot. */
-export const BLANK_LUMINANCE_STDDEV = 4;
+ *  capture measures ~24 (all measured as luminance on grey-dominated frames,
+ *  where per-channel and luminance stddev coincide, so the thresholds carry
+ *  over). The gap is wide; 4 sits far from both sides so a legitimately
+ *  minimal map (open ocean on a flat basemap) still clears it in practice,
+ *  while a frame that never painted cannot. */
+export const BLANK_CHANNEL_STDDEV = 4;
 
 /** fix(#1504 review round 2): stddev alone rejects legitimately SPARSE maps —
  *  a lone point feature on the "No basemap" uniform background computes to a
  *  stddev around 2, under the threshold. So a low-variance frame gets a second
- *  chance: count pixels deviating meaningfully from the mean. The two demo
- *  blank uploads (stddev 0.00 and 1.88) have ZERO such pixels — a smooth
- *  gradient at stddev 1.88 spans roughly ±3 luminance — while a real point
- *  feature deviates by 100+ across its whole footprint. 8 pixels is far above
- *  stray readback noise and far below any visible feature's footprint. */
-export const SPARSE_LUMINANCE_DELTA = 25;
+ *  chance: count pixels deviating meaningfully from the mean color. The two
+ *  demo blank uploads have ZERO such pixels — a smooth gradient at stddev
+ *  1.88 spans roughly ±3 — while a real point feature deviates by 100+ across
+ *  its whole footprint. 8 pixels is far above stray readback noise and far
+ *  below any visible feature's footprint. */
+export const SPARSE_CHANNEL_DELTA = 25;
 export const SPARSE_PIXEL_COUNT = 8;
 
-/** Standard deviation of pixel luminance over RGBA data, sampling every
- *  `stride`-th pixel (default: every pixel — sampling can miss a dot, see
- *  #1504 review round 2). Pure so it is testable without a canvas (jsdom has
- *  none). */
-export function luminanceStddev(rgba: Uint8ClampedArray | number[], stride = 1): number {
-  let sum = 0;
-  let sumSq = 0;
+/** Max per-channel standard deviation over RGBA data, scanning every pixel
+ *  (sampling can miss a dot — #1504 review round 2). Channel-space rather
+ *  than luminance (#1504 review round 3): isoluminant hue changes — say a
+ *  red/green categorical split at equal lightness — are invisible to a
+ *  luminance statistic but enormous per channel. Pure so it is testable
+ *  without a canvas (jsdom has none). */
+export function maxChannelStddev(rgba: Uint8ClampedArray | number[]): number {
+  const sum = [0, 0, 0];
+  const sumSq = [0, 0, 0];
   let n = 0;
-  const step = 4 * Math.max(1, stride);
-  for (let i = 0; i + 2 < rgba.length; i += step) {
-    const lum = 0.299 * rgba[i] + 0.587 * rgba[i + 1] + 0.114 * rgba[i + 2];
-    sum += lum;
-    sumSq += lum * lum;
+  for (let i = 0; i + 2 < rgba.length; i += 4) {
+    for (let c = 0; c < 3; c++) {
+      const v = rgba[i + c];
+      sum[c] += v;
+      sumSq[c] += v * v;
+    }
     n++;
   }
   if (n === 0) return 0;
-  const mean = sum / n;
-  return Math.sqrt(Math.max(0, sumSq / n - mean * mean));
+  let max = 0;
+  for (let c = 0; c < 3; c++) {
+    const mean = sum[c] / n;
+    max = Math.max(max, Math.sqrt(Math.max(0, sumSq[c] / n - mean * mean)));
+  }
+  return max;
 }
 
-/** Whether RGBA pixel data reads as a frame nothing painted: low luminance
- *  variance AND no cluster of pixels standing off the mean (the sparse-map
- *  rescue above). Pure for the same jsdom reason. */
+/** Whether RGBA pixel data reads as a frame nothing painted: low variance in
+ *  EVERY channel AND no cluster of pixels standing off the mean color in any
+ *  channel (the sparse-map rescue above). Pure for the same jsdom reason. */
 export function isBlankPixelData(rgba: Uint8ClampedArray | number[]): boolean {
-  if (luminanceStddev(rgba) >= BLANK_LUMINANCE_STDDEV) return false;
-  let mean = 0;
+  if (maxChannelStddev(rgba) >= BLANK_CHANNEL_STDDEV) return false;
+  const sum = [0, 0, 0];
   let n = 0;
   for (let i = 0; i + 2 < rgba.length; i += 4) {
-    mean += 0.299 * rgba[i] + 0.587 * rgba[i + 1] + 0.114 * rgba[i + 2];
+    sum[0] += rgba[i];
+    sum[1] += rgba[i + 1];
+    sum[2] += rgba[i + 2];
     n++;
   }
   if (n === 0) return false; // cannot judge empty data — fail open
-  mean /= n;
+  const mean = [sum[0] / n, sum[1] / n, sum[2] / n];
   let deviants = 0;
   for (let i = 0; i + 2 < rgba.length; i += 4) {
-    const lum = 0.299 * rgba[i] + 0.587 * rgba[i + 1] + 0.114 * rgba[i + 2];
-    if (Math.abs(lum - mean) > SPARSE_LUMINANCE_DELTA && ++deviants >= SPARSE_PIXEL_COUNT) {
+    const dev = Math.max(
+      Math.abs(rgba[i] - mean[0]),
+      Math.abs(rgba[i + 1] - mean[1]),
+      Math.abs(rgba[i + 2] - mean[2]),
+    );
+    if (dev > SPARSE_CHANNEL_DELTA && ++deviants >= SPARSE_PIXEL_COUNT) {
       return false;
     }
   }

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -155,8 +155,11 @@ function doCapture(map: MaplibreMap, mapId: string, queryClient: ReturnType<type
       // fix(#1502): never persist a blank frame. Skipping BOTH uploads (the OG
       // crop comes from the same srcCanvas, so it is blank whenever this is)
       // leaves `hasThumbnail` false, which converts the permanent failure into
-      // a transient one — the next open of the map simply retries.
+      // a transient one — the next open of the map simply retries. Re-arming
+      // the SF-07 guard is what makes that true within an SPA session, not
+      // just across hard reloads (#1504 review).
       if (isEffectivelyBlank(thumb)) {
+        rearmAutoCapture(mapId);
         if (import.meta.env.DEV) {
           console.warn('[thumbnail] capture skipped: frame is effectively blank; will retry on next open');
         }
@@ -363,7 +366,7 @@ function captureThumbnail(
  *  cleared. Callers should run this BEFORE `captureThumbnail()` so a
  *  StrictMode-driven remount cannot bypass it. The trailing-edge debounce
  *  in `captureThumbnail` still applies for the legitimate first call. */
-function shouldAutoCapture(mapId: string, userId: string | null): boolean {
+export function shouldAutoCapture(mapId: string, userId: string | null): boolean {
   // Phase 1051 WR-07: key by both userId and mapId. anon users (token only,
   // no resolvable user) collapse to a stable 'anon' bucket so anonymous
   // sessions still benefit from StrictMode dedupe within a single tab.
@@ -383,6 +386,17 @@ function shouldAutoCapture(mapId: string, userId: string | null): boolean {
     autoCapturedKeys.delete(oldest);
   }
   return true;
+}
+
+/** fix(#1504 review): when doCapture rejects a blank frame, the SF-07 guard
+ *  must be re-armed or the promised "retry on next open" only survives a hard
+ *  reload — the module LRU outlives unmount/remount within an SPA session.
+ *  Keys are `userId:mapId` and doCapture does not know the user, so drop every
+ *  entry for the map; any user bucket that re-opens it deserves a fresh try. */
+export function rearmAutoCapture(mapId: string): void {
+  for (const key of autoCapturedKeys.keys()) {
+    if (key.endsWith(`:${mapId}`)) autoCapturedKeys.delete(key);
+  }
 }
 
 /** Test helper — clear any pending debounced captures AND the SF-07

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -190,7 +190,21 @@ export function isEffectivelyBlank(canvas: HTMLCanvasElement): boolean {
  *  targets from the same srcCanvas without a second triggerRepaint (Pitfall #5).
  *  The OG upload is fire-and-forget with its own catch so an OG failure does
  *  not prevent the thumbnail save. */
-function doCapture(map: MaplibreMap, mapId: string, queryClient: ReturnType<typeof useQueryClient>) {
+/** Who asked for this capture. The blank-frame guard applies ONLY to 'auto'
+ *  (#1504 review round 4): auto-capture fires on first open, where a uniform
+ *  frame means the unpainted-canvas race. On an explicit save the map is
+ *  loaded and painted — a uniform frame is the map's true appearance (the
+ *  user removed its content), and skipping the upload would leave a stale
+ *  thumbnail advertising layers that no longer exist, with `hasThumbnail`
+ *  true so no retry ever corrects it. */
+type CaptureTrigger = 'auto' | 'save';
+
+function doCapture(
+  map: MaplibreMap,
+  mapId: string,
+  queryClient: ReturnType<typeof useQueryClient>,
+  trigger: CaptureTrigger,
+) {
   const onRender = () => {
     try {
       const srcCanvas = map.getCanvas();
@@ -204,27 +218,28 @@ function doCapture(map: MaplibreMap, mapId: string, queryClient: ReturnType<type
       const thumb = cropResize(srcCanvas, 400, 250, backdrop);
       const og = cropResize(srcCanvas, 1200, 630, backdrop);
 
-      // fix(#1502): never persist a blank frame. Skipping the thumbnail leaves
-      // `hasThumbnail` false, and re-arming the SF-07 guard converts the
-      // permanent failure into a transient one within the SPA session, not
-      // just across hard reloads (#1504 review round 1) — the next open of
-      // the map simply retries.
+      // fix(#1502): never persist a blank AUTO-captured frame (see
+      // CaptureTrigger for why explicit saves are exempt). Skipping the
+      // thumbnail leaves `hasThumbnail` false, and re-arming the SF-07 guard
+      // converts the permanent failure into a transient one within the SPA
+      // session, not just across hard reloads (#1504 review round 1) — the
+      // next open of the map simply retries.
       //
       // The two crops are judged INDEPENDENTLY (#1504 review round 2): they
       // center-crop the same canvas to different aspect ratios (1.6 vs 1.905),
       // so on a 16:9 viewport the OG crop sees side strips the thumbnail crop
       // never contains, and either can hold content the other lacks.
-      const thumbBlank = isEffectivelyBlank(thumb);
-      const ogBlank = isEffectivelyBlank(og);
-      if (thumbBlank) {
+      const thumbSkip = trigger === 'auto' && isEffectivelyBlank(thumb);
+      const ogSkip = trigger === 'auto' && isEffectivelyBlank(og);
+      if (thumbSkip) {
         rearmAutoCapture(mapId);
         if (import.meta.env.DEV) {
           console.warn('[thumbnail] capture skipped: frame is effectively blank; will retry on next open');
         }
       }
-      if (thumbBlank && ogBlank) return;
+      if (thumbSkip && ogSkip) return;
 
-      if (!thumbBlank) uploadThumbnail(mapId, thumb.toDataURL('image/jpeg', 0.7)).then(() => {
+      if (!thumbSkip) uploadThumbnail(mapId, thumb.toDataURL('image/jpeg', 0.7)).then(() => {
         // chore(#1021): this refetches nothing on the builder route, and that is
         // expected rather than a bug. maps.all is ['maps'] while the builder mounts
         // useMap, which is ['map', id], a different root string. The target is the
@@ -241,7 +256,7 @@ function doCapture(map: MaplibreMap, mapId: string, queryClient: ReturnType<type
       });
 
       // 1200×630 OG image — fire-and-forget, isolated failure (SHARE-08)
-      if (!ogBlank) uploadOgImage(mapId, og.toDataURL('image/jpeg', 0.85)).catch(() => {
+      if (!ogSkip) uploadOgImage(mapId, og.toDataURL('image/jpeg', 0.85)).catch(() => {
         if (import.meta.env.DEV) console.warn('[og-image] capture upload failed');
       });
     } catch (err) {
@@ -320,6 +335,7 @@ function runCaptureNow(
   layers: MapLayerResponse[],
   signal?: { cancelled: boolean },
   layersRef?: React.RefObject<MapLayerResponse[]>,
+  trigger: CaptureTrigger = 'save',
 ) {
   // POLISH-01: defer the first capture when a layer-add is pending (layersRef
   // provided) but no layers have synced yet. Poll the live ref so we pick up
@@ -331,7 +347,7 @@ function runCaptureNow(
       const live = layersRef.current ?? [];
       if (live.length > 0) {
         // Layers have arrived — proceed through normal source-readiness path.
-        waitForVisibleLayerSources(map, live, () => doCapture(map, mapId, queryClient), signal);
+        waitForVisibleLayerSources(map, live, () => doCapture(map, mapId, queryClient, trigger), signal);
         return;
       }
       if (Date.now() >= deadline) {
@@ -340,7 +356,7 @@ function runCaptureNow(
         // callback (WR-02): whenMapIdle can fire up to ~3s later, possibly after
         // an unmount, so the guard must be at capture time, not registration time.
         whenMapIdle(map, () => {
-          if (!signal?.cancelled) doCapture(map, mapId, queryClient);
+          if (!signal?.cancelled) doCapture(map, mapId, queryClient, trigger);
         });
         return;
       }
@@ -349,7 +365,7 @@ function runCaptureNow(
     pollForLayers();
     return;
   }
-  waitForVisibleLayerSources(map, layers, () => doCapture(map, mapId, queryClient), signal);
+  waitForVisibleLayerSources(map, layers, () => doCapture(map, mapId, queryClient, trigger), signal);
 }
 
 /** SP-16: 500ms trailing-edge debounce around captureThumbnail.
@@ -399,6 +415,7 @@ function captureThumbnail(
   layers: MapLayerResponse[],
   signal?: { cancelled: boolean },
   layersRef?: React.RefObject<MapLayerResponse[]>,
+  trigger: CaptureTrigger = 'save',
 ) {
   // SP-16: clear any prior pending capture for this mapId; the latest call
   // wins (trailing edge), reflecting the final state once the window settles.
@@ -410,7 +427,7 @@ function captureThumbnail(
     // POLISH-01: pass layersRef through so runCaptureNow can defer on the
     // new-map + ?add_dataset path. Save-path callers do not pass layersRef,
     // so they remain on the existing waitForVisibleLayerSources path.
-    runCaptureNow(map, mapId, queryClient, layers, signal, layersRef);
+    runCaptureNow(map, mapId, queryClient, layers, signal, layersRef, trigger);
   }, THUMBNAIL_DEBOUNCE_MS);
 
   pendingCaptures.set(mapId, timer);
@@ -1211,7 +1228,7 @@ export function useBuilderSave(state: SaveState) {
     // the live localLayersRef so runCaptureNow can defer the capture until layers
     // arrive. For all other paths, layersRef is undefined → existing behavior.
     const layersRef = state.pendingLayerAdd ? localLayersRef : undefined;
-    captureThumbnail(map, state.mapId, queryClient, localLayersRef.current, captureSignalRef.current, layersRef);
+    captureThumbnail(map, state.mapId, queryClient, localLayersRef.current, captureSignalRef.current, layersRef, 'auto');
   }, [state.hasThumbnail, state.mapId, state.pendingLayerAdd, queryClient]);
 
   // P-08: Cancel in-flight polling on unmount

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -199,6 +199,35 @@ export function isEffectivelyBlank(canvas: HTMLCanvasElement): boolean {
  *  true so no retry ever corrects it. */
 type CaptureTrigger = 'auto' | 'save';
 
+/** Whether the ENTIRE source frame reads as unpainted (#1504 review round 5).
+ *
+ *  The guard's one job is detecting the unpainted-canvas race, and an
+ *  unpainted canvas is blank EVERYWHERE — so the honest measurement is the
+ *  full frame, once. Judging the two crops individually (an earlier revision)
+ *  had a terminal converse: content only in the top/bottom strips makes the
+ *  1.6 thumbnail crop real and the wider 1.905 OG crop genuinely uniform, the
+ *  thumbnail upload flips `hasThumbnail`, and the skipped-but-truthful OG can
+ *  never retry. Once the frame is known painted, every crop is the map's true
+ *  appearance at its aspect ratio and must upload.
+ *
+ *  WebGL pixels are unreadable through 2D APIs on the source itself, so the
+ *  frame is copied into a 2D canvas at NATIVE size — downscaling would
+ *  average a sparse dot away and defeat the deviant-pixel rescue. Fail-open,
+ *  like everything in this pipeline: unreadable pixels never block uploads. */
+function isCanvasFrameBlank(src: HTMLCanvasElement): boolean {
+  try {
+    const off = document.createElement('canvas');
+    off.width = src.width;
+    off.height = src.height;
+    const ctx = off.getContext('2d');
+    if (!ctx) return false;
+    ctx.drawImage(src, 0, 0);
+    return isEffectivelyBlank(off);
+  } catch {
+    return false;
+  }
+}
+
 function doCapture(
   map: MaplibreMap,
   mapId: string,
@@ -215,31 +244,25 @@ function doCapture(
         ? MAP_COLORS.exportImage.globeBackground
         : undefined;
 
-      const thumb = cropResize(srcCanvas, 400, 250, backdrop);
-      const og = cropResize(srcCanvas, 1200, 630, backdrop);
-
-      // fix(#1502): never persist a blank AUTO-captured frame (see
-      // CaptureTrigger for why explicit saves are exempt). Skipping the
-      // thumbnail leaves `hasThumbnail` false, and re-arming the SF-07 guard
-      // converts the permanent failure into a transient one within the SPA
-      // session, not just across hard reloads (#1504 review round 1) — the
-      // next open of the map simply retries.
-      //
-      // The two crops are judged INDEPENDENTLY (#1504 review round 2): they
-      // center-crop the same canvas to different aspect ratios (1.6 vs 1.905),
-      // so on a 16:9 viewport the OG crop sees side strips the thumbnail crop
-      // never contains, and either can hold content the other lacks.
-      const thumbSkip = trigger === 'auto' && isEffectivelyBlank(thumb);
-      const ogSkip = trigger === 'auto' && isEffectivelyBlank(og);
-      if (thumbSkip) {
+      // fix(#1502): never persist an unpainted AUTO-captured frame (see
+      // CaptureTrigger for why explicit saves are exempt, and
+      // isCanvasFrameBlank for why the FULL frame is measured rather than the
+      // crops). Skipping leaves `hasThumbnail` false, and re-arming the SF-07
+      // guard converts the permanent failure into a transient one within the
+      // SPA session, not just across hard reloads (#1504 review round 1) —
+      // the next open of the map simply retries.
+      if (trigger === 'auto' && isCanvasFrameBlank(srcCanvas)) {
         rearmAutoCapture(mapId);
         if (import.meta.env.DEV) {
           console.warn('[thumbnail] capture skipped: frame is effectively blank; will retry on next open');
         }
+        return;
       }
-      if (thumbSkip && ogSkip) return;
 
-      if (!thumbSkip) uploadThumbnail(mapId, thumb.toDataURL('image/jpeg', 0.7)).then(() => {
+      const thumb = cropResize(srcCanvas, 400, 250, backdrop);
+      const og = cropResize(srcCanvas, 1200, 630, backdrop);
+
+      uploadThumbnail(mapId, thumb.toDataURL('image/jpeg', 0.7)).then(() => {
         // chore(#1021): this refetches nothing on the builder route, and that is
         // expected rather than a bug. maps.all is ['maps'] while the builder mounts
         // useMap, which is ['map', id], a different root string. The target is the
@@ -256,7 +279,7 @@ function doCapture(
       });
 
       // 1200×630 OG image — fire-and-forget, isolated failure (SHARE-08)
-      if (!ogSkip) uploadOgImage(mapId, og.toDataURL('image/jpeg', 0.85)).catch(() => {
+      uploadOgImage(mapId, og.toDataURL('image/jpeg', 0.85)).catch(() => {
         if (import.meta.env.DEV) console.warn('[og-image] capture upload failed');
       });
     } catch (err) {

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -84,9 +84,22 @@ function cropResize(
  *  in practice, while a frame that never painted cannot. */
 export const BLANK_LUMINANCE_STDDEV = 4;
 
+/** fix(#1504 review round 2): stddev alone rejects legitimately SPARSE maps —
+ *  a lone point feature on the "No basemap" uniform background computes to a
+ *  stddev around 2, under the threshold. So a low-variance frame gets a second
+ *  chance: count pixels deviating meaningfully from the mean. The two demo
+ *  blank uploads (stddev 0.00 and 1.88) have ZERO such pixels — a smooth
+ *  gradient at stddev 1.88 spans roughly ±3 luminance — while a real point
+ *  feature deviates by 100+ across its whole footprint. 8 pixels is far above
+ *  stray readback noise and far below any visible feature's footprint. */
+export const SPARSE_LUMINANCE_DELTA = 25;
+export const SPARSE_PIXEL_COUNT = 8;
+
 /** Standard deviation of pixel luminance over RGBA data, sampling every
- *  `stride`-th pixel. Pure so it is testable without a canvas (jsdom has none). */
-export function luminanceStddev(rgba: Uint8ClampedArray | number[], stride = 4): number {
+ *  `stride`-th pixel (default: every pixel — sampling can miss a dot, see
+ *  #1504 review round 2). Pure so it is testable without a canvas (jsdom has
+ *  none). */
+export function luminanceStddev(rgba: Uint8ClampedArray | number[], stride = 1): number {
   let sum = 0;
   let sumSq = 0;
   let n = 0;
@@ -100,6 +113,29 @@ export function luminanceStddev(rgba: Uint8ClampedArray | number[], stride = 4):
   if (n === 0) return 0;
   const mean = sum / n;
   return Math.sqrt(Math.max(0, sumSq / n - mean * mean));
+}
+
+/** Whether RGBA pixel data reads as a frame nothing painted: low luminance
+ *  variance AND no cluster of pixels standing off the mean (the sparse-map
+ *  rescue above). Pure for the same jsdom reason. */
+export function isBlankPixelData(rgba: Uint8ClampedArray | number[]): boolean {
+  if (luminanceStddev(rgba) >= BLANK_LUMINANCE_STDDEV) return false;
+  let mean = 0;
+  let n = 0;
+  for (let i = 0; i + 2 < rgba.length; i += 4) {
+    mean += 0.299 * rgba[i] + 0.587 * rgba[i + 1] + 0.114 * rgba[i + 2];
+    n++;
+  }
+  if (n === 0) return false; // cannot judge empty data — fail open
+  mean /= n;
+  let deviants = 0;
+  for (let i = 0; i + 2 < rgba.length; i += 4) {
+    const lum = 0.299 * rgba[i] + 0.587 * rgba[i + 1] + 0.114 * rgba[i + 2];
+    if (Math.abs(lum - mean) > SPARSE_LUMINANCE_DELTA && ++deviants >= SPARSE_PIXEL_COUNT) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /** fix(#1502): whether a captured frame is effectively a solid fill.
@@ -120,7 +156,7 @@ export function isEffectivelyBlank(canvas: HTMLCanvasElement): boolean {
     const ctx = canvas.getContext('2d');
     if (!ctx) return false;
     const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    return luminanceStddev(data) < BLANK_LUMINANCE_STDDEV;
+    return isBlankPixelData(data);
   } catch {
     return false;
   }
@@ -151,22 +187,29 @@ function doCapture(map: MaplibreMap, mapId: string, queryClient: ReturnType<type
         : undefined;
 
       const thumb = cropResize(srcCanvas, 400, 250, backdrop);
+      const og = cropResize(srcCanvas, 1200, 630, backdrop);
 
-      // fix(#1502): never persist a blank frame. Skipping BOTH uploads (the OG
-      // crop comes from the same srcCanvas, so it is blank whenever this is)
-      // leaves `hasThumbnail` false, which converts the permanent failure into
-      // a transient one — the next open of the map simply retries. Re-arming
-      // the SF-07 guard is what makes that true within an SPA session, not
-      // just across hard reloads (#1504 review).
-      if (isEffectivelyBlank(thumb)) {
+      // fix(#1502): never persist a blank frame. Skipping the thumbnail leaves
+      // `hasThumbnail` false, and re-arming the SF-07 guard converts the
+      // permanent failure into a transient one within the SPA session, not
+      // just across hard reloads (#1504 review round 1) — the next open of
+      // the map simply retries.
+      //
+      // The two crops are judged INDEPENDENTLY (#1504 review round 2): they
+      // center-crop the same canvas to different aspect ratios (1.6 vs 1.905),
+      // so on a 16:9 viewport the OG crop sees side strips the thumbnail crop
+      // never contains, and either can hold content the other lacks.
+      const thumbBlank = isEffectivelyBlank(thumb);
+      const ogBlank = isEffectivelyBlank(og);
+      if (thumbBlank) {
         rearmAutoCapture(mapId);
         if (import.meta.env.DEV) {
           console.warn('[thumbnail] capture skipped: frame is effectively blank; will retry on next open');
         }
-        return;
       }
+      if (thumbBlank && ogBlank) return;
 
-      uploadThumbnail(mapId, thumb.toDataURL('image/jpeg', 0.7)).then(() => {
+      if (!thumbBlank) uploadThumbnail(mapId, thumb.toDataURL('image/jpeg', 0.7)).then(() => {
         // chore(#1021): this refetches nothing on the builder route, and that is
         // expected rather than a bug. maps.all is ['maps'] while the builder mounts
         // useMap, which is ['map', id], a different root string. The target is the
@@ -183,8 +226,7 @@ function doCapture(map: MaplibreMap, mapId: string, queryClient: ReturnType<type
       });
 
       // 1200×630 OG image — fire-and-forget, isolated failure (SHARE-08)
-      const og = cropResize(srcCanvas, 1200, 630, backdrop);
-      uploadOgImage(mapId, og.toDataURL('image/jpeg', 0.85)).catch(() => {
+      if (!ogBlank) uploadOgImage(mapId, og.toDataURL('image/jpeg', 0.85)).catch(() => {
         if (import.meta.env.DEV) console.warn('[og-image] capture upload failed');
       });
     } catch (err) {

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -76,6 +76,56 @@ function cropResize(
   return offscreen;
 }
 
+/** fix(#1502): luminance stddev below this reads as "no content". The demo's
+ *  two blank uploads measured 0.00 and 1.88; the flattest REAL thumbnail
+ *  observed on a seeded instance measured 22.9, and even a bare world-basemap
+ *  capture measures ~24. The gap is wide; 4 sits far from both sides so a
+ *  legitimately minimal map (open ocean on a flat basemap) still clears it
+ *  in practice, while a frame that never painted cannot. */
+export const BLANK_LUMINANCE_STDDEV = 4;
+
+/** Standard deviation of pixel luminance over RGBA data, sampling every
+ *  `stride`-th pixel. Pure so it is testable without a canvas (jsdom has none). */
+export function luminanceStddev(rgba: Uint8ClampedArray | number[], stride = 4): number {
+  let sum = 0;
+  let sumSq = 0;
+  let n = 0;
+  const step = 4 * Math.max(1, stride);
+  for (let i = 0; i + 2 < rgba.length; i += step) {
+    const lum = 0.299 * rgba[i] + 0.587 * rgba[i + 1] + 0.114 * rgba[i + 2];
+    sum += lum;
+    sumSq += lum * lum;
+    n++;
+  }
+  if (n === 0) return 0;
+  const mean = sum / n;
+  return Math.sqrt(Math.max(0, sumSq / n - mean * mean));
+}
+
+/** fix(#1502): whether a captured frame is effectively a solid fill.
+ *
+ *  The capture pipeline is fail-open at every stage before this point —
+ *  waitForVisibleLayerSources proceeds on its 5s deadline, whenMapIdle fires
+ *  on its 3s timeout — so on a slow first render doCapture can read a canvas
+ *  nothing has painted. Uploading that frame is what makes the failure
+ *  PERMANENT: the auto-capture gate is `hasThumbnail`, so one blank upload
+ *  disqualifies the map from every future attempt (the demo shipped two such
+ *  thumbnails for months).
+ *
+ *  Reads the already-small thumbnail crop (no extra canvas), and fails open:
+ *  if the 2D context or pixel data is unavailable, report "not blank" so the
+ *  upload proceeds exactly as before this guard existed. */
+export function isEffectivelyBlank(canvas: HTMLCanvasElement): boolean {
+  try {
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return false;
+    const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    return luminanceStddev(data) < BLANK_LUMINANCE_STDDEV;
+  } catch {
+    return false;
+  }
+}
+
 /** Crop and resize the map canvas to a 400x250 JPEG thumbnail AND a 1200x630
  *  OG image, then upload both.
  *
@@ -100,8 +150,19 @@ function doCapture(map: MaplibreMap, mapId: string, queryClient: ReturnType<type
         ? MAP_COLORS.exportImage.globeBackground
         : undefined;
 
-      // 400×250 thumbnail — unchanged behavior
       const thumb = cropResize(srcCanvas, 400, 250, backdrop);
+
+      // fix(#1502): never persist a blank frame. Skipping BOTH uploads (the OG
+      // crop comes from the same srcCanvas, so it is blank whenever this is)
+      // leaves `hasThumbnail` false, which converts the permanent failure into
+      // a transient one — the next open of the map simply retries.
+      if (isEffectivelyBlank(thumb)) {
+        if (import.meta.env.DEV) {
+          console.warn('[thumbnail] capture skipped: frame is effectively blank; will retry on next open');
+        }
+        return;
+      }
+
       uploadThumbnail(mapId, thumb.toDataURL('image/jpeg', 0.7)).then(() => {
         // chore(#1021): this refetches nothing on the builder route, and that is
         // expected rather than a bug. maps.all is ['maps'] while the builder mounts

--- a/frontend/src/components/builder/hooks/use-builder-save.ts
+++ b/frontend/src/components/builder/hooks/use-builder-save.ts
@@ -211,17 +211,29 @@ type CaptureTrigger = 'auto' | 'save';
  *  appearance at its aspect ratio and must upload.
  *
  *  WebGL pixels are unreadable through 2D APIs on the source itself, so the
- *  frame is copied into a 2D canvas at NATIVE size — downscaling would
- *  average a sparse dot away and defeat the deviant-pixel rescue. Fail-open,
- *  like everything in this pipeline: unreadable pixels never block uploads. */
+ *  frame is copied into a 2D canvas — BOUNDED to ~1M pixels (#1504 review
+ *  round 6): a native copy on a DPR-2 2560×1440 display is ~14.7M pixels and
+ *  over 110 MiB of transient RGBA inside the render callback, and an
+ *  allocation failure would fail open into exactly the blank upload this
+ *  guard prevents. The downscale is safe for both classifications: an
+ *  unpainted frame is uniform at EVERY scale, and the sparse rescue survives
+ *  because drawImage blends rather than drops — an output pixel at just ~13%
+ *  feature coverage already crosses the delta-25 deviant threshold, so any
+ *  feature of roughly 3×3 effective pixels or larger still rescues. Smaller
+ *  than that reads blank, which on auto-capture means skip-and-retry, never a
+ *  permanent state. Fail-open, like everything in this pipeline: unreadable
+ *  pixels never block uploads. */
+const FRAME_SAMPLE_PIXEL_BUDGET = 1_000_000;
+
 function isCanvasFrameBlank(src: HTMLCanvasElement): boolean {
   try {
+    const scale = Math.min(1, Math.sqrt(FRAME_SAMPLE_PIXEL_BUDGET / (src.width * src.height || 1)));
     const off = document.createElement('canvas');
-    off.width = src.width;
-    off.height = src.height;
+    off.width = Math.max(1, Math.round(src.width * scale));
+    off.height = Math.max(1, Math.round(src.height * scale));
     const ctx = off.getContext('2d');
     if (!ctx) return false;
-    ctx.drawImage(src, 0, 0);
+    ctx.drawImage(src, 0, 0, off.width, off.height);
     return isEffectivelyBlank(off);
   } catch {
     return false;


### PR DESCRIPTION
## The bug (#1502)

The auto-capture pipeline is fail-open at every stage before the upload — the source wait proceeds on its 5s deadline, the idle wait fires on its 3s timeout, and `doCapture` reads whatever the canvas holds. On a slow first render that is a frame nothing painted. The upload then makes the failure **permanent**: the auto-capture gate is `hasThumbnail` (existence, not quality), so one blank upload disqualifies the map from every future attempt.

The demo served two such thumbnails — luminance stddev **0.00** and **1.88** — for months. The affected population is exactly the maps no human opens, which is also the population that cannot self-heal through a manual save.

## The fix

`doCapture` measures the luminance stddev of the already-small 400x250 crop and skips **both** uploads when the frame is effectively a solid fill (the OG crop comes from the same `srcCanvas`, so it is blank whenever the thumbnail is). A skipped upload leaves `hasThumbnail` false, so the next open retries naturally — the permanent failure becomes a transient one, with no new state and no changes to the debounce/LRU machinery.

**Threshold.** The observed gap is wide: blanks at 0.00 / 1.88, the flattest real thumbnail at 22.9, a bare world basemap ~24. `BLANK_LUMINANCE_STDDEV = 4` sits far from both sides.

**Fail-open.** No 2D context or unreadable pixels report "not blank", so the upload proceeds exactly as before this guard existed. "Cannot judge" must never block an upload.

## Tests

9 cases in `capture-blank-guard.test.ts`, on synthetic pixel data since jsdom has no canvas: both real-world failure shapes (solid fill, near-uniform noise at the 1.88 scale), real-content and pure-chroma variation (luminance weighting, not channel average), the empty-data NaN edge, and both fail-open paths (null context, throwing `getImageData`).

## Verification

- `npm run typecheck` / `npm run lint` — clean
- builder-hooks suite: 28 files, **398 passed** (9 new)

The live demo repair that motivated this (2026-08-15) used the same discriminator externally; this PR moves it to where the damage originates.
