### PR TITLE
fix(seed): let --force repair the Matterhorn showcase

### DIFF
--- a/scripts/seed-showcase.py
+++ b/scripts/seed-showcase.py
@@ -4164,7 +4164,16 @@ def build_matterhorn(api: Api, force: bool = False) -> str:
     print("\n[matterhorn] The Matterhorn (3D terrain via regional VRT mosaic)")
     by_title = api.datasets_by_title()
     vrt_title = "swissALTI3D Matterhorn DEM (2m mosaic)"
-    if not force and vrt_title in by_title:
+    # fix(#1508): the DEM mosaic and its 62 tile rasters are reused even under
+    # --force. The manifest endpoint refuses updates to existing raster
+    # datasets ("Manifest raster updates are not supported"), so a forced
+    # re-push aborted the whole builder before the map and OSM overlay steps —
+    # which made --force useless for exactly the repair it exists for
+    # (restoring the routes/peaks layers). Recreating the tiles for real would
+    # mean deleting 62 datasets and re-downloading gigabytes; --force keeps
+    # meaning "rebuild the MAP" here, like the vector builders rebuild cheap
+    # datasets but nobody re-pulls ETOPO.
+    if vrt_title in by_title:
         print("  [reuse] existing DEM mosaic")
         vrt_ds = by_title[vrt_title]
     else:


### PR DESCRIPTION
`seed-showcase.py --only matterhorn --force` could not perform the one repair it exists for. The builder re-pushed the 62-tile swissALTI3D manifest onto existing raster datasets, the API (correctly) refused with `Manifest raster updates are not supported` for every entry, and the builder aborted before the map and OSM overlay steps. That left no supported way to restore the Climbing routes / Route casing / Peaks layers after they went missing — the state the capture stack was in (#1508), with the map's own description promising overlays it did not carry.

The fix reuses the DEM mosaic and its tiles whenever they exist, `--force` included. Recreating the tiles for real would mean deleting 62 datasets and re-downloading gigabytes; `--force` keeps meaning "rebuild the map", the same way no builder re-pulls ETOPO under force.

## Verified against the exact broken state

- Before: `--only matterhorn --force` on the seeded dev stack → `62/62 swissALTI3D manifest entries failed` → builder dead before layers, map stuck at one layer.
- After: same invocation → `[reuse] existing DEM mosaic` → OSM fetch + ingest → map rebuilt with all four layers (Climbing routes, Route casing, Peaks, swissALTI3D relief), styling pass grouped them, and the map renders with the overlays its description promises.
- The one-layer duplicate map and an orphaned routes dataset from the aborted runs were cleaned up manually (the newest-wins duplicate behavior under `--force` is pre-existing and out of scope here).

The demo instance picks the repair up whenever the fixed seeder next runs against it. Recapturing the two Matterhorn screenshots with the restored overlays (and re-richening their alt text) follows in the capture repos once this lands.

Closes #1508.