### PR TITLE
fix(monitoring): split bulk reads out of the interactive latency alert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       alembic: ${{ steps.filter.outputs.alembic }}
       installer: ${{ steps.filter.outputs.installer }}
       backup: ${{ steps.filter.outputs.backup }}
+      monitoring: ${{ steps.filter.outputs.monitoring }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -175,6 +176,13 @@ jobs:
               - 'scripts/backup-entrypoint.sh'
               - 'scripts/init-db.sh'
               - 'scripts/lib/configure-runtime-db-role.sh'
+              # fix(#1517): test_alert_rules.py reads both of these by literal
+              # path — it checks the alert rules' handler selectors against the
+              # app's real route table, and that every rule has a promtool case.
+              # Without this, an alerts-only PR skips the only gate that would
+              # catch a selector matching nothing.
+              - 'infra/monitoring/alerts.yml'
+              - 'infra/monitoring/alerts.test.yml'
               # fix(#561): a change to this workflow can alter HOW Backend Tests
               # runs (e.g. the -n4 parallelization / coverage core), so the suite
               # must run on PRs that touch it — otherwise CI-config changes ship
@@ -321,6 +329,15 @@ jobs:
               - '.github/workflows/publish.yml'
               # The round-trip proof itself is ~220 inline lines of THIS
               # workflow — a ci.yml-only edit to those steps must run them.
+              - '.github/workflows/ci.yml'
+            # fix(#1521 review): the promtool suite. Separate from `backend`
+            # because it needs no Python at all and should not run on every
+            # backend PR; the alerts files are in BOTH filters on purpose, since
+            # backend/tests/test_alert_rules.py reads them too.
+            monitoring:
+              - 'infra/monitoring/**'
+              # The job is defined in this workflow, so a change to its steps
+              # must run them.
               - '.github/workflows/ci.yml'
 
   # ---------- backend ----------
@@ -913,6 +930,53 @@ jobs:
       # a few seconds.
       - name: Check committed README image dimensions
         run: npm run check:readme-assets
+
+  # ---------- monitoring ----------
+  # fix(#1521 review): infra/monitoring/alerts.test.yml replays every alert rule
+  # against synthetic series, and until this job existed nothing ran it. A
+  # PromQL expression that no longer parses, or an expected-alert case that
+  # stopped holding, would have shipped green — the backend suite only reads
+  # those files as text. promtool is the only thing that can evaluate a rule.
+  monitoring-rules:
+    name: Monitoring Rules
+    needs: changes
+    if: needs.changes.outputs.monitoring == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    env:
+      # Same image RUNBOOK.md §4 tells operators to run Prometheus from, pinned
+      # by digest so the gate cannot change under us on a tag re-push.
+      PROMETHEUS_IMAGE: prom/prometheus:v3.6.0@sha256:76947e7ef22f8a698fc638f706685909be425dbe09bd7a2cd7aca849f79b5f64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # `promtool test rules` reports SUCCESS on a file that declares no cases
+      # at all, and `check rules` is happy with a rule nothing exercises. Both
+      # would be a green step asserting nothing, which is the failure mode this
+      # whole job exists to close, so count the cases before trusting the run.
+      - name: Guard against an empty rule or case list
+        run: |
+          set -euo pipefail
+          alerts=$(grep -c '^      - alert:' infra/monitoring/alerts.yml)
+          cases=$(grep -c '^        alertname:' infra/monitoring/alerts.test.yml)
+          echo "alerts.yml declares $alerts rules; alerts.test.yml asserts on $cases"
+          if [ "$alerts" -lt 8 ]; then
+            echo "::error::alerts.yml declares $alerts rules, expected at least 8"
+            exit 1
+          fi
+          if [ "$cases" -lt "$alerts" ]; then
+            echo "::error::alerts.test.yml has $cases alertname assertions for $alerts rules"
+            exit 1
+          fi
+
+      - name: promtool check rules
+        run: |
+          docker run --rm -v "$PWD/infra/monitoring:/w:ro" \
+            --entrypoint promtool "$PROMETHEUS_IMAGE" check rules /w/alerts.yml
+
+      - name: promtool test rules
+        run: |
+          docker run --rm -v "$PWD/infra/monitoring:/w:ro" \
+            --entrypoint promtool "$PROMETHEUS_IMAGE" test rules /w/alerts.test.yml
 
   # ---------- CLI ----------
   # Structural enforcement that the CLI never grows
@@ -1536,6 +1600,9 @@ jobs:
       - frontend-lint
       - frontend-test
       - security-scan
+      # fix(#1521 review): the promtool suite gates nothing unless it is here —
+      # branch protection only sees CI OK.
+      - monitoring-rules
       # fix(#824): always-run jobs must feed the aggregator too — before this,
       # a failure in version-coherence or docs-contract could not block a
       # merge (branch protection only sees CI OK). changes and pre-commit are

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1093,7 +1093,8 @@ targets just need network reach to `api:8000` and `worker:8001`.
 |---|---|---|
 | `GeoLensTargetDown` | API or worker unscrapeable for >2m | critical |
 | `GeoLensApiHigh5xxRate` | 5xx share of requests >5% over 5m | critical |
-| `GeoLensApiInteractiveLatencyP95` | non-tile p95 at the 1s histogram ceiling for 10m | warning |
+| `GeoLensApiInteractiveLatencyP95` | interactive p95 ≥1s for 10m (tile and bulk-read handlers excluded) | warning |
+| `GeoLensApiBulkLatencyMean` | mean latency of a bulk read >5s for 10m | warning |
 | `GeoLensApiTileLatencyMean` | mean `/tiles/*` latency >2s for 10m | warning |
 | `GeoLensJobQueueBacklog` | any queue >100 jobs for 15m | warning |
 | `GeoLensJobFailures` | >5 job failures in 15m | warning |
@@ -1102,6 +1103,27 @@ targets just need network reach to `api:8000` and `worker:8001`.
 > Under an external pooler (`DB_USE_EXTERNAL_POOLER=true` → SQLAlchemy `NullPool`),
 > the `geolens_db_pool_*` gauges are not emitted and `GeoLensDbPoolSaturated`
 > never fires — pool health is the provider's responsibility there.
+
+Feature and item collections, dataset exports and COG downloads return whatever
+the caller asked for — `?limit=2000` on a feature collection is roughly 10MB — so
+they get a mean-based bound of their own rather than counting toward the
+interactive percentile, the same treatment `/tiles/*` has had since #658.
+`GeoLensApiBulkLatencyMean` reports which handler crossed the bound.
+
+To check the rules after editing them (`prom/prometheus` ships `promtool`):
+
+```bash
+docker run --rm -v "$PWD/infra/monitoring:/w" --entrypoint promtool \
+  prom/prometheus:v3.6.0 check rules /w/alerts.yml
+docker run --rm -v "$PWD/infra/monitoring:/w" --entrypoint promtool \
+  prom/prometheus:v3.6.0 test rules /w/alerts.test.yml
+```
+
+`alerts.test.yml` replays each rule against synthetic series, including the
+traffic shape that made `GeoLensApiInteractiveLatencyP95` page three times in a
+week (#1517). A threshold changed without a matching expectation there fails the
+second command. CI runs both commands in the Monitoring Rules job, so you get
+the same answer on a PR that touches `infra/monitoring/`.
 
 ### API worker memory & recycling
 

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -55,10 +55,36 @@ def _sweep_lock_path(multiproc_dir: str) -> str:
     return os.path.join(multiproc_dir, "sweep.lock")
 
 
+# fix(#1517): upper bounds for http_request_duration_seconds, the only latency
+# histogram carrying a `handler` label. The library default is (0.1, 0.5, 1)
+# plus the implicit +Inf, and histogram_quantile returns the highest FINITE
+# bound when the quantile lands in +Inf -- so on the default buckets p95 could
+# never exceed 1.0 for any handler selection, and every alert in
+# infra/monitoring/alerts.yml wanting a threshold above 1s was inexpressible.
+# GeoLensApiInteractiveLatencyP95 fired three times on the demo reading exactly
+# 1 each time; that was the ceiling, not a latency. Top finite bucket 10 puts
+# the clamp at 10s, well above any threshold the rules express.
+#
+# Cost, and why upstream ships it coarse: this histogram is labelled by
+# `handler` AND `method`, so each added bound multiplies its series count --
+# 4 bounds to 8 roughly doubles it. That is upstream's reason to default low,
+# not a GeoLens-specific one; at a few dozen templated handlers the extra
+# series are cheap and an expressible threshold is not optional.
+# The sibling http_request_duration_highr_seconds already carries 21 bounds up
+# to 60, but it is unlabelled, so it cannot answer "p95 excluding tiles" --
+# which is the entire point of the rules that read this one.
+LATENCY_LOWR_BUCKETS = (0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0)
+
+
 def init_metrics(app: FastAPI):
     """Instrument the FastAPI app and expose /metrics endpoint."""
     instrumentator = create_instrumentator()
-    instrumentator.instrument(app)
+    # fix(#1517): buckets are passed HERE, not in create_instrumentator().
+    # Instrumentator.__init__ accepts no bucket arguments at all;
+    # instrument() is the only place they can be set
+    # (prometheus_fastapi_instrumentator 8.1.0). instrumentator.py is the file
+    # that looks like it configures this and cannot.
+    instrumentator.instrument(app, latency_lowr_buckets=LATENCY_LOWR_BUCKETS)
     instrumentator.expose(app, include_in_schema=False, should_gzip=True)
 
     @app.middleware("http")

--- a/backend/tests/test_alert_rules.py
+++ b/backend/tests/test_alert_rules.py
@@ -1,0 +1,411 @@
+"""Structural guards for the Prometheus alert rules — fix(#1517).
+
+Monitoring config is the category where a change goes green while asserting
+nothing. A PromQL ``handler!~"..."`` that matches nothing, or matches
+everything, reads identically to a working one in a diff, and #1517 shipped a
+rule whose threshold could not be crossed by any traffic at all. These tests
+check the things review cannot see:
+
+1. Every ``histogram_quantile`` threshold in the rules is below the top finite
+   bucket the app actually configures. ``histogram_quantile`` returns the
+   highest FINITE bucket bound for anything landing in ``+Inf``, so a threshold
+   at or above it can never be crossed. The rule looks like coverage and is dead
+   on arrival. That is exactly how ``GeoLensApiInteractiveLatencyP95`` came to
+   report ``1`` on all three of its firings.
+2. The bulk-read selector partitions the app's real route table the way the
+   rules claim, over (handler, method) PAIRS rather than paths. A path is not a
+   request: ``/datasets/{dataset_id}/features`` answers GET and POST off one
+   template, so a path-only check would pass while feature creation sat outside
+   interactive monitoring (fix(#1521 review)).
+
+Every expectation list is checked against the live route table, so it cannot rot
+into a set of paths nothing matches.
+
+Filesystem, YAML parse and a route-table walk. No database, no Docker.
+``infra/monitoring/alerts.test.yml`` covers the rules' runtime behaviour under
+promtool, and the Monitoring Rules job in ci.yml runs it; this module covers the
+structure, and runs wherever the backend suite runs.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from typing import Any
+
+import pytest
+import yaml
+
+from app.observability.metrics import LATENCY_LOWR_BUCKETS
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
+ALERTS_PATH = REPO_ROOT / "infra" / "monitoring" / "alerts.yml"
+ALERTS_TEST_PATH = REPO_ROOT / "infra" / "monitoring" / "alerts.test.yml"
+
+# Bulk reads: the response is whatever the caller asked for, so over a second is
+# the cost of the payload rather than a symptom. Excluded from the interactive
+# p95 rule, covered by GeoLensApiBulkLatencyMean.
+BULK_HANDLERS = {
+    "/datasets/{dataset_id}/features",
+    "/datasets/{dataset_id}/features/",
+    "/datasets/{dataset_id}/features.geojson",
+    "/datasets/{dataset_id}/export",
+    "/datasets/{dataset_id}/download/cog",
+    "/collections/{dataset_id}/items",
+    "/collections/{dataset_id}/items/",
+    "/collections/datasets/items",
+    "/stac/collections/{collection_id}/items",
+}
+
+# Handlers whose paths look bulk and are not: single-object reads, and
+# mutations whose name merely contains "bulk". Admin exports are here on
+# purpose — see the rationale in the GeoLensApiBulkLatencyMean comment.
+BULK_LOOKALIKES = {
+    "/datasets/{dataset_id}/features/{gid}",
+    "/datasets/{dataset_id}/features/{gid}/related/{relationship_id}",
+    "/collections/{dataset_id}/items/{feature_id}",
+    "/collections/datasets/items/{record_id}",
+    "/stac/collections/{collection_id}/items/{item_id}",
+    "/stac/items/{item_id}",
+    "/datasets/bulk-delete",
+    "/maps/{map_id}/layers/bulk-delete",
+    "/admin/embed-tokens/bulk-revoke",
+    "/ingest/register/bulk",
+    "/admin/audit-logs/export/{format}",
+    "/admin/users/export.csv",
+    "/config-ops/export",
+}
+
+# The verbs that make a request to a bulk path an actual bulk transfer. HEAD is
+# here because _register_standards_head_routes() clones the GET route with the
+# same endpoint, so it does the same work and only drops the body on the wire.
+READ_METHODS = {"GET", "HEAD"}
+
+
+def _load_rules() -> dict[str, dict[str, Any]]:
+    """Every alerting rule in alerts.yml, keyed by alert name."""
+    doc = yaml.safe_load(ALERTS_PATH.read_text())
+    rules = {
+        rule["alert"]: rule
+        for group in doc["groups"]
+        for rule in group["rules"]
+        if "alert" in rule
+    }
+    assert len(rules) >= 8, (
+        f"only {len(rules)} alerting rules parsed out of {ALERTS_PATH} — the "
+        "file has at least 8. Every assertion below iterates this mapping, so "
+        "a parse that quietly yields few or none would pass vacuously."
+    )
+    return rules
+
+
+def _unquote_promql_string(raw: str) -> str:
+    r"""Return the regex a PromQL double-quoted string literal denotes.
+
+    PromQL processes escapes inside ``"..."``, so the two characters ``\\`` in
+    the YAML reach the regex engine as one backslash. Comparing the raw YAML
+    text against handler names instead of the unescaped form is the quiet way to
+    test a regex nobody is actually running.
+    """
+    return raw.replace("\\\\", "\\")
+
+
+def _matchers(expr: str, label: str) -> list[tuple[str, str]]:
+    """Every ``(operator, value)`` for *label* in a PromQL expression.
+
+    Returns a list, not one match: the interactive rule carries a ``handler!~``
+    and a ``handler=~`` in the two arms of its union, and reading only the first
+    would silently skip half the rule.
+    """
+    return re.findall(rf'{re.escape(label)}\s*(!~|=~|!=|=)\s*"([^"]*)"', expr)
+
+
+def _sole(values: list[str], what: str) -> str:
+    """The single distinct value in *values*, or an assertion failure."""
+    assert values, f"no {what} found"
+    distinct = set(values)
+    assert len(distinct) == 1, (
+        f"{what} is not spelled the same everywhere it appears: {sorted(distinct)}"
+    )
+    return values[0]
+
+
+def _bulk_selector() -> str:
+    """The bulk-path regex, asserted identical everywhere it is written."""
+    rules = _load_rules()
+    interactive = _matchers(rules["GeoLensApiInteractiveLatencyP95"]["expr"], "handler")
+    bulk = _matchers(rules["GeoLensApiBulkLatencyMean"]["expr"], "handler")
+
+    excluded = [v for op, v in interactive if op == "!~"]
+    covered = [v for op, v in interactive if op == "=~"] + [
+        v for op, v in bulk if op == "=~"
+    ]
+    assert len(excluded) == 1, (
+        f"expected exactly one handler!~ in the interactive rule, got {excluded}"
+    )
+    assert len(covered) == 3, (
+        "expected the bulk selector three times (interactive union arm, bulk "
+        f"_sum, bulk _count), got {len(covered)}"
+    )
+    selector = _sole(covered, "the bulk handler selector")
+
+    tile_prefix = "/tiles/.*|"
+    assert excluded[0].startswith(tile_prefix), (
+        "the interactive rule's exclusion no longer starts with the tile "
+        f"selector from #658: {excluded[0]!r}"
+    )
+    assert excluded[0][len(tile_prefix) :] == selector, (
+        "the interactive rule excludes a different set of paths than the bulk "
+        "rule covers, so something is double-alerted or unmonitored.\n"
+        f"  interactive excludes: {excluded[0][len(tile_prefix) :]!r}\n"
+        f"  bulk rule covers:     {selector!r}"
+    )
+    assert selector.count("|") >= 4, (
+        f"bulk selector has fewer alternatives than expected: {selector!r}"
+    )
+    return _unquote_promql_string(selector)
+
+
+def _read_method_selector() -> str:
+    """The read-verb alternation, asserted complementary across both rules."""
+    rules = _load_rules()
+    interactive = _matchers(rules["GeoLensApiInteractiveLatencyP95"]["expr"], "method")
+    bulk = _matchers(rules["GeoLensApiBulkLatencyMean"]["expr"], "method")
+
+    negated = [v for op, v in interactive if op == "!~"]
+    matched = [v for op, v in bulk if op == "=~"]
+    assert len(negated) == 1, (
+        "the interactive rule must negate the read verbs on its bulk-path arm, "
+        f"otherwise a POST to a bulk path leaves monitoring entirely: {negated}"
+    )
+    assert len(matched) == 2, (
+        f"expected method=~ on both halves of the bulk ratio, got {len(matched)}"
+    )
+    selector = _sole(matched + negated, "the read-method selector")
+    return selector
+
+
+def _route_universe() -> set[tuple[str, str]]:
+    """Every ``(handler, method)`` pair the instrumentator can label.
+
+    The handler label is the route's fully-prefixed template path, and the
+    method label is the request verb. fastapi 0.140 keeps included-router routes
+    nested, so a plain walk of ``app.routes`` sees almost nothing;
+    ``_iter_api_routes`` is the repo's own flattening helper.
+    """
+    from app.api.main import _iter_api_routes, app
+
+    pairs = {
+        (ctx.path, method)
+        for ctx in _iter_api_routes(app)
+        for method in (ctx.route.methods or set())
+    }
+    assert len(pairs) > 100, (
+        f"only {len(pairs)} (handler, method) pairs resolved from the route "
+        "table; the app registers several hundred. A near-empty universe would "
+        "make every assertion below pass without testing anything."
+    )
+    return pairs
+
+
+def test_histogram_quantile_thresholds_are_reachable():
+    """A quantile threshold at or above the top finite bucket can never fire.
+
+    This is the #1517 defect itself, as an assertion. Before that fix the top
+    finite bucket was 1.0 and the rule's bound was ``>= 1``: satisfiable only by
+    the clamp, never by a measurement.
+    """
+    top_finite_bucket = max(LATENCY_LOWR_BUCKETS)
+    checked = 0
+    for name, rule in _load_rules().items():
+        expr = rule["expr"]
+        if "histogram_quantile" not in expr:
+            continue
+        checked += 1
+        bounds = re.findall(r"[<>]=?\s*([0-9.]+)\s*$", expr.strip())
+        assert bounds, f"{name}: could not read a comparison bound from:\n{expr}"
+        threshold = float(bounds[-1])
+        assert threshold < top_finite_bucket, (
+            f"{name} compares p95 against {threshold}, but the top finite "
+            f"bucket in LATENCY_LOWR_BUCKETS is {top_finite_bucket}. "
+            "histogram_quantile clamps there, so this rule can only fire on "
+            "the clamp value, not on a latency. Widen the buckets in "
+            "backend/app/observability/metrics/__init__.py or lower the bound."
+        )
+    assert checked, (
+        "no histogram_quantile rule found in alerts.yml — this test would "
+        "otherwise pass by checking nothing."
+    )
+
+
+def test_bulk_selector_is_spelled_identically_in_both_rules():
+    """PromQL cannot share a selector, so the copies have to be kept in step."""
+    assert _bulk_selector()
+
+
+def test_read_method_partition_is_complementary():
+    """The verbs the bulk rule claims are exactly the ones interactive gives up.
+
+    Without this, `method=~"GET"` on one side and `method!~"GET|HEAD"` on the
+    other would leave HEAD requests to bulk paths in neither rule.
+    """
+    selector = _read_method_selector()
+    assert set(selector.split("|")) == READ_METHODS, (
+        f"the rules treat {sorted(set(selector.split('|')))} as bulk reads, but "
+        f"this test expects {sorted(READ_METHODS)}. If that is a deliberate "
+        "change, say why HEAD does or does not do the work of a GET and update "
+        "READ_METHODS with it."
+    )
+
+
+def test_bulk_selector_matches_exactly_the_intended_handlers():
+    """Run the shipped selector against the app's real handler labels.
+
+    PromQL label matchers are fully anchored, hence ``fullmatch``. Exact
+    equality is deliberate: a new route that lands in this set is a decision
+    about whether it is a bulk transfer, and this test is where that decision
+    gets made rather than discovered during an incident.
+    """
+    universe = {path for path, _ in _route_universe()}
+    pattern = re.compile(_bulk_selector())
+    matched = {h for h in universe if pattern.fullmatch(h)}
+
+    assert matched, (
+        "the bulk selector matches none of the "
+        f"{len(universe)} real handler labels. GeoLensApiBulkLatencyMean would "
+        "never fire and GeoLensApiInteractiveLatencyP95 would keep paging on "
+        "bulk traffic."
+    )
+    assert matched != universe, (
+        "the bulk selector matches every handler — nothing is left for "
+        "GeoLensApiInteractiveLatencyP95 to watch."
+    )
+    assert matched == BULK_HANDLERS, (
+        "bulk selector no longer matches the intended handler set.\n"
+        f"  unexpectedly matched: {sorted(matched - BULK_HANDLERS)}\n"
+        f"  expected but missed:  {sorted(BULK_HANDLERS - matched)}"
+    )
+
+
+def test_bulk_rule_claims_only_read_requests():
+    """fix(#1521 review): the bulk rule may not swallow writes to bulk paths.
+
+    ``/datasets/{dataset_id}/features`` answers GET and POST off one template.
+    Under a path-only selector, feature creation left the interactive p95 and
+    was judged against a 5s bound built for 10MB downloads.
+    """
+    universe = _route_universe()
+    bulk_paths = re.compile(_bulk_selector())
+    read_methods = re.compile(_read_method_selector())
+
+    writes_to_bulk_paths = {
+        (path, method)
+        for path, method in universe
+        if bulk_paths.fullmatch(path) and not read_methods.fullmatch(method)
+    }
+    assert writes_to_bulk_paths, (
+        "no non-read verb is registered on any bulk path, so this test proves "
+        "nothing. It is guarding the case where a read and a write share one "
+        "path template; if that stopped being true, say so here rather than "
+        "leaving an assertion that cannot fail."
+    )
+    assert ("/datasets/{dataset_id}/features", "POST") in writes_to_bulk_paths, (
+        "the POST that motivated this test is gone from the route table; "
+        f"currently found: {sorted(writes_to_bulk_paths)}"
+    )
+
+    reads_to_bulk_paths = {
+        (path, method)
+        for path, method in universe
+        if bulk_paths.fullmatch(path) and read_methods.fullmatch(method)
+    }
+    assert reads_to_bulk_paths, "the bulk rule claims no request at all"
+    assert any(method == "HEAD" for _, method in reads_to_bulk_paths), (
+        "no HEAD request on any bulk path, so the HEAD half of READ_METHODS is "
+        "untested. _register_standards_head_routes() should be registering "
+        "these; if it no longer does, drop HEAD from READ_METHODS."
+    )
+
+
+@pytest.mark.parametrize("handler", sorted(BULK_HANDLERS))
+def test_every_named_bulk_handler_is_a_real_route(handler: str):
+    """Guards the expectation list itself against rot."""
+    assert handler in {path for path, _ in _route_universe()}, (
+        f"{handler} is listed as a bulk handler but is not a route on the app. "
+        "Either the route moved (update the selector and this list together) "
+        "or the list is now fiction."
+    )
+
+
+def test_bulk_lookalike_handlers_stay_interactive():
+    """Single-object reads and "bulk"-named mutations are not bulk transfers."""
+    universe = {path for path, _ in _route_universe()}
+    pattern = re.compile(_bulk_selector())
+
+    missing = BULK_LOOKALIKES - universe
+    assert not missing, (
+        "these handlers no longer exist, so asserting they do not match is "
+        f"testing nothing: {sorted(missing)}"
+    )
+    wrongly_matched = {h for h in BULK_LOOKALIKES if pattern.fullmatch(h)}
+    assert not wrongly_matched, (
+        "the bulk selector swallowed handlers that must stay under the "
+        f"interactive p95 rule: {sorted(wrongly_matched)}"
+    )
+
+
+def test_tile_and_bulk_selectors_do_not_overlap():
+    """Tiles keep their own rule; nothing may be claimed by both."""
+    universe = {path for path, _ in _route_universe()}
+    bulk = re.compile(_bulk_selector())
+    tiles = re.compile(
+        _unquote_promql_string(
+            _sole(
+                [
+                    v
+                    for op, v in _matchers(
+                        _load_rules()["GeoLensApiTileLatencyMean"]["expr"], "handler"
+                    )
+                    if op == "=~"
+                ],
+                "the tile handler selector",
+            )
+        )
+    )
+    tile_handlers = {h for h in universe if tiles.fullmatch(h)}
+    bulk_handlers = {h for h in universe if bulk.fullmatch(h)}
+
+    assert tile_handlers, "the tile selector matches no real handler"
+    assert bulk_handlers, "the bulk selector matches no real handler"
+    assert not (tile_handlers & bulk_handlers), (
+        "handlers claimed by both the tile and bulk rules: "
+        f"{sorted(tile_handlers & bulk_handlers)}"
+    )
+
+
+def test_every_alert_has_a_promtool_case():
+    """alerts.test.yml is where the rules' behaviour is exercised.
+
+    It runs under promtool in the Monitoring Rules job, not under pytest, so
+    nothing else stops a new rule from shipping untested or a renamed one from
+    leaving a test that silently covers an alert that no longer exists.
+    """
+    rules = _load_rules()
+    test_text = ALERTS_TEST_PATH.read_text()
+
+    # Match `alertname:` assertions specifically, not the bare name anywhere in
+    # the file: every rule is named in that file's prose too, so a substring
+    # check would count a comment as coverage.
+    referenced = set(re.findall(r"alertname:\s*(\w+)", test_text))
+    assert referenced, f"no alertname assertions found in {ALERTS_TEST_PATH.name}"
+
+    untested = sorted(set(rules) - referenced)
+    assert not untested, (
+        f"alerts.yml defines rules with no case in {ALERTS_TEST_PATH.name}: {untested}"
+    )
+
+    stale = sorted(referenced - set(rules))
+    assert not stale, (
+        f"{ALERTS_TEST_PATH.name} asserts on alerts that alerts.yml no longer "
+        f"defines: {stale}"
+    )

--- a/infra/monitoring/alerts.test.yml
+++ b/infra/monitoring/alerts.test.yml
@@ -1,0 +1,637 @@
+# promtool unit tests for alerts.yml — fix(#1517).
+#
+# Run from the repo root (same pinned tag as RUNBOOK.md §4):
+#
+#   docker run --rm -v "$PWD/infra/monitoring:/w" \
+#     --entrypoint promtool prom/prometheus:v3.6.0 test rules /w/alerts.test.yml
+#
+# Why this file exists: a PromQL `handler!~"..."` that silently matches nothing,
+# or matches everything, reads identically to a working one in a diff. #1517
+# shipped from a rule whose threshold could never be crossed, and no amount of
+# reviewing the YAML would have shown it. Every handler label below is a real
+# route from the app's route table, not an invented one. The partition itself is
+# also pinned in CI by backend/tests/test_alert_rules.py, which runs the same
+# selectors against that route table without needing promtool.
+#
+# All series are per-minute increments on a 1m interval, so `0+12x30` is 12
+# requests a minute for thirty minutes — long enough to satisfy every `for: 10m`.
+
+rule_files:
+  - alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+  # --------------------------------------------------------------------------
+  # 0. Why the bucket change had to land with the rule change.
+  #
+  #    These bucket counts are not invented: they are a verbatim /metrics
+  #    scrape from a FastAPI app instrumented the way this repo instrumented it
+  #    BEFORE #1517 (library default buckets 0.1/0.5/1 + Inf), driven with 9
+  #    requests at 10ms and one slow one. The two handlers differ only in how
+  #    slow that request was — 1.5s and 11s — and the histogram cannot tell
+  #    them apart: both report p95 = 1.0, the highest finite bound, which is
+  #    what histogram_quantile returns for anything landing in +Inf.
+  #
+  #    That is why all three #1517 firings read exactly `1`. It was the ceiling,
+  #    not a latency, and no rule with a threshold above 1s could ever have
+  #    fired. Compare with scenario 1, on the widened buckets.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "pre-#1517 buckets: p95 cannot exceed 1.0, whatever the latency"
+    input_series:
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="0.1"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="0.5"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="1.0"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="+Inf"}'
+        values: "0+10x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="0.1"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="0.5"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="1.0"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="+Inf"}'
+        values: "0+10x10"
+    promql_expr_test:
+      # The clamp value is a literal bucket bound handed straight back, so it is
+      # exact on every platform and safe to assert by value.
+      - expr: |
+          histogram_quantile(0.95, sum by (le) (
+            rate(http_request_duration_seconds_bucket{handler="/slow-1500ms"}[5m])))
+        eval_time: 10m
+        exp_samples:
+          - labels: "{}"
+            value: 1
+      - expr: |
+          histogram_quantile(0.95, sum by (le) (
+            rate(http_request_duration_seconds_bucket{handler="/slow-11000ms"}[5m])))
+        eval_time: 10m
+        exp_samples:
+          - labels: "{}"
+            value: 1
+      # And the claim itself, as a boolean: on these buckets p95 cannot exceed
+      # 1.0, for an 11s request or any other. `> bool` yields exactly 0 or 1,
+      # which is the point — see scenario 0b's note on comparing interpolated
+      # quantiles by value.
+      - expr: |
+          histogram_quantile(0.95, sum by (le) (
+            rate(http_request_duration_seconds_bucket{handler="/slow-11000ms"}[5m]))) > bool 1
+        eval_time: 10m
+        exp_samples:
+          - labels: "{}"
+            value: 0
+
+  # --------------------------------------------------------------------------
+  # 0b. The same two requests through LATENCY_LOWR_BUCKETS. The 1.5s one is now
+  #     a real reading; the 11s one clamps at the new top finite bound, 10s.
+  #     Same provenance — a real scrape, this time from the shipped code.
+  #
+  #     The 1.5s reading is asserted with `> bool` / `< bool` rather than by
+  #     value. An interpolated quantile is not bit-identical across
+  #     architectures: this case is exactly 1.75 on linux/amd64 and
+  #     1.7499999999999993 on darwin/arm64, because Go contracts `a + b*c` into
+  #     a fused multiply-add on arm64 and not on amd64. promtool compares
+  #     exp_samples exactly, so a pinned literal here passes on whichever
+  #     machine produced it and fails on the other. Values that come back as a
+  #     literal bucket bound (the clamps, 1 and 10) have no such arithmetic and
+  #     stay asserted by value.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "widened buckets: p95 readable to 1.75s, ceiling now 10s"
+    input_series:
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="0.1"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="0.25"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="0.5"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="1.0"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="2.5"}'
+        values: "0+10x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="5.0"}'
+        values: "0+10x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="10.0"}'
+        values: "0+10x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-1500ms", le="+Inf"}'
+        values: "0+10x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="0.1"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="0.25"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="0.5"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="1.0"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="2.5"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="5.0"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="10.0"}'
+        values: "0+9x10"
+      - series: 'http_request_duration_seconds_bucket{handler="/slow-11000ms", le="+Inf"}'
+        values: "0+10x10"
+    promql_expr_test:
+      # p95 for the 1.5s request now lands strictly inside the (1, 2.5] bucket:
+      # a real reading, not the ceiling. Roughly 1.75; see the note above for
+      # why that number is not asserted directly.
+      - expr: |
+          histogram_quantile(0.95, sum by (le) (
+            rate(http_request_duration_seconds_bucket{handler="/slow-1500ms"}[5m]))) > bool 1
+        eval_time: 10m
+        exp_samples:
+          - labels: "{}"
+            value: 1
+      - expr: |
+          histogram_quantile(0.95, sum by (le) (
+            rate(http_request_duration_seconds_bucket{handler="/slow-1500ms"}[5m]))) < bool 2.5
+        eval_time: 10m
+        exp_samples:
+          - labels: "{}"
+            value: 1
+      # The 11s request clamps at the new top finite bound. A returned bucket
+      # bound, so exact everywhere.
+      - expr: |
+          histogram_quantile(0.95, sum by (le) (
+            rate(http_request_duration_seconds_bucket{handler="/slow-11000ms"}[5m])))
+        eval_time: 10m
+        exp_samples:
+          - labels: "{}"
+            value: 10
+
+  # --------------------------------------------------------------------------
+  # 1. The incident, replayed. Bulk reads slow (1-2.5s), interactive traffic
+  #    healthy — the exact shape of all three #1517 firings.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "healthy demo under geolens-examples CI load"
+    input_series:
+      # Interactive: 60/min, every one under 100ms.
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}", method="GET", le="0.1"}'
+        values: "0+60x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}", method="GET", le="0.25"}'
+        values: "0+60x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}", method="GET", le="0.5"}'
+        values: "0+60x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}", method="GET", le="1.0"}'
+        values: "0+60x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}", method="GET", le="2.5"}'
+        values: "0+60x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}", method="GET", le="5.0"}'
+        values: "0+60x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}", method="GET", le="10.0"}'
+        values: "0+60x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}", method="GET", le="+Inf"}'
+        values: "0+60x30"
+      # Bulk: 12/min each, every one between 1s and 2.5s.
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="GET", le="0.1"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="GET", le="0.25"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="GET", le="0.5"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="GET", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="GET", le="2.5"}'
+        values: "0+12x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="GET", le="5.0"}'
+        values: "0+12x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="GET", le="10.0"}'
+        values: "0+12x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="GET", le="+Inf"}'
+        values: "0+12x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features.geojson", method="GET", le="0.1"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features.geojson", method="GET", le="0.25"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features.geojson", method="GET", le="0.5"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features.geojson", method="GET", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features.geojson", method="GET", le="2.5"}'
+        values: "0+12x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features.geojson", method="GET", le="5.0"}'
+        values: "0+12x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features.geojson", method="GET", le="10.0"}'
+        values: "0+12x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features.geojson", method="GET", le="+Inf"}'
+        values: "0+12x30"
+      # Same bulk traffic seen by the mean rule: 1.3s average, the demo's
+      # measured healthy cost for a ~10MB response.
+      - series: 'http_request_duration_seconds_sum{handler="/collections/{dataset_id}/items", method="GET"}'
+        values: "0+15.6x30"
+      - series: 'http_request_duration_seconds_count{handler="/collections/{dataset_id}/items", method="GET"}'
+        values: "0+12x30"
+      - series: 'http_request_duration_seconds_sum{handler="/datasets/{dataset_id}/features.geojson", method="GET"}'
+        values: "0+15.6x30"
+      - series: 'http_request_duration_seconds_count{handler="/datasets/{dataset_id}/features.geojson", method="GET"}'
+        values: "0+12x30"
+
+    promql_expr_test:
+      # The rule's selector as it stood BEFORE #1517 (tiles-only exclusion), on
+      # this exact input: 2.24s, over the bound, so it pages. On the pre-#1517
+      # buckets it would have read the ceiling value 1 instead (scenario 0) and
+      # `>= 1` would have paged just the same. Either way this healthy traffic
+      # crosses the old rule's threshold — that is the false page.
+      # Both readings are interpolated quantiles, so they are compared with
+      # `>= bool` / `< bool` rather than pinned as literals — see scenario 0b.
+      # Measured values, for orientation: 2.2375s on the old selector, 0.095s on
+      # the shipped one.
+      - expr: |
+          histogram_quantile(0.95,
+            sum by (le) (rate(http_request_duration_seconds_bucket{handler!~"/tiles/.*"}[5m]))) >= bool 1
+        eval_time: 25m
+        exp_samples:
+          - labels: "{}"
+            value: 1
+      # The same input through the shipped rule's selector: a real p95, far
+      # below the bound. 28.6% of non-tile requests still exceed 1s.
+      - expr: |
+          histogram_quantile(0.95,
+            sum by (le) (rate(http_request_duration_seconds_bucket{
+              handler!~"/tiles/.*|/datasets/[^/]+/features(\\.geojson)?/?|/datasets/[^/]+/export|/datasets/[^/]+/download/cog|/collections/[^/]+/items/?|/stac/collections/[^/]+/items"
+            }[5m]))) < bool 0.5
+        eval_time: 25m
+        exp_samples:
+          - labels: "{}"
+            value: 1
+
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: GeoLensApiInteractiveLatencyP95
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: GeoLensApiBulkLatencyMean
+        exp_alerts: []
+
+  # --------------------------------------------------------------------------
+  # 2. The interactive rule is still alive. Without this the exclusion above
+  #    could have swallowed every handler and scenario 1 would still pass.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "interactive endpoint genuinely degraded"
+    input_series:
+      - series: 'http_request_duration_seconds_bucket{handler="/search/datasets/", method="GET", le="0.1"}'
+        values: "0+40x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/search/datasets/", method="GET", le="0.25"}'
+        values: "0+40x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/search/datasets/", method="GET", le="0.5"}'
+        values: "0+40x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/search/datasets/", method="GET", le="1.0"}'
+        values: "0+40x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/search/datasets/", method="GET", le="2.5"}'
+        values: "0+50x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/search/datasets/", method="GET", le="5.0"}'
+        values: "0+50x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/search/datasets/", method="GET", le="10.0"}'
+        values: "0+50x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/search/datasets/", method="GET", le="+Inf"}'
+        values: "0+50x30"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: GeoLensApiInteractiveLatencyP95
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "API p95 latency (interactive) at or above 1s"
+              description:
+                "95th-percentile latency of interactive API requests has been at
+                or above 1s for 10 minutes (2.125s). Tile and bulk-read endpoints
+                are excluded; see GeoLensApiTileLatencyMean and
+                GeoLensApiBulkLatencyMean."
+
+  # --------------------------------------------------------------------------
+  # 3. The bulk rule is not vacuous either.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "bulk endpoint genuinely degraded"
+    input_series:
+      - series: 'http_request_duration_seconds_sum{handler="/datasets/{dataset_id}/export", method="GET"}'
+        values: "0+80x30"
+      - series: 'http_request_duration_seconds_count{handler="/datasets/{dataset_id}/export", method="GET"}'
+        values: "0+10x30"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: GeoLensApiBulkLatencyMean
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              handler: "/datasets/{dataset_id}/export"
+            exp_annotations:
+              summary: "Mean bulk-read latency above 5s (/datasets/{dataset_id}/export)"
+              description:
+                "/datasets/{dataset_id}/export has averaged 8s over the last 10
+                minutes. Bulk reads are slow by design, so this bound sits well
+                above the ~1.3s a 10MB response normally costs — crossing it
+                points at the query or the export path, not at payload size."
+
+  # --------------------------------------------------------------------------
+  # 4. Selector precision. Every handler here is slow enough to pin p95, and
+  #    each one's membership is a decision the regex has to get right.
+  #
+  #    Trailing-slash twins are the trap: FastAPI registers both
+  #    /collections/{dataset_id}/items and /collections/{dataset_id}/items/, and
+  #    redirect_slashes=False means both are live, distinct handler labels. The
+  #    `/collections/.*/items` shape first proposed on #1517 covers only the
+  #    first, so the CI traffic hitting the second would have kept paging.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "bulk-adjacent handlers are on the intended side of the selector"
+    input_series:
+      # Bulk (excluded from the interactive rule).
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items/", method="GET", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items/", method="GET", le="2.5"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items/", method="GET", le="+Inf"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/stac/collections/{collection_id}/items", method="GET", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/stac/collections/{collection_id}/items", method="GET", le="2.5"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/stac/collections/{collection_id}/items", method="GET", le="+Inf"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features/", method="GET", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features/", method="GET", le="2.5"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features/", method="GET", le="+Inf"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/download/cog", method="GET", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/download/cog", method="GET", le="2.5"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/download/cog", method="GET", le="+Inf"}'
+        values: "0+20x30"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: GeoLensApiInteractiveLatencyP95
+        exp_alerts: []
+
+  - interval: 1m
+    name: "single-object reads and bulk-named mutations stay interactive"
+    input_series:
+      # A single feature read is not a bulk transfer, however much its path
+      # looks like one. Same for a mutation whose name contains "bulk".
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features/{gid}", method="GET", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features/{gid}", method="GET", le="2.5"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features/{gid}", method="GET", le="+Inf"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items/{feature_id}", method="GET", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items/{feature_id}", method="GET", le="2.5"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items/{feature_id}", method="GET", le="+Inf"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/bulk-delete", method="POST", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/bulk-delete", method="POST", le="2.5"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/bulk-delete", method="POST", le="+Inf"}'
+        values: "0+20x30"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: GeoLensApiInteractiveLatencyP95
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "API p95 latency (interactive) at or above 1s"
+              description:
+                "95th-percentile latency of interactive API requests has been at
+                or above 1s for 10 minutes (2.425s). Tile and bulk-read
+                endpoints are excluded; see GeoLensApiTileLatencyMean and
+                GeoLensApiBulkLatencyMean."
+
+  # --------------------------------------------------------------------------
+  # 4c. A path is not a request. /datasets/{dataset_id}/features answers GET and
+  #     POST off one template, so a handler-only selector would have taken
+  #     feature CREATION out of interactive monitoring and judged it against the
+  #     bulk rule's 5s bound instead. Here POST is slow and GET is healthy on
+  #     the same handler: the interactive rule has to fire on the POST, and the
+  #     bulk rule has to stay quiet even though the POST mean is 20s.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "slow feature creation stays under the interactive bound"
+    input_series:
+      # POST: 20/min, all of them over 1s.
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features", method="POST", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features", method="POST", le="2.5"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features", method="POST", le="+Inf"}'
+        values: "0+20x30"
+      # GET on the same handler: bulk, slow, and correctly excluded.
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features", method="GET", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features", method="GET", le="2.5"}'
+        values: "0+60x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/features", method="GET", le="+Inf"}'
+        values: "0+60x30"
+      # The POST averages 20s. The bulk rule must not see it at all; if it did,
+      # 20s is far over the 5s bound and it would fire.
+      - series: 'http_request_duration_seconds_sum{handler="/datasets/{dataset_id}/features", method="POST"}'
+        values: "0+400x30"
+      - series: 'http_request_duration_seconds_count{handler="/datasets/{dataset_id}/features", method="POST"}'
+        values: "0+20x30"
+      # Healthy GET reads on the same handler, well under the bulk bound.
+      - series: 'http_request_duration_seconds_sum{handler="/datasets/{dataset_id}/features", method="GET"}'
+        values: "0+78x30"
+      - series: 'http_request_duration_seconds_count{handler="/datasets/{dataset_id}/features", method="GET"}'
+        values: "0+60x30"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: GeoLensApiBulkLatencyMean
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: GeoLensApiInteractiveLatencyP95
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "API p95 latency (interactive) at or above 1s"
+              description:
+                "95th-percentile latency of interactive API requests has been at
+                or above 1s for 10 minutes (2.425s). Tile and bulk-read
+                endpoints are excluded; see GeoLensApiTileLatencyMean and
+                GeoLensApiBulkLatencyMean."
+
+  # --------------------------------------------------------------------------
+  # 4d. HEAD is a read. _register_standards_head_routes() clones the GET route
+  #     with the same endpoint, so a HEAD on a collection runs the same query
+  #     and only drops the body on the wire. It belongs on the bulk side, and a
+  #     `method="GET"` matcher would have quietly put it back on the 1s bound.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "HEAD on a bulk collection is treated as a bulk read"
+    input_series:
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="HEAD", le="1.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="HEAD", le="2.5"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/collections/{dataset_id}/items", method="HEAD", le="+Inf"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_sum{handler="/collections/{dataset_id}/items", method="HEAD"}'
+        values: "0+26x30"
+      - series: 'http_request_duration_seconds_count{handler="/collections/{dataset_id}/items", method="HEAD"}'
+        values: "0+20x30"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: GeoLensApiInteractiveLatencyP95
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: GeoLensApiBulkLatencyMean
+        exp_alerts: []
+
+  # --------------------------------------------------------------------------
+  # 5. Tiles keep their own rule, unchanged by the split.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "tile latency still has its own bound"
+    input_series:
+      - series: 'http_request_duration_seconds_sum{handler="/tiles/{table_path:path}/{z:int}/{x:int}/{y:int}.pbf", method="GET", le="+Inf"}'
+        values: "0+240x30"
+      - series: 'http_request_duration_seconds_count{handler="/tiles/{table_path:path}/{z:int}/{x:int}/{y:int}.pbf", method="GET", le="+Inf"}'
+        values: "0+100x30"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: GeoLensApiTileLatencyMean
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "Mean tile latency above 2s"
+              description:
+                "Requests under /tiles/ have averaged 2.4s over the last 10
+                minutes — vector-tile queries or the raster proxy are grinding."
+
+  # --------------------------------------------------------------------------
+  # 6. The rules #1517 did not touch. They were uncovered when this file was
+  #    added; a coverage guard that exempts whatever is inconvenient is not a
+  #    coverage guard. Each gets a firing case and a below-threshold case, so
+  #    neither direction passes for free.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "scrape target down"
+    input_series:
+      - series: 'up{job="geolens-api", instance="api:8000"}'
+        values: "1 1 1 0 0 0 0 0 0 0 0 0"
+      - series: 'up{job="geolens-worker", instance="worker:8001"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: GeoLensTargetDown
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: GeoLensTargetDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: geolens-api
+              instance: "api:8000"
+            exp_annotations:
+              summary: "geolens-api scrape target is down"
+              description:
+                "Prometheus has failed to scrape geolens-api (api:8000) for more
+                than 2 minutes — the API or worker process may be down."
+
+  - interval: 1m
+    name: "5xx ratio over 5%"
+    input_series:
+      - series: 'http_requests_total{status="200", handler="/datasets/{dataset_id}", method="GET"}'
+        values: "0+90x30"
+      - series: 'http_requests_total{status="500", handler="/datasets/{dataset_id}", method="GET"}'
+        values: "0+10x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: GeoLensApiHigh5xxRate
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: "API 5xx error ratio above 5%"
+              description:
+                "10% of API requests returned 5xx over the last 5 minutes."
+
+  - interval: 1m
+    name: "5xx ratio under 5% stays quiet"
+    input_series:
+      - series: 'http_requests_total{status="200", handler="/datasets/{dataset_id}", method="GET"}'
+        values: "0+98x30"
+      - series: 'http_requests_total{status="500", handler="/datasets/{dataset_id}", method="GET"}'
+        values: "0+2x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: GeoLensApiHigh5xxRate
+        exp_alerts: []
+
+  - interval: 1m
+    name: "job queue backlog"
+    input_series:
+      - series: 'geolens_jobs_queue_depth{queue="ingest"}'
+        values: "150x30"
+      - series: 'geolens_jobs_queue_depth{queue="tiles"}'
+        values: "4x30"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: GeoLensJobQueueBacklog
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: GeoLensJobQueueBacklog
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              queue: ingest
+            exp_annotations:
+              summary: "Job queue 'ingest' backlog above 100"
+              description:
+                "150 jobs have been waiting in the 'ingest' queue for more than
+                15 minutes — the worker may be stuck or under-provisioned.
+                Threshold is tunable."
+
+  - interval: 1m
+    name: "job failures"
+    input_series:
+      - series: 'geolens_jobs_failed_total{queue="ingest"}'
+        values: "0+1x30"
+      - series: 'geolens_jobs_failed_total{queue="tiles"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: GeoLensJobFailures
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              queue: ingest
+            exp_annotations:
+              summary: "Jobs failing in queue 'ingest'"
+              description:
+                "15 jobs failed in the 'ingest' queue in the last 15 minutes."
+
+  - interval: 1m
+    name: "db pool overflow in sustained use"
+    input_series:
+      - series: "geolens_db_pool_overflow"
+        values: "0 0 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3"
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: GeoLensDbPoolSaturated
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: GeoLensDbPoolSaturated
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "DB connection pool saturated (overflow in use)"
+              description:
+                "The base connection pool has been full and using overflow
+                connections for more than 10 minutes. Consider raising the pool
+                size or investigating slow queries."

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -43,28 +43,139 @@ groups:
       - alert: GeoLensApiInteractiveLatencyP95
         # fix(#658): replaces the all-handler p95 alert (#466), which fired
         # during plain map browsing — tile requests are the legitimate slow
-        # tail, so they get their own rule below. Excluding a handler forces
-        # the handler-labeled histogram, whose buckets top out at le=1.0, so
-        # histogram_quantile clips at 1.0 and `>= 1` is the only expressible
-        # "worse than 1s" predicate (`> 1` could never fire).
+        # tail, so they get their own rule below.
+        #
+        # fix(#1517): bulk reads are excluded for exactly the same reason, and
+        # get GeoLensApiBulkLatencyMean below. This rule fired three times on
+        # the demo, every time from geolens-examples CI pulling collections at
+        # ?limit=2000 (~10MB responses), never from the demo being slow.
+        #
+        # The bulk selector below must stay byte-identical to the one in
+        # GeoLensApiBulkLatencyMean — a handler that drifts out of one and not
+        # into the other is either double-alerted or unmonitored. Pinned by
+        # backend/tests/test_alert_rules.py, which also checks the selector
+        # against the app's real route table: `.*/export` and `/collections/.*/items`
+        # (the shapes first proposed on #1517) miss the trailing-slash twins
+        # that FastAPI registers alongside these routes, and a miss reads
+        # identically to a hit in a diff.
+        #
+        # fix(#1521 review): only bulk READS leave this rule. A path is not a
+        # request — /datasets/{dataset_id}/features[/] answers GET and POST off
+        # one template, so a handler-only exclusion would have dropped feature
+        # CREATION out of interactive monitoring and pooled its duration into a
+        # 5s bulk bound built for 10MB downloads. Hence the union below rather
+        # than one selector: everything that is neither a tile nor a bulk path,
+        # PLUS writes to bulk paths. `or` is deliberate over `unless` or
+        # subtraction — the two arms are disjoint by construction (handler!~
+        # versus handler=~), and an empty arm leaves the other untouched
+        # instead of emptying the whole expression the way a binary `-` would.
+        #
+        # HEAD counts as a read. _register_standards_head_routes() in
+        # backend/app/api/main.py clones the GET route with the SAME endpoint,
+        # so a HEAD on /collections/{id}/items runs the identical query and
+        # serialization and only drops the body on the wire. If a future
+        # explicit HEAD handler answers cheaply without doing the read (#1513
+        # adds a HEAD verb to the export route), it stops being a bulk read and
+        # belongs back here.
+        #
+        # `>= 1` not `> 1`: before #1517 this was a workaround (the histogram
+        # clipped at 1.0, so `> 1` could never fire). It is now a real p95 —
+        # the top finite bucket is 10 — and `>=` is kept deliberately, so a p95
+        # sitting exactly on the 1s bucket boundary still counts as "at or
+        # above 1s". See LATENCY_LOWR_BUCKETS in
+        # backend/app/observability/metrics/__init__.py.
+        #
+        # Not touched here: /tiles/.* is still excluded by path alone, so a POST
+        # to /tiles/tokens is out of this rule too. That is #658's shape, its
+        # population is what GeoLensApiTileLatencyMean's 2s bound was calibrated
+        # against, and re-partitioning it is a separate change.
         expr: |
-          histogram_quantile(0.95,
-            sum by (le) (rate(http_request_duration_seconds_bucket{handler!~"/tiles/.*"}[5m]))) >= 1
+          histogram_quantile(0.95, sum by (le) (
+            rate(http_request_duration_seconds_bucket{
+              handler!~"/tiles/.*|/datasets/[^/]+/features(\\.geojson)?/?|/datasets/[^/]+/export|/datasets/[^/]+/download/cog|/collections/[^/]+/items/?|/stac/collections/[^/]+/items"
+            }[5m])
+            or
+            rate(http_request_duration_seconds_bucket{
+              handler=~"/datasets/[^/]+/features(\\.geojson)?/?|/datasets/[^/]+/export|/datasets/[^/]+/download/cog|/collections/[^/]+/items/?|/stac/collections/[^/]+/items",
+              method!~"GET|HEAD"
+            }[5m])
+          )) >= 1
         for: 10m
         labels:
           severity: warning
         annotations:
-          summary: "API p95 latency (non-tile) at or above 1s"
+          summary: "API p95 latency (interactive) at or above 1s"
           description: >-
-            95th-percentile latency of non-tile API requests has been at the
-            1s histogram ceiling for 10 minutes. Tile endpoints are excluded;
-            see GeoLensApiTileLatencyMean.
+            95th-percentile latency of interactive API requests has been at or
+            above 1s for 10 minutes ({{ $value | humanizeDuration }}). Tile and
+            bulk-read endpoints are excluded; see GeoLensApiTileLatencyMean and
+            GeoLensApiBulkLatencyMean.
+
+      - alert: GeoLensApiBulkLatencyMean
+        # fix(#1517): the other half of the split. Bulk reads return whatever
+        # the caller asked for — ?limit=2000 on a feature collection is roughly
+        # 10MB — so over a second is the correct cost of the payload, the same
+        # way a slow tile is.
+        #
+        # Shape copied from GeoLensApiTileLatencyMean: the exact mean from
+        # _sum/_count, not a quantile, so the bound is a real number of seconds
+        # that does not move when bucket boundaries do.
+        #
+        # `by (handler)` rather than that rule's single pooled series: this set
+        # spans four unrelated payload shapes, and pooling would let a
+        # high-volume healthy handler dilute a low-volume degraded one. It also
+        # puts the offending handler in the notification.
+        #
+        # Bound: on the demo these average 1.2-1.4s (#1517 measured
+        # features.geojson 1334ms, /collections/{id}/items 1197ms, export
+        # 397ms). 5s is ~4x the worst healthy mean — loose on purpose, because
+        # response size here is caller-controlled and a tighter bound would page
+        # on a legitimately larger download rather than on a regression.
+        #
+        # Admin exports (/admin/audit-logs/export/{format},
+        # /admin/users/export.csv, /config-ops/export) are deliberately NOT in
+        # this set. They are admin-only one-offs, so a single legitimately huge
+        # one would carry a per-handler mean over any bound for a full rate
+        # window, which is the false page this issue is about; at their volume
+        # they cannot move the interactive p95 either.
+        #
+        # fix(#1521 review): `method=~"GET|HEAD"` keeps this to bulk READS. The
+        # complement of the same alternation appears in the interactive rule
+        # above, so POST /datasets/{dataset_id}/features stays on the 1s
+        # interactive bound rather than being pooled here against 5s. See that
+        # rule for why HEAD counts as a read.
+        #
+        # With no bulk traffic the ratio is 0/0 = NaN, which never compares true.
+        expr: |
+          sum by (handler) (rate(http_request_duration_seconds_sum{
+            handler=~"/datasets/[^/]+/features(\\.geojson)?/?|/datasets/[^/]+/export|/datasets/[^/]+/download/cog|/collections/[^/]+/items/?|/stac/collections/[^/]+/items",
+            method=~"GET|HEAD"
+          }[10m]))
+            / sum by (handler) (rate(http_request_duration_seconds_count{
+              handler=~"/datasets/[^/]+/features(\\.geojson)?/?|/datasets/[^/]+/export|/datasets/[^/]+/download/cog|/collections/[^/]+/items/?|/stac/collections/[^/]+/items",
+              method=~"GET|HEAD"
+            }[10m])) > 5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Mean bulk-read latency above 5s ({{ $labels.handler }})"
+          description: >-
+            {{ $labels.handler }} has averaged {{ $value | humanizeDuration }}
+            over the last 10 minutes. Bulk reads are slow by design, so this
+            bound sits well above the ~1.3s a 10MB response normally costs —
+            crossing it points at the query or the export path, not at payload
+            size.
 
       - alert: GeoLensApiTileLatencyMean
-        # fix(#658): tile p95 is unreadable from the handler-labeled histogram
-        # (clips at 1s), so alert on the exact mean from _sum/_count instead.
+        # fix(#658): tile p95 was unreadable from the handler-labeled histogram
+        # (it clipped at 1s), so alert on the exact mean from _sum/_count
+        # instead. fix(#1517) raised the top finite bucket to 10, so the clip is
+        # no longer the reason — the mean stays because it is the more honest
+        # reading for a family this bursty, and the bound below is calibrated
+        # against it.
         # Active map browsing keeps the mean well under 1s even while p95 sits
-        # at the ceiling; a sustained mean above 2s means tiles are genuinely
+        # high; a sustained mean above 2s means tiles are genuinely
         # grinding (raster-proxy incidents run 2.2-2.6s/tile, cf. #643).
         # With no tile traffic the ratio is 0/0 = NaN, which never compares true.
         expr: |


### PR DESCRIPTION
Closes #1517

`GeoLensApiInteractiveLatencyP95` has paged three times on the demo VM, every one from `geolens-examples` CI pulling feature collections at `?limit=2000`, none from the demo being slow. `prom-guard` is a dead-man switch, so each occurrence woke an operator.

The change does what #658 did for tiles, applied to bulk reads, plus the bucket widening that has to precede it.

## The two findings from the prior review

**1. p95 on this metric could never exceed 1.0.** Confirmed, and the buckets are widened first in the same commit. `http_request_duration_seconds` carried the library defaults `0.1, 0.5, 1` plus the implicit `+Inf`, and `histogram_quantile` returns the highest finite bound for anything landing in `+Inf`. `LATENCY_LOWR_BUCKETS` is now `(0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0)`, so the clamp moves to 10s.

Measured rather than assumed. A real FastAPI app instrumented both ways, driven with nine requests at 10ms and one slow one, then Prometheus itself evaluating the quantile over the scraped bucket counts (`promtool test rules`):

| slow request | before, p95 | after, p95 |
|---|---|---|
| 1.5s | 1.0 | 1.7499999999999993 |
| 11s | 1.0 | 10 (the new ceiling) |

Before the change the histogram cannot tell 1.5s from 11s. Both scrapes are in `infra/monitoring/alerts.test.yml` as scenarios 0 and 0b, so the property stays checkable.

**2. The buckets are not set where they look like they are set.** Confirmed, and `backend/app/observability/metrics/__init__.py:61` was the right line. `Instrumentator.__init__` in `prometheus_fastapi_instrumentator` 8.1.0 takes no bucket arguments at all; `instrument()` is the only place they can be passed. `create_instrumentator()` is untouched and carries no new comment, but the call site says why it cannot go there.

## One thing the findings did not cover

The issue prescribes a mean-based bulk rule, copied from `GeoLensApiTileLatencyMean`. A mean rule reads `_sum`/`_count`, not buckets, so it is immune to the clamp. The ordering argument in finding 1 therefore applies to a quantile-shaped bulk rule, not to the mean-shaped one that shipped here.

The widening is still load-bearing, for a different reason: it turns `GeoLensApiInteractiveLatencyP95` from a threshold-locked binary ("did more than 5% of requests exceed 1s") into a real percentile, and it is what makes any bucket-based threshold above 1s expressible at all. `$value` in that alert used to be the constant 1 on every firing; it now carries a latency.

## Handler matching, against real labels

The dev stack's live `/metrics` was not sufficient on its own: none of the bulk endpoints had been exercised, so zero of the 59 handler labels present were bulk. I exercised them, and separately built the complete label universe from the app's route table (375 labels via the instrumentator's own route resolution, a superset that contains all live labels).

Matched by the bulk selector, all confirmed as live `handler` labels:

```
/collections/datasets/items
/collections/{dataset_id}/items
/collections/{dataset_id}/items/
/datasets/{dataset_id}/export
/datasets/{dataset_id}/features
/datasets/{dataset_id}/features.geojson
/stac/collections/{collection_id}/items
```

Plus `/datasets/{dataset_id}/download/cog` from the route table. Matched by the tile selector, unchanged: the four `/tiles/*` labels. The remaining 59 live labels stay under the interactive rule, including every `/settings/*`, `/maps/*`, `/search/*`, `/admin/*` and `/auth/*` handler, and `/collections` and `/collections/datasets` (collection metadata, not item listings).

Deliberately not matched, each verified against the route table:

```
/datasets/{dataset_id}/features/{gid}                         single feature
/datasets/{dataset_id}/features/{gid}/related/{relationship_id}
/collections/{dataset_id}/items/{feature_id}                  single item
/collections/datasets/items/{record_id}
/stac/collections/{collection_id}/items/{item_id}
/stac/items/{item_id}
/datasets/bulk-delete                                         mutation, not a download
/maps/{map_id}/layers/bulk-delete
/admin/embed-tokens/bulk-revoke
/ingest/register/bulk
/admin/audit-logs/export/{format}                             admin one-off, see below
/admin/users/export.csv
/config-ops/export
```

The selector shapes suggested on the issue (`.*/export`, `/collections/.*/items`) would have missed `/collections/{dataset_id}/items/`, `/datasets/{dataset_id}/features`, `/datasets/{dataset_id}/features/` and `/stac/collections/{collection_id}/items`, and would have caught `/config-ops/export` by accident. `redirect_slashes=False` means the trailing-slash twins are separate live handler labels, so the same CI traffic would have kept paging.

Admin exports are left in the interactive rule on purpose. A single legitimately huge one would hold a per-handler mean above any bound for a whole rate window, which is the false page this issue is about, and at their volume they cannot move the interactive p95. The reasoning is in the rule's comment.

The bulk bound is 5s against measured healthy means of 1.2 to 1.4s. That is loose, and the comment says why: response size is caller-controlled, so a tighter bound pages on a larger download rather than on a regression.

## Verification

`promtool check rules` and `promtool test rules`, `prom/prometheus:v3.6.0` (the tag RUNBOOK.md pins):

```
Checking /w/alerts.yml
  SUCCESS: 8 rules found

  SUCCESS
```

`alerts.test.yml` covers all 8 rules, not only the 3 this PR touches. `GeoLensApiTargetDown`, `GeoLensApiHigh5xxRate`, `GeoLensJobQueueBacklog`, `GeoLensJobFailures` and `GeoLensDbPoolSaturated` had no test at all; each now has a firing case, and most have a below-threshold case too.

Every "must not fire" assertion was checked against a counterfactual. Three mutations of the shipped selector, each failing a different scenario:

| mutation | caught by |
|---|---|
| `\\.` over-escaped to `\\\\.` | scenario 1, `features.geojson` falls back into the interactive rule |
| the shapes proposed on the issue | scenario 4, trailing-slash twins and STAC items |
| bulk selector replaced with `.*` | scenario 2, the interactive rule goes silent |

`backend/tests/test_alert_rules.py` (15 tests, no DB, no Docker) holds the same invariants in CI: no `histogram_quantile` threshold at or above the top finite bucket, the bulk selector byte-identical in both rules, and the selector's partition of the real route table asserted by exact set equality. Each assertion carries a vacuity guard, and the rule-count, universe-size and handler-existence checks are there so an empty parse or a rotted expectation list fails loudly. Verified by mutation too: dropping `/?` from the selector fails `test_bulk_selector_matches_exactly_the_intended_handlers` with `expected but missed: ['/collections/{dataset_id}/items/']`.

Gates:

```
tests/test_alert_rules.py tests/test_layering.py tests/test_ci_alembic_filter_paths.py   71 passed
pytest tests/ -k "metric or observab or alert"                                           70 passed, 1 skipped
ruff check .                                                                             All checks passed!
ruff format --check .                                                                    1005 files already formatted
```

The skip is `test_cli_round_trip.py`, a pre-existing optional-dependency skip unrelated to this change.

## Notes for review

`infra/monitoring/alerts.test.yml` needed `git add -f`: `.git/info/exclude` carries a directory-level `infra/` entry, so new files there are invisible to `git status` and to `git add -A`. The three existing `infra/monitoring/` files predate that entry and are tracked normally. The new file is committed, confirmed in `git show --stat`.

`.github/workflows/ci.yml` gains `infra/monitoring/alerts.yml` and `infra/monitoring/alerts.test.yml` in the `backend` paths filter, for the same reason as the existing `scripts/` entries: `test_alert_rules.py` reads both by literal path, so without them an alerts-only PR would skip the only gate that checks the selectors.

`GeoLensApiTileLatencyMean` is unchanged in behaviour. Its comment claimed tile p95 was unreadable because the histogram clipped at 1s, which stopped being true with this change, so the comment now says why the mean stays.

## Review round

Two P2s, both real, both fixed.

**Only bulk reads leave the interactive rule.** `/datasets/{dataset_id}/features` and `/datasets/{dataset_id}/features/` each answer GET and POST off one template, so the handler-only exclusion had taken feature creation out of interactive monitoring and pooled its duration against a 5s bound built for 10MB downloads. The interactive rule is now a union of two disjoint arms: everything that is neither tile nor bulk, plus writes to bulk paths. `or` rather than `unless` or a subtraction, because the arms cannot overlap and an empty arm leaves the other intact, where a binary `-` would empty the whole expression whenever one side had no series.

HEAD counts as a read. `_register_standards_head_routes()` registers those routes by cloning the GET route through `_clone_api_route(..., endpoint=route.endpoint)`, so a HEAD runs the identical query and serialization and only drops the body on the wire. Four bulk paths advertise `['GET', 'HEAD']`, so this is a live case, not a hypothetical. `backend/tests/test_alert_rules.py` now builds its universe as (handler, method) pairs and asserts the partition over those, including that a non-read verb exists on some bulk path at all.

**The promtool suite now runs.** It did not before: adding the alerts files to the paths filter only ran the backend pytest job, which reads those files as text. A `Monitoring Rules` job runs `promtool check rules` and `promtool test rules` against a digest-pinned `prom/prometheus:v3.6.0`, gated on a new `monitoring` filter and listed in `ci-ok`'s `needs` so branch protection sees it. A guard step counts rules and cases first, because `promtool test rules` reports SUCCESS on a file that declares no cases at all.

Both were shown red before green, on a deliberately broken commit that narrowed the bulk rule to `method=~"GET"` and changed one expected value:

```
Monitoring Rules
  Guard against an empty rule or case list   success
  promtool check rules                       success
  promtool test rules                        failure
        exp: {} 5E-01
        got: {} 9.5E-02

Backend Tests
  FAILED tests/test_alert_rules.py::test_read_method_partition_is_complementary
  FAILED tests/test_alert_rules.py::test_bulk_rule_claims_only_read_requests
  ===== 2 failed, 8900 passed, 92 skipped in 927.62s =====
```

`check rules` passing there is the point: the break was semantic, and only `test rules` could see it.

That run also caught a defect in this PR's own test file. An interpolated quantile pinned as `1.7499999999999993`, the value darwin/arm64 produces, is exactly `1.75` on linux/amd64, because Go contracts `a + b*c` into a fused multiply-add on arm64 and not on amd64, and promtool compares `exp_samples` exactly. It would have failed on the good head. Interpolated quantiles are now asserted with `> bool` / `< bool`, which yield exactly 0 or 1; only values returned as a literal bucket bound (the `1` and `10` clamps) are still compared by value.


## Out of scope

This takes effect on the demo VM only after a redeploy, which is a separate ops task with its own procedure. Deliberately not attempted here.

Also left alone, worth a separate decision: `/tiles/.*` sweeps in `/tiles/token/{dataset_id}`, `/tiles/tokens` and `/tiles/raster-auth-check`, which are small JSON endpoints rather than tile renders. They dilute the tile mean. That predates this PR and changing it would alter a bound calibrated against the current pooling.
