### PR TITLE
fix(export): answer HEAD on the dataset export route

### DIFF
--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -13,7 +13,6 @@ embedded PROJJSON is needed here.
 
 import json
 import os
-import re
 import shutil
 import uuid
 
@@ -26,7 +25,7 @@ from app.core.async_io import run_in_thread_draining
 from app.core.config import settings
 from app.core.runtime.staging import ensure_staging_ready
 from app.processing.export.ogr import bbox_where_sql
-from app.processing.export.service import validate_where_clause
+from app.processing.export.service import export_descriptor, validate_where_clause
 from app.processing.export.where_validator import canonical_where
 from app.processing.ingest.metadata import _qtable, get_column_info
 
@@ -247,8 +246,8 @@ async def export_parquet(
     )
     temp_dir = str(exports_root / uuid.uuid4().hex)
     os.mkdir(temp_dir)
-    safe_name = re.sub(r"[^\w\-.]", "_", dataset_name)
-    filename = f"{safe_name}.parquet"
+    # fix(#1513): one naming rule for both verbs — see export_descriptor.
+    filename, _ = export_descriptor(dataset_name, "parquet")
     output_path = os.path.join(temp_dir, filename)
     geom_col = _geometry_column_name(attr_names)
     try:

--- a/backend/app/processing/export/parquet.py
+++ b/backend/app/processing/export/parquet.py
@@ -15,6 +15,7 @@ import json
 import os
 import shutil
 import uuid
+from typing import NamedTuple
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -136,23 +137,38 @@ def _write_geoparquet(
     pq.write_table(table, output_path)
 
 
-async def export_parquet(
+class ParquetExportPlan(NamedTuple):
+    """The validated selection a parquet export will read. No bytes produced."""
+
+    attr_names: list[str]
+    where_sql: str
+    params: dict
+
+
+async def plan_parquet_export(
     db: AsyncSession,
     table_name: str,
-    dataset_name: str,
     *,
     schema: str,
     bbox: list[float] | None = None,
     where: str | None = None,
-) -> tuple[str, str, str]:
-    """Export a PostGIS feature table to a GeoParquet file.
+) -> ParquetExportPlan:
+    """Everything that decides a parquet export's STATUS, producing no file.
 
-    Returns (file_path, download_filename, media_type). The caller owns the
-    returned file's parent directory (FileResponse background cleanup).
+    fix(#1513, codex P2 on #1522): split out of ``export_parquet`` so the route
+    can run it BEFORE it answers a HEAD. Live introspection, filter validation
+    and the bounded count are all queries, not conversion, so a HEAD can afford
+    them — and has to: while these lived inside ``export_parquet`` a HEAD
+    answered 200 and the caller's follow-up range GET then failed 400 or 413,
+    which is worse than the 405 the HEAD route replaced, because it lies.
 
-    Builds the whole selection in memory before writing one Parquet
-    file. Bounded by _MAX_EXPORT_FEATURES below; switch to a fixed-schema batched
-    ParquetWriter if that ceiling ever needs raising.
+    Split at the conversion boundary, not at an arbitrary point: everything
+    here is a read, and everything after it in ``export_parquet`` builds the
+    file. Returning the plan means a GET pays for this exactly once.
+
+    Raises:
+        ValueError: bad filter (unknown column, malformed clause) -> 400.
+        ExportTooLargeError: selection over the cap -> 413.
     """
     # Introspect the live table once and use it for BOTH column selection and
     # filter validation — dataset.column_info is nullable, and trusting it would
@@ -216,6 +232,33 @@ async def export_parquet(
             f"Export selects more than {_MAX_EXPORT_FEATURES} features; narrow it "
             "with a bbox or attribute filter."
         )
+
+    return ParquetExportPlan(attr_names, where_sql, params)
+
+
+async def export_parquet(
+    db: AsyncSession,
+    table_name: str,
+    dataset_name: str,
+    *,
+    schema: str,
+    plan: ParquetExportPlan,
+) -> tuple[str, str, str]:
+    """Write the planned selection to a GeoParquet file.
+
+    Takes the plan from ``plan_parquet_export`` rather than deriving it, so the
+    route can decide the response status before it commits to producing bytes
+    (fix(#1513)). Every rejection this export can produce has already happened
+    by the time it is called.
+
+    Returns (file_path, download_filename, media_type). The caller owns the
+    returned file's parent directory (FileResponse background cleanup).
+
+    Builds the whole selection in memory before writing one Parquet file.
+    Bounded by the plan's count check; switch to a fixed-schema batched
+    ParquetWriter if that ceiling ever needs raising.
+    """
+    attr_names, where_sql, params = plan
 
     # Select the attribute columns directly (not via to_jsonb) so the async
     # driver returns native Python values — dates, timestamps, UUIDs, numerics —

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -165,13 +165,27 @@ def _file_response_content_disposition(filename: str) -> str:
 def _head_export_response(dataset_title: str, format_key: str) -> Response:
     """fix(#1513): the HEAD half of the export route.
 
-    Everything that decides the RESPONSE STATUS — access control, the export
-    capability, bbox/CRS validation, the raster and geometry gates, the
-    feature-count ceiling — has already run in the shared handler above, so
-    HEAD's status matches what GET would answer. Only the conversion is
-    skipped, which is the whole point: a HEAD that ran ogr2ogr and discarded
-    the bytes would hand any anonymous caller a way to spend a worker per
-    request on a public dataset.
+    Every check that can decide the status WITHOUT producing bytes has already
+    run in the shared handler above: access control, the export capability,
+    bbox/CRS validation, the raster and geometry gates, the feature-count
+    ceiling, filter validation, and for parquet the live-column check and the
+    bounded count. The conversion itself is skipped, which is the whole point:
+    a HEAD that ran ogr2ogr and discarded the bytes would hand any anonymous
+    caller a way to spend a worker per request on a public dataset.
+
+    Two statuses HEAD therefore cannot promise, and does not claim to: 500
+    (ogr2ogr or the parquet build fails) and 503 (the staging volume is
+    unavailable). Both are knowable only by attempting the export, so a HEAD
+    answers 200 for a request whose GET would fail that way. That limit is
+    deliberate and pinned by
+    ``test_head_cannot_promise_conversion_failure_status``; everything else a
+    GET can reject, HEAD rejects identically.
+
+    An earlier revision claimed full parity while filter validation still lived
+    inside ``export_dataset``/``export_parquet``, below the HEAD return, so a
+    bad filter got 200 from HEAD and 400 from the GET (codex P2 on #1522).
+    Those checks are hoisted now; the parity claim above is the narrower one
+    the code actually supports.
 
     Content-Length is deliberately absent. An export's length is knowable only
     after the conversion, and RFC 9110 section 9.3.2 lets a HEAD omit header
@@ -396,10 +410,57 @@ async def export_dataset_endpoint(
                 ),
             )
 
-    # 6c. fix(#1513): HEAD stops here — after every gate that decides the
-    # status, before the conversion that decides the bytes. No audit event
-    # either: nothing was exported, and a `dataset.export` row for a probe
-    # would misreport who downloaded what.
+    # 6c. fix(#1513, codex P2 on #1522): the remaining checks that decide the
+    # STATUS, hoisted above the HEAD return. These used to live inside
+    # export_dataset()/export_parquet(), i.e. below it, so HEAD answered 200
+    # for a filter GET rejects with 400 and for a parquet selection GET rejects
+    # with 413. A probing client accepted that HEAD and then failed its range
+    # GET, which is worse than the 405 this route replaced: the 405 did not
+    # lie. Validation only — running the conversion to learn a status is the
+    # denial-of-service foot-gun the HEAD branch exists to avoid.
+    parquet_plan = None
+    if format == ExportFormat.parquet:
+        # Parquet validates the filter against the LIVE columns, not the
+        # nullable dataset.column_info (see plan_parquet_export), and owns the
+        # bounded count the cap guard above deliberately skips for it.
+        from app.processing.export.parquet import (
+            ExportTooLargeError,
+            plan_parquet_export,
+        )
+
+        try:
+            parquet_plan = await plan_parquet_export(
+                db,
+                dataset.table_name,
+                schema=data_schema,
+                bbox=bbox_parsed,
+                where=where,
+            )
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            )
+        except ExportTooLargeError as e:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=str(e),
+            )
+    elif where is not None:
+        # ogr2ogr path: same check export_dataset runs, against the same
+        # column_info, just early enough for HEAD to see it.
+        try:
+            validate_where_clause(where, dataset.column_info)
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            )
+
+    # 6d. HEAD stops here — after every gate that decides the status, before
+    # the conversion that decides the bytes. No audit event either: nothing was
+    # exported, and a `dataset.export` row for a probe would misreport who
+    # downloaded what.
     if request.method == "HEAD":
         return _head_export_response(dataset.record.title, format)
 
@@ -407,27 +468,16 @@ async def export_dataset_endpoint(
     # build has no Arrow driver); all other formats use the ogr2ogr path.
     try:
         if format == ExportFormat.parquet:
-            from app.processing.export.parquet import (
-                ExportTooLargeError,
-                export_parquet,
-            )
+            from app.processing.export.parquet import export_parquet
 
-            try:
-                file_path, filename, media_type = await export_parquet(
-                    db,
-                    dataset.table_name,
-                    dataset.record.title,
-                    schema=data_schema,
-                    bbox=bbox_parsed,
-                    where=where,
-                )
-            except ExportTooLargeError as e:
-                # In-memory parquet build exceeded the cap (covers datasets with a
-                # NULL feature_count that skipped the guard above).
-                raise HTTPException(
-                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                    detail=str(e),
-                )
+            assert parquet_plan is not None  # set by the parquet branch above
+            file_path, filename, media_type = await export_parquet(
+                db,
+                dataset.table_name,
+                dataset.record.title,
+                schema=data_schema,
+                plan=parquet_plan,
+            )
         else:
             file_path, filename, media_type = await export_dataset(
                 dataset.table_name,

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -187,6 +187,24 @@ def _head_export_response(dataset_title: str, format_key: str) -> Response:
     Those checks are hoisted now; the parity claim above is the narrower one
     the code actually supports.
 
+    ``Accept-Ranges: bytes`` says the endpoint serves byte ranges. It does NOT
+    say the representation is stable across requests, and here it is not: every
+    range GET re-enters this endpoint and converts the dataset again, so a
+    probing client is reading a sequence of freshly built artifacts rather than
+    slices of one (fix(#1532)). While the data is unchanged that is only
+    wasteful — the export is byte-deterministic, so consecutive conversions are
+    identical. While the data changes mid-read the sequence is incoherent, and
+    it fails LOUDLY: a spliced GeoJSON dies with ``ERROR 4: Failed to read
+    GeoJSON data`` and no output file, rather than yielding a plausible wrong
+    answer. Keeping that loud failure is a constraint on the real fix, which is
+    to serve ranges from a cached artifact.
+
+    The header stays. GDAL ranges because a size-less HEAD gives it no length,
+    not because it read this header, and the GET has advertised ``accept-ranges``
+    from starlette's ``FileResponse`` on main all along — dropping it here would
+    change nothing about the exposure and would break the size discovery this
+    HEAD depends on.
+
     Content-Length is deliberately absent. An export's length is knowable only
     after the conversion, and RFC 9110 section 9.3.2 lets a HEAD omit header
     fields "for which a value is determined only while generating the
@@ -202,9 +220,11 @@ def _head_export_response(dataset_title: str, format_key: str) -> Response:
         media_type=media_type,
         headers={
             "content-disposition": _file_response_content_disposition(filename),
-            # Truthful: the GET this describes is a FileResponse, which serves
-            # 206 byte ranges. It is also what lets a size-less HEAD work —
-            # vsicurl learns the length from the first range response.
+            # The GET this describes is a FileResponse, which serves 206 byte
+            # ranges, and this is also what lets a size-less HEAD work: vsicurl
+            # learns the length from the first range response. It promises
+            # range SERVICE, not a stable representation — see the docstring
+            # and fix(#1532).
             "accept-ranges": "bytes",
         },
     )

--- a/backend/app/processing/export/router.py
+++ b/backend/app/processing/export/router.py
@@ -4,8 +4,9 @@ import os
 import re
 import shutil
 import uuid
+from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import FileResponse
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,7 +23,11 @@ from app.core.db.tenant_session import current_tenant_var
 from app.platform.extensions import get_permission_extension, get_processing_port
 from app.processing.export.ogr import ExportError, bbox_where_sql
 from app.processing.export.schemas import ExportFormat
-from app.processing.export.service import export_dataset, validate_where_clause
+from app.processing.export.service import (
+    export_dataset,
+    export_descriptor,
+    validate_where_clause,
+)
 from app.processing.export.where_validator import canonical_where
 from app.processing.ingest.metadata import _qtable
 from app.standards.ogc.errors import (
@@ -136,6 +141,82 @@ async def _count_selected_features(
     return result.scalar_one()
 
 
+def _file_response_content_disposition(filename: str) -> str:
+    """Restate starlette ``FileResponse``'s Content-Disposition rule.
+
+    The GET half of this route hands ``filename=`` to ``FileResponse``, which
+    derives the header itself (``starlette/responses.py``, ``FileResponse
+    .__init__``): a quoted ``filename=`` for names that survive percent-
+    encoding unchanged, and an RFC 5987 ``filename*=`` otherwise. HEAD has no
+    file to hand it, so the rule is restated here.
+
+    Not ``safe_content_disposition()`` from ``export/service.py``: that one
+    always appends ``filename*``, so HEAD would advertise a different header
+    than the GET delivers. ``test_head_export_content_disposition_matches_get``
+    pins the two byte-for-byte, over both branches, so a starlette change
+    fails a test instead of shipping the mismatch.
+    """
+    quoted = quote(filename)
+    if quoted != filename:
+        return f"attachment; filename*=utf-8''{quoted}"
+    return f'attachment; filename="{filename}"'
+
+
+def _head_export_response(dataset_title: str, format_key: str) -> Response:
+    """fix(#1513): the HEAD half of the export route.
+
+    Everything that decides the RESPONSE STATUS — access control, the export
+    capability, bbox/CRS validation, the raster and geometry gates, the
+    feature-count ceiling — has already run in the shared handler above, so
+    HEAD's status matches what GET would answer. Only the conversion is
+    skipped, which is the whole point: a HEAD that ran ogr2ogr and discarded
+    the bytes would hand any anonymous caller a way to spend a worker per
+    request on a public dataset.
+
+    Content-Length is deliberately absent. An export's length is knowable only
+    after the conversion, and RFC 9110 section 9.3.2 lets a HEAD omit header
+    fields "for which a value is determined only while generating the
+    content". Measured against GDAL 3.13.0 ``/vsicurl/``, omitting it costs
+    nothing: HEAD without a length logs "HEAD did not provide file size.
+    Retrying with limited range GET", and the 206's Content-Range supplies the
+    size — same request count as a HEAD that carried Content-Length, and one
+    fewer full-body GET than the 405 this replaces.
+    """
+    filename, media_type = export_descriptor(dataset_title, format_key)
+    response = Response(
+        status_code=status.HTTP_200_OK,
+        media_type=media_type,
+        headers={
+            "content-disposition": _file_response_content_disposition(filename),
+            # Truthful: the GET this describes is a FileResponse, which serves
+            # 206 byte ranges. It is also what lets a size-less HEAD work —
+            # vsicurl learns the length from the first range response.
+            "accept-ranges": "bytes",
+        },
+    )
+    # Starlette gives every non-204 response a Content-Length from its body,
+    # which for an empty body is `content-length: 0` — a WRONG answer about the
+    # export's size rather than no answer, and strictly worse than the 405 it
+    # replaces: a client would read the export as an empty file. Strip it.
+    response.raw_headers = [
+        (key, value) for key, value in response.raw_headers if key != b"content-length"
+    ]
+    return response
+
+
+# fix(#1513): HEAD alongside GET. FastAPI's APIRoute does not add it the way
+# starlette's plain Route does, so this answered `405 allow: GET` — which RFC
+# 9110 forbids for a GET-able resource, and which breaks every client that
+# probes before downloading (GDAL/QGIS `/vsicurl/`, resumable downloaders,
+# link checkers). `_register_standards_head_routes` in app/api/main.py closes
+# the same gap for the standards surface, but by CLONING the route, which
+# would run the full conversion here; this route needs a handler that stops
+# before it, so it is registered explicitly instead.
+#
+# include_in_schema=False for the reason `_clone_api_route` gives: a derived
+# route documents nothing the canonical one does not, and publishing it would
+# churn both SDKs and the CLI.
+@router.head("/{dataset_id}/export", include_in_schema=False)
 @router.get("/{dataset_id}/export", response_class=FileResponse)
 async def export_dataset_endpoint(
     dataset_id: uuid.UUID,
@@ -156,7 +237,7 @@ async def export_dataset_endpoint(
     # per-role matrix check below.
     user: Identity | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
-) -> FileResponse:
+) -> Response:
     """Export a dataset as a downloadable file.
 
     Supports GeoPackage, GeoJSON, Shapefile (zipped), CSV, and GeoParquet
@@ -314,6 +395,13 @@ async def export_dataset_endpoint(
                     "more selective bbox or attribute filter."
                 ),
             )
+
+    # 6c. fix(#1513): HEAD stops here — after every gate that decides the
+    # status, before the conversion that decides the bytes. No audit event
+    # either: nothing was exported, and a `dataset.export` row for a probe
+    # would misreport who downloaded what.
+    if request.method == "HEAD":
+        return _head_export_response(dataset.record.title, format)
 
     # 7. Run export. GeoParquet goes through the pyarrow writer (the Debian GDAL
     # build has no Arrow driver); all other formats use the ogr2ogr path.

--- a/backend/app/processing/export/service.py
+++ b/backend/app/processing/export/service.py
@@ -115,6 +115,38 @@ def validate_where_clause(where: str, column_info: list[dict] | None) -> str:
     return where
 
 
+def export_descriptor(dataset_name: str, format_key: str) -> tuple[str, str]:
+    """The download's ``(filename, media_type)``, derived WITHOUT exporting.
+
+    fix(#1513): the export route now answers HEAD, and a HEAD must advertise
+    the same Content-Type and Content-Disposition its GET would send — while
+    running none of the conversion that produces the file. Both verbs read
+    this one function so they cannot advertise different things; nothing here
+    touches the database or the filesystem.
+
+    Raises:
+        ValueError: If format_key is not a supported export format.
+    """
+    safe_name = re.sub(r"[^\w\-.]", "_", dataset_name)
+
+    if format_key == "parquet":
+        # Function-level import: parquet.py imports this module for
+        # validate_where_clause, and it pulls pyarrow in with it.
+        from app.processing.export.parquet import PARQUET_MEDIA_TYPE
+
+        return f"{safe_name}.parquet", PARQUET_MEDIA_TYPE
+
+    if format_key not in FORMAT_MAP:
+        raise ValueError(f"Unsupported export format: {format_key}")
+
+    fmt = FORMAT_MAP[format_key]
+    # Shapefile is a multi-file format: ogr2ogr writes the export.* sidecars
+    # and the caller ships the zip, so the DOWNLOAD's extension is .zip while
+    # fmt["ext"] stays the driver's .shp.
+    ext = ".zip" if format_key == "shp" else fmt["ext"]
+    return f"{safe_name}{ext}", fmt["media"]
+
+
 async def export_dataset(
     table_name: str,
     dataset_name: str,
@@ -154,7 +186,7 @@ async def export_dataset(
     fmt = FORMAT_MAP[format_key]
     driver = fmt["driver"]
     ext = fmt["ext"]
-    media_type = fmt["media"]
+    filename, media_type = export_descriptor(dataset_name, format_key)
 
     # Verify export staging root before creating per-export temp directories.
     exports_root = ensure_staging_ready(
@@ -166,9 +198,6 @@ async def export_dataset(
     temp_dir_path = exports_root / export_id
     temp_dir_path.mkdir(parents=False, exist_ok=False)
     temp_dir = str(temp_dir_path)
-
-    # Sanitize dataset name for filename
-    safe_name = re.sub(r"[^\w\-.]", "_", dataset_name)
 
     # fix(#435): own the temp directory until we hand a path back to the caller.
     # ogr2ogr failure, an oversized ZIP, or a cancelled request used to leave the
@@ -193,14 +222,12 @@ async def export_dataset(
             # (and job heartbeats) for the duration. fix(#435 codex r4): drained on
             # cancellation so the `except BaseException` rmtree below cannot delete
             # temp_dir while the zip thread is still writing into it.
-            zip_filename = f"{safe_name}.zip"
-            zip_path = os.path.join(temp_dir, zip_filename)
+            zip_path = os.path.join(temp_dir, filename)
             await run_in_thread_draining(_zip_export_files, temp_dir, zip_path)
 
-            return zip_path, zip_filename, media_type
+            return zip_path, filename, media_type
 
         # Single-file formats
-        filename = f"{safe_name}{ext}"
         output_path = os.path.join(temp_dir, filename)
         await run_ogr2ogr_export(
             table_name,

--- a/backend/tests/test_alert_rules.py
+++ b/backend/tests/test_alert_rules.py
@@ -29,6 +29,7 @@ structure, and runs wherever the backend suite runs.
 
 from __future__ import annotations
 
+import collections
 import pathlib
 import re
 from typing import Any
@@ -143,22 +144,46 @@ def _bulk_selector() -> str:
     assert len(excluded) == 1, (
         f"expected exactly one handler!~ in the interactive rule, got {excluded}"
     )
-    assert len(covered) == 3, (
-        "expected the bulk selector three times (interactive union arm, bulk "
-        f"_sum, bulk _count), got {len(covered)}"
+
+    # fix(#1513): there are now TWO distinct handler selectors, each written
+    # exactly three times, and the count is partitioned by value rather than
+    # relaxed. The bulk set appears in the interactive union arm and both halves
+    # of the bulk ratio; the export-HEAD carve-out appears in its own
+    # interactive union arm and in the `unless` on each half of that ratio.
+    #
+    # A second selector is forced, not stylistic: Prometheus ANDs the matchers
+    # inside one selector and RE2 has no lookahead, so "the bulk paths except
+    # HEAD on export" cannot be spelled as a single handler matcher. Holding
+    # each spelling to three copies keeps the original invariant — every copy
+    # of a selector is identical — which a `>= 3` would give up entirely.
+    spellings = collections.Counter(covered)
+    assert sorted(spellings.values()) == [3, 3], (
+        "expected exactly two handler selectors written three times each (the "
+        "bulk set, and the export-HEAD carve-out), got "
+        f"{ {value: count for value, count in spellings.items()} }"
     )
-    selector = _sole(covered, "the bulk handler selector")
 
     tile_prefix = "/tiles/.*|"
     assert excluded[0].startswith(tile_prefix), (
         "the interactive rule's exclusion no longer starts with the tile "
         f"selector from #658: {excluded[0]!r}"
     )
-    assert excluded[0][len(tile_prefix) :] == selector, (
+    selector = excluded[0][len(tile_prefix) :]
+    assert spellings.get(selector) == 3, (
         "the interactive rule excludes a different set of paths than the bulk "
         "rule covers, so something is double-alerted or unmonitored.\n"
-        f"  interactive excludes: {excluded[0][len(tile_prefix) :]!r}\n"
-        f"  bulk rule covers:     {selector!r}"
+        f"  interactive excludes: {selector!r}\n"
+        f"  selectors found:      { {v: c for v, c in spellings.items()} }"
+    )
+
+    # The other spelling must be one of the alternatives the bulk selector
+    # covers. A carve-out for a path the bulk rule never claimed would move
+    # nothing and quietly leave the handler in both rules or neither.
+    carve_outs = [value for value in spellings if value != selector]
+    assert len(carve_outs) == 1, f"expected one carve-out selector, got {carve_outs}"
+    assert carve_outs[0] in selector.split("|"), (
+        "the carved-out handler is not one of the paths the bulk selector "
+        f"covers: {carve_outs[0]!r} not in {selector.split('|')}"
     )
     assert selector.count("|") >= 4, (
         f"bulk selector has fewer alternatives than expected: {selector!r}"

--- a/backend/tests/test_export_antimeridian.py
+++ b/backend/tests/test_export_antimeridian.py
@@ -324,12 +324,23 @@ class TestAntimeridianExportEndToEnd:
         )
         features_names = sorted(r["properties"]["name"] for r in rows)
 
+        # fix(#1513): planning (introspection + filter validation + the bounded
+        # count) is a separate phase from writing, so the route can decide a
+        # HEAD's status without producing bytes. Same two steps here.
+        from app.processing.export.parquet import plan_parquet_export
+
+        parquet_plan = await plan_parquet_export(
+            test_db_session,
+            antimeridian_table,
+            schema="data",
+            bbox=CROSSING_BBOX,
+        )
         parquet_path, _fn, _mt = await export_parquet(
             test_db_session,
             antimeridian_table,
             "AM Dataset",
             schema="data",
-            bbox=CROSSING_BBOX,
+            plan=parquet_plan,
         )
         try:
             import pyarrow.parquet as pq

--- a/backend/tests/test_export_head_1513.py
+++ b/backend/tests/test_export_head_1513.py
@@ -33,6 +33,7 @@ Requirements:
 import os
 import shutil
 import tempfile
+import uuid
 
 import pytest
 from httpx import AsyncClient
@@ -257,10 +258,17 @@ async def test_head_export_does_not_run_the_conversion(
 
 async def test_head_export_does_not_run_the_parquet_conversion(
     client: AsyncClient,
-    test_db_session,
+    real_table_dataset,
     monkeypatch,
 ):
-    """Same guard for the second, non-ogr2ogr conversion path (pyarrow)."""
+    """Same guard for the second, non-ogr2ogr conversion path (pyarrow).
+
+    Needs the real-table dataset: since fix(#1513 codex P2) a parquet HEAD runs
+    ``plan_parquet_export``, which introspects the live table and counts the
+    selection. That is the point — those are the queries that decide the status
+    — but it means a metadata-only dataset with no backing table now fails here
+    for both verbs alike, so it cannot be used to prove the writer stayed idle.
+    """
     calls: list[str] = []
 
     async def _fake_parquet(*args, **kwargs):
@@ -268,13 +276,196 @@ async def test_head_export_does_not_run_the_parquet_conversion(
         raise AssertionError("parquet writer must not run for a HEAD")
 
     monkeypatch.setattr("app.processing.export.parquet.export_parquet", _fake_parquet)
-    ds = await _public_dataset(test_db_session, "HeadExportParquet")
 
-    head = await client.head(f"/datasets/{ds.id}/export?format=parquet")
+    head = await client.head(f"/datasets/{real_table_dataset.id}/export?format=parquet")
 
     assert head.status_code == 200
     assert calls == [], "HEAD ran the GeoParquet writer"
     assert "content-length" not in head.headers
+
+
+@pytest.fixture
+async def real_table_dataset(test_db_session):
+    """A dataset backed by a REAL 3-row table.
+
+    The filter and cap checks on the parquet path introspect the live table and
+    run a bounded COUNT against it, so they cannot be exercised against the
+    metadata-only datasets the other tests use.
+    """
+    from sqlalchemy import text
+
+    table_name = f"head1513_{uuid.uuid4().hex[:12]}"
+    await test_db_session.execute(
+        text(
+            f"CREATE TABLE data.{table_name} "
+            "(gid serial PRIMARY KEY, pop integer, "
+            "geom geometry(Point, 4326), geom_4326 geometry(Point, 4326))"
+        )
+    )
+    await test_db_session.execute(
+        text(
+            f"INSERT INTO data.{table_name} (pop, geom, geom_4326) VALUES "
+            "(10, ST_SetSRID(ST_MakePoint(0, 0), 4326), "
+            " ST_SetSRID(ST_MakePoint(0, 0), 4326)), "
+            "(20, ST_SetSRID(ST_MakePoint(1, 1), 4326), "
+            " ST_SetSRID(ST_MakePoint(1, 1), 4326)), "
+            "(30, ST_SetSRID(ST_MakePoint(2, 2), 4326), "
+            " ST_SetSRID(ST_MakePoint(2, 2), 4326))"
+        )
+    )
+    await test_db_session.commit()
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="HeadExportRealTable",
+        table_name=table_name,
+        visibility="public",
+        record_status="published",
+        geometry_type="Point",
+        feature_count=3,
+        column_info=[
+            {"name": "gid", "type": "integer"},
+            {"name": "pop", "type": "integer"},
+        ],
+    )
+    yield ds
+    await test_db_session.execute(text(f"DROP TABLE IF EXISTS data.{table_name}"))
+    await test_db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# fix(#1513, codex P2 on #1522): status parity per FAILURE CLASS.
+#
+# The original HEAD branch returned before the filter validation that lives
+# inside export_dataset()/export_parquet(), so a bad filter got 200 from HEAD
+# and 400 from the GET that followed. Measured before the fix, against a real
+# server: HEAD=200 GET=400 for an unknown column on both geojson and parquet,
+# and for a malformed clause. A probing client accepting that HEAD and then
+# failing its range GET is worse than the 405, which at least did not lie.
+#
+# These do NOT mock the export service: the real path is what produces the
+# GET's error, and for a bad filter it raises before ogr2ogr or pyarrow is
+# ever reached, so nothing here runs a conversion.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("fmt", "where", "label"),
+    [
+        ("geojson", "nosuchcol > 1", "unknown column, ogr2ogr path"),
+        ("geojson", "pop >", "malformed clause, ogr2ogr path"),
+        ("parquet", "nosuchcol > 1", "unknown column, pyarrow path"),
+        ("parquet", "pop >", "malformed clause, pyarrow path"),
+    ],
+)
+async def test_head_matches_get_on_bad_where(
+    fmt,
+    where,
+    label,
+    client: AsyncClient,
+    real_table_dataset,
+):
+    """400 parity: a filter GET rejects must be rejected by HEAD too."""
+    url = f"/datasets/{real_table_dataset.id}/export?format={fmt}&where={where}"
+
+    head = await client.head(url)
+    get = await client.get(url)
+
+    assert get.status_code == 400, (
+        f"precondition for {label!r}: GET should reject this filter, "
+        f"got {get.status_code}"
+    )
+    assert head.status_code == get.status_code, (
+        f"HEAD/GET status disagree for {label!r}: HEAD {head.status_code} vs "
+        f"GET {get.status_code}. A client that trusts the HEAD will fail its "
+        f"range GET."
+    )
+
+
+async def test_head_matches_get_on_feature_count_ceiling(
+    client: AsyncClient,
+    test_db_session,
+):
+    """413 parity on the ogr2ogr path's unfiltered-export ceiling."""
+    ds = await _public_dataset(
+        test_db_session, "HeadExportOversized", feature_count=5_000_001
+    )
+
+    head = await client.head(f"/datasets/{ds.id}/export?format=geojson")
+    get = await client.get(f"/datasets/{ds.id}/export?format=geojson")
+
+    assert get.status_code == 413, (
+        f"precondition: GET should 413, got {get.status_code}"
+    )
+    assert head.status_code == get.status_code, (
+        f"HEAD/GET disagree on the feature-count ceiling: "
+        f"{head.status_code} vs {get.status_code}"
+    )
+
+
+async def test_head_matches_get_on_parquet_bounded_count(
+    client: AsyncClient,
+    real_table_dataset,
+    monkeypatch,
+):
+    """413 parity on the parquet path's own bounded count.
+
+    Parquet is exempt from the router's feature_count ceiling and runs its own
+    COUNT against the live table, so this ceiling is reachable only here. The
+    cap is lowered to 1 against a real 3-row table rather than inserting 5M
+    rows.
+    """
+    from app.processing.export import parquet as parquet_mod
+
+    monkeypatch.setattr(parquet_mod, "_MAX_EXPORT_FEATURES", 1)
+
+    url = f"/datasets/{real_table_dataset.id}/export?format=parquet"
+    head = await client.head(url)
+    get = await client.get(url)
+
+    assert get.status_code == 413, (
+        f"precondition: GET should 413, got {get.status_code}"
+    )
+    assert head.status_code == get.status_code, (
+        f"HEAD/GET disagree on the parquet bounded count: "
+        f"{head.status_code} vs {get.status_code}"
+    )
+
+
+async def test_head_cannot_promise_conversion_failure_status(
+    client: AsyncClient,
+    test_db_session,
+    monkeypatch,
+):
+    """The documented LIMIT, pinned so it cannot drift silently.
+
+    A conversion that fails (ogr2ogr non-zero exit -> 500, staging gone -> 503)
+    is knowable only by running the conversion, which HEAD must not do. HEAD
+    answers 200 in that case, and the docstring on ``_head_export_response``
+    says so. This test exists so that if someone later makes HEAD detect it,
+    or makes it worse, the documented contract is what fails.
+    """
+    from app.processing.export.ogr import ExportError
+
+    async def _boom(*args, **kwargs):
+        raise ExportError("ogr2ogr exploded")
+
+    monkeypatch.setattr("app.processing.export.router.export_dataset", _boom)
+    ds = await _public_dataset(test_db_session, "HeadExportConversionFailure")
+
+    head = await client.head(f"/datasets/{ds.id}/export?format=geojson")
+    get = await client.get(f"/datasets/{ds.id}/export?format=geojson")
+
+    assert get.status_code == 500, (
+        f"precondition: GET should 500, got {get.status_code}"
+    )
+    assert head.status_code == 200, (
+        "Documented limit: HEAD reports the request as servable because it "
+        "does not run the conversion that would fail. If this changed, update "
+        "the _head_export_response docstring in the same commit."
+    )
 
 
 async def test_head_export_denial_matches_get(

--- a/backend/tests/test_export_head_1513.py
+++ b/backend/tests/test_export_head_1513.py
@@ -1,0 +1,325 @@
+"""fix(#1513): HEAD on /datasets/{id}/export must answer, not 405.
+
+FastAPI's ``APIRoute`` does not add HEAD alongside GET the way starlette's
+plain ``Route`` does, so a bare ``@router.get`` answers ``405 allow: GET``.
+``_register_standards_head_routes`` (backend/app/api/main.py, fix #1470/#1478)
+closes that gap for the standards surface only; ``/datasets/{id}/export`` is a
+native download route and fell outside it.
+
+Why it matters concretely, measured with GDAL 3.13.0 against a server that
+streams the plain GET without a Content-Length (what the production edge does):
+
+  * HEAD -> 405: ``HEAD not allowed. Retrying with GET``; the fallback GET
+    learns no size either, so vsicurl decides the object is empty
+    (``Request at offset 0, after end of file``), probes the parent path as a
+    directory, and fails to open the layer at all.
+  * HEAD -> 200 with no Content-Length: ``HEAD did not provide file size.
+    Retrying with limited range GET``; the 206 carries Content-Range, vsicurl
+    learns the size, and the layer opens — with ZERO full-body GETs.
+
+The design decision these tests pin: HEAD answers with the headers a GET would
+send and deliberately WITHOUT Content-Length, because the length of an export
+is only known after a conversion that HEAD must not run (RFC 9110 section
+9.3.2 permits omitting header fields whose value is determined only while
+generating the content). ``content-length: 0`` would be worse than the 405 —
+it is a wrong answer rather than no answer — so its absence is asserted.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Run with: set -a && source ../.env.test && set +a
+              uv run pytest tests/test_export_head_1513.py -v
+"""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+from httpx import AsyncClient
+
+from app.processing.export.ogr import FORMAT_MAP
+
+from tests.factories import create_dataset, get_user_id
+
+
+@pytest.fixture
+def mock_export_service(monkeypatch):
+    """Stand in for ogr2ogr, and count how often the conversion actually runs.
+
+    The counter is the point: a HEAD that runs a full export and throws the
+    bytes away would pass a status-code assertion while handing anyone an
+    unauthenticated way to spend a worker. ``calls`` makes that visible.
+    """
+    temp_dir = tempfile.mkdtemp(prefix="test_export_head_1513_")
+    calls: list[str] = []
+
+    async def _fake_export(
+        table_name,
+        dataset_name,
+        format_key,
+        *,
+        schema,
+        target_srs=None,
+        bbox=None,
+        where=None,
+        column_info=None,
+    ):
+        calls.append(format_key)
+        # Derive names through the same helper the route uses for HEAD, so a
+        # header comparison between the two verbs tests the ROUTE's wiring
+        # rather than this fixture's guess at a filename.
+        from app.processing.export.service import export_descriptor
+
+        filename, media = export_descriptor(dataset_name, format_key)
+        file_path = os.path.join(temp_dir, filename)
+        with open(file_path, "wb") as f:
+            f.write(b"mock export data")
+        return file_path, filename, media
+
+    monkeypatch.setattr("app.processing.export.router.export_dataset", _fake_export)
+    _fake_export.calls = calls  # type: ignore[attr-defined]
+
+    yield _fake_export
+
+    if os.path.isdir(temp_dir):
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+async def _public_dataset(test_db_session, name: str, **kwargs):
+    admin_id = await get_user_id(test_db_session, "admin")
+    return await create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name=name,
+        visibility=kwargs.pop("visibility", "public"),
+        record_status=kwargs.pop("record_status", "published"),
+        **kwargs,
+    )
+
+
+async def test_head_export_is_not_405(
+    client: AsyncClient,
+    test_db_session,
+    mock_export_service,
+):
+    """The reported bug, reduced to one assertion."""
+    ds = await _public_dataset(test_db_session, "HeadExportNot405")
+
+    resp = await client.head(f"/datasets/{ds.id}/export?format=geojson")
+
+    assert resp.status_code != 405, (
+        f"HEAD on the export route answered 405 (allow: "
+        f"{resp.headers.get('allow')!r}); GDAL /vsicurl/ and any client that "
+        f"probes before downloading gets refused."
+    )
+    assert resp.status_code == 200, (
+        f"Expected HEAD to agree with GET's 200, got {resp.status_code}"
+    )
+
+
+@pytest.mark.parametrize("fmt", ["gpkg", "geojson", "csv", "shp"])
+async def test_head_export_agrees_with_get(
+    fmt,
+    client: AsyncClient,
+    test_db_session,
+    mock_export_service,
+):
+    """HEAD and GET must agree on status and content-type, for every format.
+
+    Includes ``shp``, whose download is a zip built after the conversion — the
+    format where a HEAD is most tempted to guess wrong about the media type.
+    """
+    ds = await _public_dataset(test_db_session, f"HeadExportAgrees_{fmt}")
+
+    head = await client.head(f"/datasets/{ds.id}/export?format={fmt}")
+    get = await client.get(f"/datasets/{ds.id}/export?format={fmt}")
+
+    assert head.status_code == get.status_code, (
+        f"HEAD/GET status disagree for {fmt!r}: {head.status_code} vs {get.status_code}"
+    )
+    assert head.headers.get("content-type") == get.headers.get("content-type"), (
+        f"HEAD/GET content-type disagree for {fmt!r}: "
+        f"{head.headers.get('content-type')!r} vs {get.headers.get('content-type')!r}"
+    )
+    # startswith, not equality: starlette appends "; charset=utf-8" to any
+    # text/* media type, on both verbs (csv is the one format that hits it).
+    assert head.headers.get("content-type", "").startswith(FORMAT_MAP[fmt]["media"]), (
+        f"HEAD advertised {head.headers.get('content-type')!r} for {fmt!r}, "
+        f"expected the format's {FORMAT_MAP[fmt]['media']!r}"
+    )
+    assert head.content == b"", "A HEAD response must carry no body"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "HeadExportDisposition",
+        # Non-ASCII title: starlette's FileResponse switches to the RFC 5987
+        # filename* form here, so this catches a HEAD that only handles the
+        # easy branch.
+        "Zürich Höhenmodell",
+    ],
+)
+async def test_head_export_content_disposition_matches_get(
+    name,
+    client: AsyncClient,
+    test_db_session,
+    mock_export_service,
+):
+    """Byte-for-byte parity on content-disposition.
+
+    GET's value is derived by starlette's ``FileResponse``; HEAD's is derived
+    by the route. This is the anti-drift guard for that duplication — if
+    starlette changes its rule, this fails rather than shipping a HEAD that
+    advertises a different filename than the GET delivers.
+    """
+    ds = await _public_dataset(test_db_session, name)
+
+    head = await client.head(f"/datasets/{ds.id}/export?format=geojson")
+    get = await client.get(f"/datasets/{ds.id}/export?format=geojson")
+
+    assert head.headers.get("content-disposition") == get.headers.get(
+        "content-disposition"
+    ), (
+        f"HEAD/GET content-disposition disagree for {name!r}: "
+        f"{head.headers.get('content-disposition')!r} vs "
+        f"{get.headers.get('content-disposition')!r}"
+    )
+
+
+async def test_head_export_omits_content_length_and_advertises_ranges(
+    client: AsyncClient,
+    test_db_session,
+    mock_export_service,
+):
+    """The two headers that decide whether /vsicurl/ can open the file.
+
+    ``accept-ranges: bytes`` must be truthful — the route's GET is a
+    ``FileResponse``, which serves 206 byte ranges — and ``content-length``
+    must be ABSENT rather than 0.
+    """
+    ds = await _public_dataset(test_db_session, "HeadExportHeaders")
+
+    head = await client.head(f"/datasets/{ds.id}/export?format=geojson")
+    get = await client.get(f"/datasets/{ds.id}/export?format=geojson")
+
+    assert head.status_code == 200
+    assert head.headers.get("accept-ranges") == "bytes", (
+        "HEAD must advertise range support; vsicurl falls back to a limited "
+        "range GET to learn the size when Content-Length is missing."
+    )
+    assert get.headers.get("accept-ranges") == "bytes", (
+        "The advertisement must be true of the GET it describes."
+    )
+    assert "content-length" not in head.headers, (
+        f"HEAD sent content-length={head.headers.get('content-length')!r}. The "
+        f"size is unknown before conversion, and a wrong length (0) makes a "
+        f"client treat the export as an empty file."
+    )
+
+
+async def test_head_export_does_not_run_the_conversion(
+    client: AsyncClient,
+    test_db_session,
+    mock_export_service,
+):
+    """A HEAD must not spend an ogr2ogr run to produce bytes it discards."""
+    ds = await _public_dataset(test_db_session, "HeadExportNoConversion")
+
+    head = await client.head(f"/datasets/{ds.id}/export?format=geojson")
+
+    assert head.status_code == 200
+    assert mock_export_service.calls == [], (
+        f"HEAD ran the export conversion {len(mock_export_service.calls)} "
+        f"time(s). Every HEAD would then cost a full table conversion — an "
+        f"unauthenticated amplification foot-gun on a public dataset."
+    )
+
+    get = await client.get(f"/datasets/{ds.id}/export?format=geojson")
+
+    assert get.status_code == 200
+    assert mock_export_service.calls == ["geojson"], (
+        "GET must still run exactly one conversion"
+    )
+
+
+async def test_head_export_does_not_run_the_parquet_conversion(
+    client: AsyncClient,
+    test_db_session,
+    monkeypatch,
+):
+    """Same guard for the second, non-ogr2ogr conversion path (pyarrow)."""
+    calls: list[str] = []
+
+    async def _fake_parquet(*args, **kwargs):
+        calls.append("parquet")
+        raise AssertionError("parquet writer must not run for a HEAD")
+
+    monkeypatch.setattr("app.processing.export.parquet.export_parquet", _fake_parquet)
+    ds = await _public_dataset(test_db_session, "HeadExportParquet")
+
+    head = await client.head(f"/datasets/{ds.id}/export?format=parquet")
+
+    assert head.status_code == 200
+    assert calls == [], "HEAD ran the GeoParquet writer"
+    assert "content-length" not in head.headers
+
+
+async def test_head_export_denial_matches_get(
+    client: AsyncClient,
+    test_db_session,
+):
+    """HEAD must not become a side channel that GET is not.
+
+    An anonymous caller gets 404 for a private dataset on GET; HEAD has to
+    return the same, or HEAD becomes an existence oracle for hidden datasets.
+    """
+    ds = await _public_dataset(
+        test_db_session, "HeadExportPrivateDenied", visibility="private"
+    )
+
+    head = await client.head(f"/datasets/{ds.id}/export?format=geojson")
+    get = await client.get(f"/datasets/{ds.id}/export?format=geojson")
+
+    assert head.status_code == get.status_code, (
+        f"HEAD/GET disagree on a denial: {head.status_code} vs {get.status_code}"
+    )
+    assert head.status_code in {401, 403, 404}
+
+
+async def test_head_export_rejects_raster_like_get(
+    client: AsyncClient,
+    test_db_session,
+    mock_export_service,
+):
+    """Validation parity: a pre-conversion 400 must reach HEAD too."""
+    ds = await _public_dataset(
+        test_db_session,
+        "HeadExportRaster",
+        record_type="raster_dataset",
+        geometry_type=None,
+    )
+
+    head = await client.head(f"/datasets/{ds.id}/export?format=geojson")
+    get = await client.get(f"/datasets/{ds.id}/export?format=geojson")
+
+    assert head.status_code == get.status_code == 400, (
+        f"HEAD {head.status_code} vs GET {get.status_code}, expected both 400"
+    )
+
+
+async def test_head_export_stays_out_of_the_openapi_schema(client: AsyncClient):
+    """The HEAD route is derived, not new API surface.
+
+    ``_clone_api_route`` hides the standards HEAD routes for the same reason:
+    "A derived route documents nothing the canonical one does not, and
+    publishing it would churn every generated SDK." Publishing this one would
+    add a ``headExportDataset`` to both SDKs and the CLI for no gain.
+    """
+    spec = (await client.get("/openapi.json")).json()
+    methods = spec["paths"]["/datasets/{dataset_id}/export"]
+
+    assert set(methods) == {"get"}, (
+        f"Export path publishes {sorted(methods)}; the HEAD route must be "
+        f"registered with include_in_schema=False."
+    )

--- a/backend/tests/test_export_head_1513.py
+++ b/backend/tests/test_export_head_1513.py
@@ -151,27 +151,34 @@ async def test_head_export_agrees_with_get(
 
 
 @pytest.mark.parametrize(
-    "name",
+    ("name", "expected_prefix"),
     [
-        "HeadExportDisposition",
-        # Non-ASCII title: starlette's FileResponse switches to the RFC 5987
-        # filename* form here, so this catches a HEAD that only handles the
-        # easy branch.
-        "Zürich Höhenmodell",
+        # ASCII-safe title: quote() leaves it unchanged, so starlette emits the
+        # plain quoted form.
+        ("HeadExportDisposition", 'attachment; filename="'),
+        # Non-ASCII title survives the [^\w\-.] sanitizer (\w is unicode-aware),
+        # so quote() changes it and starlette switches to RFC 5987.
+        ("Zürich Höhenmodell", "attachment; filename*=utf-8''"),
     ],
 )
 async def test_head_export_content_disposition_matches_get(
     name,
+    expected_prefix,
     client: AsyncClient,
     test_db_session,
     mock_export_service,
 ):
-    """Byte-for-byte parity on content-disposition.
+    """Byte-for-byte parity on content-disposition, over BOTH branches.
 
     GET's value is derived by starlette's ``FileResponse``; HEAD's is derived
     by the route. This is the anti-drift guard for that duplication — if
     starlette changes its rule, this fails rather than shipping a HEAD that
     advertises a different filename than the GET delivers.
+
+    ``expected_prefix`` is what stops the parity check from going vacuous. The
+    two cases are only meaningful if they land on DIFFERENT branches of that
+    rule, and nothing in the parity assertion itself would notice if a change
+    to the filename sanitizer collapsed both onto the quoted form.
     """
     ds = await _public_dataset(test_db_session, name)
 
@@ -184,6 +191,11 @@ async def test_head_export_content_disposition_matches_get(
         f"HEAD/GET content-disposition disagree for {name!r}: "
         f"{head.headers.get('content-disposition')!r} vs "
         f"{get.headers.get('content-disposition')!r}"
+    )
+    assert head.headers.get("content-disposition", "").startswith(expected_prefix), (
+        f"{name!r} was meant to exercise the {expected_prefix!r} branch but "
+        f"produced {head.headers.get('content-disposition')!r}; the two "
+        f"parameters are no longer covering both branches."
     )
 
 

--- a/backend/tests/test_ingest_parquet.py
+++ b/backend/tests/test_ingest_parquet.py
@@ -485,8 +485,12 @@ class TestParquetRoundTrip:
         import shutil
         from pathlib import Path
 
+        # fix(#1513): plan then write — the two phases the export route uses.
+        from app.processing.export.parquet import plan_parquet_export
+
+        plan = await plan_parquet_export(test_db_session, seeded_table, schema="data")
         file_path, _, _ = await export_parquet(
-            test_db_session, seeded_table, "roundtrip", schema="data"
+            test_db_session, seeded_table, "roundtrip", schema="data", plan=plan
         )
         try:
             info = await run_ogrinfo(file_path)

--- a/infra/monitoring/alerts.test.yml
+++ b/infra/monitoring/alerts.test.yml
@@ -491,6 +491,48 @@ tests:
         exp_alerts: []
 
   # --------------------------------------------------------------------------
+  # 4e. ...but the export HEAD is not that kind of HEAD. fix(#1513) gave the
+  #     export route an EXPLICIT HEAD handler that stops before the ogr2ogr
+  #     conversion, so it answers from metadata alone. Unlike 4d's cloned
+  #     standards route it does not run the read it describes, which is exactly
+  #     the condition the interactive rule's comment names for moving a handler
+  #     back. Same traffic judged both ways: 6s per request is a screaming
+  #     interactive regression and an unremarkable bulk download.
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: "HEAD on the export route is interactive, not a bulk read"
+    input_series:
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/export", method="HEAD", le="5.0"}'
+        values: "0+0x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/export", method="HEAD", le="10.0"}'
+        values: "0+20x30"
+      - series: 'http_request_duration_seconds_bucket{handler="/datasets/{dataset_id}/export", method="HEAD", le="+Inf"}'
+        values: "0+20x30"
+      # 20 requests/min averaging 6s: over the bulk rule's 5s bound, so if this
+      # handler were still on the bulk side that rule would fire. Both
+      # assertions below therefore flip if the partition regresses.
+      - series: 'http_request_duration_seconds_sum{handler="/datasets/{dataset_id}/export", method="HEAD"}'
+        values: "0+120x30"
+      - series: 'http_request_duration_seconds_count{handler="/datasets/{dataset_id}/export", method="HEAD"}'
+        values: "0+20x30"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: GeoLensApiInteractiveLatencyP95
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "API p95 latency (interactive) at or above 1s"
+              description:
+                "95th-percentile latency of interactive API requests has been at
+                or above 1s for 10 minutes (9.75s). Tile and bulk-read
+                endpoints are excluded; see GeoLensApiTileLatencyMean and
+                GeoLensApiBulkLatencyMean."
+      - eval_time: 25m
+        alertname: GeoLensApiBulkLatencyMean
+        exp_alerts: []
+
+  # --------------------------------------------------------------------------
   # 5. Tiles keep their own rule, unchanged by the split.
   # --------------------------------------------------------------------------
   - interval: 1m

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -73,10 +73,24 @@ groups:
         # HEAD counts as a read. _register_standards_head_routes() in
         # backend/app/api/main.py clones the GET route with the SAME endpoint,
         # so a HEAD on /collections/{id}/items runs the identical query and
-        # serialization and only drops the body on the wire. If a future
-        # explicit HEAD handler answers cheaply without doing the read (#1513
-        # adds a HEAD verb to the export route), it stops being a bulk read and
-        # belongs back here.
+        # serialization and only drops the body on the wire.
+        #
+        # fix(#1513): the export HEAD is the exception that condition
+        # anticipated, and the third union arm below is where it landed. It is
+        # NOT free — it runs every check that decides the status, so a parquet
+        # HEAD costs a live-column introspection plus a bounded COUNT, roughly
+        # half a second on a 5M-row table. It is judged here anyway, because
+        # the bulk bound exists to tolerate PAYLOAD TRANSFER and a HEAD never
+        # transfers a payload. A HEAD spending over a second in query work is a
+        # real regression signal, not the caller asking for 10MB; leaving it on
+        # the bulk side would let a 5s bound tolerate a second of pure query
+        # time on a request that returns no bytes.
+        #
+        # `method="HEAD"` there is an exact `=`, deliberately, NOT `=~`.
+        # _read_method_selector() in backend/tests/test_alert_rules.py collects
+        # only `=~` and `!~`, so the exact form leaves its counts untouched and
+        # the GET|HEAD partition it pins keeps meaning what it meant. Tidying
+        # this to `=~"HEAD"` would break that helper for no gain.
         #
         # `>= 1` not `> 1`: before #1517 this was a workaround (the histogram
         # clipped at 1.0, so `> 1` could never fire). It is now a real p95 —
@@ -98,6 +112,11 @@ groups:
             rate(http_request_duration_seconds_bucket{
               handler=~"/datasets/[^/]+/features(\\.geojson)?/?|/datasets/[^/]+/export|/datasets/[^/]+/download/cog|/collections/[^/]+/items/?|/stac/collections/[^/]+/items",
               method!~"GET|HEAD"
+            }[5m])
+            or
+            rate(http_request_duration_seconds_bucket{
+              handler=~"/datasets/[^/]+/export",
+              method="HEAD"
             }[5m])
           )) >= 1
         for: 10m
@@ -143,18 +162,31 @@ groups:
         # complement of the same alternation appears in the interactive rule
         # above, so POST /datasets/{dataset_id}/features stays on the 1s
         # interactive bound rather than being pooled here against 5s. See that
-        # rule for why HEAD counts as a read.
+        # rule for why HEAD counts as a read, and why the export HEAD is the
+        # one exception — carved out of both halves of the ratio below with
+        # `unless`, so it is judged by the interactive rule instead. `unless`
+        # rather than a subtraction for the same reason the union above uses
+        # `or`: an empty right-hand side leaves the left untouched instead of
+        # emptying the whole expression.
         #
         # With no bulk traffic the ratio is 0/0 = NaN, which never compares true.
         expr: |
           sum by (handler) (rate(http_request_duration_seconds_sum{
             handler=~"/datasets/[^/]+/features(\\.geojson)?/?|/datasets/[^/]+/export|/datasets/[^/]+/download/cog|/collections/[^/]+/items/?|/stac/collections/[^/]+/items",
             method=~"GET|HEAD"
-          }[10m]))
+          }[10m])
+            unless rate(http_request_duration_seconds_sum{
+              handler=~"/datasets/[^/]+/export",
+              method="HEAD"
+            }[10m]))
             / sum by (handler) (rate(http_request_duration_seconds_count{
               handler=~"/datasets/[^/]+/features(\\.geojson)?/?|/datasets/[^/]+/export|/datasets/[^/]+/download/cog|/collections/[^/]+/items/?|/stac/collections/[^/]+/items",
               method=~"GET|HEAD"
-            }[10m])) > 5
+            }[10m])
+              unless rate(http_request_duration_seconds_count{
+                handler=~"/datasets/[^/]+/export",
+                method="HEAD"
+              }[10m])) > 5
         for: 10m
         labels:
           severity: warning


### PR DESCRIPTION
Closes #1513

`HEAD /api/datasets/{id}/export` answered `405 allow: GET`. FastAPI's `APIRoute` does not add HEAD alongside GET the way starlette's plain `Route` does, and `_register_standards_head_routes` (#1470/#1478) is scoped to the standards surface, so this native download route was never covered.

## The design decision

The issue leaves open what HEAD should return when `Content-Length` is only knowable after a live conversion.

HEAD runs every check that can decide the status without producing bytes, and none of the work that produces them. It shares the GET handler and returns just before the conversion, after access control, the export capability check, bbox/CRS validation, the raster and geometry gates, the feature-count ceiling, filter validation, and for parquet the live-column check and the bounded count. It skips the conversion, and it skips the audit event: nothing was exported, and a `dataset.export` row for a probe would misreport who downloaded what.

Two statuses HEAD cannot promise, documented rather than claimed away: 500 (the conversion fails) and 503 (staging unavailable). Both are knowable only by attempting the export, so HEAD answers 200 for a request whose GET would fail that way. `test_head_cannot_promise_conversion_failure_status` pins that limit so it cannot drift.

The filter checks reached that position in `de9197171`, after codex flagged (P2) that they still lived inside `export_dataset()`/`export_parquet()`, below the HEAD return. Measured before that commit: `HEAD=200 GET=400` for an unknown column and for a malformed clause on both the ogr2ogr and parquet paths, and `HEAD=200 GET=413` for a parquet selection over the cap. A probing client accepted the HEAD and then failed its range GET, which is worse than the 405 this route replaces, because the 405 did not lie. For parquet the whole pre-conversion phase is now split out as `plan_parquet_export` (live introspection, filter validation, bounded count) and `export_parquet` takes the resulting plan, so a GET pays for it exactly once and the verbs cannot diverge.

It sends no `Content-Length`. RFC 9110 §9.3.2 permits a HEAD to omit header fields "for which a value is determined only while generating the content", which is exactly this case. Starlette attaches `content-length: 0` to any empty response, so the route strips it: a wrong size is worse than no size, because a client reads zero as an empty file. Running ogr2ogr just to learn the real length would hand any anonymous caller a way to spend a worker per request on a public dataset.

It does send `Accept-Ranges: bytes`, which is true of the GET it describes: that GET is a `FileResponse`, and it serves 206 ranges. The advertisement is also what makes a size-less HEAD work, since GDAL falls back to a limited-range GET and reads the length out of `Content-Range`.

`export_descriptor()` gives both verbs one naming rule, so HEAD cannot advertise a filename or media type the GET does not deliver.

## One part of the issue's root cause does not hold up

The issue says vsicurl "never falls back to a plain GET" against a 405. GDAL 3.13.0 does fall back. With `CPL_DEBUG=ON` the unfixed endpoint logs:

```
VSICURL: HEAD not allowed. Retrying with GET
```

And against a plain local uvicorn, the unfixed route opens fine:

```
$ ogrinfo -so "/vsicurl/http://localhost:8001/api/datasets/d062c4e5-.../export?format=geojson"
using driver `GeoJSON' successful.        # 5s, 10 range requests, unfixed code
```

So the 405 alone does not hang anything. The failure needs a second ingredient the issue did not identify: the fallback GET has to arrive **without a Content-Length**, which is what the production edge does and what a bare uvicorn does not. Then vsicurl learns no size from the fallback either, concludes the object is empty, and probes the parent path as a directory:

```
VSICURL: GetFileSize(https://demo.getgeolens.com/api/.../export?format=geojson): response_code=200, ... passed 1360 returned 0
VSICURL: Request at offset 0, after end of file
VSICURL: GetFileList(/vsicurl/https://demo.getgeolens.com/api/datasets/de602fbe-.../)
```

That also corrects the reproduction. It is not an infinite hang: left to run, the demo fails after 403 seconds with `ERROR 4: not recognized as being in a supported file format`. The issue killed it at 25s and read the silence as a hang. So the 405 is a necessary cause but not a sufficient one.

The fix still works, and for a reason worth stating precisely: a HEAD that returns 200 without a Content-Length pushes GDAL onto the ranged path, where `Content-Range` supplies the size that neither the 405 nor the size-less fallback GET could.

## Verification

Backend, from the worktree (`localhost:5434`):

```
uv run pytest tests/test_export_head_1513.py -v      # 13 passed
```

Red first, against unfixed code: 12 of the 13 failed, headline failure `HEAD 405 vs GET 400, expected both 400`. The one that passed was `test_head_export_stays_out_of_the_openapi_schema`, which is a guard rather than a bug detector.

Suites around the change:

```
uv run pytest tests/test_export*.py tests/test_tenant_ingest_export_routing.py -q     # 170 passed, 3 skipped
uv run pytest tests/test_layering.py tests/test_rule1_structural.py \
             tests/test_rule2_structural.py tests/test_api_contract_openapi.py \
             tests/test_ogc_discovery.py -q                                            # 193 passed
uv run ruff check . && uv run ruff format --check .                                    # clean
make openapi-check                                                                     # no diff
make sdks-check                                                                         # no drift, TS build + tests pass
make cli-test                                                                           # 8 passed, 2 skipped
```

### Driving the real GDAL condition

A status-code test proves the handler, not the fix, so the failing command from the issue was run against real GeoLens code on both sides. The dev stack bind-mounts the main checkout, so the fixed backend was served by a host-run uvicorn on `:8123`; `:8001` is the main checkout's container and stands in for the unfixed side. Both talk to the same database and the same dataset. A reverse proxy in front of each re-frames the full-body GET as chunked with no Content-Length, reproducing the edge shape measured on the demo; HEAD and ranged GETs pass through untouched.

| | unfixed (`main`) | fixed (this branch) |
|---|---|---|
| `ogrinfo -so /vsicurl/...` | `rc=1`, `ERROR 4: not recognized as being in a supported file format` | `rc=0`, ``using driver `GeoJSON' successful`` |
| vsicurl log | `HEAD not allowed. Retrying with GET` → `after end of file` → `GetFileList` | `HEAD did not provide file size. Retrying with limited range GET` → `GetFileSize(...)=6080217 response_code=206` |
| requests | 1 HEAD, 4 full GETs, 1 range | 1 HEAD, 1 full GET, 9 ranges |

Every ogrinfo run was bounded by a SIGALRM timeout that fails loudly rather than waiting, since a hang and a rejection are different failure classes.

Headers on the fixed route, real server, real dataset:

```
$ curl -I "http://127.0.0.1:8123/api/datasets/652ff64f-.../export?format=geojson"
HTTP/1.1 200 OK
content-disposition: attachment; filename="Matterhorn_Peaks.geojson"
accept-ranges: bytes
content-type: application/geo+json
                                    # no content-length, by design
```

The GET is byte-identical on `content-type` and `content-disposition`, and adds `content-length: 1037`.

## Schema and API impact

None. The HEAD route is registered `include_in_schema=False`, for the reason `_clone_api_route` already gives for the standards HEAD pass: a derived route documents nothing the canonical one does not, and publishing it would churn both SDKs and the CLI. `make openapi-check` reports no diff and `backend/openapi.json` is unchanged, so no SDK or CLI output is committed here. No migrations, no config.

## Left out

- `/datasets/{id}/download/cog` still answers HEAD with 405. It is the other route where `/vsicurl/` matters, and it deserves a different decision, not the same few lines: it serves stored object bytes rather than a live conversion, so its HEAD could carry a real `Content-Length`. Its local-storage branch is a `StreamingResponse` that advertises no `Accept-Ranges` at all, which matters more for a COG than the missing HEAD does. Worth its own issue.
- `/admin/users/export.csv`, `/admin/audit-logs/export/{format}` and `/config-ops/export/` are also GET-only. They are admin CSV/JSON downloads with no `/vsicurl/` story, so they were left alone.

## Known cost, not introduced here

Every request to the export route re-runs the whole conversion, so a `/vsicurl/` open now costs about ten of them. That is why the fixed run takes 5.4s where the unfixed one fails in 0.7s. It is pre-existing behaviour of a stateless export endpoint, not something this change adds, but it is the next thing to fix if `/vsicurl/` is meant to be a supported way in.
