### PR TITLE
docs: link the client examples hub and place it in security scope

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -36,6 +36,8 @@ This policy covers:
 - Official packages published to PyPI (`geolens`, `geolens-cli`, `geolens-mcp`) and npm (`@geolens/sdk`)
 - The public demo at demo.getgeolens.com
 
+That includes a server, image, package, or demo bug you find while running one of the client examples in [geolens-examples](https://github.com/geolens-io/geolens-examples), which ships sample client code and nothing else. An unsafe pattern in the example code itself belongs to that repo's own policy, which routes to this same address alongside GitHub private vulnerability reporting. See [its SECURITY.md](https://github.com/geolens-io/geolens-examples/blob/main/SECURITY.md).
+
 Out of scope here (report to the respective repo or contact): the marketing/docs website (getgeolens.com), and Helm/deployment packaging ([geolens-deployments](https://github.com/geolens-io/geolens-deployments)).
 
 ## Recognition

--- a/README.de.md
+++ b/README.de.md
@@ -106,6 +106,8 @@ PostGIS und pgvector teilen sich eine Datenbank. Bei aktivierter semantischer Su
 
 Direkt aus QGIS verbinden: **Layer > Add WFS / OGC API Features**, Ziel `http://localhost:8080/api/`.
 
+Dieselben Endpunkte aus einer Kartenbibliothek: [geolens-examples](https://github.com/geolens-io/geolens-examples) enthält Ein-Datei-Seiten für MapLibre, Leaflet, OpenLayers und das ArcGIS SDK, eine Python/GeoPandas-Analyse und eine MCP-Konfiguration. Jedes Beispiel läuft gegen die öffentliche Demo, und die CI führt sie wöchentlich erneut dagegen aus. Was Sie kopieren, hat also diese Woche funktioniert. [Galerie ansehen](https://geolens-io.github.io/geolens-examples/).
+
 ## Funktionen
 
 Für jedes Beispiel gibt es eine vollständige Anleitung in der [Dokumentation](https://docs.getgeolens.com/guides/). GeoLens liest, schreibt und veröffentlicht:
@@ -352,6 +354,7 @@ API und Worker exportieren sofort Prometheus-Metriken (HTTP-Rate/Latenz/Fehler, 
 | [CLI & Manifeste](https://docs.getgeolens.com/guides/cli/) | Dateien veröffentlichen und Kataloge mit `geolens` verwalten |
 | [API-Referenz](https://docs.getgeolens.com/guides/api/) | Automatisch erzeugte Referenz; interaktive Swagger UI unter `/api/docs` zur Laufzeit |
 | [Manifestbeispiele](examples/manifests/) | Anpassbare `geolens.yaml`-Vorlagen: public-cog (entferntes COG), url-source, s3-source, publication-states |
+| [Client-Beispiele](https://github.com/geolens-io/geolens-examples) | Lauffähige Beispiele für MapLibre, Leaflet, OpenLayers, ArcGIS JS, Python/GeoPandas und MCP, in der CI gegen die öffentliche Demo geprüft ([Galerie](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Community
 

--- a/README.de.md
+++ b/README.de.md
@@ -106,7 +106,7 @@ PostGIS und pgvector teilen sich eine Datenbank. Bei aktivierter semantischer Su
 
 Direkt aus QGIS verbinden: **Layer > Add WFS / OGC API Features**, Ziel `http://localhost:8080/api/`.
 
-Dieselben Endpunkte aus einer Kartenbibliothek: [geolens-examples](https://github.com/geolens-io/geolens-examples) enthält Ein-Datei-Seiten für MapLibre, Leaflet, OpenLayers und das ArcGIS SDK, eine Python/GeoPandas-Analyse und eine MCP-Konfiguration. Jedes Beispiel läuft gegen die öffentliche Demo, und die CI führt sie wöchentlich erneut dagegen aus. Was Sie kopieren, hat also diese Woche funktioniert. [Galerie ansehen](https://geolens-io.github.io/geolens-examples/).
+Dieselben Endpunkte aus einer Kartenbibliothek: [geolens-examples](https://github.com/geolens-io/geolens-examples) enthält Ein-Datei-Seiten für MapLibre, Leaflet, OpenLayers und das ArcGIS SDK, dazu beide GeoLens-SDKs, eine eingebettete gespeicherte Karte, eine Python/GeoPandas-Analyse und eine MCP-Konfiguration. Jedes Beispiel läuft gegen die öffentliche Demo, und die CI führt sie wöchentlich erneut dagegen aus. Was Sie kopieren, hat also diese Woche funktioniert. [Galerie ansehen](https://geolens-io.github.io/geolens-examples/).
 
 ## Funktionen
 
@@ -354,7 +354,7 @@ API und Worker exportieren sofort Prometheus-Metriken (HTTP-Rate/Latenz/Fehler, 
 | [CLI & Manifeste](https://docs.getgeolens.com/guides/cli/) | Dateien veröffentlichen und Kataloge mit `geolens` verwalten |
 | [API-Referenz](https://docs.getgeolens.com/guides/api/) | Automatisch erzeugte Referenz; interaktive Swagger UI unter `/api/docs` zur Laufzeit |
 | [Manifestbeispiele](examples/manifests/) | Anpassbare `geolens.yaml`-Vorlagen: public-cog (entferntes COG), url-source, s3-source, publication-states |
-| [Client-Beispiele](https://github.com/geolens-io/geolens-examples) | Lauffähige Beispiele für MapLibre, Leaflet, OpenLayers, ArcGIS JS, Python/GeoPandas und MCP, in der CI gegen die öffentliche Demo geprüft ([Galerie](https://geolens-io.github.io/geolens-examples/)) |
+| [Client-Beispiele](https://github.com/geolens-io/geolens-examples) | Lauffähige Browser-, SDK-, Embed-, Python- und MCP-Beispiele, in der CI gegen die öffentliche Demo geprüft ([Galerie](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Community
 

--- a/README.es.md
+++ b/README.es.md
@@ -107,7 +107,7 @@ PostGIS y pgvector comparten una única base de datos, de modo que, con la búsq
 
 Conecta directamente desde QGIS: **Capa > Añadir WFS / OGC API Features** y apunta a `http://localhost:8080/api/`.
 
-Los mismos endpoints desde una biblioteca de mapas: [geolens-examples](https://github.com/geolens-io/geolens-examples) reúne páginas de un solo archivo para MapLibre, Leaflet, OpenLayers y el SDK de ArcGIS, un análisis en Python/GeoPandas y una configuración de MCP. Cada ejemplo se ejecuta contra la demo pública y CI los vuelve a ejecutar todos cada semana, así que lo que copias es código que funcionaba esta semana. [Explora la galería](https://geolens-io.github.io/geolens-examples/).
+Los mismos endpoints desde una biblioteca de mapas: [geolens-examples](https://github.com/geolens-io/geolens-examples) reúne páginas de un solo archivo para MapLibre, Leaflet, OpenLayers y el SDK de ArcGIS, además de ambos SDK de GeoLens, un mapa guardado incrustado, un análisis en Python/GeoPandas y una configuración de MCP. Cada ejemplo se ejecuta contra la demo pública y CI los vuelve a ejecutar todos cada semana, así que lo que copias es código que funcionaba esta semana. [Explora la galería](https://geolens-io.github.io/geolens-examples/).
 
 ## Funciones
 
@@ -355,7 +355,7 @@ La API y el worker exportan métricas Prometheus de serie (tasa/latencia/errores
 | [CLI y manifiestos](https://docs.getgeolens.com/guides/cli/) | Publica archivos y gestiona catálogos con la CLI `geolens` |
 | [Referencia de la API](https://docs.getgeolens.com/guides/api/) | Referencia generada en docs.getgeolens.com; Swagger UI interactiva en `/api/docs` durante la ejecución |
 | [Ejemplos de manifiestos](examples/manifests/) | Plantillas `geolens.yaml` adaptables: public-cog (COG remoto), url-source, s3-source, publication-states |
-| [Ejemplos de clientes](https://github.com/geolens-io/geolens-examples) | Ejemplos ejecutables de MapLibre, Leaflet, OpenLayers, ArcGIS JS, Python/GeoPandas y MCP, verificados en CI contra la demo pública ([galería](https://geolens-io.github.io/geolens-examples/)) |
+| [Ejemplos de clientes](https://github.com/geolens-io/geolens-examples) | Ejemplos ejecutables de navegador, SDK, incrustación, Python y MCP, verificados en CI contra la demo pública ([galería](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Comunidad
 

--- a/README.es.md
+++ b/README.es.md
@@ -107,6 +107,8 @@ PostGIS y pgvector comparten una única base de datos, de modo que, con la búsq
 
 Conecta directamente desde QGIS: **Capa > Añadir WFS / OGC API Features** y apunta a `http://localhost:8080/api/`.
 
+Los mismos endpoints desde una biblioteca de mapas: [geolens-examples](https://github.com/geolens-io/geolens-examples) reúne páginas de un solo archivo para MapLibre, Leaflet, OpenLayers y el SDK de ArcGIS, un análisis en Python/GeoPandas y una configuración de MCP. Cada ejemplo se ejecuta contra la demo pública y CI los vuelve a ejecutar todos cada semana, así que lo que copias es código que funcionaba esta semana. [Explora la galería](https://geolens-io.github.io/geolens-examples/).
+
 ## Funciones
 
 Cada ejemplo anterior tiene una guía completa en la [documentación](https://docs.getgeolens.com/guides/). GeoLens lee, escribe y publica lo siguiente:
@@ -353,6 +355,7 @@ La API y el worker exportan métricas Prometheus de serie (tasa/latencia/errores
 | [CLI y manifiestos](https://docs.getgeolens.com/guides/cli/) | Publica archivos y gestiona catálogos con la CLI `geolens` |
 | [Referencia de la API](https://docs.getgeolens.com/guides/api/) | Referencia generada en docs.getgeolens.com; Swagger UI interactiva en `/api/docs` durante la ejecución |
 | [Ejemplos de manifiestos](examples/manifests/) | Plantillas `geolens.yaml` adaptables: public-cog (COG remoto), url-source, s3-source, publication-states |
+| [Ejemplos de clientes](https://github.com/geolens-io/geolens-examples) | Ejemplos ejecutables de MapLibre, Leaflet, OpenLayers, ArcGIS JS, Python/GeoPandas y MCP, verificados en CI contra la demo pública ([galería](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Comunidad
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -106,6 +106,8 @@ PostGIS et pgvector partagent une base de données. Lorsque la recherche sémant
 
 Connectez-vous directement depuis QGIS : **Couche > Ajouter une couche WFS / OGC API Features** et indiquez `http://localhost:8080/api/`.
 
+Les mêmes points de terminaison depuis une bibliothèque cartographique : [geolens-examples](https://github.com/geolens-io/geolens-examples) rassemble des pages d’un seul fichier pour MapLibre, Leaflet, OpenLayers et le SDK ArcGIS, une analyse Python/GeoPandas et une configuration MCP. Chaque exemple s’exécute sur la démo publique, et la CI les rejoue tous chaque semaine : ce que vous copiez est donc du code qui fonctionnait cette semaine. [Parcourir la galerie](https://geolens-io.github.io/geolens-examples/).
+
 ## Fonctionnalités
 
 Chaque exemple ci-dessus dispose d’un guide complet dans la [documentation](https://docs.getgeolens.com/guides/). Voici ce que GeoLens lit, écrit et expose :
@@ -352,6 +354,7 @@ L’API et le worker exportent nativement des métriques Prometheus (taux/latenc
 | [CLI et manifestes](https://docs.getgeolens.com/guides/cli/) | Publication de fichiers et gestion des catalogues avec la CLI `geolens` |
 | [Référence API](https://docs.getgeolens.com/guides/api/) | Référence générée sur docs.getgeolens.com ; Swagger UI interactive sur `/api/docs` à l’exécution |
 | [Exemples de manifestes](examples/manifests/) | Modèles `geolens.yaml` : public-cog (COG distant), url-source, s3-source, publication-states |
+| [Exemples clients](https://github.com/geolens-io/geolens-examples) | Exemples exécutables MapLibre, Leaflet, OpenLayers, ArcGIS JS, Python/GeoPandas et MCP, vérifiés par la CI sur la démo publique ([galerie](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Communauté
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -106,7 +106,7 @@ PostGIS et pgvector partagent une base de données. Lorsque la recherche sémant
 
 Connectez-vous directement depuis QGIS : **Couche > Ajouter une couche WFS / OGC API Features** et indiquez `http://localhost:8080/api/`.
 
-Les mêmes points de terminaison depuis une bibliothèque cartographique : [geolens-examples](https://github.com/geolens-io/geolens-examples) rassemble des pages d’un seul fichier pour MapLibre, Leaflet, OpenLayers et le SDK ArcGIS, une analyse Python/GeoPandas et une configuration MCP. Chaque exemple s’exécute sur la démo publique, et la CI les rejoue tous chaque semaine : ce que vous copiez est donc du code qui fonctionnait cette semaine. [Parcourir la galerie](https://geolens-io.github.io/geolens-examples/).
+Les mêmes points de terminaison depuis une bibliothèque cartographique : [geolens-examples](https://github.com/geolens-io/geolens-examples) rassemble des pages d’un seul fichier pour MapLibre, Leaflet, OpenLayers et le SDK ArcGIS, ainsi que les deux SDK GeoLens, une carte enregistrée intégrée, une analyse Python/GeoPandas et une configuration MCP. Chaque exemple s’exécute sur la démo publique, et la CI les rejoue tous chaque semaine : ce que vous copiez est donc du code qui fonctionnait cette semaine. [Parcourir la galerie](https://geolens-io.github.io/geolens-examples/).
 
 ## Fonctionnalités
 
@@ -354,7 +354,7 @@ L’API et le worker exportent nativement des métriques Prometheus (taux/latenc
 | [CLI et manifestes](https://docs.getgeolens.com/guides/cli/) | Publication de fichiers et gestion des catalogues avec la CLI `geolens` |
 | [Référence API](https://docs.getgeolens.com/guides/api/) | Référence générée sur docs.getgeolens.com ; Swagger UI interactive sur `/api/docs` à l’exécution |
 | [Exemples de manifestes](examples/manifests/) | Modèles `geolens.yaml` : public-cog (COG distant), url-source, s3-source, publication-states |
-| [Exemples clients](https://github.com/geolens-io/geolens-examples) | Exemples exécutables MapLibre, Leaflet, OpenLayers, ArcGIS JS, Python/GeoPandas et MCP, vérifiés par la CI sur la démo publique ([galerie](https://geolens-io.github.io/geolens-examples/)) |
+| [Exemples clients](https://github.com/geolens-io/geolens-examples) | Exemples exécutables navigateur, SDK, intégration, Python et MCP, vérifiés par la CI sur la démo publique ([galerie](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Communauté
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ PostGIS and pgvector share one database, so with semantic search enabled you can
 
 Connect directly from QGIS: **Layer > Add WFS / OGC API Features** and point at `http://localhost:8080/api/`.
 
-The same endpoints from a map library: [geolens-examples](https://github.com/geolens-io/geolens-examples) holds single-file MapLibre, Leaflet, OpenLayers, and ArcGIS SDK pages, a Python/GeoPandas analysis, and an MCP setup. Each one runs against the live demo, and CI re-runs them all against it weekly, so what you copy is code that worked this week. [Browse the gallery](https://geolens-io.github.io/geolens-examples/).
+The same endpoints from a map library: [geolens-examples](https://github.com/geolens-io/geolens-examples) holds single-file MapLibre, Leaflet, OpenLayers, and ArcGIS SDK pages, plus both GeoLens SDKs, a saved-map embed, a Python/GeoPandas analysis, and an MCP setup. Each one runs against the live demo, and CI re-runs them all against it weekly, so what you copy is code that worked this week. [Browse the gallery](https://geolens-io.github.io/geolens-examples/).
 
 ## Features
 
@@ -417,7 +417,7 @@ see [RUNBOOK.md §4](RUNBOOK.md#4-monitoring) for the setup steps.
 | [CLI & Manifests](https://docs.getgeolens.com/guides/cli/) | Publish files and manage catalogs with the `geolens` CLI |
 | [API Reference](https://docs.getgeolens.com/guides/api/) | Auto-generated reference at docs.getgeolens.com; interactive Swagger UI at `/api/docs` when running |
 | [Manifest examples](examples/manifests/) | Template `geolens.yaml` manifests to adapt: public-cog (remote COG), url-source, s3-source, publication-states |
-| [Client examples](https://github.com/geolens-io/geolens-examples) | Runnable MapLibre, Leaflet, OpenLayers, ArcGIS JS, Python/GeoPandas, and MCP examples, verified against the live demo in CI ([gallery](https://geolens-io.github.io/geolens-examples/)) |
+| [Client examples](https://github.com/geolens-io/geolens-examples) | Runnable browser, SDK, embed, Python, and MCP examples, verified against the live demo in CI ([gallery](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ PostGIS and pgvector share one database, so with semantic search enabled you can
 
 Connect directly from QGIS: **Layer > Add WFS / OGC API Features** and point at `http://localhost:8080/api/`.
 
+The same endpoints from a map library: [geolens-examples](https://github.com/geolens-io/geolens-examples) holds single-file MapLibre, Leaflet, OpenLayers, and ArcGIS SDK pages, a Python/GeoPandas analysis, and an MCP setup. Each one runs against the live demo, and CI re-runs them all against it weekly, so what you copy is code that worked this week. [Browse the gallery](https://geolens-io.github.io/geolens-examples/).
+
 ## Features
 
 Each example above has a full guide in the [docs](https://docs.getgeolens.com/guides/). What GeoLens reads, writes, and exposes:
@@ -415,6 +417,7 @@ see [RUNBOOK.md §4](RUNBOOK.md#4-monitoring) for the setup steps.
 | [CLI & Manifests](https://docs.getgeolens.com/guides/cli/) | Publish files and manage catalogs with the `geolens` CLI |
 | [API Reference](https://docs.getgeolens.com/guides/api/) | Auto-generated reference at docs.getgeolens.com; interactive Swagger UI at `/api/docs` when running |
 | [Manifest examples](examples/manifests/) | Template `geolens.yaml` manifests to adapt: public-cog (remote COG), url-source, s3-source, publication-states |
+| [Client examples](https://github.com/geolens-io/geolens-examples) | Runnable MapLibre, Leaflet, OpenLayers, ArcGIS JS, Python/GeoPandas, and MCP examples, verified against the live demo in CI ([gallery](https://geolens-io.github.io/geolens-examples/)) |
 
 ## Community
 


### PR DESCRIPTION
Docs only. Two commits: the README link-back, then the SECURITY scope line.

## The README never pointed at the examples hub

The only "examples" pointer in the reference table was `examples/manifests/`, which is internal manifest templates. A reader of the main README had no route to [geolens-io/geolens-examples](https://github.com/geolens-io/geolens-examples), now the public showcase.

Two placements, not three:

- **A `Client examples` row in the Reference table**, next to `Manifest examples`. The two sit together and the labels tell them apart, which the old single row could not do.
- **One paragraph at the end of `See it in action`**, after the QGIS line. That section is curl against `localhost:8080`; a reader who has just watched the API answer is exactly where wanting the same endpoints from a map library starts, and the hub answers it.

Both landed in all four locales. The reference table is maintained row-for-row across `README.md`, `README.es.md`, `README.fr.md` and `README.de.md`, so an English-only row would have been drift on the first pass.

The description names what is actually merged over there: MapLibre, Leaflet, OpenLayers, ArcGIS JS, a Python/GeoPandas analysis, and MCP. TypeScript SDK, Python SDK and embed examples are in flight and are deliberately not described.

## SECURITY scope now says where the examples repo sits

Both policies already route to security@getgeolens.com, so nothing was mis-routed. What was missing was which half lands where. The examples repo ships sample client code and nothing else, so it splits cleanly:

- A server, image, package, or demo bug found **while running an example** is in scope here.
- An unsafe pattern **in the example code itself** belongs to that repo's own policy, which takes this same address alongside GitHub private vulnerability reporting.

That mirrors what [the examples repo's SECURITY.md](https://github.com/geolens-io/geolens-examples/blob/main/SECURITY.md) already says in the other direction, so the two now agree rather than each being silent about the other.

## Verified

| Claim | How |
|---|---|
| `https://github.com/geolens-io/geolens-examples` resolves | `curl -o /dev/null -w %{http_code}` returns 200 |
| The gallery URL resolves | Same, against `https://geolens-io.github.io/geolens-examples/`, returns 200 |
| The examples repo's SECURITY.md exists and routes as described | Read from `origin/main` of that repo; it names GitHub private vulnerability reporting plus security@getgeolens.com, and it points server-side reports back here |
| The hub covers exactly what the row says | Directory listing on `origin/main`: `maplibre/`, `leaflet/`, `openlayers/`, `arcgis-js/`, `python/`, `claude-mcp/` |
| CI there re-runs the examples against the live demo weekly | `.github/workflows/verify.yml`: push, pull_request, and a Monday 06:00 UTC cron |
| `examples/manifests/` still holds the four templates its row names | Directory listing in this repo: `public-cog`, `url-source.yaml`, `s3-source.yaml`, `publication-states.yaml`, plus `first-catalog` |
| No docs-contract violation | `python scripts/check_docs_contract.py` passes |

## One wording note, left alone on purpose

`## Features` opens with "Each example above has a full guide in the docs." The examples-hub paragraph now sits above that line, and the hub is not a docs guide. The sentence stays true of the curl examples it was written for, and tightening it would mean touching four locales for a sentence that is not wrong, so I left it. Worth a second opinion if you disagree.
