### PR TITLE
fix(tiles): let a genuine 404 through on the public raster-tile route

### DIFF
--- a/backend/tests/test_nginx_raster_cors_1464.py
+++ b/backend/tests/test_nginx_raster_cors_1464.py
@@ -4,12 +4,19 @@ Raster tiles are served from the app origin at ``/raster-tiles/...`` and never
 pass through the api's CORS handling, so the header has to come from nginx.
 Two properties matter and neither is visible from a single grep:
 
-* the header must reach the ``@empty_tile`` fallback as well, because
-  ``error_page 404 = @empty_tile`` internal-redirects and nginx then emits only
-  the FINAL location's ``add_header`` set; and
+* the header must be declared ``always``, because the outcomes that need it
+  most are not 200s. Out-of-extent tiles are a 204 from the api, a missing
+  dataset is a 404 (#1516), and the ``limit_req`` ceiling is a 503; a plain
+  ``add_header`` would skip every one of them and a sparse raster would fail
+  CORS on exactly its edge tiles.
 * the value must stay the static ``*``, because the route sits behind the
   ``raster_cache`` proxy cache (and a CDN tile cache in the demo), where a
   reflected ``$http_origin`` would be replayed to the wrong origin.
+
+Until #1516 the 204 came from an internal redirect to a ``@empty_tile``
+location, which had to repeat the header because nginx emits only the FINAL
+location's ``add_header`` set. That redirect is gone: the api answers 204
+itself, so the header now reaches every outcome from this one block.
 """
 
 import re
@@ -19,7 +26,6 @@ from tests.repo_paths import repo_root
 NGINX_CONF = repo_root(__file__) / "frontend" / "nginx.conf"
 
 RASTER_TILES_LOCATION = r"location\s+~\s+\^/raster-tiles/"
-EMPTY_TILE_LOCATION = r"location\s+@empty_tile\b"
 
 _ACAO_DIRECTIVE = re.compile(
     r'add_header\s+Access-Control-Allow-Origin\s+"\*"\s+always\s*;'
@@ -60,35 +66,37 @@ def test_raster_tiles_location_emits_cors_header():
     )
 
 
-def test_empty_tile_fallback_repeats_the_cors_header():
-    """Out-of-extent tiles 404 upstream and are served from @empty_tile.
+def test_raster_cors_header_is_declared_always():
+    """A plain add_header would drop the header on 204, 404 and 503.
 
-    nginx emits the add_header set of the location that finally handles the
-    request, so the header on the /raster-tiles/ block does not survive the
-    internal redirect. Without this, sparse rasters fail CORS on every edge tile.
+    Those are the statuses this route actually returns for an out-of-extent
+    tile, a missing dataset (#1516) and the rate-limit ceiling. Measured
+    against nginx serving this config: all three carry the wildcard.
     """
     conf = _without_comments(NGINX_CONF.read_text())
-    block = _location_block(conf, EMPTY_TILE_LOCATION)
+    block = _location_block(conf, RASTER_TILES_LOCATION)
 
-    assert _ACAO_DIRECTIVE.search(block), (
-        "@empty_tile must repeat the CORS header; add_header sets are not "
-        "inherited across the error_page internal redirect"
+    plain = re.search(
+        r'add_header\s+Access-Control-Allow-Origin\s+"\*"\s*;',
+        block,
     )
+    assert plain is None, (
+        "Access-Control-Allow-Origin must be declared `always`; without it "
+        "nginx emits the header on 2xx/3xx only and every empty, missing or "
+        "rate-limited tile fails CORS in the browser"
+    )
+    assert _ACAO_DIRECTIVE.search(block)
 
 
 def test_raster_cors_header_is_static_never_reflected():
     """A reflected origin is cache-poisonous behind raster_cache and the CDN.
 
-    Scoped to the two raster locations on purpose. The cache-safety invariant
+    Scoped to the raster location on purpose. The cache-safety invariant
     belongs to this cached route, and an uncached location elsewhere may have
     good reason to answer a specific origin.
     """
     conf = _without_comments(NGINX_CONF.read_text())
-    values = [
-        value
-        for pattern in (RASTER_TILES_LOCATION, EMPTY_TILE_LOCATION)
-        for value in _ANY_ACAO_VALUE.findall(_location_block(conf, pattern))
-    ]
+    values = _ANY_ACAO_VALUE.findall(_location_block(conf, RASTER_TILES_LOCATION))
 
     assert values, "expected at least one Access-Control-Allow-Origin header"
     for value in values:
@@ -96,26 +104,6 @@ def test_raster_cors_header_is_static_never_reflected():
             f'Access-Control-Allow-Origin must be the static "*", got {value!r}; '
             "a per-origin value would be cached and replayed to other origins"
         )
-
-
-def test_empty_tile_keeps_its_security_headers():
-    """The CORS header must not cost @empty_tile its inherited security headers.
-
-    add_header disables inheritance from the server scope, so the three headers
-    this 204 carried before #1464 have to be re-declared alongside the new one.
-    """
-    conf = _without_comments(NGINX_CONF.read_text())
-    block = _location_block(conf, EMPTY_TILE_LOCATION)
-
-    for header, value in (
-        ("X-Frame-Options", "SAMEORIGIN"),
-        ("X-Content-Type-Options", "nosniff"),
-        ("Referrer-Policy", "strict-origin-when-cross-origin"),
-    ):
-        assert re.search(
-            rf'add_header\s+{re.escape(header)}\s+"{re.escape(value)}"\s+always\s*;',
-            block,
-        ), f"@empty_tile must re-declare {header}; add_header disables inheritance"
 
 
 def test_raster_tiles_hides_upstream_cors_header():

--- a/backend/tests/test_nginx_raster_tile_404_1516.py
+++ b/backend/tests/test_nginx_raster_tile_404_1516.py
@@ -1,0 +1,92 @@
+"""The public raster-tile route must not turn a 404 into an empty tile (#1516).
+
+``/raster-tiles/{id}/tiles/{z}/{x}/{y}.{fmt}`` and
+``/api/tiles/raster-proxy/{id}/{z}/{x}/{y}.{fmt}`` serve the same tile from the
+same handler, and the public one is what dataset metadata, saved-map styles and
+search results hand to clients. While nginx carried
+``proxy_intercept_errors on; error_page 404 = @empty_tile;`` they disagreed on
+the one case that matters: a dataset id that does not exist answered 204 on the
+public route and 404 on the api one, so a typo'd id rendered as a blank map with
+nothing anywhere to report.
+
+The mapping was added when a tile outside the raster's extent 404'd upstream.
+``raster_tile_proxy`` converts Titiler's out-of-bounds 404 into a 204 itself
+now, so it no longer catches that case, and the only 404s left to catch are
+genuine. Measured against the api: in-footprint 200, out-of-extent 204, missing
+dataset 404, private-and-anonymous 401.
+
+This file is a text check on the config. The behaviour was verified by running
+nginx over it against the dev api.
+"""
+
+import re
+
+from tests.repo_paths import repo_root
+
+NGINX_CONF = repo_root(__file__) / "frontend" / "nginx.conf"
+
+RASTER_TILES_LOCATION = r"location\s+~\s+\^/raster-tiles/"
+
+
+def _without_comments(text: str) -> str:
+    """Drop nginx comment lines so prose can never satisfy an assertion."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _location_block(text: str, header_pattern: str) -> str:
+    """Return the body of the first location block whose header matches."""
+    match = re.search(header_pattern, text)
+    assert match, f"expected a location block matching {header_pattern!r}"
+    start = text.index("{", match.start())
+    depth = 0
+    for index in range(start, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start + 1 : index]
+    raise AssertionError(f"unbalanced braces after {header_pattern!r}")
+
+
+def test_raster_tiles_does_not_map_404_to_an_empty_tile():
+    conf = _without_comments(NGINX_CONF.read_text())
+    block = _location_block(conf, RASTER_TILES_LOCATION)
+
+    assert not re.search(r"\berror_page\s+404\b", block), (
+        "the /raster-tiles/ location must let a genuine upstream 404 through; "
+        "mapping it to an empty tile makes a missing dataset indistinguishable "
+        "from a tile outside the extent, which the api already answers 204"
+    )
+
+
+def test_raster_tiles_does_not_intercept_upstream_errors():
+    """`proxy_intercept_errors` is inert with no error_page, so it should go.
+
+    Left behind it reads as an active policy and invites the next reader to
+    re-add an error_page for a case the api already handles.
+    """
+    conf = _without_comments(NGINX_CONF.read_text())
+    block = _location_block(conf, RASTER_TILES_LOCATION)
+
+    assert not re.search(r"\bproxy_intercept_errors\s+on\b", block), (
+        "the /raster-tiles/ location should pass upstream statuses through"
+    )
+
+
+def test_no_empty_tile_location_remains():
+    """The named location was reachable only through that error_page.
+
+    A location nothing routes to is not a fallback, it is a comment that looks
+    like one. The CORS header it repeated for #1464 now comes from the
+    /raster-tiles/ block's own `always` declaration, which reaches the 204 the
+    api returns directly.
+    """
+    conf = _without_comments(NGINX_CONF.read_text())
+
+    assert not re.search(r"@empty_tile", conf), (
+        "@empty_tile is unreachable once the error_page mapping is gone; "
+        "delete it rather than leaving a guard wired to nothing"
+    )

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -134,8 +134,19 @@ server {
         proxy_set_header Authorization $http_authorization;
         proxy_set_header X-Embed-Token $http_x_embed_token;
 
-        proxy_intercept_errors on;
-        error_page 404 = @empty_tile;
+        # fix(#1516): upstream 404s reach the client. This block used to carry
+        # `proxy_intercept_errors on; error_page 404 = @empty_tile;`, added when
+        # a tile outside the raster's extent 404'd upstream. The api answers 204
+        # for that case itself now, so the mapping stopped catching what it was
+        # for and only ever caught genuine 404s: "no such dataset" and the
+        # `No raster asset` path in processing/tiles/router.py. Those arrived as
+        # 204 — byte-identical to a correct empty tile — so a typo'd dataset id
+        # rendered as a blank map with nothing to report, while
+        # /api/tiles/raster-proxy/ answered 404 for the same request. The two
+        # routes agree again. Measured against the api: in-footprint 200,
+        # out-of-extent 204, missing dataset 404, private-and-anonymous 401.
+        # The add_header set below is `always`, so every one of those carries
+        # the #1464 CORS header without an internal redirect.
 
         # Tile cache — keyed on dataset/zxy. The api enforces auth on cache
         # MISS, so cache HITS for the same tile across users are safe for
@@ -177,24 +188,6 @@ server {
         # Allow-Credentials is involved.
         proxy_hide_header Access-Control-Allow-Origin;
         add_header Access-Control-Allow-Origin "*" always;
-    }
-
-    # fix(#1464): a tile outside the raster's extent 404s upstream and arrives
-    # here through `error_page 404 = @empty_tile`. That internal redirect makes
-    # THIS the final location, so nginx emits this block's add_header set and
-    # discards the /raster-tiles/ block's entirely (same semantics documented at
-    # `location ~ ^/m/` below; verified against nginx 1.31.3). Repeat the header
-    # or every edge tile of a sparse raster still fails CORS in the browser while
-    # the covered tiles succeed.
-    location @empty_tile {
-        add_header Access-Control-Allow-Origin "*" always;
-        # Adding any add_header here disables inheritance, so re-declare the
-        # server-scope security headers this 204 carried before #1464 rather
-        # than dropping them as a side effect of the CORS fix.
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        return 204;
     }
 
     # fix(#430 BA-22): /metrics is unauthenticated by design and scraped internally on


### PR DESCRIPTION
Closes #1516

## What changed

`frontend/nginx.conf` no longer maps upstream 404s on `/raster-tiles/` to an empty tile. `proxy_intercept_errors on;` and `error_page 404 = @empty_tile;` are gone, and the `@empty_tile` location goes with them, since that mapping was the only thing routing to it.

Two new test files pin the result: `backend/tests/test_nginx_raster_tile_404_1516.py` for the mapping's absence, and a rewritten `test_nginx_raster_cors_1464.py`, whose two `@empty_tile` cases were describing a mechanism that no longer exists. The invariant they protected (CORS on a non-200 tile) now rests on the `always` in the `/raster-tiles/` block, which is what the rewritten file asserts.

## The premise, verified locally

The issue's claim that the api answers 204 for an out-of-extent tile was dated 2026-08-15 against the demo. Confirmed against a local stack, using a private swissALTI3D DEM whose footprint is about 1 km across, so out-of-extent is a real tile rather than a hypothetical:

```
### API directly (127.0.0.1:8001/tiles/raster-proxy/)
DEM, tile INSIDE footprint (z16)               200 59609b
DEM, tile OUTSIDE footprint (z14)              204 0b
dataset id that does not exist                 404 84b
private DEM, ANONYMOUS                         401 93b
```

So `raster_tile_proxy` converts Titiler's out-of-bounds 404 into a 204 on its own (`processing/tiles/router.py:1379`), and the `error_page` rule had stopped catching the case it was added for. Nothing regresses by removing it, because nothing out-of-extent was reaching it.

## Before and after, through nginx

A throwaway `nginx:alpine` container renders `frontend/nginx.conf` through the same four `envsubst` variables `frontend/docker-entrypoint.sh` uses and attaches to `geolens_default`, so the upstream is the real dev api. The dev stack on :8080 runs Vite, not this config, and would not have shown any of it.

| request | api route | `/raster-tiles/` before | `/raster-tiles/` after |
|---|---|---|---|
| real dataset, tile in footprint | 200 59609b | 200 59609b | 200 59609b |
| real dataset, tile outside footprint | 204 0b | 204 0b | 204 0b |
| **dataset id that does not exist** | **404 84b** | **204 0b** | **404 84b** |
| real dataset, private, anonymous | 401 93b | 401 93b | 401 93b |

The Vite dev proxy has no equivalent rule, so `localhost:8080` already answered `404 84b` for a missing dataset. Production nginx was the only one of the three disagreeing.

## The two traps

**CORS survives on the out-of-extent path.** It was never coming from `@empty_tile` in the first place: an out-of-extent tile is a pass-through 204 from the api, so it picks up the `/raster-tiles/` block's own `add_header ... always`. Measured with `Origin: https://example.com`, before and after the change, all three outcomes carry the wildcard:

```
in-footprint       status=200  Access-Control-Allow-Origin: *
out-of-extent      status=204  Access-Control-Allow-Origin: *
missing-dataset    status=404  Access-Control-Allow-Origin: *      (was 204, also with the header)
```

The security headers `@empty_tile` used to re-declare also survive, from the api's `SecurityHeadersMiddleware`:

```
HTTP/1.1 404 Not Found
x-content-type-options: nosniff
referrer-policy: strict-origin-when-cross-origin
x-frame-options: DENY
Access-Control-Allow-Origin: *
```

`X-Frame-Options` is `DENY` here where `@empty_tile` said `SAMEORIGIN`. That is stricter, and a tile image is not a framing target.

**Nothing floods.** A 404 tile is a new response for these clients, so I checked what MapLibre does with one. A real raster source pointed at a missing dataset, same page, before and after:

| | tile requests | statuses | maplibre `error` events | console errors |
|---|---|---|---|---|
| before | 16 | 204 x16 | 0 | 0 |
| after | 30 | 404 x30 | 0 | 30 |

The 30 is one retry per visible tile and it is bounded: 30 at 6 s, 30 at 12 s, 30 at 30 s. A real dataset still loads 16 tiles, all 200, with no errors.

Worth knowing for the client side that prompted the issue: MapLibre does **not** raise a `map.on('error')` event for a 404 raster tile, though the browser logs the failed request. It does raise one for a 401 (16 tiles, 16 `AJAXError: Unauthorized` events, measured on the same page). So a page listening on the map's error channel still will not hear about a missing dataset, but the request is now visible in devtools and readable by anything that inspects the response, which was not true before.

## Dataset-id enumeration

The issue's argument holds. Anonymously, against the local stack:

```
collections: real dataset (public), anon        200 729b
collections: bogus id, anon                     404 126b
collections: PRIVATE dataset, anon              404 126b
```

`/api/collections/{id}` already distinguishes a real public dataset from one that does not exist, so the tile route is not where that is being protected. It answers 404 for a private dataset as well, so it does not disclose private ids.

One correction to the issue's framing. It says the current mapping hides existence "whether or not it was chosen for the reason". It mostly does not: on the tile route today a private dataset answers 401 while a nonexistent one answers 204, so existence is already distinguishable for exactly the ids most worth protecting. What this PR changes is that a public dataset is now distinguishable from a nonexistent one there too, which `/api/collections/{id}` has always been.

## Not in scope

Vector tiles have the same client-side symptom, and the issue says so. `/api/tiles/data.no_such_table/...` already returns the right status, so there is no nginx rule to remove and nothing here to change. Left alone deliberately.

## Verification

```
cd frontend && npm run build           # exit 0
cd frontend && npm run lint            # exit 0
cd frontend && npm run typecheck       # exit 0
cd frontend && npm run test:coverage   # exit 0, 398 files, 4980 tests
cd backend && uv run pytest tests/test_nginx_raster_tile_404_1516.py tests/test_nginx_raster_cors_1464.py   # 7 passed
cd backend && uv run pytest tests/test_csp_sec020.py tests/test_docker_audit_regressions.py \
  tests/test_nginx_apikey_log_scrub_sec006.py tests/test_phase_272_dockerfile.py \
  tests/test_nginx_raster_cors_1464.py tests/test_nginx_raster_tile_404_1516.py   # 39 passed
cd backend && uv run pytest tests/test_embed_frame_policy.py tests/test_raster_tile_url_version_1372.py   # 14 passed
```

`nginx -t` passes on the rendered config, and the container serving it produced every number above. The three new tests in `test_nginx_raster_tile_404_1516.py` were run against the pre-change `nginx.conf` and all three fail there, so they are not vacuous.

No Playwright suite was run. This worktree's specs execute against the main checkout's stack, which does not serve this config. The browser numbers come from a standalone Chromium script pointed at the harness container.

No backend `app/` code changed, so `test_layering.py` does not apply.
