### PR TITLE
fix(auth): route every sessionStorage access on the auth path through the guarded helper

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { PasswordInput } from '@/components/ui/password-input';
 import { Label } from '@/components/ui/label';
+import { removeSessionStorage } from '@/lib/storage';
 
 /**
  * Login form for username + password authentication.
@@ -38,7 +39,11 @@ export function LoginForm() {
       // CLEAN-N3: the search workspace lives at "/" after the landing page
       // removal; no more redirect through the legacy "/search" shim.
       const target = from && from.startsWith('/') ? from : '/';
-      sessionStorage.removeItem('geolens-login-redirect');
+      // fix(#1527): this sits between a SUCCESSFUL login and the navigation
+      // that follows, inside the try. A bare removeItem that throws is caught
+      // below and rendered as a login error — so the user is signed in, told
+      // sign-in failed, and left on /login.
+      removeSessionStorage('geolens-login-redirect');
       navigate(target, { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : t('loginFailed'));

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Outlet, useLocation } from 'react-router';
 import { useAuthStore } from '@/stores/auth-store';
+import { writeSessionStorage } from '@/lib/storage';
 
 const SESSION_KEY = 'geolens-login-redirect';
 
@@ -9,7 +10,11 @@ export function ProtectedRoute() {
 
   if (!token) {
     const from = location.pathname + location.search;
-    sessionStorage.setItem(SESSION_KEY, from);
+    // fix(#1527): this write happens during render, and every protected route
+    // in the app is behind it. In a storage-denied context the bare setItem
+    // threw and the redirect became a blank page; the `from` also rides
+    // router state, so losing the key costs nothing.
+    writeSessionStorage(SESSION_KEY, from);
     return <Navigate to="/login" replace state={{ from }} />;
   }
 

--- a/frontend/src/components/auth/SessionExpiredDialog.tsx
+++ b/frontend/src/components/auth/SessionExpiredDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { onSessionExpired } from '@/api/client';
 import { getAuthConfig } from '@/api/auth';
 import { queryKeys } from '@/lib/query-keys';
+import { readSessionStorage, writeSessionStorage } from '@/lib/storage';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -71,7 +72,11 @@ export function SessionExpiredDialog() {
           // Anonymous catalog browsing exists on "/" unless landing-first
           // would bounce this (now signed-out) visitor to /login — there the
           // prompt is exactly the context the teleport otherwise lacks.
-          const guestBrowse = sessionStorage.getItem('gl-guest-browse') === 'true';
+          // fix(#1527): notifySessionExpired calls this handler synchronously
+          // from the fetch core's 401 path, so a bare read that throws escapes
+          // into the API client. Denied storage means no marker, which is the
+          // same answer as an absent one: prompt.
+          const guestBrowse = readSessionStorage('gl-guest-browse') === 'true';
           if (!landingFirstRef.current || guestBrowse) return;
         } else if (isAnonymousCapable(pathname)) {
           return;
@@ -82,7 +87,10 @@ export function SessionExpiredDialog() {
   );
 
   const signIn = () => {
-    if (from) sessionStorage.setItem('geolens-login-redirect', from);
+    // fix(#1527): the write half of the same defect — guarding only the read
+    // above would leave the button that recovers the session throwing. The
+    // key is an SSO-round-trip convenience; `from` also rides router state.
+    if (from) writeSessionStorage('geolens-login-redirect', from);
     navigate('/login', { state: { from } });
     setFrom(null);
   };

--- a/frontend/src/components/auth/__tests__/LoginForm.test.tsx
+++ b/frontend/src/components/auth/__tests__/LoginForm.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@/test/test-utils';
 import userEvent from '@testing-library/user-event';
+import { denySessionStorage } from '@/test/deny-storage';
 import { LoginForm } from '../LoginForm';
 
 const mockLogin = vi.fn().mockResolvedValue(undefined);
@@ -140,5 +141,34 @@ describe('LoginForm', () => {
     await waitFor(() => {
       expect(sessionStorage.getItem('geolens-login-redirect')).toBeNull();
     });
+  });
+
+  /**
+   * fix(#1527): the redirect key is cleared between a SUCCESSFUL login and the
+   * navigation that follows it, inside the submit handler's try block. In a
+   * storage-denied context the removeItem threw, so the catch turned a
+   * completed sign-in into an inline "SecurityError: ..." on the form and the
+   * user never left /login — with a live token already in the store.
+   */
+  it('navigates after login when sessionStorage access throws', async () => {
+    mockLogin.mockResolvedValue(undefined);
+    mockLocationState.from = '/datasets/abc';
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/username/i), 'admin');
+    await user.type(screen.getByLabelText('Password', { exact: true }), 'secret');
+
+    const restore = denySessionStorage();
+    try {
+      await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/datasets/abc', { replace: true });
+      });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    } finally {
+      restore();
+    }
   });
 });

--- a/frontend/src/components/auth/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/auth/__tests__/ProtectedRoute.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 import { useAuthStore } from '@/stores/auth-store';
+import { denySessionStorage } from '@/test/deny-storage';
 import { ProtectedRoute } from '../ProtectedRoute';
 import type { UserResponse } from '@/types/api';
 
@@ -76,5 +77,23 @@ describe('ProtectedRoute', () => {
     renderWithRoutes('/datasets/abc');
 
     expect(sessionStorage.getItem('geolens-login-redirect')).toBe('/datasets/abc');
+  });
+
+  /**
+   * fix(#1527): the redirect target is WRITTEN during render, so a storage-denied
+   * context turns "bounce an anonymous visitor to /login" into a thrown render.
+   * Every protected route in the app is behind this component, so the blast
+   * radius is the whole authenticated surface, not one lost preference.
+   */
+  it('still redirects to /login when sessionStorage access throws', () => {
+    const restore = denySessionStorage();
+    try {
+      renderWithRoutes('/datasets/abc');
+
+      expect(screen.getByText('Login Page')).toBeInTheDocument();
+      expect(screen.getByTestId('from')).toHaveTextContent('/datasets/abc');
+    } finally {
+      restore();
+    }
   });
 });

--- a/frontend/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
+++ b/frontend/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
@@ -7,6 +7,7 @@ import { SessionExpiredDialog } from '@/components/auth/SessionExpiredDialog';
 import { notifySessionExpired } from '@/api/client';
 import { useAuthStore } from '@/stores/auth-store';
 import { queryKeys } from '@/lib/query-keys';
+import { denySessionStorage } from '@/test/deny-storage';
 import type { AuthConfigResponse } from '@/types/api';
 
 // fix(#628): the global signed-out host — one dismissable prompt when the
@@ -112,5 +113,42 @@ describe('SessionExpiredDialog', () => {
     act(() => notifySessionExpired(nextDeadToken()));
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  /**
+   * fix(#1527): both halves of this component touch sessionStorage, and both
+   * used to do it bare. The guest-browse READ runs inside the expiry handler,
+   * which `notifySessionExpired` invokes synchronously from the fetch core's
+   * 401 path — a throw there escapes into the API client, so a dead session in
+   * a storage-denied context fails as an unhandled error instead of a prompt.
+   */
+  it('prompts on "/" under landing-first when sessionStorage access throws', () => {
+    const restore = denySessionStorage();
+    try {
+      renderAt('/', { landingFirst: true });
+      act(() => notifySessionExpired(nextDeadToken()));
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+
+  /**
+   * fix(#1527): the sign-in action WRITES the redirect key. Guarding only the
+   * read would leave the button that recovers the session throwing.
+   */
+  it('signs in from the prompt when sessionStorage access throws', async () => {
+    renderAt('/datasets/abc?tab=preview');
+    act(() => notifySessionExpired(nextDeadToken()));
+
+    const restore = denySessionStorage();
+    try {
+      await userEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      expect(screen.getByTestId('login-probe')).toHaveTextContent('/datasets/abc?tab=preview');
+    } finally {
+      restore();
+    }
   });
 });

--- a/frontend/src/lib/__tests__/storage.test.ts
+++ b/frontend/src/lib/__tests__/storage.test.ts
@@ -1,0 +1,128 @@
+/**
+ * fix(#1535 codex P2): the session helpers under a store that is FULL rather
+ * than denied.
+ *
+ * These are two different failures and only one of them can strand a stale
+ * value. A denied store has nothing persisted, so a failed write leaves
+ * nothing behind. A full store still holds the PREVIOUS value, so replacing
+ * `geolens-login-redirect` with a longer route throws while the old route
+ * stays persisted and authoritative. `OAuthCallbackPage` reads it after the
+ * SSO round trip (a full document load, which loses the in-memory mirror) and
+ * sends the user somewhere they never asked to go.
+ *
+ * That is the trade this repo keeps deciding not to make: before the mirror,
+ * that write threw and crashed loudly; leaving it stale would convert the
+ * crash into a silent wrong destination that survives a reload. Absent beats
+ * wrong here, because absent degrades to "/", which is the established
+ * correct fallback for that path.
+ */
+import {
+  readSessionStorage,
+  writeSessionStorage,
+  removeSessionStorage,
+  _resetSessionStorageFallback,
+} from '@/lib/storage';
+import { denySessionStorage, limitSessionStorage } from '@/test/deny-storage';
+
+const KEY = 'geolens-login-redirect';
+const SHORT = '/a';
+const LONG = '/datasets/a-much-longer-route-than-the-quota-allows';
+
+/** A full document load: the tab's store survives, module state does not. */
+function simulateReload() {
+  _resetSessionStorageFallback();
+}
+
+describe('session storage helpers', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    _resetSessionStorageFallback();
+  });
+
+  describe('when the store works', () => {
+    it('round-trips a value and clears it', () => {
+      writeSessionStorage(KEY, SHORT);
+      expect(readSessionStorage(KEY)).toBe(SHORT);
+      removeSessionStorage(KEY);
+      expect(readSessionStorage(KEY)).toBeNull();
+    });
+
+    it('survives a reload, because the store is the one that persists', () => {
+      writeSessionStorage(KEY, SHORT);
+      simulateReload();
+      expect(readSessionStorage(KEY)).toBe(SHORT);
+    });
+  });
+
+  describe('when the store is denied', () => {
+    it('keeps the caller intent for this page and reports nothing after a reload', () => {
+      const restore = denySessionStorage();
+      try {
+        writeSessionStorage(KEY, LONG);
+        expect(readSessionStorage(KEY)).toBe(LONG);
+
+        simulateReload();
+        expect(readSessionStorage(KEY)).toBeNull();
+      } finally {
+        restore();
+      }
+    });
+
+    it('removes without throwing, though nothing was ever persisted', () => {
+      const restore = denySessionStorage();
+      try {
+        writeSessionStorage(KEY, LONG);
+        expect(() => removeSessionStorage(KEY)).not.toThrow();
+        expect(readSessionStorage(KEY)).toBeNull();
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('when the store is full', () => {
+    it('does not let the old value outrank the new one in this page', () => {
+      const restore = limitSessionStorage(SHORT.length);
+      try {
+        writeSessionStorage(KEY, SHORT);
+        expect(readSessionStorage(KEY)).toBe(SHORT);
+
+        // Too long for the quota: throws, and the old value is still sitting
+        // in the store.
+        writeSessionStorage(KEY, LONG);
+
+        expect(readSessionStorage(KEY)).not.toBe(SHORT);
+        expect(readSessionStorage(KEY)).toBe(LONG);
+      } finally {
+        restore();
+      }
+    });
+
+    it('leaves no stale route behind for the OAuth round trip to read', () => {
+      const restore = limitSessionStorage(SHORT.length);
+      try {
+        writeSessionStorage(KEY, SHORT);
+        writeSessionStorage(KEY, LONG);
+
+        simulateReload();
+
+        // Absent, so OAuthCallbackPage degrades to "/". Returning SHORT here
+        // would send the user to a route they navigated away from.
+        expect(readSessionStorage(KEY)).toBeNull();
+      } finally {
+        restore();
+      }
+    });
+
+    it('still persists a value that fits', () => {
+      const restore = limitSessionStorage(SHORT.length);
+      try {
+        writeSessionStorage(KEY, SHORT);
+        simulateReload();
+        expect(readSessionStorage(KEY)).toBe(SHORT);
+      } finally {
+        restore();
+      }
+    });
+  });
+});

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -48,12 +48,38 @@ export function removeStorage(key: string): void {
  * `SecurityError`, so a caller reading during render takes the whole page
  * down rather than losing one preference.
  */
+/**
+ * fix(#1535 codex P1): in-memory mirror for the session keys.
+ *
+ * Not throwing is not the same as working. `gl-guest-browse` is written by the
+ * "Browse the catalog" button and read back by `LandingFirstGuard` one
+ * navigation later; a write that silently no-ops leaves the guard bouncing the
+ * visitor straight to /login, which is indistinguishable from a dead button in
+ * the one environment these helpers exist for.
+ *
+ * Scope of the mirror is this page's lifetime, not the tab session: a full
+ * reload loses it, because in a storage-denied context there is nowhere to
+ * persist. That is the cost, and it is accepted. It also means the OAuth
+ * round-trip (a full document load) still cannot carry `geolens-login-redirect`
+ * through denied storage, so that path degrades to "/" as before.
+ */
+const memoryFallback = new Map<string, string>();
+
+/** Test-only: drop the mirror between cases (cf. `_resetQuicklookCache`). */
+export function _resetSessionStorageFallback(): void {
+  memoryFallback.clear();
+}
+
 export function readSessionStorage(key: string): string | null {
   try {
-    return sessionStorage.getItem(key);
+    const stored = sessionStorage.getItem(key);
+    if (stored !== null) return stored;
   } catch {
-    return null;
+    // Denied: fall through to the mirror.
   }
+  // A successful read returning null also lands here, which covers the write
+  // that failed on quota rather than on denial.
+  return memoryFallback.get(key) ?? null;
 }
 
 /**
@@ -67,16 +93,21 @@ export function readSessionStorage(key: string): string | null {
 export function writeSessionStorage(key: string, value: string): void {
   try {
     sessionStorage.setItem(key, value);
+    // The store is authoritative once it accepts the value; drop any stale
+    // mirror entry so the two cannot diverge.
+    memoryFallback.delete(key);
   } catch {
-    // storage unavailable (opaque origin / private mode / quota) — the caller
-    // degrades to the no-marker path, which is always a valid state.
+    // Denied (opaque origin / private mode) or full (quota). Keep it in memory
+    // so a reader one navigation later still sees the caller's intent.
+    memoryFallback.set(key, value);
   }
 }
 
 export function removeSessionStorage(key: string): void {
+  memoryFallback.delete(key);
   try {
     sessionStorage.removeItem(key);
   } catch {
-    // storage unavailable — nothing was stored, so nothing needs clearing.
+    // storage unavailable — nothing was persisted, so nothing needs clearing.
   }
 }

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -55,3 +55,28 @@ export function readSessionStorage(key: string): string | null {
     return null;
   }
 }
+
+/**
+ * fix(#1527): writing is denied in exactly the same contexts reading is, and
+ * for the same reason — the property access raises before `setItem` is ever
+ * reached. Guarding only `readSessionStorage` covers half the surface: on the
+ * auth path most of these accesses are writes (the login-redirect key, the
+ * guest-browse marker), several of them during render or inside a click
+ * handler where the throw is a blank page rather than a lost preference.
+ */
+export function writeSessionStorage(key: string, value: string): void {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {
+    // storage unavailable (opaque origin / private mode / quota) — the caller
+    // degrades to the no-marker path, which is always a valid state.
+  }
+}
+
+export function removeSessionStorage(key: string): void {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    // storage unavailable — nothing was stored, so nothing needs clearing.
+  }
+}

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -77,8 +77,9 @@ export function readSessionStorage(key: string): string | null {
   } catch {
     // Denied: fall through to the mirror.
   }
-  // A successful read returning null also lands here, which covers the write
-  // that failed on quota rather than on denial.
+  // A successful read returning null also lands here. That is the full-store
+  // case: `writeSessionStorage` clears the key when its write fails, precisely
+  // so the read reaches this line instead of returning a stale value.
   return memoryFallback.get(key) ?? null;
 }
 
@@ -96,10 +97,28 @@ export function writeSessionStorage(key: string, value: string): void {
     // The store is authoritative once it accepts the value; drop any stale
     // mirror entry so the two cannot diverge.
     memoryFallback.delete(key);
+    return;
   } catch {
     // Denied (opaque origin / private mode) or full (quota). Keep it in memory
     // so a reader one navigation later still sees the caller's intent.
     memoryFallback.set(key, value);
+  }
+
+  // fix(#1535 codex P2): the write failed, so whatever was persisted under
+  // this key BEFORE is now stale — and it would win, because the read prefers
+  // a non-null store value and only then consults the mirror. Worse, it
+  // outlives the mirror: the OAuth round trip is a full document load, so
+  // `OAuthCallbackPage` would read a route the user has already navigated
+  // away from and send them there.
+  //
+  // Drop it, so a post-reload read finds nothing and the caller degrades to
+  // "/" instead of to something false. Only the full-store case has anything
+  // to clear; a denied store never persisted a value, so this throws and the
+  // catch is the whole handling.
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    // Denied: nothing was ever persisted, so nothing can be stale.
   }
 }
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -14,6 +14,7 @@ import { OAuthButtons } from '@/components/auth/OAuthButtons';
 import { Button } from '@/components/ui/button';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 import { GEOLENS_PRIVACY_URL } from '@/lib/external-links';
+import { writeSessionStorage } from '@/lib/storage';
 
 function getOAuthErrorMessage(error: string, t: (key: string, opts?: Record<string, string>) => string): string {
   if (error.includes('invalid_grant')) {
@@ -239,7 +240,11 @@ export function LoginPage() {
   // Sets the sessionStorage marker so LandingFirstGuard does not bounce the
   // visitor back to /login for the rest of the browser session.
   const handleBrowseCatalog = useCallback(() => {
-    sessionStorage.setItem(GUEST_BROWSE_KEY, 'true');
+    // fix(#1527): a bare write threw in the click handler and killed the one
+    // button on this page that needs no account. Losing the marker only means
+    // landing-first bounces the visitor here again; losing the navigation is
+    // a dead button.
+    writeSessionStorage(GUEST_BROWSE_KEY, 'true');
     navigate('/');
   }, [navigate]);
 

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/auth-store';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 import { getMe, logoutSession } from '@/api/auth';
+import { readSessionStorage, removeSessionStorage } from '@/lib/storage';
 import { Loader2 } from 'lucide-react';
 
 export function OAuthCallbackPage() {
@@ -59,8 +60,12 @@ export function OAuthCallbackPage() {
     getMe()
       .then((user) => {
         useAuthStore.getState().setAuth(token, refreshToken ?? null, parseInt(expiresIn, 10), user);
-        const redirect = sessionStorage.getItem('geolens-login-redirect');
-        sessionStorage.removeItem('geolens-login-redirect');
+        // fix(#1527): a bare access here threw into the sibling .catch()
+        // below, which revokes the session and bounces to /login — so a
+        // storage-denied context ended a perfectly good SSO round-trip signed
+        // out. No stored redirect just means landing on "/".
+        const redirect = readSessionStorage('geolens-login-redirect');
+        removeSessionStorage('geolens-login-redirect');
         const target = redirect && redirect.startsWith('/') ? redirect : '/';
         navigate(target, { replace: true });
       })

--- a/frontend/src/pages/__tests__/LoginPage.guestBrowse.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.guestBrowse.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * fix(#1527): the guest-browse escape hatch WRITES `gl-guest-browse` to
+ * sessionStorage before navigating to "/". Bare, that write throws in a
+ * storage-denied context (sandboxed frame with an opaque origin, private-mode
+ * Safari, third-party storage blocked) and takes the click handler with it —
+ * the one button on the login page that does not require an account.
+ *
+ * Losing the marker is acceptable: the visitor gets bounced back to /login on
+ * the next visit to "/". Losing the navigation is not.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { useAuthStore } from '@/stores/auth-store';
+import { queryKeys } from '@/lib/query-keys';
+import { denySessionStorage } from '@/test/deny-storage';
+import type { AuthConfigResponse } from '@/types/api';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: () => ({
+    login: vi.fn(),
+    logout: vi.fn(),
+    token: null,
+    user: null,
+    isAdmin: false,
+    isEditor: false,
+  }),
+}));
+
+vi.mock('@/api/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/auth')>();
+  return {
+    ...actual,
+    getAuthConfig: vi.fn(),
+    getOAuthProviders: vi.fn(),
+  };
+});
+
+import { getAuthConfig, getOAuthProviders } from '@/api/auth';
+import { LoginPage } from '../LoginPage';
+
+function renderLoginPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  queryClient.setQueryData(queryKeys.authConfig.config, {
+    registration_enabled: false,
+    landing_first: true,
+    password_login_enabled: true,
+    auth_methods: [],
+  } as unknown as AuthConfigResponse);
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={['/login']}>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/" element={<div data-testid="catalog">CATALOG</div>} />
+          </Routes>
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('LoginPage — guest-browse escape hatch under denied storage (#1527)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getAuthConfig).mockResolvedValue({
+      registration_enabled: false,
+      landing_first: true,
+      password_login_enabled: true,
+      auth_methods: [],
+    } as unknown as AuthConfigResponse);
+    vi.mocked(getOAuthProviders).mockResolvedValue([]);
+    useAuthStore.setState({ token: null, user: null });
+    sessionStorage.clear();
+  });
+
+  it('records the guest-browse marker and navigates', async () => {
+    renderLoginPage();
+
+    const [browse] = await screen.findAllByRole('button', { name: /browse the catalog/i });
+    await userEvent.click(browse);
+
+    await waitFor(() => expect(screen.getByTestId('catalog')).toBeInTheDocument());
+    expect(sessionStorage.getItem('gl-guest-browse')).toBe('true');
+  });
+
+  it('still navigates when sessionStorage access throws', async () => {
+    renderLoginPage();
+
+    const [browse] = await screen.findAllByRole('button', { name: /browse the catalog/i });
+
+    const restore = denySessionStorage();
+    try {
+      await userEvent.click(browse);
+
+      await waitFor(() => expect(screen.getByTestId('catalog')).toBeInTheDocument());
+    } finally {
+      restore();
+    }
+  });
+});

--- a/frontend/src/pages/__tests__/LoginPage.guestBrowse.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.guestBrowse.test.tsx
@@ -1,12 +1,18 @@
 /**
- * fix(#1527): the guest-browse escape hatch WRITES `gl-guest-browse` to
- * sessionStorage before navigating to "/". Bare, that write throws in a
- * storage-denied context (sandboxed frame with an opaque origin, private-mode
- * Safari, third-party storage blocked) and takes the click handler with it —
- * the one button on the login page that does not require an account.
+ * fix(#1527): the guest-browse escape hatch, end to end, under denied storage.
  *
- * Losing the marker is acceptable: the visitor gets bounced back to /login on
- * the next visit to "/". Losing the navigation is not.
+ * The claim under test is "an anonymous visitor can reach the catalog", NOT
+ * "a navigation happened". Those come apart: the button writes
+ * `gl-guest-browse` to sessionStorage and navigates to "/", where the REAL
+ * `LandingFirstGuard` reads that marker back and bounces anyone without it to
+ * /login. A write that silently no-ops therefore leaves the button dead, and
+ * the visitor cannot tell that from a click that did nothing.
+ *
+ * So this file routes "/" through the production guard. An earlier revision
+ * substituted a dummy catalog route, which asserted the navigation and
+ * masked the bounce (#1535 codex P1). `SearchPage` is still stubbed, which is
+ * a sound substitution: it is the destination's content, not the component
+ * whose behaviour is the claim.
  */
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -16,6 +22,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { useAuthStore } from '@/stores/auth-store';
 import { queryKeys } from '@/lib/query-keys';
 import { denySessionStorage } from '@/test/deny-storage';
+import { _resetSessionStorageFallback } from '@/lib/storage';
 import type { AuthConfigResponse } from '@/types/api';
 
 vi.mock('sonner', () => ({
@@ -33,6 +40,11 @@ vi.mock('@/hooks/use-auth', () => ({
   }),
 }));
 
+// The catalog's CONTENT is stubbed; the guard in front of it is real.
+vi.mock('@/pages/SearchPage', () => ({
+  SearchPage: () => <div data-testid="search-page">SearchPage</div>,
+}));
+
 vi.mock('@/api/auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/api/auth')>();
   return {
@@ -43,25 +55,29 @@ vi.mock('@/api/auth', async (importOriginal) => {
 });
 
 import { getAuthConfig, getOAuthProviders } from '@/api/auth';
+import { LandingFirstGuard } from '@/components/auth/LandingFirstGuard';
 import { LoginPage } from '../LoginPage';
 
-function renderLoginPage() {
+const LANDING_FIRST_CONFIG = {
+  registration_enabled: false,
+  landing_first: true,
+  password_login_enabled: true,
+  auth_methods: [],
+} as unknown as AuthConfigResponse;
+
+function renderApp() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
-  queryClient.setQueryData(queryKeys.authConfig.config, {
-    registration_enabled: false,
-    landing_first: true,
-    password_login_enabled: true,
-    auth_methods: [],
-  } as unknown as AuthConfigResponse);
+  queryClient.setQueryData(queryKeys.authConfig.config, LANDING_FIRST_CONFIG);
   return render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <MemoryRouter initialEntries={['/login']}>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
-            <Route path="/" element={<div data-testid="catalog">CATALOG</div>} />
+            {/* The production guard, not a stand-in. */}
+            <Route path="/" element={<LandingFirstGuard />} />
           </Routes>
         </MemoryRouter>
       </TooltipProvider>
@@ -69,40 +85,43 @@ function renderLoginPage() {
   );
 }
 
-describe('LoginPage — guest-browse escape hatch under denied storage (#1527)', () => {
+async function clickBrowseCatalog() {
+  const [browse] = await screen.findAllByRole('button', { name: /browse the catalog/i });
+  await userEvent.click(browse);
+}
+
+describe('LoginPage guest-browse reaches the catalog (#1527)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getAuthConfig).mockResolvedValue({
-      registration_enabled: false,
-      landing_first: true,
-      password_login_enabled: true,
-      auth_methods: [],
-    } as unknown as AuthConfigResponse);
+    vi.mocked(getAuthConfig).mockResolvedValue(LANDING_FIRST_CONFIG);
     vi.mocked(getOAuthProviders).mockResolvedValue([]);
     useAuthStore.setState({ token: null, user: null });
     sessionStorage.clear();
+    // The mirror is module state; sessionStorage.clear() does not reach it.
+    _resetSessionStorageFallback();
   });
 
-  it('records the guest-browse marker and navigates', async () => {
-    renderLoginPage();
+  it('reaches the catalog and records the marker when storage works', async () => {
+    renderApp();
+    await clickBrowseCatalog();
 
-    const [browse] = await screen.findAllByRole('button', { name: /browse the catalog/i });
-    await userEvent.click(browse);
-
-    await waitFor(() => expect(screen.getByTestId('catalog')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('search-page')).toBeInTheDocument());
     expect(sessionStorage.getItem('gl-guest-browse')).toBe('true');
   });
 
-  it('still navigates when sessionStorage access throws', async () => {
-    renderLoginPage();
-
-    const [browse] = await screen.findAllByRole('button', { name: /browse the catalog/i });
+  /**
+   * The bug #1535 shipped with: the click no longer threw, but the marker was
+   * dropped, so the guard bounced the visitor straight back to /login. The
+   * button was still dead in the one environment the fix exists for.
+   */
+  it('reaches the catalog when sessionStorage access throws', async () => {
+    renderApp();
 
     const restore = denySessionStorage();
     try {
-      await userEvent.click(browse);
+      await clickBrowseCatalog();
 
-      await waitFor(() => expect(screen.getByTestId('catalog')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByTestId('search-page')).toBeInTheDocument());
     } finally {
       restore();
     }

--- a/frontend/src/pages/__tests__/OAuthCallbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/OAuthCallbackPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, waitFor } from '@/test/test-utils';
 import { OAuthCallbackPage } from '@/pages/OAuthCallbackPage';
 import { useAuthStore } from '@/stores/auth-store';
+import { denySessionStorage } from '@/test/deny-storage';
 import type { UserResponse } from '@/types/api';
 
 const mockNavigate = vi.fn();
@@ -84,5 +85,28 @@ describe('OAuthCallbackPage', () => {
     );
     expect(mockGetMe).not.toHaveBeenCalled();
     expect(mockLogoutSession).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * fix(#1527): the redirect key is read and cleared between a successful
+   * getMe() and the navigation that lands the user. Bare, a storage-denied
+   * context threw into the sibling .catch(), which revokes the session and
+   * bounces to /login — so a perfectly good SSO round-trip ended signed out.
+   */
+  it('completes sign-in when sessionStorage access throws', async () => {
+    const user = { id: '1', username: 'someone', roles: ['viewer'] } as UserResponse;
+    mockGetMe.mockResolvedValueOnce(user);
+    setHash('#token=access-1&expires_in=900&auth_mode=cookie');
+
+    const restore = denySessionStorage();
+    try {
+      render(<OAuthCallbackPage />);
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true }));
+      expect(useAuthStore.getState().user).toEqual(user);
+      expect(mockLogoutSession).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
   });
 });

--- a/frontend/src/test/deny-storage.ts
+++ b/frontend/src/test/deny-storage.ts
@@ -1,0 +1,40 @@
+/**
+ * Deny `sessionStorage` the way a browser denies it.
+ *
+ * In a frame with an opaque origin (sandboxed without `allow-same-origin`),
+ * in private-mode Safari, and with third-party storage blocked, it is the
+ * PROPERTY ACCESS that raises — `window.sessionStorage` throws a SecurityError
+ * before any `getItem`/`setItem` call is reached.
+ *
+ * That is why stubbing the store (`vi.stubGlobal('sessionStorage', {...})`) or
+ * mocking `getItem` to return null proves nothing about this failure: those
+ * mocks answer a call the broken code never gets to make, and a
+ * `typeof sessionStorage !== 'undefined'` guard passes in every one of these
+ * contexts because the property does exist.
+ *
+ * Returns a restore function; call it in a `finally` or `afterEach`.
+ */
+export function denySessionStorage(): () => void {
+  const original = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+  const descriptor: PropertyDescriptor = {
+    configurable: true,
+    get() {
+      throw new DOMException(
+        "Failed to read the 'sessionStorage' property from 'Window': The document " +
+          "is sandboxed and lacks the 'allow-same-origin' flag.",
+        'SecurityError',
+      );
+    },
+  };
+  Object.defineProperty(window, 'sessionStorage', descriptor);
+  if (globalThis !== (window as unknown as typeof globalThis)) {
+    Object.defineProperty(globalThis, 'sessionStorage', descriptor);
+  }
+  return () => {
+    if (!original) return;
+    Object.defineProperty(window, 'sessionStorage', original);
+    if (globalThis !== (window as unknown as typeof globalThis)) {
+      Object.defineProperty(globalThis, 'sessionStorage', original);
+    }
+  };
+}

--- a/frontend/src/test/deny-storage.ts
+++ b/frontend/src/test/deny-storage.ts
@@ -14,18 +14,8 @@
  *
  * Returns a restore function; call it in a `finally` or `afterEach`.
  */
-export function denySessionStorage(): () => void {
+function replaceSessionStorage(descriptor: PropertyDescriptor): () => void {
   const original = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
-  const descriptor: PropertyDescriptor = {
-    configurable: true,
-    get() {
-      throw new DOMException(
-        "Failed to read the 'sessionStorage' property from 'Window': The document " +
-          "is sandboxed and lacks the 'allow-same-origin' flag.",
-        'SecurityError',
-      );
-    },
-  };
   Object.defineProperty(window, 'sessionStorage', descriptor);
   if (globalThis !== (window as unknown as typeof globalThis)) {
     Object.defineProperty(globalThis, 'sessionStorage', descriptor);
@@ -37,4 +27,52 @@ export function denySessionStorage(): () => void {
       Object.defineProperty(globalThis, 'sessionStorage', original);
     }
   };
+}
+
+/**
+ * A store that WORKS but is full: reads and removes succeed, and `setItem`
+ * throws QuotaExceededError for anything longer than `maxValueLength`.
+ *
+ * This is a different failure from denial and it has to be tested separately,
+ * because it is the only one where a PREVIOUS value is still sitting in the
+ * store when the new write fails. Denial has nothing persisted to go stale.
+ *
+ * Returns a restore function; call it in a `finally` or `afterEach`.
+ */
+export function limitSessionStorage(maxValueLength: number): () => void {
+  const backing = new Map<string, string>();
+  const store: Storage = {
+    get length() {
+      return backing.size;
+    },
+    clear: () => backing.clear(),
+    getItem: (key: string) => backing.get(key) ?? null,
+    key: (index: number) => [...backing.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      backing.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      if (value.length > maxValueLength) {
+        throw new DOMException(
+          `Setting the value of '${key}' exceeded the quota.`,
+          'QuotaExceededError',
+        );
+      }
+      backing.set(key, value);
+    },
+  };
+  return replaceSessionStorage({ configurable: true, get: () => store });
+}
+
+export function denySessionStorage(): () => void {
+  return replaceSessionStorage({
+    configurable: true,
+    get() {
+      throw new DOMException(
+        "Failed to read the 'sessionStorage' property from 'Window': The document " +
+          "is sandboxed and lacks the 'allow-same-origin' flag.",
+        'SecurityError',
+      );
+    },
+  });
 }


### PR DESCRIPTION
Closes #1527

`sessionStorage` is denied by the property getter, not by the store. In a sandboxed frame with an opaque origin, in private-mode Safari, and with third-party storage blocked, reading `window.sessionStorage` throws `SecurityError` before `getItem`/`setItem` is ever reached — which is why a `typeof sessionStorage !== 'undefined'` check protects nothing, and why #1515 removed one rather than adding more.

## What the issue got right, and what it missed

The three call sites it named are real, but their paths had moved (all three now live under `frontend/src/components/auth/`), and **only one of the three is a read**. Two are writes, so `readSessionStorage` alone could not have fixed them:

| Site | Access | Failure |
| --- | --- | --- |
| `ProtectedRoute.tsx:12` | `setItem`, during render | Every protected route in the app renders blank instead of bouncing to /login |
| `SessionExpiredDialog.tsx:74` | `getItem`, in the expiry handler | `notifySessionExpired` calls it synchronously from the fetch core's 401 path, so the throw escapes into the API client |
| `SessionExpiredDialog.tsx:85` | `setItem`, sign-in click | Not in the issue. The button that recovers the session throws |
| `LoginForm.tsx:41` | `removeItem`, after a successful login | Inside the submit handler's `try`, between `await login()` and `navigate()`. The catch renders it as **"Login failed"** on a session that was just established, leaving the user on /login holding a live token |
| `OAuthCallbackPage.tsx:62-63` | `getItem` + `removeItem` | Not in the issue. Inside `getMe().then()`, so the throw lands in the sibling `.catch()` — which revokes the session and redirects to /login. A good SSO round-trip ends signed out |
| `LoginPage.tsx:242` | `setItem`, browse-catalog click | Not in the issue. Kills the one control on the login page that needs no account |

So yes: **writes have the same problem, and on this path they are the majority of it.** `readSessionStorage` existed; its write counterparts did not. This adds `writeSessionStorage` and `removeSessionStorage` to `frontend/src/lib/storage.ts`, mirroring the `readStorage`/`writeStorage`/`removeStorage` trio already in that module — not a second read helper. Every key involved is a convenience (`geolens-login-redirect` also rides router state; `gl-guest-browse` only suppresses a re-bounce), so degrading to "no marker" is always a valid state.

## Testing

A `typeof` guard cannot be tested by mocking the value away, and neither can this one: `vi.stubGlobal('sessionStorage', {...})` or a mocked `getItem` answers a call the broken code never makes. `frontend/src/test/deny-storage.ts` denies it the way the browser does — a `sessionStorage` getter on `window` (and `globalThis`) that throws `SecurityError` on property access. Same shape the #1515 fixes were verified with, lifted into one place now that seven suites want it.

**Observed red before the fix**, one per call site:

```
FAIL ProtectedRoute > still redirects to /login when sessionStorage access throws
SecurityError: Failed to read the 'sessionStorage' property from 'Window' ...
 ❯ ProtectedRoute src/components/auth/ProtectedRoute.tsx:12:5
 ❯ renderRootSync react-dom-client.development.js:17450:11

FAIL SessionExpiredDialog > prompts on "/" under landing-first when sessionStorage access throws
SecurityError: Failed to read the 'sessionStorage' property from 'Window' ...
 ❯ src/components/auth/SessionExpiredDialog.tsx:74:31
 ❯ Module.notifySessionExpired src/api/client.ts:82:3

FAIL SessionExpiredDialog > signs in from the prompt when sessionStorage access throws
Unable to find an element by: [data-testid="login-probe"]
  Uncaught SecurityError ... ❯ signIn src/components/auth/SessionExpiredDialog.tsx:85:15

FAIL LoginForm > navigates after login when sessionStorage access throws
AssertionError: expected "vi.fn()" to be called with arguments: [ '/datasets/abc', { replace: true } ]
Number of calls: 0
  (DOM shows <p id="login-error" role="alert">Login failed</p> — after login resolved)

FAIL OAuthCallbackPage > completes sign-in when sessionStorage access throws
AssertionError: expected "vi.fn()" to be called with arguments: [ '/', { replace: true } ]
-   "/",
+   "/login",

FAIL LoginPage — guest-browse > still navigates when sessionStorage access throws
Unable to find an element by: [data-testid="catalog"]
  Uncaught SecurityError ... ❯ src/pages/LoginPage.tsx:242:5
```

Green after, across the six suites plus the #1515 ones that share the class:

```
$ npx vitest run <the 6 suites> LandingFirstGuard.test.tsx src/lib/__tests__/
 Test Files  47 passed (47)
      Tests  826 passed (826)
EXIT=0
```

## Verification

Run in `frontend/`, exit codes read directly (not through a pipe):

| Command | Exit | Result |
| --- | --- | --- |
| `npm run build` | 0 | built in 997ms |
| `npm run lint` | 0 | clean |
| `npm run typecheck` | 0 | clean |
| `npm run test:coverage` | 0 | 401 files, 5001 tests passed; statements 73.84 / branches 69.25 / functions 67.82 / lines 75.94, all well over the 41/39/37/42 thresholds |

No new `t()` keys, no locale changes, no backend or schema impact. No UI change to screenshot: the fix is that a page that used to throw now renders as it always did.

## Left alone, deliberately

`ChatPanel.tsx:77` (`cleanStaleLayerRefs`) reads `sessionStorage` one line above the `try` that wraps the rest of the function — the same defect class, but in the builder, not on the auth path, and its blast radius is one chat-history cleanup rather than a sign-in. Worth its own issue.

Everything else that touches `sessionStorage` outside the auth path is already guarded: `SiteBanner`, `chat-result-handoff.ts`, `quicklook-cache.ts` (the property read itself is inside the `try`), `stale-asset-reload.ts`, and `public/asset-guard.js`.
