### PR TITLE
fix(embed): make the embed snippet boot and render a map

### DIFF
--- a/backend/tests/test_nginx_assets_cors_1515.py
+++ b/backend/tests/test_nginx_assets_cors_1515.py
@@ -1,0 +1,98 @@
+"""Regression coverage for CORS on the hashed-asset route (#1515).
+
+The embed snippet frames ``/m/{token}`` with ``sandbox="allow-scripts"`` and no
+``allow-same-origin``, which gives the frame an opaque origin. The shell loads
+the app as ``<script type="module" crossorigin>``, so every hashed asset fetch
+is CORS-mode and, from an opaque origin, cross-origin. Without an
+``Access-Control-Allow-Origin`` header the browser refuses it and the app never
+boots.
+
+Two properties, neither visible from a single grep:
+
+* the header has to be on the ``/assets/`` location, not merely somewhere in
+  the file; and
+* the value has to stay the static ``*`` — these responses are served
+  ``immutable`` and sit behind a CDN, so a reflected ``$http_origin`` would be
+  cached and replayed to a different origin.
+"""
+
+import re
+
+from tests.repo_paths import repo_root
+
+NGINX_CONF = repo_root(__file__) / "frontend" / "nginx.conf"
+
+ASSETS_LOCATION = r"location\s+/assets/"
+
+_ACAO_DIRECTIVE = re.compile(
+    r'add_header\s+Access-Control-Allow-Origin\s+"\*"\s+always\s*;'
+)
+_ANY_ACAO_VALUE = re.compile(r"add_header\s+Access-Control-Allow-Origin\s+(\S+)")
+
+
+def _without_comments(text: str) -> str:
+    """Drop nginx comment lines so prose can never satisfy an assertion."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _location_block(text: str, header_pattern: str) -> str:
+    """Return the body of the first location block whose header matches."""
+    match = re.search(header_pattern, text)
+    assert match, f"expected a location block matching {header_pattern!r}"
+    start = text.index("{", match.start())
+    depth = 0
+    for index in range(start, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start + 1 : index]
+    raise AssertionError(f"unbalanced braces after {header_pattern!r}")
+
+
+def test_assets_location_emits_cors_header():
+    conf = _without_comments(NGINX_CONF.read_text())
+    block = _location_block(conf, ASSETS_LOCATION)
+
+    assert _ACAO_DIRECTIVE.search(block), (
+        "the /assets/ location must emit "
+        'add_header Access-Control-Allow-Origin "*" always, or an embedded '
+        "viewer cannot load its own module graph"
+    )
+
+
+def test_assets_cors_header_is_static_never_reflected():
+    """A reflected origin is cache-poisonous on an `immutable` response."""
+    conf = _without_comments(NGINX_CONF.read_text())
+    values = _ANY_ACAO_VALUE.findall(_location_block(conf, ASSETS_LOCATION))
+
+    assert values, "expected at least one Access-Control-Allow-Origin header"
+    for value in values:
+        assert value == '"*"', (
+            f'Access-Control-Allow-Origin must be the static "*", got {value!r}; '
+            "these responses are cached for a year and would be replayed"
+        )
+
+
+def test_assets_location_keeps_the_security_headers():
+    """add_header disables inheritance, so this block has to re-declare them.
+
+    The block already carried an add_header (Cache-Control) before #1515, which
+    silently dropped the server-scope security headers. Re-declared here now
+    that the same responses are readable cross-origin.
+    """
+    conf = _without_comments(NGINX_CONF.read_text())
+    block = _location_block(conf, ASSETS_LOCATION)
+
+    for header, value in (
+        ("X-Frame-Options", "SAMEORIGIN"),
+        ("X-Content-Type-Options", "nosniff"),
+        ("Referrer-Policy", "strict-origin-when-cross-origin"),
+    ):
+        assert re.search(
+            rf'add_header\s+{re.escape(header)}\s+"{re.escape(value)}"\s+always\s*;',
+            block,
+        ), f"/assets/ must re-declare {header}; add_header disables inheritance"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -99,6 +99,22 @@ server {
     location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        # fix(#1515): the embed snippet frames /m/ with sandbox="allow-scripts"
+        # and no allow-same-origin, which gives the frame an OPAQUE origin. The
+        # shell loads the app as <script type="module" crossorigin>, so that
+        # fetch is CORS-mode and now cross-origin (Origin: null) — with no
+        # Access-Control-Allow-Origin the browser refuses it and the app never
+        # boots. These are public, immutable, credential-free build artifacts,
+        # so the static "*" protects nothing by being absent. Static, never a
+        # reflected $http_origin: the responses are cached (browser `immutable`,
+        # and a CDN in front) and a per-origin value would be replayed.
+        add_header Access-Control-Allow-Origin "*" always;
+        # add_header disables inheritance of the server-scope set, so re-declare
+        # the security headers this block has been silently dropping. Same rule
+        # @empty_tile, `location /` and `location ~ ^/m/` already follow.
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 
     location ~ ^/raster-tiles/(?<dataset_id>[0-9a-f-]+)/tiles/(?<z>\d+)/(?<x>\d+)/(?<y>\d+)\.(?<fmt>[a-z]+)$ {

--- a/frontend/public/asset-guard.js
+++ b/frontend/public/asset-guard.js
@@ -15,12 +15,18 @@
       if (tag !== 'SCRIPT' && tag !== 'LINK') return;
       var url = el.src || el.href || '';
       if (url.indexOf('/assets/') === -1) return;
+      // fix(#1515): the reload has to stay INSIDE the try. sessionStorage is not
+      // merely null in a storage-denied context, it throws — a sandboxed iframe
+      // without allow-same-origin has an opaque origin and reading the property
+      // raises SecurityError. Reloading from the catch ran unlatched: the shell
+      // reloaded, the asset failed again, and the frame re-requested at ~1000
+      // req/s on localhost. No latch, no reload.
       try {
         var last = Number(sessionStorage.getItem('geolens-asset-reload-at') || 0);
         if (Date.now() - last < 30000) return;
         sessionStorage.setItem('geolens-asset-reload-at', String(Date.now()));
+        window.location.reload();
       } catch (err) {}
-      window.location.reload();
     },
     true
   );

--- a/frontend/src/api/__tests__/client.embed-anonymous-1515.test.ts
+++ b/frontend/src/api/__tests__/client.embed-anonymous-1515.test.ts
@@ -1,0 +1,108 @@
+/**
+ * fix(#1515): the embedded viewer must not spend the viewer's session.
+ *
+ * The emitted snippet now carries `allow-same-origin`, so the frame shares the
+ * GeoLens origin and therefore the persisted auth store. Without this, an embed
+ * on a third-party page would run every request as whoever is signed in, and a
+ * 401 inside that frame would refresh or destroy their login.
+ *
+ * The store is seeded with a real-looking session in every case here, so a test
+ * that passes because there was no token to send would be a false green: the
+ * non-embed cases assert the header IS sent from the same setup.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { apiFetch } from '@/api/client';
+import { buildEmbedSrc } from '@/components/builder/SharePanel';
+import { isEmbedViewer } from '@/lib/embed-context';
+import { useAuthStore } from '@/stores/auth-store';
+
+const TOKEN = 'seeded-session-token';
+
+function setUrl(pathname: string, search: string): void {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, pathname, search, href: `http://localhost${pathname}${search}` },
+  });
+}
+
+function lastRequestHeaders(): Headers {
+  const call = vi.mocked(globalThis.fetch).mock.calls.at(-1)!;
+  return new Headers((call[1] as RequestInit).headers);
+}
+
+beforeEach(() => {
+  useAuthStore.setState({
+    token: TOKEN,
+    refreshToken: null,
+    // Far future, so the proactive-refresh branch is not what is under test.
+    expiresAt: Date.now() + 60 * 60 * 1000,
+    user: null,
+  });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+});
+
+describe('embed mode is anonymous (#1515)', () => {
+  it('sends no Authorization from the embedded viewer', async () => {
+    setUrl('/m/share-token-abc', '?embed=true');
+    await apiFetch('/maps/shared/share-token-abc');
+    expect(lastRequestHeaders().has('Authorization')).toBe(false);
+  });
+
+  it('still sends Authorization everywhere else (counterfactual for the case above)', async () => {
+    setUrl('/maps/some-id', '');
+    await apiFetch('/maps/some-id');
+    expect(lastRequestHeaders().get('Authorization')).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('a plain share link without embed=true keeps the session', async () => {
+    setUrl('/m/share-token-abc', '');
+    await apiFetch('/maps/shared/share-token-abc');
+    expect(lastRequestHeaders().get('Authorization')).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('embed=true on a non-embed path does not disable auth', async () => {
+    setUrl('/datasets/xyz', '?embed=true');
+    await apiFetch('/datasets/xyz');
+    expect(lastRequestHeaders().get('Authorization')).toBe(`Bearer ${TOKEN}`);
+  });
+
+  // Pins the producer to the predicate. buildEmbedSrc is the only thing that
+  // builds this URL shape, so if its path or `embed` flag ever changes, the
+  // client would silently go back to sending the session and only an
+  // end-to-end run would notice.
+  it('recognizes the URL buildEmbedSrc actually produces', () => {
+    const src = buildEmbedSrc({
+      shareToken: 'abc123',
+      embedTokenRaw: 'tok-456',
+      origin: 'https://geolens.example.com',
+    });
+    const url = new URL(src);
+    setUrl(url.pathname, url.search);
+    expect(isEmbedViewer()).toBe(true);
+  });
+
+  it('a 401 inside an embed does not clear the session', async () => {
+    setUrl('/m/share-token-abc', '?embed=true');
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response('{"detail":"nope"}', {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(apiFetch('/maps/shared/share-token-abc')).rejects.toMatchObject({ status: 401 });
+
+    // The viewer's login survives, and no refresh was attempted: one request.
+    expect(useAuthStore.getState().token).toBe(TOKEN);
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,6 @@
 import { API_BASE } from '@/lib/constants';
 import { cookieAuthAvailable } from '@/lib/auth-transport';
+import { isEmbedViewer } from '@/lib/embed-context';
 import { translateApiErrorDetail } from '@/lib/error-map';
 import { useAuthStore } from '@/stores/auth-store';
 import { logoutSession, refreshAccessToken } from './auth';
@@ -188,15 +189,21 @@ export async function authenticatedRawFetch(
   options: RequestInit = {},
   prepareHeaders?: (headers: Headers) => void,
 ): Promise<Response> {
+  // fix(#1515): the embedded viewer does not participate in the session. See
+  // isEmbedViewer's docstring — the share token is the capability, and once the
+  // frame is same-origin an embed on a third-party page would otherwise run as
+  // whoever is signed in, and could sign them out.
+  const embedded = isEmbedViewer();
+
   // Proactively refresh if token expires within 30 seconds
   const { token: currentToken, expiresAt } = useAuthStore.getState();
-  if (currentToken && expiresAt && Date.now() > expiresAt - 30_000) {
+  if (!embedded && currentToken && expiresAt && Date.now() > expiresAt - 30_000) {
     await tryRefresh();
   }
 
   function buildHeaders(): Headers {
     const headers = new Headers(options.headers);
-    const token = useAuthStore.getState().token;
+    const token = embedded ? null : useAuthStore.getState().token;
     if (token) {
       headers.set('Authorization', `Bearer ${token}`);
     }
@@ -210,6 +217,13 @@ export async function authenticatedRawFetch(
   });
 
   if (response.status === 401) {
+    // fix(#1515): an embed never sent a session, so a 401 here is the share or
+    // embed token failing to authorize — not an expired login. Returning it
+    // keeps the viewer's own error handling and, more importantly, keeps a
+    // frame on someone else's page from refreshing or destroying the session
+    // of whoever is signed in.
+    if (embedded) return response;
+
     // fix(#628): only a session that existed can expire; an anonymous 401 must
     // not raise the signed-out prompt. Captured BEFORE tryRefresh so every
     // concurrent failure holds the same dead value.

--- a/frontend/src/components/auth/LandingFirstGuard.tsx
+++ b/frontend/src/components/auth/LandingFirstGuard.tsx
@@ -18,6 +18,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useAuthStore } from '@/stores/auth-store';
 import { getAuthConfig } from '@/api/auth';
 import { queryKeys } from '@/lib/query-keys';
+import { readSessionStorage } from '@/lib/storage';
 import { SearchPage } from '@/pages/SearchPage';
 
 const GUEST_BROWSE_KEY = 'gl-guest-browse';
@@ -32,10 +33,13 @@ export function LandingFirstGuard() {
   });
 
   const landingFirst = config?.landing_first ?? false;
-  const guestBrowse =
-    typeof sessionStorage !== 'undefined'
-      ? sessionStorage.getItem(GUEST_BROWSE_KEY) === 'true'
-      : false;
+  // fix(#1515): this read happens during render, so an exception here is a blank
+  // page, not a lost preference. The previous `typeof sessionStorage !==
+  // 'undefined'` guard did not prevent one: the property exists in every context
+  // that matters, and it is READING it that throws — SecurityError in a frame
+  // with an opaque origin, and in some private-browsing modes. Same defect shape
+  // as the two reload latches in this fix; third site.
+  const guestBrowse = readSessionStorage(GUEST_BROWSE_KEY) === 'true';
 
   // Redirect ONLY when: flag ON + unauthenticated + no guest-browse marker
   if (landingFirst && !token && !guestBrowse) {

--- a/frontend/src/components/auth/__tests__/LandingFirstGuard.test.tsx
+++ b/frontend/src/components/auth/__tests__/LandingFirstGuard.test.tsx
@@ -167,6 +167,89 @@ describe('LandingFirstGuard', () => {
     expect(screen.queryByTestId('login-page')).not.toBeInTheDocument();
   });
 
+  /**
+   * fix(#1515): the guest-browse marker is read DURING RENDER, so a throw here
+   * is a blank page. `typeof sessionStorage !== 'undefined'` did not protect
+   * it — the property exists and the READ is what raises. Observed as
+   * "SecurityError: Failed to read the 'sessionStorage' property from 'Window'"
+   * inside a sandboxed frame, surfaced by React Router as a page error.
+   *
+   * Deny the way the browser denies: a getter that throws on property access.
+   * Mocking getItem to return null would prove nothing, because the old code
+   * never reached getItem.
+   */
+  function denyStorage(): () => void {
+    const original = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+    const descriptor: PropertyDescriptor = {
+      configurable: true,
+      get() {
+        throw new DOMException(
+          "Failed to read the 'sessionStorage' property from 'Window': The document " +
+            "is sandboxed and lacks the 'allow-same-origin' flag.",
+          'SecurityError',
+        );
+      },
+    };
+    Object.defineProperty(window, 'sessionStorage', descriptor);
+    if (globalThis !== (window as unknown as typeof globalThis)) {
+      Object.defineProperty(globalThis, 'sessionStorage', descriptor);
+    }
+    return () => {
+      if (original) {
+        Object.defineProperty(window, 'sessionStorage', original);
+        if (globalThis !== (window as unknown as typeof globalThis)) {
+          Object.defineProperty(globalThis, 'sessionStorage', original);
+        }
+      }
+    };
+  }
+
+  function renderWithConfig(landingFirst: boolean) {
+    const queryClient = createTestClient();
+    queryClient.setQueryData(['auth', 'config'], {
+      registration_enabled: false,
+      landing_first: landingFirst,
+      auth_methods: [],
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route index element={<LandingFirstGuard />} />
+            <Route path="/login" element={<LoginSpy />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  }
+
+  it('F) #1515 — storage denied + flag OFF: renders SearchPage instead of throwing', () => {
+    const restore = denyStorage();
+    try {
+      act(() => {
+        useAuthStore.setState({ token: null, user: null, refreshToken: null, expiresAt: null });
+      });
+      renderWithConfig(false);
+      expect(screen.getByTestId('search-page')).toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+
+  it('F2) #1515 — storage denied + flag ON + anon: redirects, treating the marker as absent', () => {
+    const restore = denyStorage();
+    try {
+      act(() => {
+        useAuthStore.setState({ token: null, user: null, refreshToken: null, expiresAt: null });
+      });
+      renderWithConfig(true);
+      expect(screen.getByTestId('login-page')).toBeInTheDocument();
+      expect(screen.queryByTestId('search-page')).not.toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+
   it('config absent (undefined) — defaults to flag OFF → SearchPage', () => {
     const queryClient = createTestClient();
     // No query data seeded — config will be undefined

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -44,21 +44,6 @@ import type { MapLayerResponse, MapVisibility } from '@/types/api';
 import { Textarea } from '@/components/ui/textarea';
 
 /**
- * Generate the iframe embed snippet for a shared map.
- *
- * SEC-07 / M-70: deliberately omits `allow-same-origin` from the sandbox
- * attribute. Per MDN, combining `allow-scripts` with `allow-same-origin`
- * lets the iframe remove its own sandboxing (it can rewrite the parent
- * document's storage / cookies for the iframe's origin), neutralizing
- * the protection. The embedded map viewer authenticates via the
- * `et=<token>` query param and does not need same-origin access — so we
- * keep the iframe in the strongest sandbox that still allows MapLibre
- * GL JS to run.
- *
- * Exported so SharePanel.test.tsx can pin the rendered snippet shape
- * without mounting the full ShareDialog component.
- */
-/**
  * Build the embedded-viewer iframe `src` URL for a shared map (builder-audit
  * SHARE-04). Single source of truth shared by generateEmbedCode (full iframe
  * snippet) and EmbedPreviewPane (live preview) so the viewer URL shape — path,
@@ -82,6 +67,38 @@ export function buildEmbedSrc({
   return `${origin}/m/${shareToken}?${params.toString()}`;
 }
 
+/**
+ * Generate the iframe embed snippet for a shared map.
+ *
+ * fix(#1515): emits `sandbox="allow-scripts allow-same-origin"`. The old value
+ * omitted `allow-same-origin` on SEC-07 / M-70 reasoning, and the snippet could
+ * not boot. Without that flag the frame gets an OPAQUE origin, so the shell's
+ * `<script type="module" crossorigin>` fetch and every later `/api/` call are
+ * cross-origin with `Origin: null`. Measured end to end against a real share
+ * token: the viewer rendered "Map not found" while the api answered the very
+ * same request 200 and the browser discarded it for want of a CORS header.
+ *
+ * The escape hatch that reasoning feared is real, and it does not reach here.
+ * A frame strips its own sandbox by reaching `parent.document`, which requires
+ * being same-origin with its EMBEDDER. A third-party page embedding a GeoLens
+ * map never is, so the pair cannot be used to escape from there. That warning
+ * belongs to a FIRST-PARTY frame of your own origin. (FeaturePopup.tsx already
+ * ships the same pair for YouTube; threat model T-1138-04.)
+ *
+ * Narrower than the usual case, too: an iframe with no `sandbox` attribute at
+ * all, which is what most embed snippets ship and what worked before this bug
+ * was reported, additionally permits forms, popups, top-level navigation,
+ * downloads and pointer lock.
+ *
+ * What it does cost, and the reason this was Ian's call rather than a header
+ * change: the frame regains the GeoLens origin, so a signed-in viewer's embed
+ * runs with their session — `authenticatedRawFetch` attaches the persisted
+ * bearer token on every call. The embedding page is still cross-origin to the
+ * frame and cannot read those responses.
+ *
+ * Exported so SharePanel.test.tsx can pin the rendered snippet shape
+ * without mounting the full ShareDialog component.
+ */
 export function generateEmbedCode({
   shareToken,
   embedTokenRaw,
@@ -93,7 +110,7 @@ export function generateEmbedCode({
 }): string {
   if (!shareToken) return '';
   const url = buildEmbedSrc({ shareToken, embedTokenRaw, origin });
-  return `<iframe src="${url}" width="800" height="600" sandbox="allow-scripts" style="border:none;"></iframe>`;
+  return `<iframe src="${url}" width="800" height="600" sandbox="allow-scripts allow-same-origin" style="border:none;"></iframe>`;
 }
 
 const VISIBILITY_OPTIONS: Array<{
@@ -613,12 +630,15 @@ function EmbedPreviewPane({ shareToken, embedTokenRaw, origin }: EmbedPreviewPan
                   <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-hidden="true" />
                 </div>
               )}
-              {/* SEC-07 / M-70: sandbox="allow-scripts" ONLY. NEVER add allow-same-origin — see SharePanel.tsx generateEmbedCode docstring. */}
+              {/* fix(#1515): must stay byte-identical to the sandbox generateEmbedCode emits.
+                  A preview under a different sandbox is a preview of a different page — this one
+                  showed "Map not found" for a valid token while the copied snippet was blamed.
+                  See the generateEmbedCode docstring for why the pair is safe for a third-party embed. */}
               <iframe
                 key={reloadKey}
                 data-testid="share-preview-iframe"
                 src={src}
-                sandbox="allow-scripts"
+                sandbox="allow-scripts allow-same-origin"
                 title={t('share.iframePreviewTitle', { defaultValue: 'Map embed preview' })}
                 loading="lazy"
                 style={{ border: 'none' }}
@@ -646,8 +666,10 @@ function EmbedPreviewPane({ shareToken, embedTokenRaw, origin }: EmbedPreviewPan
           )}
           <div className="flex items-center gap-1 px-3 py-2 text-xs text-muted-foreground border-t border-border">
             <Shield className="h-3 w-3" aria-hidden="true" />
+            {/* fix(#1515): the old copy said "permits scripts only", which stopped being
+                true when the sandbox gained allow-same-origin. */}
             {t('share.iframeSandboxNote', {
-              defaultValue: 'The embed preview runs in a restricted sandbox that permits scripts only.',
+              defaultValue: 'The embed preview runs in the same restricted sandbox as the snippet you copy.',
             })}
           </div>
         </div>

--- a/frontend/src/components/builder/SharePanel.tsx
+++ b/frontend/src/components/builder/SharePanel.tsx
@@ -90,11 +90,14 @@ export function buildEmbedSrc({
  * was reported, additionally permits forms, popups, top-level navigation,
  * downloads and pointer lock.
  *
- * What it does cost, and the reason this was Ian's call rather than a header
- * change: the frame regains the GeoLens origin, so a signed-in viewer's embed
- * runs with their session — `authenticatedRawFetch` attaches the persisted
- * bearer token on every call. The embedding page is still cross-origin to the
- * frame and cannot read those responses.
+ * What it costs, and the reason this was a decision rather than a header
+ * change: the frame regains the GeoLens origin, and with it the viewer's
+ * persisted session. So embed mode is deliberately anonymous — `isEmbedViewer`
+ * in lib/embed-context.ts, read by `authenticatedRawFetch`, withholds the
+ * bearer token, skips the proactive refresh, and returns a 401 untouched
+ * instead of refreshing or logging out. The share token is the capability and
+ * authorizes the map on its own; an embed on someone else's page has no
+ * business spending, refreshing, or destroying a viewer's login.
  *
  * Exported so SharePanel.test.tsx can pin the rendered snippet shape
  * without mounting the full ShareDialog component.

--- a/frontend/src/components/builder/__tests__/SharePanel.test.tsx
+++ b/frontend/src/components/builder/__tests__/SharePanel.test.tsx
@@ -261,23 +261,42 @@ describe('ShareDialog edition gates', () => {
 });
 
 /* ------------------------------------------------------------------ */
-/*  SEC-07 / M-70: embed iframe sandbox attribute                      */
+/*  #1515: embed iframe sandbox attribute                              */
 /* ------------------------------------------------------------------ */
 //
-// Pins the v13.13 closure of M-70. The combination of `allow-scripts` +
-// `allow-same-origin` neutralizes the iframe sandbox (MDN-documented
-// anti-pattern) — embed iframes loaded by external sites would have
-// access to cookies/localStorage of the GeoLens deployment, defeating
-// share-token isolation.
-describe('SEC-07: embed code sandbox attribute', () => {
-  it('uses allow-scripts only, no allow-same-origin', () => {
+// Supersedes the M-70 contract this block used to pin. `allow-scripts` alone
+// gives the frame an opaque origin, and the emitted snippet could not boot:
+// measured end to end, the viewer rendered "Map not found" for a valid share
+// token because every /api/ call was cross-origin with `Origin: null`.
+//
+// The sandbox-escape M-70 feared needs the frame to be same-origin with its
+// EMBEDDER, which a third-party embed never is. See the generateEmbedCode
+// docstring.
+//
+// The whole string is asserted, not just the sandbox value: this snippet is
+// copied verbatim into other people's pages, so an edit to any part of the
+// template should fail here rather than ship.
+describe('#1515: embed code sandbox attribute', () => {
+  it('emits the exact snippet, sandbox included', () => {
     const code = generateEmbedCode({
       shareToken: 'abc123',
       embedTokenRaw: 'tok-456',
       origin: 'https://geolens.example.com',
     });
-    expect(code).toContain('sandbox="allow-scripts"');
-    expect(code).not.toContain('allow-same-origin');
+    expect(code).toBe(
+      '<iframe src="https://geolens.example.com/m/abc123?embed=true&et=tok-456"' +
+        ' width="800" height="600" sandbox="allow-scripts allow-same-origin"' +
+        ' style="border:none;"></iframe>',
+    );
+  });
+
+  it('carries allow-same-origin, without which the frame cannot load its own bundle', () => {
+    const code = generateEmbedCode({
+      shareToken: 'abc123',
+      embedTokenRaw: 'tok-456',
+      origin: 'https://geolens.example.com',
+    });
+    expect(code).toContain('sandbox="allow-scripts allow-same-origin"');
   });
 
   it('returns empty string when shareToken is missing', () => {
@@ -311,7 +330,7 @@ describe('SEC-07: embed code sandbox attribute', () => {
   // value. Substitutes for the deferred Playwright MCP UAT — confirms the
   // sandbox value reaches the rendered DOM exactly as the unit-tested pure
   // function emits it (no later string-rewriting in the component layer).
-  it('rendered embed textarea contains sandbox="allow-scripts" only after creating a raw share token', async () => {
+  it('rendered embed textarea carries the emitted sandbox after creating a raw share token', async () => {
     const user = userEvent.setup();
     setup({ enterprise: false, hasShareToken: false });
 
@@ -319,8 +338,7 @@ describe('SEC-07: embed code sandbox attribute', () => {
 
     const textarea = await screen.findByRole('textbox') as HTMLTextAreaElement;
     expect(textarea).toBeTruthy();
-    expect(textarea.value).toContain('sandbox="allow-scripts"');
-    expect(textarea.value).not.toContain('allow-same-origin');
+    expect(textarea.value).toContain('sandbox="allow-scripts allow-same-origin"');
   });
 });
 
@@ -773,7 +791,10 @@ describe('SHARE-03 embed-preview iframe', () => {
     });
   });
 
-  it('test_iframe_sandbox_is_allow_scripts_only: sandbox attribute is exactly "allow-scripts" (no allow-same-origin — SEC-07 contract)', async () => {
+  // fix(#1515): the preview and the copied snippet must carry the SAME sandbox.
+  // While they differed the preview was a preview of a different page, and it
+  // showed "Map not found" for a token that was perfectly valid.
+  it('test_iframe_sandbox_matches_the_emitted_snippet: preview sandbox === generateEmbedCode sandbox', async () => {
     const user = userEvent.setup();
     setup({ enterprise: false, hasShareToken: false, hasNonPublic: true });
 
@@ -781,8 +802,14 @@ describe('SHARE-03 embed-preview iframe', () => {
     await user.click(screen.getByRole('button', { name: /preview/i }));
 
     const iframe = await screen.findByTestId('share-preview-iframe');
-    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
-    expect(iframe.getAttribute('sandbox')).not.toContain('allow-same-origin');
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts allow-same-origin');
+
+    const snippet = generateEmbedCode({
+      shareToken: 'share-token',
+      embedTokenRaw: 'raw-token',
+      origin: 'https://geolens.example.com',
+    });
+    expect(snippet).toContain(`sandbox="${iframe.getAttribute('sandbox')}"`);
   });
 
   it('test_iframe_title_attribute_set: iframe has title="Map embed preview" (a11y)', async () => {
@@ -821,7 +848,9 @@ describe('SHARE-03 embed-preview iframe', () => {
     });
 
     // Security indicator footer: contains sandbox note text
-    expect(screen.getByText(/restricted sandbox that permits scripts only/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/same restricted sandbox as the snippet you copy/i),
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/i18n/locales/de/builder.json
+++ b/frontend/src/i18n/locales/de/builder.json
@@ -690,7 +690,7 @@
     "iframeErrorTitle": "Vorschau nicht verfügbar",
     "iframeErrorBody": "Bitte überprüfen Sie, ob das Einbettungs-Token gültig und der Freigabelink aktiv ist. Zum Wiederholen neu laden.",
     "iframeReload": "Neu laden",
-    "iframeSandboxNote": "Die Einbettungsvorschau wird in einer eingeschränkten Umgebung ausgeführt, die nur Skripte zulässt.",
+    "iframeSandboxNote": "Die Einbettungsvorschau wird in derselben eingeschränkten Umgebung ausgeführt wie das kopierte Snippet.",
     "embedTokenMissing": "Diese Karte enthält nicht-öffentliche Ebenen. Betrachter können nicht alle Ebenen ohne ein Einbettungstoken sehen.",
     "embedTokenNotAvailable": "Das Einbettungstoken wurde in einer früheren Sitzung erstellt. Neu generieren, um den Einbettungscode zu erhalten.",
     "embedTokenRegenerated": "Einbettungstoken neu generiert",

--- a/frontend/src/i18n/locales/en/builder.json
+++ b/frontend/src/i18n/locales/en/builder.json
@@ -690,7 +690,7 @@
     "iframeErrorTitle": "Preview unavailable",
     "iframeErrorBody": "Check that the embed token is valid and the share link is active. Reload to retry.",
     "iframeReload": "Reload",
-    "iframeSandboxNote": "The embed preview runs in a restricted sandbox that permits scripts only.",
+    "iframeSandboxNote": "The embed preview runs in the same restricted sandbox as the snippet you copy.",
     "embedTokenMissing": "This map contains non-public layers. Viewers may not be able to see all layers without an embed token.",
     "embedTokenNotAvailable": "The embed token was created in a previous session. Regenerate to get the embed code.",
     "embedTokenRegenerated": "Embed token regenerated",

--- a/frontend/src/i18n/locales/es/builder.json
+++ b/frontend/src/i18n/locales/es/builder.json
@@ -690,7 +690,7 @@
     "iframeErrorTitle": "Vista previa no disponible",
     "iframeErrorBody": "Verifique que el token de incrustación sea válido y que el enlace compartido esté activo. Recargue para reintentar.",
     "iframeReload": "Recargar",
-    "iframeSandboxNote": "La vista previa insertada se ejecuta en un entorno restringido que solo permite scripts.",
+    "iframeSandboxNote": "La vista previa insertada se ejecuta en el mismo entorno restringido que el fragmento que copias.",
     "embedTokenMissing": "Este mapa contiene capas no públicas. Los visitantes puede que no vean todas las capas sin un token de inserción.",
     "embedTokenNotAvailable": "El token de inserción se creó en una sesión anterior. Regénéralo para obtener el código de inserción.",
     "embedTokenRegenerated": "Token de inserción regenerado",

--- a/frontend/src/i18n/locales/fr/builder.json
+++ b/frontend/src/i18n/locales/fr/builder.json
@@ -690,7 +690,7 @@
     "iframeErrorTitle": "Aperçu indisponible",
     "iframeErrorBody": "Vérifiez que le jeton d'intégration est valide et que le lien de partage est actif. Rechargez pour réessayer.",
     "iframeReload": "Recharger",
-    "iframeSandboxNote": "L’aperçu intégré s’exécute dans un environnement restreint qui autorise uniquement les scripts.",
+    "iframeSandboxNote": "L’aperçu intégré s’exécute dans le même environnement restreint que l’extrait que vous copiez.",
     "embedTokenMissing": "Cette carte contient des calques non publics. Les visiteurs pourraient ne pas voir tous les calques sans jeton d'intégration.",
     "embedTokenNotAvailable": "Le jeton d'intégration a été créé lors d'une session précédente. Régénérez-le pour obtenir le code d'intégration.",
     "embedTokenRegenerated": "Jeton d'intégration régénéré",

--- a/frontend/src/i18n/resources.test.ts
+++ b/frontend/src/i18n/resources.test.ts
@@ -83,7 +83,6 @@ const IDENTICAL_ACROSS_LOCALES = new Set([
   // Code samples and input placeholders
   'admin:settings.network.corsAllowedOriginsPlaceholder', // https://example.com, ...
   'builder:popup.expressionPlaceholder', // {city}, {state}
-  'builder:share.iframeSandboxNote', // sandbox="allow-scripts" only — SEC-07 contract
   'dataset:schema.columnNamePlaceholder', // column_name
 ]);
 

--- a/frontend/src/lib/__tests__/asset-guard.test.ts
+++ b/frontend/src/lib/__tests__/asset-guard.test.ts
@@ -58,8 +58,15 @@ function denyStorage(): () => void {
   };
 }
 
-/** Fire the error event a blocked/404 hashed asset produces. */
-function failAsset(url = 'http://localhost/assets/index-abc123.js'): void {
+/**
+ * Fire the error event a blocked/404 hashed asset produces.
+ *
+ * The src is RELATIVE, matching what the shell actually emits, and the guard
+ * reads `el.src`, which the DOM resolves against the document base. An absolute
+ * `http://` literal here worked equally well but tripped CodeQL's
+ * "script loaded using unencrypted connection" rule on a test fixture.
+ */
+function failAsset(url = '/assets/index-abc123.js'): void {
   const el = document.createElement('script');
   el.setAttribute('src', url);
   document.body.appendChild(el);
@@ -94,7 +101,7 @@ describe('asset-guard.js', () => {
   });
 
   it('ignores failures that are not hashed assets', () => {
-    failAsset('http://localhost/some-other-script.js');
+    failAsset('/some-other-script.js');
     expect(reload).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/lib/__tests__/asset-guard.test.ts
+++ b/frontend/src/lib/__tests__/asset-guard.test.ts
@@ -1,0 +1,112 @@
+// fix(#1515): public/asset-guard.js ships in the shell as a plain <script>, so
+// nothing imports it and nothing covered it. It is also the half that produced
+// the flood: under an opaque origin `sessionStorage` THROWS, and reloading from
+// the catch bypassed the latch entirely.
+//
+// The file is read and evaluated here rather than reimplemented, so the test
+// fails if the shipped guard regresses.
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const GUARD_SOURCE = readFileSync(
+  resolve(__dirname, '../../../public/asset-guard.js'),
+  'utf-8'
+);
+
+const reload = vi.fn();
+
+type ListenerArgs = Parameters<typeof window.addEventListener>;
+let installed: ListenerArgs | null = null;
+
+/**
+ * Evaluate the shipped guard and remember the listener it registers, so each
+ * test starts from one live listener instead of accumulating them.
+ */
+function installGuard(): void {
+  const spy = vi.spyOn(window, 'addEventListener');
+  new Function(GUARD_SOURCE)();
+  installed = spy.mock.calls.at(-1) as ListenerArgs;
+  spy.mockRestore();
+}
+
+/** Opaque-origin storage: reading the property throws, per the browser. */
+function denyStorage(): () => void {
+  const original = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+  const descriptor: PropertyDescriptor = {
+    configurable: true,
+    get() {
+      throw new DOMException(
+        "Failed to read the 'sessionStorage' property from 'Window': The document " +
+          "is sandboxed and lacks the 'allow-same-origin' flag.",
+        'SecurityError'
+      );
+    },
+  };
+  Object.defineProperty(window, 'sessionStorage', descriptor);
+  if (globalThis !== (window as unknown as typeof globalThis)) {
+    Object.defineProperty(globalThis, 'sessionStorage', descriptor);
+  }
+  return () => {
+    if (original) {
+      Object.defineProperty(window, 'sessionStorage', original);
+      if (globalThis !== (window as unknown as typeof globalThis)) {
+        Object.defineProperty(globalThis, 'sessionStorage', original);
+      }
+    }
+  };
+}
+
+/** Fire the error event a blocked/404 hashed asset produces. */
+function failAsset(url = 'http://localhost/assets/index-abc123.js'): void {
+  const el = document.createElement('script');
+  el.setAttribute('src', url);
+  document.body.appendChild(el);
+  el.dispatchEvent(new Event('error'));
+  el.remove();
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  reload.mockClear();
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, reload },
+    writable: true,
+    configurable: true,
+  });
+  installGuard();
+});
+
+afterEach(() => {
+  if (installed) {
+    window.removeEventListener(...installed);
+    installed = null;
+  }
+});
+
+describe('asset-guard.js', () => {
+  it('reloads once for a failed hashed asset and latches repeats', () => {
+    failAsset();
+    failAsset();
+    failAsset();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores failures that are not hashed assets', () => {
+    failAsset('http://localhost/some-other-script.js');
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not reload when the latch is unreachable (#1515)', () => {
+    const restore = denyStorage();
+    try {
+      failAsset();
+      failAsset();
+      failAsset();
+      expect(reload).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/frontend/src/lib/__tests__/stale-asset-reload.test.ts
+++ b/frontend/src/lib/__tests__/stale-asset-reload.test.ts
@@ -1,10 +1,43 @@
 // fix(#645): the reload latch must fire once, block rapid repeats, and allow
 // a later retry after the window expires — otherwise a broken build loops.
+// fix(#1515): and when the latch itself is unreachable, it must not reload at
+// all — an unlatched reload IS the loop.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { installStaleAssetReload, reloadOnceForStaleAssets } from '../stale-asset-reload';
 
 const reload = vi.fn();
+
+/**
+ * Make `sessionStorage` behave the way a sandboxed iframe without
+ * allow-same-origin does: the PROPERTY ACCESS throws, it does not return null
+ * or an object whose methods fail. Restored by the returned callback.
+ */
+function denyStorage(): () => void {
+  const original = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+  const descriptor: PropertyDescriptor = {
+    configurable: true,
+    get() {
+      throw new DOMException(
+        "Failed to read the 'sessionStorage' property from 'Window': The document " +
+          "is sandboxed and lacks the 'allow-same-origin' flag.",
+        'SecurityError'
+      );
+    },
+  };
+  Object.defineProperty(window, 'sessionStorage', descriptor);
+  if (globalThis !== (window as unknown as typeof globalThis)) {
+    Object.defineProperty(globalThis, 'sessionStorage', descriptor);
+  }
+  return () => {
+    if (original) {
+      Object.defineProperty(window, 'sessionStorage', original);
+      if (globalThis !== (window as unknown as typeof globalThis)) {
+        Object.defineProperty(globalThis, 'sessionStorage', original);
+      }
+    }
+  };
+}
 
 beforeEach(() => {
   sessionStorage.clear();
@@ -34,6 +67,18 @@ describe('reloadOnceForStaleAssets', () => {
     expect(reloadOnceForStaleAssets()).toBe(true);
     expect(reload).toHaveBeenCalledTimes(2);
   });
+
+  it('does not reload at all when the latch is unreachable (#1515)', () => {
+    const restore = denyStorage();
+    try {
+      expect(reloadOnceForStaleAssets()).toBe(false);
+      expect(reloadOnceForStaleAssets()).toBe(false);
+      expect(reloadOnceForStaleAssets()).toBe(false);
+      expect(reload).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
 });
 
 describe('installStaleAssetReload', () => {
@@ -52,5 +97,18 @@ describe('installStaleAssetReload', () => {
     window.dispatchEvent(event);
     expect(reload).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('lets the preload error surface when the latch is unreachable (#1515)', () => {
+    installStaleAssetReload();
+    const restore = denyStorage();
+    try {
+      const event = new Event('vite:preloadError', { cancelable: true });
+      window.dispatchEvent(event);
+      expect(reload).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    } finally {
+      restore();
+    }
   });
 });

--- a/frontend/src/lib/embed-context.ts
+++ b/frontend/src/lib/embed-context.ts
@@ -1,0 +1,33 @@
+/**
+ * fix(#1515): is this document the embedded map viewer?
+ *
+ * The embed snippet now ships `sandbox="allow-scripts allow-same-origin"`,
+ * because without it the frame has an opaque origin and cannot load its own
+ * module graph. Restoring the origin also restores the viewer's persisted
+ * session, and an embed running as whoever happens to be signed in is not what
+ * an embed is for: the share token is the capability, and it authorizes the map
+ * on its own. So the API client reads this and stays out of the session
+ * entirely — no bearer token, no proactive refresh, and no logout on a 401.
+ *
+ * That last one is not a nicety. Before this change the frame was opaque and
+ * had no session to spend; now a 401 from inside someone else's page would
+ * otherwise run the refresh-then-logout path and sign the viewer out of GeoLens
+ * in their other tabs.
+ *
+ * Read from `window.location` rather than router state because the API client
+ * is not inside the React tree. Both the path and the flag are required: `/m/`
+ * without `embed=true` is an ordinary share link opened directly, which should
+ * behave like any other page, and `embed=true` on some other path is not an
+ * embed at all. `buildEmbedSrc()` is the only producer of this URL shape and a
+ * test pins its output against this predicate.
+ */
+export function isEmbedViewer(): boolean {
+  try {
+    return (
+      window.location.pathname.startsWith('/m/') &&
+      new URLSearchParams(window.location.search).get('embed') === 'true'
+    );
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/lib/stale-asset-reload.ts
+++ b/frontend/src/lib/stale-asset-reload.ts
@@ -3,7 +3,9 @@
 // pre-fix heuristic caches or tabs left open across a deploy. When a lazy
 // route chunk fails to load, reload once — the reload revalidates the
 // no-cache shell and picks up the current build. Time-latched via
-// sessionStorage so a genuinely broken server can't cause a reload loop.
+// sessionStorage so a genuinely broken server can't cause a reload loop — and,
+// fix(#1515), skipped outright when the latch cannot be read or written, since
+// an unlatched reload is the loop the latch exists to prevent.
 // Keep the latch key + window in sync with public/asset-guard.js (the same
 // guard for the initial <script>/<link> loads, which must live in the shell).
 
@@ -16,8 +18,13 @@ export function reloadOnceForStaleAssets(): boolean {
     if (Date.now() - last < LATCH_WINDOW_MS) return false;
     sessionStorage.setItem(LATCH_KEY, String(Date.now()));
   } catch {
-    // Storage unavailable (privacy mode): reload without a latch — the
-    // window.location round-trip itself throttles retries.
+    // fix(#1515): fail closed. Storage is not merely unavailable in a sandboxed
+    // frame with an opaque origin — reading the property throws SecurityError —
+    // and the previous comment here claimed the window.location round-trip
+    // throttled retries when there was no latch. It does not: measured against
+    // an `immutable` shell, the unlatched path reloaded ~12,000 times in 12s on
+    // localhost (~60/s over the internet). No latch, no reload.
+    return false;
   }
   window.location.reload();
   return true;

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -38,3 +38,20 @@ export function removeStorage(key: string): void {
     // storage unavailable — ignore.
   }
 }
+
+/**
+ * fix(#1515): sessionStorage counterpart, for the same reason the file exists.
+ *
+ * A `typeof sessionStorage !== 'undefined'` check does NOT make a read safe:
+ * the property exists, and it is reading it that raises. In a frame with an
+ * opaque origin (sandboxed without `allow-same-origin`) the getter throws
+ * `SecurityError`, so a caller reading during render takes the whole page
+ * down rather than losing one preference.
+ */
+export function readSessionStorage(key: string): string | null {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #1515

The embed snippet renders a map again, and it does so anonymously. Three commits: the module fetch and the reload flood, then the sandbox value that let a booted viewer reach its data, then keeping that viewer out of the session it can now see.

## What changed

**Snippet and preview**
- `generateEmbedCode()` emits `sandbox="allow-scripts allow-same-origin"`. Ian's call, taken with the measurements below in front of him, together with the anonymity change that follows.

**Embed mode is anonymous**
- `isEmbedViewer()` (new, `lib/embed-context.ts`) recognizes the one URL shape `buildEmbedSrc` produces. `authenticatedRawFetch` reads it and withholds the bearer token, skips the proactive refresh, and returns a 401 untouched instead of refreshing or logging out.
- `EmbedPreviewPane` carried the same old value, so the in-app preview had the same bug and showed "Map not found" for a valid token. It now tracks the emitted snippet, and a test pins the two to each other.
- The `generateEmbedCode` docstring argued against exactly this pairing. Rewritten, because stale reasoning sitting next to contradicting code is how a fix gets reverted. It now states the rule: the escape it feared needs the frame to be same-origin with its **embedder**, which a third-party embed never is.

**Storage reads that throw**
- `frontend/public/asset-guard.js` and `frontend/src/lib/stale-asset-reload.ts`: the reload now happens inside the `try`. Storage denied means no reload.
- `LandingFirstGuard.tsx` read `sessionStorage` during render behind `typeof sessionStorage !== 'undefined'`, which passes because the property exists and the **read** is what raises. Same defect as the two latches, third site. Routed through a new `readSessionStorage` in `lib/storage.ts`, a module whose docstring already described this exact failure ("private-mode Safari and storage-disabled browsers throw on access").

**nginx**
- `/assets/*` sends `Access-Control-Allow-Origin: *`, and the block re-declares the three server-scope security headers it had been silently dropping since it acquired its first `add_header`.

**Copy**
- `share.iframeSandboxNote` said the preview "permits scripts only", which stopped being true. Updated in all four locales. Its entry in `IDENTICAL_ACROSS_LOCALES` came out: that list means "this string is the same in every locale", the string is genuinely translated in es/fr/de, and the entry's comment described the SEC-07 contract that no longer exists. Removed and the i18n suite still passes.

## Measured end to end

Same share link, same stack, 15 s window. A throwaway `nginx:alpine` container renders `frontend/nginx.conf` through the same four `envsubst` vars `frontend/docker-entrypoint.sh` uses, serves that branch's own `npm run build` output, and attaches to `geolens_default` so `api` is the real dev API. `localhost:8080` serves the main checkout and was never involved. Row A's page was written by calling `generateEmbedCode()` itself, so the measurement runs the real template rather than a hand-copied one.

Reporting what rendered, not statuses:

| # | sandbox | build | shell loads | what the frame shows |
|---|---|---|---|---|
| **A** | **`allow-scripts allow-same-origin` (now emitted)** | this branch | 1 | **the map**: canvas 800x600, "40.72 N / 73.97 W / z 10.2", "New York From Orbit" |
| B | `allow-scripts` (old value) | this branch | 1 | "Map not found", 7 refused `/api/` |
| C | `allow-scripts` (old value) | unfixed main | **12625** | blank, `#root` empty, 25247 refused |
| D | no sandbox attribute | this branch | 1 | the map |

Row A makes 7 `/api/` calls, all 200, zero refused, zero console errors.

Row B is the reason the `/assets/` header stays even though the embed no longer needs it: with the header and the fail-closed latches, a hand-written stricter sandbox degrades to one load that cannot reach the API. Without them it was row C.

**Why row B fails**, captured with curl exactly as the browser sends it:

```
$ curl -X OPTIONS -H "Origin: null" \
    -H "Access-Control-Request-Method: GET" \
    -H "Access-Control-Request-Headers: content-type" \
    .../api/maps/shared/{token}
HTTP/1.1 405 Method Not Allowed
allow: GET
                                    <- no access-control-* headers at all

$ curl -H "Origin: null" -H "Content-Type: application/json" .../api/maps/shared/{token}
HTTP/1.1 200 OK
Content-Type: application/json      <- the api is willing; the browser discards it
```

`DynamicCORSMiddleware` only synthesizes an `OPTIONS 200` for an already-allowed origin, so a disallowed one falls through to FastAPI, which has no OPTIONS route. And the request preflights at all because `apiFetch` sets `Content-Type: application/json` whenever it is unset and the body is not URLSearchParams/FormData, which includes a bodyless GET (`client.ts:280-281`).

## Red before green

Every new test was run against the pre-fix source.

`LandingFirstGuard`, denied storage the way the browser denies it (a getter that throws on property access, not a mocked-away value, since the old code never reached `getItem` and mocking it would prove nothing):

```
FAIL F) #1515 — storage denied + flag OFF: renders SearchPage instead of throwing
FAIL F2) #1515 — storage denied + flag ON + anon: redirects, treating the marker as absent
SecurityError: Failed to read the 'sessionStorage' property from 'Window':
  The document is sandboxed and lacks the 'allow-same-origin' flag.
```

Embed anonymity, against the old `client.ts`, with a session seeded in the store so a pass cannot come from having no token to send:

```
FAIL sends no Authorization from the embedded viewer
  expected true to be false
FAIL a 401 inside an embed does not clear the session
  expected null to be 'seeded-session-token'
```

Its non-embed cases are the counterfactual in the other direction: the same setup on `/maps/{id}`, on a plain `/m/` share link, and on `embed=true` at a non-embed path all assert the header IS sent, so the fix cannot pass by disabling auth everywhere.

Snippet and preview, against the old `allow-scripts` source:

```
FAIL emits the exact snippet, sandbox included
FAIL carries allow-same-origin, without which the frame cannot load its own bundle
FAIL rendered embed textarea carries the emitted sandbox after creating a raw share token
FAIL test_iframe_sandbox_matches_the_emitted_snippet: preview sandbox === generateEmbedCode sandbox
```

The first of those asserts the **whole** emitted string, not just the sandbox value, because this snippet is copied verbatim into other people's pages and any edit to the template should fail a test rather than ship.

The two reload latches, from the first commit: three tests red, the asset-guard one reporting "expected vi.fn() to not be called at all, but actually been called 3 times", which is the unlatched loop itself. `test_nginx_assets_cors_1515.py` fails all three cases against the pre-fix `nginx.conf`.

## The session the frame can now see, and why it does not spend it

`allow-same-origin` restores the GeoLens origin and with it the persisted auth store. That is not theoretical. Signed in, with a real session seeded in `localStorage`, measured on the previous head of this branch (`aef09e00b`, sandbox fixed, anonymity not yet):

```
session in localStorage       : eyJhbGciOiJIUzI1Ni... (live)
/api/ requests from the frame : 7
  ... carrying Authorization  : 6      <- the viewer's own bearer token
  ... carrying X-Embed-Token  : 0
WHAT THE FRAME SHOWS          : mapCanvas=800x600, the map
```

`/api/maps/shared/{token}` and the tile-token POST were both among the six. And the 401 path was worse than the header: the frame used to be opaque and had no session to spend, so a 401 inside a third-party page would now run `tryRefresh` and then `notifySessionExpired`/`logout()`. The counterfactual for the new test says it plainly, against the old client: `expected null to be 'seeded-session-token'`. An embed could sign the viewer out.

Same measurement on this head:

```
session in localStorage       : eyJhbGciOiJIUzI1Ni... (live)
/api/ requests from the frame : 7
  ... carrying Authorization  : 0
WHAT THE FRAME SHOWS          : mapCanvas=800x600, the map
```

Both halves, because "no Authorization" is trivially true of a frame that renders nothing. The restricted path was checked too, with a real embed token in `et=`: 0 Authorization, `X-Embed-Token` on the 2 requests that need it, map renders. The share token is the capability and it authorizes the map on its own, as claimed.

For scale on the sandbox itself: an iframe with no `sandbox` attribute at all, which is what most embed snippets ship and what row D measures, additionally permits forms, popups, top-level navigation, downloads and pointer lock. The emitted value is narrower than that, and now it carries no identity either.

## What the unfixed loop actually did to the API

Worth recording, because it is worse than the issue's sustained-bleed framing. On the real `/m/{token}` path the reload loop is self-terminating, into a hard 500. Each reload fires the `/m/` `auth_request` at `/embed/frame-policy`; the API rate-limits it; nginx converts a non-2xx auth_request into a 500; and the 500 page carries no `/assets/` script, so the guard stops firing. Measured on unfixed main: 97 loads in 3 s, 145 in 8 s, ending on `500 Internal Server Error nginx`, with the harness nginx log saying

```
[error] auth request unexpected status: 429 while sending to client,
        request: "GET /m/{token}?embed=true"
```

So an unfixed frame burns the frame-policy rate limit and leaves the embed shell 500 for everyone behind that IP. The 12625-load figure in row C is from the SPA shell path, which has no `auth_request` and therefore nothing to throttle it.

## Verification

```
cd frontend && npm run build           # exit 0
cd frontend && npm run lint            # exit 0
cd frontend && npm run typecheck       # exit 0
cd frontend && npm run test:i18n       # exit 0
cd frontend && npm run test:coverage   # exit 0, 400 files, 4994 tests
cd backend && uv run pytest tests/test_nginx_assets_cors_1515.py tests/test_nginx_raster_cors_1464.py   # 8 passed
```

`nginx -t` passes on the rendered config and the container serving it produced every measurement above. No Playwright suite was run and no `playwright.config.ts` was loaded, so the worktree guard never applied: the browser numbers come from a standalone Chromium script driven against a container serving this branch, which is the condition the guard exists to protect.

No backend `app/` code changed, so `test_layering.py` does not apply.
