### PR TITLE
test(raster): stop seeding two replace payloads from a salted hash

### DIFF
--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -2280,22 +2280,31 @@ class TestRetainedOriginalLivesOutsideThePurgesDomain:
         dataset_id = live.dataset.id
         record_id = live.dataset.record_id
 
-        # Written up front so the precondition can be checked before either
-        # replace runs: a collapse here is a broken test, not a broken product,
-        # and it should say so at the top rather than through the final assert.
-        sources = []
-        for name, seed in (("first.tif", 401), ("second.tif", 402)):
-            source = tmp_path / name
-            source.write_bytes(_geotiff_bytes(seed=seed))
-            sources.append(source)
-        assert len({sha256_file(str(s)) for s in sources}) == 2, (
-            "precondition: the two uploads must carry different bytes. One "
-            "content hash is one archive, so identical payloads would make the "
-            "assertion below a statement about the upsert rather than about "
-            "two originals coexisting."
-        )
-
         try:
+            # Written up front so the precondition can be checked before either
+            # replace runs: a collapse here is a broken test, not a broken
+            # product, and it should say so at the top rather than through the
+            # final assert.
+            #
+            # fix(#1537 review): inside the try, not before it. `_make_live_raster`
+            # has already committed the record, dataset and asset, and
+            # `test_db_session` has no rollback teardown — isolation on this
+            # suite is explicit per-test cleanup. So a precondition that fired
+            # out there would skip `_purge` and leave those rows in the shared
+            # per-worker database, which is this test's own regression leaving
+            # residue for somebody else's to trip over.
+            sources = []
+            for name, seed in (("first.tif", 401), ("second.tif", 402)):
+                source = tmp_path / name
+                source.write_bytes(_geotiff_bytes(seed=seed))
+                sources.append(source)
+            assert len({sha256_file(str(s)) for s in sources}) == 2, (
+                "precondition: the two uploads must carry different bytes. One "
+                "content hash is one archive, so identical payloads would make "
+                "the assertion below a statement about the upsert rather than "
+                "about two originals coexisting."
+            )
+
             for source in sources:
                 job = await _queue_replace_job(
                     test_db_session,
@@ -2710,11 +2719,15 @@ class TestArchiveCannotDestroyThePreviousOriginal:
         dataset_id = live.dataset.id
         record_id = live.dataset.record_id
 
-        first_bytes = _geotiff_bytes(seed=141)
-        second_bytes = _geotiff_bytes(seed=142)
-        assert first_bytes != second_bytes
-
         try:
+            # fix(#1537 review): inside the cleanup scope. `_make_live_raster`
+            # has committed and `test_db_session` has no rollback teardown, so
+            # a precondition firing above the `try` would leak those rows into
+            # the shared per-worker database.
+            first_bytes = _geotiff_bytes(seed=141)
+            second_bytes = _geotiff_bytes(seed=142)
+            assert first_bytes != second_bytes
+
             # A successful lossy replace, archiving "scene.tif".
             source = tmp_path / "scene.tif"
             source.write_bytes(first_bytes)
@@ -3535,10 +3548,13 @@ class TestEveryKeptOriginalIsCounted:
         dataset_id = live.dataset.id
         record_id = live.dataset.record_id
 
-        payloads = [_geotiff_bytes(seed=201), _geotiff_bytes(seed=202)]
-        assert payloads[0] != payloads[1]
-
         try:
+            # fix(#1537 review): inside the cleanup scope, for the same reason
+            # as its siblings — the rows are already committed by here and
+            # nothing rolls them back if the precondition fires.
+            payloads = [_geotiff_bytes(seed=201), _geotiff_bytes(seed=202)]
+            assert payloads[0] != payloads[1]
+
             for i, payload in enumerate(payloads):
                 source = tmp_path / f"r{i}" / "scene.tif"
                 source.parent.mkdir()

--- a/backend/tests/test_raster_replace_1221.py
+++ b/backend/tests/test_raster_replace_1221.py
@@ -2254,10 +2254,21 @@ class TestRetainedOriginalLivesOutsideThePurgesDomain:
         self, test_db_session, raster_storage, tmp_path
     ) -> None:
         """The lifecycle question: what happens to the kept original when the
-        dataset is replaced again. They coexist, keyed by uploaded filename, so
-        a differently-named upload adds and a same-named one overwrites. Both
-        are reaped together when the dataset is deleted, because
-        `delete_dataset` already cleans the whole `originals/<id>/` prefix."""
+        dataset is replaced again. Two uploads that differ in CONTENT coexist,
+        because the archive's identity is its content hash and nothing else
+        (`archived_original_uri`) — the uploaded name rides along on the row's
+        description, where no equality depends on it. Both are reaped together
+        when the dataset is deleted, because `delete_dataset` already cleans the
+        whole `originals/<id>/` prefix.
+
+        fix(#1526): the two payloads were seeded `hash(name) % 500`, and `hash`
+        on a str is salted per interpreter, so about one process in 500 drew the
+        same seed for both names. Identical bytes are one archive key by design,
+        the upsert collapses them into a single row, and the assertion below
+        then read `['second.tif']` — an intermittent CI failure landing on
+        whatever PR happened to be running, with nothing to do with its diff.
+        Fixed seeds, and the precondition asserted rather than assumed.
+        """
         admin_id = (
             await test_db_session.execute(
                 select(User.id).where(User.username == "admin")
@@ -2269,10 +2280,23 @@ class TestRetainedOriginalLivesOutsideThePurgesDomain:
         dataset_id = live.dataset.id
         record_id = live.dataset.record_id
 
+        # Written up front so the precondition can be checked before either
+        # replace runs: a collapse here is a broken test, not a broken product,
+        # and it should say so at the top rather than through the final assert.
+        sources = []
+        for name, seed in (("first.tif", 401), ("second.tif", 402)):
+            source = tmp_path / name
+            source.write_bytes(_geotiff_bytes(seed=seed))
+            sources.append(source)
+        assert len({sha256_file(str(s)) for s in sources}) == 2, (
+            "precondition: the two uploads must carry different bytes. One "
+            "content hash is one archive, so identical payloads would make the "
+            "assertion below a statement about the upsert rather than about "
+            "two originals coexisting."
+        )
+
         try:
-            for name in ("first.tif", "second.tif"):
-                source = tmp_path / name
-                source.write_bytes(_geotiff_bytes(seed=hash(name) % 500))
+            for source in sources:
                 job = await _queue_replace_job(
                     test_db_session,
                     dataset_id=dataset_id,


### PR DESCRIPTION
Closes #1526

## What actually reaps it: nothing does

The issue's hypothesis was that another test's retention purge reaps the archived original out from under this one. That is refuted:

- `raster_storage` is a `LocalStorageProvider` rooted at the test's own `tmp_path`, so no other test can touch its objects.
- The assertion does not read storage at all. `_archived_names` reads `catalog.dataset_assets` scoped to a dataset id created inside the test.
- Nothing in `backend/app/` or `backend/tests/` deletes `dataset_assets` rows outside the `delete_dataset` cascade, so there is no mechanism for a cross-test purge to reach them.
- The failure reproduces deterministically in a single-test, single-process run with no other tests in the session.

The real cause is inside the test:

```python
source.write_bytes(_geotiff_bytes(seed=hash(name) % 500))
```

`hash` on a str is salted per interpreter (`PYTHONHASHSEED` is randomized per process and nothing in CI pins it), so `hash("first.tif") % 500` and `hash("second.tif") % 500` collide for about one process in 500. When they do, both replaces upload byte-identical files.

Identical bytes are one archive by design. `archived_original_uri` derives the key from content alone, `archived_original_asset_key` does the same for the counted row, and `upsert_archived_original_row` conflicts on `uq_dataset_assets_key` and overwrites `description` with the later filename. Two uploads become one row described as `second.tif` — exactly the reported `assert ['second.tif'] == ['first.tif', 'second.tif']`.

pytest-xdist workers are separate processes, each drawing its own hash seed, which is why the same sha produced opposite results on `gw3` and `gw2`. That is process-level randomness, not worker interference.

## Reproduction

Measured collision rate over 23,000 `PYTHONHASHSEED` values under the project's CPython 3.14.5: 37 collide, 0.161% (theoretical 1/500 = 0.2%). In 1..3000 the colliding seeds are **784** and **896**.

```bash
cd backend && set -a && source ../.env.test && set +a
PYTHONHASHSEED=784 uv run pytest \
  "tests/test_raster_replace_1221.py::TestRetainedOriginalLivesOutsideThePurgesDomain::test_a_second_lossy_replace_keeps_both_originals" -q
```

Pre-fix that fails 100% of the time with the reported message, and no concurrency is needed.

## Before / after

| | colliding seeds (784, 896) | non-colliding seeds | random seeds, `-n 2` |
|---|---|---|---|
| before | 2/2 failed | 0/6 failed | — |
| after | 0/2 failed | 0/22 failed | 0/25 failed |

Also green: the full `tests/test_raster_replace_1221.py` under `-n 4` (112 passed), `tests/test_layering.py` (47 passed), `ruff check`, `ruff format --check`.

## The change

Test-only. The two payloads get fixed, distinct seeds, and the precondition that they differ is asserted before either replace runs rather than assumed. The retention property under test is untouched — the final assertion still requires both originals to survive.

The class docstring also said the originals were "keyed by uploaded filename". That has been wrong since identity became content-only, and it is the mental model that made a name-derived payload seed look reasonable, so it is corrected.

No schema, API, or config impact.

---

## Round 2 — cleanup-scope fix (codex P2)

The precondition added above sat *before* the `try/finally`. `_make_live_raster` has already committed, and `test_db_session` has no rollback teardown, so the assertion would have skipped `_purge` on exactly the path it exists to detect — a fix for a shared-database flake leaking rows into the shared database.

Moved inside the `try`, still ahead of the replacements. Measured with the precondition forced to fire, counting leftover rows from a detector test in the same pytest session:

| assertion position | result | leftover rows |
|---|---|---|
| above the `try` | fails | 1 |
| inside the `try` | fails | 0 |

Loud in both cases — not swallowed by the `finally`, not converted to a skip.

### Audit of the file's cleanup boundaries

AST sweep over all 99 tests in the file:

- **55** commit before the cleanup `try`. That is the suite's convention and is fine: the statements in that gap are setup, not checks.
- **3** had an *assertion* in that gap — the shape that actually fires. This one, plus `test_failed_replace_leaves_the_prior_original_intact` and `test_two_distinct_lossy_replaces_leave_two_counted_rows`. All three fixed; the sweep now reports none.
- **0** commit without cleanup.

Both siblings already used fixed seeds with a distinctness precondition, which is corroboration that the `hash(name) % 500` line was this file's outlier rather than its habit.
