### PR TITLE
fix(embeddings): pin the embedding endpoint for the length of a backfill run

### DIFF
--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -23,6 +23,7 @@ from app.processing.embeddings.service import (
     build_content_text,
     compute_content_hash,
     generate_embeddings_batch,
+    resolve_embedding_base_url,
 )
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -37,15 +38,23 @@ _BATCH_SIZE = 128
 _PREFLIGHT_TEXT = "geolens embedding preflight"
 
 
-async def _snapshot_embedding_config(session: AsyncSession) -> tuple[str, int | None]:
-    """Capture (model, dimensions) as one consistent pair, or refuse the run.
+async def _snapshot_embedding_config(
+    session: AsyncSession,
+) -> tuple[str, int | None, str | None]:
+    """Capture (model, dimensions, endpoint) as one consistent set, or refuse.
 
-    The two values come from separate `PersistentConfig` reads — there is no
+    The values come from separate `PersistentConfig` reads — there is no
     combined read, and building one would bypass the per-key validation and
-    cache machinery in `PersistentConfig.get`. So capture both, then read both
-    again and compare. Any single admin change lands inside one of the two
-    windows and shows up as a difference; only a change-and-revert inside the
-    same few milliseconds slips through, which is not a case worth more code.
+    cache machinery in `PersistentConfig.get`. So capture them, then read them
+    again and compare. Any single admin change lands inside one of the windows
+    and shows up as a difference; only a change-and-revert inside the same few
+    milliseconds slips through, which is not a case worth more code.
+
+    fix(#1525): the endpoint is captured and compared the same way, in a
+    window of its own (see below). It is resolved through the provider rather
+    than read here, because the fallback chain and the credential binding
+    belong to whichever provider extension is registered (see
+    `resolve_embedding_base_url`).
 
     fix(#1511 review r2, codex P1): without the comparison a run could pin
     model A with model B's dimensions, a pairing that never existed in config.
@@ -95,11 +104,28 @@ async def _snapshot_embedding_config(session: AsyncSession) -> tuple[str, int | 
             "untouched; re-run to use the new configuration."
         )
 
-    return model_name, dimensions
+    # fix(#1525): the endpoint is captured the same way but in its own window,
+    # not folded into the pair above. Resolving it calls the provider
+    # extension, which is an arbitrarily long await — a third-party provider
+    # may do I/O — and putting that between the model capture and the model
+    # re-read would widen the coupled pair's window by the length of a provider
+    # call, making a spurious abort likelier for the two values that actually
+    # have to agree with each other. The endpoint has no partner to be mixed
+    # with; it only has to equal itself across its own window.
+    base_url = await resolve_embedding_base_url(session)
+    if await resolve_embedding_base_url(session) != base_url:
+        logger.error("backfill_aborted_embedding_endpoint_changed")
+        raise RuntimeError(
+            "Cannot regenerate embeddings: the embedding endpoint changed while "
+            "the run was starting. Existing vectors were left untouched; re-run "
+            "to use the new configuration."
+        )
+
+    return model_name, dimensions, base_url
 
 
 async def _preflight_embedding(
-    session: AsyncSession, pinned: tuple[str, int | None]
+    session: AsyncSession, pinned: tuple[str, int | None, str | None]
 ) -> None:
     """Generate one throwaway embedding to prove regeneration can work.
 
@@ -126,10 +152,14 @@ async def _preflight_embedding(
             in the column as it currently stands. The caller must run this
             BEFORE deleting anything.
     """
-    model_name, dimensions = pinned
+    model_name, dimensions, base_url = pinned
     try:
         vectors = await generate_embeddings_batch(
-            [_PREFLIGHT_TEXT], session, model=model_name, dimensions=dimensions
+            [_PREFLIGHT_TEXT],
+            session,
+            model=model_name,
+            dimensions=dimensions,
+            base_url=base_url,
         )
     except Exception as exc:  # broad: any provider/config failure means the regenerate cannot be promised
         logger.error(
@@ -206,7 +236,7 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
     """
     port = get_processing_port()
 
-    pinned: tuple[str, int | None] | None = None
+    pinned: tuple[str, int | None, str | None] | None = None
 
     if force:
         Record = port.get_record_orm_class()
@@ -325,14 +355,17 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
     # resolution can fail between the two calls, and by then the delete has
     # committed. The non-force path has nothing to destroy, so it snapshots
     # here, where the original read lived.
-    # fix(#1511 review, codex P1): both halves are pinned into every provider
+    # fix(#1511 review, codex P1): all three parts are pinned into every provider
     # call below. generate_embeddings_batch would otherwise re-read the config
     # per call, so an admin swapping models mid-run gets model B's vectors
     # stored under model A's label — search on the active model then skips rows
-    # it believes it wrote.
+    # it believes it wrote. fix(#1525): the endpoint is the third part. The rows
+    # name a model, and a model served by two endpoints is two vector spaces
+    # under one label; on the shipped provider the same edit instead makes every
+    # remaining batch raise, which abandons the rest of the catalog.
     if pinned is None:
         pinned = await _snapshot_embedding_config(session)
-    model_name, embedding_dims = pinned
+    model_name, embedding_dims, base_url = pinned
 
     # Build embeddable (record_id, content_text) pairs; empty content skips.
     skipped = 0
@@ -363,6 +396,7 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                 session,
                 model=model_name,
                 dimensions=embedding_dims,
+                base_url=base_url,
             )
             for (record_id, content), vector in zip(batch, vectors):
                 session.add(
@@ -393,6 +427,7 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                         session,
                         model=model_name,
                         dimensions=embedding_dims,
+                        base_url=base_url,
                     )
                     session.add(
                         RecordEmbedding(

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -176,15 +176,19 @@ async def _preflight_embedding(
         ) from exc
 
     # fix(#1511 review r4, codex P1): generating a vector is only half the
-    # promise — it also has to fit the column. `update_settings` runs
-    # _auto_detect_embedding_dims() and rebuild_embedding_column() on MUTUALLY
-    # EXCLUSIVE branches (`embedding_dims` absent from the request versus
-    # present, modules/settings/router.py:348-360), so an admin who switches
-    # model without naming dimensions gets the detected width persisted and the
-    # column left at its old one. The provider then answers happily at the new
-    # width, this pre-flight passed, the DELETE committed, and every insert
-    # failed on the typmod. Zero coverage, by the exact route the pre-flight
-    # exists to close.
+    # promise — it also has to fit the column. The width a model produces and
+    # the width the column declares are written by different code at different
+    # times, so they can disagree, and when they do the provider answers
+    # happily at the new width, this pre-flight passes, the DELETE commits and
+    # every insert dies on the typmod.
+    #
+    # The case that found it was a settings write that persisted a newly
+    # detected width without rebuilding the column, so switching model without
+    # naming dimensions left storage at the old width (that path is the subject
+    # of #1529). This check is deliberately NOT written against that path: it
+    # asks storage what it will accept, so it holds for any cause — a rebuild
+    # that failed partway, a restored dump, a column altered by hand, a writer
+    # nobody has added yet. Closing one route does not make it redundant.
     #
     # Read the width off the live column rather than trusting EMBEDDING_DIMS:
     # the setting is what disagreed with storage in the first place. pgvector
@@ -212,8 +216,8 @@ async def _preflight_embedding(
             f"Cannot regenerate embeddings: model {model_name!r} produces "
             f"{generated}-dimension vectors but catalog.record_embeddings."
             f"embedding is vector({column_dims}). Existing vectors were left "
-            "untouched. Set the embedding dimensions explicitly in Settings so "
-            "the column is rebuilt, then re-run."
+            "untouched. Re-save the embedding configuration in Settings so the "
+            f"column is rebuilt to {generated} dimensions, then re-run."
         )
 
 
@@ -277,12 +281,13 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
 
         # fix(#1511 review r3, codex P1): the checks above test proxies for
         # "regeneration will work". This one tests the property itself, because
-        # the proxies keep running out. `update_settings` commits a new
-        # embedding_model and only then probes for its dimensions
-        # (settings/router.py), so between those two steps the stored pair is
-        # mismatched, committed and STABLE — re-reading it agrees with itself
-        # and learns nothing. That window opens exactly when an admin has just
-        # switched models, which is exactly when someone clicks Regenerate All.
+        # the proxies keep running out. A comparison-based guard can only catch
+        # a value that MOVES. It is blind to a pair that is wrong, committed and
+        # stable, because re-reading such a pair agrees with itself and learns
+        # nothing. What made that concrete was a settings write publishing a new
+        # model before its dimensions were known (that publish is the subject of
+        # #1529), but the blindness belongs to comparing, not to that one writer.
+        #
         # One real embedding proves the live config can produce a vector, and
         # covers the modes nobody has enumerated yet: provider down, revoked
         # key, exhausted quota, dimensions the model rejects.

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -159,6 +159,36 @@ async def _snapshot_embedding_config(
     return model_name, dimensions, base_url
 
 
+class _PinDrift(RuntimeError):
+    """Drift detected with a batch already generated but not yet committed.
+
+    A distinct type only so the per-batch handler can re-raise it instead of
+    counting it as a provider failure and retrying the batch record by record.
+    It is a `RuntimeError`, so every caller that already treats this module's
+    aborts as one — the admin route included — is unaffected.
+    """
+
+
+async def _raise_on_pin_drift(
+    session: AsyncSession,
+    pinned: tuple[str, int | None, str | None],
+    processed: int,
+    *,
+    error: type[RuntimeError] = RuntimeError,
+) -> None:
+    """Stop the run if the configuration it pinned is no longer the active one."""
+    drift = await _pinned_config_drift(session, pinned)
+    if drift is None:
+        return
+    logger.error("backfill_aborted_pin_drift", detail=drift, processed=processed)
+    raise error(
+        f"Embedding regeneration stopped after {processed} records: {drift} "
+        "while the run was in progress. The rows already written are "
+        "consistent with the configuration that produced them; re-run to "
+        "cover the rest under the new one."
+    )
+
+
 async def _pinned_config_drift(
     session: AsyncSession, pinned: tuple[str, int | None, str | None]
 ) -> str | None:
@@ -391,6 +421,19 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
         # key, exhausted quota, dimensions the model rejects.
         await _preflight_embedding(session, pinned)
 
+        # DESTRUCTIVE-FIRST, DELIBERATELY (#1549). This commits before the run
+        # knows it can finish, so a drift abort in the batch loop below leaves
+        # the table empty and the operator has to re-run. That is the chosen
+        # side of the trade, not an oversight: rows record only `model_name`,
+        # so a run that carried on under a stale pin would leave a FULL table
+        # whose vectors live in a space the active search silently fails to
+        # match. Empty is loud and one re-run away; populated-and-wrong looks
+        # healthy and is not. Removing the destructive-first shape needs
+        # per-batch delete-and-replace in one transaction (which wants #1546's
+        # per-row configuration stamp first, or it trades a loud failure for a
+        # silent one), a shadow table and swap, or the job lifecycle in #1542 —
+        # none of which belong in a PR about pinning a configuration.
+        #
         # The HNSW index lives in Alembic migration 0012 (and is recreated
         # by service.rebuild_embedding_column on dimension change). On
         # force=True we just clear the active tenant's rows; no need to drop
@@ -503,16 +546,16 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
         # an endpoint identity per row so search can filter on it is #1546.
         #
         # Outside the try below, deliberately: this must stop the run, not be
-        # counted as a batch error and retried per record.
-        drift = await _pinned_config_drift(session, pinned)
-        if drift is not None:
-            logger.error("backfill_aborted_pin_drift", detail=drift, processed=created)
-            raise RuntimeError(
-                f"Embedding regeneration stopped after {created} records: "
-                f"{drift} while the run was in progress. The rows already "
-                "written are consistent with the configuration that produced "
-                "them; re-run to cover the rest under the new one."
-            )
+        # counted as a batch error and retried per record. The sibling check
+        # after the provider call cannot have that placement, so it raises
+        # `_PinDrift` and the batch handler re-raises it to the same effect.
+        #
+        # Kept alongside that one rather than replaced by it: a post-call check
+        # alone is sufficient for correctness, but drift that lands BETWEEN
+        # batches would then only surface after the next batch had already been
+        # generated and paid for. One config read per batch is the cheaper half
+        # of that trade.
+        await _raise_on_pin_drift(session, pinned, created)
 
         batch = items[start : start + _BATCH_SIZE]
         try:
@@ -523,6 +566,15 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                 dimensions=embedding_dims,
                 base_url=base_url,
             )
+            # fix(#1525 review r5, codex P2): and again before ACCEPTING the
+            # batch, not only before requesting it. The check above has no
+            # successor for the LAST batch, so an edit landing during that
+            # final provider call was never observed: the vectors were written
+            # and the run reported success while the active endpoint had moved.
+            # Checking here means the batch in flight is discarded rather than
+            # committed, so the run stops without adding a row nothing will
+            # match. `_PinDrift` is re-raised past the batch handler below.
+            await _raise_on_pin_drift(session, pinned, created, error=_PinDrift)
             for (record_id, content), vector in zip(batch, vectors):
                 session.add(
                     RecordEmbedding(
@@ -534,6 +586,13 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                 )
             await session.commit()
             created += len(batch)
+        except _PinDrift:
+            # fix(#1525 review r5, codex P2): not a batch failure. Retrying it
+            # per record would generate the same vectors against the same stale
+            # pin and commit them one at a time, which is the outcome the check
+            # exists to prevent.
+            await session.rollback()
+            raise
         except Exception:  # broad: per-batch backfill is isolated; embedding API/DB errors are counted not raised
             await session.rollback()
             logger.warning(

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -50,8 +50,8 @@ async def _snapshot_embedding_config(
     and shows up as a difference; only a change-and-revert inside the same few
     milliseconds slips through, which is not a case worth more code.
 
-    fix(#1525): the endpoint is captured and compared the same way, in a
-    window of its own (see below). It is resolved through the provider rather
+    fix(#1525): the endpoint is captured and compared inside that same single
+    window, for the reason below. It is resolved through the provider rather
     than read here, because the fallback chain and the credential binding
     belong to whichever provider extension is registered (see
     `resolve_embedding_base_url`).
@@ -92,33 +92,26 @@ async def _snapshot_embedding_config(
             "once the AI configuration resolves."
         )
     dimensions = await EMBEDDING_DIMS.get(session)
+    base_url = await resolve_embedding_base_url(session)
 
+    # fix(#1525 review, codex P1): ONE window over all three, not a window per
+    # value. An earlier revision gave the endpoint its own capture-and-compare
+    # after the pair had already been compared, which left a gap between the
+    # two: an admin updating model and endpoint together in that gap produced
+    # old model + new endpoint, a configuration that never existed, and neither
+    # comparison could see it. Splitting a race guard by value does not close
+    # the race, it relocates it. If values are pinned as a unit they have to be
+    # verified as a unit.
     if (
         await resolve_embedding_model_name(session) != model_name
         or await EMBEDDING_DIMS.get(session) != dimensions
+        or await resolve_embedding_base_url(session) != base_url
     ):
         logger.error("backfill_aborted_embedding_config_changed")
         raise RuntimeError(
-            "Cannot regenerate embeddings: the embedding model or dimensions "
-            "changed while the run was starting. Existing vectors were left "
-            "untouched; re-run to use the new configuration."
-        )
-
-    # fix(#1525): the endpoint is captured the same way but in its own window,
-    # not folded into the pair above. Resolving it calls the provider
-    # extension, which is an arbitrarily long await — a third-party provider
-    # may do I/O — and putting that between the model capture and the model
-    # re-read would widen the coupled pair's window by the length of a provider
-    # call, making a spurious abort likelier for the two values that actually
-    # have to agree with each other. The endpoint has no partner to be mixed
-    # with; it only has to equal itself across its own window.
-    base_url = await resolve_embedding_base_url(session)
-    if await resolve_embedding_base_url(session) != base_url:
-        logger.error("backfill_aborted_embedding_endpoint_changed")
-        raise RuntimeError(
-            "Cannot regenerate embeddings: the embedding endpoint changed while "
-            "the run was starting. Existing vectors were left untouched; re-run "
-            "to use the new configuration."
+            "Cannot regenerate embeddings: the embedding model, dimensions or "
+            "endpoint changed while the run was starting. Existing vectors were "
+            "left untouched; re-run to use the new configuration."
         )
 
     return model_name, dimensions, base_url

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -276,11 +276,17 @@ async def _preflight_embedding(
     #
     # The case that found it was a settings write that persisted a newly
     # detected width without rebuilding the column, so switching model without
-    # naming dimensions left storage at the old width (that path is the subject
-    # of #1529). This check is deliberately NOT written against that path: it
-    # asks storage what it will accept, so it holds for any cause — a rebuild
-    # that failed partway, a restored dump, a column altered by hand, a writer
-    # nobody has added yet. Closing one route does not make it redundant.
+    # naming dimensions left storage at the old width. #1529 closed that route:
+    # an auto-detected width now joins `validated_settings` and goes down the
+    # same rebuild branch as one an admin typed, so the column follows every
+    # width the settings API publishes.
+    #
+    # This check is deliberately NOT written against that route, which is why
+    # closing it did not retire the check. It asks storage what it will accept,
+    # so it holds for any cause. Still live after #1529: a rebuild that failed
+    # partway, a restored dump, a column altered by hand, and ENV_ONLY_CONFIG
+    # deployments, where the model comes from the environment, no settings
+    # write happens, and therefore no rebuild is ever triggered.
     #
     # Read the width off the live column rather than trusting EMBEDDING_DIMS:
     # the setting is what disagreed with storage in the first place. pgvector

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -56,6 +56,28 @@ async def _snapshot_embedding_config(
     belong to whichever provider extension is registered (see
     `resolve_embedding_base_url`).
 
+    KNOWN RESIDUE (#1525 review r2): the model and dimensions are read
+    uncached, so they are always the committed state. The endpoint is not, and
+    cannot be from here — it is resolved BY THE PROVIDER, which reads its own
+    keys through the same per-key cache. Making that read uncached needs either
+    a copy of the provider's fallback chain and credential binding in this
+    caller, which would be wrong for any extension resolving its endpoint from
+    somewhere else, or an uncached mode on the extension interface itself.
+
+    What that leaves open: a settings update that is committed but whose
+    endpoint key is not yet evicted, so the provider answers from a stale entry
+    beside an uncached model. For the SHIPPED provider it is unreachable — with
+    an API key configured the endpoint is derived from the environment rather
+    than the database (`ai_credentials.bind_openai_credential_base_url`), so it
+    cannot go stale at all. It is reachable only for an extension provider that
+    resolves a database-derived endpoint.
+
+    A partial guard was tried here and removed: comparing the cached model and
+    dimensions against the uncached ones detects the eviction window, but only
+    the half where the model key has not been evicted yet, and it aborts
+    whenever a caller mocks one read and not the other. A guard that fires on
+    incomplete test doubles more often than on the hazard does not survive.
+
     fix(#1511 review r2, codex P1): without the comparison a run could pin
     model A with model B's dimensions, a pairing that never existed in config.
     A provider that rejects it fails every insert; one that accepts it writes
@@ -80,7 +102,15 @@ async def _snapshot_embedding_config(
         resolve_embedding_model_name,
     )
 
-    model_name = await resolve_embedding_model_name(session)
+    # fix(#1525 review r2, codex P1): read the pinned values straight from the
+    # DB. `PersistentConfig.get` answers from a PER-KEY cache, and
+    # `update_settings` commits the whole batch and only then evicts each key in
+    # turn (settings/router.py:338-345). During that eviction, reads of two
+    # different keys can land on opposite sides of one committed update, and
+    # comparing them cannot see it: two reads through the same stale entry agree
+    # with each other perfectly. `get_uncached` neither reads nor writes the
+    # cache, so these observe the committed state instead.
+    model_name = await resolve_embedding_model_name(session, uncached=True)
     if model_name == UNKNOWN_EMBEDDING_MODEL:
         # Loud, not silent: the admin route maps this to a 502 and a "failed"
         # audit entry. Returning zero counts would look like a completed run
@@ -91,7 +121,7 @@ async def _snapshot_embedding_config(
             "not be resolved. Existing vectors were left untouched; retry "
             "once the AI configuration resolves."
         )
-    dimensions = await EMBEDDING_DIMS.get(session)
+    dimensions = await EMBEDDING_DIMS.get_uncached(session)
     base_url = await resolve_embedding_base_url(session)
 
     # fix(#1525 review, codex P1): ONE window over all three, not a window per
@@ -103,8 +133,8 @@ async def _snapshot_embedding_config(
     # the race, it relocates it. If values are pinned as a unit they have to be
     # verified as a unit.
     if (
-        await resolve_embedding_model_name(session) != model_name
-        or await EMBEDDING_DIMS.get(session) != dimensions
+        await resolve_embedding_model_name(session, uncached=True) != model_name
+        or await EMBEDDING_DIMS.get_uncached(session) != dimensions
         or await resolve_embedding_base_url(session) != base_url
     ):
         logger.error("backfill_aborted_embedding_config_changed")

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -12,6 +12,8 @@ sink its batchmates; only the individually-failing records count as errors.
 Can be run as a module: python -m app.embeddings.backfill
 """
 
+from typing import Any
+
 import structlog
 from sqlalchemy import delete, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -162,10 +164,11 @@ async def _snapshot_embedding_config(
 class _PinDrift(RuntimeError):
     """Drift detected with a batch already generated but not yet committed.
 
-    A distinct type only so the per-batch handler can re-raise it instead of
-    counting it as a provider failure and retrying the batch record by record.
-    It is a `RuntimeError`, so every caller that already treats this module's
-    aborts as one — the admin route included — is unaffected.
+    A distinct type only so the two broad handlers below can re-raise it: the
+    per-batch one instead of retrying the batch record by record, and the
+    per-record one instead of counting it as a bad input. It is a
+    `RuntimeError`, so every caller that already treats this module's aborts as
+    one — the admin route included — is unaffected.
     """
 
 
@@ -187,6 +190,82 @@ async def _raise_on_pin_drift(
         "consistent with the configuration that produced them; re-run to "
         "cover the rest under the new one."
     )
+
+
+async def _retry_batch_per_record(
+    session: AsyncSession,
+    batch: list[tuple[Any, str]],
+    pinned: tuple[str, int | None, str | None],
+    created: int,
+    *,
+    model_name: str,
+    embedding_dims: int | None,
+    base_url: str | None,
+) -> tuple[int, int]:
+    """Re-embed a failed batch one record at a time; return (created, errors).
+
+    fix(#449, codex P2): one rejected input (e.g. a record over the model's
+    token limit) must not sink the other 127, so only the bad ones count as
+    errors. That behaviour is unchanged; what is new is the drift bracketing.
+    It lives in its own function because adding that pushed
+    `backfill_embeddings` past the McCabe gate, and the per-file burn-down list
+    in pyproject.toml may shrink but never grow.
+
+    `created` is the run's running total, passed in only so an abort message
+    can say how many records the run had written before it stopped.
+    """
+    made = 0
+    failed = 0
+    for record_id, content in batch:
+        try:
+            # fix(#1525 review r6, codex P2): the drift checks bracket the
+            # retry's own provider call too. This path had none, so the window
+            # the batch path closed survived one path over, and it is the
+            # LIKELIER one: a provider outage is exactly when an operator goes
+            # and edits the endpoint. The batch call raised, so the batch's
+            # post-call check never ran, and every vector generated here would
+            # otherwise be committed under a pin that had already stopped being
+            # active.
+            #
+            # The check before the call is not redundant with the one after the
+            # previous record's: that record may have FAILED, in which case its
+            # post-call check never ran either.
+            await _raise_on_pin_drift(session, pinned, created + made, error=_PinDrift)
+            [vector] = await generate_embeddings_batch(
+                [content],
+                session,
+                model=model_name,
+                dimensions=embedding_dims,
+                base_url=base_url,
+            )
+            await _raise_on_pin_drift(session, pinned, created + made, error=_PinDrift)
+            session.add(
+                RecordEmbedding(
+                    record_id=record_id,
+                    embedding=vector,
+                    model_name=model_name,
+                    content_hash=compute_content_hash(content),
+                )
+            )
+            await session.commit()
+            made += 1
+        except _PinDrift:
+            # fix(#1525 review r6, codex P2): drift is not a bad record.
+            # Counting it would leave the run reporting partial success with
+            # the rest of the catalog written into a vector space the active
+            # search cannot match — the silent outcome these checks exist to
+            # prevent. It stops the run, as on the batch path.
+            await session.rollback()
+            raise
+        except Exception:  # broad: same isolation, per record
+            await session.rollback()
+            failed += 1
+            logger.warning(
+                "Backfill: error processing record",
+                record_id=record_id,
+                exc_info=True,
+            )
+    return made, failed
 
 
 async def _pinned_config_drift(
@@ -601,36 +680,17 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
                 batch_size=len(batch),
                 exc_info=True,
             )
-            # fix(#449, codex P2): one rejected input (e.g. a record over the
-            # model's token limit) must not sink the other 127 — retry the
-            # failed batch per record so only the bad ones count as errors.
-            for record_id, content in batch:
-                try:
-                    [vector] = await generate_embeddings_batch(
-                        [content],
-                        session,
-                        model=model_name,
-                        dimensions=embedding_dims,
-                        base_url=base_url,
-                    )
-                    session.add(
-                        RecordEmbedding(
-                            record_id=record_id,
-                            embedding=vector,
-                            model_name=model_name,
-                            content_hash=compute_content_hash(content),
-                        )
-                    )
-                    await session.commit()
-                    created += 1
-                except Exception:  # broad: same isolation, per record
-                    await session.rollback()
-                    errors += 1
-                    logger.warning(
-                        "Backfill: error processing record",
-                        record_id=record_id,
-                        exc_info=True,
-                    )
+            made, failed = await _retry_batch_per_record(
+                session,
+                batch,
+                pinned,
+                created,
+                model_name=model_name,
+                embedding_dims=embedding_dims,
+                base_url=base_url,
+            )
+            created += made
+            errors += failed
 
         logger.info(
             "Backfill progress",

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -159,6 +159,63 @@ async def _snapshot_embedding_config(
     return model_name, dimensions, base_url
 
 
+async def _pinned_config_drift(
+    session: AsyncSession, pinned: tuple[str, int | None, str | None]
+) -> str | None:
+    """Describe how the live config has left the pinned one, or None if it has not.
+
+    fix(#1525 review r4, codex P2): every guard on this path so far protects a
+    run from config moving DURING a read. This one notices that the run itself
+    has outlived the configuration it pinned, which no amount of care inside a
+    single batch can see.
+
+    Read the same way `_snapshot_embedding_config` reads, for the same reason:
+    a cached read can agree with a stale entry and report no drift.
+
+    Two states are deliberately NOT treated as drift, because neither is
+    evidence that the pinned configuration stopped being the right one:
+
+    - An unresolvable model. `resolve_embedding_model_name` answers with its
+      sentinel when persistent-config resolution fails for any reason, so
+      treating it as a change would abort a long run on a transient DB blip.
+    - A provider resolve that RAISES. For the shipped provider that is what an
+      endpoint edit diverging from the operator-approved environment URL looks
+      like (`ai_credentials.bind_openai_credential_base_url`), and it says
+      nothing about where vectors are going: `embed` re-binds to that same
+      approved URL, so the pin is still accurate. Aborting there would undo the
+      abandon-the-catalog fix earlier in this PR. Only a resolve that SUCCEEDS
+      and answers differently means the endpoint actually moved.
+    """
+    from app.processing.embeddings.helpers import (
+        UNKNOWN_EMBEDDING_MODEL,
+        resolve_embedding_model_name,
+    )
+
+    model_name, dimensions, base_url = pinned
+
+    active_model = await resolve_embedding_model_name(session, uncached=True)
+    if active_model not in (model_name, UNKNOWN_EMBEDDING_MODEL):
+        return f"the embedding model changed from {model_name!r} to {active_model!r}"
+
+    active_dims = await EMBEDDING_DIMS.get_uncached(session)
+    if active_dims != dimensions:
+        return (
+            f"the embedding dimensions changed from {dimensions!r} to {active_dims!r}"
+        )
+
+    try:
+        active_base_url = await resolve_embedding_base_url(session)
+    except (
+        Exception
+    ):  # broad: an endpoint that cannot be resolved is not an endpoint that moved
+        return None
+    if active_base_url != base_url:
+        # Deliberately unquoted: an endpoint can name an internal host, and this
+        # string reaches an audit log.
+        return "the embedding endpoint changed"
+    return None
+
+
 async def _preflight_embedding(
     session: AsyncSession, pinned: tuple[str, int | None, str | None]
 ) -> None:
@@ -429,6 +486,28 @@ async def backfill_embeddings(session: AsyncSession, *, force: bool = False) -> 
     errors = 0
 
     for start in range(0, len(items), _BATCH_SIZE):
+        # fix(#1525 review r4, codex P2): the pin protects each batch from the
+        # config moving underneath it, but nothing was noticing that it HAD
+        # moved. A run pinned to endpoint A that keeps going after the active
+        # endpoint becomes B writes A-space vectors for the rest of the
+        # catalog, and `RecordEmbedding` records only `model_name`, so semantic
+        # search later builds its query vector from the live endpoint and
+        # filters stored rows by model alone — B-space queries against A-space
+        # documents under one label, and the backfill reported success. Persisting
+        # an endpoint identity per row so search can filter on it is #1546.
+        #
+        # Outside the try below, deliberately: this must stop the run, not be
+        # counted as a batch error and retried per record.
+        drift = await _pinned_config_drift(session, pinned)
+        if drift is not None:
+            logger.error("backfill_aborted_pin_drift", detail=drift, processed=created)
+            raise RuntimeError(
+                f"Embedding regeneration stopped after {created} records: "
+                f"{drift} while the run was in progress. The rows already "
+                "written are consistent with the configuration that produced "
+                "them; re-run to cover the rest under the new one."
+            )
+
         batch = items[start : start + _BATCH_SIZE]
         try:
             vectors = await generate_embeddings_batch(

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -66,11 +66,23 @@ async def _snapshot_embedding_config(
 
     What that leaves open: a settings update that is committed but whose
     endpoint key is not yet evicted, so the provider answers from a stale entry
-    beside an uncached model. For the SHIPPED provider it is unreachable — with
-    an API key configured the endpoint is derived from the environment rather
-    than the database (`ai_credentials.bind_openai_credential_base_url`), so it
-    cannot go stale at all. It is reachable only for an extension provider that
-    resolves a database-derived endpoint.
+    beside an uncached model. For the SHIPPED provider it is unreachable, on
+    both branches of `ai_credentials.bind_openai_credential_base_url`:
+
+    - With an API key configured, the candidate value is used only to compare
+      against the operator-approved environment URL. Equal returns that same
+      approved string; unequal raises `OpenAICredentialDestinationError`. A
+      stale cached endpoint therefore either resolves to the identical string
+      or fails loudly, and can never silently pin a different destination.
+    - With no API key, `DefaultOpenAIEmbeddingProvider.embed` raises
+      `EmbeddingUnavailableError` before producing a vector, and on the force
+      path `_preflight_embedding` runs BEFORE the DELETE, so the run aborts
+      with every existing vector still in place.
+
+    So the residue is confined to an extension provider that resolves its
+    endpoint from the database and applies no such binding. Closing it needs an
+    uncached mode on the extension interface, which does not belong in a fix
+    PR; the underlying per-key eviction window is #1543.
 
     A partial guard was tried here and removed: comparing the cached model and
     dimensions against the uncached ones detects the eviction window, but only

--- a/backend/app/processing/embeddings/helpers.py
+++ b/backend/app/processing/embeddings/helpers.py
@@ -39,8 +39,16 @@ async def set_hnsw_recall(session: AsyncSession, *, ef: int = 100) -> None:
     await session.execute(text(f"SET LOCAL hnsw.ef_search = {int(ef)}"))
 
 
-async def resolve_embedding_model_name(session: AsyncSession) -> str:
+async def resolve_embedding_model_name(
+    session: AsyncSession, *, uncached: bool = False
+) -> str:
     """Return the active embedding model name, or a sentinel on failure.
+
+    fix(#1525 review r2, codex P1): ``uncached`` reads straight from the DB via
+    ``PersistentConfig.get_uncached``, for the one caller that gates a
+    destructive operation on this value. The cached read is right for
+    everything else and stays the default; see `_snapshot_embedding_config` in
+    `backfill.py` for why the backfill's pre-delete snapshot cannot use it.
 
     PERF-10 (Phase 274): the resolved name partitions the has_embeddings
     cache so a model swap forces a fresh DB lookup. Errors during
@@ -65,7 +73,11 @@ async def resolve_embedding_model_name(session: AsyncSession) -> str:
     try:
         from app.core.persistent_config import EMBEDDING_MODEL
 
-        value = await EMBEDDING_MODEL.get(session)
+        value = await (
+            EMBEDDING_MODEL.get_uncached(session)
+            if uncached
+            else EMBEDDING_MODEL.get(session)
+        )
         return value or UNKNOWN_EMBEDDING_MODEL
     except Exception:  # broad: persistent_config resolution can fail for any DB/cache reason; fall back to sentinel
         logger.warning("has_embeddings_model_resolution_failed", exc_info=True)

--- a/backend/app/processing/embeddings/service.py
+++ b/backend/app/processing/embeddings/service.py
@@ -48,12 +48,29 @@ async def generate_embedding(text: str, session: AsyncSession) -> list[float]:
     return vectors[0]
 
 
+async def resolve_embedding_base_url(session: AsyncSession) -> str | None:
+    """Resolve the provider endpoint exactly as generate_embeddings_batch does.
+
+    fix(#1525): a caller pinning a configuration for a whole run needs the
+    endpoint too, and has to get it from the provider rather than reading
+    ``EMBEDDING_BASE_URL`` itself. The fallback chain (EMBEDDING_BASE_URL ->
+    OPENAI_BASE_URL -> the operator-approved default, plus the credential
+    binding in ``app/core/ai_credentials.py``) belongs to the provider
+    extension; a second copy of it in the caller would drift from whatever
+    provider is actually registered.
+    """
+    provider_ext = get_embedding_provider("openai_compatible")
+    runtime_config = await provider_ext.resolve_runtime_config(session)
+    return runtime_config.get("base_url")
+
+
 async def generate_embeddings_batch(
     texts: list[str],
     session: AsyncSession,
     *,
     model: str | None = None,
     dimensions: int | None = None,
+    base_url: str | None = None,
 ) -> list[list[float]]:
     """Generate embedding vectors for many texts in ONE provider call.
 
@@ -65,20 +82,23 @@ async def generate_embeddings_batch(
 
     fix(#1511 review): ``model`` and ``dimensions`` let a caller that already
     resolved the pair pin it for the whole run instead of having this function
-    re-read the config on every call.
+    re-read the config on every call. fix(#1525): ``base_url`` completes the
+    set — the label a run writes names a model, and which endpoint served that
+    model is part of what the label promises.
 
-    **A caller that writes its own ``model_name`` label MUST pass both.** Such
-    a caller resolves the model once to label its rows; without pinning, this
-    function re-reads the config per call, so an admin swap mid-run has the
+    **A caller that writes its own ``model_name`` label MUST pass all three.**
+    Such a caller resolves the model once to label its rows; without pinning,
+    this function re-reads the config per call, so an admin swap mid-run has the
     provider generate from model B while the rows are labelled model A. Search
     reads only active-model rows, so those vectors are invisible to the model
-    that supposedly produced them. Passing only one is worse than passing
-    neither: model A with model B's dimensions is a pair that never existed in
-    config. Today `processing/embeddings/backfill.py` is the only such caller;
-    `generate_embedding` above makes a single call and labels nothing, so it
-    deliberately does not pin.
+    that supposedly produced them. Passing a subset is worse than passing none:
+    model A with model B's dimensions is a pair that never existed in config,
+    and model A against a repointed endpoint is a vector space nothing in the
+    catalog can name. Today `processing/embeddings/backfill.py` is the only such
+    caller; `generate_embedding` above makes a single call and labels nothing,
+    so it deliberately does not pin.
 
-    Omitting both keeps the pre-existing per-call resolution, which is correct
+    Omitting them keeps the pre-existing per-call resolution, which is correct
     for a single-call caller and silently racy for a multi-call labelling one.
     Nothing enforces that distinction mechanically, so it is stated here.
 
@@ -98,7 +118,21 @@ async def generate_embeddings_batch(
     # Phase 231 D-12: hardcode "openai_compatible" — community ships one
     # embedding provider; overlays add more under different names.
     provider_ext = get_embedding_provider("openai_compatible")
-    runtime_config = await provider_ext.resolve_runtime_config(session)
+    # fix(#1525): resolve the live config only when something below would still
+    # come out of it. A fully pinned call needs nothing from it, and asking
+    # anyway reopens the window the pin exists to close: the shipped provider's
+    # resolve RAISES (not diverges) once an admin repoints the endpoint, because
+    # `bind_openai_credential_base_url` refuses to aim the environment API key at
+    # a database-supplied URL. Every batch after such an edit then failed, was
+    # retried per record, failed again and counted as an error — a run pinned to
+    # a configuration it had already validated, abandoning the catalog over a
+    # value it was no longer going to use.
+    #
+    # The gate is the exact set of conditions under which a value is taken from
+    # `runtime_config` below, so nothing else about resolution order changes.
+    runtime_config: dict[str, object] = {}
+    if not model or not dimensions or base_url is None:
+        runtime_config = await provider_ext.resolve_runtime_config(session)
     # `is None` rather than falsy: a pinned value the caller supplied is
     # honored as given, and only an absent one re-reads the config. Both then
     # fall back to the provider default exactly as an empty config value does.
@@ -108,7 +142,8 @@ async def generate_embeddings_batch(
     if dimensions is None:
         dimensions = await EMBEDDING_DIMS.get(session)
     dimensions = dimensions or runtime_config.get("default_dims")
-    base_url = runtime_config.get("base_url")
+    if base_url is None:
+        base_url = runtime_config.get("base_url")
 
     # Truncate very long inputs
     texts = [t[:_MAX_INPUT_CHARS] if len(t) > _MAX_INPUT_CHARS else t for t in texts]

--- a/backend/app/processing/embeddings/service.py
+++ b/backend/app/processing/embeddings/service.py
@@ -23,6 +23,30 @@ class EmbeddingUnavailableError(Exception):
     """Raised when no embedding provider is configured."""
 
 
+class _Unset:
+    """Sentinel type: "the caller pinned nothing", distinct from a pinned None.
+
+    fix(#1525 review, codex P2): `None` is a legitimate RESOLVED endpoint. The
+    provider interface lets an extension answer `{"base_url": None}`, meaning
+    "use the client default", and a run that snapshots that has pinned a real
+    value. Testing `base_url is None` would read that pin as an omission and
+    re-resolve per batch, so the providers most likely to have an unusual
+    endpoint config are exactly the ones the pin would stop protecting.
+
+    `model` and `dimensions` keep their `is None` test: for those, `None` is
+    not something the config resolves to, and the falsy fallback below already
+    covers the resolved-but-empty case.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid only
+        return "<unset>"
+
+
+_UNSET = _Unset()
+
+
 async def generate_embedding(text: str, session: AsyncSession) -> list[float]:
     """Generate an embedding vector for the given text.
 
@@ -70,7 +94,7 @@ async def generate_embeddings_batch(
     *,
     model: str | None = None,
     dimensions: int | None = None,
-    base_url: str | None = None,
+    base_url: str | None | _Unset = _UNSET,
 ) -> list[list[float]]:
     """Generate embedding vectors for many texts in ONE provider call.
 
@@ -84,7 +108,9 @@ async def generate_embeddings_batch(
     resolved the pair pin it for the whole run instead of having this function
     re-read the config on every call. fix(#1525): ``base_url`` completes the
     set — the label a run writes names a model, and which endpoint served that
-    model is part of what the label promises.
+    model is part of what the label promises. It is pinned by presence rather
+    than by not-None, because ``None`` is a value the config can resolve TO
+    (see ``_Unset``); omit the argument to keep the old per-call resolution.
 
     **A caller that writes its own ``model_name`` label MUST pass all three.**
     Such a caller resolves the model once to label its rows; without pinning,
@@ -131,7 +157,7 @@ async def generate_embeddings_batch(
     # The gate is the exact set of conditions under which a value is taken from
     # `runtime_config` below, so nothing else about resolution order changes.
     runtime_config: dict[str, object] = {}
-    if not model or not dimensions or base_url is None:
+    if not model or not dimensions or isinstance(base_url, _Unset):
         runtime_config = await provider_ext.resolve_runtime_config(session)
     # `is None` rather than falsy: a pinned value the caller supplied is
     # honored as given, and only an absent one re-reads the config. Both then
@@ -142,7 +168,7 @@ async def generate_embeddings_batch(
     if dimensions is None:
         dimensions = await EMBEDDING_DIMS.get(session)
     dimensions = dimensions or runtime_config.get("default_dims")
-    if base_url is None:
+    if isinstance(base_url, _Unset):
         base_url = runtime_config.get("base_url")
 
     # Truncate very long inputs

--- a/backend/tests/test_embedding_backfill_base_url_pinning.py
+++ b/backend/tests/test_embedding_backfill_base_url_pinning.py
@@ -56,6 +56,7 @@ from app.processing.embeddings.models import RecordEmbedding
 from tests.factories import create_dataset, get_user_id
 
 _MODEL = "endpoint-pin-model"
+_MODEL_AFTER = "endpoint-pin-model-after"
 # Matches the fixed vector column, so every row this run writes still inserts
 # and the assertions stay on the endpoint rather than on storage.
 _DIMS = 1536
@@ -131,6 +132,61 @@ class _SnapshotWindowProvider(_EndpointRecordingProvider):
             "default_dims": _DIMS,
             "base_url": current,
         }
+
+
+class _AtomicSwitchProvider(_EndpointRecordingProvider):
+    """Repoints model AND endpoint together, from inside the first resolve.
+
+    fix(#1525 review, codex P1). An admin who changes both in one PUT is the
+    case a per-value guard cannot see: with the endpoint captured in a window
+    of its own, after the model had already been compared, the model comparison
+    passed on the old value and the endpoint comparison saw the new one twice,
+    so the run pinned old-model-plus-new-endpoint. That pairing never existed
+    in config, and if the new endpoint happens to accept the old model nothing
+    downstream rejects it.
+
+    Returning the post-edit endpoint from this very call is what makes the two
+    implementations distinguishable: a split window agrees with itself, and a
+    single window over all three sees the model move.
+    """
+
+    async def resolve_runtime_config(self, session):
+        self._session = session
+        if not self._edited:
+            self._edited = True
+            await EMBEDDING_MODEL.set(session, _MODEL_AFTER)
+            await EMBEDDING_BASE_URL.set(session, _URL_B)
+        return {
+            "default_model": "provider-fallback-model",
+            "default_dims": _DIMS,
+            "base_url": await EMBEDDING_BASE_URL.get(session),
+        }
+
+
+class _NullEndpointProvider:
+    """Resolves its endpoint to None, which the provider interface permits.
+
+    fix(#1525 review, codex P2). `None` is a resolved value, not an omission,
+    so a run that snapshots it has pinned something. Counting resolves is what
+    shows whether the pin held: a gate testing `base_url is None` reads the pin
+    as absent and re-resolves per batch.
+    """
+
+    def __init__(self):
+        self.calls: list[dict] = []
+        self.resolves = 0
+
+    async def resolve_runtime_config(self, session):
+        self.resolves += 1
+        return {
+            "default_model": "provider-fallback-model",
+            "default_dims": _DIMS,
+            "base_url": None,
+        }
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        self.calls.append({"model": model, "base_url": base_url})
+        return [[1.0] + [0.0] * (_DIMS - 1) for _ in texts]
 
 
 @pytest.fixture
@@ -322,3 +378,118 @@ async def test_an_edit_inside_the_snapshot_window_aborts_the_run(
     # the comparison to catch, and the run would have aborted for some other
     # reason or not at all.
     assert await EMBEDDING_BASE_URL.get(test_db_session) == _URL_B
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("force", [True, False], ids=["force", "non_force"])
+async def test_an_atomic_model_and_endpoint_swap_cannot_pin_a_mixed_pair(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+    force,
+):
+    """Both values move together, so the snapshot has to look at both again.
+
+    fix(#1525 review, codex P1): the values are pinned as a unit, so they have
+    to be verified as a unit. Capturing and comparing the endpoint separately,
+    after the model had already been compared, left a gap between the two
+    comparisons that a single PUT changing model and endpoint together lands
+    in. The pinned result is the old model against the new endpoint, which no
+    admin ever chose, and nothing downstream can tell: the model still names a
+    real model and the endpoint still names a real endpoint.
+
+    On the force path the snapshot runs ahead of the DELETE, so the abort also
+    has to leave the existing vectors alone.
+    """
+    await _seed_two_records(test_db_session, f"Atomic Swap {force}")
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS)
+    await EMBEDDING_BASE_URL.set(test_db_session, _URL_A)
+
+    user_id = await get_user_id(test_db_session, "admin")
+    seeded = await create_dataset(
+        test_db_session, created_by=user_id, name=f"Atomic Swap Seed {force}"
+    )
+    test_db_session.add(
+        RecordEmbedding(
+            record_id=seeded.record_id,
+            embedding=[1.0] + [0.0] * (_DIMS - 1),
+            model_name=_MODEL,
+            content_hash=uuid.uuid4().hex[:64],
+        )
+    )
+    await test_db_session.commit()
+    before = (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one()
+    assert before > 0
+
+    provider = _AtomicSwitchProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+
+    aborted = False
+    try:
+        await backfill_module.backfill_embeddings(test_db_session, force=force)
+    except RuntimeError:
+        aborted = True
+
+    # Checked first: a tree that pins the mixed pair fails here, on the vectors
+    # it went on to write from an endpoint the run never validated the model
+    # against. That is the damage; the missing raise is only how it happened.
+    assert provider.calls == []
+    assert (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one() == before
+    assert aborted
+    # Non-vacuity: both halves have to have actually moved, or there was no
+    # mixed pair available to pin and the run aborted for some other reason.
+    assert await EMBEDDING_MODEL.get(test_db_session) == _MODEL_AFTER
+    assert await EMBEDDING_BASE_URL.get(test_db_session) == _URL_B
+
+
+@pytest.mark.anyio
+async def test_an_endpoint_that_resolves_to_none_is_still_pinned(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+):
+    """A resolved None is a pin, not an omission.
+
+    fix(#1525 review, codex P2): the provider interface lets an extension
+    answer `{"base_url": None}`, meaning "use the client default". Testing
+    `base_url is None` to decide whether the caller pinned anything reads that
+    as an omission and resolves the live config again on every batch, so the
+    providers most likely to have an unusual endpoint config are exactly the
+    ones the pin stops protecting.
+
+    Resolve calls are the observable. The snapshot makes two, to capture and to
+    compare; a batch loop that adds one per batch is the bug.
+    """
+    await _seed_two_records(test_db_session, "Null Endpoint")
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS)
+
+    provider = _NullEndpointProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+    monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 1)
+
+    await backfill_module.backfill_embeddings(test_db_session, force=False)
+
+    # Non-vacuity: with fewer than two batches there is no per-batch growth to
+    # detect, and the count below would hold on the unfixed tree too.
+    assert len(provider.calls) >= 2, "the run made fewer than two provider calls"
+    # Two, and only two: `_snapshot_embedding_config` captures then re-reads.
+    # Anything more means a batch resolved the config for itself.
+    assert provider.resolves == 2
+    # And the pinned value actually reached the provider as itself.
+    assert {call["base_url"] for call in provider.calls} == {None}

--- a/backend/tests/test_embedding_backfill_base_url_pinning.py
+++ b/backend/tests/test_embedding_backfill_base_url_pinning.py
@@ -180,6 +180,46 @@ class _AtomicSwitchProvider(_EndpointRecordingProvider):
         }
 
 
+class _BatchFailsWithTheEditProvider(_EndpointRecordingProvider):
+    """Fails the batch call and lands the endpoint edit as it fails.
+
+    fix(#1525 review r6, codex P2). A provider stumble and an admin edit in the
+    same window is the shape the per-record fallback was blind to, and it is
+    not a coincidence: an outage is exactly when someone goes and repoints the
+    endpoint. Because the batch call raises, the batch's own post-call check
+    never runs, so the retry loop is entered under a pin that has already
+    stopped being active.
+    """
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        self.calls.append(
+            {"model": model, "dimensions": dimensions, "base_url": base_url}
+        )
+        if len(self.calls) == 1:
+            await self._land_the_admin_edit()
+            raise RuntimeError("provider stumbled on the batch call")
+        return [[1.0] + [0.0] * (_DIMS - 1) for _ in texts]
+
+
+class _RetryLandsTheEditProvider(_EndpointRecordingProvider):
+    """Fails the batch call cleanly, then lands the edit during the first retry.
+
+    fix(#1525 review r6, codex P2). The other half: nothing has drifted when
+    the retry loop starts, so the check before the retry's provider call passes
+    and only the one AFTER it can catch the edit, before that record's vector
+    is committed.
+    """
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        self.calls.append(
+            {"model": model, "dimensions": dimensions, "base_url": base_url}
+        )
+        if len(self.calls) == 1:
+            raise RuntimeError("provider stumbled on the batch call")
+        await self._land_the_admin_edit()
+        return [[1.0] + [0.0] * (_DIMS - 1) for _ in texts]
+
+
 class _QuietRecordingProvider:
     """Records what each call received and changes nothing.
 
@@ -769,6 +809,116 @@ async def test_an_edit_during_the_final_batch_is_not_committed(
 
     # The finding: the generated batch must not reach the table. An unfixed
     # tree commits it and returns a success dict.
+    assert (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one() == before
+    assert stopped
+
+
+@pytest.mark.anyio
+async def test_an_edit_during_a_failed_batch_stops_the_per_record_retry(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+):
+    """Drift must not slip through on the failure path.
+
+    fix(#1525 review r6, codex P2): the per-record fallback (#449) ran with no
+    drift check at all. A batch call that fails while an admin repoints the
+    endpoint skips the batch's post-call check entirely, and every retry below
+    it then generated against the stale pin and committed one vector at a time,
+    finishing with a partial-success dict.
+
+    The check before the retry's own provider call catches it here, so the run
+    stops before generating anything: one provider call in total.
+    """
+    await _seed_two_records(test_db_session, "Failed Batch")
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS)
+    await EMBEDDING_BASE_URL.set(test_db_session, _URL_A)
+
+    before = (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one()
+
+    provider = _BatchFailsWithTheEditProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+    monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 10_000)
+
+    stopped = False
+    try:
+        await backfill_module.backfill_embeddings(test_db_session, force=False)
+    except RuntimeError:
+        stopped = True
+
+    # Non-vacuity: the edit lands from inside the failing call, so without that
+    # call there was no edit and nothing for the check to catch.
+    assert await EMBEDDING_BASE_URL.get(test_db_session) == _URL_B, (
+        "the admin edit never landed"
+    )
+    # The batch call, and nothing after it. A retry that generated a vector
+    # before checking would show a second call here.
+    assert len(provider.calls) == 1, "the retry loop generated under a stale pin"
+
+    # Drift must stop the run, not be counted as a bad record. An unfixed tree
+    # commits both records one at a time and returns a success dict.
+    assert (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one() == before
+    assert stopped
+
+
+@pytest.mark.anyio
+async def test_an_edit_during_a_per_record_retry_is_not_committed(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+):
+    """The retry's own call is bracketed, not just preceded.
+
+    fix(#1525 review r6, codex P2): nothing has drifted when the retry loop
+    starts here, so the check before the call passes and only the one after it
+    can see the edit that landed during the call. Without it that record's
+    vector is committed against the stale pin.
+    """
+    await _seed_two_records(test_db_session, "Retry Edit")
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS)
+    await EMBEDDING_BASE_URL.set(test_db_session, _URL_A)
+
+    before = (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one()
+
+    provider = _RetryLandsTheEditProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+    monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 10_000)
+
+    stopped = False
+    try:
+        await backfill_module.backfill_embeddings(test_db_session, force=False)
+    except RuntimeError:
+        stopped = True
+
+    # Non-vacuity: the failed batch call plus exactly one retry. The edit rides
+    # that retry, so a run that stopped before it would catch nothing, and a
+    # run that carried on would show a second retry.
+    assert len(provider.calls) == 2, "the retry loop did not reach the edit"
+    assert await EMBEDDING_BASE_URL.get(test_db_session) == _URL_B, (
+        "the admin edit never landed"
+    )
+
+    # The vector generated by that retry must not reach the table.
     assert (
         await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
     ).scalar_one() == before

--- a/backend/tests/test_embedding_backfill_base_url_pinning.py
+++ b/backend/tests/test_embedding_backfill_base_url_pinning.py
@@ -36,11 +36,12 @@ Requirements:
   - Alembic migrations must be applied
 """
 
+import json
 import uuid
 from types import SimpleNamespace
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 
 from app.core import ai_credentials
 from app.core.persistent_config import (
@@ -60,6 +61,9 @@ _MODEL_AFTER = "endpoint-pin-model-after"
 # Matches the fixed vector column, so every row this run writes still inserts
 # and the assertions stay on the endpoint rather than on storage.
 _DIMS = 1536
+# Different enough to be visible in an assertion; the fake provider answers at
+# _DIMS whatever it is asked for, so the row still inserts.
+_DIMS_AFTER = 768
 # Canonical already (no trailing slash, lowercase host, no query): the shipped
 # provider canonicalizes what it returns, and a non-canonical literal here would
 # make the comparison fail for a reason that is not the finding.
@@ -493,3 +497,86 @@ async def test_an_endpoint_that_resolves_to_none_is_still_pinned(
     assert provider.resolves == 2
     # And the pinned value actually reached the provider as itself.
     assert {call["base_url"] for call in provider.calls} == {None}
+
+
+@pytest.mark.anyio
+async def test_a_half_evicted_cache_cannot_pin_a_mixed_pair(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+):
+    """Two reads through one stale cache entry agree with each other.
+
+    fix(#1525 review r2, codex P1): `PersistentConfig.get` answers from a
+    PER-KEY cache, and `update_settings` commits the whole batch before evicting
+    each key in turn (settings/router.py:338-345). Between the commit and the
+    last eviction, one key answers from the DB while another answers from cache,
+    so a snapshot built out of cached reads can pin the new model beside the old
+    dimensions. Comparing those reads cannot see it: both passes hit the same
+    stale entry and agree. It is the settings-window bug one layer out, a
+    consistent read of an inconsistent state.
+
+    Driven through a real `InMemoryCacheProvider`, so the read path under test
+    is the production one, and the half-evicted state is built the way the
+    router builds it: commit both values, then evict only one key.
+
+    Note what is asserted. Uncached reads do not make the run abort here, they
+    make it pin the committed pair, so the assertion is on the pair the
+    provider received rather than on a raise. Aborting would be wrong: nothing
+    is inconsistent in the database, only in the cache.
+    """
+    from app.core.persistent_config import _CACHE_PREFIX
+    from app.platform.cache import provider as cache_provider_module
+    from app.platform.cache.memory import InMemoryCacheProvider
+
+    cache = InMemoryCacheProvider()
+    monkeypatch.setattr(cache_provider_module, "_cache_provider", cache)
+
+    await _seed_two_records(test_db_session, "Half Evicted")
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS)
+    await EMBEDDING_BASE_URL.set(test_db_session, _URL_A)
+
+    # Warm both keys, then commit the update straight to app_settings so the
+    # entries survive. `PersistentConfig.set` would evict them, which is the
+    # state AFTER the window this test is about.
+    assert await EMBEDDING_MODEL.get(test_db_session) == _MODEL
+    assert await EMBEDDING_DIMS.get(test_db_session) == _DIMS
+    await test_db_session.execute(
+        text(
+            "UPDATE catalog.app_settings SET value = :v WHERE key = 'embedding_model'"
+        ),
+        {"v": json.dumps({"v": _MODEL_AFTER})},
+    )
+    await test_db_session.execute(
+        text("UPDATE catalog.app_settings SET value = :v WHERE key = 'embedding_dims'"),
+        {"v": json.dumps({"v": _DIMS_AFTER})},
+    )
+    await test_db_session.commit()
+    # Only the model key is evicted. This is mid-eviction, not a finished one.
+    await cache.delete(f"{_CACHE_PREFIX}embedding_model")
+
+    # Vacuity guard, and the whole premise in three lines: one key now answers
+    # from the DB, the other from a stale entry, and the DB knows better. With
+    # no cache provider installed these would all agree and the assertions at
+    # the end would hold on the unfixed tree too.
+    assert await EMBEDDING_MODEL.get(test_db_session) == _MODEL_AFTER
+    assert await EMBEDDING_DIMS.get(test_db_session) == _DIMS
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _DIMS_AFTER
+
+    provider = _EndpointRecordingProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+
+    await backfill_module.backfill_embeddings(test_db_session, force=False)
+
+    # Non-vacuity: nothing was pinned if nothing was generated.
+    assert provider.calls, "the provider was never called"
+    # The finding: an unfixed tree pins _MODEL_AFTER beside _DIMS, a pair that
+    # was never committed together, and generates the catalog under it.
+    assert {call["model"] for call in provider.calls} == {_MODEL_AFTER}
+    assert {call["dimensions"] for call in provider.calls} == {_DIMS_AFTER}

--- a/backend/tests/test_embedding_backfill_base_url_pinning.py
+++ b/backend/tests/test_embedding_backfill_base_url_pinning.py
@@ -1,0 +1,324 @@
+"""One backfill run must reach one endpoint (#1525).
+
+Follow-up to #1511/#1519, which pinned the model and the dimensions for the
+length of a run. `base_url` was left re-reading per provider call: every
+`generate_embeddings_batch` call asked the provider extension to
+`resolve_runtime_config` again, so an endpoint edit landing mid-run changed
+where later batches went while the rows kept the label the run pinned.
+
+Two scenarios, because the shipped provider and an extension provider fail
+differently on the same edit.
+
+`_EndpointRecordingProvider` is an extension that resolves its own endpoint
+from configuration, which is all `EmbeddingProviderExtension` asks of it. There
+the edit splits the run across two endpoints, which is the corruption #1525
+describes: same `model_name` label, vectors from two vector spaces.
+
+`_BoundEndpointProvider` delegates to the shipped
+`DefaultOpenAIEmbeddingProvider.resolve_runtime_config`, so the real credential
+binding runs. That binding (`app/core/ai_credentials.py`) refuses to point the
+environment-provided API key at a database-supplied endpoint, so the shipped
+provider cannot be redirected — it raises instead. Every batch after the edit
+therefore fails, is retried per record, fails again, and lands in `errors`. The
+run reaches one endpoint and abandons the rest of the catalog.
+
+The edit is driven through the real `PersistentConfig.set`, from inside the
+first provider call — the run spends its time there, so that is where an admin
+edit realistically lands, and it is after the snapshot has captured its values.
+Both paths are covered: the divergence is identical on force and non-force,
+exactly as it was for the model in #1519.
+
+The last test covers the earlier window instead: an edit landing *inside* the
+snapshot, which the run refuses rather than pins.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Alembic migrations must be applied
+"""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import func, select
+
+from app.core import ai_credentials
+from app.core.persistent_config import (
+    EMBEDDING_BASE_URL,
+    EMBEDDING_DIMS,
+    EMBEDDING_MODEL,
+)
+from app.platform.extensions.defaults_ai_openai import DefaultOpenAIEmbeddingProvider
+from app.processing.embeddings import backfill as backfill_module
+from app.processing.embeddings import service as service_module
+from app.processing.embeddings.models import RecordEmbedding
+
+from tests.factories import create_dataset, get_user_id
+
+_MODEL = "endpoint-pin-model"
+# Matches the fixed vector column, so every row this run writes still inserts
+# and the assertions stay on the endpoint rather than on storage.
+_DIMS = 1536
+# Canonical already (no trailing slash, lowercase host, no query): the shipped
+# provider canonicalizes what it returns, and a non-canonical literal here would
+# make the comparison fail for a reason that is not the finding.
+_URL_A = "https://embeddings-a.invalid/v1"
+_URL_B = "https://embeddings-b.invalid/v1"
+
+
+class _EndpointRecordingProvider:
+    """An extension provider that resolves its endpoint from configuration.
+
+    Records what each call received, and lands the admin's endpoint edit during
+    the first provider call.
+    """
+
+    def __init__(self):
+        self.calls: list[dict] = []
+        self._session = None
+        self._edited = False
+
+    async def resolve_runtime_config(self, session):
+        self._session = session
+        return {
+            "default_model": "provider-fallback-model",
+            "default_dims": _DIMS,
+            "base_url": await EMBEDDING_BASE_URL.get(session),
+        }
+
+    async def _land_the_admin_edit(self) -> None:
+        """Repoint the embedding endpoint, once, through the real setter."""
+        if self._edited or self._session is None:
+            return
+        self._edited = True
+        await EMBEDDING_BASE_URL.set(self._session, _URL_B)
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        self.calls.append(
+            {"model": model, "dimensions": dimensions, "base_url": base_url}
+        )
+        await self._land_the_admin_edit()
+        return [[1.0] + [0.0] * (_DIMS - 1) for _ in texts]
+
+
+class _BoundEndpointProvider(_EndpointRecordingProvider):
+    """Resolves through the shipped provider, credential binding included.
+
+    `DefaultOpenAIEmbeddingProvider.resolve_runtime_config` runs
+    `bind_openai_credential_base_url`, which refuses a database endpoint that
+    differs from the operator-approved environment one. So this provider cannot
+    be redirected by the edit; it raises for every call made after it.
+    """
+
+    async def resolve_runtime_config(self, session):
+        self._session = session
+        return await DefaultOpenAIEmbeddingProvider().resolve_runtime_config(session)
+
+
+class _SnapshotWindowProvider(_EndpointRecordingProvider):
+    """Repoints the endpoint from inside the snapshot's first resolve.
+
+    Returns the pre-edit value from that call, so the snapshot's second read
+    sees a different endpoint — the window the comparison exists to catch.
+    """
+
+    async def resolve_runtime_config(self, session):
+        self._session = session
+        current = await EMBEDDING_BASE_URL.get(session)
+        await self._land_the_admin_edit()
+        return {
+            "default_model": "provider-fallback-model",
+            "default_dims": _DIMS,
+            "base_url": current,
+        }
+
+
+@pytest.fixture
+async def restore_embedding_config(test_db_session):
+    """Put the AI config back; the worker DB is shared across tests."""
+    before = (
+        await EMBEDDING_MODEL.get(test_db_session),
+        await EMBEDDING_DIMS.get(test_db_session),
+        await EMBEDDING_BASE_URL.get(test_db_session),
+    )
+    yield
+    await EMBEDDING_MODEL.set(test_db_session, before[0])
+    await EMBEDDING_DIMS.set(test_db_session, before[1])
+    await EMBEDDING_BASE_URL.set(test_db_session, before[2])
+
+
+async def _seed_two_records(session, label: str) -> None:
+    """Two embeddable records, so the run makes more than one provider call."""
+    user_id = await get_user_id(session, "admin")
+    await create_dataset(session, created_by=user_id, name=f"{label} One")
+    await create_dataset(session, created_by=user_id, name=f"{label} Two")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("force", [True, False], ids=["force", "non_force"])
+async def test_a_mid_run_endpoint_edit_cannot_split_a_run_across_providers(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+    force,
+):
+    """Every vector a run stores must come from the endpoint it resolved."""
+    await _seed_two_records(test_db_session, f"Endpoint Pinning {force}")
+
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS)
+    await EMBEDDING_BASE_URL.set(test_db_session, _URL_A)
+
+    provider = _EndpointRecordingProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+    # One record per provider call. The edit lands during the first call, so
+    # the run needs a second one for it to be in front of — and at the default
+    # batch size of 128 the non-force path makes exactly one.
+    monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 1)
+
+    await backfill_module.backfill_embeddings(test_db_session, force=force)
+
+    # Non-vacuity, both halves. With fewer than two calls there is no pair of
+    # endpoints to compare and the set assertion below passes on nothing; with
+    # the edit never landing there was no switch to survive in the first place.
+    assert len(provider.calls) >= 2, "the run made fewer than two provider calls"
+    assert await EMBEDDING_BASE_URL.get(test_db_session) == _URL_B, (
+        "the admin edit never landed"
+    )
+
+    # The finding itself: one run, one endpoint, and it is the one the run
+    # resolved rather than whatever the config said by the time it was called.
+    assert {call["base_url"] for call in provider.calls} == {_URL_A}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("force", [True, False], ids=["force", "non_force"])
+async def test_a_mid_run_endpoint_edit_does_not_abandon_the_rest_of_the_catalog(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+    force,
+):
+    """The shipped provider's version of the same edit.
+
+    Credential binding stops the endpoint from moving, so the damage is not a
+    mislabelled vector — it is a run that resolves the config again per call
+    and raises from the second call onward. Each batch fails, is retried per
+    record, fails again, and counts as an error, so an edit that a pinned run
+    would not even notice costs the whole remainder of the catalog.
+    """
+    await _seed_two_records(test_db_session, f"Endpoint Binding {force}")
+
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS)
+    await EMBEDDING_BASE_URL.set(test_db_session, _URL_A)
+
+    provider = _BoundEndpointProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+    # The binding compares the database endpoint against the operator-approved
+    # environment one, so the environment has to name _URL_A for the run to
+    # start at all, and an API key has to be present for the check to run.
+    monkeypatch.setattr(
+        ai_credentials,
+        "settings",
+        SimpleNamespace(
+            openai_api_key="pin-test-key",
+            embedding_base_url=_URL_A,
+            openai_base_url=None,
+        ),
+    )
+    monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 1)
+
+    result = await backfill_module.backfill_embeddings(test_db_session, force=force)
+
+    # The damage first: an unpinned run fails here showing the records it gave
+    # up on, which is the finding. The call-count guard below would otherwise
+    # fire first and report the symptom (no second call) instead.
+    assert result["errors"] == 0
+    assert result["created"] >= 2
+    assert await EMBEDDING_BASE_URL.get(test_db_session) == _URL_B, (
+        "the admin edit never landed"
+    )
+
+    # Non-vacuity for the endpoint comparison: one call is not a comparison.
+    assert len(provider.calls) >= 2, "the run made fewer than two provider calls"
+    assert {call["base_url"] for call in provider.calls} == {_URL_A}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("force", [True, False], ids=["force", "non_force"])
+async def test_an_edit_inside_the_snapshot_window_aborts_the_run(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+    force,
+):
+    """An endpoint that moves while the run is starting is refused, not pinned.
+
+    The tests above flip the endpoint once the snapshot has already captured
+    it, which is what pinning is for. This one lands the edit *inside* the
+    capture, where there is no single value to pin: the run would otherwise
+    commit to an endpoint config no longer names. The snapshot resolves twice
+    and compares, and on the force path it does so ahead of the DELETE, so an
+    abort has to leave existing vectors alone.
+    """
+    await _seed_two_records(test_db_session, f"Endpoint Snapshot {force}")
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS)
+    await EMBEDDING_BASE_URL.set(test_db_session, _URL_A)
+
+    # A row to lose, so the force path's survival is observable.
+    user_id = await get_user_id(test_db_session, "admin")
+    seeded = await create_dataset(
+        test_db_session, created_by=user_id, name=f"Endpoint Snapshot Seed {force}"
+    )
+    test_db_session.add(
+        RecordEmbedding(
+            record_id=seeded.record_id,
+            embedding=[1.0] + [0.0] * (_DIMS - 1),
+            model_name=_MODEL,
+            content_hash=uuid.uuid4().hex[:64],
+        )
+    )
+    await test_db_session.commit()
+    before = (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one()
+    assert before > 0
+
+    provider = _SnapshotWindowProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+
+    aborted = False
+    try:
+        await backfill_module.backfill_embeddings(test_db_session, force=force)
+    except RuntimeError:
+        aborted = True
+
+    # Checked before the abort flag: an unguarded tree fails on the vectors it
+    # destroyed and the endpoint it used, which is the damage, not the missing
+    # raise.
+    assert provider.calls == []
+    assert (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one() == before
+    assert aborted
+    # Non-vacuity: without the edit actually landing there was no change for
+    # the comparison to catch, and the run would have aborted for some other
+    # reason or not at all.
+    assert await EMBEDDING_BASE_URL.get(test_db_session) == _URL_B

--- a/backend/tests/test_embedding_backfill_base_url_pinning.py
+++ b/backend/tests/test_embedding_backfill_base_url_pinning.py
@@ -546,12 +546,13 @@ async def test_an_endpoint_that_resolves_to_none_is_still_pinned(
     # Non-vacuity: with fewer than two batches there is no per-batch growth to
     # detect, and the count below would hold on the unfixed tree too.
     assert len(provider.calls) >= 2, "the run made fewer than two provider calls"
-    # Two for `_snapshot_embedding_config` (capture then re-read), plus exactly
-    # one per batch for the drift check added by #1525 review r4. A batch that
-    # resolved the config for its own VALUE as well would add a second per
-    # batch, which is the bug: with `base_url is None` as the pin test, a
-    # resolved None reads as an omission and every batch re-resolves.
-    assert provider.resolves == 2 + len(provider.calls)
+    # Two for `_snapshot_embedding_config` (capture then re-read), plus two per
+    # batch for the drift checks: one before requesting it (#1525 review r4)
+    # and one before accepting it (r5). A batch that resolved the config for
+    # its own VALUE as well would add a third, which is the bug: with
+    # `base_url is None` as the pin test, a resolved None reads as an omission
+    # and every batch re-resolves.
+    assert provider.resolves == 2 + 2 * len(provider.calls)
     # And the pinned value actually reached the provider as itself.
     assert {call["base_url"] for call in provider.calls} == {None}
 
@@ -621,7 +622,7 @@ async def test_a_half_evicted_cache_cannot_pin_a_mixed_pair(
     assert await EMBEDDING_DIMS.get(test_db_session) == _DIMS
     assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _DIMS_AFTER
 
-    provider = _EndpointRecordingProvider()
+    provider = _QuietRecordingProvider()
     monkeypatch.setattr(
         service_module, "get_embedding_provider", lambda _name: provider
     )
@@ -712,3 +713,63 @@ async def test_a_wholly_stale_cache_cannot_pin_a_superseded_pair(
     # it wrote carry this same model name, so the label names the active model.
     assert {call["model"] for call in provider.calls} == {_MODEL_AFTER}
     assert {call["dimensions"] for call in provider.calls} == {_DIMS_AFTER}
+
+
+@pytest.mark.anyio
+async def test_an_edit_during_the_final_batch_is_not_committed(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+):
+    """The batch with no successor to catch it.
+
+    fix(#1525 review r5, codex P2): checking for drift before requesting each
+    batch leaves the LAST one uncovered, because there is no next iteration.
+    An edit landing during that final provider call was never observed: the
+    vectors were generated against the pinned endpoint, committed, and the run
+    reported success while the active endpoint had already moved. Rows record
+    only `model_name`, so semantic search would then query the new endpoint's
+    vector space and silently fail to match them.
+
+    So the check runs again before ACCEPTING the batch. The run here is forced
+    into a single batch, which makes that batch both the first and the last —
+    the exact shape the pre-request check cannot see.
+    """
+    await _seed_two_records(test_db_session, "Final Batch")
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS)
+    await EMBEDDING_BASE_URL.set(test_db_session, _URL_A)
+
+    before = (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one()
+
+    provider = _EndpointRecordingProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+    # One batch for the whole run, so the only provider call is the final one.
+    monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 10_000)
+
+    stopped = False
+    try:
+        await backfill_module.backfill_embeddings(test_db_session, force=False)
+    except RuntimeError:
+        stopped = True
+
+    # Non-vacuity: the edit lands from inside the provider call, so without a
+    # call there was no edit and nothing for the check to catch.
+    assert provider.calls, "the provider was never called"
+    assert await EMBEDDING_BASE_URL.get(test_db_session) == _URL_B, (
+        "the admin edit never landed"
+    )
+
+    # The finding: the generated batch must not reach the table. An unfixed
+    # tree commits it and returns a success dict.
+    assert (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one() == before
+    assert stopped

--- a/backend/tests/test_embedding_backfill_base_url_pinning.py
+++ b/backend/tests/test_embedding_backfill_base_url_pinning.py
@@ -28,8 +28,21 @@ edit realistically lands, and it is after the snapshot has captured its values.
 Both paths are covered: the divergence is identical on force and non-force,
 exactly as it was for the model in #1519.
 
-The last test covers the earlier window instead: an edit landing *inside* the
-snapshot, which the run refuses rather than pins.
+The remaining tests cover the other windows a run has to survive, in the order
+they were found:
+
+- An edit landing *inside* the snapshot, which the run refuses rather than pins.
+- An edit changing model and endpoint together, which is why all three values
+  are captured and compared as one unit instead of one window per value
+  (#1525 review, codex P1).
+- An endpoint that resolves to `None`, which is a pin and not an omission
+  (#1525 review, codex P2).
+- Two cache windows (#1525 review r2, codex P1). `update_settings` commits the
+  whole batch and then evicts each key in turn, so between the commit and the
+  last eviction a cached read can be stale. With one key evicted the snapshot
+  could pin a MIXED pair; with none evicted it could pin a wholly SUPERSEDED
+  one. Both are invisible to a comparison of cached reads, because two reads
+  through the same stale entry agree, which is why the snapshot reads uncached.
 
 Requirements:
   - Docker database must be running (docker compose up db)
@@ -165,6 +178,30 @@ class _AtomicSwitchProvider(_EndpointRecordingProvider):
             "default_dims": _DIMS,
             "base_url": await EMBEDDING_BASE_URL.get(session),
         }
+
+
+class _QuietRecordingProvider:
+    """Records what each call received and changes nothing.
+
+    The cache tests are about what the SNAPSHOT observed, so the provider must
+    not also be editing config underneath them.
+    """
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def resolve_runtime_config(self, session):
+        return {
+            "default_model": "provider-fallback-model",
+            "default_dims": _DIMS,
+            "base_url": await EMBEDDING_BASE_URL.get(session),
+        }
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        self.calls.append(
+            {"model": model, "dimensions": dimensions, "base_url": base_url}
+        )
+        return [[1.0] + [0.0] * (_DIMS - 1) for _ in texts]
 
 
 class _NullEndpointProvider:
@@ -578,5 +615,80 @@ async def test_a_half_evicted_cache_cannot_pin_a_mixed_pair(
     assert provider.calls, "the provider was never called"
     # The finding: an unfixed tree pins _MODEL_AFTER beside _DIMS, a pair that
     # was never committed together, and generates the catalog under it.
+    assert {call["model"] for call in provider.calls} == {_MODEL_AFTER}
+    assert {call["dimensions"] for call in provider.calls} == {_DIMS_AFTER}
+
+
+@pytest.mark.anyio
+async def test_a_wholly_stale_cache_cannot_pin_a_superseded_pair(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+):
+    """The other half of the eviction window: nothing evicted yet.
+
+    The test above evicts one key, which is what produces a MIXED pair. This
+    one evicts neither, which is the state immediately after `db.commit()` and
+    before any `apply_side_effects`. Both keys then answer from cache, so the
+    pair is internally consistent and simply superseded — no comparison of
+    cached reads can object, because there is nothing to disagree with.
+
+    It still corrupts a run. Every row is stamped with the pinned `model_name`,
+    so a run pinned to the superseded model labels the whole catalog with a
+    model that is no longer active, and semantic search reads active-model rows
+    only. That is #1519's corruption reached through the cache instead of
+    through a mid-run swap.
+
+    Uncached reads see past both entries at once: `update_settings` commits the
+    whole batch before evicting anything, so a read that ignores the cache gets
+    the entire new batch or the entire old one, never a mixture.
+    """
+    from app.platform.cache import provider as cache_provider_module
+    from app.platform.cache.memory import InMemoryCacheProvider
+
+    monkeypatch.setattr(
+        cache_provider_module, "_cache_provider", InMemoryCacheProvider()
+    )
+
+    await _seed_two_records(test_db_session, "Wholly Stale")
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS)
+    await EMBEDDING_BASE_URL.set(test_db_session, _URL_A)
+
+    # Warm both, then commit both straight to app_settings and evict NOTHING.
+    assert await EMBEDDING_MODEL.get(test_db_session) == _MODEL
+    assert await EMBEDDING_DIMS.get(test_db_session) == _DIMS
+    await test_db_session.execute(
+        text(
+            "UPDATE catalog.app_settings SET value = :v WHERE key = 'embedding_model'"
+        ),
+        {"v": json.dumps({"v": _MODEL_AFTER})},
+    )
+    await test_db_session.execute(
+        text("UPDATE catalog.app_settings SET value = :v WHERE key = 'embedding_dims'"),
+        {"v": json.dumps({"v": _DIMS_AFTER})},
+    )
+    await test_db_session.commit()
+
+    # Vacuity guard: both cached reads are genuinely stale and the DB genuinely
+    # moved. Warm-but-equal would make the assertions below hold on any tree.
+    assert await EMBEDDING_MODEL.get(test_db_session) == _MODEL
+    assert await EMBEDDING_DIMS.get(test_db_session) == _DIMS
+    assert await EMBEDDING_MODEL.get_uncached(test_db_session) == _MODEL_AFTER
+    assert await EMBEDDING_DIMS.get_uncached(test_db_session) == _DIMS_AFTER
+
+    provider = _QuietRecordingProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+
+    await backfill_module.backfill_embeddings(test_db_session, force=False)
+
+    assert provider.calls, "the provider was never called"
+    # The run generated under the committed pair, not the cached one. The rows
+    # it wrote carry this same model name, so the label names the active model.
     assert {call["model"] for call in provider.calls} == {_MODEL_AFTER}
     assert {call["dimensions"] for call in provider.calls} == {_DIMS_AFTER}

--- a/backend/tests/test_embedding_backfill_base_url_pinning.py
+++ b/backend/tests/test_embedding_backfill_base_url_pinning.py
@@ -278,19 +278,36 @@ async def test_a_mid_run_endpoint_edit_cannot_split_a_run_across_providers(
     # batch size of 128 the non-force path makes exactly one.
     monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 1)
 
-    await backfill_module.backfill_embeddings(test_db_session, force=force)
+    # fix(#1525 review r4, codex P2): the run STOPS at the next batch boundary
+    # once the endpoint it pinned is no longer the active one, instead of
+    # quietly finishing the catalog in a vector space the live search will
+    # never match. So "one run reached two endpoints" is now unreachable rather
+    # than merely avoided — the guard prevents the second call, it does not
+    # make the second call use the right value.
+    #
+    # Which means this test no longer covers the pin ITSELF: with the
+    # `base_url=` argument removed from the batch calls, the first batch would
+    # re-resolve, still get _URL_A because the edit has not landed yet, and the
+    # run would stop at the same boundary with the same observables. The pin is
+    # covered by `test_an_endpoint_that_resolves_to_none_is_still_pinned`,
+    # which counts resolves and so sees a batch resolving a value for itself.
+    stopped = False
+    try:
+        await backfill_module.backfill_embeddings(test_db_session, force=force)
+    except RuntimeError:
+        stopped = True
 
-    # Non-vacuity, both halves. With fewer than two calls there is no pair of
-    # endpoints to compare and the set assertion below passes on nothing; with
-    # the edit never landing there was no switch to survive in the first place.
-    assert len(provider.calls) >= 2, "the run made fewer than two provider calls"
+    # Non-vacuity, both halves. No provider call means no argument to compare,
+    # and the edit never landing means there was no switch to survive.
+    assert provider.calls, "the provider was never called"
     assert await EMBEDDING_BASE_URL.get(test_db_session) == _URL_B, (
         "the admin edit never landed"
     )
 
-    # The finding itself: one run, one endpoint, and it is the one the run
-    # resolved rather than whatever the config said by the time it was called.
+    # The finding itself: every vector this run produced came from the endpoint
+    # it resolved, never from the one the config moved to.
     assert {call["base_url"] for call in provider.calls} == {_URL_A}
+    assert stopped
 
 
 @pytest.mark.anyio
@@ -529,9 +546,12 @@ async def test_an_endpoint_that_resolves_to_none_is_still_pinned(
     # Non-vacuity: with fewer than two batches there is no per-batch growth to
     # detect, and the count below would hold on the unfixed tree too.
     assert len(provider.calls) >= 2, "the run made fewer than two provider calls"
-    # Two, and only two: `_snapshot_embedding_config` captures then re-reads.
-    # Anything more means a batch resolved the config for itself.
-    assert provider.resolves == 2
+    # Two for `_snapshot_embedding_config` (capture then re-read), plus exactly
+    # one per batch for the drift check added by #1525 review r4. A batch that
+    # resolved the config for its own VALUE as well would add a second per
+    # batch, which is the bug: with `base_url is None` as the pin test, a
+    # resolved None reads as an omission and every batch re-resolves.
+    assert provider.resolves == 2 + len(provider.calls)
     # And the pinned value actually reached the provider as itself.
     assert {call["base_url"] for call in provider.calls} == {None}
 

--- a/backend/tests/test_embedding_backfill_force_guard.py
+++ b/backend/tests/test_embedding_backfill_force_guard.py
@@ -72,7 +72,10 @@ def _pin_model(monkeypatch, name: str) -> None:
     patching the module attribute reaches it.
     """
 
-    async def _resolve(_session):
+    # fix(#1525 review r2): the snapshot passes `uncached=True`, so the stub has
+    # to accept it. It answers the same either way — this pins the resolution,
+    # not which layer it came from.
+    async def _resolve(_session, **_kwargs):
         return name
 
     monkeypatch.setattr(helpers, "resolve_embedding_model_name", _resolve)

--- a/backend/tests/test_embedding_backfill_model_pinning.py
+++ b/backend/tests/test_embedding_backfill_model_pinning.py
@@ -54,8 +54,12 @@ class _RecordingProvider:
 
     def __init__(self):
         self.calls: list[dict] = []
+        # Stashed for the subclass that has to write config from inside a
+        # provider call; `embed` is not handed a session.
+        self._session = None
 
     async def resolve_runtime_config(self, session):
+        self._session = session
         return {
             "default_model": "provider-fallback-model",
             "default_dims": 1536,
@@ -111,18 +115,40 @@ class _ExplodingProvider(_RecordingProvider):
 
 
 class _SwitchingProvider(_RecordingProvider):
-    """Flips the live config from inside the provider call.
+    """Flips the live config from inside the first provider call.
 
-    `resolve_runtime_config` is the one await `service.py` makes after backfill
-    has captured its own values and before the service would re-read them, so
-    this covers the late window: a swap that lands once the run is already
-    generating.
+    Covers the late window: a swap that lands once the run is already
+    generating, after the snapshot has captured its own values and before the
+    service would re-read them.
+
+    The flip hangs on `embed` rather than on `resolve_runtime_config`, which is
+    where it used to sit. fix(#1525) made `_snapshot_embedding_config` resolve
+    the endpoint through `resolve_runtime_config`, so a flip there now lands
+    INSIDE the capture window and the snapshot's comparison aborts the run.
+    That is a real behaviour and it has its own coverage
+    (`test_an_edit_inside_the_snapshot_window_aborts_the_run`), but it is not
+    the scenario this file is about. `embed` is the first await after the
+    snapshot completes on both paths, and it is where a run actually spends its
+    time, so it is the more faithful place for an admin edit to land.
     """
 
-    async def resolve_runtime_config(self, session):
-        await EMBEDDING_MODEL.set(session, _MODEL_B)
-        await EMBEDDING_DIMS.set(session, _DIMS_B)
-        return await super().resolve_runtime_config(session)
+    def __init__(self):
+        super().__init__()
+        self._switched = False
+
+    async def embed(self, *, texts, model, dimensions, base_url, timeout):
+        vectors = await super().embed(
+            texts=texts,
+            model=model,
+            dimensions=dimensions,
+            base_url=base_url,
+            timeout=timeout,
+        )
+        if not self._switched:
+            self._switched = True
+            await EMBEDDING_MODEL.set(self._session, _MODEL_B)
+            await EMBEDDING_DIMS.set(self._session, _DIMS_B)
+        return vectors
 
 
 async def _embedding_count(session) -> int:
@@ -157,6 +183,14 @@ async def test_a_mid_run_model_switch_cannot_mislabel_a_vector(
     dataset = await create_dataset(
         test_db_session, created_by=user_id, name=f"Model Pinning {force}"
     )
+    # A second record, so the non-force path always has work for a second
+    # batch. It selects only records with no vector under the ACTIVE model, and
+    # a sibling run that already embedded the catalog under _MODEL_A leaves
+    # exactly one: this test's own new dataset. One call is one call too few to
+    # catch a swap that lands during the first.
+    await create_dataset(
+        test_db_session, created_by=user_id, name=f"Model Pinning Second {force}"
+    )
 
     await EMBEDDING_MODEL.set(test_db_session, _MODEL_A)
     await EMBEDDING_DIMS.set(test_db_session, _DIMS_A)
@@ -168,12 +202,21 @@ async def test_a_mid_run_model_switch_cannot_mislabel_a_vector(
     monkeypatch.setattr(
         service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
     )
+    # One record per provider call. The swap lands during the first call, so
+    # the run needs a second one for it to be in front of; at the default batch
+    # size of 128 the non-force path makes exactly one and the assertions below
+    # would hold on an unpinned tree too.
+    monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 1)
 
     await backfill_module.backfill_embeddings(test_db_session, force=force)
 
-    # Non-vacuity: with no provider call there is no argument to compare, and
-    # with no stored row there is no label. Both would pass silently below.
-    assert provider.calls, "the provider was never called"
+    # Non-vacuity: with fewer than two provider calls there is no post-swap call
+    # to catch, and with no stored row there is no label. Both would pass
+    # silently below.
+    assert len(provider.calls) >= 2, "the run made fewer than two provider calls"
+    assert await EMBEDDING_MODEL.get(test_db_session) == _MODEL_B, (
+        "the admin swap never landed"
+    )
     stored_label = (
         await test_db_session.execute(
             select(RecordEmbedding.model_name).where(
@@ -182,13 +225,13 @@ async def test_a_mid_run_model_switch_cannot_mislabel_a_vector(
         )
     ).scalar_one()
 
-    call = provider.calls[0]
-    # The finding itself: the row's label has to describe the vector in it.
-    assert call["model"] == stored_label
+    # The finding itself: the row's label has to describe the vector in it, and
+    # EVERY call has to agree, not just the one before the swap.
+    assert {call["model"] for call in provider.calls} == {stored_label}
     # And both halves have to come from the run's own resolution, not from
     # whatever the config happened to say by the time the provider was called.
-    assert call["model"] == _MODEL_A
-    assert call["dimensions"] == _DIMS_A
+    assert {call["model"] for call in provider.calls} == {_MODEL_A}
+    assert {call["dimensions"] for call in provider.calls} == {_DIMS_A}
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_embedding_backfill_model_pinning.py
+++ b/backend/tests/test_embedding_backfill_model_pinning.py
@@ -144,7 +144,12 @@ class _SwitchingProvider(_RecordingProvider):
             base_url=base_url,
             timeout=timeout,
         )
-        if not self._switched:
+        # Not during the force path's pre-flight. That call happens before the
+        # first batch, so a swap landing there is caught by the drift check at
+        # the batch boundary and the run stops having written nothing — a real
+        # behaviour, covered in test_embedding_backfill_base_url_pinning.py,
+        # but not the "already generating" window this file is about.
+        if not self._switched and list(texts) != [backfill_module._PREFLIGHT_TEXT]:
             self._switched = True
             await EMBEDDING_MODEL.set(self._session, _MODEL_B)
             await EMBEDDING_DIMS.set(self._session, _DIMS_B)
@@ -202,18 +207,29 @@ async def test_a_mid_run_model_switch_cannot_mislabel_a_vector(
     monkeypatch.setattr(
         service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
     )
-    # One record per provider call. The swap lands during the first call, so
-    # the run needs a second one for it to be in front of; at the default batch
-    # size of 128 the non-force path makes exactly one and the assertions below
-    # would hold on an unpinned tree too.
-    monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 1)
+    # One batch for the whole run, deliberately. The drift check added by
+    # #1525 review r4 runs at each batch boundary, so with several batches this
+    # run would stop at the second one and the record whose label is asserted
+    # below might never be written — the order records come back in is not
+    # fixed. A single batch keeps this test on the question it asks (does the
+    # label describe the vector) and leaves the stop-on-drift behaviour to
+    # test_embedding_backfill_base_url_pinning.py, which asserts it directly.
+    monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 10_000)
 
+    # fix(#1525 review r4, codex P2): this test no longer covers the pin
+    # ITSELF. With the swap landing during the batch's own provider call, an
+    # unpinned tree reads the config before the swap and produces the same
+    # single call a pinned one does; and with several batches the run would
+    # stop at the next boundary rather than make a divergent call. What it
+    # still covers is the label: every vector this run wrote came from one
+    # model, and the rows carry that model's name. The pin's own contract is
+    # asserted in
+    # test_generate_embeddings_batch_uses_the_pinned_pair_not_the_live_config.
     await backfill_module.backfill_embeddings(test_db_session, force=force)
 
-    # Non-vacuity: with fewer than two provider calls there is no post-swap call
-    # to catch, and with no stored row there is no label. Both would pass
-    # silently below.
-    assert len(provider.calls) >= 2, "the run made fewer than two provider calls"
+    # Non-vacuity: no provider call means no argument to compare, and no stored
+    # row means no label. Both would pass silently below.
+    assert provider.calls, "the provider was never called"
     assert await EMBEDDING_MODEL.get(test_db_session) == _MODEL_B, (
         "the admin swap never landed"
     )
@@ -232,6 +248,54 @@ async def test_a_mid_run_model_switch_cannot_mislabel_a_vector(
     # whatever the config happened to say by the time the provider was called.
     assert {call["model"] for call in provider.calls} == {_MODEL_A}
     assert {call["dimensions"] for call in provider.calls} == {_DIMS_A}
+
+
+@pytest.mark.anyio
+async def test_generate_embeddings_batch_uses_the_pinned_pair_not_the_live_config(
+    test_db_session,
+    monkeypatch,
+    restore_embedding_config,
+):
+    """The pin's own contract, asserted without the backfill loop around it.
+
+    The run-level tests above cannot cover this any more. #1525 review r4 added
+    a drift check at the batch boundary, so a config change mid-run stops the
+    run before an unpinned re-read could produce a divergent second call, and
+    an unpinned tree therefore produces the same observables there as a pinned
+    one.
+
+    The pin still matters, and this is where. It governs the batch ALREADY IN
+    FLIGHT: without it, `generate_embeddings_batch` re-reads the config it was
+    handed values for, and the rows that batch writes get a model the label
+    does not name. The drift check only notices at the next boundary, by which
+    time those rows exist.
+    """
+    await EMBEDDING_MODEL.set(test_db_session, _MODEL_B)
+    await EMBEDDING_DIMS.set(test_db_session, _DIMS_B)
+
+    provider = _RecordingProvider()
+    monkeypatch.setattr(
+        service_module, "get_embedding_provider", lambda _name: provider
+    )
+    monkeypatch.setattr(
+        service_module, "settings", SimpleNamespace(openai_api_key="pin-test-key")
+    )
+
+    await service_module.generate_embeddings_batch(
+        ["a text to embed"],
+        test_db_session,
+        model=_MODEL_A,
+        dimensions=_DIMS_A,
+        base_url="http://pinned.invalid",
+    )
+
+    # Vacuity: the live config genuinely says something else, so "used what it
+    # was given" is a different outcome from "read the config". Without this,
+    # a call that ignored its arguments entirely could still pass.
+    assert await EMBEDDING_MODEL.get(test_db_session) == _MODEL_B
+    assert await EMBEDDING_DIMS.get(test_db_session) == _DIMS_B
+
+    assert provider.calls == [{"model": _MODEL_A, "dimensions": _DIMS_A}]
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_embedding_backfill_model_pinning.py
+++ b/backend/tests/test_embedding_backfill_model_pinning.py
@@ -280,18 +280,32 @@ async def test_a_switch_between_the_model_and_dims_reads_aborts_the_run(
     before = await _embedding_count(test_db_session)
     assert before > 0
 
+    # fix(#1525 review r2): hung on the UNCACHED read, which is the one the
+    # snapshot makes now. The cached read is still what everything else uses, so
+    # both are patched and the flip fires on whichever the snapshot reaches
+    # first — the point is that it lands between the two captures, not which
+    # layer serves them.
     original_dims_get = EMBEDDING_DIMS.get
+    original_dims_get_uncached = EMBEDDING_DIMS.get_uncached
     flipped = False
 
-    async def _flip_then_read(session):
+    async def _flip(session) -> None:
         nonlocal flipped
         if not flipped:
             flipped = True
             await EMBEDDING_MODEL.set(session, _MODEL_B)
             await EMBEDDING_DIMS.set(session, _DIMS_B)
+
+    async def _flip_then_read(session):
+        await _flip(session)
         return await original_dims_get(session)
 
+    async def _flip_then_read_uncached(session):
+        await _flip(session)
+        return await original_dims_get_uncached(session)
+
     monkeypatch.setattr(EMBEDDING_DIMS, "get", _flip_then_read)
+    monkeypatch.setattr(EMBEDDING_DIMS, "get_uncached", _flip_then_read_uncached)
 
     provider = _RecordingProvider()
     monkeypatch.setattr(

--- a/backend/tests/test_embedding_backfill_model_pinning.py
+++ b/backend/tests/test_embedding_backfill_model_pinning.py
@@ -351,13 +351,17 @@ async def test_a_generated_vector_that_cannot_be_stored_does_not_destroy_vectors
 ):
     """Generating is only half the promise: the vector has to fit the column.
 
-    fix(#1511 review r4, codex P1): `update_settings` runs
-    `_auto_detect_embedding_dims()` and `rebuild_embedding_column()` on
-    MUTUALLY EXCLUSIVE branches — the first when `embedding_dims` is absent
-    from the request, the second when it is present
-    (`modules/settings/router.py:348-360`). So an admin who switches model
-    without naming dimensions gets the detected width persisted and the column
-    left at its old one.
+    fix(#1511 review r4, codex P1): the width a model produces and the width
+    the column declares are written by different code at different times, so
+    they can disagree. What found it was a settings write that persisted a
+    newly detected width without rebuilding the column, leaving storage at the
+    old one (that path is the subject of #1529).
+
+    The scenario below is built from the mismatch itself rather than from that
+    route: a model whose vectors are the wrong width for the live column. It
+    therefore holds whatever produced the mismatch, which is the point of the
+    guard it covers — that guard reads storage, not config, so closing any one
+    route does not retire it.
 
     Every earlier guard passes here, and that is the point. Model and
     dimensions are consistent with each other, they are stable, and the

--- a/backend/tests/test_embedding_backfill_model_pinning.py
+++ b/backend/tests/test_embedding_backfill_model_pinning.py
@@ -183,9 +183,9 @@ async def test_a_mid_run_model_switch_cannot_mislabel_a_vector(
     restore_embedding_config,
     force,
 ):
-    """The label on a stored row must name the model that produced it."""
+    """A model swap landing mid-generation must leave no row behind."""
     user_id = await get_user_id(test_db_session, "admin")
-    dataset = await create_dataset(
+    await create_dataset(
         test_db_session, created_by=user_id, name=f"Model Pinning {force}"
     )
     # A second record, so the non-force path always has work for a second
@@ -199,6 +199,8 @@ async def test_a_mid_run_model_switch_cannot_mislabel_a_vector(
 
     await EMBEDDING_MODEL.set(test_db_session, _MODEL_A)
     await EMBEDDING_DIMS.set(test_db_session, _DIMS_A)
+
+    before = await _embedding_count(test_db_session)
 
     provider = _SwitchingProvider()
     monkeypatch.setattr(
@@ -216,38 +218,45 @@ async def test_a_mid_run_model_switch_cannot_mislabel_a_vector(
     # test_embedding_backfill_base_url_pinning.py, which asserts it directly.
     monkeypatch.setattr(backfill_module, "_BATCH_SIZE", 10_000)
 
-    # fix(#1525 review r4, codex P2): this test no longer covers the pin
-    # ITSELF. With the swap landing during the batch's own provider call, an
-    # unpinned tree reads the config before the swap and produces the same
-    # single call a pinned one does; and with several batches the run would
-    # stop at the next boundary rather than make a divergent call. What it
-    # still covers is the label: every vector this run wrote came from one
-    # model, and the rows carry that model's name. The pin's own contract is
-    # asserted in
-    # test_generate_embeddings_batch_uses_the_pinned_pair_not_the_live_config.
-    await backfill_module.backfill_embeddings(test_db_session, force=force)
+    # fix(#1525 review r5, codex P2): the swap lands during this batch's own
+    # provider call, and the drift check that runs before the batch is ACCEPTED
+    # now catches it, so the batch is discarded rather than committed. The
+    # label can no longer be wrong because no label is written — a stronger
+    # guarantee than the one this test was built to check, and it changes what
+    # is observable here: there is no stored row left to compare against.
+    #
+    # So this test no longer covers the pin ITSELF either. That is asserted in
+    # test_generate_embeddings_batch_uses_the_pinned_pair_not_the_live_config,
+    # and the caller threading it through is covered by the cache tests in
+    # test_embedding_backfill_base_url_pinning.py. What it covers now is the
+    # run's behaviour: a swap mid-generation writes nothing at all.
+    stopped = False
+    try:
+        await backfill_module.backfill_embeddings(test_db_session, force=force)
+    except RuntimeError:
+        stopped = True
 
-    # Non-vacuity: no provider call means no argument to compare, and no stored
-    # row means no label. Both would pass silently below.
+    # Non-vacuity: no provider call means no argument to compare, and no swap
+    # means nothing for the drift check to catch.
     assert provider.calls, "the provider was never called"
     assert await EMBEDDING_MODEL.get(test_db_session) == _MODEL_B, (
         "the admin swap never landed"
     )
-    stored_label = (
-        await test_db_session.execute(
-            select(RecordEmbedding.model_name).where(
-                RecordEmbedding.record_id == dataset.record_id
-            )
-        )
-    ).scalar_one()
 
-    # The finding itself: the row's label has to describe the vector in it, and
-    # EVERY call has to agree, not just the one before the swap.
-    assert {call["model"] for call in provider.calls} == {stored_label}
-    # And both halves have to come from the run's own resolution, not from
-    # whatever the config happened to say by the time the provider was called.
+    # Every call came from the run's own resolution, not from whatever the
+    # config said by the time the provider was reached.
     assert {call["model"] for call in provider.calls} == {_MODEL_A}
     assert {call["dimensions"] for call in provider.calls} == {_DIMS_A}
+
+    # And nothing was stored. On the force path that means an EMPTY table: the
+    # delete committed before the run could know it would finish, which is the
+    # #1549 trade taken deliberately — empty and loud beats populated with
+    # vectors the active search will silently fail to match.
+    remaining = (
+        await test_db_session.execute(select(func.count()).select_from(RecordEmbedding))
+    ).scalar_one()
+    assert remaining == (0 if force else before)
+    assert stopped
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_embedding_tenant_isolation.py
+++ b/backend/tests/test_embedding_tenant_isolation.py
@@ -309,6 +309,14 @@ async def test_force_backfill_deletes_only_active_tenant_embeddings(
             "generate_embeddings_batch",
             AsyncMock(return_value=[[1.0] + [0.0] * 1535]),
         )
+        # fix(#1525): and for the endpoint, the third value the force path now
+        # snapshots before it deletes. It resolves through the provider, whose
+        # first act is another app_settings read this role is denied.
+        monkeypatch.setattr(
+            backfill_module,
+            "resolve_embedding_base_url",
+            AsyncMock(return_value=None),
+        )
 
         from app.core.db.tenant_session import current_tenant_var
 

--- a/backend/tests/test_embedding_tenant_isolation.py
+++ b/backend/tests/test_embedding_tenant_isolation.py
@@ -297,6 +297,12 @@ async def test_force_backfill_deletes_only_active_tenant_embeddings(
         monkeypatch.setattr(
             backfill_module.EMBEDDING_DIMS, "get", AsyncMock(return_value=1536)
         )
+        # fix(#1525 review r2): the snapshot reads the dimensions uncached now,
+        # to see past a mid-eviction cache. Same app_settings denial, so the
+        # same precondition has to be supplied.
+        monkeypatch.setattr(
+            backfill_module.EMBEDDING_DIMS, "get_uncached", AsyncMock(return_value=1536)
+        )
         # fix(#1511 review r3): likewise for the AI gate, which force now
         # checks before its delete, and the pre-flight embedding. Either would
         # otherwise abort this run before the DELETE under test — the gate by


### PR DESCRIPTION
Closes #1525.

## The change

`generate_embeddings_batch` resolved the endpoint from `resolve_runtime_config` on every call. #1511/#1519 pinned the model and the dimensions for the length of a run and filed the endpoint as the narrower half of the same class.

`_snapshot_embedding_config` now captures the endpoint too and returns it with the pair, `_preflight_embedding` and both batch call sites pass it through, and `generate_embeddings_batch` accepts an optional `base_url` that skips the config read exactly as `model` and `dimensions` do. `generate_embedding` still does not pin: it makes one call and labels nothing.

Two decisions worth review:

**The service resolves the live config only when a value would still come out of it.** Passing `base_url` alone would have fixed nothing for the shipped provider, because `resolve_runtime_config` was still called per batch and it is that call which fails. The gate (`not model or not dimensions or base_url is None`) is the exact set of conditions under which a value is read out of `runtime_config` below it, so behaviour is unchanged for every input except a fully pinned call, where the only difference is that the provider's resolve is not invoked.

**The endpoint is captured in its own window rather than folded into the model/dimensions comparison.** Resolving it calls the provider extension, which is an arbitrarily long await, and putting that between the model capture and the model re-read would widen the coupled pair's window by the length of a provider call. The pair has to agree with each other; the endpoint only has to equal itself.

## Where the issue is wrong

The issue says a mid-run edit "routes later batches to a different provider ... Deployments can serve different vector spaces for the same model string." That is true of a provider extension that resolves its own endpoint. It is not reachable through the shipped one.

`bind_openai_credential_base_url` (`app/core/ai_credentials.py`) refuses to aim the environment-provided API key at a database-supplied URL. With a key configured it returns the operator-approved environment value or raises, and `generate_embeddings_batch` raises `EmbeddingUnavailableError` up front when no key is configured, so the un-bound branch is unreachable from a backfill. `DefaultOpenAIEmbeddingProvider.embed` re-binds as well, so a pinned endpoint is still validated at the SDK boundary.

So the shipped provider does not diverge, it raises. Every batch after the edit fails, is retried per record, fails again and counts as an error, and the run gives up on the rest of the catalog while reporting a successful completion with a large error count. That is the reachable damage, and it needed the resolve-skip above rather than the pin alone. `test_a_mid_run_endpoint_edit_does_not_abandon_the_rest_of_the_catalog` covers it against the real `resolve_runtime_config` and the real binding; `test_a_mid_run_endpoint_edit_cannot_split_a_run_across_providers` covers the divergence the issue describes, against an extension provider. The two tests fail independently, so neither half of the fix is load-bearing for the other's coverage.

The mechanism claims in the issue both check out. `resolve_runtime_config` reads `EMBEDDING_BASE_URL` then `OPENAI_BASE_URL` per call with no memoisation, and `PersistentConfig.set` commits and then calls `apply_side_effects`, which does `cache.delete`, so a re-read misses the cache and hits the DB.

## Verification

New file `backend/tests/test_embedding_backfill_base_url_pinning.py`, six tests, both force and non-force. The edit is driven through the real `PersistentConfig.set` from inside the first provider call, which is where a run spends its time. Batch size is patched to 1 so the non-force path makes more than one provider call. Every test asserts the provider was actually called and that the edit actually landed before comparing what it received.

Red, with the two app files reverted:

```
tests/test_embedding_backfill_base_url_pinning.py:172: AssertionError: assert {'https://emb...b.invalid/v1'} == {'https://emb...a.invalid/v1'}
tests/test_embedding_backfill_base_url_pinning.py:172: AssertionError: assert {'https://emb...b.invalid/v1'} == {'https://emb...a.invalid/v1'}
tests/test_embedding_backfill_base_url_pinning.py:223: assert 6 == 0
tests/test_embedding_backfill_base_url_pinning.py:223: assert 7 == 0
FAILED ...::test_a_mid_run_endpoint_edit_cannot_split_a_run_across_providers[force]
FAILED ...::test_a_mid_run_endpoint_edit_cannot_split_a_run_across_providers[non_force]
FAILED ...::test_a_mid_run_endpoint_edit_does_not_abandon_the_rest_of_the_catalog[force]
FAILED ...::test_a_mid_run_endpoint_edit_does_not_abandon_the_rest_of_the_catalog[non_force]
4 failed, 45 warnings in 6.80s
```

The snapshot's endpoint comparison is a third guard, so it got its own counterfactual. With the comparison deleted and the single capture left in place:

```
tests/test_embedding_backfill_base_url_pinning.py:316: AssertionError: assert [{'model': 'e....invalid/v1'}] == []
FAILED ...::test_an_edit_inside_the_snapshot_window_aborts_the_run[force]
FAILED ...::test_an_edit_inside_the_snapshot_window_aborts_the_run[non_force]
2 failed, 4 passed
```

Green, the embeddings-adjacent set:

```
$ uv run pytest tests/test_embedding_backfill.py tests/test_embedding_backfill_model_pinning.py \
    tests/test_embedding_backfill_base_url_pinning.py tests/test_embedding_backfill_force_guard.py \
    tests/test_embedding_backfill_model_scope.py tests/test_embedding_tenant_isolation.py \
    tests/test_processing_port.py -q
35 passed, 49 warnings in 12.47s
```

Everything else that touches the embedding service or the backfill:

```
$ uv run pytest tests/ -q -k "embedding or backfill"
162 passed, 1 skipped, 8883 deselected, 50 warnings in 91.97s

$ uv run pytest tests/test_ai_provider_extension.py tests/test_admin_user_operations.py tests/test_hybrid_search.py \
    tests/test_ai_credential_binding.py tests/test_admin_ai_probe.py tests/test_embedding_pipeline.py \
    tests/test_tenant_rls_migration.py tests/test_embedding_provider_extension.py tests/test_settings_router.py \
    tests/test_embedding_service.py tests/test_search_embedding_cache.py -q
112 passed, 50 warnings in 41.32s
```

Gates:

```
$ uv run pytest tests/test_layering.py -q
47 passed in 9.95s

$ uv run ruff check . && uv run ruff format --check .
All checks passed!
1011 files already formatted
```

No `_MODULE_LOC_CAPS` entry to raise: `backfill.py` is 460 lines and `service.py` is 411, both well under the 1000-line inclusion threshold and neither is currently listed.

## One test edit worth flagging

`test_force_backfill_deletes_only_active_tenant_embeddings` runs as `geolens_reader`, which is denied `app_settings`, and #1511 already had to stub each config read it added to the force path (`resolve_embedding_model_name`, `EMBEDDING_DIMS.get`, `AI_ENABLED.get`, `generate_embeddings_batch`). The endpoint snapshot is one more such read, so it is stubbed the same way with a comment naming this fix. The test's subject, the tenant scoping of the DELETE, is untouched.


## Second commit: stale-comment cleanup ahead of #1529

`3d8cf0975` is unrelated to `base_url` and changes no behaviour. #1538 (gl-1529) removes `_auto_detect_embedding_dims` and routes the detected width through the rebuild branch, which falsifies text #1519 wrote in this file: the storage guard and the test covering it justified themselves by naming `update_settings`'s two mutually exclusive branches, and the operator message told an admin to set the dimensions explicitly because the auto-detect path did not rebuild.

I did not write these to describe the post-#1538 world, and I did not hold them. Both of those options are correct only under one merge order, and #1538 is `MERGEABLE` but `BLOCKED` with an open P1, so the order is not knowable from here. The text is now true in both worlds, which needs no follow-up on either.

That is not a compromise position, it is the better comment. The instruction with these was that the guard must not read as redundant, and anchoring it to *any* specific settings route is what makes it deletable, whether the route is the old one or the new one. It now says what it actually does: it reads the live `atttypmod` rather than trusting `EMBEDDING_DIMS`, so it holds for a width mismatch from any cause, including a rebuild that failed partway, a restored dump, or a writer nobody has added yet. The settings path stays as the case that found it, in the past tense, anchored to #1529.

The operator message is the one item that genuinely cannot be true in both worlds if it names a route, so it no longer names one. It states the width the column has to reach and leaves the route to Settings:

> Existing vectors were left untouched. Re-save the embedding configuration in Settings so the column is rebuilt to 768 dimensions, then re-run.

Once #1538 is on `main`, appending "or re-save the model on its own" is a one-line change if you want the shortest route spelled out. It would not be a correction.


## Why the uncached snapshot read is load-bearing

Five rounds on this PR, each fixing a two-value consistency bug and each relocating it one layer out. #1519 pinned the model and left the dimensions. This PR pinned model and dimensions and left the endpoint. Then it pinned all three but verified them in two separate windows, so an atomic model-and-endpoint edit landed in the gap. Then it verified all three as one unit — and the per-key **cache** turned out to be the layer nobody had checked, because two reads through the same stale entry agree with each other perfectly.

That is why `_snapshot_embedding_config` reads uncached rather than merely comparing carefully. A comparison can only catch a value that moves between two reads; it cannot catch a value that is wrong in both, and a cache that has not been evicted yet is wrong in both. The uncached read is the only thing in this file that establishes what the database actually says.

The residue is written into that function's docstring rather than left implicit: the endpoint still resolves through the provider extension's own cached reads, unreachable for the shipped provider (its endpoint is environment-derived under an API key) and closable for extension providers only by adding an uncached mode to the extension interface.


## Stop on a stale pin (#1525 review r4, codex P2)

The pin kept each batch consistent, but nothing noticed the pinned configuration had stopped being the active one. A run pinned to endpoint A that continues after the active endpoint becomes B writes A-space vectors for the rest of the catalog. `RecordEmbedding` records only `model_name`, so semantic search builds its query vector from the live endpoint and filters stored rows by model alone: B-space queries against A-space documents under one label, with the backfill reporting success. `_pinned_config_drift` re-reads the pinned triple at each batch boundary and the loop raises if it moved, outside the `try` so it stops the run instead of being retried per record. Persisting an endpoint identity per row is #1546.

Two states are deliberately not treated as drift. An unresolvable model, because that is what `resolve_embedding_model_name` answers on any transient config failure. And a provider resolve that raises, because for the shipped provider that is precisely what an endpoint edit diverging from the operator-approved environment URL looks like, and it says nothing about where vectors are going — `embed` re-binds to that same approved URL. Treating it as drift would undo the abandon-the-catalog fix earlier in this PR.

### On the uncached snapshot and non-force

To be accurate about scope: `backfill_embeddings` calls one `_snapshot_embedding_config` from both paths, so making the snapshot uncached necessarily makes the non-force pin uncached too. That is harmless and strictly better — non-force destroys nothing and a more accurate pin cannot hurt it. What stays on the cached `get` is everything else: the per-batch value reads, and every other `PersistentConfig` caller in the codebase.

### Test decomposition, because the drift check changed what the run-level tests can see

Once a run stops at the first batch boundary after a config change, an unpinned tree produces the same observables as a pinned one — the guard prevents the divergent call rather than correcting it. So the properties were split apart and each one verified by reverting its own mechanism:

| Property | Test | Red when reverted |
|---|---|---|
| The pin is honoured inside `generate_embeddings_batch` | `test_generate_embeddings_batch_uses_the_pinned_pair_not_the_live_config` | `assert [...] == [...]` on the recorded call |
| The caller threads the pin through | the two cache tests | `assert {1536} == {768}` and `{'...'} == {'...-after'}` |
| No per-batch re-resolution | `test_an_endpoint_that_resolves_to_none_is_still_pinned` | `assert 4 == 2` |
| The run stops on drift | `test_a_mid_run_endpoint_edit_cannot_split_a_run_across_providers` | `assert False` on the stop |
| One window over all three | `test_an_atomic_model_and_endpoint_swap_cannot_pin_a_mixed_pair` | `assert [{...}] == []` |

Each row was measured, not argued: the mechanism was reverted with a patch file and the named assertion observed failing.
