### PR TITLE
fix(settings): publish the embedding model and its dimensions atomically

### DIFF
--- a/backend/app/modules/settings/router.py
+++ b/backend/app/modules/settings/router.py
@@ -156,7 +156,49 @@ def _require_enterprise_for_key(key: str) -> None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
 
-async def _probe_embedding_dims_for_model(db: AsyncSession, model: str) -> int:
+async def _probe_base_url(
+    db: AsyncSession, provider_ext: object, requested: dict[str, object]
+) -> object:
+    """Endpoint the probe should call, honoring a URL this request publishes.
+
+    When the request names neither URL key this is exactly
+    ``resolve_runtime_config(db)["base_url"]``. When it names either, the
+    provider's own chain is reproduced with each half taken from the request
+    where present: EMBEDDING_BASE_URL -> OPENAI_BASE_URL -> None, then bound to
+    the operator-approved destination. Clearing ``embedding_base_url`` in the
+    same PUT therefore falls through to the ``openai_base_url`` that PUT sets,
+    exactly as it will once the batch commits.
+
+    ``resolve_runtime_config`` is deliberately not called on that branch. It
+    reads COMMITTED configuration, which is the value the request is replacing,
+    and it *raises* when that value is a stale row bound to a different
+    destination than the environment credential.
+    """
+    if not ({"embedding_base_url", "openai_base_url"} & requested.keys()):
+        runtime_config = await provider_ext.resolve_runtime_config(db)  # type: ignore[attr-defined]
+        return runtime_config.get("base_url")
+
+    from app.core.ai_credentials import bind_openai_credential_base_url
+    from app.core.persistent_config import EMBEDDING_BASE_URL, OPENAI_BASE_URL
+
+    embedding_url = (
+        requested["embedding_base_url"]
+        if "embedding_base_url" in requested
+        else await EMBEDDING_BASE_URL.get_uncached(db)
+    )
+    openai_url = (
+        requested["openai_base_url"]
+        if "openai_base_url" in requested
+        else await OPENAI_BASE_URL.get_uncached(db)
+    )
+    return bind_openai_credential_base_url(
+        str(embedding_url or openai_url or "") or None, purpose="embedding"
+    )
+
+
+async def _probe_embedding_dims_for_model(
+    db: AsyncSession, model: str, requested: dict[str, object]
+) -> int:
     """Ask the provider for the natural output width of an explicitly named model.
 
     fix(#1529): ``probe_embedding_dimensions`` resolves the model from
@@ -164,6 +206,10 @@ async def _probe_embedding_dims_for_model(db: AsyncSession, model: str) -> int:
     which is the publish-then-probe ordering the issue is about. ``update_settings``
     needs the width of the model it is about to publish, at a point where nothing
     has been committed, so the model name is passed in rather than read back out.
+
+    fix(#1538 review): the endpoint comes from ``requested`` too. Everything the
+    probe resolves has to describe the configuration being published, not the
+    one being replaced — the model was only half of that.
 
     Raises:
         EmbeddingUnavailableError: no embedding provider is configured, or the
@@ -179,13 +225,16 @@ async def _probe_embedding_dims_for_model(db: AsyncSession, model: str) -> int:
         )
 
     provider_ext = get_embedding_provider("openai_compatible")
-    runtime_config = await provider_ext.resolve_runtime_config(db)
     # dimensions=None means "discover the model's natural width" (Phase 231 D-02).
+    # `model` carries no fallback to the runtime default on purpose: this path is
+    # only reached when the request names embedding_model, and the community
+    # provider's default_model IS the committed EMBEDDING_MODEL, so falling back
+    # to it would probe the very model being replaced.
     vectors = await provider_ext.embed(
         texts=["dimension probe"],
-        model=model or str(runtime_config.get("default_model") or ""),
+        model=model,
         dimensions=None,
-        base_url=runtime_config.get("base_url"),
+        base_url=await _probe_base_url(db, provider_ext, requested),
         timeout=30.0,
     )
     embedding = vectors[0] if vectors else []
@@ -196,7 +245,9 @@ async def _probe_embedding_dims_for_model(db: AsyncSession, model: str) -> int:
     return len(embedding)
 
 
-async def _detect_dims_for_requested_model(db: AsyncSession, model: str) -> int:
+async def _detect_dims_for_requested_model(
+    db: AsyncSession, model: str, requested: dict[str, object]
+) -> int:
     """Probe ``model`` for ``update_settings``, mapping failures to HTTP status.
 
     Same mapping as POST /settings/detect-embedding-dims: a missing provider is
@@ -207,7 +258,7 @@ async def _detect_dims_for_requested_model(db: AsyncSession, model: str) -> int:
     from app.processing.embeddings.service import EmbeddingUnavailableError
 
     try:
-        return await _probe_embedding_dims_for_model(db, model)
+        return await _probe_embedding_dims_for_model(db, model, requested)
     except EmbeddingUnavailableError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -370,6 +421,10 @@ async def update_settings(
     # Probing ahead of the SSO guard is deliberate: that guard row-locks the
     # enabled OAuth providers, and holding those locks across a provider
     # network call would serialize unrelated provider mutations behind it.
+    #
+    # The whole validated batch is handed to the probe, not just the model:
+    # a PUT can change the endpoint in the same request, and the probe has to
+    # describe the configuration being published (see _probe_base_url).
     if (
         "embedding_model" in validated_settings
         and "embedding_dims" not in validated_settings
@@ -383,7 +438,9 @@ async def update_settings(
         if requested_model != await EMBEDDING_MODEL.get_uncached(db):
             validated_settings["embedding_dims"] = _canonicalize_setting_value(
                 "embedding_dims",
-                await _detect_dims_for_requested_model(db, requested_model),
+                await _detect_dims_for_requested_model(
+                    db, requested_model, validated_settings
+                ),
                 registry_map["embedding_dims"],
             )
 

--- a/backend/app/modules/settings/router.py
+++ b/backend/app/modules/settings/router.py
@@ -21,6 +21,7 @@ from app.core.dependencies import get_client_ip, get_db
 from app.core.edition import is_enterprise
 from app.core.persistent_config import (
     EMBEDDING_DIMS,
+    EMBEDDING_MODEL,
     ENTERPRISE_ONLY_TABS,
     PASSWORD_LOGIN_ENABLED,
     _registry,
@@ -70,7 +71,7 @@ router = APIRouter(prefix="/settings", tags=["Admin"], responses=ERROR_RESPONSES
 
 # Phase 279 ADMIN-09 (L-01): The PUT/RESET handlers below intentionally end with
 # `return await get_all_settings(...)` to capture side-effects from
-# rebuild_embedding_column rollback, _auto_detect_embedding_dims write, and
+# rebuild_embedding_column rollback, validator coercion, and
 # request-derived URL computation (public_app_url / public_api_url, computed
 # from `request` in get_all_settings — NOT stored in AppSetting). An inline
 # response construction would have to duplicate get_all_settings's body
@@ -155,23 +156,75 @@ def _require_enterprise_for_key(key: str) -> None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
 
-async def _auto_detect_embedding_dims(
-    db: AsyncSession, user_id: uuid.UUID, ip: str | None
-) -> None:
-    """Probe the current embedding model and persist its dimension count."""
-    try:
-        from app.processing.embeddings.service import probe_embedding_dimensions
+async def _probe_embedding_dims_for_model(db: AsyncSession, model: str) -> int:
+    """Ask the provider for the natural output width of an explicitly named model.
 
-        dims = await probe_embedding_dimensions(db)
-        await EMBEDDING_DIMS.set(db, dims, user_id=user_id, ip_address=ip)
-    except Exception:  # broad: embedding probe spans third-party SDK calls; non-fatal so admin can set manually
-        # Non-fatal — admin can still set manually. Log with traceback so
-        # operators can diagnose embedding probe failures (bad API key,
-        # provider outage, network timeout) instead of seeing a silent skip.
-        logger.warning(
-            "Failed to auto-detect embedding dimensions",
-            exc_info=True,
+    fix(#1529): ``probe_embedding_dimensions`` resolves the model from
+    PersistentConfig, so it can only probe a model that is ALREADY published —
+    which is the publish-then-probe ordering the issue is about. ``update_settings``
+    needs the width of the model it is about to publish, at a point where nothing
+    has been committed, so the model name is passed in rather than read back out.
+
+    Raises:
+        EmbeddingUnavailableError: no embedding provider is configured, or the
+            provider answered with an empty vector.
+        Exception: whatever the provider SDK raises for a failed call.
+    """
+    from app.platform.extensions import get_embedding_provider
+    from app.processing.embeddings.service import EmbeddingUnavailableError
+
+    if not app_settings.openai_api_key:
+        raise EmbeddingUnavailableError(
+            "Embedding generation requires an OpenAI-compatible API key."
         )
+
+    provider_ext = get_embedding_provider("openai_compatible")
+    runtime_config = await provider_ext.resolve_runtime_config(db)
+    # dimensions=None means "discover the model's natural width" (Phase 231 D-02).
+    vectors = await provider_ext.embed(
+        texts=["dimension probe"],
+        model=model or str(runtime_config.get("default_model") or ""),
+        dimensions=None,
+        base_url=runtime_config.get("base_url"),
+        timeout=30.0,
+    )
+    embedding = vectors[0] if vectors else []
+    if not embedding:
+        raise EmbeddingUnavailableError(
+            f"Embedding probe for model '{model}' returned empty vector."
+        )
+    return len(embedding)
+
+
+async def _detect_dims_for_requested_model(db: AsyncSession, model: str) -> int:
+    """Probe ``model`` for ``update_settings``, mapping failures to HTTP status.
+
+    Same mapping as POST /settings/detect-embedding-dims: a missing provider is
+    a 422, any other provider failure is a 502. Both are raised BEFORE anything
+    is committed, so a failed probe leaves the previous model/dimension pair
+    exactly as it was.
+    """
+    from app.processing.embeddings.service import EmbeddingUnavailableError
+
+    try:
+        return await _probe_embedding_dims_for_model(db, model)
+    except EmbeddingUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Cannot detect the dimension count for embedding model '{model}': "
+                f"{exc} Send embedding_dims alongside embedding_model to publish "
+                "the pair explicitly."
+            ),
+        ) from exc
+    except Exception as exc:  # broad: third-party embedding SDK can throw provider-specific errors; map to 502
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                f"Embedding probe for model '{model}' failed: {exc}. Neither "
+                "embedding_model nor embedding_dims was changed."
+            ),
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -302,6 +355,38 @@ async def update_settings(
 
         validated_settings[key] = _canonicalize_setting_value(key, value, cfg)
 
+    # fix(#1529): publish embedding_model and its detected width ATOMICALLY.
+    # The probe runs HERE — before the provider row locks below, before any
+    # value is staged, and before the batch commit — and its result joins the
+    # same batch, so the pair lands in one transaction. A reader therefore sees
+    # the old pair or the new pair and never the new model beside the old
+    # model's dimension count, and a failed probe leaves both values untouched.
+    #
+    # Folding the detected width into validated_settings also puts auto-detect
+    # on the SAME commit-and-rebuild path as an explicitly named embedding_dims.
+    # The two used to be mutually exclusive branches, which is how a detected
+    # width could be persisted while the vector column kept the old one.
+    #
+    # Probing ahead of the SSO guard is deliberate: that guard row-locks the
+    # enabled OAuth providers, and holding those locks across a provider
+    # network call would serialize unrelated provider mutations behind it.
+    if (
+        "embedding_model" in validated_settings
+        and "embedding_dims" not in validated_settings
+        # In ENV_ONLY_CONFIG mode every cfg.set() below raises 403, so probing
+        # would only burn a provider call on a request that cannot land.
+        and not _is_env_only()
+    ):
+        requested_model = str(validated_settings["embedding_model"])
+        # Uncached on purpose: a stale cache entry naming the requested model
+        # would skip the probe and publish that model with an unrelated width.
+        if requested_model != await EMBEDDING_MODEL.get_uncached(db):
+            validated_settings["embedding_dims"] = _canonicalize_setting_value(
+                "embedding_dims",
+                await _detect_dims_for_requested_model(db, requested_model),
+                registry_map["embedding_dims"],
+            )
+
     # SSO-04 (Phase 1236 Plan 02): lockout guard — refuse to disable password
     # login when zero enabled OAuth providers exist.  This runs AFTER Pass-1
     # validation but BEFORE the apply loop so nothing is persisted on rejection.
@@ -324,10 +409,21 @@ async def update_settings(
                 ),
             )
 
-    # Capture old embedding_dims before any changes (needed for rollback)
+    # Capture the previous embedding pair before any changes (rollback source
+    # for the column rebuild below). Uncached so the rollback restores what is
+    # actually committed rather than a cache entry that may already be stale.
     old_dims_value: int | None = None
+    old_model_value: str | None = None
+    rollback_model = False
     if "embedding_dims" in validated_settings:
-        old_dims_value = await EMBEDDING_DIMS.get(db)
+        old_dims_value = await EMBEDDING_DIMS.get_uncached(db)
+        # fix(#1529): a request that publishes both halves has to roll back
+        # both halves. Restoring embedding_dims alone would leave the NEW model
+        # standing beside the OLD width — the mismatched pair, reached through
+        # the failure path instead of the probe window.
+        rollback_model = "embedding_model" in validated_settings
+        if rollback_model:
+            old_model_value = await EMBEDDING_MODEL.get_uncached(db)
 
     ip = get_client_ip(request)
     for key, value in validated_settings.items():
@@ -344,14 +440,10 @@ async def update_settings(
     for key, value in validated_settings.items():
         await registry_map[key].apply_side_effects(value)
 
-    # Auto-detect embedding dimensions when embedding_model changes
-    if (
-        "embedding_model" in validated_settings
-        and "embedding_dims" not in validated_settings
-    ):
-        await _auto_detect_embedding_dims(db, user.id, ip)
-
-    # Rebuild column + index when embedding dimensions change
+    # Rebuild column + index when embedding dimensions change. An auto-detected
+    # width reaches this branch too (#1529): it was added to validated_settings
+    # above, so the column follows every published width, not only the ones an
+    # admin typed.
     if "embedding_dims" in validated_settings:
         from app.processing.embeddings.service import rebuild_embedding_column
 
@@ -359,26 +451,43 @@ async def update_settings(
         try:
             await rebuild_embedding_column(db, new_dims)
         except Exception as exc:  # broad: DDL rebuild can fail for schema/lock reasons; roll setting back atomically
-            # Roll back the persisted embedding_dims setting to the previous value
-            await EMBEDDING_DIMS.set(db, old_dims_value, user_id=user.id, ip_address=ip)
+            # Roll the published pair back to its previous value(s) in ONE
+            # transaction — same reason the forward publish is one transaction.
+            # Side effects follow the commit, never precede it (fix #430 codex
+            # r3): invalidating the cache first lets a concurrent reader
+            # repopulate it with the value being rolled back.
+            await EMBEDDING_DIMS.set(
+                db, old_dims_value, user_id=user.id, ip_address=ip, commit=False
+            )
+            if rollback_model:
+                await EMBEDDING_MODEL.set(
+                    db, old_model_value, user_id=user.id, ip_address=ip, commit=False
+                )
             await db.commit()
+            await EMBEDDING_DIMS.apply_side_effects(old_dims_value)
+            if rollback_model:
+                await EMBEDDING_MODEL.apply_side_effects(old_model_value)
             logger.exception(
-                "Embedding column rebuild failed, rolling back embedding_dims",
+                "Embedding column rebuild failed, rolling back the embedding pair",
                 old_dims=old_dims_value,
                 new_dims=new_dims,
+                old_model=old_model_value if rollback_model else None,
+                rolled_back_model=rollback_model,
             )
             raise HTTPException(
                 status_code=503,
-                detail="Embedding column rebuild failed. The embedding_dims setting has been reverted.",
+                detail=(
+                    "Embedding column rebuild failed. The embedding settings have "
+                    "been reverted to their previous values."
+                ),
             ) from exc
 
     # Phase 279 ADMIN-09 (L-01): The second get_all_settings() call is INTENTIONAL.
-    # update_settings runs three side-effect pathways that mutate AppSetting AFTER
-    # the main registry loop:
-    #   1. _auto_detect_embedding_dims (above) -- writes EMBEDDING_DIMS via .set()
-    #      when embedding_model changes without an explicit dims value.
-    #   2. rebuild_embedding_column failure (above) -- rolls back the
-    #      requested embedding_dims to old_dims_value if the DDL fails.
+    # update_settings can persist values the request body does not name:
+    #   1. an auto-detected embedding_dims (#1529) joins validated_settings
+    #      before the apply loop when embedding_model changes on its own.
+    #   2. rebuild_embedding_column failure (above) -- rolls the published
+    #      embedding pair back to its previous value(s) if the DDL fails.
     #   3. .set() with commit=False above batches the writes; the final commit
     #      may differ from the request body if a validator coerced the value.
     # Additionally, get_all_settings computes public_app_url / public_api_url from

--- a/backend/tests/test_settings_router.py
+++ b/backend/tests/test_settings_router.py
@@ -2,8 +2,10 @@ import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import anyio
 import pytest
 from httpx import AsyncClient
+from pydantic import SecretStr
 
 
 # ---------------------------------------------------------------------------
@@ -363,3 +365,412 @@ async def test_put_settings_accepts_valid_quota(
         },
         headers=admin_auth_header,
     )
+
+
+# ---------------------------------------------------------------------------
+# #1529: the embedding model and its dimensions publish atomically
+# ---------------------------------------------------------------------------
+#
+# `update_settings` used to commit a new `embedding_model` and only then await
+# the provider probe that discovers that model's width. For the length of that
+# network call the committed pair was the new model beside the OLD model's
+# dimension count — committed, stable, and self-consistent, so no reader could
+# tell it from a real configuration by reading it twice.
+#
+# These tests drive the endpoint itself with a probe that blocks, and look at
+# the committed pair from a SEPARATE connection while the probe is in flight.
+# That is the window, opened deliberately and observed from outside.
+
+_OLD_MODEL = "atomic-publish-model-a"
+_NEW_MODEL = "atomic-publish-model-b"
+_OLD_DIMS = 1536
+_PROBED_DIMS = 768
+
+
+class _ProbeProvider:
+    """Base fake embedding provider: records what each probe asked for."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def resolve_runtime_config(self, session):
+        return {
+            "default_model": "provider-fallback-model",
+            "default_dims": 1536,
+            "base_url": "http://embeddings.invalid",
+        }
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        raise NotImplementedError
+
+
+class _FixedWidthProbeProvider(_ProbeProvider):
+    """Answers every probe with a vector of one fixed width."""
+
+    def __init__(self, width: int):
+        super().__init__()
+        self._width = width
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        self.calls.append({"model": model, "dimensions": dimensions})
+        return [[0.0] * self._width for _ in texts]
+
+
+class _BlockingProbeProvider(_FixedWidthProbeProvider):
+    """Holds the probe open until a reader has looked at the published pair.
+
+    A real probe is a provider network call, so the window is however long that
+    takes. Blocking on an event is the same window under test control: the
+    reader below cannot look "somewhere in the middle" by luck, it looks while
+    the call is provably still in flight.
+    """
+
+    def __init__(self, width: int):
+        super().__init__(width)
+        self.entered = anyio.Event()
+        self.release = anyio.Event()
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        self.calls.append({"model": model, "dimensions": dimensions})
+        self.entered.set()
+        await self.release.wait()
+        return [[0.0] * self._width for _ in texts]
+
+
+class _ExplodingProbeProvider(_ProbeProvider):
+    """Fails every probe, the way an unreachable or misconfigured provider does."""
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        self.calls.append({"model": model, "dimensions": dimensions})
+        raise RuntimeError("simulated provider failure")
+
+
+def _install_probe_provider(monkeypatch, provider) -> None:
+    """Route BOTH probe paths at ``provider``.
+
+    The pre-fix tree probes through `probe_embedding_dimensions`, which binds
+    `get_embedding_provider` into the embeddings service module at import time.
+    The fixed tree probes from the settings router, which resolves the same
+    name out of `app.platform.extensions` at call time. Patching both is what
+    lets one test body run against either tree — which is what makes an
+    observed red run mean anything.
+    """
+    import app.platform.extensions as extensions_module
+    from app.core.config import settings as core_settings
+    from app.processing.embeddings import service as service_module
+
+    monkeypatch.setattr(
+        extensions_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    # Both probe paths refuse to call a provider without a key configured.
+    monkeypatch.setattr(core_settings, "openai_api_key", SecretStr("probe-test-key"))
+
+
+async def _column_dims(session) -> int | None:
+    """Declared width of the vector column, or None if the table is absent."""
+    from sqlalchemy import text
+
+    return (
+        await session.execute(
+            text(
+                "SELECT atttypmod FROM pg_attribute "
+                "WHERE attrelid = 'catalog.record_embeddings'::regclass "
+                "AND attname = 'embedding' AND NOT attisdropped"
+            )
+        )
+    ).scalar_one_or_none()
+
+
+@pytest.fixture
+async def restore_embedding_settings(test_db_session):
+    """Put the embedding pair and the vector column back afterwards.
+
+    The per-worker database is shared across the whole session, and these tests
+    change global configuration and run real DDL.
+    """
+    from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+    from app.processing.embeddings.service import rebuild_embedding_column
+
+    before = (
+        await EMBEDDING_MODEL.get(test_db_session),
+        await EMBEDDING_DIMS.get(test_db_session),
+        await _column_dims(test_db_session),
+    )
+    yield
+    await EMBEDDING_MODEL.set(test_db_session, before[0])
+    await EMBEDDING_DIMS.set(test_db_session, before[1])
+    if before[2] is not None and before[2] > 0:
+        await rebuild_embedding_column(test_db_session, before[2])
+
+
+@pytest.mark.anyio
+async def test_no_reader_sees_the_new_model_beside_the_old_dimensions(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    monkeypatch,
+    restore_embedding_settings,
+):
+    """The window itself: look at the committed pair while the probe is running.
+
+    On the publish-then-probe tree the reader below sees `(_NEW_MODEL,
+    _OLD_DIMS)` — a pair that never existed in any configuration — and the
+    request has not even reached the provider's answer yet.
+    """
+    import app.core.db as db_module
+    from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+
+    # Non-vacuity: if the probed width matched the old one, the new model
+    # beside the old width would be a legitimate pair and there would be
+    # nothing here to detect.
+    assert _PROBED_DIMS != _OLD_DIMS
+    assert _NEW_MODEL != _OLD_MODEL
+
+    await EMBEDDING_MODEL.set(test_db_session, _OLD_MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _OLD_DIMS)
+
+    provider = _BlockingProbeProvider(_PROBED_DIMS)
+    _install_probe_provider(monkeypatch, provider)
+    # The column rebuild has its own test below; stub it so this one is about
+    # the published pair and nothing else.
+    rebuild = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.processing.embeddings.service.rebuild_embedding_column", rebuild
+    )
+
+    observations: list[tuple] = []
+
+    async def _look_while_the_probe_is_in_flight():
+        try:
+            # A tree that never opens the window would otherwise hang here.
+            with anyio.fail_after(30):
+                await provider.entered.wait()
+            # A separate connection, so this reads committed state — exactly
+            # what a backfill, a semantic search, or the coverage stats read.
+            async with db_module.async_session() as reader:
+                observations.append(
+                    (
+                        await EMBEDDING_MODEL.get_uncached(reader),
+                        await EMBEDDING_DIMS.get_uncached(reader),
+                    )
+                )
+        finally:
+            provider.release.set()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_look_while_the_probe_is_in_flight)
+        resp = await client.put(
+            "/settings/",
+            json={"settings": {"embedding_model": _NEW_MODEL}},
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 200
+    # Non-vacuity: the probe has to have run, against the model being
+    # published, asking for its natural width. Without that call there is no
+    # window and the reader below is just reading the settled state.
+    assert provider.calls == [{"model": _NEW_MODEL, "dimensions": None}]
+    # The finding: mid-probe, the committed pair is still the OLD one, whole.
+    assert observations == [(_OLD_MODEL, _OLD_DIMS)]
+    # And afterwards it is the NEW one, whole.
+    assert await EMBEDDING_MODEL.get_uncached(test_db_session) == _NEW_MODEL
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _PROBED_DIMS
+    # The detected width reaches the column rebuild too — the auto-detect and
+    # explicit-dims branches are no longer mutually exclusive.
+    rebuild.assert_awaited_once()
+    assert rebuild.await_args.args[1] == _PROBED_DIMS
+
+
+@pytest.mark.anyio
+async def test_a_failed_probe_publishes_neither_half(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    monkeypatch,
+    restore_embedding_settings,
+):
+    """If the probe fails there is no width to publish, so the model stays put."""
+    from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+
+    await EMBEDDING_MODEL.set(test_db_session, _OLD_MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _OLD_DIMS)
+
+    provider = _ExplodingProbeProvider()
+    _install_probe_provider(monkeypatch, provider)
+    rebuild = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.processing.embeddings.service.rebuild_embedding_column", rebuild
+    )
+
+    resp = await client.put(
+        "/settings/",
+        json={"settings": {"embedding_model": _NEW_MODEL}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 502
+    # Non-vacuity: a request that never reached the provider would satisfy
+    # every assertion below without proving the failure was handled.
+    assert provider.calls == [{"model": _NEW_MODEL, "dimensions": None}]
+    assert await EMBEDDING_MODEL.get_uncached(test_db_session) == _OLD_MODEL
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _OLD_DIMS
+    rebuild.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_an_auto_detected_width_rebuilds_the_vector_column(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    monkeypatch,
+    restore_embedding_settings,
+):
+    """A published width the column does not have is the same bug, one layer down.
+
+    Auto-detect used to persist the detected width and leave the column alone,
+    because the rebuild only ran on the explicit-dims branch. Every insert then
+    failed on the typmod while the configuration read as consistent.
+    """
+    from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+
+    column_before = await _column_dims(test_db_session)
+    # Non-vacuity: a dimensionless `vector` column (atttypmod -1) accepts any
+    # width, so there would be no mismatch for the rebuild to resolve.
+    assert column_before is not None and column_before > 0
+    target = 768 if column_before != 768 else 512
+    assert target != column_before
+
+    await EMBEDDING_MODEL.set(test_db_session, _OLD_MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, column_before)
+
+    provider = _FixedWidthProbeProvider(target)
+    _install_probe_provider(monkeypatch, provider)
+
+    resp = await client.put(
+        "/settings/",
+        json={"settings": {"embedding_model": _NEW_MODEL}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200
+    assert provider.calls == [{"model": _NEW_MODEL, "dimensions": None}]
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) == target
+    # Storage is the one thing no config-level consistency check looks at.
+    assert await _column_dims(test_db_session) == target
+
+
+@pytest.mark.anyio
+async def test_a_failed_rebuild_rolls_back_both_published_halves(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    monkeypatch,
+    restore_embedding_settings,
+):
+    """Rolling back the width alone would recreate the mismatched pair.
+
+    A request naming both halves publishes both; a DDL failure has to restore
+    both, or the failure path leaves exactly the state the probe ordering was
+    changed to prevent.
+    """
+    from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+
+    await EMBEDDING_MODEL.set(test_db_session, _OLD_MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _OLD_DIMS)
+
+    monkeypatch.setattr(
+        "app.processing.embeddings.service.rebuild_embedding_column",
+        AsyncMock(side_effect=RuntimeError("simulated DDL failure")),
+    )
+
+    resp = await client.put(
+        "/settings/",
+        json={
+            "settings": {
+                "embedding_model": _NEW_MODEL,
+                "embedding_dims": _PROBED_DIMS,
+            }
+        },
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 503
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _OLD_DIMS
+    assert await EMBEDDING_MODEL.get_uncached(test_db_session) == _OLD_MODEL
+
+
+@pytest.mark.anyio
+async def test_resending_the_unchanged_model_does_not_probe(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    monkeypatch,
+    restore_embedding_settings,
+):
+    """A save that re-sends the current model must not depend on the provider.
+
+    The AI settings tab sends only dirty fields, but an API or CLI caller can
+    PUT the whole tab. Probing on presence rather than on change would turn
+    every such save into a 502 whenever the provider is unreachable — and
+    would also overwrite an explicitly configured width.
+    """
+    from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+
+    await EMBEDDING_MODEL.set(test_db_session, _OLD_MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _OLD_DIMS)
+
+    provider = _ExplodingProbeProvider()
+    _install_probe_provider(monkeypatch, provider)
+
+    resp = await client.put(
+        "/settings/",
+        json={"settings": {"embedding_model": _OLD_MODEL}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200
+    assert provider.calls == []
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _OLD_DIMS
+
+
+@pytest.mark.anyio
+async def test_a_probed_width_out_of_range_publishes_neither_half(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    monkeypatch,
+    restore_embedding_settings,
+):
+    """A detected width goes through the same validator an admin-typed one does.
+
+    The published width becomes the ``vector(N)`` the column is rebuilt to, so
+    "whatever the provider answered" is not an acceptable source for it. Out of
+    the [1, 4096] range the request is rejected whole, exactly as a typed value
+    would be.
+    """
+    from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+
+    await EMBEDDING_MODEL.set(test_db_session, _OLD_MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _OLD_DIMS)
+
+    provider = _FixedWidthProbeProvider(8192)
+    _install_probe_provider(monkeypatch, provider)
+    rebuild = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.processing.embeddings.service.rebuild_embedding_column", rebuild
+    )
+
+    resp = await client.put(
+        "/settings/",
+        json={"settings": {"embedding_model": _NEW_MODEL}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 422
+    assert "embedding_dims" in resp.json()["detail"]
+    assert await EMBEDDING_MODEL.get_uncached(test_db_session) == _OLD_MODEL
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _OLD_DIMS
+    rebuild.assert_not_awaited()

--- a/backend/tests/test_settings_router.py
+++ b/backend/tests/test_settings_router.py
@@ -491,19 +491,26 @@ async def restore_embedding_settings(test_db_session):
     The per-worker database is shared across the whole session, and these tests
     change global configuration and run real DDL.
     """
-    from app.core.persistent_config import EMBEDDING_DIMS, EMBEDDING_MODEL
+    from app.core.persistent_config import (
+        EMBEDDING_BASE_URL,
+        EMBEDDING_DIMS,
+        EMBEDDING_MODEL,
+        OPENAI_BASE_URL,
+    )
     from app.processing.embeddings.service import rebuild_embedding_column
 
-    before = (
-        await EMBEDDING_MODEL.get(test_db_session),
-        await EMBEDDING_DIMS.get(test_db_session),
-        await _column_dims(test_db_session),
-    )
+    # The base URLs are restored too: the endpoint tests below stage a stale one,
+    # and leaving it behind would break every later test that resolves the
+    # embedding runtime config on this worker's database.
+    keys = (EMBEDDING_MODEL, EMBEDDING_DIMS, EMBEDDING_BASE_URL, OPENAI_BASE_URL)
+    before = [await cfg.get(test_db_session) for cfg in keys]
+    before_column = await _column_dims(test_db_session)
     yield
-    await EMBEDDING_MODEL.set(test_db_session, before[0])
-    await EMBEDDING_DIMS.set(test_db_session, before[1])
-    if before[2] is not None and before[2] > 0:
-        await rebuild_embedding_column(test_db_session, before[2])
+    for cfg, value in zip(keys, before):
+        if await cfg.get_uncached(test_db_session) != value:
+            await cfg.set(test_db_session, value)
+    if before_column is not None and before_column > 0:
+        await rebuild_embedding_column(test_db_session, before_column)
 
 
 @pytest.mark.anyio
@@ -774,3 +781,178 @@ async def test_a_probed_width_out_of_range_publishes_neither_half(
     assert await EMBEDDING_MODEL.get_uncached(test_db_session) == _OLD_MODEL
     assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _OLD_DIMS
     rebuild.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# #1538 review: the probe must call the endpoint THIS request publishes
+# ---------------------------------------------------------------------------
+#
+# `resolve_runtime_config(db)` reads COMMITTED configuration, and the probe runs
+# before anything in the batch is staged. So a PUT that changes the endpoint and
+# the model together resolved the endpoint from the value it was replacing.
+#
+# Destination binding bounds the damage: with an API key present, a DB base URL
+# that disagrees with the operator-approved one is rejected at validation, so a
+# width from a foreign endpoint cannot be published. What it does NOT bound is a
+# stale row staged while no key existed. Repairing that row and changing the
+# model in one request made `resolve_runtime_config` raise on the value being
+# repaired, and the repair was refused with a 502.
+
+_APPROVED_URL = "https://approved-endpoint.example.com/v1"
+_STALE_URL = "https://stale-staged-endpoint.example.com/v1"
+_APPROVED_WIDTH = 768
+_STALE_WIDTH = 1536
+
+
+class _PerEndpointProvider(_ProbeProvider):
+    """Different widths at different endpoints, and the REAL config resolution.
+
+    Same-named models on two deployments can have different output widths, so
+    the width alone identifies which endpoint answered. `resolve_runtime_config`
+    delegates to the real provider on purpose: the committed-config read is the
+    thing under test, and a stubbed one would answer with whatever this file
+    hardcoded and never ask the question.
+    """
+
+    def __init__(self, widths: dict[str, int]):
+        super().__init__()
+        self._widths = widths
+
+    async def resolve_runtime_config(self, session):
+        from app.platform.extensions.defaults_ai_openai import (
+            DefaultOpenAIEmbeddingProvider,
+        )
+
+        return await DefaultOpenAIEmbeddingProvider().resolve_runtime_config(session)
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        self.calls.append(
+            {"model": model, "dimensions": dimensions, "base_url": base_url}
+        )
+        width = self._widths.get(base_url)
+        if width is None:
+            raise RuntimeError(f"no endpoint at {base_url!r}")
+        return [[0.0] * width for _ in texts]
+
+
+@pytest.mark.anyio
+async def test_the_probe_calls_the_endpoint_this_request_publishes(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    monkeypatch,
+    restore_embedding_settings,
+):
+    """Repairing a stale endpoint and switching model in one PUT must work.
+
+    Before the fix the probe resolved its endpoint from committed config, which
+    is the stale row being repaired, so `resolve_runtime_config` raised against
+    the operator-approved destination and the request 502'd without ever
+    reaching a provider.
+    """
+    from app.core.ai_credentials import operator_openai_base_url
+    from app.core.config import settings as core_settings
+    from app.core.persistent_config import (
+        EMBEDDING_BASE_URL,
+        EMBEDDING_DIMS,
+        EMBEDDING_MODEL,
+    )
+
+    # Non-vacuity: identical widths would pass whichever endpoint answered.
+    assert _APPROVED_WIDTH != _STALE_WIDTH
+
+    # Stage a stale endpoint the way an operator can before supplying a key.
+    monkeypatch.setattr(core_settings, "openai_api_key", None)
+    await EMBEDDING_BASE_URL.set(test_db_session, _STALE_URL)
+    await EMBEDDING_MODEL.set(test_db_session, _OLD_MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _STALE_WIDTH)
+
+    # The operator now supplies a credential bound to a DIFFERENT endpoint.
+    monkeypatch.setattr(core_settings, "openai_api_key", SecretStr("probe-test-key"))
+    monkeypatch.setattr(core_settings, "embedding_base_url", _APPROVED_URL)
+    monkeypatch.setattr(core_settings, "openai_base_url", _APPROVED_URL)
+
+    # Non-vacuity: the two endpoints have to actually differ, or there is no
+    # committed-versus-requested divergence for the probe to get wrong.
+    assert await EMBEDDING_BASE_URL.get_uncached(test_db_session) == _STALE_URL
+    assert operator_openai_base_url(purpose="embedding") == _APPROVED_URL
+
+    provider = _PerEndpointProvider(
+        {_APPROVED_URL: _APPROVED_WIDTH, _STALE_URL: _STALE_WIDTH}
+    )
+    _install_probe_provider(monkeypatch, provider)
+    monkeypatch.setattr(core_settings, "openai_api_key", SecretStr("probe-test-key"))
+    rebuild = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.processing.embeddings.service.rebuild_embedding_column", rebuild
+    )
+
+    resp = await client.put(
+        "/settings/",
+        json={
+            "settings": {
+                "embedding_model": _NEW_MODEL,
+                "embedding_base_url": _APPROVED_URL,
+            }
+        },
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200
+    # The probe reached a provider at all, and reached the REQUESTED endpoint.
+    assert provider.calls == [
+        {"model": _NEW_MODEL, "dimensions": None, "base_url": _APPROVED_URL}
+    ]
+    # The published width is the requested endpoint's, not the replaced one's.
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _APPROVED_WIDTH
+    assert await EMBEDDING_MODEL.get_uncached(test_db_session) == _NEW_MODEL
+    assert await EMBEDDING_BASE_URL.get_uncached(test_db_session) == _APPROVED_URL
+
+
+@pytest.mark.anyio
+async def test_a_url_free_request_still_resolves_the_committed_endpoint(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session,
+    monkeypatch,
+    restore_embedding_settings,
+):
+    """A model-only PUT keeps using the provider's own config resolution.
+
+    Counterfactual for the test above: the request-aware branch must not take
+    over when the request names no endpoint, or the committed configuration
+    would stop being consulted at all.
+    """
+    from app.core.config import settings as core_settings
+    from app.core.persistent_config import (
+        EMBEDDING_BASE_URL,
+        EMBEDDING_DIMS,
+        EMBEDDING_MODEL,
+    )
+
+    monkeypatch.setattr(core_settings, "openai_api_key", SecretStr("probe-test-key"))
+    monkeypatch.setattr(core_settings, "embedding_base_url", _APPROVED_URL)
+    monkeypatch.setattr(core_settings, "openai_base_url", _APPROVED_URL)
+    await EMBEDDING_BASE_URL.set(test_db_session, _APPROVED_URL)
+    await EMBEDDING_MODEL.set(test_db_session, _OLD_MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _STALE_WIDTH)
+
+    provider = _PerEndpointProvider({_APPROVED_URL: _APPROVED_WIDTH})
+    _install_probe_provider(monkeypatch, provider)
+    monkeypatch.setattr(core_settings, "openai_api_key", SecretStr("probe-test-key"))
+    rebuild = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.processing.embeddings.service.rebuild_embedding_column", rebuild
+    )
+
+    resp = await client.put(
+        "/settings/",
+        json={"settings": {"embedding_model": _NEW_MODEL}},
+        headers=admin_auth_header,
+    )
+
+    assert resp.status_code == 200
+    assert provider.calls == [
+        {"model": _NEW_MODEL, "dimensions": None, "base_url": _APPROVED_URL}
+    ]
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _APPROVED_WIDTH


### PR DESCRIPTION
Closes #1529

`update_settings` committed a new `embedding_model` and only then awaited the provider probe that discovers that model's width. For the length of that network call the committed pair was the new model beside the OLD model's dimension count. It was committed and it was stable, so re-reading it agreed with itself and told the reader nothing.

Both mechanism claims in the issue were verified against the tree before anything was designed, and the line numbers were still accurate (model committed at `router.py:337-338`, probe awaited at `347-352`).

## What changed

The probe runs before anything is staged, against the model the request is asking to publish, and its result joins the same `validated_settings` batch. Model and width land in one `db.commit()`, so a reader sees the old pair or the new pair and nothing between them. A failed probe publishes neither half.

`probe_embedding_dimensions` resolves the model from PersistentConfig, so it can only probe a model that is already published, which is the ordering under repair. The router asks the provider extension about a named model instead: the same call `POST /settings/detect-embedding-dims` makes, with the model supplied rather than read back out.

Failure mapping matches that sibling endpoint. No provider configured is a 422 whose message names the escape hatch (send `embedding_dims` alongside `embedding_model` and the probe is skipped entirely); any other provider failure is a 502. Both are raised before the first write, so the previous configuration is untouched.

## Decision: auto-detect rebuilds the column too

**It rebuilds.** Persisting a width the vector column does not have is the same bug one layer down, and there were only two ways out: rebuild the column, or stop persisting the width. Not persisting it is not an option, because readers then fall back to the provider's `default_dims`, which is a different number for a different provider. That is the same mismatch, just implicit and harder to see.

The implementation is the absence of a special case. The detected width goes into `validated_settings` before the apply loop, so it reaches the existing `if "embedding_dims" in validated_settings` rebuild exactly as a typed one does. Auto-detect and explicit-dims were mutually exclusive branches; now there is one path.

What this costs: switching models now deletes existing embeddings whenever the width actually changes, because that is what `rebuild_embedding_column` does. That was already true for an explicitly named width, and those vectors were unusable anyway. They are the old model's, at a width the column no longer has, and search filters on the active model. When the width does not change (a 1536 model swapped for another 1536 model) the rebuild is a no-op and nothing is deleted.

Two things follow from routing auto-detect through the rebuild:

- **The rollback restores both halves.** The existing path rolled back `embedding_dims` alone. A request that publishes model and width together and then hits a DDL failure would be left with the new model beside the old width, which is the mismatched pair reached through the failure path instead of the probe window. Both halves are now restored in one transaction, with side effects applied after the commit rather than before it (fix #430 codex r3: invalidating the cache first lets a concurrent reader repopulate it with the value being rolled back). A dims-only request still rolls back dims only.
- **The probe fires on a changed model, not a present one.** The old code probed whenever `embedding_model` appeared in the request body. Now that a probe failure is fatal, probing on presence would turn any save that re-sends the current model into a 502 whenever the provider is unreachable. It would also keep overwriting a width the admin set on purpose. The AI settings tab sends only dirty fields, but an API or CLI caller can PUT the whole tab. The comparison reads `get_uncached`, because a stale cache entry naming the requested model would skip the probe and publish that model unprobed.

The detected width is run through `_canonicalize_setting_value` like any admin-supplied one. It becomes the `vector(N)` the column is rebuilt to, so "whatever the provider answered" is not an acceptable source for it; out of the [1, 4096] range the request is rejected whole.

## Second commit: the endpoint is part of the published configuration

Review found that the probe resolved its endpoint through `resolve_runtime_config(db)`, which reads committed configuration. Nothing in the batch is staged when the probe runs, so a PUT changing the base URL and the model together resolved the URL it was replacing. Publishing the model atomically with its width was only half of it; the width has to describe the endpoint being published too.

I drove all three cases through the endpoint before changing anything, because the impact turned out to be different from what it looked like:

| case | result |
|---|---|
| requested URL != operator-approved, credential present | **422** at validation, `provider.calls == []`, nothing published |
| requested URL == operator-approved | 200, probe called the approved URL, which is also the committed one |
| no credential | **422** from the probe's own guard, `provider.calls == []` |

`bind_openai_credential_base_url` binds the destination to the environment credential, so while `OPENAI_API_KEY` is set any DB base URL that differs from `operator_openai_base_url(purpose="embedding")` is rejected in pass-1, before the probe. The probe therefore cannot reach the replaced endpoint, and a width from one endpoint cannot be published beside another. Without a credential the URLs can diverge, but the probe refuses before reading any runtime config.

What binding does not cover is a **stale row staged while no credential existed**. Repairing that row and switching model in one request made `resolve_runtime_config` raise on the value under repair, and the repair came back 502 without reaching a provider at all:

```
status=502
detail=Embedding probe for model 'stale-row-model-b' failed: The environment-provided
       OpenAI-compatible credential is bound to the operator-approved EMBEDDING_BASE_URL...
provider.calls=[]
url now='https://stale-staged.example.com/v1'    <- repair refused
```

`_probe_base_url` now takes the endpoint from the validated batch when the request names either URL key, reproducing the provider's own chain with each half taken from the request where present (`EMBEDDING_BASE_URL`, then `OPENAI_BASE_URL`, then bound to the approved destination). Clearing `embedding_base_url` in the same PUT falls through to the `openai_base_url` that PUT sets, exactly as it will once the batch commits. A request naming neither URL still goes through `resolve_runtime_config` unchanged.

Red on the repair flow: `assert 502 == 200`. Green after, with the probe reaching the requested endpoint and its width published. Two stub endpoints answer at different widths (768 vs 1536) so the width identifies which one replied, and the stub delegates `resolve_runtime_config` to the real provider, since the committed-config read is the thing under test. `test_a_url_free_request_still_resolves_the_committed_endpoint` is the counterfactual for the other branch and passes on both trees.

The `model` argument also loses its fallback to the runtime default. This path only runs when the request names `embedding_model`, and the community provider's `default_model` *is* the committed `EMBEDDING_MODEL`, so the fallback could only ever name the model being replaced.

## Relationship to #1519

#1519 (closing #1511) mitigated this bug from the consumer side, and the two are complementary rather than overlapping. `_preflight_embedding` in `backfill.py` generates one real vector with the pinned pair before the DELETE, so a mismatched pair makes the provider reject and nothing is deleted; it then reads `atttypmod` off the live column and refuses when the generated width does not fit, which is the storage half.

Both guards sit inside `if force:` in `backfill_embeddings`. They protect the destructive path, which is the one that turned full coverage into zero. They do not cover the other readers the issue lists, because those readers never delete anything and so never reach a pre-flight: semantic search's vector arm resolves the pair per query, ingest-time generation resolves it per record, and the admin coverage stats read it directly. This PR removes the state from the database instead of catching it, so those readers are covered against a *committed* mismatched pair. It does not make every read atomic; see the cache note below.

The pre-flight also does not care that the window is now closed. It tests the property rather than reasoning about it, which is exactly why it survives a change to the writer.

**Neither guard becomes redundant, and neither should be removed on the strength of this PR.** Read the storage half in particular: it takes the width from the live `atttypmod` rather than from `EMBEDDING_DIMS`, so it catches a config/column disagreement whatever produced it. This PR closes the one route that was known to produce it. It cannot close routes nobody has enumerated: a restore from a backup taken mid-rebuild, a manual `ALTER TABLE`, an overlay provider writing config by another path, a future edit to this handler. A guard that asks storage directly keeps holding under all of them, which is the property that made it worth writing.

What does go stale in `backfill.py` is the *explanation* around those guards and the remediation text they print, both of which describe the mutually exclusive branches this PR removes. Those are listed under follow-up below. Correcting a comment is not a reason to delete the check it sits above.

## Residual, stated plainly

**The cache layer is not atomic, and this PR does not make it so. Filed as #1543.** `apply_side_effects` awaits a separate `cache.delete` per key, so a reader landing between the two evictions gets the new model from the database (cache miss) beside the old width from cache. Measured by instrumenting `cache.delete` to run a reader after each eviction: the mismatched pair is observable, in a window of 1.8us for a model-only save and 40us when four other settings share the request, because the detected width is evicted last. Those are in-memory-cache floors; with Valkey each eviction is a round-trip.

It is left out of this PR deliberately. Ordering cannot fix it (swapping mismatches the other way, and evicting before the commit is the fix #430 codex r3 hazard), so the real options all change `PersistentConfig` or the `CacheProvider` contract for every setting in the system, not these two. #1543 carries the measurements and the options. Unlike the committed window this PR closes, the cache one is transient rather than durable, self-heals when the pending delete lands, and surfaces as a provider rejection that succeeds on retry rather than a wrong answer, and the destructive path stays covered by #1519's pre-flight meanwhile.

Between the batch commit and the column rebuild finishing, the persisted width is the new one and the column is still the old one. That window is a DDL, not a network call, and it is the pre-existing behavior of the explicit-dims path, whose rollback covers the failure case. Closing it would need the rebuild inside the settings transaction, and `rebuild_embedding_column` commits internally. On the destructive path, #1519's storage check already refuses to delete anything it cannot store.

## Evidence

Six tests in `backend/tests/test_settings_router.py`, all driving `PUT /settings/` through the real endpoint. The concurrency test blocks inside the provider's `embed()` on an event and looks at the committed pair from a **separate connection** while the probe is provably still in flight, which is what a backfill, a semantic search, or the coverage stats would read.

The test body runs against either tree: it patches `get_embedding_provider` on both `app.platform.extensions` (resolved at call time by the new path) and `app.processing.embeddings.service` (bound at import time by the old one). That is what makes the red run mean something.

### Observed red, on the tree before this commit

```
E   AssertionError: assert [('atomic-pub...del-b', 1536)] == [('atomic-pub...del-a', 1536)]
test_settings_router.py:577  test_no_reader_sees_the_new_model_beside_the_old_dimensions
E   assert 200 == 502
test_settings_router.py:614  test_a_failed_probe_publishes_neither_half
E   assert 1536 == 768
test_settings_router.py:662  test_an_auto_detected_width_rebuilds_the_vector_column
E   AssertionError: assert 'atomic-publish-model-b' == 'atomic-publish-model-a'
test_settings_router.py:702  test_a_failed_rebuild_rolls_back_both_published_halves
E   AssertionError: assert [{'model': 'a...sions': None}] == []
test_settings_router.py:735  test_resending_the_unchanged_model_does_not_probe
5 failed, 14 deselected
```

The first line is the finding itself: a reader on another connection observed `('atomic-publish-model-b', 1536)` while the request had not yet reached the provider's answer. Model B beside model A's width, a pair that never existed in any configuration. The third is the mutual-exclusivity claim: the persisted width went to 768 and the column stayed at 1536.

### Green

```
$ uv run pytest tests/test_settings_router.py -p no:randomly -q
20 passed, 50 warnings in 13.52s
```

Every assertion has a vacuity guard. The probe call is asserted by value (`[{"model": _NEW_MODEL, "dimensions": None}]`), so a run where the window never opened fails instead of quietly reading settled state; `anyio.fail_after(30)` turns a probe that never happens into a failure rather than a hang; the probed width and the old width are asserted different, since equal ones would make the mismatched pair a legitimate configuration; and the column test asserts `atttypmod > 0` first, because a dimensionless `vector` column accepts any width and would have nothing to detect.

## Verification

```
tests/test_settings_router.py                                    22 passed
tests/test_settings_admin.py tests/test_settings_oauth_crud.py
  tests/test_phase_279_settings_admin.py tests/test_persistent_config.py
                                                                 93 passed
tests/test_embedding_backfill*.py tests/test_embedding_service.py
  tests/test_embedding_pipeline.py tests/test_embedding_provider_extension.py
  tests/test_embedding_vector_migration_config.py
  tests/test_allowed_email_domains_settings.py
  tests/test_branding_settings.py                                81 passed
tests/test_embedding_stats_model_scope.py tests/test_embedding_tenant_isolation.py
  tests/test_tenant_cache_partitioning.py tests/test_phase_274_caches_and_pool.py
  tests/test_rule1_structural.py tests/test_rule2_structural.py 148 passed
tests/test_layering.py                                           47 passed
uv run ruff check .                                              All checks passed
uv run ruff format --check .                                     1010 files already formatted
pre-commit run --files <both changed files>                      all hooks passed
python scripts/dump_openapi.py --check                           clean, openapi.json unchanged
```

No API surface change, so no SDK or CLI regeneration. `settings/router.py` is 1170 lines against the 1500 default cap, so no `_MODULE_LOC_CAPS` entry is needed.

## Follow-up, not touched here

Two comments elsewhere describe the old shape and are now stale. Both are in files this change does not own:

- `backend/app/processing/embeddings/backfill.py:148-157` and `:248-255` describe `_auto_detect_embedding_dims()` and `rebuild_embedding_column()` as mutually exclusive branches, and the settings window as open. Neither is true after this change, and `_auto_detect_embedding_dims` no longer exists.
- `backend/tests/test_embedding_backfill_model_pinning.py:354-360` repeats the same description with line numbers.

One is more than a stale comment. The storage-mismatch guard at `backfill.py:181-187` tells the operator to "Set the embedding dimensions explicitly in Settings so the column is rebuilt." That advice existed because auto-detect did not rebuild. It now does, so the explicit setting is no longer the only route and the remediation text is over-specific. **The wording is what is stale; the check is not.** See the note above.

Neither test breaks. Both construct the mismatched state directly through `PersistentConfig.set`, which is still the right way to test a consumer-side guard against a state the writer can no longer produce.



