### PR TITLE
fix(cog): answer HEAD and serve byte ranges on the COG download

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -20,7 +20,7 @@ configure_gdal_s3_env(settings)
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import func, select, text
-from starlette.middleware.gzip import GZipMiddleware
+from starlette.middleware.gzip import DEFAULT_EXCLUDED_CONTENT_TYPES, GZipMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.api.router import api_router
@@ -972,7 +972,27 @@ app.add_middleware(
 # Pinned by tests/test_phase_273_middleware_order.py — do not flip without
 # updating that regression test.
 app.add_middleware(SecurityHeadersMiddleware)
-app.add_middleware(GZipMiddleware, minimum_size=256, compresslevel=4)
+# fix(#1540 review P2): image/tiff joins starlette's default exclusions, which
+# already cover avif/gif/jpeg/png/webp and simply predate anyone serving TIFF.
+#
+# Not a CPU optimization, though it is that too — a COG is internally compressed
+# already, so DEFLATE over a multi-GB one buys close to nothing. It is a
+# CORRECTNESS fix for the strong ETag the COG download route publishes. A strong
+# validator must identify one representation including its content coding, and
+# this middleware compresses a 200 while skipping a 206 by design
+# (`self.partial_response = status == 206`). One ETag therefore named two
+# different byte streams: gzip bytes on the full download, raw bytes on every
+# range. A client resuming the encoded representation could have its validator
+# accepted and splice raw bytes at encoded offsets — doing everything right and
+# still assembling a corrupt file. Excluding the type restores the invariant
+# without variant-specific validators, which would need their own HEAD metadata
+# and Vary story.
+app.add_middleware(
+    GZipMiddleware,
+    minimum_size=256,
+    compresslevel=4,
+    exclude_content_types=DEFAULT_EXCLUDED_CONTENT_TYPES + ("image/tiff",),
+)
 app.add_middleware(DynamicCORSMiddleware)
 
 app.include_router(api_router)

--- a/backend/app/api/middleware/cors.py
+++ b/backend/app/api/middleware/cors.py
@@ -92,18 +92,36 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
 
     @staticmethod
     def _set_cors_headers(response: Response, origin: str) -> None:
-        """Add standard CORS headers to the response."""
+        """Add standard CORS headers to the response.
+
+        fix(#1540 review P2): HEAD, the conditional/range request headers, and
+        the range response headers are all here because #1528 gave
+        ``/datasets/{id}/download/cog`` a HEAD, byte ranges, an ``ETag`` and
+        ``If-Range``/``If-None-Match`` handling, and a browser client could use
+        none of it. A preflight for ``If-Range`` was refused, so a resumable
+        cross-origin download never started; and where the request did succeed,
+        JavaScript could not read ``ETag`` or ``Content-Range``, because a
+        response header not named in ``Access-Control-Expose-Headers`` is not
+        merely undocumented — it is invisible to the caller.
+
+        ``Range`` is listed even though the Fetch standard safelists simple
+        byte-range values: the safelisting is conditional on the syntax, and a
+        request pairing it with ``If-Range`` is preflighted regardless.
+        ``Content-Length`` is NOT listed because it is already a safelisted
+        response header, and repeating it here would suggest the others are too.
+        """
         response.headers["Access-Control-Allow-Origin"] = origin
         response.headers["Access-Control-Allow-Credentials"] = "true"
         response.headers["Access-Control-Allow-Methods"] = (
-            "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+            "GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS"
         )
         response.headers["Access-Control-Allow-Headers"] = (
             "Authorization, Content-Type, Accept, X-Api-Key, X-Embed-Token, "
-            "X-Config-Preview-Token"
+            "X-Config-Preview-Token, Range, If-Range, If-None-Match"
         )
         response.headers["Access-Control-Expose-Headers"] = (
             "X-Total-Count, Link, Content-Crs, Content-Language, "
+            "ETag, Content-Range, Accept-Ranges, Content-Disposition, "
             "X-GeoLens-Source-Dataset-Count, X-GeoLens-Serialized-Dataset-Count, "
             "X-GeoLens-Excluded-Dataset-Count, "
             "X-GeoLens-Metadata-Fallback-Dataset-Count, "

--- a/backend/app/api/middleware/cors.py
+++ b/backend/app/api/middleware/cors.py
@@ -109,6 +109,14 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         request pairing it with ``If-Range`` is preflighted regardless.
         ``Content-Length`` is NOT listed because it is already a safelisted
         response header, and repeating it here would suggest the others are too.
+
+        ``If-Match`` arrived a round later than the rest, and its absence was
+        the same defect a second time: the endpoint grew a precondition and this
+        list did not learn about it. Remembering to edit both is not a control,
+        so ``tests/test_cors_range_headers_1540.py`` now reads the route's own
+        source for the conditional headers it evaluates and the response headers
+        it sets, and fails if either is missing here. Add a header there and
+        this list is what breaks — before a browser console does.
         """
         response.headers["Access-Control-Allow-Origin"] = origin
         response.headers["Access-Control-Allow-Credentials"] = "true"
@@ -117,7 +125,7 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
         )
         response.headers["Access-Control-Allow-Headers"] = (
             "Authorization, Content-Type, Accept, X-Api-Key, X-Embed-Token, "
-            "X-Config-Preview-Token, Range, If-Range, If-None-Match"
+            "X-Config-Preview-Token, Range, If-Range, If-None-Match, If-Match"
         )
         response.headers["Access-Control-Expose-Headers"] = (
             "X-Total-Count, Link, Content-Crs, Content-Language, "

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -714,10 +714,11 @@ async def get_geodcat_ap_record(
 # COG download
 # ---------------------------------------------------------------------------
 
-# fix(#1528): chunk size for a streamed byte range. A range can be most of a
-# multi-GB COG, so it is read in bounded pieces rather than buffered whole —
-# the same reason the full-object path streams via get_stream() (ING-03).
-_COG_RANGE_CHUNK_BYTES = 1024 * 1024  # 1 MiB
+# fix(#1528): a range can be most of a multi-GB COG, so it is read in bounded
+# pieces rather than buffered whole — the same reason the full-object path
+# streams via get_stream() (ING-03). fix(#1540 review P1): the chunk size that
+# used to live here belongs to the provider now, along with the loop that used
+# it; see the note where `_iter_storage_range` was.
 
 # One anchored pattern, deliberately strict about what it accepts:
 #   bytes=FIRST-LAST | bytes=FIRST- | bytes=-SUFFIX
@@ -727,7 +728,20 @@ _COG_RANGE_CHUNK_BYTES = 1024 * 1024  # 1 MiB
 # range, an unknown unit, a reversed pair) is IGNORED per RFC 9110 section
 # 14.2, which is the safe direction: the client gets the whole representation
 # it can already handle, never a partial one mislabelled as something else.
-_BYTE_RANGE_RE = re.compile(r"^bytes=(?:([0-9]+)-([0-9]*)|-([0-9]+))$")
+#
+# fix(#1540 review P2): the unit match is case-INSENSITIVE. A range unit is a
+# token (RFC 9110 section 14.1), and tokens compare case-insensitively unless
+# the grammar says otherwise, so `Bytes=0-16383` is a conforming request. Being
+# strict about it did not reject that request — "ignore the Range" sent the
+# whole COG with a 200, turning a 16 KiB tile read into a multi-gigabyte
+# transfer. Strictness that fails toward MORE bytes is not strictness.
+#
+# Only the unit. The digits stay `[0-9]`, and the entity-tag comparisons in
+# `_range_bound_to_this_version` and `_if_none_match_matches` stay
+# case-SENSITIVE, because an entity-tag is opaque and section 8.8.3.2 compares
+# it octet by octet — and the weak prefix is `%s"W/"`, spelled with a
+# case-sensitive string literal in the grammar itself.
+_BYTE_RANGE_RE = re.compile(r"^bytes=(?:([0-9]+)-([0-9]*)|-([0-9]+))$", re.IGNORECASE)
 
 # The Range named no byte of the representation (first-byte-pos at or past the
 # end, or a zero-length suffix). RFC 9110 section 15.5.17 wants a 416 carrying
@@ -812,31 +826,21 @@ def _parse_cog_range(raw: str | None, size: int) -> tuple[int, int] | str | None
     return (start, min(end, size - 1))
 
 
-async def _iter_storage_range(storage, key: str, start: int, length: int):
-    """Yield exactly ``length`` bytes from ``start``, in bounded chunks.
-
-    ``storage.get_range`` returns bytes rather than a stream, so a single call
-    for a whole range would materialize it in memory — fine for the 16 KB
-    header read a COG client opens with, not for a caller that asks for a
-    gigabyte. The loop keeps resident memory at one chunk regardless of the
-    range's size.
-
-    A short read ends the stream instead of looping forever: if the object
-    shrank under us the response is truncated against its Content-Length, which
-    every HTTP client reports as a failed transfer. That is the loud failure;
-    padding to length would be the quiet corrupt one.
-    """
-    remaining = length
-    offset = start
-    while remaining > 0:
-        chunk = await storage.get_range(
-            key, offset, min(remaining, _COG_RANGE_CHUNK_BYTES)
-        )
-        if not chunk:
-            return
-        yield chunk
-        offset += len(chunk)
-        remaining -= len(chunk)
+# fix(#1540 review P1): `_iter_storage_range` used to live here, looping
+# `storage.get_range` at `_COG_RANGE_CHUNK_BYTES` a call. It kept resident
+# memory to one chunk, which was the point, and paid for it in object-store
+# requests: one per chunk, so `Range: bytes=0-` on a 5 GiB COG issued 5,120 of
+# them serially while the rate limiter counted one API request. That is the
+# same amplification the stale-resume fallback was fixed for a round earlier,
+# on the path an ordinary tile read takes — and on an S3 or Azure deployment
+# every managed raster takes it, because ingest writes `storage_backend="local"`
+# whatever the object store is.
+#
+# The bound belongs in the provider, which is the only layer that can ask for a
+# window once and hand back the response as it arrives. `get_range_stream` is
+# that method; see its contract in `platform/storage/provider.py`. Deleting the
+# loop rather than repairing it is deliberate: a helper that turns one range
+# into N reads has no correct chunk size, only less-wrong ones.
 
 
 async def _resolve_download_user(
@@ -1515,7 +1519,7 @@ async def _local_cog_response(
         # this is ever implemented by slicing a full-object stream.
         start, end = byte_range
         return StreamingResponse(
-            _iter_storage_range(storage, physical_asset_key, start, end - start + 1),
+            storage.get_range_stream(physical_asset_key, start, end - start + 1),
             status_code=status.HTTP_206_PARTIAL_CONTENT,
             media_type="image/tiff",
             headers={

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -1073,26 +1073,46 @@ async def download_cog(
     # recording either as `dataset.download_cog` would misreport who downloaded
     # what. The sequence is the one RFC 9110 section 13.2.2 fixes: If-Match,
     # then If-None-Match, then Range and If-Range.
+    storage = get_storage()
     etag = _cog_etag(raster_asset)
-    if _this_service_owns_the_bytes(raster_asset) and not _if_match_passes(
-        request.headers.get("if-match"), etag
+    total_bytes: int | None = None
+
+    if _this_service_owns_the_bytes(raster_asset) and (
+        request.headers.get("if-match") or request.headers.get("if-none-match")
     ):
-        # fix(#1540 review P2): a resuming client may say "only if this is still
-        # the representation I have" with If-Match instead of If-Range. Ignoring
-        # it left the absent If-Range reading as permission, so a replacement
-        # mid-download was answered with a 206 of the new COG at the old offsets
-        # — the same splice, through the header the client happened to choose.
-        # A failed If-Match is a 412, not a degradation: unlike If-Range, the
-        # RFC gives it no "ignore and serve the whole thing" fallback.
-        raise HTTPException(
-            status_code=status.HTTP_412_PRECONDITION_FAILED,
-            detail="COG has changed since the version you hold",
-            headers={"ETag": etag} if etag is not None else None,
+        # fix(#1540 review P2): stat BEFORE answering either precondition. RFC
+        # 9110 section 13.2.1 puts preconditions after the normal request
+        # checks, and existence is one: a row whose object has been deleted
+        # answers 404 unconditionally, so a 304 here told a cache its stale copy
+        # was a current representation of something that no longer exists — and
+        # the same URL disagreed with itself about whether it existed depending
+        # on whether the client sent a validator. The size is carried down
+        # rather than re-measured, so a conditional request that goes on to
+        # transfer bytes still stats exactly once (fix(#1540 review P2), the
+        # double-stat round).
+        total_bytes = await _cog_object_size(
+            storage,
+            physical_asset_key=_managed_key(raster_asset),
+            dataset_id=dataset_id,
         )
-    if etag is not None and _if_none_match_matches(
-        request.headers.get("if-none-match"), etag
-    ):
-        return _cog_not_modified(etag)
+        if not _if_match_passes(request.headers.get("if-match"), etag):
+            # A resuming client may say "only if this is still the
+            # representation I have" with If-Match instead of If-Range.
+            # Ignoring it left the absent If-Range reading as permission, so a
+            # replacement mid-download was answered with a 206 of the new COG
+            # at the old offsets — the same splice, through the header the
+            # client happened to choose. A failed If-Match is a 412, not a
+            # degradation: unlike If-Range, the RFC gives it no "ignore and
+            # serve the whole thing" fallback.
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail="COG has changed since the version you hold",
+                headers={"ETag": etag} if etag is not None else None,
+            )
+        if etag is not None and _if_none_match_matches(
+            request.headers.get("if-none-match"), etag
+        ):
+            return _cog_not_modified(etag)
 
     # 6. Audit log. user_id may be None for anonymous downloads (KNOWN-01).
     # The audit_logs.user_id column is nullable; AuditEvent.user_id is typed
@@ -1127,9 +1147,8 @@ async def download_cog(
         )
         await db.commit()
 
-    # 7. Storage-backend branching
-    storage = get_storage()
-
+    # 7. Storage-backend branching. `storage` was resolved above, because the
+    # precondition block may already have had to stat the object.
     if raster_asset.storage_backend == "remote":
         # STAC import: asset_uri is the original remote COG URL — redirect.
         # SEC-06 / M-68: DNS records can change between import time (when
@@ -1158,9 +1177,7 @@ async def download_cog(
 
         return RedirectResponse(url=raster_asset.asset_uri, status_code=302)
 
-    physical_asset_key = resolve_storage_key(
-        raster_asset.asset_uri, tenant_id=current_tenant_var.get()
-    )
+    physical_asset_key = _managed_key(raster_asset)
 
     if raster_asset.storage_backend == "s3":
         return await _s3_cog_response(
@@ -1170,6 +1187,7 @@ async def download_cog(
             filename=filename,
             dataset_id=dataset_id,
             etag=etag,
+            total_bytes=total_bytes,
         )
 
     return await _local_cog_response(
@@ -1179,6 +1197,19 @@ async def download_cog(
         filename=filename,
         dataset_id=dataset_id,
         etag=etag,
+        total_bytes=total_bytes,
+    )
+
+
+def _managed_key(raster_asset) -> str:
+    """The physical storage key for an asset whose bytes this service owns.
+
+    One call site became three when the precondition block had to stat the
+    object before answering (fix(#1540 review P2)), and the tenant namespace
+    this crosses is exactly the seam ``resolve_storage_key`` exists to own.
+    """
+    return resolve_storage_key(
+        raster_asset.asset_uri, tenant_id=current_tenant_var.get()
     )
 
 
@@ -1190,6 +1221,7 @@ async def _s3_cog_response(
     filename: str,
     dataset_id: uuid.UUID,
     etag: str | None,
+    total_bytes: int | None = None,
 ) -> Response:
     """The s3 backend: HEAD here, a stale resume here, everything else redirected.
 
@@ -1223,10 +1255,16 @@ async def _s3_cog_response(
     bucket's egress to ours.
     """
     if request.method == "HEAD":
-        total_bytes = await _cog_object_size(
-            storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
+        return _cog_head_response(
+            await _cog_size_once(
+                total_bytes,
+                storage,
+                physical_asset_key=physical_asset_key,
+                dataset_id=dataset_id,
+            ),
+            filename,
+            etag,
         )
-        return _cog_head_response(total_bytes, filename, etag)
 
     if request.headers.get("range") and not _range_bound_to_this_version(
         request.headers.get("if-range"), etag
@@ -1238,8 +1276,11 @@ async def _s3_cog_response(
         # 5,120 object-store requests that the per-request rate limiter counts
         # as one. `_iter_storage_range` is right where the client named a
         # window and wrong here, where the answer is the entire object.
-        total_bytes = await _cog_object_size(
-            storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
+        total_bytes = await _cog_size_once(
+            total_bytes,
+            storage,
+            physical_asset_key=physical_asset_key,
+            dataset_id=dataset_id,
         )
         return StreamingResponse(
             storage.get_stream(physical_asset_key),
@@ -1441,6 +1482,28 @@ async def _cog_object_size(
         )
 
 
+async def _cog_size_once(
+    already_known: int | None,
+    storage,
+    *,
+    physical_asset_key: str,
+    dataset_id: uuid.UUID,
+) -> int:
+    """The object's size, stat'ing only if the caller has not already.
+
+    fix(#1540 review P2): the precondition block has to stat before it can
+    answer a 304 — a row whose bytes are gone must 404 whether or not the
+    client sent a validator. Handing that measurement down is what keeps the
+    single-stat property the double-stat round established: a conditional
+    request that goes on to transfer bytes still touches object metadata once.
+    """
+    if already_known is not None:
+        return already_known
+    return await _cog_object_size(
+        storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
+    )
+
+
 def _cog_headers(filename: str, etag: str | None) -> dict[str, str]:
     """Headers every stored-bytes response from this route carries.
 
@@ -1507,6 +1570,7 @@ async def _local_cog_response(
     filename: str,
     dataset_id: uuid.UUID,
     etag: str | None,
+    total_bytes: int | None = None,
 ) -> Response:
     """Serve stored COG bytes: HEAD, a byte range, or the whole object.
 
@@ -1522,8 +1586,11 @@ async def _local_cog_response(
     # Local storage: stream bytes from disk in 1 MiB chunks (ING-03 / P2-03).
     # The full file is NOT buffered into memory — a 5 GB COG no longer pins
     # 5 GB of resident memory before the first byte streams.
-    total_bytes = await _cog_object_size(
-        storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
+    total_bytes = await _cog_size_once(
+        total_bytes,
+        storage,
+        physical_asset_key=physical_asset_key,
+        dataset_id=dataset_id,
     )
     cog_headers = _cog_headers(filename, etag)
 

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -735,6 +735,39 @@ _BYTE_RANGE_RE = re.compile(r"^bytes=(?:([0-9]+)-([0-9]*)|-([0-9]+))$")
 # tile and silently received the entire COG splices it at the wrong offset.
 _RANGE_UNSATISFIABLE = "unsatisfiable"
 
+# fix(#1540 review P2): every numeric field is saturated at this many digits
+# before it reaches int(). CPython refuses to convert an integer literal longer
+# than sys.get_int_max_str_digits() (4300 by default) and raises ValueError, so
+# an unbounded `int(group)` turns `Range: bytes=<4301 digits>-` — which fits
+# comfortably inside the 8 KiB per-header budget nginx and uvicorn both allow —
+# into a 500 on a header RFC 9110 lets a server ignore.
+#
+# Saturating rather than rejecting because the RFC answer to each of these is
+# already defined and none of them is "serve the whole object": a first-byte-pos
+# past the end is a 416 carrying the real size (section 15.5.17), and a
+# last-byte-pos or suffix past the end clamps to the object (section 14.1.1).
+# Dropping an over-long value on the floor and replying 200 would hand a client
+# that asked for one tile the entire COG — the corrupt-splice failure
+# `_RANGE_UNSATISFIABLE` exists to prevent.
+#
+# 19 digits because 2**63-1 has 19 and no object is that large; every value
+# above it compares against `size` identically.
+_MAX_RANGE_DIGITS = 19
+
+
+def _range_int(digits: str, size: int) -> int:
+    """``int(digits)``, saturated above any size a stored object can have.
+
+    Leading zeros are stripped before the length test so that a padded literal
+    is measured by its value and not by its typing: ``bytes=-0000...0`` is a
+    zero-length suffix and must reach the 416 branch, not be mistaken for an
+    astronomically large one.
+    """
+    trimmed = digits.lstrip("0") or "0"
+    if len(trimmed) > _MAX_RANGE_DIGITS:
+        return size + 1
+    return int(trimmed)
+
 
 def _parse_cog_range(raw: str | None, size: int) -> tuple[int, int] | str | None:
     """Resolve a Range header to an inclusive ``(start, end)`` byte pair.
@@ -760,17 +793,18 @@ def _parse_cog_range(raw: str | None, size: int) -> tuple[int, int] | str | None
 
     if suffix is not None:
         # bytes=-N: the final N bytes. A zero-length suffix names nothing.
-        if int(suffix) == 0 or size == 0:
+        wanted = _range_int(suffix, size)
+        if wanted == 0 or size == 0:
             return _RANGE_UNSATISFIABLE
-        return (max(0, size - int(suffix)), size - 1)
+        return (max(0, size - wanted), size - 1)
 
-    start = int(first)
+    start = _range_int(first, size)
     if size == 0 or start >= size:
         return _RANGE_UNSATISFIABLE
     if last == "":
         # bytes=N-: from N to the end.
         return (start, size - 1)
-    end = int(last)
+    end = _range_int(last, size)
     if end < start:
         return None  # reversed pair: invalid, so ignore rather than reject
     # A last-byte-pos past the end is CLAMPED, not rejected — clients that do
@@ -962,6 +996,13 @@ async def download_cog(
     user-None to enforce public visibility and emit the audit row with
     user_id=NULL.
     """
+    # The docstring above is the published OpenAPI description for the GET
+    # operation, so it describes the GET only — the HEAD route is
+    # include_in_schema=False and, since fix(#1540) review P1, answers the s3
+    # backend from object metadata rather than redirecting. Adding that to the
+    # docstring moves openapi.json and churns both SDKs and the CLI for prose
+    # about an operation the schema does not carry, so it lives on the branch
+    # itself instead.
     from slugify import slugify
 
     from app.modules.auth.permissions import get_effective_permissions
@@ -1086,6 +1127,32 @@ async def download_cog(
     )
 
     if raster_asset.storage_backend == "s3":
+        # fix(#1540 review P1): HEAD is answered here, from object metadata,
+        # instead of falling through to the presigned redirect below.
+        #
+        # `generate_presigned_get_url` signs `get_object`, and the HTTP method
+        # is part of an S3/MinIO SigV4 canonical request. A redirect-following
+        # client keeps HEAD across a 302 (RFC 9110 section 15.4 only rewrites
+        # the method for 303), so the redirected HEAD arrives at the bucket
+        # signed for the wrong verb and is refused. MEASURED against MinIO
+        # RELEASE.2025-09-07: a presigned get_object URL answers GET 200 and
+        # HEAD 403, and the mirror image — a head_object URL fetched with GET —
+        # returns `SignatureDoesNotMatch` in the body, which is the same
+        # rejection with a readable payload. That is the whole point of this
+        # PR failing on every S3 deployment: /vsicurl/ probes with HEAD.
+        #
+        # Answering directly rather than signing a second URL for `head_object`
+        # is the better of the two fixes: one round trip instead of two, no
+        # dependence on the client preserving its method across the hop, and
+        # HEAD then behaves identically on `local` and `s3` because it runs the
+        # same `_cog_object_size` and returns the same `_cog_head_response`.
+        # The GET keeps redirecting — the bytes still come from the bucket, and
+        # a presigned GET honours a Range once the client gets there.
+        if request.method == "HEAD":
+            total_bytes = await _cog_object_size(
+                storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
+            )
+            return _cog_head_response(total_bytes, filename)
         url = storage.generate_presigned_get_url(physical_asset_key, expiration=3600)
         return RedirectResponse(url=url, status_code=302)
 
@@ -1095,6 +1162,89 @@ async def download_cog(
         physical_asset_key=physical_asset_key,
         filename=filename,
         dataset_id=dataset_id,
+    )
+
+
+async def _cog_object_size(
+    storage, *, physical_asset_key: str, dataset_id: uuid.UUID
+) -> int:
+    """Stat the stored COG: 404 when it is gone, 503 when the backend is not.
+
+    Probing existence upfront is what lets ``FileNotFoundError`` surface as a
+    404 BEFORE an async iterator is handed to ``StreamingResponse``. Starlette
+    consumes that iterator after returning the response, so a deferred raise
+    inside the generator would produce a 500 (or a broken Transfer-Encoding
+    chunk) rather than a clean 404.
+
+    The size comes from the same guarded block because it is what makes both
+    halves of fix(#1528) honest — a real Content-Length on HEAD and on the full
+    GET, and the denominator of every Content-Range — and a backend that throws
+    on ``size()`` must map to the same 503 as one that throws on ``exists()``,
+    not to a raw 500.
+
+    fix(#1540 review P1): shared with the ``s3`` branch rather than living
+    inside the local one, so a HEAD gets the same 200/404/503 answer whichever
+    backend holds the bytes.
+    """
+    try:
+        if not await storage.exists(physical_asset_key):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="COG file not found",
+            )
+        return await storage.size(physical_asset_key)
+    except HTTPException:
+        raise
+    except Exception:  # broad: storage backend (S3/MinIO/local) can throw varied SDK/I/O errors; map to 503
+        logger.exception("cog_storage_error", dataset_id=str(dataset_id))
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="COG download temporarily unavailable",
+        )
+
+
+def _cog_headers(filename: str) -> dict[str, str]:
+    """Headers every stored-bytes response from this route carries.
+
+    fix(#1528): ``accept-ranges`` goes on all of them, including the 416 — RFC
+    9110 section 14.3 scopes it to the RESOURCE, not to the one response
+    carrying it, and a client that just got a 416 is precisely the one that
+    needs telling it may retry with a corrected range.
+
+    Content-Disposition does NOT go on the 416, which is why the caller merges
+    this dict rather than the 416 reusing it. That response's body is the JSON
+    error, not the raster; naming it ``attachment; filename="....cog.tif"``
+    would have a browser save an error document under the COG's filename.
+    """
+    return {
+        "Accept-Ranges": "bytes",
+        "Content-Disposition": get_catalog_port().safe_content_disposition(filename),
+    }
+
+
+def _cog_head_response(total_bytes: int, filename: str) -> Response:
+    """The HEAD answer: one stat, no read, a real length.
+
+    A HEAD that streamed the object to learn its length would make every
+    /vsicurl/ open cost a full download — the amplification the export route's
+    HEAD avoids by not running its conversion.
+
+    A Range on a HEAD is deliberately ignored. HEAD describes the selected
+    representation, so answering 206 here would report a tile's length as the
+    size of the COG.
+
+    Passing content-length explicitly also suppresses starlette's own:
+    ``init_headers`` populates it from the body, which for this empty one is
+    ``content-length: 0`` — a confident wrong answer that reads as an empty COG,
+    and strictly worse than the 405 this replaces. fix(#1513) had to strip that
+    header for the same reason; here the real value displaces it.
+    ``test_head_cog_carries_the_real_content_length`` fails if this is ever
+    dropped back to the default.
+    """
+    return Response(
+        status_code=status.HTTP_200_OK,
+        media_type="image/tiff",
+        headers={**_cog_headers(filename), "Content-Length": str(total_bytes)},
     )
 
 
@@ -1120,70 +1270,13 @@ async def _local_cog_response(
     # Local storage: stream bytes from disk in 1 MiB chunks (ING-03 / P2-03).
     # The full file is NOT buffered into memory — a 5 GB COG no longer pins
     # 5 GB of resident memory before the first byte streams.
-    #
-    # Probe existence upfront so FileNotFoundError surfaces as 404 BEFORE the
-    # async iterator is handed to StreamingResponse. Starlette consumes the
-    # iterator after returning the response, so a deferred raise inside the
-    # generator would produce a 500 (or a broken Transfer-Encoding chunk)
-    # rather than a clean 404.
-    #
-    # fix(#1528): the size is read in the same guarded block. It is what makes
-    # both halves of this fix honest — a real Content-Length on HEAD and on the
-    # full GET, and the denominator of every Content-Range below — and a
-    # backend that throws on size() must map to the same 503 as one that throws
-    # on exists(), not to a raw 500.
-    try:
-        if not await storage.exists(physical_asset_key):
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="COG file not found",
-            )
-        total_bytes = await storage.size(physical_asset_key)
-    except HTTPException:
-        raise
-    except Exception:  # broad: storage backend (S3/MinIO/local) can throw varied SDK/I/O errors; map to 503
-        logger.exception("cog_storage_error", dataset_id=str(dataset_id))
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="COG download temporarily unavailable",
-        )
-
-    # fix(#1528): `accept-ranges` goes on every response from this branch,
-    # including the 416 — RFC 9110 section 14.3 scopes it to the RESOURCE, not
-    # to the one response carrying it, and a client that just got a 416 is
-    # precisely the one that needs telling it may retry with a corrected range.
-    #
-    # Content-Disposition does NOT go on the 416, which is why these are two
-    # dicts and not one. That response's body is the JSON error, not the
-    # raster; naming it `attachment; filename="....cog.tif"` would have a
-    # browser save an error document under the COG's filename.
-    cog_headers = {
-        "Accept-Ranges": "bytes",
-        "Content-Disposition": get_catalog_port().safe_content_disposition(filename),
-    }
+    total_bytes = await _cog_object_size(
+        storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
+    )
+    cog_headers = _cog_headers(filename)
 
     if request.method == "HEAD":
-        # Answered entirely from metadata: one stat, no read. A HEAD that
-        # streamed the object to learn its length would make every /vsicurl/
-        # open cost a full download — the amplification the export route's HEAD
-        # avoids by not running its conversion.
-        #
-        # A Range on a HEAD is deliberately ignored. HEAD describes the
-        # selected representation, so answering 206 here would report a tile's
-        # length as the size of the COG.
-        #
-        # Passing content-length explicitly also suppresses starlette's own:
-        # `init_headers` populates it from the body, which for this empty one
-        # is `content-length: 0` — a confident wrong answer that reads as an
-        # empty COG, and strictly worse than the 405 this replaces. fix(#1513)
-        # had to strip that header for the same reason; here the real value
-        # displaces it. `test_head_cog_carries_the_real_content_length` fails
-        # if this is ever dropped back to the default.
-        return Response(
-            status_code=status.HTTP_200_OK,
-            media_type="image/tiff",
-            headers={**cog_headers, "Content-Length": str(total_bytes)},
-        )
+        return _cog_head_response(total_bytes, filename)
 
     byte_range = _parse_cog_range(request.headers.get("range"), total_bytes)
 

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -1,5 +1,6 @@
 """Dataset export endpoints: DCAT JSON-LD catalog and COG download."""
 
+import re
 import uuid
 
 import jwt
@@ -713,6 +714,96 @@ async def get_geodcat_ap_record(
 # COG download
 # ---------------------------------------------------------------------------
 
+# fix(#1528): chunk size for a streamed byte range. A range can be most of a
+# multi-GB COG, so it is read in bounded pieces rather than buffered whole —
+# the same reason the full-object path streams via get_stream() (ING-03).
+_COG_RANGE_CHUNK_BYTES = 1024 * 1024  # 1 MiB
+
+# One anchored pattern, deliberately strict about what it accepts:
+#   bytes=FIRST-LAST | bytes=FIRST- | bytes=-SUFFIX
+# `[0-9]` rather than `\d` because Python's `\d` is unicode-aware, and
+# int("٣") succeeds while int("²") raises — a header parser should not have
+# opinions about Arabic-Indic digits. Anything this does not match (a second
+# range, an unknown unit, a reversed pair) is IGNORED per RFC 9110 section
+# 14.2, which is the safe direction: the client gets the whole representation
+# it can already handle, never a partial one mislabelled as something else.
+_BYTE_RANGE_RE = re.compile(r"^bytes=(?:([0-9]+)-([0-9]*)|-([0-9]+))$")
+
+# The Range named no byte of the representation (first-byte-pos at or past the
+# end, or a zero-length suffix). RFC 9110 section 15.5.17 wants a 416 carrying
+# the real size, NOT a 200 with the whole object: a client that asked for one
+# tile and silently received the entire COG splices it at the wrong offset.
+_RANGE_UNSATISFIABLE = "unsatisfiable"
+
+
+def _parse_cog_range(raw: str | None, size: int) -> tuple[int, int] | str | None:
+    """Resolve a Range header to an inclusive ``(start, end)`` byte pair.
+
+    Returns ``None`` when there is no usable range and the caller should serve
+    the complete representation, ``_RANGE_UNSATISFIABLE`` when it must answer
+    416, and otherwise the resolved pair — already clamped to the object, so
+    callers never have to re-check the bounds.
+
+    Multi-range requests return ``None``. RFC 9110 section 14.2 lets a server
+    answer a multi-range request with a single range or with the whole
+    representation; ``multipart/byteranges`` is not implemented here, and
+    answering the FIRST range while echoing only its Content-Range would be
+    the corrupt-download failure — a client expecting two parts writes one of
+    them over both offsets.
+    """
+    if not raw:
+        return None
+    match = _BYTE_RANGE_RE.match(raw.strip())
+    if match is None:
+        return None
+    first, last, suffix = match.groups()
+
+    if suffix is not None:
+        # bytes=-N: the final N bytes. A zero-length suffix names nothing.
+        if int(suffix) == 0 or size == 0:
+            return _RANGE_UNSATISFIABLE
+        return (max(0, size - int(suffix)), size - 1)
+
+    start = int(first)
+    if size == 0 or start >= size:
+        return _RANGE_UNSATISFIABLE
+    if last == "":
+        # bytes=N-: from N to the end.
+        return (start, size - 1)
+    end = int(last)
+    if end < start:
+        return None  # reversed pair: invalid, so ignore rather than reject
+    # A last-byte-pos past the end is CLAMPED, not rejected — clients that do
+    # not know the size ask for more than exists on purpose.
+    return (start, min(end, size - 1))
+
+
+async def _iter_storage_range(storage, key: str, start: int, length: int):
+    """Yield exactly ``length`` bytes from ``start``, in bounded chunks.
+
+    ``storage.get_range`` returns bytes rather than a stream, so a single call
+    for a whole range would materialize it in memory — fine for the 16 KB
+    header read a COG client opens with, not for a caller that asks for a
+    gigabyte. The loop keeps resident memory at one chunk regardless of the
+    range's size.
+
+    A short read ends the stream instead of looping forever: if the object
+    shrank under us the response is truncated against its Content-Length, which
+    every HTTP client reports as a failed transfer. That is the loud failure;
+    padding to length would be the quiet corrupt one.
+    """
+    remaining = length
+    offset = start
+    while remaining > 0:
+        chunk = await storage.get_range(
+            key, offset, min(remaining, _COG_RANGE_CHUNK_BYTES)
+        )
+        if not chunk:
+            return
+        yield chunk
+        offset += len(chunk)
+        remaining -= len(chunk)
+
 
 async def _resolve_download_user(
     request: Request,
@@ -828,6 +919,26 @@ async def _resolve_download_user(
     )
 
 
+# fix(#1528): HEAD alongside GET. FastAPI's APIRoute does not add it the way
+# starlette's plain Route does, so this answered `405 allow: GET` — refusing
+# every client that probes before downloading (GDAL/QGIS `/vsicurl/`, resumable
+# downloaders, link checkers). Same gap fix(#1513) closed for the export route,
+# and `_register_standards_head_routes` in app/api/main.py for the standards
+# surface.
+#
+# The HEAD is stronger than the export route's, and the difference is the
+# point. That route runs a live conversion, so its length is unknowable before
+# generating the content and its HEAD omits Content-Length under RFC 9110
+# section 9.3.2. This one serves STORED bytes: one storage.size() gives a real
+# Content-Length, and the `Accept-Ranges: bytes` it advertises is backed by an
+# actual 206 below rather than by starlette's FileResponse re-running a
+# conversion per range (the instability fix(#1532) tracks). A COG endpoint that
+# could not serve ranges would be a COG endpoint in name only.
+#
+# include_in_schema=False for the reason `_clone_api_route` gives: a derived
+# route documents nothing the canonical one does not, and publishing it would
+# churn both SDKs and the CLI.
+@router.head("/{dataset_id}/download/cog", include_in_schema=False)
 @router.get(
     "/{dataset_id}/download/cog",
     response_class=Response,
@@ -909,21 +1020,35 @@ async def download_cog(
     # 6. Audit log. user_id may be None for anonymous downloads (KNOWN-01).
     # The audit_logs.user_id column is nullable; AuditEvent.user_id is typed
     # uuid.UUID | None to match.
-    await audit_emit(
-        db,
-        AuditEvent(
-            user_id=user.id if user is not None else None,
-            action="dataset.download_cog",
-            resource_type="dataset",
-            resource_id=dataset_id,
-            details={
-                "filename": filename,
-                "storage_backend": raster_asset.storage_backend,
-            },
-            ip_address=request.client.host if request.client else None,
-        ),
-    )
-    await db.commit()
+    #
+    # fix(#1528): not for HEAD. Nothing is transferred, so a
+    # `dataset.download_cog` row for a probe misreports who downloaded what,
+    # and every /vsicurl/ open begins with one. Same call fix(#1513) made on
+    # the export route.
+    #
+    # Range GETs ARE audited, each one. That is a deliberate volume cost — a
+    # COG client reading tiles emits a row per read where it used to emit one
+    # per download — taken because the alternative is an audit blind spot: a
+    # caller could otherwise pull an entire COG in ranges and appear in the log
+    # zero times. `details.range` is what separates a tile read from a full
+    # download when reading the log back.
+    if request.method != "HEAD":
+        await audit_emit(
+            db,
+            AuditEvent(
+                user_id=user.id if user is not None else None,
+                action="dataset.download_cog",
+                resource_type="dataset",
+                resource_id=dataset_id,
+                details={
+                    "filename": filename,
+                    "storage_backend": raster_asset.storage_backend,
+                    "range": request.headers.get("range"),
+                },
+                ip_address=request.client.host if request.client else None,
+            ),
+        )
+        await db.commit()
 
     # 7. Storage-backend branching
     storage = get_storage()
@@ -964,6 +1089,34 @@ async def download_cog(
         url = storage.generate_presigned_get_url(physical_asset_key, expiration=3600)
         return RedirectResponse(url=url, status_code=302)
 
+    return await _local_cog_response(
+        request,
+        storage,
+        physical_asset_key=physical_asset_key,
+        filename=filename,
+        dataset_id=dataset_id,
+    )
+
+
+async def _local_cog_response(
+    request: Request,
+    storage,
+    *,
+    physical_asset_key: str,
+    filename: str,
+    dataset_id: uuid.UUID,
+) -> Response:
+    """Serve stored COG bytes: HEAD, a byte range, or the whole object.
+
+    Split out of ``download_cog`` in fix(#1528) — folding three response
+    shapes into a handler that already branches over three storage backends put
+    it past ruff's complexity ceiling (C901, 17 > 15).
+
+    Everything that decides the STATUS has already run in the caller: access
+    control, the raster-type gate, and the RasterAsset lookup. This function
+    only decides which representation to send, which is why it is safe for HEAD
+    and GET to share it.
+    """
     # Local storage: stream bytes from disk in 1 MiB chunks (ING-03 / P2-03).
     # The full file is NOT buffered into memory — a 5 GB COG no longer pins
     # 5 GB of resident memory before the first byte streams.
@@ -973,12 +1126,19 @@ async def download_cog(
     # iterator after returning the response, so a deferred raise inside the
     # generator would produce a 500 (or a broken Transfer-Encoding chunk)
     # rather than a clean 404.
+    #
+    # fix(#1528): the size is read in the same guarded block. It is what makes
+    # both halves of this fix honest — a real Content-Length on HEAD and on the
+    # full GET, and the denominator of every Content-Range below — and a
+    # backend that throws on size() must map to the same 503 as one that throws
+    # on exists(), not to a raw 500.
     try:
         if not await storage.exists(physical_asset_key):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="COG file not found",
             )
+        total_bytes = await storage.size(physical_asset_key)
     except HTTPException:
         raise
     except Exception:  # broad: storage backend (S3/MinIO/local) can throw varied SDK/I/O errors; map to 503
@@ -988,10 +1148,77 @@ async def download_cog(
             detail="COG download temporarily unavailable",
         )
 
+    # fix(#1528): `accept-ranges` goes on every response from this branch,
+    # including the 416 — RFC 9110 section 14.3 scopes it to the RESOURCE, not
+    # to the one response carrying it, and a client that just got a 416 is
+    # precisely the one that needs telling it may retry with a corrected range.
+    #
+    # Content-Disposition does NOT go on the 416, which is why these are two
+    # dicts and not one. That response's body is the JSON error, not the
+    # raster; naming it `attachment; filename="....cog.tif"` would have a
+    # browser save an error document under the COG's filename.
+    cog_headers = {
+        "Accept-Ranges": "bytes",
+        "Content-Disposition": get_catalog_port().safe_content_disposition(filename),
+    }
+
+    if request.method == "HEAD":
+        # Answered entirely from metadata: one stat, no read. A HEAD that
+        # streamed the object to learn its length would make every /vsicurl/
+        # open cost a full download — the amplification the export route's HEAD
+        # avoids by not running its conversion.
+        #
+        # A Range on a HEAD is deliberately ignored. HEAD describes the
+        # selected representation, so answering 206 here would report a tile's
+        # length as the size of the COG.
+        #
+        # Passing content-length explicitly also suppresses starlette's own:
+        # `init_headers` populates it from the body, which for this empty one
+        # is `content-length: 0` — a confident wrong answer that reads as an
+        # empty COG, and strictly worse than the 405 this replaces. fix(#1513)
+        # had to strip that header for the same reason; here the real value
+        # displaces it. `test_head_cog_carries_the_real_content_length` fails
+        # if this is ever dropped back to the default.
+        return Response(
+            status_code=status.HTTP_200_OK,
+            media_type="image/tiff",
+            headers={**cog_headers, "Content-Length": str(total_bytes)},
+        )
+
+    byte_range = _parse_cog_range(request.headers.get("range"), total_bytes)
+
+    if byte_range == _RANGE_UNSATISFIABLE:
+        raise HTTPException(
+            status_code=status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE,
+            detail="Requested range not satisfiable",
+            headers={
+                "Accept-Ranges": "bytes",
+                # The size is the whole point of the 416: it is how a client
+                # that guessed at the length learns the real one and retries.
+                "Content-Range": f"bytes */{total_bytes}",
+            },
+        )
+
+    if byte_range is not None:
+        # The reason the format exists: a client reads the COG header, then
+        # fetches only the tiles it needs. Served through get_range() so the
+        # bytes outside the window are never read — see
+        # `test_range_request_does_not_read_the_whole_object`, which fails if
+        # this is ever implemented by slicing a full-object stream.
+        start, end = byte_range
+        return StreamingResponse(
+            _iter_storage_range(storage, physical_asset_key, start, end - start + 1),
+            status_code=status.HTTP_206_PARTIAL_CONTENT,
+            media_type="image/tiff",
+            headers={
+                **cog_headers,
+                "Content-Range": f"bytes {start}-{end}/{total_bytes}",
+                "Content-Length": str(end - start + 1),
+            },
+        )
+
     return StreamingResponse(
         storage.get_stream(physical_asset_key),
         media_type="image/tiff",
-        headers={
-            "Content-Disposition": get_catalog_port().safe_content_disposition(filename)
-        },
+        headers={**cog_headers, "Content-Length": str(total_bytes)},
     )

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -1058,6 +1058,24 @@ async def download_cog(
     # 5. Build filename
     filename = f"{slugify(dataset.record.title)}.cog.tif"
 
+    # 5b. Conditional request. fix(#1540 review P2): the ETag this route
+    # publishes is only half a cache contract — a client that stores it and
+    # revalidates has to be told "unchanged", or it re-downloads a COG it
+    # already has, which for a multi-GB raster is the entire cost the header
+    # was supposed to save.
+    #
+    # Before the audit row, and above the storage branching, for the reason
+    # HEAD skips the audit: a 304 transfers no bytes, so recording it as
+    # `dataset.download_cog` would misreport who downloaded what. It is also
+    # the order RFC 9110 section 13.2.2 requires — If-None-Match is evaluated
+    # ahead of Range and If-Range, so a client that already holds this exact
+    # representation gets 304 whether or not it asked for a range.
+    etag = _cog_etag(raster_asset)
+    if etag is not None and _if_none_match_matches(
+        request.headers.get("if-none-match"), etag
+    ):
+        return _cog_not_modified(etag)
+
     # 6. Audit log. user_id may be None for anonymous downloads (KNOWN-01).
     # The audit_logs.user_id column is nullable; AuditEvent.user_id is typed
     # uuid.UUID | None to match.
@@ -1127,34 +1145,14 @@ async def download_cog(
     )
 
     if raster_asset.storage_backend == "s3":
-        # fix(#1540 review P1): HEAD is answered here, from object metadata,
-        # instead of falling through to the presigned redirect below.
-        #
-        # `generate_presigned_get_url` signs `get_object`, and the HTTP method
-        # is part of an S3/MinIO SigV4 canonical request. A redirect-following
-        # client keeps HEAD across a 302 (RFC 9110 section 15.4 only rewrites
-        # the method for 303), so the redirected HEAD arrives at the bucket
-        # signed for the wrong verb and is refused. MEASURED against MinIO
-        # RELEASE.2025-09-07: a presigned get_object URL answers GET 200 and
-        # HEAD 403, and the mirror image — a head_object URL fetched with GET —
-        # returns `SignatureDoesNotMatch` in the body, which is the same
-        # rejection with a readable payload. That is the whole point of this
-        # PR failing on every S3 deployment: /vsicurl/ probes with HEAD.
-        #
-        # Answering directly rather than signing a second URL for `head_object`
-        # is the better of the two fixes: one round trip instead of two, no
-        # dependence on the client preserving its method across the hop, and
-        # HEAD then behaves identically on `local` and `s3` because it runs the
-        # same `_cog_object_size` and returns the same `_cog_head_response`.
-        # The GET keeps redirecting — the bytes still come from the bucket, and
-        # a presigned GET honours a Range once the client gets there.
-        if request.method == "HEAD":
-            total_bytes = await _cog_object_size(
-                storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
-            )
-            return _cog_head_response(total_bytes, filename, _cog_etag(raster_asset))
-        url = storage.generate_presigned_get_url(physical_asset_key, expiration=3600)
-        return RedirectResponse(url=url, status_code=302)
+        return await _s3_cog_response(
+            request,
+            storage,
+            physical_asset_key=physical_asset_key,
+            filename=filename,
+            dataset_id=dataset_id,
+            etag=etag,
+        )
 
     return await _local_cog_response(
         request,
@@ -1162,7 +1160,112 @@ async def download_cog(
         physical_asset_key=physical_asset_key,
         filename=filename,
         dataset_id=dataset_id,
-        etag=_cog_etag(raster_asset),
+        etag=etag,
+    )
+
+
+async def _s3_cog_response(
+    request: Request,
+    storage,
+    *,
+    physical_asset_key: str,
+    filename: str,
+    dataset_id: uuid.UUID,
+    etag: str | None,
+) -> Response:
+    """The s3 backend: HEAD here, a stale resume here, everything else redirected.
+
+    fix(#1540 review P1): HEAD is answered from object metadata instead of
+    falling through to the presigned redirect. `generate_presigned_get_url`
+    signs `get_object`, and the HTTP method is part of an S3/MinIO SigV4
+    canonical request. A redirect-following client keeps HEAD across a 302 (RFC
+    9110 section 15.4 only rewrites the method for 303), so the redirected HEAD
+    arrives at the bucket signed for the wrong verb and is refused. MEASURED
+    against MinIO RELEASE.2025-09-07: a presigned get_object URL answers GET 200
+    and HEAD 403, and the mirror image — a head_object URL fetched with GET —
+    returns `SignatureDoesNotMatch`, the same rejection with a readable payload.
+    Every /vsicurl/ open begins with that probe.
+
+    fix(#1540 review P2): a resumed range whose validator no longer matches is
+    also answered here, and this is the one case where the bytes come through
+    this process. The bucket cannot be asked to decide it. MEASURED against the
+    same MinIO: a presigned GET carrying `Range` plus an `If-Range` that does
+    not match the object answers **206 anyway** — for the bucket's own ETag, for
+    a foreign one, and for `If-None-Match` as well. The precondition is simply
+    not evaluated. So a 302 here would hand a client resuming the OLD COG a 206
+    of the NEW one, which is the splice fix(#1540 review P2) exists to prevent,
+    and no redirect can prevent it: the client re-sends its `Range` across the
+    hop and nothing in a 302 can strip it.
+
+    Everything else still redirects, which is what keeps the design honest —
+    whole-object GETs and matching resumes never touch this process's
+    bandwidth, and they are the requests that carry the multi-GB payloads. The
+    proxied case needs a replacement to have landed mid-download, and its cost
+    is the same object the client was already downloading, moved from the
+    bucket's egress to ours.
+    """
+    if request.method == "HEAD":
+        total_bytes = await _cog_object_size(
+            storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
+        )
+        return _cog_head_response(total_bytes, filename, etag)
+
+    if request.headers.get("range") and not _range_bound_to_this_version(
+        request.headers.get("if-range"), etag
+    ):
+        total_bytes = await _cog_object_size(
+            storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
+        )
+        return StreamingResponse(
+            _iter_storage_range(storage, physical_asset_key, 0, total_bytes),
+            media_type="image/tiff",
+            headers={
+                **_cog_headers(filename, etag),
+                "Content-Length": str(total_bytes),
+            },
+        )
+
+    url = storage.generate_presigned_get_url(physical_asset_key, expiration=3600)
+    return RedirectResponse(url=url, status_code=302)
+
+
+def _if_none_match_matches(if_none_match: str | None, etag: str) -> bool:
+    """Does the client already hold this representation? RFC 9110 section 13.1.2.
+
+    WEAK comparison, unlike ``If-Range`` above, and the difference is not an
+    oversight: a cache revalidation only needs the two representations to be
+    equivalent, while a resumed range needs them byte-identical. The spec picks
+    a different comparison function for each, so this route does too.
+
+    ``*`` matches any current representation, which by the time this is called
+    is exactly the one whose ETag was passed in. A list is a list: a client may
+    hold several versions and offer all of them.
+    """
+    if not if_none_match:
+        return False
+    candidates = [tag.strip() for tag in if_none_match.split(",")]
+    if "*" in candidates:
+        return True
+    return any(_without_weak_prefix(tag) == etag for tag in candidates)
+
+
+def _without_weak_prefix(tag: str) -> str:
+    return tag[2:] if tag.startswith("W/") else tag
+
+
+def _cog_not_modified(etag: str) -> Response:
+    """304: the client's copy is current, so send it nothing else.
+
+    The ETag goes back per RFC 9110 section 15.4.5, and ``Accept-Ranges``
+    with it so a client revalidating before a resume does not have to
+    re-probe to learn ranges are available. No body and no ``Content-Length``:
+    starlette's ``init_headers`` skips the length for 304 (and 204) exactly as
+    the spec requires, which is why this response does not need the explicit
+    header ``_cog_head_response`` has to pass.
+    """
+    return Response(
+        status_code=status.HTTP_304_NOT_MODIFIED,
+        headers={"ETag": etag, "Accept-Ranges": "bytes"},
     )
 
 
@@ -1188,7 +1291,15 @@ def _cog_etag(raster_asset) -> str | None:
     None on rows ingested before the column was populated. A response then
     carries no validator, and ``_range_bound_to_this_version`` refuses to honour
     a conditional range rather than guessing — see its docstring.
+
+    None for the ``remote`` backend too, and for a different reason: those bytes
+    belong to a third-party origin this service redirects to and never reads.
+    Publishing a digest recorded at import time would claim an object is
+    unchanged on the strength of a measurement that may be months old, and the
+    origin already answers with validators of its own.
     """
+    if raster_asset.storage_backend == "remote":
+        return None
     sha = raster_asset.sha256
     return f'"{sha}"' if sha else None
 

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -1213,11 +1213,18 @@ async def _s3_cog_response(
     if request.headers.get("range") and not _range_bound_to_this_version(
         request.headers.get("if-range"), etag
     ):
+        # fix(#1540 review P1): ONE get_object, streamed — not
+        # `_iter_storage_range` over the whole object, which issues a ranged
+        # request per 1 MiB chunk. A caller can select this branch deliberately
+        # by sending any stale validator, so at a chunk apiece a 5 GiB COG cost
+        # 5,120 object-store requests that the per-request rate limiter counts
+        # as one. `_iter_storage_range` is right where the client named a
+        # window and wrong here, where the answer is the entire object.
         total_bytes = await _cog_object_size(
             storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
         )
         return StreamingResponse(
-            _iter_storage_range(storage, physical_asset_key, 0, total_bytes),
+            storage.get_stream(physical_asset_key),
             media_type="image/tiff",
             headers={
                 **_cog_headers(filename, etag),

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -1168,33 +1168,40 @@ async def download_cog(
 async def _cog_object_size(
     storage, *, physical_asset_key: str, dataset_id: uuid.UUID
 ) -> int:
-    """Stat the stored COG: 404 when it is gone, 503 when the backend is not.
+    """Stat the stored COG ONCE: 404 when it is gone, 503 when the backend is not.
 
-    Probing existence upfront is what lets ``FileNotFoundError`` surface as a
-    404 BEFORE an async iterator is handed to ``StreamingResponse``. Starlette
-    consumes that iterator after returning the response, so a deferred raise
-    inside the generator would produce a 500 (or a broken Transfer-Encoding
-    chunk) rather than a clean 404.
+    Stat'ing upfront is what lets a missing object surface as a 404 BEFORE an
+    async iterator is handed to ``StreamingResponse``. Starlette consumes that
+    iterator after returning the response, so a deferred raise inside the
+    generator would produce a 500 (or a broken Transfer-Encoding chunk) rather
+    than a clean 404. The size is that same call's answer, which is what makes
+    both halves of fix(#1528) honest — a real Content-Length on HEAD and on the
+    full GET, and the denominator of every Content-Range.
 
-    The size comes from the same guarded block because it is what makes both
-    halves of fix(#1528) honest — a real Content-Length on HEAD and on the full
-    GET, and the denominator of every Content-Range — and a backend that throws
-    on ``size()`` must map to the same 503 as one that throws on ``exists()``,
-    not to a raw 500.
+    fix(#1540 review P2): ONE ``size()``, not ``exists()`` then ``size()``. Every
+    provider normalizes a missing object to ``FileNotFoundError`` (the
+    ``StorageProvider`` protocol says so; S3 and Azure convert their native
+    not-found under fix(#430 BA-24)), so the existence answer was already inside
+    the size answer, and asking twice cost a second ``head_object`` per
+    ``/vsicurl/`` probe — against a PR whose argument for answering HEAD here
+    rather than signing a second URL was that it is ONE round trip. It also
+    opened a window: a delete landing between the calls made ``exists()`` say yes
+    and ``size()`` raise, which the handler below turned into a 503 for an object
+    that was merely gone. ``test_head_cog_issues_exactly_one_s3_metadata_call``
+    and ``test_a_delete_racing_the_stat_is_a_404_not_a_503`` fail if either half
+    comes back.
 
     fix(#1540 review P1): shared with the ``s3`` branch rather than living
     inside the local one, so a HEAD gets the same 200/404/503 answer whichever
     backend holds the bytes.
     """
     try:
-        if not await storage.exists(physical_asset_key):
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="COG file not found",
-            )
         return await storage.size(physical_asset_key)
-    except HTTPException:
-        raise
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="COG file not found",
+        )
     except Exception:  # broad: storage backend (S3/MinIO/local) can throw varied SDK/I/O errors; map to 503
         logger.exception("cog_storage_error", dataset_id=str(dataset_id))
         raise HTTPException(

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -1152,7 +1152,7 @@ async def download_cog(
             total_bytes = await _cog_object_size(
                 storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
             )
-            return _cog_head_response(total_bytes, filename)
+            return _cog_head_response(total_bytes, filename, _cog_etag(raster_asset))
         url = storage.generate_presigned_get_url(physical_asset_key, expiration=3600)
         return RedirectResponse(url=url, status_code=302)
 
@@ -1162,7 +1162,63 @@ async def download_cog(
         physical_asset_key=physical_asset_key,
         filename=filename,
         dataset_id=dataset_id,
+        etag=_cog_etag(raster_asset),
     )
+
+
+def _cog_etag(raster_asset) -> str | None:
+    """The stored COG's own SHA-256, quoted as a STRONG entity-tag.
+
+    fix(#1540 review P2): a range response has to say which version of the
+    object it is a slice of, or a resumable client can splice two of them. The
+    stable download URL names a dataset, not a build: a replacement swaps
+    ``asset_uri`` and ``sha256`` on the same row
+    (``tasks_raster_swap.py:_write_swapped_fields``), so consecutive range GETs
+    to one URL can read different objects while every response is a 206. The
+    client assembles a prefix of the old COG and a suffix of the new one, gets
+    no error at any point, and treats the result as a raster.
+
+    ``sha256`` is the digest of the COG bytes themselves (``sha256_file`` over
+    the converted file in ``tasks_raster.py``), so it changes if and only if
+    those bytes change. That is the definition of a strong validator, and it is
+    why nothing weaker is offered: ``Last-Modified`` has one-second granularity,
+    and a replacement that lands inside the same second as its predecessor is
+    exactly the case this exists to catch.
+
+    None on rows ingested before the column was populated. A response then
+    carries no validator, and ``_range_bound_to_this_version`` refuses to honour
+    a conditional range rather than guessing — see its docstring.
+    """
+    sha = raster_asset.sha256
+    return f'"{sha}"' if sha else None
+
+
+def _range_bound_to_this_version(if_range: str | None, etag: str | None) -> bool:
+    """May this Range be served, given the client's ``If-Range`` precondition?
+
+    RFC 9110 section 13.1.5: ``If-Range`` is evaluated with the STRONG
+    comparison function, and on a mismatch the server MUST ignore the Range
+    header field — which means answering 200 with the whole representation, not
+    416 and not a 206 of the new bytes. The client throws away the prefix it
+    was resuming and starts again, which is the outcome that keeps two COGs
+    from being spliced into one file.
+
+    Three ways this returns False, all of them "cannot prove the client is
+    resuming the object it started":
+
+    - the validators differ (the usual case: a replacement landed);
+    - the client sent ``W/"..."``, which strong comparison never matches;
+    - this row has no ``sha256`` at all, so there is nothing to compare against.
+
+    An absent ``If-Range`` returns True: the client asked for a range with no
+    precondition, and RFC 9110 gives the server nothing to check it against.
+    Such a client can still splice across a replacement, and no server-side
+    change can stop it — which is why the validator has to be ON the response,
+    where a client that wants to resume safely can pick it up.
+    """
+    if if_range is None:
+        return True
+    return etag is not None and if_range.strip() == etag
 
 
 async def _cog_object_size(
@@ -1210,7 +1266,7 @@ async def _cog_object_size(
         )
 
 
-def _cog_headers(filename: str) -> dict[str, str]:
+def _cog_headers(filename: str, etag: str | None) -> dict[str, str]:
     """Headers every stored-bytes response from this route carries.
 
     fix(#1528): ``accept-ranges`` goes on all of them, including the 416 — RFC
@@ -1218,18 +1274,26 @@ def _cog_headers(filename: str) -> dict[str, str]:
     carrying it, and a client that just got a 416 is precisely the one that
     needs telling it may retry with a corrected range.
 
+    fix(#1540 review P2): ``ETag`` likewise, on the 200, the 206 and the HEAD.
+    Advertising ``Accept-Ranges`` without a validator invites exactly the
+    resumable client that can splice two COGs, and the 206 in particular is
+    useless for that client unless it can name the version its slice came from.
+
     Content-Disposition does NOT go on the 416, which is why the caller merges
     this dict rather than the 416 reusing it. That response's body is the JSON
     error, not the raster; naming it ``attachment; filename="....cog.tif"``
     would have a browser save an error document under the COG's filename.
     """
-    return {
+    headers = {
         "Accept-Ranges": "bytes",
         "Content-Disposition": get_catalog_port().safe_content_disposition(filename),
     }
+    if etag is not None:
+        headers["ETag"] = etag
+    return headers
 
 
-def _cog_head_response(total_bytes: int, filename: str) -> Response:
+def _cog_head_response(total_bytes: int, filename: str, etag: str | None) -> Response:
     """The HEAD answer: one stat, no read, a real length.
 
     A HEAD that streamed the object to learn its length would make every
@@ -1247,11 +1311,16 @@ def _cog_head_response(total_bytes: int, filename: str) -> Response:
     header for the same reason; here the real value displaces it.
     ``test_head_cog_carries_the_real_content_length`` fails if this is ever
     dropped back to the default.
+
+    The ETag matters most on THIS response: a HEAD is how a resumable client
+    learns both that ranges are available and which version it is about to
+    start reading, and it is the only answer the ``s3`` backend gets from this
+    process at all.
     """
     return Response(
         status_code=status.HTTP_200_OK,
         media_type="image/tiff",
-        headers={**_cog_headers(filename), "Content-Length": str(total_bytes)},
+        headers={**_cog_headers(filename, etag), "Content-Length": str(total_bytes)},
     )
 
 
@@ -1262,6 +1331,7 @@ async def _local_cog_response(
     physical_asset_key: str,
     filename: str,
     dataset_id: uuid.UUID,
+    etag: str | None,
 ) -> Response:
     """Serve stored COG bytes: HEAD, a byte range, or the whole object.
 
@@ -1280,12 +1350,28 @@ async def _local_cog_response(
     total_bytes = await _cog_object_size(
         storage, physical_asset_key=physical_asset_key, dataset_id=dataset_id
     )
-    cog_headers = _cog_headers(filename)
+    cog_headers = _cog_headers(filename, etag)
 
     if request.method == "HEAD":
-        return _cog_head_response(total_bytes, filename)
+        return _cog_head_response(total_bytes, filename, etag)
 
     byte_range = _parse_cog_range(request.headers.get("range"), total_bytes)
+
+    if byte_range is not None and not _range_bound_to_this_version(
+        request.headers.get("if-range"), etag
+    ):
+        # fix(#1540 review P2): the resumed range names a version this object is
+        # no longer at — a replacement landed between the client's requests.
+        # RFC 9110 section 13.1.5 says ignore the Range, so the client gets the
+        # whole current COG and 200. Before the ETag it got a 206 of the NEW
+        # bytes at the OLD offsets, appended those to the prefix it already had,
+        # and wrote out a file that is half of each: no error anywhere, and a
+        # raster it then treats as authoritative.
+        #
+        # Before the 416 check on purpose. "Ignore the Range" means ignore it,
+        # including when the stale offsets no longer fit the new object; a 416
+        # would be answering a question that is no longer being asked.
+        byte_range = None
 
     if byte_range == _RANGE_UNSATISFIABLE:
         raise HTTPException(
@@ -1296,6 +1382,10 @@ async def _local_cog_response(
                 # The size is the whole point of the 416: it is how a client
                 # that guessed at the length learns the real one and retries.
                 "Content-Range": f"bytes */{total_bytes}",
+                # And the version that size belongs to: a client that retries
+                # against a length it learned here should be able to tell if the
+                # object changed again in between.
+                **({"ETag": etag} if etag is not None else {}),
             },
         )
 

--- a/backend/app/modules/catalog/datasets/api/router_export.py
+++ b/backend/app/modules/catalog/datasets/api/router_export.py
@@ -1069,12 +1069,26 @@ async def download_cog(
     # was supposed to save.
     #
     # Before the audit row, and above the storage branching, for the reason
-    # HEAD skips the audit: a 304 transfers no bytes, so recording it as
-    # `dataset.download_cog` would misreport who downloaded what. It is also
-    # the order RFC 9110 section 13.2.2 requires — If-None-Match is evaluated
-    # ahead of Range and If-Range, so a client that already holds this exact
-    # representation gets 304 whether or not it asked for a range.
+    # HEAD skips the audit: neither a 412 nor a 304 transfers bytes, so
+    # recording either as `dataset.download_cog` would misreport who downloaded
+    # what. The sequence is the one RFC 9110 section 13.2.2 fixes: If-Match,
+    # then If-None-Match, then Range and If-Range.
     etag = _cog_etag(raster_asset)
+    if _this_service_owns_the_bytes(raster_asset) and not _if_match_passes(
+        request.headers.get("if-match"), etag
+    ):
+        # fix(#1540 review P2): a resuming client may say "only if this is still
+        # the representation I have" with If-Match instead of If-Range. Ignoring
+        # it left the absent If-Range reading as permission, so a replacement
+        # mid-download was answered with a 206 of the new COG at the old offsets
+        # — the same splice, through the header the client happened to choose.
+        # A failed If-Match is a 412, not a degradation: unlike If-Range, the
+        # RFC gives it no "ignore and serve the whole thing" fallback.
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail="COG has changed since the version you hold",
+            headers={"ETag": etag} if etag is not None else None,
+        )
     if etag is not None and _if_none_match_matches(
         request.headers.get("if-none-match"), etag
     ):
@@ -1240,6 +1254,45 @@ async def _s3_cog_response(
     return RedirectResponse(url=url, status_code=302)
 
 
+def _this_service_owns_the_bytes(raster_asset) -> bool:
+    """Is this asset's content ours to make claims about?
+
+    The ``remote`` backend is a redirect to a third-party origin whose bytes
+    this service never reads. It publishes no validator (see ``_cog_etag``) and
+    evaluates no precondition: a client's ``If-Match`` there was issued by that
+    origin, travels to it across the redirect, and is answered by the only party
+    that can answer it. Managed backends are the opposite case — this service is
+    the origin server, so an unverifiable precondition is a 412 rather than a
+    shrug.
+    """
+    return raster_asset.storage_backend != "remote"
+
+
+def _if_match_passes(if_match: str | None, etag: str | None) -> bool:
+    """May this request proceed, given the client's ``If-Match``? Section 13.1.1.
+
+    STRONG comparison, like ``If-Range`` and unlike ``If-None-Match``: the
+    client is saying "only act on the representation I already hold", and a
+    weak validator cannot promise byte-for-byte identity.
+
+    ``*`` passes whenever a current representation exists, which by this point
+    is what the RasterAsset row asserts — deliberately including a row with no
+    digest, because ``*`` asks whether there is a representation at all, not
+    whether it is the one the client remembers.
+
+    A specific tag against a row with no ``sha256`` is False: unverifiable is
+    not a pass. That is the same call ``_range_bound_to_this_version`` makes,
+    and it costs those rows nothing a conditional request was going to give
+    them anyway.
+    """
+    if not if_match:
+        return True
+    candidates = [tag.strip() for tag in if_match.split(",")]
+    if "*" in candidates:
+        return True
+    return etag is not None and etag in candidates
+
+
 def _if_none_match_matches(if_none_match: str | None, etag: str) -> bool:
     """Does the client already hold this representation? RFC 9110 section 13.1.2.
 
@@ -1309,7 +1362,7 @@ def _cog_etag(raster_asset) -> str | None:
     unchanged on the strength of a measurement that may be months old, and the
     origin already answers with validators of its own.
     """
-    if raster_asset.storage_backend == "remote":
+    if not _this_service_owns_the_bytes(raster_asset):
         return None
     sha = raster_asset.sha256
     return f'"{sha}"' if sha else None

--- a/backend/app/platform/storage/azure.py
+++ b/backend/app/platform/storage/azure.py
@@ -35,7 +35,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator, BinaryIO
 
-from azure.core.exceptions import ResourceNotFoundError
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient
 
 from app.platform.storage.provider import StoredObject
@@ -151,6 +151,55 @@ class AzureBlobStorageProvider:
             "never be reached."
         )
         yield b""  # unreachable, satisfies AsyncIterator return type
+
+    async def get_range_stream(
+        self, key: str, start: int, length: int
+    ) -> AsyncIterator[bytes]:
+        """Stream a byte window from ONE ``download_blob`` call.
+
+        fix(#1540 review P1): the same amplification S3 had. Serving a range by
+        calling ``get_range`` per 1 MiB chunk meant a separate download call per
+        chunk, and an Azure deployment reaches this code by the ordinary path —
+        managed rasters carry ``storage_backend="local"``, so their range
+        requests are served here rather than redirected.
+
+        One ``download_blob(offset, length)`` for the window, chunked as it
+        arrives. Precisely: one CALL, where S3's is one REQUEST. The Azure SDK
+        satisfies a download larger than its ``max_single_get_size`` with its
+        own internal chunking, so a very large window is still several requests
+        at the SDK's chunk size rather than one — bounded by the SDK's transfer
+        strategy instead of by a loop this code writes at 1 MiB.
+        """
+        blob = self._client.get_blob_client(container=self.container, blob=key)
+
+        def _open():
+            try:
+                return blob.download_blob(offset=start, length=length)
+            except ResourceNotFoundError as e:
+                # fix(#430 BA-24): normalize missing-object to FileNotFoundError across providers.
+                raise FileNotFoundError(key) from e
+            except HttpResponseError as e:
+                # A window at or past the end: Azure raises where S3 answers
+                # 416 and a local seek-then-read simply reads nothing. The
+                # contract is the local one, so it is normalized here —
+                # MEASURED against Azurite 3.35.0, which answers this exact
+                # request with ErrorCode InvalidRange while the other two
+                # providers return empty.
+                if getattr(e, "error_code", None) == "InvalidRange":
+                    return None
+                raise
+
+        downloader = await asyncio.to_thread(_open)
+        if downloader is None:
+            return
+        chunks = await asyncio.to_thread(downloader.chunks)
+        iterator = iter(chunks)
+        sentinel = object()
+        while True:
+            chunk = await asyncio.to_thread(next, iterator, sentinel)
+            if chunk is sentinel or not chunk:
+                return
+            yield chunk
 
     async def get_to_file(self, key: str, dest: Path) -> Path:
         """Download key to a local file path. Creates parent dirs."""

--- a/backend/app/platform/storage/local.py
+++ b/backend/app/platform/storage/local.py
@@ -138,6 +138,38 @@ class LocalStorageProvider:
         finally:
             await asyncio.to_thread(f.close)
 
+    async def get_range_stream(
+        self, key: str, start: int, length: int
+    ) -> AsyncIterator[bytes]:
+        """Stream ``length`` bytes from ``start`` off ONE open file handle.
+
+        fix(#1540 review P1): the interesting implementation is S3's, where the
+        alternative was a request per chunk. Local storage never paid that, but
+        it implements the same method so the route has one call to make and the
+        object stores are not a special case at the call site.
+
+        Handle closed in a ``finally`` for the reason ``get_stream`` gives:
+        a client disconnecting mid-range must not leak a descriptor.
+        """
+        path = self._resolve_contained(key)
+        if not await asyncio.to_thread(path.exists):
+            raise FileNotFoundError(f"Storage key not found: {key}")
+
+        f = await asyncio.to_thread(open, path, "rb")
+        try:
+            await asyncio.to_thread(f.seek, start)
+            remaining = length
+            while remaining > 0:
+                chunk = await asyncio.to_thread(
+                    f.read, min(remaining, _STREAM_CHUNK_BYTES)
+                )
+                if not chunk:
+                    return
+                yield chunk
+                remaining -= len(chunk)
+        finally:
+            await asyncio.to_thread(f.close)
+
     async def get_to_file(self, key: str, dest: Path) -> Path:
         """Copy file to dest. If src == dest, return as-is."""
         src = self._resolve_contained(key)

--- a/backend/app/platform/storage/provider.py
+++ b/backend/app/platform/storage/provider.py
@@ -69,6 +69,32 @@ class StorageProvider(Protocol):
         """
         ...
 
+    def get_range_stream(
+        self, key: str, start: int, length: int
+    ) -> AsyncIterator[bytes]:
+        """Stream a bounded window as ``get_range``, in chunks as ``get_stream``.
+
+        fix(#1540 review P1): the COG download route needs both properties at
+        once and had neither method that gives them. ``get_range`` returns
+        ``bytes``, so a multi-GB range would be materialized whole; calling it
+        in a loop instead — which is what the route did — turns ONE range
+        request into a separate object-store request per chunk. A client asking
+        for ``Range: bytes=0-`` on a 5 GiB COG cost 5,120 of them, serially,
+        while the per-request rate limiter counted a single API call.
+
+        **Implementations must issue one provider read for the whole window**
+        and chunk the response as it arrives. That is what makes a range
+        request cost what a range request should cost, and it is the property
+        the route depends on rather than a suggestion.
+
+        ``length`` must be positive. The stream ends early if the object is
+        shorter than the window — a truncated response against a declared
+        Content-Length is a transfer error every HTTP client reports, which is
+        the loud failure; padding to length would be the quiet corrupt one.
+        Raises FileNotFoundError if the key does not exist (BA-24).
+        """
+        ...
+
     async def get_to_file(self, key: str, dest: Path) -> Path:
         """Download key to a local file path. For ogr2ogr consumption."""
         ...

--- a/backend/app/platform/storage/s3.py
+++ b/backend/app/platform/storage/s3.py
@@ -212,6 +212,52 @@ class S3StorageProvider:
         finally:
             await asyncio.to_thread(body.close)
 
+    async def get_range_stream(
+        self, key: str, start: int, length: int
+    ) -> AsyncIterator[bytes]:
+        """Stream a byte window from ONE ranged ``get_object``.
+
+        fix(#1540 review P1): this is the method whose absence produced the
+        defect twice. Serving a range by calling ``get_range`` per 1 MiB chunk
+        issues a separate ``GetObject`` per chunk, so an ordinary
+        ``Range: bytes=0-`` against a 5 GiB COG became 5,120 serial object-store
+        requests — one API request by the rate limiter's count, thousands by the
+        bill's. The window is requested once here and the body is read off the
+        socket in chunks, which is what a range request should cost.
+
+        A window starting at or past the end is an empty stream rather than an
+        error, matching ``get_range`` and local/POSIX seek-then-read: the caller
+        has already decided what a zero-length window means.
+        """
+
+        def _open():
+            try:
+                return self.client.get_object(
+                    Bucket=self.bucket,
+                    Key=key,
+                    Range=f"bytes={start}-{start + length - 1}",
+                )["Body"]
+            except ClientError as e:
+                code = e.response.get("Error", {}).get("Code")
+                # fix(#430 BA-24): normalize missing-object to FileNotFoundError across providers.
+                if code in ("404", "NoSuchKey"):
+                    raise FileNotFoundError(key) from e
+                if code in ("416", "InvalidRange", "RequestedRangeNotSatisfiable"):
+                    return None
+                raise
+
+        body = await asyncio.to_thread(_open)
+        if body is None:
+            return
+        try:
+            while True:
+                chunk = await asyncio.to_thread(body.read, _STREAM_CHUNK_BYTES)
+                if not chunk:
+                    break
+                yield chunk
+        finally:
+            await asyncio.to_thread(body.close)
+
     async def get_to_file(self, key: str, dest: Path) -> Path:
         """Download key to a local file path. Creates parent dirs."""
         dest.parent.mkdir(parents=True, exist_ok=True)

--- a/backend/app/platform/storage/s3.py
+++ b/backend/app/platform/storage/s3.py
@@ -32,6 +32,10 @@ from botocore.exceptions import ClientError
 
 from app.platform.storage.provider import StoredObject
 
+# Matches LocalStorageProvider's chunk size: one 1 MiB buffer resident per
+# stream, whatever the object weighs.
+_STREAM_CHUNK_BYTES = 1024 * 1024
+
 
 def _as_utc(value: datetime) -> datetime:
     """Normalize a provider timestamp to timezone-aware UTC.
@@ -166,21 +170,47 @@ class S3StorageProvider:
         return await asyncio.to_thread(_get_range)
 
     async def get_stream(self, key: str) -> AsyncIterator[bytes]:
-        """S3 streaming is served via presigned GET redirect; never reached.
+        """Stream the whole object from ONE ``get_object``, in 1 MiB chunks.
 
-        The router (``router_export.py:375-379``) returns
-        ``RedirectResponse(presigned_url, 302)`` for the ``s3`` storage
-        backend, so this method is unreachable in the current code path.
-        Defining it explicitly satisfies the ``StorageProvider`` Protocol
-        and surfaces a clear error if a future refactor accidentally
-        invokes it on S3.
+        fix(#1540 review P1): this used to raise ``NotImplementedError`` on the
+        grounds that the s3 backend always redirects. That stopped being true
+        when the COG download route gained the one case it cannot delegate to
+        the bucket — a resumed range whose ``If-Range`` no longer matches, which
+        RFC 9110 section 13.1.5 says must be answered with the complete
+        representation, and which a presigned URL cannot answer because the
+        bucket does not evaluate the precondition.
+
+        The first version of that fallback streamed through
+        ``_iter_storage_range``, which issues a separate ranged ``get_object``
+        per chunk: 5,120 object-store requests for a 5 GiB COG, selectable by
+        any caller willing to send a stale validator, and counted by the rate
+        limiter as one request. One ``get_object``, read in chunks off the
+        socket, costs the same as any other full download.
+
+        Chunked rather than ``.read()`` for the reason the local provider gives:
+        a multi-GB COG must never be materialized as a single ``bytes``. The
+        body is closed in a ``finally`` so a client that disconnects mid-stream
+        releases its connection back to the pool instead of leaking it.
         """
-        raise NotImplementedError(
-            "S3 streaming is served via presigned GET redirect from the "
-            "router; this method should never be reached. See "
-            "router_export.py:375-379."
-        )
-        yield b""  # unreachable, satisfies AsyncIterator return type
+
+        def _open():
+            try:
+                return self.client.get_object(Bucket=self.bucket, Key=key)["Body"]
+            except ClientError as e:
+                # fix(#430 BA-24): normalize missing-object to FileNotFoundError across providers.
+                if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+                    raise FileNotFoundError(key) from e
+                raise
+
+        body = await asyncio.to_thread(_open)
+        try:
+            while True:
+                chunk = await asyncio.to_thread(body.read, _STREAM_CHUNK_BYTES)
+                if not chunk:
+                    break
+                yield chunk
+        finally:
+            await asyncio.to_thread(body.close)
 
     async def get_to_file(self, key: str, dest: Path) -> Path:
         """Download key to a local file path. Creates parent dirs."""

--- a/backend/tests/test_cog_head_ranges_1528.py
+++ b/backend/tests/test_cog_head_ranges_1528.py
@@ -27,12 +27,18 @@ or a 206 whose Content-Range does not describe the bytes in the body. Both are
 worse than the 405 they replace, because the 405 did not lie. Every length and
 every range here is checked against the real stored bytes.
 
+The review findings on the PR belong to that same class, which is why they live
+here rather than in a module of their own. The last section is the sharpest case
+of it: two 206 responses that are each individually truthful, taken from either
+side of a raster replacement, assembling into a file that is neither COG.
+
 Requirements:
   - Docker database must be running (docker compose up db)
   - Run with: set -a && source ../.env.test && set +a
               uv run pytest tests/test_cog_head_ranges_1528.py -v
 """
 
+import hashlib
 import uuid
 from unittest.mock import AsyncMock, patch
 
@@ -59,8 +65,15 @@ async def _raster_dataset(
     storage_backend: str = "local",
     asset_uri: str | None = None,
     visibility: str = "public",
+    sha256: str | None = None,
 ) -> tuple[Dataset, RasterAsset]:
-    """Create a Record + Dataset + RasterAsset for the COG download route."""
+    """Create a Record + Dataset + RasterAsset for the COG download route.
+
+    ``sha256`` is the digest of the COG bytes, which real ingest always stamps
+    (``tasks_raster_common.py`` on create, ``tasks_raster_swap.py`` on replace)
+    and which fix(#1540 review P2) turns into the response ETag. It stays
+    optional because rows predating the column exist and must still download.
+    """
     admin_id = await get_user_id(session, "admin")
     record = Record(
         title=f"COG Head Ranges {uuid.uuid4().hex[:6]}",
@@ -88,6 +101,7 @@ async def _raster_dataset(
         asset_uri=asset_uri
         or f"rasters/{dataset.id}/{uuid.uuid4().hex[:8]}/src.cog.tif",
         storage_backend=storage_backend,
+        sha256=sha256,
     )
     session.add(raster_asset)
     await session.flush()
@@ -105,11 +119,49 @@ async def local_cog(test_db_session):
     rooted in the per-test staging dir, so these are real bytes on a real disk
     read back through the real provider — a range assertion here compares
     against the stored object, not against a mock's idea of it.
+
+    The row carries the digest of those exact bytes, because a real one does:
+    ingest stamps ``sha256`` from ``sha256_file`` over the converted COG. The
+    ETag assertions below would prove nothing against a row whose digest was
+    invented here.
     """
-    dataset, raster_asset = await _raster_dataset(test_db_session)
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session, sha256=hashlib.sha256(_COG_BYTES).hexdigest()
+    )
     # Single-tenant: resolve_storage_key returns the logical uri unchanged.
     await get_storage().put(raster_asset.asset_uri, _COG_BYTES)
     return dataset, raster_asset
+
+
+# A second COG for the replacement cases. Same length as `_COG_BYTES` so a
+# splice is about CONTENT rather than about the file getting shorter, and
+# byte-for-byte different at every offset (i vs 255-i never coincide), so a
+# response that silently continued across the replacement is detectable
+# wherever the client resumed.
+_REPLACEMENT_BYTES = bytes(range(255, -1, -1)) * 800
+
+
+async def _complete_a_replacement(session, raster_asset, new_bytes: bytes) -> str:
+    """Land a raster replacement, the way a finished replace job leaves it.
+
+    ``_write_swapped_fields`` (``app/processing/ingest/tasks_raster_swap.py``)
+    points the SAME asset row at a NEW storage key and restamps ``sha256`` and
+    ``size_bytes``; the dataset id, and therefore the download URL, do not move.
+    That is what makes the URL stable and its bytes not: two range requests to
+    one URL, either side of this, read two different objects.
+
+    Only the three fields the download route reads are set here. Running the
+    real job would need GDAL, a source upload and the queue — this module is
+    about what the download route does once the swap has happened.
+    """
+    new_key = f"rasters/{uuid.uuid4().hex[:8]}/replacement.cog.tif"
+    await get_storage().put(new_key, new_bytes)
+    raster_asset.asset_uri = new_key
+    raster_asset.sha256 = hashlib.sha256(new_bytes).hexdigest()
+    raster_asset.size_bytes = len(new_bytes)
+    session.add(raster_asset)
+    await session.commit()
+    return new_key
 
 
 # ---------------------------------------------------------------------------
@@ -532,6 +584,7 @@ async def test_head_cog_on_s3_is_answered_from_object_metadata(
         test_db_session,
         storage_backend="s3",
         asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+        sha256=hashlib.sha256(_COG_BYTES).hexdigest(),
     )
     await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
 
@@ -545,6 +598,15 @@ async def test_head_cog_on_s3_is_answered_from_object_metadata(
         f"HEAD on the s3 backend returned {head.status_code} after "
         f"{len(head.history)} redirect(s); a presigned GET URL refuses HEAD, so "
         f"this route has to answer the probe itself."
+    )
+    # fix(#1540 review P2): this HEAD is the only answer an s3 deployment gets
+    # from this process — the GET redirects, and the bucket then applies its own
+    # validator to any range. A client that wants to resume safely picks the
+    # version up here or nowhere.
+    assert head.headers.get("etag") == f'"{raster_asset.sha256}"', (
+        f"the s3 HEAD carried etag={head.headers.get('etag')!r}; a probe that "
+        f"advertises Accept-Ranges without naming a version tells a resumable "
+        f"client nothing it can check its next request against."
     )
     assert head.history == [], (
         f"HEAD was answered with a redirect to "
@@ -1260,6 +1322,266 @@ async def test_range_request_does_not_read_the_whole_object(
         "A range request opened the full-object stream; the range must be read "
         "through storage.get_range()."
     )
+
+
+# ---------------------------------------------------------------------------
+# fix(#1540) review P2: a range must name the version it is a slice of
+# ---------------------------------------------------------------------------
+
+
+async def test_every_stored_bytes_response_carries_a_strong_etag(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """HEAD, the whole-object GET and the 206 all name the same version.
+
+    A response that advertises ``Accept-Ranges`` and no validator is what makes
+    the splice below possible: the client is invited to resume and given nothing
+    to resume against. All three shapes carry it because a resumable client
+    reads the ETag from whichever one it happened to start with.
+
+    Strong, not weak. ``W/`` tags are excluded from the ``If-Range`` comparison
+    by RFC 9110 section 13.1.5, so a weak tag here would be a validator that can
+    never authorize a range — worse than none, because it looks like one.
+    """
+    dataset, raster_asset = local_cog
+    expected = f'"{raster_asset.sha256}"'
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    head = await client.head(url, headers=admin_auth_header)
+    whole = await client.get(url, headers=admin_auth_header)
+    sliced = await client.get(url, headers={**admin_auth_header, "Range": "bytes=0-99"})
+
+    assert sliced.status_code == 206, (
+        f"precondition: the range request should 206, got {sliced.status_code}"
+    )
+    for name, resp in (("HEAD", head), ("GET", whole), ("206", sliced)):
+        assert resp.headers.get("etag") == expected, (
+            f"the {name} response carried etag={resp.headers.get('etag')!r}, "
+            f"expected the COG's own digest {expected!r}"
+        )
+        assert not resp.headers["etag"].startswith("W/"), (
+            f"the {name} ETag is weak; If-Range never matches a weak validator, "
+            f"so a resumable client could not use it."
+        )
+
+
+async def test_the_etag_changes_when_the_cog_is_replaced(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, local_cog
+):
+    """A validator that survived a replacement would authorize the splice.
+
+    The dataset id does not move across a replace, so the download URL does not
+    either. The bytes behind it do. If the ETag tracked the URL rather than the
+    object, a stale ``If-Range`` would match and the range would be served from
+    the new COG at the old offsets — precisely the failure, wearing a validator.
+    """
+    dataset, raster_asset = local_cog
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    before = await client.head(url, headers=admin_auth_header)
+    await _complete_a_replacement(test_db_session, raster_asset, _REPLACEMENT_BYTES)
+    after = await client.head(url, headers=admin_auth_header)
+
+    assert _COG_BYTES != _REPLACEMENT_BYTES, "precondition: the two COGs differ"
+    assert before.headers.get("etag") and after.headers.get("etag"), (
+        f"both responses need a validator: {before.headers.get('etag')!r} then "
+        f"{after.headers.get('etag')!r}"
+    )
+    assert before.headers["etag"] != after.headers["etag"], (
+        f"the ETag survived a replacement ({before.headers['etag']}), so it "
+        f"identifies the URL and not the bytes."
+    )
+    assert (
+        after.headers["etag"] == f'"{hashlib.sha256(_REPLACEMENT_BYTES).hexdigest()}"'
+    )
+
+
+async def test_a_resumed_range_across_a_replacement_does_not_splice_two_cogs(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, local_cog
+):
+    """The failure itself: two COGs, one file, no error anywhere.
+
+    A resumable downloader reads a prefix, loses its connection, and comes back
+    for the rest. A replacement lands in between. Without a validator both
+    requests succeed with 206 and the client writes out a file that is the head
+    of the old COG and the tail of the new one — no status code ever says
+    otherwise, and the result is a raster the user treats as authoritative.
+
+    With one, the second request cannot match and RFC 9110 section 13.1.5 says
+    ignore the Range: the client gets the whole current object with 200, throws
+    away its prefix, and starts again. Slower and correct.
+    """
+    dataset, raster_asset = local_cog
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    first = await client.get(url, headers={**admin_auth_header, "Range": "bytes=0-99"})
+    assert first.status_code == 206, (
+        f"precondition: the first leg should 206, got {first.status_code}"
+    )
+    assert first.content == _COG_BYTES[:100], "precondition: the prefix is the old COG"
+    validator = first.headers["etag"]
+
+    await _complete_a_replacement(test_db_session, raster_asset, _REPLACEMENT_BYTES)
+
+    resumed = await client.get(
+        url,
+        headers={**admin_auth_header, "Range": "bytes=100-199", "If-Range": validator},
+    )
+
+    # Non-vacuous: the two COGs differ at these exact offsets, so a 206 here
+    # would be a genuinely corrupt assembly rather than a harmless one.
+    assert _COG_BYTES[100:200] != _REPLACEMENT_BYTES[100:200]
+    assert resumed.status_code == 200, (
+        f"the resumed range returned {resumed.status_code}. A 206 here hands the "
+        f"client bytes 100-199 of the REPLACEMENT to append to bytes 0-99 of the "
+        f"COG it started with, and nothing in the exchange reports a problem."
+    )
+    assert "content-range" not in resumed.headers, (
+        f"a 200 that still carries {resumed.headers.get('content-range')!r} "
+        f"describes a partial representation with a whole-object status."
+    )
+    assert resumed.content == _REPLACEMENT_BYTES, (
+        f"the client got {len(resumed.content)} bytes; ignoring the Range means "
+        f"serving the complete current representation."
+    )
+
+
+async def test_a_resumed_range_within_one_version_still_serves_206(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """The vacuity guard: If-Range must still ADMIT the ranges it should.
+
+    A fix that answered 200 to every conditional range would pass the splice
+    test above and destroy resumable downloads — the feature this PR exists to
+    add. Nothing has been replaced here, so the validator still matches and the
+    client resumes exactly as intended.
+    """
+    dataset, raster_asset = local_cog
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    resumed = await client.get(
+        url,
+        headers={
+            **admin_auth_header,
+            "Range": "bytes=100-199",
+            "If-Range": f'"{raster_asset.sha256}"',
+        },
+    )
+
+    assert resumed.status_code == 206, (
+        f"a conditional range whose validator still matches returned "
+        f"{resumed.status_code}; resumable downloads are broken."
+    )
+    assert resumed.content == _COG_BYTES[100:200]
+    assert resumed.headers["content-range"] == f"bytes 100-199/{len(_COG_BYTES)}"
+
+
+async def test_a_weak_validator_never_authorizes_a_resumed_range(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """``W/"..."`` is not a match, even wrapping the right digest.
+
+    RFC 9110 section 13.1.5 evaluates If-Range with the STRONG comparison
+    function. A weak validator only promises semantic equivalence, which is not
+    enough to promise that byte 100 of one representation is byte 100 of the
+    other — the only property a resumed range depends on.
+    """
+    dataset, raster_asset = local_cog
+
+    resumed = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={
+            **admin_auth_header,
+            "Range": "bytes=100-199",
+            "If-Range": f'W/"{raster_asset.sha256}"',
+        },
+    )
+
+    assert resumed.status_code == 200, (
+        f"a weak If-Range returned {resumed.status_code}; strong comparison "
+        f"means W/ never matches, however familiar the digest inside it looks."
+    )
+    assert resumed.content == _COG_BYTES
+
+
+async def test_a_stale_conditional_range_past_the_new_end_is_not_a_416(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, local_cog
+):
+    """Ignoring the Range means ignoring it, including its bounds.
+
+    The replacement here is SHORTER than what the client was reading, so the
+    offsets it wants no longer exist. Both answers are defensible in isolation;
+    416 is the wrong one, because the range it reports as unsatisfiable was
+    never evaluated — the validator already said this client is asking about a
+    version that is gone. Answering 416 would send it back to negotiate offsets
+    against an object it has not been told it is now reading.
+    """
+    dataset, raster_asset = local_cog
+    short = b"\x2a" * 512
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    stale = (await client.head(url, headers=admin_auth_header)).headers["etag"]
+    await _complete_a_replacement(test_db_session, raster_asset, short)
+
+    resumed = await client.get(
+        url,
+        headers={
+            **admin_auth_header,
+            "Range": f"bytes=1024-{len(_COG_BYTES) - 1}",
+            "If-Range": stale,
+        },
+    )
+
+    assert resumed.status_code == 200, (
+        f"expected the whole 512-byte replacement, got {resumed.status_code} "
+        f"(416 answers a range question that the stale validator retired)."
+    )
+    assert resumed.content == short
+
+
+async def test_a_row_with_no_digest_refuses_a_conditional_range(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """Rows predating the sha256 column still download; they just cannot resume.
+
+    No digest means no validator to publish and nothing for an ``If-Range`` to
+    be compared against. The safe direction is the whole object: a server that
+    treated "I cannot check" as "it matches" would serve exactly the spliced
+    range this finding is about, on precisely the rows least likely to be
+    noticed.
+
+    An UNCONDITIONAL range still works. Legacy rows keep byte-range downloads;
+    what they lose is the guarantee across a replacement, which they never had.
+    """
+    dataset, raster_asset = await _raster_dataset(test_db_session, sha256=None)
+    await get_storage().put(raster_asset.asset_uri, _COG_BYTES)
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    head = await client.head(url, headers=admin_auth_header)
+    plain = await client.get(url, headers={**admin_auth_header, "Range": "bytes=0-99"})
+    conditional = await client.get(
+        url,
+        headers={
+            **admin_auth_header,
+            "Range": "bytes=0-99",
+            "If-Range": '"whatever-the-client-remembers"',
+        },
+    )
+
+    assert "etag" not in head.headers, (
+        f"a row with no digest published etag={head.headers.get('etag')!r}; an "
+        f"invented validator is worse than none, it authorizes resumes it "
+        f"cannot vouch for."
+    )
+    assert plain.status_code == 206, (
+        f"an unconditional range on a legacy row returned {plain.status_code}; "
+        f"the missing digest must not cost these rows byte ranges."
+    )
+    assert conditional.status_code == 200, (
+        f"a conditional range with nothing to check against returned "
+        f"{conditional.status_code}; unverifiable must not mean honoured."
+    )
+    assert conditional.content == _COG_BYTES
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_cog_head_ranges_1528.py
+++ b/backend/tests/test_cog_head_ranges_1528.py
@@ -759,6 +759,188 @@ async def test_head_cog_issues_exactly_one_s3_metadata_call(
     )
 
 
+async def test_a_stale_resume_on_s3_is_not_redirected(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """fix(#1540 review P2, round 4): the version binding reaches the s3 branch.
+
+    It landed in ``_local_cog_response`` first, which left the splice open on
+    the backend this PR was extended to support. The bucket cannot be asked to
+    close it: MEASURED against MinIO RELEASE.2025-09-07, a presigned GET
+    carrying `Range` plus a non-matching `If-Range` answers **206 anyway** (see
+    ``test_a_presigned_get_ignores_conditional_headers`` in
+    ``test_cog_s3_head_wire_1540.py``). Nor can a 302 strip the client's Range
+    on the way past. So the route answers this one case itself.
+
+    ``history == []`` is the assertion that separates the fix from the bug: a
+    redirect here, however the object store answers it afterwards, is a client
+    appending bytes 100-199 of the replacement to bytes 0-99 of the COG it
+    started with.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+        sha256=hashlib.sha256(_COG_BYTES).hexdigest(),
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+    stale = f'"{raster_asset.sha256}"'
+
+    new_key = f"rasters/{uuid.uuid4().hex[:8]}/replacement.cog.tif"
+    await s3_storage.put(new_key, _REPLACEMENT_BYTES)
+    raster_asset.asset_uri = new_key
+    raster_asset.sha256 = hashlib.sha256(_REPLACEMENT_BYTES).hexdigest()
+    test_db_session.add(raster_asset)
+    await test_db_session.commit()
+
+    resumed = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": "bytes=100-199", "If-Range": stale},
+        follow_redirects=True,
+    )
+
+    assert _COG_BYTES[100:200] != _REPLACEMENT_BYTES[100:200]
+    assert resumed.history == [], (
+        f"the stale resume was redirected to "
+        f"{[r.headers.get('location') for r in resumed.history]}. The bucket "
+        f"does not evaluate If-Range, so that redirect ends in a 206 of the "
+        f"replacement at the offsets of the COG the client started with."
+    )
+    assert resumed.status_code == 200, (
+        f"the stale resume returned {resumed.status_code}, not the whole "
+        f"current representation RFC 9110 section 13.1.5 calls for."
+    )
+    assert resumed.content == _REPLACEMENT_BYTES
+    assert "content-range" not in resumed.headers
+
+
+async def test_if_none_match_answers_304_on_s3_too(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """Revalidation is answered before the storage branching, so s3 gets it.
+
+    The 304 saves more here than anywhere else: the alternative is a redirect
+    the client follows to the bucket, and then the whole object it already
+    holds, billed as egress.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+        sha256=hashlib.sha256(_COG_BYTES).hexdigest(),
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+
+    conditional = {**admin_auth_header, "If-None-Match": f'"{raster_asset.sha256}"'}
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    revalidated = await client.get(url, headers=conditional, follow_redirects=False)
+    probed = await client.head(url, headers=conditional, follow_redirects=False)
+
+    assert revalidated.status_code == 304, (
+        f"a revalidating GET on s3 returned {revalidated.status_code}; a 302 "
+        f"here sends the client to the bucket for bytes it already has."
+    )
+    assert probed.status_code == 304, (
+        f"a revalidating HEAD on s3 returned {probed.status_code}"
+    )
+    assert revalidated.headers.get("etag") == f'"{raster_asset.sha256}"'
+
+
+async def test_a_bucket_issued_validator_is_not_recognized_and_fails_safe(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """The s3 asymmetry this design accepts, pinned so it is a decision.
+
+    A client can pick up two different validators for one resource here. A HEAD
+    is answered by this route and carries the COG's SHA-256; a ranged GET is
+    redirected, so the 206 the client reads is the bucket's and carries the
+    bucket's own ETag, which is an MD5 (or a multipart digest) and never equal
+    to ours.
+
+    A resume carrying the bucket's tag is therefore unrecognized, and
+    unrecognized means refused: the whole current object, not a 206. That is the
+    safe direction and it is not free — the client re-downloads through this
+    process rather than resuming from the bucket. Closing that gap would mean
+    either serving every s3 range from here or publishing the bucket's ETag
+    instead of a content digest, and both are larger changes than the splice
+    this round is fixing.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+        sha256=hashlib.sha256(_COG_BYTES).hexdigest(),
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+
+    resumed = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={
+            **admin_auth_header,
+            "Range": "bytes=100-199",
+            # What a bucket reports: an MD5 of the object, not our digest.
+            "If-Range": '"d41d8cd98f00b204e9800998ecf8427e"',
+        },
+        follow_redirects=False,
+    )
+
+    assert resumed.status_code == 200, (
+        f"a resume carrying a validator this route did not issue returned "
+        f"{resumed.status_code}; it cannot be matched, so it cannot authorize "
+        f"a range."
+    )
+    assert resumed.content == _COG_BYTES
+
+
+async def test_s3_keeps_redirecting_everything_that_is_not_a_stale_resume(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """The vacuity guard for the branch above: s3 is not now a proxy.
+
+    Whole-object GETs and valid resumes carry the multi-GB payloads, and they
+    must keep coming from the bucket. A fix that answered every s3 GET from
+    this process would pass the splice test and put every COG download through
+    the API's bandwidth, which is the cost the redirect design exists to avoid.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+        sha256=hashlib.sha256(_COG_BYTES).hexdigest(),
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    whole = await client.get(url, headers=admin_auth_header, follow_redirects=False)
+    unconditional = await client.get(
+        url,
+        headers={**admin_auth_header, "Range": "bytes=0-99"},
+        follow_redirects=False,
+    )
+    valid_resume = await client.get(
+        url,
+        headers={
+            **admin_auth_header,
+            "Range": "bytes=100-199",
+            "If-Range": f'"{raster_asset.sha256}"',
+        },
+        follow_redirects=False,
+    )
+
+    for name, resp in (
+        ("whole-object GET", whole),
+        ("unconditional range", unconditional),
+        ("resume with a matching validator", valid_resume),
+    ):
+        assert resp.status_code == 302, (
+            f"the {name} on s3 returned {resp.status_code} instead of a "
+            f"redirect; those bytes must come from the bucket, not through "
+            f"this process."
+        )
+        assert "location" in resp.headers
+
+
 async def test_head_cog_remote_ssrf_denial_matches_get(
     client: AsyncClient, admin_auth_header: dict, test_db_session
 ):
@@ -1003,7 +1185,7 @@ async def test_unsatisfiable_range_returns_416_with_the_size(
     hand a client that asked for 1 KB a whole COG it will splice into the wrong
     offset.
     """
-    dataset, _ = local_cog
+    dataset, raster_asset = local_cog
     past_eof = len(_COG_BYTES) + 10
 
     resp = await client.get(
@@ -1020,6 +1202,11 @@ async def test_unsatisfiable_range_returns_416_with_the_size(
     assert resp.headers.get("accept-ranges") == "bytes", (
         "the client that most needs to know it may retry with a corrected "
         "range is the one that just sent a bad one"
+    )
+    assert resp.headers.get("etag") == f'"{raster_asset.sha256}"', (
+        "the 416 reports a size, so it has to say which version that size "
+        "belongs to; a client retrying against it can otherwise not tell the "
+        "object changed again in between"
     )
     assert "content-disposition" not in resp.headers, (
         "This response's body is the JSON error, not the raster. Labelling it "
@@ -1582,6 +1769,195 @@ async def test_a_row_with_no_digest_refuses_a_conditional_range(
         f"{conditional.status_code}; unverifiable must not mean honoured."
     )
     assert conditional.content == _COG_BYTES
+
+
+async def test_if_none_match_answers_304_for_every_request_shape(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """A revalidating client must not be told to download the COG again.
+
+    Publishing an ETag without evaluating ``If-None-Match`` is the expensive
+    half of a cache contract: the client dutifully stores the validator, offers
+    it back, and gets another 200 with a multi-GB body it already has on disk.
+
+    All three shapes, including the ranged one. RFC 9110 section 13.2.2 puts
+    If-None-Match ahead of Range and If-Range in the evaluation order, so a
+    client holding this exact representation is told so whether or not it asked
+    for a slice of it.
+    """
+    dataset, raster_asset = local_cog
+    url = f"/datasets/{dataset.id}/download/cog"
+    validator = f'"{raster_asset.sha256}"'
+    conditional = {**admin_auth_header, "If-None-Match": validator}
+
+    head = await client.head(url, headers=conditional)
+    whole = await client.get(url, headers=conditional)
+    sliced = await client.get(url, headers={**conditional, "Range": "bytes=0-99"})
+
+    for name, resp in (("HEAD", head), ("GET", whole), ("ranged GET", sliced)):
+        assert resp.status_code == 304, (
+            f"a revalidating {name} got {resp.status_code}; the client already "
+            f"holds this representation and is now re-downloading it."
+        )
+        assert resp.content == b"", f"the 304 for {name} carried a body"
+        assert resp.headers.get("etag") == validator, (
+            f"the 304 for {name} dropped the ETag; RFC 9110 section 15.4.5 "
+            f"wants it back so the cache can restamp its entry."
+        )
+        assert "content-length" not in resp.headers, (
+            f"the 304 for {name} carried content-length="
+            f"{resp.headers.get('content-length')!r}"
+        )
+
+
+async def test_the_two_conditionals_use_their_own_comparison_functions(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """``W/`` revalidates a cache. It does not authorize a resume.
+
+    One header, two rules, and the split is the specification's, not a
+    shortcut: RFC 9110 evaluates ``If-None-Match`` with weak comparison
+    (section 13.1.2) because a cache only needs equivalence, and ``If-Range``
+    with strong comparison (section 13.1.5) because a resumed range needs the
+    two representations to be byte-identical at the offsets it skipped.
+
+    Asserting both in one test is the point. Implementing either comparison
+    once and reusing it for the other passes half of this and fails the other.
+    """
+    dataset, raster_asset = local_cog
+    url = f"/datasets/{dataset.id}/download/cog"
+    weak = f'W/"{raster_asset.sha256}"'
+
+    revalidated = await client.get(
+        url, headers={**admin_auth_header, "If-None-Match": weak}
+    )
+    resumed = await client.get(
+        url,
+        headers={**admin_auth_header, "Range": "bytes=100-199", "If-Range": weak},
+    )
+
+    assert revalidated.status_code == 304, (
+        f"a weak If-None-Match returned {revalidated.status_code}; weak "
+        f"comparison is what caches are supposed to get."
+    )
+    assert resumed.status_code == 200, (
+        f"a weak If-Range returned {resumed.status_code}; strong comparison "
+        f"means a weak tag can never authorize a resume."
+    )
+
+
+async def test_a_star_if_none_match_revalidates_and_a_foreign_one_downloads(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """``*`` matches any current representation; anything else must not.
+
+    The second half is the vacuity guard for the whole 304 path. An
+    implementation that answered 304 to every conditional request would pass
+    the tests above and quietly break every client that holds a stale copy,
+    which is the population the header exists for.
+    """
+    dataset, _ = local_cog
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    star = await client.get(url, headers={**admin_auth_header, "If-None-Match": "*"})
+    stale = await client.get(
+        url, headers={**admin_auth_header, "If-None-Match": '"a-cog-from-last-week"'}
+    )
+
+    assert star.status_code == 304, f"If-None-Match: * returned {star.status_code}"
+    assert stale.status_code == 200, (
+        f"a client holding an OLD validator got {stale.status_code}; it needs "
+        f"the current bytes, not a 304 telling it the stale copy is fine."
+    )
+    assert stale.content == _COG_BYTES
+
+
+async def test_a_304_writes_no_download_audit_row(
+    client: AsyncClient, admin_auth_header: dict, local_cog, test_db_session
+):
+    """Revalidation is not a download, for the same reason a probe is not.
+
+    Sibling of ``test_head_cog_does_not_write_a_download_audit_row``. Nothing
+    is transferred, so a ``dataset.download_cog`` row would misreport who
+    downloaded what, and a browser that revalidates on every page view would
+    inflate the count without moving a byte.
+    """
+    from app.modules.audit.models import AuditLog
+
+    dataset, raster_asset = local_cog
+
+    async def _download_rows() -> int:
+        result = await test_db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "dataset.download_cog",
+                AuditLog.resource_id == dataset.id,
+            )
+        )
+        return len(result.scalars().all())
+
+    assert await _download_rows() == 0, "precondition: no audit rows yet"
+
+    revalidated = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "If-None-Match": f'"{raster_asset.sha256}"'},
+    )
+
+    assert revalidated.status_code == 304
+    assert await _download_rows() == 0, (
+        "a 304 wrote a dataset.download_cog audit row. Nothing was downloaded."
+    )
+
+
+async def test_a_remote_cog_publishes_no_validator(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """The `remote` backend answers for bytes this service does not hold.
+
+    Its asset is a third-party URL that this route redirects to and never
+    reads. A digest recorded at import time would claim an object is unchanged
+    on the strength of a months-old measurement, so no ETag is published and no
+    conditional is evaluated: the origin at the other end of the redirect
+    answers with validators of its own.
+    """
+    dataset, _ = await _raster_dataset(
+        test_db_session,
+        storage_backend="remote",
+        asset_uri="https://example.com/remote.cog.tif",
+        sha256=hashlib.sha256(_COG_BYTES).hexdigest(),
+    )
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    head = await client.head(url, headers=admin_auth_header, follow_redirects=False)
+    revalidated = await client.get(
+        url,
+        headers={**admin_auth_header, "If-None-Match": "*"},
+        follow_redirects=False,
+    )
+    resumed = await client.get(
+        url,
+        headers={
+            **admin_auth_header,
+            "Range": "bytes=100-199",
+            "If-Range": '"anything-at-all"',
+        },
+        follow_redirects=False,
+    )
+
+    assert (resumed.status_code, "etag" in resumed.headers) == (302, False), (
+        f"a conditional range on the remote branch answered "
+        f"{resumed.status_code}; range semantics there belong to the origin "
+        f"that owns the bytes, and this service publishes no validator to "
+        f"evaluate them against."
+    )
+    assert "etag" not in head.headers, (
+        f"the remote branch published etag={head.headers.get('etag')!r} for "
+        f"bytes it neither stores nor hashes."
+    )
+    assert revalidated.status_code == 302, (
+        f"a conditional GET on the remote branch returned "
+        f"{revalidated.status_code}; answering 304 there vouches for a "
+        f"third-party object this service has not looked at."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_cog_head_ranges_1528.py
+++ b/backend/tests/test_cog_head_ranges_1528.py
@@ -1134,17 +1134,17 @@ async def test_get_cog_advertises_ranges_and_length(
     documented: a fallback GET that carries no length leaves vsicurl deciding
     the object is empty.
 
-    ``Accept-Encoding: identity`` is not incidental — see
-    ``test_gzip_middleware_strips_content_length_from_the_full_cog_get`` for
-    what the global GZipMiddleware does to this same response when the client
-    offers gzip, which is the reason this assertion has to name an encoding at
-    all.
+    No ``Accept-Encoding`` workaround any more. This assertion used to need
+    ``identity`` because the global GZipMiddleware compressed the response and
+    deleted its length; fix(#1540 review P2) excluded ``image/tiff`` there, and
+    ``test_one_etag_names_one_byte_stream_whatever_the_client_accepts`` is what
+    now holds that ground — including for a client that does ask for gzip.
     """
     dataset, _ = local_cog
 
     get = await client.get(
         f"/datasets/{dataset.id}/download/cog",
-        headers={**admin_auth_header, "Accept-Encoding": "identity"},
+        headers=admin_auth_header,
     )
 
     assert get.status_code == 200
@@ -1159,57 +1159,60 @@ async def test_get_cog_advertises_ranges_and_length(
     assert get.content == _COG_BYTES, "the full GET must still deliver the object"
 
 
-async def test_gzip_middleware_strips_content_length_from_the_full_cog_get(
+async def test_one_etag_names_one_byte_stream_whatever_the_client_accepts(
     client: AsyncClient, admin_auth_header: dict, local_cog
 ):
-    """MEASURED LIMIT, pinned so it is a decision rather than a surprise.
+    """fix(#1540 review P2): a strong validator identifies ONE representation.
 
-    ``app/api/main.py`` installs ``GZipMiddleware(minimum_size=256)`` globally.
-    Starlette 1.6.0's responder compresses any streaming 200 whose client
-    offered gzip and DELETES the Content-Length while doing it
-    (``middleware/gzip.py``, the ``more_body`` branch). So the length this route
-    sets survives to the wire only for a client that does not ask for gzip.
+    ``GZipMiddleware`` compresses a 200 and skips a 206 by design
+    (``self.partial_response = status == 206``). While ``image/tiff`` was
+    missing from its exclusion list, that asymmetry made one strong ETag name
+    two different byte streams: gzip bytes on the full download, raw bytes on
+    every range. RFC 9110 section 8.8.3 requires a strong validator to change
+    when the representation does, and a content coding is part of the
+    representation — so a client that resumed the encoded one could have its
+    validator accepted and splice raw bytes at encoded offsets. Everything it
+    did was correct, and the file it assembled was not.
 
-    The COG path is unaffected, which is why this is recorded rather than
-    worked around here:
+    ``image/tiff`` is excluded at the middleware now, which is also free CPU: a
+    COG is internally compressed, so DEFLATE over one buys nearly nothing.
 
-      * HEAD keeps its length — an empty body is under ``minimum_size``, so the
-        responder passes it through, and HEAD is where /vsicurl/ learns the
-        size.
-      * 206 keeps its length AND its Content-Range — the responder skips
-        partial responses outright (``self.partial_response = status == 206``).
-
-    What remains is a plain full-file download that is chunked instead of
-    length-delimited, and a COG — already-compressed pixel data — being run
-    through DEFLATE for no gain. Fixing that means excluding image types at the
-    middleware, which is ``app/api/main.py``, outside this change.
-
-    If someone later excludes ``image/tiff`` there, THIS test fails and the one
-    above stops needing its ``identity`` header. That is the intended signal.
+    The assertion is the invariant, not the mechanism: the same request that
+    used to come back gzipped returns the raw object with its real length, and
+    a range of it is a slice of exactly those bytes.
     """
-    dataset, _ = local_cog
+    dataset, raster_asset = local_cog
+    url = f"/datasets/{dataset.id}/download/cog"
 
-    get = await client.get(
-        f"/datasets/{dataset.id}/download/cog",
-        headers={**admin_auth_header, "Accept-Encoding": "gzip"},
+    whole = await client.get(
+        url, headers={**admin_auth_header, "Accept-Encoding": "gzip"}
+    )
+    sliced = await client.get(
+        url,
+        headers={
+            **admin_auth_header,
+            "Accept-Encoding": "gzip",
+            "Range": "bytes=1000-1099",
+        },
     )
 
-    assert get.status_code == 200
-    assert get.content == _COG_BYTES, "the bytes are still correct once decoded"
-    assert get.headers.get("accept-ranges") == "bytes", (
-        "the range advertisement must survive compression — it is what tells "
-        "the client it can skip the full download next time"
+    assert whole.status_code == 200
+    assert "content-encoding" not in whole.headers, (
+        f"the full COG came back {whole.headers.get('content-encoding')!r}-"
+        f"encoded while a 206 of the same resource does not, so the ETag both "
+        f"carry describes two different byte streams."
     )
-    assert get.headers.get("content-encoding") == "gzip", (
-        "Expected the global GZipMiddleware to compress this response. If it "
-        "no longer does, image types were excluded at the middleware and this "
-        "test should be deleted along with the Accept-Encoding: identity "
-        "header in test_get_cog_advertises_ranges_and_length."
+    assert whole.headers.get("content-length") == str(len(_COG_BYTES)), (
+        f"content-length={whole.headers.get('content-length')!r} for "
+        f"{len(_COG_BYTES)} raw bytes; compression is what used to delete it."
     )
-    assert "content-length" not in get.headers, (
-        "GZipMiddleware kept a Content-Length on a compressed streaming "
-        "response; if starlette changed that, the identity workaround above is "
-        "no longer needed."
+    assert whole.content == _COG_BYTES
+
+    assert sliced.status_code == 206
+    assert whole.headers["etag"] == sliced.headers["etag"] == f'"{raster_asset.sha256}"'
+    assert sliced.content == whole.content[1000:1100], (
+        "the 206 must be a slice of the bytes the 200 delivers — that is the "
+        "whole promise the shared ETag makes to a resuming client."
     )
 
 
@@ -1988,6 +1991,164 @@ async def test_if_none_match_answers_304_for_every_request_shape(
             f"the 304 for {name} carried content-length="
             f"{resp.headers.get('content-length')!r}"
         )
+
+
+async def test_a_stale_if_match_refuses_the_range_instead_of_splicing(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, local_cog
+):
+    """fix(#1540 review P2): the same splice, through the other spelling.
+
+    ``If-Match`` and ``If-Range`` are two ways for a resuming client to say the
+    same thing: only give me bytes if this is still the representation I have.
+    Evaluating one and ignoring the other meant a conforming client that chose
+    ``If-Match`` had its precondition dropped, the absent ``If-Range`` read as
+    permission, and a 206 of the replacement appended to a prefix of the COG it
+    started with.
+
+    A failed If-Match is 412, not a degradation. Unlike If-Range, RFC 9110 gives
+    it no "ignore the condition and serve the whole thing" fallback — section
+    13.1.1 says do not perform the method.
+    """
+    dataset, raster_asset = local_cog
+    url = f"/datasets/{dataset.id}/download/cog"
+    stale = f'"{raster_asset.sha256}"'
+
+    await _complete_a_replacement(test_db_session, raster_asset, _REPLACEMENT_BYTES)
+
+    resumed = await client.get(
+        url, headers={**admin_auth_header, "Range": "bytes=100-199", "If-Match": stale}
+    )
+
+    assert _COG_BYTES[100:200] != _REPLACEMENT_BYTES[100:200]
+    assert resumed.status_code == 412, (
+        f"a stale If-Match answered {resumed.status_code}. A 206 here is bytes "
+        f"100-199 of the replacement, on their way to being appended to bytes "
+        f"0-99 of the COG this client already has."
+    )
+    assert resumed.headers.get("etag") == f'"{raster_asset.sha256}"', (
+        "the 412 should name the version that IS current, so the client can "
+        "restart against it without a second round trip"
+    )
+
+
+async def test_a_matching_if_match_still_serves_the_range(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """The vacuity guard: If-Match must admit the requests it should.
+
+    An implementation that answered 412 to every If-Match would pass the test
+    above and break every conforming client that uses the header correctly,
+    which is the population it exists for.
+    """
+    dataset, raster_asset = local_cog
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    matching = await client.get(
+        url,
+        headers={
+            **admin_auth_header,
+            "Range": "bytes=100-199",
+            "If-Match": f'"{raster_asset.sha256}"',
+        },
+    )
+    star = await client.get(url, headers={**admin_auth_header, "If-Match": "*"})
+
+    assert matching.status_code == 206, (
+        f"a matching If-Match returned {matching.status_code}; resumable "
+        f"downloads through this header are broken."
+    )
+    assert matching.content == _COG_BYTES[100:200]
+    assert star.status_code == 200, (
+        f"If-Match: * asks whether a current representation exists at all, and "
+        f"one does; got {star.status_code}."
+    )
+
+
+async def test_if_match_is_evaluated_before_if_none_match(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, local_cog
+):
+    """RFC 9110 section 13.2.2 fixes the order, and the order is observable.
+
+    A client holding an old copy can send both: ``If-Match`` naming the version
+    it wants to act on, ``If-None-Match`` naming the copy it has cached — here
+    the same stale tag. Evaluating If-None-Match first answers 304, telling the
+    client its stale copy is current. Evaluating If-Match first answers 412,
+    which is the truth: the representation moved.
+    """
+    dataset, raster_asset = local_cog
+    stale = f'"{raster_asset.sha256}"'
+
+    await _complete_a_replacement(test_db_session, raster_asset, _REPLACEMENT_BYTES)
+
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "If-Match": stale, "If-None-Match": stale},
+    )
+
+    assert resp.status_code == 412, (
+        f"got {resp.status_code}. A 304 here tells a client whose copy is out "
+        f"of date that it is current, which is the more expensive lie: it stops "
+        f"asking."
+    )
+
+
+async def test_a_row_with_no_digest_refuses_a_specific_if_match_but_allows_star(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """Unverifiable is not a pass, but ``*`` is asking something else.
+
+    A specific tag against a row with no ``sha256`` cannot be compared, and the
+    safe answer is 412 — the same call ``_range_bound_to_this_version`` makes
+    for a conditional range. ``*`` is a different question: does a current
+    representation exist at all? It does, digest or no digest.
+    """
+    dataset, raster_asset = await _raster_dataset(test_db_session, sha256=None)
+    await get_storage().put(raster_asset.asset_uri, _COG_BYTES)
+    url = f"/datasets/{dataset.id}/download/cog"
+
+    specific = await client.get(
+        url, headers={**admin_auth_header, "If-Match": '"a-cog-from-last-week"'}
+    )
+    star = await client.get(url, headers={**admin_auth_header, "If-Match": "*"})
+
+    assert specific.status_code == 412, (
+        f"a tag this route cannot check returned {specific.status_code}; "
+        f"unverifiable must not mean honoured."
+    )
+    assert star.status_code == 200, (
+        f"If-Match: * returned {star.status_code} for an object that exists"
+    )
+    assert star.content == _COG_BYTES
+
+
+async def test_a_remote_cog_leaves_if_match_to_the_origin(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """The blank row stays blank, in both directions.
+
+    This service publishes no validator for a ``remote`` asset, so any
+    ``If-Match`` a client sends was issued by the origin at the other end of
+    the redirect — and it travels there with the request. Answering 412 on its
+    behalf would refuse a precondition this service is in no position to
+    evaluate, using a digest recorded at import time.
+    """
+    dataset, _ = await _raster_dataset(
+        test_db_session,
+        storage_backend="remote",
+        asset_uri="https://example.com/remote.cog.tif",
+        sha256=hashlib.sha256(_COG_BYTES).hexdigest(),
+    )
+
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "If-Match": '"issued-by-the-origin"'},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302, (
+        f"a conditional GET on the remote branch returned {resp.status_code}; "
+        f"the origin owns those bytes and their validators."
+    )
 
 
 async def test_the_two_conditionals_use_their_own_comparison_functions(

--- a/backend/tests/test_cog_head_ranges_1528.py
+++ b/backend/tests/test_cog_head_ranges_1528.py
@@ -1,0 +1,859 @@
+"""fix(#1528): HEAD and byte ranges on /datasets/{id}/download/cog.
+
+Two defects, and the second is the one that matters for the format.
+
+**HEAD answered 405.** Same FastAPI/starlette gap #1513 documented: ``APIRoute``
+does not add HEAD alongside GET the way starlette's plain ``Route`` does, so a
+bare ``@router.get`` answers ``405 allow: GET``.
+
+**The local-storage branch advertised no ``Accept-Ranges`` and served no 206.**
+A Cloud-Optimized GeoTIFF exists so a client can read the header and then fetch
+only the tiles it needs by byte range. A COG endpoint that cannot serve ranges
+forces the whole file down the wire, which is the thing the format was invented
+to avoid.
+
+Why this route's HEAD is BETTER than the export route's, not a copy of it:
+``/datasets/{id}/export`` runs a live ogr2ogr/pyarrow conversion, so its length
+is unknowable before generating the content and its HEAD omits Content-Length
+under RFC 9110 section 9.3.2. This route serves STORED bytes. ``storage.size()``
+is one stat, so HEAD carries a real Content-Length and a truthful
+``Accept-Ranges: bytes``, and the GET it describes actually honours a Range.
+
+The failure class these tests are built around is not "405" — #1513 established
+a 405 alone does not hang GDAL, because vsicurl falls back to a plain GET. The
+class is a response that is CONFIDENTLY WRONG: a Content-Length of 0 on a HEAD
+(what starlette supplies for an empty body if the explicit header is dropped),
+or a 206 whose Content-Range does not describe the bytes in the body. Both are
+worse than the 405 they replace, because the 405 did not lie. Every length and
+every range here is checked against the real stored bytes.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Run with: set -a && source ../.env.test && set +a
+              uv run pytest tests/test_cog_head_ranges_1528.py -v
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.storage import get_storage
+from app.processing.raster.models import RasterAsset
+
+from tests.factories import get_user_id
+
+# Big enough that a range is a genuine slice rather than the whole object, and
+# that a multi-chunk range crosses the streaming chunk boundary at least once
+# is checked separately by monkeypatching the chunk size (see
+# test_range_spanning_multiple_chunks_is_byte_exact).
+_COG_BYTES = bytes(range(256)) * 800  # 204_800 bytes, every byte value present
+
+
+async def _raster_dataset(
+    session,
+    *,
+    storage_backend: str = "local",
+    asset_uri: str | None = None,
+    visibility: str = "public",
+) -> tuple[Dataset, RasterAsset]:
+    """Create a Record + Dataset + RasterAsset for the COG download route."""
+    admin_id = await get_user_id(session, "admin")
+    record = Record(
+        title=f"COG Head Ranges {uuid.uuid4().hex[:6]}",
+        summary="Dataset for the #1528 HEAD/Range tests",
+        theme_category=["test"],
+        visibility=visibility,
+        record_status="published",
+        record_type="raster_dataset",
+        created_by=admin_id,
+    )
+    session.add(record)
+    await session.flush()
+
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"cog_head_1528_{uuid.uuid4().hex[:8]}",
+        source_format="geotiff",
+        source_filename="test.tif",
+    )
+    session.add(dataset)
+    await session.flush()
+
+    raster_asset = RasterAsset(
+        dataset_id=dataset.id,
+        asset_uri=asset_uri
+        or f"rasters/{dataset.id}/{uuid.uuid4().hex[:8]}/src.cog.tif",
+        storage_backend=storage_backend,
+    )
+    session.add(raster_asset)
+    await session.flush()
+    await session.commit()
+    await session.refresh(dataset)
+    await session.refresh(raster_asset)
+    return dataset, raster_asset
+
+
+@pytest.fixture
+async def local_cog(test_db_session):
+    """A public raster dataset whose COG bytes really exist in local storage.
+
+    The conftest points the storage singleton at a ``LocalStorageProvider``
+    rooted in the per-test staging dir, so these are real bytes on a real disk
+    read back through the real provider — a range assertion here compares
+    against the stored object, not against a mock's idea of it.
+    """
+    dataset, raster_asset = await _raster_dataset(test_db_session)
+    # Single-tenant: resolve_storage_key returns the logical uri unchanged.
+    await get_storage().put(raster_asset.asset_uri, _COG_BYTES)
+    return dataset, raster_asset
+
+
+# ---------------------------------------------------------------------------
+# Defect 1: HEAD
+# ---------------------------------------------------------------------------
+
+
+async def test_head_cog_is_not_405(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """The reported bug, reduced to one assertion."""
+    dataset, _ = local_cog
+
+    resp = await client.head(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+
+    assert resp.status_code != 405, (
+        f"HEAD on the COG download answered 405 (allow: "
+        f"{resp.headers.get('allow')!r}); every client that probes before "
+        f"downloading — GDAL/QGIS /vsicurl/, resumable downloaders, link "
+        f"checkers — is refused."
+    )
+    assert resp.status_code == 200, (
+        f"Expected HEAD to agree with GET's 200, got {resp.status_code}"
+    )
+
+
+async def test_head_cog_carries_the_real_content_length(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """The decision that differs from the export route's HEAD.
+
+    The export route omits Content-Length because a conversion's length is
+    unknowable before running it. Here the bytes are already stored, so HEAD
+    can and must state the real size — checked against the body a GET actually
+    delivers, so a plausible-but-wrong length fails.
+    """
+    dataset, _ = local_cog
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+    get = await client.get(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+
+    assert head.status_code == get.status_code == 200
+    assert head.content == b"", "A HEAD response must carry no body"
+    assert len(get.content) == len(_COG_BYTES), "precondition: GET returns the object"
+
+    assert "content-length" in head.headers, (
+        "HEAD sent no Content-Length. The object is stored, so its size is one "
+        "stat away; omitting it costs vsicurl an extra range GET for nothing."
+    )
+    assert head.headers["content-length"] == str(len(_COG_BYTES)), (
+        f"HEAD advertised content-length={head.headers['content-length']!r} for "
+        f"a {len(_COG_BYTES)}-byte object. A WRONG length is worse than the 405 "
+        f"it replaces: starlette's default for an empty body is 0, which makes "
+        f"a client read the COG as an empty file."
+    )
+    assert head.headers.get("content-type") == get.headers.get("content-type")
+    assert head.headers.get("content-disposition") == get.headers.get(
+        "content-disposition"
+    ), "HEAD must advertise the filename the GET actually delivers"
+
+
+async def test_head_cog_does_not_read_the_object(
+    client: AsyncClient, admin_auth_header: dict, local_cog, monkeypatch
+):
+    """A HEAD must answer from metadata, never by streaming bytes it discards.
+
+    Mirrors ``test_head_export_does_not_run_the_conversion``: a HEAD that reads
+    a 5 GB COG to produce a length would hand any authorized caller a way to
+    spend the full download cost per probe.
+    """
+    dataset, _ = local_cog
+    storage = get_storage()
+    reads: list[str] = []
+
+    original_stream = storage.get_stream
+
+    def _counting_stream(key):
+        reads.append(key)
+        return original_stream(key)
+
+    monkeypatch.setattr(storage, "get_stream", _counting_stream)
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+
+    assert head.status_code == 200
+    assert reads == [], (
+        f"HEAD opened the object stream {len(reads)} time(s); it must answer "
+        f"from storage.size() alone."
+    )
+
+
+async def test_head_cog_does_not_write_a_download_audit_row(
+    client: AsyncClient, admin_auth_header: dict, local_cog, test_db_session
+):
+    """A probe is not a download.
+
+    Same call #1513 made: recording ``dataset.download_cog`` for a HEAD would
+    misreport who downloaded what, and every vsicurl open would inflate the
+    count.
+    """
+    from app.modules.audit.models import AuditLog
+
+    dataset, _ = local_cog
+
+    async def _download_rows() -> int:
+        result = await test_db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "dataset.download_cog",
+                AuditLog.resource_id == dataset.id,
+            )
+        )
+        return len(result.scalars().all())
+
+    assert await _download_rows() == 0, "precondition: no audit rows yet"
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+    assert head.status_code == 200
+    assert await _download_rows() == 0, (
+        "HEAD wrote a dataset.download_cog audit row. Nothing was downloaded."
+    )
+
+    get = await client.get(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+    assert get.status_code == 200
+    assert await _download_rows() == 1, "GET must still record exactly one download"
+
+
+# ---------------------------------------------------------------------------
+# Defect 1, failure-class parity: HEAD and GET must agree on EVERY status
+# ---------------------------------------------------------------------------
+
+
+async def test_head_cog_denial_matches_get(client: AsyncClient, test_db_session):
+    """HEAD must not become an existence oracle GET is not."""
+    dataset, _ = await _raster_dataset(test_db_session, visibility="private")
+
+    head = await client.head(f"/datasets/{dataset.id}/download/cog")
+    get = await client.get(f"/datasets/{dataset.id}/download/cog")
+
+    assert head.status_code == get.status_code, (
+        f"HEAD/GET disagree on a denial: {head.status_code} vs {get.status_code}. "
+        f"A HEAD that skips the authorization the GET runs tells an anonymous "
+        f"caller whether a private dataset exists."
+    )
+    assert head.status_code in {401, 403, 404}
+
+
+async def test_head_cog_matches_get_on_missing_object(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """404 parity when the catalog row outlives the stored bytes.
+
+    The dataset and RasterAsset exist; nothing was ever written to storage.
+    """
+    dataset, _ = await _raster_dataset(test_db_session)
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+    get = await client.get(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+
+    assert get.status_code == 404, (
+        f"precondition: GET should 404, got {get.status_code}"
+    )
+    assert head.status_code == get.status_code, (
+        f"HEAD/GET disagree on a missing object: {head.status_code} vs "
+        f"{get.status_code}. A HEAD claiming 200 makes the client fail its "
+        f"range GET instead."
+    )
+
+
+async def test_head_cog_matches_get_on_storage_failure(
+    client: AsyncClient, admin_auth_header: dict, local_cog, monkeypatch
+):
+    """503 parity: a storage backend that throws must throw for both verbs.
+
+    Distinct from the missing-object case above — that one is a clean 404, this
+    one is the backend erroring — and it is the class HEAD is most likely to
+    miss, because HEAD reaches storage by a different call (``size``) than the
+    GET's (``get_stream``).
+    """
+    dataset, _ = local_cog
+    storage = get_storage()
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("backend exploded")
+
+    monkeypatch.setattr(storage, "exists", _boom)
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+    get = await client.get(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+
+    assert get.status_code == 503, (
+        f"precondition: GET should 503, got {get.status_code}"
+    )
+    assert head.status_code == get.status_code, (
+        f"HEAD/GET disagree on a storage failure: {head.status_code} vs "
+        f"{get.status_code}"
+    )
+
+
+async def test_head_cog_matches_get_on_non_raster(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """400 parity on the record-type gate."""
+    from tests.factories import create_dataset
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    ds = await create_dataset(
+        test_db_session,
+        created_by=admin_id,
+        name="CogHeadNonRaster",
+        visibility="public",
+        record_status="published",
+    )
+
+    head = await client.head(
+        f"/datasets/{ds.id}/download/cog", headers=admin_auth_header
+    )
+    get = await client.get(f"/datasets/{ds.id}/download/cog", headers=admin_auth_header)
+
+    assert head.status_code == get.status_code == 400, (
+        f"HEAD {head.status_code} vs GET {get.status_code}, expected both 400"
+    )
+
+
+@pytest.mark.parametrize("backend", ["s3", "remote"])
+async def test_head_cog_redirect_matches_get(
+    backend, client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+):
+    """302 parity on both redirecting backends.
+
+    These branches hand the client off to storage that serves its own HEAD and
+    its own ranges, so the honest HEAD here is the same redirect the GET sends —
+    not a fabricated 200 carrying a length this service never measured. A HEAD
+    that answered 200 here would be inventing metadata for bytes it does not
+    hold.
+
+    The presign is stubbed because the test storage singleton is a
+    ``LocalStorageProvider``, which raises NotImplementedError for it; the
+    branch under test is the router's, not the provider's.
+    """
+    presigned = "https://s3.example.test/presigned-cog?sig=abc"
+    monkeypatch.setattr(
+        get_storage(),
+        "generate_presigned_get_url",
+        lambda key, expiration=3600: presigned,
+    )
+
+    dataset, _ = await _raster_dataset(
+        test_db_session,
+        storage_backend=backend,
+        asset_uri=(
+            "https://example.com/data.tif"
+            if backend == "remote"
+            else f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif"
+        ),
+    )
+
+    with patch(
+        "app.platform.security.validate_url_for_ssrf", new=AsyncMock(return_value=None)
+    ):
+        head = await client.head(
+            f"/datasets/{dataset.id}/download/cog",
+            headers=admin_auth_header,
+            follow_redirects=False,
+        )
+        get = await client.get(
+            f"/datasets/{dataset.id}/download/cog",
+            headers=admin_auth_header,
+            follow_redirects=False,
+        )
+
+    assert get.status_code == 302, (
+        f"precondition: GET should 302, got {get.status_code}"
+    )
+    assert head.status_code == get.status_code, (
+        f"HEAD/GET disagree on the {backend} redirect: {head.status_code} vs "
+        f"{get.status_code}"
+    )
+    assert head.headers.get("location") == get.headers.get("location"), (
+        "HEAD must redirect where the GET redirects"
+    )
+    assert (
+        "content-length" not in head.headers or head.headers["content-length"] == "0"
+    ), (
+        "A redirect describes no representation; HEAD must not attach a size "
+        "to one it never measured."
+    )
+
+
+async def test_head_cog_remote_ssrf_denial_matches_get(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """403 parity: HEAD must not skip the download-time SSRF re-validation.
+
+    SEC-06 re-runs ``validate_url_for_ssrf`` on the remote branch to defeat
+    DNS-rebinding TOCTOU. A HEAD that returned the redirect without it would
+    hand a client the location the GET refuses to give.
+    """
+    from app.platform.security import SSRFError
+
+    dataset, _ = await _raster_dataset(
+        test_db_session, storage_backend="remote", asset_uri="https://example.com/d.tif"
+    )
+
+    with patch(
+        "app.platform.security.validate_url_for_ssrf",
+        new=AsyncMock(side_effect=SSRFError("resolves to a private address")),
+    ):
+        head = await client.head(
+            f"/datasets/{dataset.id}/download/cog",
+            headers=admin_auth_header,
+            follow_redirects=False,
+        )
+        get = await client.get(
+            f"/datasets/{dataset.id}/download/cog",
+            headers=admin_auth_header,
+            follow_redirects=False,
+        )
+
+    assert get.status_code == 403, (
+        f"precondition: GET should 403, got {get.status_code}"
+    )
+    assert head.status_code == get.status_code, (
+        f"HEAD/GET disagree on the SSRF denial: {head.status_code} vs {get.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defect 2: byte ranges. The point of the format.
+# ---------------------------------------------------------------------------
+
+
+async def test_get_cog_advertises_ranges_and_length(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """The full GET must state the size and admit it serves ranges.
+
+    The missing Content-Length is the second ingredient in the GDAL hang #1513
+    documented: a fallback GET that carries no length leaves vsicurl deciding
+    the object is empty.
+
+    ``Accept-Encoding: identity`` is not incidental — see
+    ``test_gzip_middleware_strips_content_length_from_the_full_cog_get`` for
+    what the global GZipMiddleware does to this same response when the client
+    offers gzip, which is the reason this assertion has to name an encoding at
+    all.
+    """
+    dataset, _ = local_cog
+
+    get = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Accept-Encoding": "identity"},
+    )
+
+    assert get.status_code == 200
+    assert get.headers.get("accept-ranges") == "bytes", (
+        "The COG GET does not advertise range support, so a client must "
+        "download the whole file to read one tile."
+    )
+    assert get.headers.get("content-length") == str(len(_COG_BYTES)), (
+        f"GET advertised content-length="
+        f"{get.headers.get('content-length')!r} for {len(_COG_BYTES)} bytes"
+    )
+    assert get.content == _COG_BYTES, "the full GET must still deliver the object"
+
+
+async def test_gzip_middleware_strips_content_length_from_the_full_cog_get(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """MEASURED LIMIT, pinned so it is a decision rather than a surprise.
+
+    ``app/api/main.py`` installs ``GZipMiddleware(minimum_size=256)`` globally.
+    Starlette 1.6.0's responder compresses any streaming 200 whose client
+    offered gzip and DELETES the Content-Length while doing it
+    (``middleware/gzip.py``, the ``more_body`` branch). So the length this route
+    sets survives to the wire only for a client that does not ask for gzip.
+
+    The COG path is unaffected, which is why this is recorded rather than
+    worked around here:
+
+      * HEAD keeps its length — an empty body is under ``minimum_size``, so the
+        responder passes it through, and HEAD is where /vsicurl/ learns the
+        size.
+      * 206 keeps its length AND its Content-Range — the responder skips
+        partial responses outright (``self.partial_response = status == 206``).
+
+    What remains is a plain full-file download that is chunked instead of
+    length-delimited, and a COG — already-compressed pixel data — being run
+    through DEFLATE for no gain. Fixing that means excluding image types at the
+    middleware, which is ``app/api/main.py``, outside this change.
+
+    If someone later excludes ``image/tiff`` there, THIS test fails and the one
+    above stops needing its ``identity`` header. That is the intended signal.
+    """
+    dataset, _ = local_cog
+
+    get = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Accept-Encoding": "gzip"},
+    )
+
+    assert get.status_code == 200
+    assert get.content == _COG_BYTES, "the bytes are still correct once decoded"
+    assert get.headers.get("accept-ranges") == "bytes", (
+        "the range advertisement must survive compression — it is what tells "
+        "the client it can skip the full download next time"
+    )
+    assert get.headers.get("content-encoding") == "gzip", (
+        "Expected the global GZipMiddleware to compress this response. If it "
+        "no longer does, image types were excluded at the middleware and this "
+        "test should be deleted along with the Accept-Encoding: identity "
+        "header in test_get_cog_advertises_ranges_and_length."
+    )
+    assert "content-length" not in get.headers, (
+        "GZipMiddleware kept a Content-Length on a compressed streaming "
+        "response; if starlette changed that, the identity workaround above is "
+        "no longer needed."
+    )
+
+
+async def test_head_cog_advertises_ranges(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """``Accept-Ranges`` on HEAD must be TRUE of the GET it describes.
+
+    Asserted together with a real 206 below, so the advertisement cannot pass
+    while the range support behind it is absent.
+    """
+    dataset, _ = local_cog
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+
+    assert head.headers.get("accept-ranges") == "bytes"
+
+
+@pytest.mark.parametrize(
+    ("header", "expected_start", "expected_end"),
+    [
+        # The COG access pattern: a small header read, then a tile read from
+        # the middle of the file.
+        ("bytes=0-511", 0, 511),
+        ("bytes=100000-100999", 100_000, 100_999),
+        # Open-ended: everything from an offset to EOF.
+        (f"bytes={len(_COG_BYTES) - 10}-", len(_COG_BYTES) - 10, len(_COG_BYTES) - 1),
+        # Suffix: the last N bytes, which is how a client finds a trailing
+        # index without knowing the size.
+        ("bytes=-1024", len(_COG_BYTES) - 1024, len(_COG_BYTES) - 1),
+        # Last byte past EOF must be CLAMPED, not rejected (RFC 9110 14.1.1).
+        (f"bytes=0-{len(_COG_BYTES) + 5000}", 0, len(_COG_BYTES) - 1),
+        # Suffix longer than the object is the whole object.
+        (f"bytes=-{len(_COG_BYTES) + 5000}", 0, len(_COG_BYTES) - 1),
+    ],
+)
+async def test_range_request_returns_the_exact_slice(
+    header,
+    expected_start,
+    expected_end,
+    client: AsyncClient,
+    admin_auth_header: dict,
+    local_cog,
+):
+    """206, a correct Content-Range, and bytes that MATCH that slice.
+
+    The status and the header are the cheap half. The assertion that carries
+    the weight is the last one: a 206 whose body is not the slice its
+    Content-Range names is succeed-with-garbage — the client writes a corrupt
+    COG and never learns why.
+    """
+    dataset, _ = local_cog
+    expected_body = _COG_BYTES[expected_start : expected_end + 1]
+
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": header},
+    )
+
+    assert resp.status_code == 206, (
+        f"Range {header!r} got {resp.status_code}, expected 206 Partial Content"
+    )
+    assert resp.headers.get("content-range") == (
+        f"bytes {expected_start}-{expected_end}/{len(_COG_BYTES)}"
+    ), f"Range {header!r} produced content-range={resp.headers.get('content-range')!r}"
+    assert resp.headers.get("content-length") == str(len(expected_body))
+    assert resp.headers.get("accept-ranges") == "bytes"
+    assert resp.content == expected_body, (
+        f"Range {header!r} returned {len(resp.content)} bytes that are NOT the "
+        f"slice its Content-Range claims. This is the corrupt-download class: "
+        f"the client cannot detect it."
+    )
+
+
+async def test_range_spanning_multiple_chunks_is_byte_exact(
+    client: AsyncClient, admin_auth_header: dict, local_cog, monkeypatch
+):
+    """A range longer than one read chunk must reassemble in order.
+
+    A range is streamed rather than buffered so a multi-GB range cannot pin
+    memory, which means the chunk loop is real code with a real off-by-one
+    surface. The chunk size is shrunk here so an ordinary-sized range crosses
+    many boundaries; at the production 1 MiB every range in this file would fit
+    in a single read and the loop would never be exercised.
+    """
+    from app.modules.catalog.datasets.api import router_export
+
+    monkeypatch.setattr(router_export, "_COG_RANGE_CHUNK_BYTES", 997)
+
+    dataset, _ = local_cog
+    start, end = 1234, 40_000
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": f"bytes={start}-{end}"},
+    )
+
+    assert resp.status_code == 206
+    assert resp.content == _COG_BYTES[start : end + 1], (
+        "A multi-chunk range did not reassemble to the stored slice"
+    )
+    assert len(resp.content) == end - start + 1
+
+
+async def test_unsatisfiable_range_returns_416_with_the_size(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """Reject, do not silently serve something else.
+
+    A first-byte-pos past the end cannot be satisfied. RFC 9110 section 15.5.17
+    requires 416 with a ``Content-Range: bytes * /size`` so the client learns the
+    real size and can retry — answering 200 with the whole object here would
+    hand a client that asked for 1 KB a whole COG it will splice into the wrong
+    offset.
+    """
+    dataset, _ = local_cog
+    past_eof = len(_COG_BYTES) + 10
+
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": f"bytes={past_eof}-{past_eof + 100}"},
+    )
+
+    assert resp.status_code == 416, (
+        f"A range starting past EOF got {resp.status_code}; expected 416"
+    )
+    assert resp.headers.get("content-range") == f"bytes */{len(_COG_BYTES)}", (
+        f"416 must report the real size, got {resp.headers.get('content-range')!r}"
+    )
+    assert resp.headers.get("accept-ranges") == "bytes", (
+        "the client that most needs to know it may retry with a corrected "
+        "range is the one that just sent a bad one"
+    )
+    assert "content-disposition" not in resp.headers, (
+        "This response's body is the JSON error, not the raster. Labelling it "
+        "'attachment; filename=\"....cog.tif\"' makes a browser save an error "
+        "document under the COG's name."
+    )
+
+
+async def test_zero_byte_object_answers_416_for_any_range(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """An empty stored object has no byte to hand out, so every range is 416.
+
+    A truncated-to-zero COG is a real state (an interrupted ingest), and it is
+    the one size at which the range arithmetic has no valid answer: ``bytes=0-``
+    names byte 0 of a file with no byte 0. RFC 9110 section 15.5.17 says 416,
+    and the Content-Range must still report the size — 0 — so the client can
+    tell "empty" from "you asked wrongly".
+    """
+    dataset, raster_asset = await _raster_dataset(test_db_session)
+    await get_storage().put(raster_asset.asset_uri, b"")
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+    assert head.status_code == 200
+    assert head.headers.get("content-length") == "0"
+
+    for header in ("bytes=0-", "bytes=0-99", "bytes=-10"):
+        resp = await client.get(
+            f"/datasets/{dataset.id}/download/cog",
+            headers={**admin_auth_header, "Range": header},
+        )
+        assert resp.status_code == 416, (
+            f"Range {header!r} on a zero-byte object got {resp.status_code}"
+        )
+        assert resp.headers.get("content-range") == "bytes */0"
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "bytes=abc-def",  # not numbers
+        "bytes=500-100",  # last < first
+        "items=0-100",  # unsupported unit
+        "bytes=",  # empty spec
+        "bytes=-",  # neither first nor suffix
+        "0-100",  # no unit at all
+        "bytes=0-100, 200-300",  # multipart/byteranges: not implemented here
+    ],
+)
+async def test_unusable_range_is_ignored_and_serves_the_whole_object(
+    header, client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """The abort class: a Range this route cannot honour must not 500 or 206.
+
+    RFC 9110 section 14.2 says an unsatisfiable-because-invalid Range is to be
+    IGNORED, and section 14.2 permits serving a single range or none at all for
+    a multi-range request. Both land on the same safe answer: 200 with the
+    complete representation. What must never happen is a 206 whose body is not
+    what Content-Range claims — a client that asked for two ranges and got one
+    labelled as both writes a corrupt file.
+    """
+    dataset, _ = local_cog
+
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": header},
+    )
+
+    assert resp.status_code == 200, (
+        f"Range {header!r} produced {resp.status_code}; an unusable Range must "
+        f"be ignored, not answered with a partial or an error."
+    )
+    assert "content-range" not in resp.headers, (
+        f"Range {header!r} produced a 200 carrying content-range="
+        f"{resp.headers.get('content-range')!r}, which describes a partial "
+        f"response this is not."
+    )
+    assert resp.content == _COG_BYTES
+
+
+async def test_head_with_a_range_header_still_describes_the_whole_object(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """A HEAD is a probe for the representation, not for a slice.
+
+    vsicurl sends a plain HEAD, but link checkers and proxies do send Range on
+    HEAD. Answering 206 with a partial Content-Length would tell the client the
+    object is 512 bytes long.
+    """
+    dataset, _ = local_cog
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": "bytes=0-511"},
+    )
+
+    assert head.status_code == 200
+    assert head.headers.get("content-length") == str(len(_COG_BYTES)), (
+        "HEAD reported a partial length as the object size"
+    )
+
+
+async def test_range_request_is_denied_like_a_plain_get(
+    client: AsyncClient, test_db_session
+):
+    """The range path must not skip authorization.
+
+    Ranges are served from a branch reached after the access checks; this pins
+    that, so a future refactor that hoists range handling above them fails here
+    rather than shipping an anonymous read of a private COG.
+    """
+    dataset, raster_asset = await _raster_dataset(test_db_session, visibility="private")
+    await get_storage().put(raster_asset.asset_uri, _COG_BYTES)
+
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog", headers={"Range": "bytes=0-511"}
+    )
+
+    assert resp.status_code in {401, 403, 404}, (
+        f"An anonymous range request on a private COG got {resp.status_code}"
+    )
+    assert resp.content != _COG_BYTES[:512]
+
+
+async def test_range_request_does_not_read_the_whole_object(
+    client: AsyncClient, admin_auth_header: dict, local_cog, monkeypatch
+):
+    """The efficiency claim, made falsifiable.
+
+    ``Accept-Ranges`` is only worth advertising if a range actually avoids
+    reading the rest of the file. A 206 built by streaming the whole object and
+    slicing it would pass every assertion above while delivering none of the
+    benefit the format exists for.
+    """
+    dataset, _ = local_cog
+    storage = get_storage()
+    full_reads: list[str] = []
+    original_stream = storage.get_stream
+
+    def _counting_stream(key):
+        full_reads.append(key)
+        return original_stream(key)
+
+    monkeypatch.setattr(storage, "get_stream", _counting_stream)
+
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": "bytes=0-511"},
+    )
+
+    assert resp.status_code == 206
+    assert full_reads == [], (
+        "A range request opened the full-object stream; the range must be read "
+        "through storage.get_range()."
+    )
+
+
+# ---------------------------------------------------------------------------
+# API surface
+# ---------------------------------------------------------------------------
+
+
+async def test_cog_head_stays_out_of_the_openapi_schema(client: AsyncClient):
+    """The HEAD route is derived, not new API surface.
+
+    Same call ``_clone_api_route`` and fix(#1513) make: a derived route
+    documents nothing the canonical one does not, and publishing it would add a
+    ``headDownloadCog`` to both SDKs and the CLI for no gain.
+    """
+    spec = (await client.get("/openapi.json")).json()
+    methods = spec["paths"]["/datasets/{dataset_id}/download/cog"]
+
+    assert set(methods) == {"get"}, (
+        f"The COG download path publishes {sorted(methods)}; the HEAD route "
+        f"must be registered with include_in_schema=False."
+    )

--- a/backend/tests/test_cog_head_ranges_1528.py
+++ b/backend/tests/test_cog_head_ranges_1528.py
@@ -893,6 +893,101 @@ async def test_a_bucket_issued_validator_is_not_recognized_and_fails_safe(
     assert resumed.content == _COG_BYTES
 
 
+async def test_a_full_download_works_when_the_provider_is_s3(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """The shape a real S3 deployment has, which is NOT the ``s3`` row.
+
+    ``storage_backend`` is a property of the ASSET, and no ingest path writes
+    ``"s3"`` to it: ``tasks_raster_common.py`` and ``tasks_vrt.py`` both create
+    rows as ``"local"``, the replace swap resets them to ``"local"``, and STAC
+    imports write ``"remote"``. ``"local"`` means "GeoLens owns these bytes";
+    which object store holds them is ``get_storage()``'s business. So on a
+    deployment configured for S3 the COG download takes this branch, with an
+    ``S3StorageProvider`` underneath — and its whole-object GET calls
+    ``get_stream``, which raised ``NotImplementedError`` on the strength of a
+    docstring saying the router always redirects for s3.
+
+    That is fixed as a consequence of fix(#1540 review P1), which needed a real
+    ``get_stream`` for the stale-resume fallback. This test is here because the
+    two facts are independent: the fallback could be implemented some other way
+    and this path would silently go back to raising.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="local",  # what ingest actually writes, S3 or not
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/managed.cog.tif",
+        sha256=hashlib.sha256(_COG_BYTES).hexdigest(),
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+
+    whole = await client.get(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+
+    assert whole.status_code == 200, (
+        f"a full COG download on an S3-backed deployment returned "
+        f"{whole.status_code}; this is the path every managed raster takes."
+    )
+    assert whole.content == _COG_BYTES
+    assert whole.headers.get("etag") == f'"{raster_asset.sha256}"'
+
+
+async def test_the_stale_resume_fallback_makes_one_object_store_request(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """fix(#1540 review P1): the fallback must not re-request the object per MiB.
+
+    Answering a stale resume with the whole representation is the RFC 9110
+    section 13.1.5 contract and is not in question. How the body is produced
+    was: streaming it through ``_iter_storage_range`` issued a ranged
+    ``get_object`` per 1 MiB, so a 5 GiB COG cost 5,120 object-store requests
+    and the per-request rate limiter counted the lot as one.
+
+    It is selectable, too. Any caller who can reach this route — including an
+    anonymous holder of a download token for a public dataset — sends one stale
+    validator and picks the expensive branch on purpose.
+
+    3 MiB rather than the module's usual payload because the amplification is
+    invisible below the chunk size: at 204,800 bytes the old loop and the new
+    stream both make exactly one request.
+    """
+    big = bytes(range(256)) * (3 * 1024 * 4)  # 3 MiB exactly
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/big.cog.tif",
+        sha256=hashlib.sha256(big).hexdigest(),
+    )
+    await s3_storage.put(raster_asset.asset_uri, big)
+
+    calls: list[str] = []
+    s3_storage.client.meta.events.register(
+        "before-call.s3", lambda model, **kwargs: calls.append(model.name)
+    )
+
+    resumed = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={
+            **admin_auth_header,
+            "Range": "bytes=1048576-2097151",
+            "If-Range": '"' + "0" * 64 + '"',
+        },
+        follow_redirects=False,
+    )
+
+    assert resumed.status_code == 200, (
+        f"precondition: the stale resume should serve the whole object, got "
+        f"{resumed.status_code}"
+    )
+    assert resumed.content == big
+    assert calls == ["HeadObject", "GetObject"], (
+        f"serving a 3 MiB object took {len(calls)} object-store requests "
+        f"{calls}. One stat for the length and one body: a request per chunk "
+        f"is an amplification a caller can select with a header."
+    )
+
+
 async def test_s3_keeps_redirecting_everything_that_is_not_a_stale_resume(
     client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
 ):

--- a/backend/tests/test_cog_head_ranges_1528.py
+++ b/backend/tests/test_cog_head_ranges_1528.py
@@ -303,6 +303,12 @@ async def test_head_cog_matches_get_on_storage_failure(
     one is the backend erroring — and it is the class HEAD is most likely to
     miss, because HEAD reaches storage by a different call (``size``) than the
     GET's (``get_stream``).
+
+    ``size`` is the call to break, and since fix(#1540 review P2) it is the ONLY
+    one the stat makes: breaking ``exists`` used to fail both verbs here and now
+    fails neither, because nothing calls it. A ``RuntimeError`` rather than a
+    ``FileNotFoundError`` on purpose — the latter is the 404 the sibling test
+    covers, and this one is about the 503 the broad handler is for.
     """
     dataset, _ = local_cog
     storage = get_storage()
@@ -310,7 +316,7 @@ async def test_head_cog_matches_get_on_storage_failure(
     async def _boom(*args, **kwargs):
         raise RuntimeError("backend exploded")
 
-    monkeypatch.setattr(storage, "exists", _boom)
+    monkeypatch.setattr(storage, "size", _boom)
 
     head = await client.head(
         f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
@@ -325,6 +331,46 @@ async def test_head_cog_matches_get_on_storage_failure(
     assert head.status_code == get.status_code, (
         f"HEAD/GET disagree on a storage failure: {head.status_code} vs "
         f"{get.status_code}"
+    )
+
+
+async def test_a_delete_racing_the_stat_is_a_404_not_a_503(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+):
+    """fix(#1540 review P2): an object that vanished is gone, not broken.
+
+    The stat used to be ``exists()`` and then ``size()``, and a delete landing
+    between them produced exactly the pair asserted here: ``exists()`` answering
+    yes about an object that was there when it looked, and ``size()`` raising
+    ``FileNotFoundError`` about the same key a moment later. The broad handler
+    caught that raise and called it 503 — telling the client the backend was
+    unwell and to come back later, about a COG that is never coming back.
+
+    ``exists`` is monkeypatched to the stale answer rather than the test trying
+    to win a real race; the ``FileNotFoundError`` is real, raised by ``stat()``
+    on a file that genuinely is not there. Since the fix, ``exists`` is not
+    consulted at all — which is why the lie changes nothing and the missing
+    bytes answer 404 on both verbs.
+    """
+    dataset, _ = await _raster_dataset(test_db_session)  # local backend, no bytes
+    storage = get_storage()
+
+    async def _stale_yes(key):
+        return True
+
+    monkeypatch.setattr(storage, "exists", _stale_yes)
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+    get = await client.get(
+        f"/datasets/{dataset.id}/download/cog", headers=admin_auth_header
+    )
+
+    assert (head.status_code, get.status_code) == (404, 404), (
+        f"HEAD {head.status_code} / GET {get.status_code} for bytes that are "
+        f"gone. 503 here means the existence check is back and the object "
+        f"disappeared inside the window between it and the size call."
     )
 
 
@@ -605,6 +651,49 @@ async def test_head_cog_on_a_missing_s3_object_is_404(
     )
     assert head.status_code == 404, (
         f"HEAD on a missing s3 object returned {head.status_code}, not 404"
+    )
+
+
+async def test_head_cog_issues_exactly_one_s3_metadata_call(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """fix(#1540 review P2): one ``HeadObject`` per probe, not two.
+
+    The reason this PR answers HEAD here instead of signing a second URL for
+    ``head_object`` is that it is ONE round trip. ``exists()`` then ``size()``
+    quietly made it two — both are ``head_object`` on the S3 provider — so every
+    ``/vsicurl/`` open paid two object-store round trips and two request charges
+    for one probe, and the argument the design was chosen on stopped being true.
+
+    Counted at the botocore layer rather than by patching the provider, so it is
+    requests that are counted and not method calls. The recorded sequence is
+    asserted whole: a ``GetObject`` appearing here would mean the HEAD had
+    started reading the object to learn its length, which is the amplification
+    ``_cog_head_response`` exists to avoid.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+
+    calls: list[str] = []
+    s3_storage.client.meta.events.register(
+        "before-call.s3", lambda model, **kwargs: calls.append(model.name)
+    )
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog",
+        headers=admin_auth_header,
+        follow_redirects=True,
+    )
+
+    assert head.status_code == 200, f"precondition: HEAD should 200, got {head}"
+    assert calls == ["HeadObject"], (
+        f"the HEAD made {len(calls)} S3 request(s) {calls}, not one HeadObject. "
+        f"exists() and size() are both head_object, so splitting the stat in two "
+        f"doubles the round trips and the request charges on every probe."
     )
 
 

--- a/backend/tests/test_cog_head_ranges_1528.py
+++ b/backend/tests/test_cog_head_ranges_1528.py
@@ -2213,6 +2213,103 @@ async def test_a_star_if_none_match_revalidates_and_a_foreign_one_downloads(
     assert stale.content == _COG_BYTES
 
 
+async def test_a_conditional_request_for_bytes_that_are_gone_is_a_404(
+    client: AsyncClient, admin_auth_header: dict, test_db_session
+):
+    """fix(#1540 review P2): a validator cannot vouch for an object that is gone.
+
+    The catalog row outliving its stored bytes is the case
+    ``test_head_cog_matches_get_on_missing_object`` already covers: 404, on both
+    verbs. Add a matching ``If-None-Match`` and the route used to answer 304
+    before it ever looked at storage — so the same URL disagreed with itself
+    about whether the resource existed, depending on whether the client held a
+    validator. The 304 is the worse half: it tells a cache its stale copy is a
+    current representation of something that no longer exists, and the cache
+    goes on serving it.
+
+    RFC 9110 section 13.2.1 puts preconditions after the normal request checks
+    for exactly this reason. ``If-Match`` is asserted alongside because it takes
+    the same path and would otherwise answer 412 — also wrong, and wrong in a
+    way that reads as "your version is stale" rather than "there is nothing
+    here".
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session, sha256=hashlib.sha256(_COG_BYTES).hexdigest()
+    )  # no bytes ever written to storage
+    url = f"/datasets/{dataset.id}/download/cog"
+    validator = f'"{raster_asset.sha256}"'
+
+    unconditional = await client.get(url, headers=admin_auth_header)
+    revalidated = await client.get(
+        url, headers={**admin_auth_header, "If-None-Match": validator}
+    )
+    matched = await client.get(
+        url, headers={**admin_auth_header, "If-Match": validator}
+    )
+    probed = await client.head(
+        url, headers={**admin_auth_header, "If-None-Match": validator}
+    )
+
+    assert unconditional.status_code == 404, (
+        f"precondition: the plain GET should 404, got {unconditional.status_code}"
+    )
+    assert revalidated.status_code == 404, (
+        f"a conditional GET answered {revalidated.status_code} for an object "
+        f"that is gone. A 304 tells a cache to keep serving its copy of a "
+        f"representation that no longer exists."
+    )
+    assert matched.status_code == 404, (
+        f"If-Match answered {matched.status_code}; 412 says the client's "
+        f"version is stale, when the truth is there is no version at all."
+    )
+    assert probed.status_code == 404, (
+        f"HEAD and GET must agree on a missing object with a validator too, "
+        f"got HEAD {probed.status_code} vs GET {revalidated.status_code}"
+    )
+
+
+async def test_a_conditional_request_that_transfers_still_stats_once(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """The existence check must not reintroduce the double stat.
+
+    Answering a precondition needs the object's size, and so does the response
+    that follows when the precondition passes. Measuring twice would undo
+    fix(#1540 review P2)'s first finding — two ``head_object`` round trips per
+    request — on any client that sends a validator, which after this PR is
+    every well-behaved resumable downloader.
+
+    The size is carried from the precondition block into the response instead.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+        sha256=hashlib.sha256(_COG_BYTES).hexdigest(),
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+
+    calls: list[str] = []
+    s3_storage.client.meta.events.register(
+        "before-call.s3", lambda model, **kwargs: calls.append(model.name)
+    )
+
+    probed = await client.head(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "If-Match": f'"{raster_asset.sha256}"'},
+    )
+
+    assert probed.status_code == 200, (
+        f"precondition: a matching If-Match should let the HEAD through, got "
+        f"{probed.status_code}"
+    )
+    assert calls == ["HeadObject"], (
+        f"a conditional HEAD made {len(calls)} object-store requests {calls}. "
+        f"The precondition check and the response need the same measurement, "
+        f"so it is taken once and handed down."
+    )
+
+
 async def test_a_304_writes_no_download_audit_row(
     client: AsyncClient, admin_auth_header: dict, local_cog, test_db_session
 ):

--- a/backend/tests/test_cog_head_ranges_1528.py
+++ b/backend/tests/test_cog_head_ranges_1528.py
@@ -353,17 +353,25 @@ async def test_head_cog_matches_get_on_non_raster(
     )
 
 
-@pytest.mark.parametrize("backend", ["s3", "remote"])
+@pytest.mark.parametrize("backend", ["remote"])
 async def test_head_cog_redirect_matches_get(
     backend, client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
 ):
-    """302 parity on both redirecting backends.
+    """302 parity on the ``remote`` backend.
 
-    These branches hand the client off to storage that serves its own HEAD and
-    its own ranges, so the honest HEAD here is the same redirect the GET sends —
-    not a fabricated 200 carrying a length this service never measured. A HEAD
-    that answered 200 here would be inventing metadata for bytes it does not
-    hold.
+    This branch hands the client off to a third-party origin that serves its
+    own HEAD and its own ranges, at a URL this service never signed. The honest
+    HEAD is therefore the same redirect the GET sends — not a fabricated 200
+    carrying a length this service never measured, which would be inventing
+    metadata for bytes it does not hold.
+
+    ``s3`` used to be parametrized here too and no longer is: fix(#1540) review
+    P1. That URL IS signed by this service, for ``get_object``, and the HTTP
+    method is part of an S3/MinIO SigV4 signature — so the redirect a HEAD
+    followed landed on a 403. See
+    ``test_head_cog_on_s3_is_answered_from_object_metadata`` for the fix, and
+    ``test_s3_head_and_get_are_deliberately_asymmetric`` for the invariant that
+    replaces this one on that backend.
 
     The presign is stubbed because the test storage singleton is a
     ``LocalStorageProvider``, which raises NotImplementedError for it; the
@@ -415,6 +423,188 @@ async def test_head_cog_redirect_matches_get(
     ), (
         "A redirect describes no representation; HEAD must not attach a size "
         "to one it never measured."
+    )
+
+
+@pytest.fixture
+def s3_storage(monkeypatch):
+    """Point the storage singleton at a real ``S3StorageProvider`` on moto.
+
+    A stub would let this suite assert whatever it liked about the object's
+    size. moto runs the actual boto3 ``head_object`` against a bucket holding
+    the actual bytes, so the Content-Length the route reports below is measured
+    the same way a MinIO deployment would measure it.
+
+    What moto CANNOT show is the failure itself: it does not verify SigV4
+    signatures, so a presigned URL it mints is accepted for any method. The 403
+    was measured against a real MinIO instead — see the module docstring of
+    ``test_cog_s3_head_wire_1540.py``, which replays the whole route over a
+    socket against one.
+    """
+    import boto3
+    from moto import mock_aws
+
+    import app.platform.storage.provider as storage_provider_module
+    from app.platform.storage.s3 import S3StorageProvider
+
+    for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
+        monkeypatch.setenv(var, "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="cog-1540")
+        provider = S3StorageProvider(
+            bucket="cog-1540",
+            region="us-east-1",
+            access_key_id="testing",
+            secret_access_key="testing",
+        )
+        monkeypatch.setattr(storage_provider_module, "_storage", provider)
+        yield provider
+
+
+async def test_head_cog_on_s3_is_answered_from_object_metadata(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """fix(#1540) review P1: the S3 HEAD must not be a redirect.
+
+    ``generate_presigned_get_url`` signs ``get_object``, and the HTTP method is
+    part of an S3/MinIO SigV4 canonical request. A 302 does not rewrite the
+    method (RFC 9110 section 15.4 reserves that for 303), so a redirect-
+    following client re-issued its HEAD against a URL signed for GET and was
+    refused — MEASURED at 403 against MinIO RELEASE.2025-09-07. Every
+    ``/vsicurl/`` open starts with that probe, so the feature this PR exists to
+    deliver was broken on exactly the deployments that store COGs in a bucket.
+
+    The assertion is the feature, not the plumbing: a real client, following
+    redirects the way curl and GDAL do, gets 200 with ``Accept-Ranges`` and the
+    object's true length. ``head.history == []`` is the sharp half — it fails if
+    this ever regresses to answering with a redirect, whether or not whatever
+    sits behind that redirect happens to reply 200.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog",
+        headers=admin_auth_header,
+        follow_redirects=True,
+    )
+
+    assert head.status_code == 200, (
+        f"HEAD on the s3 backend returned {head.status_code} after "
+        f"{len(head.history)} redirect(s); a presigned GET URL refuses HEAD, so "
+        f"this route has to answer the probe itself."
+    )
+    assert head.history == [], (
+        f"HEAD was answered with a redirect to "
+        f"{[r.headers.get('location') for r in head.history]}. That URL is "
+        f"signed for get_object and rejects HEAD with 403."
+    )
+    assert head.headers.get("content-length") == str(len(_COG_BYTES)), (
+        f"HEAD reported content-length="
+        f"{head.headers.get('content-length')!r} for a "
+        f"{len(_COG_BYTES)}-byte object"
+    )
+    assert head.headers.get("accept-ranges") == "bytes"
+
+
+async def test_s3_head_and_get_are_deliberately_asymmetric(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """HEAD 200 / GET 302 on s3, on purpose. This replaces a parity assertion.
+
+    ``test_head_cog_redirect_matches_get`` used to run for ``s3`` as well and
+    asserted that HEAD and GET agree on status. fix(#1540) review P1 retires
+    that invariant for this backend rather than dropping it silently, because
+    the asymmetry IS the fix: HEAD no longer travels the redirect, since the
+    presigned URL at the end of it is signed for GET and answers a HEAD with
+    403. Parity with a broken GET-shaped answer was the bug.
+
+    The GET is deliberately untouched. The bytes must keep coming from the
+    bucket rather than through this process — a presigned GET honours a Range
+    once the client gets there, and proxying multi-GB COGs through the API to
+    avoid one redirect would trade a signature bug for a bandwidth bill.
+    """
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/src.cog.tif",
+    )
+    await s3_storage.put(raster_asset.asset_uri, _COG_BYTES)
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog",
+        headers=admin_auth_header,
+        follow_redirects=False,
+    )
+    get = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers=admin_auth_header,
+        follow_redirects=False,
+    )
+
+    assert (head.status_code, get.status_code) == (200, 302), (
+        f"expected the deliberate HEAD 200 / GET 302 split on s3, got "
+        f"HEAD {head.status_code} / GET {get.status_code}. Equal statuses here "
+        f"mean HEAD is back on the redirect."
+    )
+    assert "location" not in head.headers
+    location = get.headers["location"]
+    assert raster_asset.asset_uri in location, (
+        f"the GET redirected to {location!r}, which does not name the object"
+    )
+    # Signature parameter, not a specific one: boto3 picks SigV2 or SigV4 from
+    # the endpoint it is talking to, and this assertion is about the redirect
+    # still being presigned, not about which scheme signed it.
+    assert "Signature=" in location, (
+        f"the GET redirected to an UNSIGNED url ({location!r}); a public URL "
+        f"to a private bucket object is either broken or a leak."
+    )
+
+
+async def test_head_cog_on_a_missing_s3_object_is_404(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """A HEAD for bytes the bucket does not hold answers 404, like local does.
+
+    Routing both branches through ``_cog_object_size`` is what stops the S3
+    HEAD drifting into its own error vocabulary — the local counterpart is
+    ``test_head_cog_matches_get_on_missing_object``. Before fix(#1540) the S3
+    branch stat'd nothing at all: it answered 302 to a presigned URL for a key
+    with no object behind it, so the 404 arrived from the bucket one hop later
+    and only for a client that followed.
+    """
+    dataset, _ = await _raster_dataset(
+        test_db_session,
+        storage_backend="s3",
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/absent.cog.tif",
+    )
+
+    head = await client.head(
+        f"/datasets/{dataset.id}/download/cog",
+        headers=admin_auth_header,
+        follow_redirects=True,
+    )
+
+    # The 404 alone is NOT the assertion. Before the fix this test passed for
+    # the wrong reason: the route answered 302 to an s3.amazonaws.com URL,
+    # ASGITransport handed that back to the same app, no route matched, and the
+    # 404 came from the router rather than from the object store. `history`
+    # is what separates "this endpoint stat'd the bucket and found nothing"
+    # from "a redirect fell off the end of the world".
+    assert head.history == [], (
+        f"HEAD was redirected to "
+        f"{[r.headers.get('location') for r in head.history]} instead of "
+        f"stat'ing the object; any 404 after that is the redirect's, not this "
+        f"route's."
+    )
+    assert head.status_code == 404, (
+        f"HEAD on a missing s3 object returned {head.status_code}, not 404"
     )
 
 
@@ -759,6 +949,151 @@ async def test_unusable_range_is_ignored_and_serves_the_whole_object(
         f"response this is not."
     )
     assert resp.content == _COG_BYTES
+
+
+# A digit string one longer than CPython's default int-from-string limit
+# (sys.get_int_max_str_digits() == 4300). ~4.2 KB of header, comfortably inside
+# the 8 KiB per-header budget nginx's `large_client_header_buffers 4 8k` and
+# uvicorn's h11 limit both allow, so it reaches the app on a real deployment.
+_OVERLONG_DIGITS = "9" * 4301
+
+
+@pytest.mark.parametrize(
+    ("header", "expected_status", "expected_content_range"),
+    [
+        # first-byte-pos beyond any object: RFC 9110 section 15.5.17 wants a 416
+        # carrying the real size so the client can retry.
+        (f"bytes={_OVERLONG_DIGITS}-", 416, f"bytes */{len(_COG_BYTES)}"),
+        # last-byte-pos beyond the end: clamped, section 14.1.1. Clients that do
+        # not know the size ask for more than exists on purpose.
+        (
+            f"bytes=0-{_OVERLONG_DIGITS}",
+            206,
+            f"bytes 0-{len(_COG_BYTES) - 1}/{len(_COG_BYTES)}",
+        ),
+        # suffix longer than the object: also clamped, to the whole object.
+        (
+            f"bytes=-{_OVERLONG_DIGITS}",
+            206,
+            f"bytes 0-{len(_COG_BYTES) - 1}/{len(_COG_BYTES)}",
+        ),
+    ],
+    ids=["first-byte-pos", "last-byte-pos", "suffix-length"],
+)
+async def test_an_overlong_range_number_does_not_500(
+    header,
+    expected_status,
+    expected_content_range,
+    client: AsyncClient,
+    admin_auth_header: dict,
+    local_cog,
+):
+    """fix(#1540) review P2: a huge Range digit string must not reach ``int()``.
+
+    CPython refuses to convert an integer literal longer than
+    ``sys.get_int_max_str_digits()`` (4300 by default) and raises ValueError.
+    Each of these headers is syntactically valid under RFC 9110 section 14.1.1
+    (``first-pos = 1*DIGIT``), so it matched the route's pattern and went
+    straight into ``int()`` — turning a header the RFC lets a server handle in
+    stride into a 500.
+
+    One case per numeric field, because the three do not share a code path:
+    ``first`` decides 416-vs-206, ``last`` is clamped against the size, and the
+    suffix is subtracted from it. A guard on only the one a reviewer happened to
+    anchor to would leave the other two live.
+
+    The status is asserted exactly rather than as "not 500". Saturating instead
+    of ignoring matters: ignoring an unusable Range and replying 200 is the
+    right answer for a MALFORMED header, but these are well-formed and merely
+    enormous, and handing a client that asked for one tile the entire COG is the
+    corrupt-splice failure the 416 branch exists to prevent.
+    """
+    dataset, _ = local_cog
+
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": header},
+    )
+
+    assert resp.status_code != 500, (
+        f"Range with a {len(_OVERLONG_DIGITS)}-digit number produced a 500; "
+        f"int() raised on the header instead of it being bounded first."
+    )
+    assert resp.status_code == expected_status, (
+        f"Range {header[:24]}...{header[-4:]!r} produced {resp.status_code}, "
+        f"expected {expected_status}"
+    )
+    assert resp.headers.get("content-range") == expected_content_range
+
+
+@pytest.mark.parametrize(
+    "form",
+    ["bytes={n}-", "bytes=0-{n}", "bytes=-{n}"],
+    ids=["first-byte-pos", "last-byte-pos", "suffix-length"],
+)
+async def test_an_overlong_range_agrees_with_a_merely_large_one(
+    form, client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """The bound must not invent a THIRD behaviour for each range form.
+
+    This is the trap in fixing P2 by rejecting instead of saturating. "Too many
+    digits" is not a synonym for "unsatisfiable": only the first form earns a
+    416, and a single length check that bails out before branching per form
+    would turn the other two valid 206s into 416s. A suffix longer than the
+    representation IS the representation — ``bytes=-<huge>`` means "give me all
+    of it", not "I asked for something impossible".
+
+    So the assertion is agreement rather than three hardcoded answers: whatever
+    the route already does for a merely-too-big number, it must do for an
+    astronomical one. That cannot drift out of sync with the non-overlong tests
+    the way a duplicated expectation can, and it fails for whichever form a
+    future "simplification" of the guard breaks.
+    """
+    dataset, _ = local_cog
+    big = len(_COG_BYTES) + 5000
+
+    async def fetch(n: str):
+        return await client.get(
+            f"/datasets/{dataset.id}/download/cog",
+            headers={**admin_auth_header, "Range": form.format(n=n)},
+        )
+
+    overlong = await fetch(_OVERLONG_DIGITS)
+    merely_large = await fetch(str(big))
+
+    assert overlong.status_code == merely_large.status_code, (
+        f"{form.format(n='<4301 digits>')} answered {overlong.status_code} but "
+        f"{form.format(n=big)} answered {merely_large.status_code}. The digit "
+        f"bound changed this form's semantics instead of only its arithmetic."
+    )
+    assert overlong.headers.get("content-range") == merely_large.headers.get(
+        "content-range"
+    )
+    assert len(overlong.content) == len(merely_large.content)
+
+
+async def test_a_zero_padded_suffix_is_still_a_zero_length_suffix(
+    client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """The bound is on the VALUE, not on how many characters express it.
+
+    ``bytes=-0000...0`` is 4301 characters and names zero bytes. A length check
+    that ran before stripping the padding would read it as astronomically large
+    and clamp it to the whole object — a 206 where the RFC wants a 416, which is
+    the one direction ``_RANGE_UNSATISFIABLE`` was added to rule out.
+    """
+    dataset, _ = local_cog
+
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": f"bytes=-{'0' * 4301}"},
+    )
+
+    assert resp.status_code == 416, (
+        f"a zero-length suffix written with 4301 zeros produced "
+        f"{resp.status_code}, not the 416 a zero-length suffix earns"
+    )
+    assert resp.headers.get("content-range") == f"bytes */{len(_COG_BYTES)}"
 
 
 async def test_head_with_a_range_header_still_describes_the_whole_object(

--- a/backend/tests/test_cog_head_ranges_1528.py
+++ b/backend/tests/test_cog_head_ranges_1528.py
@@ -933,6 +933,52 @@ async def test_a_full_download_works_when_the_provider_is_s3(
     assert whole.headers.get("etag") == f'"{raster_asset.sha256}"'
 
 
+async def test_an_ordinary_range_makes_one_object_store_request(
+    client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
+):
+    """fix(#1540 review P1): the everyday tile read, not just the odd branch.
+
+    The stale-resume fallback was fixed a round earlier and this path was left
+    looping ``get_range`` at 1 MiB a call — and it is the path that matters
+    most, because on an S3 or Azure deployment ordinary ingested assets carry
+    ``storage_backend="local"`` and every range request lands here. No stale
+    validator needed: ``Range: bytes=0-`` on a 5 GiB COG issued 5,120 serial
+    object-store requests while the rate limiter counted one API call.
+
+    A 3 MiB object and a range spanning all of it, because at 204,800 bytes the
+    loop and the stream are indistinguishable — one chunk either way.
+    """
+    big = bytes(range(256)) * (3 * 1024 * 4)  # 3 MiB exactly
+    dataset, raster_asset = await _raster_dataset(
+        test_db_session,
+        storage_backend="local",  # what ingest writes on an S3 deployment too
+        asset_uri=f"rasters/{uuid.uuid4().hex[:8]}/big.cog.tif",
+        sha256=hashlib.sha256(big).hexdigest(),
+    )
+    await s3_storage.put(raster_asset.asset_uri, big)
+
+    calls: list[str] = []
+    s3_storage.client.meta.events.register(
+        "before-call.s3", lambda model, **kwargs: calls.append(model.name)
+    )
+
+    ranged = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": "bytes=0-"},
+    )
+
+    assert ranged.status_code == 206, (
+        f"precondition: an open-ended range should be a 206, got {ranged.status_code}"
+    )
+    assert ranged.content == big
+    assert calls == ["HeadObject", "GetObject"], (
+        f"a single range request issued {len(calls)} object-store requests "
+        f"{calls}. One stat for the length and one ranged read: at a request "
+        f"per MiB this is 5,120 of them for a 5 GiB COG, and the rate limiter "
+        f"sees one."
+    )
+
+
 async def test_the_stale_resume_fallback_makes_one_object_store_request(
     client: AsyncClient, admin_auth_header: dict, test_db_session, s3_storage
 ):
@@ -1250,10 +1296,15 @@ async def test_range_spanning_multiple_chunks_is_byte_exact(
     surface. The chunk size is shrunk here so an ordinary-sized range crosses
     many boundaries; at the production 1 MiB every range in this file would fit
     in a single read and the loop would never be exercised.
-    """
-    from app.modules.catalog.datasets.api import router_export
 
-    monkeypatch.setattr(router_export, "_COG_RANGE_CHUNK_BYTES", 997)
+    The knob moved in fix(#1540 review P1). The route used to do its own
+    chunking, one ``get_range`` call per chunk, which is what made an ordinary
+    range cost a request per MiB; the provider now streams the window from one
+    read and owns the chunk size. Same assertion, one layer down.
+    """
+    from app.platform.storage import local as local_storage
+
+    monkeypatch.setattr(local_storage, "_STREAM_CHUNK_BYTES", 997)
 
     dataset, _ = local_cog
     start, end = 1234, 40_000
@@ -1267,6 +1318,40 @@ async def test_range_spanning_multiple_chunks_is_byte_exact(
         "A multi-chunk range did not reassemble to the stored slice"
     )
     assert len(resp.content) == end - start + 1
+
+
+@pytest.mark.parametrize("unit", ["bytes", "Bytes", "BYTES", "bYtEs"])
+async def test_the_range_unit_is_matched_case_insensitively(
+    unit, client: AsyncClient, admin_auth_header: dict, local_cog
+):
+    """fix(#1540 review P2): ``Bytes=0-99`` is a conforming request.
+
+    A range unit is a token (RFC 9110 section 14.1) and tokens compare
+    case-insensitively. Matching only lowercase did not reject the odd-looking
+    request — "unusable Range" means ignore it and serve the whole
+    representation, so a 16 KiB tile read came back as the entire COG with a
+    200. The client cannot even tell: it asked for a window, got a valid
+    response, and reads gigabytes.
+
+    Every case pattern, not just the capitalized one the review named: a
+    ``.lower()`` on the header, a case-folded prefix check and an
+    ``re.IGNORECASE`` all pass the first two and only one of them passes
+    ``bYtEs``.
+    """
+    dataset, _ = local_cog
+
+    resp = await client.get(
+        f"/datasets/{dataset.id}/download/cog",
+        headers={**admin_auth_header, "Range": f"{unit}=0-99"},
+    )
+
+    assert resp.status_code == 206, (
+        f"Range unit {unit!r} answered {resp.status_code} with "
+        f"{len(resp.content)} bytes; a conforming range request must not be "
+        f"upgraded into a whole-object transfer."
+    )
+    assert resp.content == _COG_BYTES[:100]
+    assert resp.headers["content-range"] == f"bytes 0-99/{len(_COG_BYTES)}"
 
 
 async def test_unsatisfiable_range_returns_416_with_the_size(

--- a/backend/tests/test_cog_s3_head_wire_1540.py
+++ b/backend/tests/test_cog_s3_head_wire_1540.py
@@ -1,0 +1,260 @@
+"""fix(#1540) review P1: the S3 HEAD, over a socket, against a real bucket.
+
+``test_cog_head_ranges_1528.py`` proves the route's intent through
+``httpx.ASGITransport`` and a moto bucket. Neither can show the defect this
+module is about, because moto does not verify SigV4 signatures at all — it
+accepts a presigned URL for any HTTP method, so the redirect the route used to
+send would have "worked" there.
+
+Real S3 and real MinIO do not. The method is part of the SigV4 canonical
+request, so a URL signed for ``get_object`` is not a URL you may HEAD.
+
+MEASURED against MinIO RELEASE.2025-09-07T16-13-09Z, presigning through boto3
+exactly as ``S3StorageProvider.generate_presigned_get_url`` does:
+
+  presigned for get_object    GET  -> 200  content-length=4096  accept-ranges=bytes
+                              HEAD -> 403  (no body: it is a HEAD)
+  presigned for head_object   HEAD -> 200  content-length=4096
+                              GET  -> 403  SignatureDoesNotMatch
+
+The GET-on-a-head_object-URL row is the same rejection with a readable payload,
+and it is what names the failure: ``SignatureDoesNotMatch``.
+
+End to end through this route on the same MinIO, HEAD with redirects followed
+the way curl -L and GDAL's /vsicurl/ follow them:
+
+  before   302 -> 403.  The probe every /vsicurl/ open begins with fails, on
+           every deployment that keeps its COGs in a bucket — which is the
+           entire population fix(#1528) was written for.
+  after    200, content-length = the object's real size, accept-ranges: bytes,
+           in one hop with no redirect at all.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - An S3-compatible endpoint. The compose stack ships one behind the cloud-dev
+    profile (``docker compose --profile cloud-dev up -d minio``), or run a
+    throwaway::
+
+        docker run -d --name minio-1540 -p 127.0.0.1:9010:9000 \\
+          -e MINIO_ROOT_USER=user -e MINIO_ROOT_PASSWORD=secretpw \\
+          quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+
+  - Run with::
+
+        set -a && source ../.env.test && set +a
+        GEOLENS_TEST_S3_ENDPOINT=http://127.0.0.1:9010 \\
+        GEOLENS_TEST_S3_ACCESS_KEY=user \\
+        GEOLENS_TEST_S3_SECRET_KEY=secretpw \\
+        uv run pytest tests/test_cog_s3_head_wire_1540.py -v
+
+The endpoint is opt-in rather than assumed: the ``backend-test`` CI job has no
+MinIO service (only ``backup-roundtrip`` does), so requiring one here would turn
+a green suite red everywhere it is not provisioned. The always-running guard
+against this regression is
+``test_head_cog_on_s3_is_answered_from_object_metadata``; this module is how the
+claim about real signature enforcement gets re-measured on demand.
+"""
+
+import asyncio
+import os
+import socket
+import uuid
+
+import pytest
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.processing.raster.models import RasterAsset
+
+from tests.factories import get_user_id
+
+_ENDPOINT = os.environ.get("GEOLENS_TEST_S3_ENDPOINT")
+
+pytestmark = pytest.mark.skipif(
+    not _ENDPOINT,
+    reason="set GEOLENS_TEST_S3_ENDPOINT to an S3-compatible endpoint (see module docstring)",
+)
+
+_BUCKET = os.environ.get("GEOLENS_TEST_S3_BUCKET", "geolens-cog-1540")
+_COG_BYTES = bytes(range(256)) * 800  # 204_800 bytes
+
+
+@pytest.fixture
+def real_s3_storage(monkeypatch):
+    """Point the storage singleton at the real endpoint, bucket created."""
+    import app.platform.storage.provider as storage_provider_module
+    from app.platform.storage.s3 import S3StorageProvider
+
+    provider = S3StorageProvider(
+        bucket=_BUCKET,
+        endpoint=_ENDPOINT,
+        region="us-east-1",
+        access_key_id=os.environ.get("GEOLENS_TEST_S3_ACCESS_KEY"),
+        secret_access_key=os.environ.get("GEOLENS_TEST_S3_SECRET_KEY"),
+        allow_http=_ENDPOINT.startswith("http://"),
+        addressing_style="path",
+    )
+    try:
+        provider.client.create_bucket(Bucket=_BUCKET)
+    except provider.client.exceptions.BucketAlreadyOwnedByYou:
+        pass
+    except provider.client.exceptions.BucketAlreadyExists:
+        pass
+
+    monkeypatch.setattr(storage_provider_module, "_storage", provider)
+    return provider
+
+
+@pytest.fixture
+async def s3_cog(client, test_db_session, real_s3_storage):
+    """A public raster dataset whose COG bytes really live in the bucket."""
+    from datetime import UTC, datetime, timedelta
+
+    import jwt as _jwt
+
+    from app.core.config import settings
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    record = Record(
+        title=f"S3 COG {uuid.uuid4().hex[:6]}",
+        summary="COG for the fix(#1540) P1 wire test",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        record_type="raster_dataset",
+        created_by=admin_id,
+    )
+    test_db_session.add(record)
+    await test_db_session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"s3_cog_{uuid.uuid4().hex[:8]}",
+        source_format="geotiff",
+        source_filename="probe.tif",
+    )
+    test_db_session.add(dataset)
+    await test_db_session.flush()
+    asset_uri = f"rasters/{dataset.id}/{uuid.uuid4().hex[:8]}/src.cog.tif"
+    test_db_session.add(
+        RasterAsset(dataset_id=dataset.id, asset_uri=asset_uri, storage_backend="s3")
+    )
+    await test_db_session.flush()
+    await test_db_session.commit()
+
+    await real_s3_storage.put(asset_uri, _COG_BYTES)
+
+    # ?token= rather than a header: it is the lane a GDAL client can use, since
+    # /vsicurl/ takes a URL and not an Authorization header.
+    token = _jwt.encode(
+        {
+            "typ": "download",
+            "scope": f"dataset:{dataset.id}",
+            "exp": datetime.now(UTC) + timedelta(seconds=600),
+            "iat": datetime.now(UTC),
+        },
+        settings.jwt_secret_key.get_secret_value(),
+        algorithm=settings.jwt_algorithm,
+    )
+    return dataset.id, token
+
+
+@pytest.fixture
+async def uvicorn_url(client):
+    """The real app on a real free port.
+
+    Same shape as ``test_cog_vsicurl_1528.py``'s fixture: the ``client``
+    fixture has already installed the DB override and the admin user, and
+    uvicorn re-uses that same wired ``app``.
+    """
+    import uvicorn
+
+    from app.api.main import app as fastapi_app
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    config = uvicorn.Config(
+        fastapi_app, host="127.0.0.1", port=port, log_level="error", lifespan="off"
+    )
+    server = uvicorn.Server(config)
+    serve_task = asyncio.create_task(server.serve())
+
+    for _ in range(50):
+        await asyncio.sleep(0.1)
+        if server.started:
+            break
+    else:
+        server.should_exit = True
+        try:
+            await asyncio.wait_for(serve_task, timeout=5)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            serve_task.cancel()
+        pytest.fail("uvicorn server did not start within 5s")
+
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        try:
+            await asyncio.wait_for(serve_task, timeout=5)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            serve_task.cancel()
+
+
+async def test_head_on_an_s3_backed_cog_answers_200_over_the_wire(uvicorn_url, s3_cog):
+    """A redirect-following client HEADs the route and gets a usable answer.
+
+    ``follow_redirects=True`` is the point. Before fix(#1540) this returned a
+    302, httpx re-issued the HEAD against the presigned URL exactly as curl -L
+    and vsicurl do, and MinIO answered 403 because that URL is signed for GET.
+    Nothing about that failure is visible without a client that follows and a
+    bucket that checks signatures.
+    """
+    import httpx
+
+    dataset_id, token = s3_cog
+    url = f"{uvicorn_url}/datasets/{dataset_id}/download/cog?token={token}"
+
+    async with httpx.AsyncClient(follow_redirects=True) as raw:
+        head = await raw.head(url)
+
+    chain = [r.status_code for r in head.history] + [head.status_code]
+    assert 403 not in chain, (
+        f"the HEAD chain was {chain}: a presigned get_object URL refuses HEAD "
+        f"with 403, so this route must answer the probe itself."
+    )
+    assert head.status_code == 200, f"HEAD chain {chain}, expected a 200"
+    assert head.history == [], (
+        f"HEAD was redirected to {[r.headers.get('location') for r in head.history]}"
+    )
+    assert head.headers.get("content-length") == str(len(_COG_BYTES))
+    assert head.headers.get("accept-ranges") == "bytes"
+
+
+async def test_a_presigned_get_url_really_does_reject_head(real_s3_storage):
+    """The premise, measured rather than assumed.
+
+    If this ever passes a HEAD on a GET-signed URL, the endpoint under test is
+    not enforcing SigV4 and the test above is proving nothing about redirects.
+    That makes this the vacuity guard for the whole module.
+    """
+    import httpx
+
+    key = f"rasters/{uuid.uuid4().hex[:8]}/sigcheck.cog.tif"
+    await real_s3_storage.put(key, b"x" * 4096)
+    presigned = real_s3_storage.generate_presigned_get_url(key, expiration=600)
+
+    async with httpx.AsyncClient() as raw:
+        signed_get = await raw.get(presigned)
+        signed_head = await raw.head(presigned)
+
+    assert signed_get.status_code == 200, (
+        f"the presigned URL does not even work for the method it was signed "
+        f"for ({signed_get.status_code}); the endpoint is misconfigured."
+    )
+    assert signed_head.status_code == 403, (
+        f"HEAD on a get_object-signed URL returned {signed_head.status_code}, "
+        f"not 403. This endpoint is not enforcing the SigV4 method binding, so "
+        f"it cannot stand in for S3 or MinIO here."
+    )

--- a/backend/tests/test_cog_s3_head_wire_1540.py
+++ b/backend/tests/test_cog_s3_head_wire_1540.py
@@ -56,6 +56,7 @@ claim about real signature enforcement gets re-measured on demand.
 """
 
 import asyncio
+import hashlib
 import os
 import socket
 import uuid
@@ -134,8 +135,16 @@ async def s3_cog(client, test_db_session, real_s3_storage):
     test_db_session.add(dataset)
     await test_db_session.flush()
     asset_uri = f"rasters/{dataset.id}/{uuid.uuid4().hex[:8]}/src.cog.tif"
+    # The digest ingest would have stamped. Without it the route publishes no
+    # ETag, and the resume test below would pass on the digest-less rule
+    # instead of on the validator it says it is exercising.
     test_db_session.add(
-        RasterAsset(dataset_id=dataset.id, asset_uri=asset_uri, storage_backend="s3")
+        RasterAsset(
+            dataset_id=dataset.id,
+            asset_uri=asset_uri,
+            storage_backend="s3",
+            sha256=hashlib.sha256(_COG_BYTES).hexdigest(),
+        )
     )
     await test_db_session.flush()
     await test_db_session.commit()
@@ -230,6 +239,123 @@ async def test_head_on_an_s3_backed_cog_answers_200_over_the_wire(uvicorn_url, s
     )
     assert head.headers.get("content-length") == str(len(_COG_BYTES))
     assert head.headers.get("accept-ranges") == "bytes"
+
+
+async def test_a_presigned_get_ignores_conditional_headers(real_s3_storage):
+    """The premise of the round-4 fix: the bucket does not evaluate If-Range.
+
+    The redirect design would be free of the splice hazard if a presigned GET
+    honoured the ``If-Range`` a resuming client re-sends across the hop. It does
+    not. MEASURED here rather than assumed, because the whole decision to answer
+    a stale resume from the API process instead of redirecting rests on it.
+
+    Every row below is a 206 against MinIO RELEASE.2025-09-07: the bucket's own
+    ETag, a foreign ETag, and ``If-None-Match`` as well. The precondition is
+    simply not part of the answer.
+    """
+    import httpx
+
+    key = f"rasters/{uuid.uuid4().hex[:8]}/ifrange.cog.tif"
+    await real_s3_storage.put(key, _COG_BYTES)
+    presigned = real_s3_storage.generate_presigned_get_url(key, expiration=600)
+    bucket_etag = real_s3_storage.client.head_object(Bucket=_BUCKET, Key=key)["ETag"]
+
+    conditionals = {
+        "the bucket's own etag": bucket_etag,
+        "a foreign etag (what this route publishes)": '"' + "0" * 64 + '"',
+    }
+    async with httpx.AsyncClient() as raw:
+        plain = await raw.get(presigned, headers={"Range": "bytes=100-199"})
+        answers = {
+            name: await raw.get(
+                presigned, headers={"Range": "bytes=100-199", "If-Range": tag}
+            )
+            for name, tag in conditionals.items()
+        }
+
+    assert plain.status_code == 206, (
+        f"precondition: an unconditional range should be a 206, got "
+        f"{plain.status_code}. This endpoint cannot stand in for S3 here."
+    )
+    for name, resp in answers.items():
+        assert resp.status_code == 206, (
+            f"a presigned GET with If-Range set to {name} returned "
+            f"{resp.status_code}. If this is ever a 200, the bucket has started "
+            f"evaluating If-Range and the API no longer has to answer a stale "
+            f"resume itself."
+        )
+
+
+async def test_a_stale_resume_over_the_wire_is_not_spliced(
+    uvicorn_url, s3_cog, real_s3_storage, test_db_session
+):
+    """The whole failure, end to end, with a client that follows redirects.
+
+    This is the shape a resumable downloader has: a 206 for the first leg, a
+    connection loss, a raster replacement, then a resume carrying the validator
+    it started with. Through `httpx.ASGITransport` a redirect goes back into the
+    same app and dies at the router; over a socket against a real bucket it
+    reaches MinIO, which serves the replacement's bytes at the old offsets
+    because it does not evaluate If-Range. Only this arrangement can show that.
+
+    The validator is taken from the HEAD on purpose, and the assertion that it
+    is the route's own digest is load-bearing. On this backend the first leg is
+    a redirect, so the 206 the client reads is MinIO's and carries MinIO's ETag.
+    Resuming with THAT also ends safely, because the route does not recognize it
+    and refuses the range, which means a test that used whichever ETag came back
+    would pass without ever consulting the version binding under test.
+    """
+    import httpx
+    from sqlalchemy import text
+
+    dataset_id, token = s3_cog
+    url = f"{uvicorn_url}/datasets/{dataset_id}/download/cog?token={token}"
+    replacement = bytes(range(255, -1, -1)) * 800
+
+    async with httpx.AsyncClient(follow_redirects=True) as raw:
+        first = await raw.get(url, headers={"Range": "bytes=0-99"})
+        assert first.status_code == 206, (
+            f"precondition: the first leg should be a 206, got {first.status_code}"
+        )
+        assert first.content == _COG_BYTES[:100]
+
+        validator = (await raw.head(url)).headers["etag"]
+        assert validator == f'"{hashlib.sha256(_COG_BYTES).hexdigest()}"', (
+            f"the HEAD published {validator!r}, which is not this route's own "
+            f"digest of the stored COG, so the resume below would exercise the "
+            f"unrecognized-validator path instead of the stale-validator one."
+        )
+
+        new_key = f"rasters/{uuid.uuid4().hex[:8]}/replacement.cog.tif"
+        await real_s3_storage.put(new_key, replacement)
+        await test_db_session.execute(
+            text(
+                "UPDATE catalog.raster_assets SET asset_uri = :uri, sha256 = :sha "
+                "WHERE dataset_id = :id"
+            ),
+            {
+                "uri": new_key,
+                "sha": hashlib.sha256(replacement).hexdigest(),
+                "id": dataset_id,
+            },
+        )
+        await test_db_session.commit()
+
+        resumed = await raw.get(
+            url, headers={"Range": "bytes=100-199", "If-Range": validator}
+        )
+
+    assert _COG_BYTES[100:200] != replacement[100:200]
+    assert resumed.status_code == 200, (
+        f"the resumed leg returned {resumed.status_code} after "
+        f"{len(resumed.history)} redirect(s). A 206 here is 100 bytes of the "
+        f"replacement about to be appended to 100 bytes of the COG this client "
+        f"started with, and neither response reports a problem."
+    )
+    assert resumed.content == replacement, (
+        f"the resume returned {len(resumed.content)} bytes; ignoring the stale "
+        f"Range means serving the complete current representation."
+    )
 
 
 async def test_a_presigned_get_url_really_does_reject_head(real_s3_storage):

--- a/backend/tests/test_cog_vsicurl_1528.py
+++ b/backend/tests/test_cog_vsicurl_1528.py
@@ -1,0 +1,292 @@
+"""fix(#1528): a real GDAL client must be able to open the COG over HTTP.
+
+Every other test for this route asserts on headers through
+``httpx.ASGITransport``, which never builds an HTTP message — it hands ASGI
+dicts straight to the app. That proves the route's intent and proves nothing
+about the wire. The failure this issue is about lives on the wire: whether
+uvicorn frames the response with a Content-Length or with
+``transfer-encoding: chunked``, and whether GDAL's /vsicurl/ can therefore
+learn the object's size.
+
+So this one boots the real app on a real socket (the ``uvicorn_url`` pattern
+from ``test_cli_round_trip.py`` / ``test_sdks_round_trip.py``), writes a real
+COG, and opens it with rasterio through ``/vsicurl/``. rasterio rather than the
+``gdalinfo`` CLI because it is a hard backend dependency and is therefore
+present wherever these tests run.
+
+MEASURED, GDAL 3.13.0 CLI and rasterio 1.5.1 / GDAL 3.12.4, against this same
+harness on a bare uvicorn — no nginx, no production edge:
+
+  before (main)   HEAD -> 405 allow: GET, and the GET is a StreamingResponse
+                  with no length, so uvicorn frames it chunked. vsicurl logs
+                  ``HEAD not allowed. Retrying with GET``, the fallback GET
+                  teaches it nothing either, and it concludes ``Request at
+                  offset 0, after end of file``. gdalinfo exits 1 with
+                  ``ERROR 4: ... not recognized as a supported dataset name``;
+                  rasterio raises OpenFailedError. The COG cannot be opened AT
+                  ALL.
+
+  after           HEAD -> 200 with content-length and accept-ranges. vsicurl
+                  logs ``GetFileSize``, then ``Downloading 0-16383`` ->
+                  ``Got response_code=206``, and opens the file. gdalinfo exits
+                  0; rasterio reports the overviews and reads a window.
+
+Worth recording because it corrects the premise this issue was filed with:
+#1513 found that a 405 alone does not break GDAL, because the fallback GET
+still carries a Content-Length on a bare uvicorn and only the production edge
+strips it. That reasoning does not transfer here. This route's GET was a
+``StreamingResponse`` with no Content-Length, so uvicorn *itself* frames it
+chunked — the second ingredient was already inside the route, and no edge was
+needed to reproduce the failure.
+
+Requirements:
+  - Docker database must be running (docker compose up db)
+  - Run with: set -a && source ../.env.test && set +a
+              uv run pytest tests/test_cog_vsicurl_1528.py -v
+"""
+
+import asyncio
+import socket
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.storage import get_storage
+from app.processing.raster.models import RasterAsset
+
+from tests.factories import get_user_id
+
+rasterio = pytest.importorskip("rasterio", reason="rasterio (GDAL) not installed")
+
+
+def _build_cog(path: str) -> bytes:
+    """Write a genuine tiled, overviewed COG and hand back its bytes.
+
+    Tiled with overviews on purpose: an untiled GeoTIFF would be readable in
+    one sequential pass, so it could not distinguish a client that ranges from
+    one that downloads everything. 1024x1024 at 256 blocks gives GDAL real
+    overviews to discover, which is the access pattern the format exists for.
+    """
+    import numpy as np
+    from rasterio.transform import from_origin
+
+    data = (np.random.default_rng(1528).random((1024, 1024)) * 255).astype("uint8")
+    with rasterio.open(
+        path,
+        "w",
+        driver="COG",
+        height=1024,
+        width=1024,
+        count=1,
+        dtype="uint8",
+        crs="EPSG:4326",
+        transform=from_origin(-100, 40, 0.001, 0.001),
+        blocksize=256,
+    ) as dst:
+        dst.write(data, 1)
+    with open(path, "rb") as fh:
+        return fh.read()
+
+
+@pytest.fixture
+async def vsicurl_cog(client, test_db_session, tmp_path):
+    """A public raster dataset with real COG bytes, plus a download token."""
+    from datetime import UTC, datetime, timedelta
+
+    import jwt as _jwt
+
+    from app.core.config import settings
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    record = Record(
+        title=f"VsiCurl COG {uuid.uuid4().hex[:6]}",
+        summary="COG for the #1528 /vsicurl/ round trip",
+        theme_category=["test"],
+        visibility="public",
+        record_status="published",
+        record_type="raster_dataset",
+        created_by=admin_id,
+    )
+    test_db_session.add(record)
+    await test_db_session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=f"vsicurl_cog_{uuid.uuid4().hex[:8]}",
+        source_format="geotiff",
+        source_filename="probe.tif",
+    )
+    test_db_session.add(dataset)
+    await test_db_session.flush()
+    # No "/vsicurl/" segment in the key: resolve_storage_key's
+    # _validate_asset_uri rejects that pattern outright (GDAL path injection),
+    # and it does so before this route is reached.
+    asset_uri = f"rasters/{dataset.id}/cogread/src.cog.tif"
+    test_db_session.add(
+        RasterAsset(dataset_id=dataset.id, asset_uri=asset_uri, storage_backend="local")
+    )
+    await test_db_session.flush()
+    await test_db_session.commit()
+
+    cog_bytes = _build_cog(str(tmp_path / "probe.cog.tif"))
+    await get_storage().put(asset_uri, cog_bytes)
+
+    # A download-scoped token on ?token=, the lane a GDAL client can actually
+    # use: vsicurl takes a URL, not an Authorization header.
+    token = _jwt.encode(
+        {
+            "typ": "download",
+            "scope": f"dataset:{dataset.id}",
+            "exp": datetime.now(UTC) + timedelta(seconds=600),
+            "iat": datetime.now(UTC),
+        },
+        settings.jwt_secret_key.get_secret_value(),
+        algorithm=settings.jwt_algorithm,
+    )
+    return dataset.id, token, len(cog_bytes)
+
+
+@pytest.fixture
+async def uvicorn_url(client):
+    """The real app on a real free port.
+
+    Verbatim shape of ``test_cli_round_trip.py``'s fixture: the ``client``
+    fixture has already installed the DB override, the admin user and the local
+    storage provider, and uvicorn re-uses that same wired ``app``.
+    """
+    import uvicorn
+
+    from app.api.main import app as fastapi_app
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    config = uvicorn.Config(
+        fastapi_app, host="127.0.0.1", port=port, log_level="error", lifespan="off"
+    )
+    server = uvicorn.Server(config)
+    serve_task = asyncio.create_task(server.serve())
+
+    for _ in range(50):
+        await asyncio.sleep(0.1)
+        if server.started:
+            break
+    else:
+        server.should_exit = True
+        try:
+            await asyncio.wait_for(serve_task, timeout=5)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            serve_task.cancel()
+        pytest.fail("uvicorn server did not start within 5s")
+
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        try:
+            await asyncio.wait_for(serve_task, timeout=5)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            serve_task.cancel()
+
+
+def _open_and_read(url: str) -> dict:
+    """Open through /vsicurl/ and read one block. Blocking — call in a thread.
+
+    ``GDAL_DISABLE_READDIR_ON_OPEN`` because this URL's path ends in
+    ``/download/cog`` with the token in the query string: with no file
+    extension to go on, vsicurl otherwise probes the parent path as a directory
+    listing, which this API has no concept of.
+    """
+    with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR"):
+        with rasterio.open(f"/vsicurl/{url}") as ds:
+            window = ds.read(1, window=((0, 256), (0, 256)))
+            return {
+                "width": ds.width,
+                "height": ds.height,
+                "count": ds.count,
+                "overviews": ds.overviews(1),
+                "window_shape": window.shape,
+            }
+
+
+async def test_gdal_vsicurl_opens_the_cog_over_http(
+    uvicorn_url, vsicurl_cog, test_db_session
+):
+    """The end-to-end claim: a GDAL client opens this endpoint and reads a tile.
+
+    On main this raises OpenFailedError — see the module docstring for the
+    measured before/after. It is the one assertion in this change that a header
+    check cannot stand in for.
+    """
+    from app.modules.audit.models import AuditLog
+
+    dataset_id, token, total_size = vsicurl_cog
+    url = f"{uvicorn_url}/datasets/{dataset_id}/download/cog?token={token}"
+
+    info = await asyncio.to_thread(_open_and_read, url)
+
+    assert info["width"] == 1024 and info["height"] == 1024
+    assert info["count"] == 1
+    assert info["window_shape"] == (256, 256)
+    assert info["overviews"], (
+        "GDAL opened the file but found no overviews; the COG's pyramid is the "
+        "part a range-reading client navigates by."
+    )
+
+    # The efficiency claim, checked server-side rather than asserted. Every GET
+    # on this route writes an audit row carrying its Range header, so the log
+    # is a complete record of how GDAL fetched the object. If any row has a
+    # null range, GDAL pulled the whole COG down and the ranges bought nothing.
+    rows = (
+        (
+            await test_db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.action == "dataset.download_cog",
+                    AuditLog.resource_id == dataset_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert rows, "no download was recorded; the open cannot have gone over HTTP"
+    full_body_gets = [r for r in rows if not (r.details or {}).get("range")]
+    assert full_body_gets == [], (
+        f"GDAL issued {len(full_body_gets)} full-object GET(s) against a "
+        f"{total_size}-byte COG. Opening a COG is supposed to cost a header "
+        f"read and the tiles actually wanted, not the whole file."
+    )
+
+
+async def test_head_on_the_wire_carries_the_size(uvicorn_url, vsicurl_cog):
+    """The framing itself, over a real socket rather than through ASGI.
+
+    ``ASGITransport`` cannot show this: uvicorn is what decides between a
+    Content-Length and ``transfer-encoding: chunked``, and that decision is the
+    whole reason /vsicurl/ could not open this endpoint.
+    """
+    import httpx
+
+    dataset_id, token, total_size = vsicurl_cog
+    url = f"{uvicorn_url}/datasets/{dataset_id}/download/cog?token={token}"
+
+    async with httpx.AsyncClient() as raw:
+        head = await raw.head(url)
+        ranged = await raw.get(url, headers={"Range": "bytes=0-16383"})
+
+    assert head.status_code == 200, (
+        f"HEAD on the wire returned {head.status_code} "
+        f"(allow: {head.headers.get('allow')!r})"
+    )
+    assert head.headers.get("content-length") == str(total_size)
+    assert head.headers.get("accept-ranges") == "bytes"
+
+    # 16 KiB is the window vsicurl actually asks for first; measured above as
+    # "Downloading 0-16383 ... Got response_code=206".
+    assert ranged.status_code == 206
+    assert ranged.headers.get("content-range") == f"bytes 0-16383/{total_size}"
+    assert len(ranged.content) == 16384

--- a/backend/tests/test_cors_range_headers_1540.py
+++ b/backend/tests/test_cors_range_headers_1540.py
@@ -20,10 +20,107 @@ against the middleware's answers rather than the constant it builds them from,
 so they fail for a client, not for a string.
 """
 
+import ast
+import pathlib
+
 import pytest
 from httpx import AsyncClient
 
 _ORIGIN = "http://cors-1540.example.com"
+
+_ROUTE_SOURCE = pathlib.Path(__file__).resolve().parents[1] / (
+    "app/modules/catalog/datasets/api/router_export.py"
+)
+
+# Fetch's CORS-safelisted response headers: readable by JavaScript without being
+# named in Access-Control-Expose-Headers. Everything else the route sets has to
+# be listed or the browser hides it from the caller.
+_SAFELISTED_RESPONSE_HEADERS = {
+    "cache-control",
+    "content-language",
+    "content-length",
+    "content-type",
+    "expires",
+    "last-modified",
+    "pragma",
+}
+
+
+def _route_ast() -> ast.Module:
+    return ast.parse(_ROUTE_SOURCE.read_text())
+
+
+def _conditional_headers_the_route_reads() -> set[str]:
+    """Every ``request.headers.get("...")`` in the module that gates on a validator.
+
+    Module-wide rather than per-function: a conditional or range header read
+    anywhere in this file is one a browser client has to be allowed to send.
+    """
+    found: set[str] = set()
+    for node in ast.walk(_route_ast()):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "headers"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            name = node.args[0].value.lower()
+            if name == "range" or name.startswith("if-"):
+                found.add(name)
+    return found
+
+
+def _response_headers_the_cog_route_sets() -> set[str]:
+    """Header names in any ``headers=`` dict inside the COG download helpers.
+
+    Scoped by the ``cog`` in the function names, which is the convention this
+    route already follows, because the DCAT handlers in the same module set
+    headers of their own that no browser client needs to read.
+
+    Reads ``headers=`` keyword values specifically rather than every dict
+    literal: the audit call in ``download_cog`` passes a ``details=`` dict whose
+    keys include ``range``, and demanding that one be exposed would be nonsense.
+    """
+    found: set[str] = set()
+    for node in ast.walk(_route_ast()):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if "cog" not in node.name:
+            continue
+        for inner in ast.walk(node):
+            values = []
+            if isinstance(inner, ast.keyword) and inner.arg == "headers":
+                values.append(inner.value)
+            elif isinstance(inner, ast.Assign) and any(
+                isinstance(t, ast.Name) and "header" in t.id for t in inner.targets
+            ):
+                values.append(inner.value)
+            elif isinstance(inner, ast.Assign) and any(
+                isinstance(t, ast.Subscript)
+                and isinstance(t.value, ast.Name)
+                and "header" in t.value.id
+                and isinstance(t.slice, ast.Constant)
+                for t in inner.targets
+            ):
+                found.update(
+                    t.slice.value.lower()
+                    for t in inner.targets
+                    if isinstance(t, ast.Subscript)
+                    and isinstance(t.slice, ast.Constant)
+                )
+            for value in values:
+                for sub in ast.walk(value):
+                    if isinstance(sub, ast.Dict):
+                        found.update(
+                            k.value.lower()
+                            for k in sub.keys
+                            if isinstance(k, ast.Constant) and isinstance(k.value, str)
+                        )
+    return found
 
 
 @pytest.fixture
@@ -117,6 +214,77 @@ async def test_the_range_response_headers_are_readable_by_javascript(
     assert not missing, (
         f"{sorted(missing)} are not exposed, so JavaScript cannot read them "
         f"even when the response carries them. Exposed: {sorted(exposed)}"
+    )
+
+
+def _middleware_lists() -> tuple[set[str], set[str]]:
+    """What the middleware actually answers, read off a response it writes."""
+    from starlette.responses import Response
+
+    from app.api.middleware.cors import DynamicCORSMiddleware
+
+    resp = Response()
+    DynamicCORSMiddleware._set_cors_headers(resp, _ORIGIN)
+    return (
+        _listed(resp.headers.get("access-control-allow-headers")),
+        _listed(resp.headers.get("access-control-expose-headers")),
+    )
+
+
+def test_every_conditional_header_the_route_evaluates_is_allowed():
+    """The coupling, enforced instead of remembered.
+
+    This endpoint and this middleware have now drifted apart twice: #1528 gave
+    the route a range contract the allow-list did not know about, that was
+    fixed, and then the route grew ``If-Match`` and the allow-list did not learn
+    about that either. Both times the symptom was invisible from the server —
+    the endpoint worked perfectly, and a browser refused to send the request.
+
+    So the link is a test rather than a habit. The header names come from the
+    route's own source: any ``request.headers.get("if-…")`` or ``…("range")``
+    it reads must be a header a cross-origin client is permitted to send. Add
+    ``If-Unmodified-Since`` handling and this fails, naming it, before anyone
+    has to notice a preflight failing in a console.
+    """
+    reads = _conditional_headers_the_route_reads()
+    allowed, _ = _middleware_lists()
+
+    assert {"range", "if-range", "if-none-match", "if-match"} <= reads, (
+        f"the source scan found {sorted(reads)}, which is missing headers this "
+        f"route is known to evaluate. The scan is broken, and a broken scan "
+        f"passes this test for the wrong reason."
+    )
+    missing = reads - allowed
+    assert not missing, (
+        f"the route evaluates {sorted(missing)} but a cross-origin client may "
+        f"not send them, so the preflight fails and the request never leaves "
+        f"the browser. Add them to Access-Control-Allow-Headers in "
+        f"app/api/middleware/cors.py."
+    )
+
+
+def test_every_response_header_the_route_sets_is_readable():
+    """The other half of the same coupling.
+
+    A response header outside Fetch's safelist is not merely undocumented to a
+    cross-origin caller — it is invisible. The route can set a perfect ``ETag``
+    and ``Content-Range`` and the browser will strip both before JavaScript
+    sees them, which for a resumable download means the client cannot tell
+    which version it holds or which bytes it just received.
+    """
+    sets = _response_headers_the_cog_route_sets()
+    _, exposed = _middleware_lists()
+
+    assert {"etag", "content-range", "accept-ranges", "content-disposition"} <= sets, (
+        f"the source scan found {sorted(sets)}, which is missing headers this "
+        f"route is known to set; a scan that finds nothing would pass this "
+        f"test while proving nothing."
+    )
+    missing = sets - _SAFELISTED_RESPONSE_HEADERS - exposed
+    assert not missing, (
+        f"the route sets {sorted(missing)}, which a cross-origin caller cannot "
+        f"read. Add them to Access-Control-Expose-Headers in "
+        f"app/api/middleware/cors.py, or confirm they are CORS-safelisted."
     )
 
 

--- a/backend/tests/test_cors_range_headers_1540.py
+++ b/backend/tests/test_cors_range_headers_1540.py
@@ -1,0 +1,142 @@
+"""fix(#1540) review P2: CORS has to know the download route grew ranges.
+
+#1528 gave ``/datasets/{id}/download/cog`` a HEAD, byte ranges, a strong
+``ETag``, and ``If-Range``/``If-None-Match`` handling. A browser client on an
+allowed origin could use none of it, because the middleware that decides what a
+cross-origin caller may send and read had not changed:
+
+- ``If-Range`` was not in ``Access-Control-Allow-Headers``, so the preflight for
+  a resumable download was refused and the request never went out;
+- ``ETag`` and ``Content-Range`` were not in ``Access-Control-Expose-Headers``,
+  so on a request that did succeed the browser HID them from JavaScript. Not
+  "undocumented" — unreadable. A client cannot resume against a validator it
+  cannot see;
+- ``HEAD`` was missing from ``Access-Control-Allow-Methods``, which is the one
+  request a client makes to learn ranges are available at all.
+
+The failure class is the wave's recurring one: a handler was extended and a
+second component that has to agree with it was not. These tests are written
+against the middleware's answers rather than the constant it builds them from,
+so they fail for a client, not for a string.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+_ORIGIN = "http://cors-1540.example.com"
+
+
+@pytest.fixture
+async def allowed_origin(client: AsyncClient, admin_auth_header: dict):
+    """Put _ORIGIN in the allowlist and clear the module-global cache.
+
+    The cache is a 30s module global keyed on nothing: a request in the last 30
+    seconds leaves another test's allowlist in it, and the PUT does not
+    invalidate it. Same guard, and same reason, as the sibling assertions in
+    ``test_persistent_config.py``.
+    """
+    from app.api.middleware import cors as cors_middleware
+
+    await client.put(
+        "/settings/",
+        json={"settings": {"cors_allowed_origins": _ORIGIN}},
+        headers=admin_auth_header,
+    )
+    cors_middleware._origins_cache = (0.0, set())
+    yield _ORIGIN
+    cors_middleware._origins_cache = (0.0, set())
+
+
+def _listed(header_value: str | None) -> set[str]:
+    return {part.strip().lower() for part in (header_value or "").split(",")}
+
+
+async def test_a_resumable_download_survives_preflight(
+    client: AsyncClient, allowed_origin: str
+):
+    """The preflight a resuming browser client actually sends.
+
+    ``If-Range`` and ``If-None-Match`` are not CORS-safelisted request headers,
+    so this OPTIONS is not optional: the browser sends it first and refuses to
+    issue the real request if the answer does not list them.
+    """
+    preflight = await client.options(
+        "/datasets/00000000-0000-0000-0000-000000000000/download/cog",
+        headers={
+            "Origin": allowed_origin,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "range, if-range, if-none-match",
+        },
+    )
+
+    assert preflight.status_code == 200
+    allowed = _listed(preflight.headers.get("access-control-allow-headers"))
+    missing = {"range", "if-range", "if-none-match"} - allowed
+    assert not missing, (
+        f"the preflight refused {sorted(missing)}, so a cross-origin resumable "
+        f"download never leaves the browser. Allowed: {sorted(allowed)}"
+    )
+
+
+async def test_head_is_an_allowed_method(client: AsyncClient, allowed_origin: str):
+    """HEAD is how a client learns there are ranges to ask for.
+
+    #1528 added the route's HEAD precisely so a client can probe before
+    downloading. Omitting it here leaves that probe available to curl and GDAL
+    and not to a browser.
+    """
+    preflight = await client.options(
+        "/datasets/00000000-0000-0000-0000-000000000000/download/cog",
+        headers={
+            "Origin": allowed_origin,
+            "Access-Control-Request-Method": "HEAD",
+        },
+    )
+
+    methods = _listed(preflight.headers.get("access-control-allow-methods"))
+    assert "head" in methods, (
+        f"HEAD is not an allowed method ({sorted(methods)}), so the probe this "
+        f"route grew in #1528 is unavailable to any browser client."
+    )
+
+
+async def test_the_range_response_headers_are_readable_by_javascript(
+    client: AsyncClient, allowed_origin: str, admin_auth_header: dict
+):
+    """A validator the caller cannot read is a validator it cannot use.
+
+    Anything outside the CORS-safelisted response headers has to be named in
+    ``Access-Control-Expose-Headers`` or the browser drops it before the caller
+    sees it. ``ETag`` decides whether a resume is safe, ``Content-Range`` says
+    which bytes arrived, and ``Accept-Ranges`` says ranges are possible at all.
+    """
+    resp = await client.get("/health", headers={"Origin": allowed_origin})
+
+    exposed = _listed(resp.headers.get("access-control-expose-headers"))
+    missing = {"etag", "content-range", "accept-ranges"} - exposed
+    assert not missing, (
+        f"{sorted(missing)} are not exposed, so JavaScript cannot read them "
+        f"even when the response carries them. Exposed: {sorted(exposed)}"
+    )
+
+
+async def test_the_existing_cors_contract_is_unchanged(
+    client: AsyncClient, allowed_origin: str
+):
+    """The vacuity guard: the additions must not have displaced anything.
+
+    ``Access-Control-Allow-Headers`` and ``-Expose-Headers`` are single
+    comma-separated strings, so appending to the wrong one, or replacing rather
+    than extending, silently revokes access every other client depends on.
+    """
+    resp = await client.get("/health", headers={"Origin": allowed_origin})
+
+    allowed = _listed(resp.headers.get("access-control-allow-headers"))
+    exposed = _listed(resp.headers.get("access-control-expose-headers"))
+    methods = _listed(resp.headers.get("access-control-allow-methods"))
+
+    assert {"authorization", "content-type", "accept", "x-api-key"} <= allowed
+    assert {"x-total-count", "link", "content-crs"} <= exposed
+    assert {"get", "post", "put", "patch", "delete", "options"} <= methods
+    assert resp.headers.get("access-control-allow-credentials") == "true"
+    assert resp.headers.get("access-control-allow-origin") == allowed_origin

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3424,7 +3424,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # If-Range) and a 302 cannot strip the client's Range on the way past. The rest
     # is _if_none_match_matches and _cog_not_modified, so the ETag this route
     # publishes can end a revalidation with 304 instead of another multi-GB body.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1525,
+    #
+    # +7, all comment. The stale-resume fallback now streams from one get_object
+    # rather than _iter_storage_range over the whole object, which issued a ranged
+    # request per 1 MiB — 5,120 of them for a 5 GiB COG, selectable by any caller
+    # willing to send a stale validator and counted by the rate limiter as one
+    # request. The lines say which of the two streaming helpers belongs where.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1532,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3370,6 +3370,27 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # otherwise a stable set of CRUD helpers over the record's related tables
     # and is not where new domains should land.
     "backend/app/modules/catalog/records/service.py": 1007,
+    # fix(#1528): crossed the inclusion threshold, and this is the file the
+    # inclusion rule's own comment named as one of the two "routers-by-role the
+    # glob's filename match cannot see ... watched by nothing until they cross
+    # 1000". It just did.
+    #
+    # What the lines bought: HEAD and byte-range service on
+    # /datasets/{id}/download/cog. A COG exists to be read by range — client
+    # reads the header, fetches only the tiles it needs — and this endpoint
+    # served neither, so GDAL /vsicurl/ could not open it at all (measured:
+    # ERROR 4, not a slow download). The additions are the Range parser and its
+    # RFC 9110 ignore/clamp/416 rules, a chunked range streamer that keeps a
+    # multi-GB range off the heap, the 200/206/416 response shapes, and
+    # _local_cog_response, which exists because folding three representations
+    # into a handler that already branches over three storage backends put
+    # download_cog past ruff's C901 ceiling.
+    #
+    # Roughly half the diff is comment: which starlette behaviour each explicit
+    # header displaces, and why HEAD here carries a Content-Length where the
+    # export route's deliberately omits one. Cap at the exact size. The DCAT
+    # feed handlers above are the natural split if this grows again.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1224,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3452,7 +3452,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # with * handling, _this_service_owns_the_bytes names the rule that already
     # governed the remote branch's blank validator row, and the 412 carries the
     # ETag that IS current so a refused client can restart in one round trip.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1589,
+    #
+    # +36 for the last two review findings. If-Match had to be reachable from a
+    # browser (the CORS half is enforced by a test now, not a memory), and the
+    # precondition block had to stat the object before answering: a row whose
+    # bytes are gone answers 404 unconditionally, so a 304 there told a cache its
+    # stale copy was current for a representation that no longer exists. That
+    # stat is handed down through _cog_size_once so a conditional request that
+    # goes on to transfer bytes still measures once, and _managed_key names the
+    # tenant-key seam the block now crosses in a second place.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1656,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3390,7 +3390,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # header displaces, and why HEAD here carries a Content-Length where the
     # export route's deliberately omits one. Cap at the exact size. The DCAT
     # feed handlers above are the natural split if this grows again.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1224,
+    #
+    # +93 for the two fix(#1540) review findings. P1 pulled the object stat and
+    # the HEAD response out of _local_cog_response into _cog_object_size /
+    # _cog_headers / _cog_head_response so the `s3` branch can answer HEAD from
+    # metadata instead of redirecting to a URL signed for GET — sharing them is
+    # what makes HEAD provably identical on both backends, and it moved the long
+    # explanatory comments from inline into three docstrings. P2 added
+    # _range_int, which saturates every Range numeric field before int() so a
+    # 4301-digit header cannot raise ValueError into a 500.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1317,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3406,7 +3406,17 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # head_object was worth removing: it doubled the round trips and the request
     # charges on every /vsicurl/ probe, against a design chosen for costing one,
     # and the gap between the two calls turned a deleted object into a 503.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1324,
+    #
+    # +90 for the range validator, which is what finishes the range feature rather
+    # than extending it. _cog_etag publishes the COG's own sha256 as a strong ETag
+    # on every stored-bytes response, and _range_bound_to_this_version evaluates
+    # If-Range so a range resumed across a raster replacement returns the whole
+    # current object instead of a 206 the client appends to a prefix of the COG it
+    # is no longer reading. Ranges without a validator are how two COGs become one
+    # corrupt file with no error anywhere, so the explanation is on the two helpers
+    # and at the branch. If this file grows again, the DCAT feed handlers remain
+    # the natural split.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1414,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3416,7 +3416,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # corrupt file with no error anywhere, so the explanation is on the two helpers
     # and at the branch. If this file grows again, the DCAT feed handlers remain
     # the natural split.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1414,
+    #
+    # +111 for the two halves of that binding the first pass missed. _s3_cog_response
+    # is an extraction, not new branching: the s3 block moved out of download_cog so
+    # it could evaluate If-Range before redirecting, which it has to do because the
+    # bucket does not (MEASURED: a presigned GET answers 206 for a non-matching
+    # If-Range) and a 302 cannot strip the client's Range on the way past. The rest
+    # is _if_none_match_matches and _cog_not_modified, so the ETag this route
+    # publishes can end a revalidation with 304 instead of another multi-GB body.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1525,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3399,7 +3399,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # explanatory comments from inline into three docstrings. P2 added
     # _range_int, which saturates every Range numeric field before int() so a
     # 4301-digit header cannot raise ValueError into a 500.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1317,
+    #
+    # +7, all prose. The double-stat review finding DELETED code — _cog_object_size
+    # now calls size() once and maps its FileNotFoundError to 404 instead of asking
+    # exists() first — and the lines are the paragraph saying why the second
+    # head_object was worth removing: it doubled the round trips and the request
+    # charges on every /vsicurl/ probe, against a design chosen for costing one,
+    # and the gap between the two calls turned a deleted object into a 503.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1324,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2276,7 +2276,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # openapi.json and the rendered /docs page), and the answer could not be
     # written down before #1518 because it depended on which router you hit.
     # Cap 1470 -> 1499, exact.
-    "backend/app/api/main.py": 1573,
+    # fix(#1540 review P2): +20 — image/tiff joins starlette's default gzip
+    # exclusions, and the comment says why it is a correctness fix rather than a
+    # CPU one: the middleware compresses a 200 and skips a 206, so one strong
+    # ETag named gzip bytes on the full download and raw bytes on every range,
+    # and a client resuming the encoded representation could splice raw bytes at
+    # encoded offsets. Cap 1573 -> 1593, exact.
+    "backend/app/api/main.py": 1593,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
@@ -3438,7 +3444,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # once and stream the answer, so `get_range_stream` is where the bound lives
     # now; what is left here is the note saying why a helper that turns one range
     # into N reads was removed rather than retuned.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1536,
+    #
+    # +53 for If-Match. A resuming client may spell "only if this is still my
+    # representation" as If-Match rather than If-Range, and honouring one while
+    # ignoring the other left the absent If-Range reading as permission — the
+    # same splice through the other header. _if_match_passes is strong comparison
+    # with * handling, _this_service_owns_the_bytes names the rule that already
+    # governed the remote branch's blank validator row, and the 412 carries the
+    # ETag that IS current so a refused client can restart in one round trip.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1589,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3430,7 +3430,15 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # request per 1 MiB — 5,120 of them for a 5 GiB COG, selectable by any caller
     # willing to send a stale validator and counted by the rate limiter as one
     # request. The lines say which of the two streaming helpers belongs where.
-    "backend/app/modules/catalog/datasets/api/router_export.py": 1532,
+    #
+    # +4 net, and the code went DOWN: `_iter_storage_range` is deleted. Serving a
+    # range by calling get_range per 1 MiB issued an object-store request per
+    # chunk on the ORDINARY path this time, which on an S3 or Azure deployment is
+    # every managed raster's range request. Only the provider can ask for a window
+    # once and stream the answer, so `get_range_stream` is where the bound lives
+    # now; what is left here is the note saying why a helper that turns one range
+    # into N reads was removed rather than retuned.
+    "backend/app/modules/catalog/datasets/api/router_export.py": 1536,
 }
 
 

--- a/backend/tests/test_storage_azure.py
+++ b/backend/tests/test_storage_azure.py
@@ -194,10 +194,63 @@ async def test_get_stream_raises_not_implemented(azurite_provider):
 
     get_stream is an async generator — the NotImplementedError is raised
     on first iteration, not on call. Mirror the s3.py pattern.
+
+    fix(#1540 review P1) found this is not merely unreached: a managed raster
+    on an Azure deployment carries ``storage_backend="local"``, so the COG
+    download route serves it here rather than redirecting, and its whole-object
+    GET calls this method. That is a pre-existing gap on ``main`` — the call
+    site predates #1528 — and it is filed rather than fixed here, because the
+    Azure SDK's chunked download needs its request behaviour measured the way
+    botocore's was. This test pins the CURRENT behaviour so the gap cannot be
+    mistaken for working; ``get_range_stream`` below is the half that is fixed.
     """
     with pytest.raises(NotImplementedError, match="SAS"):
         async for _ in azurite_provider.get_stream("any_key"):
             pass
+
+
+@pytest.mark.asyncio
+async def test_get_range_stream_round_trip(azurite_provider):
+    """A window streams back byte-exact, from one download call.
+
+    fix(#1540 review P1): the COG route used to serve a range by calling
+    ``get_range`` once per 1 MiB, which on this provider is a download call per
+    chunk. Azure reaches that path by the ordinary route, not an exotic one:
+    managed rasters are ``storage_backend="local"`` whatever the object store.
+    """
+    payload = bytes(range(256)) * 4096  # 1 MiB exactly
+    key = "test/range_stream.bin"
+    await azurite_provider.put(key, payload)
+
+    chunks = [
+        chunk async for chunk in azurite_provider.get_range_stream(key, 1000, 5000)
+    ]
+
+    assert b"".join(chunks) == payload[1000:6000]
+
+
+@pytest.mark.asyncio
+async def test_get_range_stream_missing_key_raises(azurite_provider):
+    """Same FileNotFoundError contract every provider normalizes to (#430 BA-24)."""
+    with pytest.raises(FileNotFoundError):
+        async for _ in azurite_provider.get_range_stream("nope.bin", 0, 10):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_get_range_stream_past_the_end_is_empty(azurite_provider):
+    """A window beyond the blob ends the stream instead of raising.
+
+    Matches ``get_range`` and the local/POSIX seek-then-read the other
+    providers give: the caller has already decided what an empty window means,
+    and for the COG route that decision is the 416 it computes from the size.
+    """
+    key = "test/range_stream_short.bin"
+    await azurite_provider.put(key, b"0123456789")
+
+    chunks = [chunk async for chunk in azurite_provider.get_range_stream(key, 50, 100)]
+
+    assert b"".join(chunks) == b""
 
 
 def test_presigned_methods_raise_not_implemented(azurite_provider):

--- a/backend/tests/test_storage_get_stream.py
+++ b/backend/tests/test_storage_get_stream.py
@@ -85,3 +85,97 @@ async def test_get_stream_handle_cleanup(
     chunks = [chunk async for chunk in local_provider.get_stream("big.bin")]
     reconstructed = b"".join(chunks)
     assert reconstructed == _PAYLOAD_3MIB
+
+
+# ---------------------------------------------------------------------------
+# S3, fix(#1540) review P1: the same contract, and one request to honour it
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def s3_provider(monkeypatch):
+    """An ``S3StorageProvider`` against a moto bucket.
+
+    moto runs real boto3 calls, so the request COUNT below is measured rather
+    than asserted about a stub.
+    """
+    import boto3
+    from moto import mock_aws
+
+    from app.platform.storage.s3 import S3StorageProvider
+
+    for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
+        monkeypatch.setenv(var, "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="stream-1540")
+        yield S3StorageProvider(
+            bucket="stream-1540",
+            region="us-east-1",
+            access_key_id="testing",
+            secret_access_key="testing",
+        )
+
+
+@pytest.mark.asyncio
+async def test_s3_get_stream_is_one_request_not_one_per_chunk(s3_provider) -> None:
+    """The amplification this method exists to remove.
+
+    fix(#1540 review P1): the COG route's stale-resume fallback streamed the
+    whole object through a per-chunk ranged read, so a 5 GiB COG became 5,120
+    object-store requests — selectable by any caller willing to send a stale
+    validator, and billed by the rate limiter as one request. A single
+    ``get_object``, read in chunks off the socket, costs what a download costs.
+
+    Counted at the botocore layer: requests, not method calls.
+    """
+    calls: list[str] = []
+    s3_provider.client.meta.events.register(
+        "before-call.s3", lambda model, **kwargs: calls.append(model.name)
+    )
+    await s3_provider.put("big.bin", _PAYLOAD_3MIB)
+    calls.clear()
+
+    chunks = [chunk async for chunk in s3_provider.get_stream("big.bin")]
+
+    assert b"".join(chunks) == _PAYLOAD_3MIB
+    assert len(chunks) >= 3, (
+        f"a 3 MiB object arrived in {len(chunks)} chunk(s); a single-buffer "
+        f"read would put the whole object in memory at once."
+    )
+    assert calls == ["GetObject"], (
+        f"streaming 3 MiB issued {calls}. One object, one request: a ranged "
+        f"read per chunk is what turned a 5 GiB download into thousands of "
+        f"them."
+    )
+
+
+@pytest.mark.asyncio
+async def test_s3_get_stream_missing_key_raises(s3_provider) -> None:
+    """Same FileNotFoundError contract every provider normalizes to (#430 BA-24).
+
+    It is what lets the COG route answer 404 rather than 503 for an object that
+    is simply gone.
+    """
+    with pytest.raises(FileNotFoundError):
+        _ = [chunk async for chunk in s3_provider.get_stream("nope.bin")]
+
+
+@pytest.mark.asyncio
+async def test_s3_get_stream_releases_the_body_on_abort(s3_provider) -> None:
+    """A client that disconnects mid-download must not strand its connection.
+
+    The local provider closes its file handle in a ``finally``; this one closes
+    the botocore body for the same reason, and the check is the same: a second
+    consumer reads the object end to end afterwards.
+    """
+    await s3_provider.put("big.bin", _PAYLOAD_3MIB)
+
+    gen = s3_provider.get_stream("big.bin").__aiter__()
+    first_chunk = await gen.__anext__()
+    assert len(first_chunk) > 0
+    await gen.aclose()
+
+    chunks = [chunk async for chunk in s3_provider.get_stream("big.bin")]
+    assert b"".join(chunks) == _PAYLOAD_3MIB

--- a/backend/tests/test_storage_get_stream.py
+++ b/backend/tests/test_storage_get_stream.py
@@ -163,6 +163,64 @@ async def test_s3_get_stream_missing_key_raises(s3_provider) -> None:
 
 
 @pytest.mark.asyncio
+async def test_s3_get_range_stream_is_one_request(s3_provider) -> None:
+    """A range is one ranged GetObject, however many chunks it arrives in.
+
+    fix(#1540 review P1), second occurrence: the COG route served ranges by
+    calling ``get_range`` per 1 MiB, so ``Range: bytes=0-`` on a 5 GiB object
+    became 5,120 serial requests. This is the method that makes a range cost
+    one, and the count is measured at the botocore layer rather than inferred.
+    """
+    calls: list[str] = []
+    s3_provider.client.meta.events.register(
+        "before-call.s3", lambda model, **kwargs: calls.append(model.name)
+    )
+    await s3_provider.put("big.bin", _PAYLOAD_3MIB)
+    calls.clear()
+
+    window = 2 * 1024 * 1024 + 12345  # spans several chunks, ends mid-chunk
+    chunks = [
+        chunk async for chunk in s3_provider.get_range_stream("big.bin", 4096, window)
+    ]
+
+    assert b"".join(chunks) == _PAYLOAD_3MIB[4096 : 4096 + window]
+    assert len(chunks) >= 2, "a multi-MiB window must not arrive as one buffer"
+    assert calls == ["GetObject"], (
+        f"streaming one window issued {calls}; a request per chunk is the "
+        f"amplification this method exists to remove."
+    )
+
+
+@pytest.mark.asyncio
+async def test_range_stream_contract_matches_across_providers(
+    s3_provider, local_provider: LocalStorageProvider
+) -> None:
+    """Local and S3 answer a past-the-end window the same way: empty, not error.
+
+    The route never asks for one — ``_parse_cog_range`` turns a first-byte-pos
+    at or past the end into a 416 before any read — but a provider contract
+    that holds only for the caller who happens to avoid the edge is not a
+    contract. Azure needed normalizing to reach the same answer, which is what
+    ``test_get_range_stream_past_the_end_is_empty`` in ``test_storage_azure.py``
+    covers; this is the other two.
+    """
+    await local_provider.put("small.bin", b"0123456789")
+    await s3_provider.put("small.bin", b"0123456789")
+
+    local_chunks = [
+        c async for c in local_provider.get_range_stream("small.bin", 50, 100)
+    ]
+    s3_chunks = [c async for c in s3_provider.get_range_stream("small.bin", 50, 100)]
+
+    assert b"".join(local_chunks) == b""
+    assert b"".join(s3_chunks) == b""
+
+    for name, provider in (("local", local_provider), ("s3", s3_provider)):
+        with pytest.raises(FileNotFoundError):
+            _ = [c async for c in provider.get_range_stream("nope.bin", 0, 10)], name
+
+
+@pytest.mark.asyncio
 async def test_s3_get_stream_releases_the_body_on_abort(s3_provider) -> None:
     """A client that disconnects mid-download must not strand its connection.
 


### PR DESCRIPTION
Closes #1528.

`/api/datasets/{id}/download/cog` answered `405 allow: GET` for HEAD, and its local-storage branch advertised no `Accept-Ranges` and honoured no `Range`. The second defect is the one that matters for the format: a Cloud-Optimized GeoTIFF exists so a client can read the header and then fetch only the tiles it needs. This endpoint made that impossible.

## What HEAD returns, and why it differs from the export route's

`/datasets/{id}/export` (#1513, merged as #1522) runs a live ogr2ogr/pyarrow conversion, so its length is unknowable before generating the content, and its HEAD deliberately omits `Content-Length` under RFC 9110 §9.3.2.

This route serves **stored bytes**, so it gives a strictly better answer:

| | export route HEAD | this HEAD |
|---|---|---|
| `Content-Length` | absent (unknowable) | real, from one `storage.size()` |
| `Accept-Ranges: bytes` | true of range *service*, but the representation is regenerated per request (#1532) | true, and backed by an actual 206 over a stable object |

HEAD runs the same authorization, record-type and storage checks as GET and agrees with it on **every** status — including denial, so it never becomes an existence oracle. It reads no bytes (answered from `size()` alone), and it writes no audit row, because nothing was transferred.

On the `remote` backend HEAD returns the same 302 the GET returns, rather than inventing a 200 with a length this service never measured for bytes it does not hold. That branch still re-runs the SEC-06 SSRF re-validation on HEAD, so HEAD cannot hand out a location the GET refuses. The `s3` backend answered a 302 here too in the first revision, which turned out to be the P1 below: it answers HEAD directly now.

## GDAL evidence

Measured against a **bare uvicorn** serving this app (no nginx), GDAL 3.13.0 CLI and rasterio 1.5.1 / GDAL 3.12.4, on a real 1.8 MB tiled COG with overviews.

**Before (`main`):**

```
$ curl -I .../download/cog
HTTP/1.1 405 Method Not Allowed
allow: GET

$ curl -H 'Range: bytes=0-99' -D - .../download/cog
HTTP/1.1 200 OK          <- Range ignored
transfer-encoding: chunked   <- and no content-length

$ gdalinfo /vsicurl/...
VSICURL: HEAD not allowed. Retrying with GET
VSICURL: GetFileSize(...)
VSICURL: Request at offset 0, after end of file
ERROR 4: ... not recognized as a supported dataset name.   (rc=1)

rasterio: CPLE_OpenFailedError: not recognized as being in a supported file format
```

**After:**

```
$ curl -I .../download/cog
HTTP/1.1 200 OK
accept-ranges: bytes
content-length: 1824576
content-type: image/tiff

$ curl -H 'Range: bytes=0-99' -D - .../download/cog
HTTP/1.1 206 Partial Content
content-range: bytes 0-99/1824576
content-length: 100

$ gdalinfo /vsicurl/...                                    (rc=0)
VSICURL: GetFileSize(...)
VSICURL: Downloading 0-16383 (...)
VSICURL: Got response_code=206
GTiff: Opened 512x512 overview.
GTiff: Opened 256x256 overview.

rasterio: OPENED 1024 1024 1 ('uint8',) / overviews [2, 4] / window read OK
```

The whole COG now opens on a 16 KB read.

### This contradicts the issue's verification note

The issue (following #1513) says the hang "needs a second ingredient: the fallback GET arriving without a Content-Length, which the production edge produces and a bare uvicorn does not."

**That does not transfer to this route.** Its GET was a `StreamingResponse` with no `Content-Length`, so uvicorn framed it `transfer-encoding: chunked` *on its own* — visible in the before/after above. The second ingredient was already inside the route, so no production edge was needed to reproduce it, and I did not have to substitute anything. It is also not a hang here: both clients fail fast and hard, refusing to open the file at all.

## Range semantics

Followed RFC 9110, with the safe direction chosen at each fork:

- **Unusable Range** (bad syntax, reversed pair, unknown unit, `bytes=`, multi-range) → **ignored**, whole object served (§14.2). Multi-range specifically: `multipart/byteranges` is not implemented, and answering only the first range while labelling it as both is the corrupt-download failure.
- **Last-byte-pos past EOF** → clamped, not rejected. Clients that do not know the size ask for too much on purpose.
- **First-byte-pos at/past EOF, or a zero-length suffix** → **416** with `Content-Range: bytes */size` (§15.5.17), so the client learns the real size. Serving 200 with the whole object here would have a client splice a full COG at a tile offset.
- **A Range whose `If-Range` no longer matches** → **ignored**, whole current object served (§13.1.5), on `local` and on `s3` alike. That one came out of review; the reasoning is under "a resumed range could splice two COGs" below.
- **A range unit in any case** (`Bytes=`, `BYTES=`) is a conforming request and is served as one (§14.1). Also from review.
- Ranges stream through `storage.get_range_stream()`: one provider read for the window, delivered in 1 MiB chunks, so a multi-GB range neither lands on the heap nor costs a request per chunk, and the bytes outside the window are never read.

## Two decisions worth flagging

**Range GETs are audited individually.** A COG client now emits an audit row per tile read where it used to emit one per download. That volume cost is deliberate: the alternative is a blind spot where a caller pulls an entire COG in ranges and appears in the log zero times. `details.range` distinguishes a tile read from a full download.

**An adjacent defect that turned out to be this one.** `app/api/main.py` installs `GZipMiddleware(minimum_size=256)` globally, and it compressed the full COG GET while skipping every 206. That was recorded here as a cosmetic limit — a browser download chunked instead of length-delimited, and already-compressed pixel data run through DEFLATE for no gain — with a test pinning it and a note saying what to delete when someone excluded image types. Review round seven showed it was not cosmetic: the asymmetry made one strong ETag name two different byte streams. It is fixed below, and the workaround it forced (`Accept-Encoding: identity` in `test_get_cog_advertises_ranges_and_length`) is gone.

## Review findings, and what each one changed

### P1: the s3 HEAD was refused by the object store

The HEAD described above fell through to `generate_presigned_get_url()`, which signs `get_object`. The HTTP method is part of an S3/MinIO SigV4 canonical request, and a 302 does not rewrite the method (RFC 9110 §15.4 reserves that for 303). So a redirect-following client re-issued its HEAD against a URL signed for GET and was refused. Every `/vsicurl/` open begins with that probe, which left this PR broken on exactly the deployments that keep their COGs in a bucket.

**Measured** against MinIO `RELEASE.2025-09-07T16-13-09Z`, presigning through this repo's own `S3StorageProvider`:

```
presigned get_object   GET  -> 200 (content-length 4096, accept-ranges bytes)
                       HEAD -> 403
presigned head_object  HEAD -> 200
                       GET  -> 403 SignatureDoesNotMatch
```

That table settles two things at once. A GET-signed URL really does reject HEAD, so the finding is real. It also shows the redirect could have been repaired in place by signing a second URL for `head_object`, which makes what follows a choice between two fixes that both work rather than a correction of a broken one.

This takes the other route: answer HEAD here, from `storage.size()`, and drop the redirect for that method alone.

- One round trip instead of two.
- No dependence on the client preserving its method across the hop, which is the fragile assumption that produced the bug in the first place.
- HEAD becomes identical on `local` and `s3`, 404 and 503 included, because both now run the same `_cog_object_size` / `_cog_headers` / `_cog_head_response`.
- No new method on the `StorageProvider` protocol and its three implementations, one of which nothing would have called.

The cost is one `head_object` per probe, a metadata call the local branch already pays as a stat. The GET is untouched: bytes still come from the bucket, and a presigned GET honours a Range once the client gets there.

End to end through the route, on real uvicorn over a real socket against real MinIO, with HEAD following redirects the way `curl -L` and `/vsicurl/` do:

| | HEAD chain |
|---|---|
| before | `302 -> 403` |
| after | `200`, one hop, real `content-length`, `accept-ranges: bytes` |

**Which backends were exercised.** The GDAL evidence above is the `local` backend. The s3 path is measured, not inferred: real MinIO at the release pinned above, driven through the app's own provider rather than a hand-configured client. `remote` is unchanged and still redirects. The four cells were also reproduced independently, by a separate probe written without reference to the first.

One note for anyone re-running this. These presigned URLs come out SigV2-shaped against MinIO (`AWSAccessKeyId`, `Expires`, `Signature`) even though the client reports its `signature_version` as `s3v4`. Comparing the two URLs on `X-Amz-Signature` therefore compares `None` against `None` and reports a clean, false "the signatures match". Read `Signature` instead.

**A retired invariant, on purpose.** `test_head_cog_redirect_matches_get` asserted that HEAD and GET agree on status, and ran for both redirecting backends. It now runs for `remote` only. The asymmetry is the fix: s3 answers HEAD 200 / GET 302 because HEAD no longer travels the redirect, and `test_s3_head_and_get_are_deliberately_asymmetric` pins that so its disappearance does not read as an oversight. `remote` keeps the parity, correctly, since that URL is a third-party origin this service never signed.

### P2: an overlong Range number reached `int()`

CPython refuses to convert an integer literal longer than `sys.get_int_max_str_digits()`, 4300 by default. `Range: bytes=<4301 digits>-` is syntactically valid under §14.1.1 and fits inside the 8 KiB per-header budget nginx and uvicorn both allow, so it matched the pattern above and raised `ValueError` into a **500**, on a header the RFC lets a server handle in stride.

Every numeric field is now saturated above any size an object can have before conversion. All three of them, not only the one the review anchored to. Saturating rather than rejecting is what preserves the semantics per form, because "too many digits" does not mean "unsatisfiable":

| header | result | why |
|---|---|---|
| `bytes=<overlong>-` | 416 | first-byte-pos past EOF |
| `bytes=0-<overlong>` | 206, whole object | last-byte-pos past EOF is clamped |
| `bytes=-<overlong>` | 206, whole object | a suffix at least as long as the representation *is* the representation |

Leading zeros are stripped before the length test, so `bytes=-0000…0` at 4301 characters still reads as the zero-length suffix it is, and still earns its 416.

`test_an_overlong_range_agrees_with_a_merely_large_one` asserts that each form answers an astronomical number exactly as it answers a merely-too-big one, instead of restating three expected values that could drift away from the clamp tests beside them. Both wrong fixes were simulated against it: rejecting overlong values turns the last two forms into 416s, and ignoring them turns all three into a 200 carrying the whole object. It goes red on precisely those forms.

### P2: the HEAD stat'd the object twice

`_cog_object_size` called `exists()` and then `size()`. On S3 both are `head_object`, so the probe justified in the P1 above on the grounds that it costs **one** round trip was quietly costing two, plus two request charges, on every `/vsicurl/` open.

The split was also a check separated from its use. A delete landing between the two calls left `exists()` answering yes and `size()` raising `FileNotFoundError`, and the broad handler turned that into a **503**: come back later, about an object that is never coming back.

One `size()` now, with its `FileNotFoundError` mapped to 404. Every provider already normalizes a missing object to that exception (the `StorageProvider` protocol says so, and S3 and Azure convert their native not-found under #430 BA-24), so the existence answer was inside the size answer all along.

`test_head_cog_issues_exactly_one_s3_metadata_call` counts requests at the botocore layer, not method calls on the provider: `['HeadObject', 'HeadObject']` before, `['HeadObject']` after. `test_a_delete_racing_the_stat_is_a_404_not_a_503` drives the race with the stale `exists()` answer a delete produces, and reported `(503, 503)` before the fix. `test_head_cog_matches_get_on_storage_failure` now breaks `size` instead of `exists`, since breaking a call the route no longer makes would have passed for no reason at all.

### P2: a resumed range could splice two COGs

The download URL names a dataset, not a build. A replacement swaps `asset_uri` and `sha256` on the same `raster_assets` row, so two range requests to one stable URL can read two different objects, and neither response said which.

A resumable downloader reads bytes 0-99 of the old COG, loses its connection, comes back for 100-199, and gets them from the replacement. Both requests succeed with 206. Both `Content-Range` headers are accurate. The file it writes out is the head of one COG and the tail of another, nothing in the exchange reports a problem, and the result is then used as data.

Adding ranges is what opened that window. Before this PR the route served whole objects, so the validator finishes the feature rather than extending it.

The COG's own `sha256` is already persisted, and it is strong by construction: `sha256_file` over the converted file, so it changes if and only if the bytes change. It now goes out as a strong `ETag` on the HEAD, the 200, the 206 and the 416, and `If-Range` is evaluated with the strong comparison §13.1.5 requires.

| request | answer |
|---|---|
| `If-Range` matches | 206. Resumable downloads still work, which is the point of the feature |
| `If-Range` is stale | 200, the whole current object. The client drops its prefix and starts again |
| `If-Range: W/"…"` | 200. Strong comparison never matches a weak tag, however familiar the digest inside it looks |
| stale, and the old offsets no longer exist | 200, not 416. Ignoring a Range means ignoring its bounds |
| no `If-Range` | 206, unchanged. There is nothing to check it against |
| row with no `sha256` | no ETag, and a conditional range gets 200. Unverifiable must not mean honoured |

Nothing weaker is offered on purpose. `Last-Modified` has one-second granularity, and a replacement landing inside the same second as its predecessor is exactly the case this exists to catch.

The test drives the failure instead of describing it: a real 206, a completed replacement, then the resume. It now returns the whole new COG where it used to return a 206 the client would have appended to a prefix of the COG it was no longer reading. The two objects differ at every byte offset, so a silent continuation is detectable wherever the client resumed.

**Not #1532.** #1532 is the export route, where every request regenerates the representation, so its `Accept-Ranges` promises ranges over an artifact that does not stably exist; the fix there is a cached artifact to range over. This route serves stored bytes that are already stable, and the only thing that changes them is someone replacing the raster, which is what the ETag detects. A validator here gives the export route nothing, and #1532 stays open.

### P2: the binding landed on one backend, and the ETag was half a contract

Round 3 put the version binding in `_local_cog_response`, which left the splice open on `s3` — the branch this PR was extended to support two rounds earlier, and the same pair that produced the P1 above.

**The bucket cannot be asked to close it.** Measured against MinIO `RELEASE.2025-09-07T16-13-09Z`, on a presigned GET:

```
Range only                                     -> 206
Range + If-Range: the bucket's own etag        -> 206
Range + If-Range: a foreign etag (ours)        -> 206
Range + If-None-Match: a foreign etag          -> 206
```

The precondition is not evaluated at all. Nor can a 302 help: the client re-sends its `Range` across the hop, and nothing in a redirect strips it. So the route evaluates `If-Range` itself, and a resume whose validator no longer matches is answered here with the whole current object. Everything else on `s3` still redirects — whole-object GETs and valid resumes carry the multi-GB payloads and must keep coming from the bucket. The proxied case needs a replacement to have landed mid-download, and it costs the same object the client was already pulling, moved from the bucket's egress to ours.

The ETag also needed the other half of its contract. A client stored it, offered it back, and got another 200 with a body it already had. `If-None-Match` is now evaluated with the weak comparison §13.1.2 specifies, ahead of Range and If-Range per §13.2.2, and above the storage branching so every backend that publishes a validator can answer 304. It sits before the audit row for the reason HEAD does: nothing was transferred.

**The grid, since two findings on this PR came from a fix landing in one cell of it.** The rows are *asset* backends, not deployment backends, and the difference turns out to matter: `raster_assets.storage_backend` is one of `local`/`s3`/`remote`, and **nothing writes `s3`**. `tasks_raster_common.py` and `tasks_vrt.py` create rows as `local`, the replace swap resets them to `local`, STAC imports write `remote`, and which object store holds the bytes is `get_storage()`'s business. So an S3 or Azure deployment takes the `local` row, and the `s3` row is reachable only for data no current code path produces.

| asset backend | shape | ETag | If-None-Match | If-Range |
|---|---|---|---|---|
| `local` (disk, S3 or Azure provider) | HEAD | yes | 304 | n/a (a Range on HEAD is ignored by design) |
| `local` | full GET | yes | 304 | n/a (no Range) |
| `local` | ranged GET | yes, on the 206 and the 416 | 304, ahead of the range | yes: mismatch serves the whole object, 200 |
| `s3` | HEAD | yes | 304 | n/a |
| `s3` | full GET | no — a 302 describes no representation | 304 | n/a |
| `s3` | ranged GET | on the proxied stale resume, yes; on the redirect, the bucket's | 304 | yes: mismatch is answered here, match redirects |
| `remote` | all three | no | no | no |

`remote` is a deliberate blank row. Those bytes belong to a third-party origin this service redirects to and never reads, so a digest recorded at import time cannot vouch for what is there now, and the origin answers with validators of its own.

**Two corrections to an earlier revision of this table.** It said Azure implements `size`/`get_range`/`get_stream` and therefore rides `_local_cog_response` unchanged. The first two are implemented; `get_stream` raises `NotImplementedError`, under a docstring asserting the router redirects for Azure. Combined with the row above — Azure deployments store `local` assets — that means **a full COG download on Azure raises `NotImplementedError` today, on `main`, and still does**: the call site at `router_export.py` predates this PR. It is a pre-existing gap on a supported backend, it wants its own issue, and it is not fixed here because the Azure SDK's chunked download has request-count semantics I cannot measure the way botocore's can be measured, and guessing at that is how a sixth review round starts.

S3 had the identical gap and **is** fixed, because the stale-resume fallback needed a real `get_stream` anyway: before this PR, a full COG download on any S3-backed deployment raised `NotImplementedError` too. `test_a_full_download_works_when_the_provider_is_s3` pins it independently of the fallback.

**One asymmetry this accepts, pinned by `test_a_bucket_issued_validator_is_not_recognized_and_fails_safe`.** On `s3` a client can pick up two different validators for one resource: ours from the HEAD, or the bucket's from a redirected 206. A resume carrying the bucket's tag is unrecognized, and unrecognized means refused — the whole object, through this process. Safe, and not free. Closing it needs either every s3 range served from here or the bucket's ETag published instead of a content digest, and both are larger changes than the splice this round fixes.

### P1: the mismatch fallback re-requested the object once per MiB

The fallback above returns the right thing. It produced it by streaming through `_iter_storage_range`, which issues a ranged `GetObject` per 1 MiB — so a 5 GiB COG cost 5,120 object-store requests, and the per-request rate limiter counted the lot as one. Any caller who can reach the route, an anonymous download-token holder on a public dataset included, selects that branch by sending a single stale validator.

`S3StorageProvider.get_stream` now exists and does it in one `GetObject`, read off the socket in 1 MiB chunks, with the body closed in a `finally` so a client that disconnects mid-download releases its connection instead of stranding it. Measured at the botocore layer on a 3 MiB object: `['HeadObject', 'GetObject', 'GetObject', 'GetObject']` before, `['HeadObject', 'GetObject']` after — one stat for the length, one body. `_iter_storage_range` stays where it belongs, on the ranged reads the client actually asked for.

### P2: the CORS middleware never learned the endpoint grew

For a browser client on an allowed origin the whole feature was unusable, and each half fails differently:

| gap | consequence |
|---|---|
| `If-Range` / `If-None-Match` not in `Access-Control-Allow-Headers` | the preflight is refused, so the request never leaves the browser |
| `ETag`, `Content-Range`, `Accept-Ranges` not in `Access-Control-Expose-Headers` | the response arrives and the browser hides those headers from JavaScript — a validator the caller cannot read is one it cannot resume against |
| `HEAD` not in `Access-Control-Allow-Methods` | the probe #1528 added is available to curl and GDAL and not to a browser |

All three are fixed together, plus `Content-Disposition` on the exposed list so a browser client can name the file it saves. `Range` is listed explicitly even though the Fetch standard safelists simple byte-range values, because that safelisting is conditional on the syntax and a request pairing it with `If-Range` is preflighted regardless. `Content-Length` is deliberately not listed: it is already a safelisted response header, and repeating it would imply the others are.

**Nothing else declares this contract.** The nginx `/api/` block sets no `proxy_hide_header` for any of these, adds no `ETag` of its own, and `image/tiff` is not in `gzip_types`, so it passes ranges and validators through untouched. The OpenAPI operation still documents only its 403; adding 206/304/416 there would move `backend/openapi.json` and both SDKs for a documentation-only gain, which is a call worth making deliberately rather than inside a review round.

### P1: so did the ordinary range, on the path that carries the traffic

The round above fixed the fallback and left the main road. `_iter_storage_range` served every 206 by calling `get_range` per 1 MiB, one object-store request a chunk, and that is where the everyday tile read goes: on an S3 or Azure deployment ordinary ingested assets carry `storage_backend="local"`, so `Range: bytes=0-` against a 5 GiB COG issued 5,120 serial requests and counted as one API call. Selecting it needed no stale validator, just a range.

Fixed at the shared cause. `get_range_stream` is a new `StorageProvider` method whose contract is **one provider read for the whole window, chunked as it arrives** — one ranged `GetObject` on S3, one `download_blob` on Azure, one open file handle on local. `_iter_storage_range` is deleted rather than retuned: a helper that turns one range into N reads has no correct chunk size, only less-wrong ones.

Writing the Azure half turned up a disagreement the route had never reached. A window starting past the end of the blob raises `InvalidRange` there, where S3 answers 416 and a local seek-then-read returns nothing. Measured against Azurite 3.35.0 and normalized to the local answer, because a contract that holds only for the caller who avoids the edge is not a contract.

**Every path from this route to object storage, and what each costs.** The question was worth answering once rather than one branch at a time:

| request | object-store requests |
|---|---|
| HEAD (any managed backend) | 1 — `size()` |
| 304 revalidation, or a 412 | 1 — `size()`, because a precondition cannot vouch for an object without checking it is there (round eight) |
| full GET, `local` asset | 2 — `size()`, then one streamed read |
| ranged GET 206, `local` asset | 2 — `size()`, then one ranged read, whatever the window's size |
| 416, `local` asset | 1 — `size()` |
| full GET, `s3` asset | 0 — presigned redirect; the client pays the bucket directly |
| ranged GET, `s3` asset, valid or absent `If-Range` | 0 — same redirect |
| ranged GET, `s3` asset, stale `If-Range` | 2 — `size()`, then one streamed read |
| any `remote` asset | 0 (one DNS resolution for the SSRF re-check) |

Nothing on this route now issues a number of object-store requests that scales with the size of the object.

### P2: the range unit was matched case-sensitively

`Bytes=0-16383` is a conforming request — a range unit is a token (§14.1) and tokens compare case-insensitively. Matching only lowercase did not reject it. "Unusable Range" means *ignore the Range*, so the client got the whole COG with a 200: a 16 KiB tile read answered with a multi-gigabyte transfer, and nothing in the exchange says so. `bytes`, `Bytes`, `BYTES` and `bYtEs` are all parametrized, because a `.lower()`, a case-folded prefix check and an `re.IGNORECASE` differ only on the last one.

The audit that came with it: the entity-tag comparisons in `_range_bound_to_this_version` and `_if_none_match_matches` stay **case-sensitive** on purpose. §8.8.3.2 compares entity-tags octet by octet, and the weak prefix is `%s"W/"` — spelled with a case-sensitive string literal in the grammar itself. The unit was the only case bug.

### P2: `If-Match` was never evaluated

`If-Match` and `If-Range` are two spellings of one client intent: *only give me bytes if this is still the representation I have.* Honouring one and ignoring the other meant a conforming client that chose `If-Match` had its precondition dropped, the absent `If-Range` read as permission, and a replacement mid-download was answered with a 206 of the new COG at the old offsets. The same splice, through the other header.

It is evaluated first now, in the order §13.2.2 fixes — If-Match, then If-None-Match, then Range and If-Range — with strong comparison and `*` handling. A failure is **412**, not a degradation: unlike If-Range, the RFC gives it no "ignore the condition and serve the whole thing" fallback. The 412 carries the ETag that *is* current, so a refused client can restart in one round trip instead of two.

| request | answer |
|---|---|
| `If-Match` matches | proceeds — 206 for a range, 200 for the whole object |
| `If-Match` stale | 412, carrying the current ETag |
| `If-Match: *` | proceeds; it asks whether a current representation exists, and one does |
| specific tag, row with no `sha256` | 412 — unverifiable is not a pass, the same call the conditional-range path makes |
| `If-Match: *`, row with no `sha256` | proceeds; the question is existence, not identity |
| any `If-Match`, `remote` asset | not evaluated — travels to the origin that issued it |

`test_if_match_is_evaluated_before_if_none_match` is the one worth naming: a client can send both, and getting the order wrong answers 304 — telling a client whose copy is out of date that it is current, which is the more expensive lie because it stops asking.

### P2: gzip made one strong ETag name two byte streams

`GZipMiddleware` compresses a 200 and skips a 206 by design (`self.partial_response = status == 206`). With `image/tiff` missing from its exclusion list, one strong ETag therefore identified gzip bytes on the full download and raw bytes on every range — and §8.8.3 requires a strong validator to change when the representation does, content coding included. A client resuming the encoded representation could have its validator accepted and splice raw bytes at encoded offsets: everything done right, and a corrupt file at the end.

The fix is one argument. Starlette's `GZipMiddleware` already takes `exclude_content_types`, and its default list covers avif, gif, jpeg, png and webp — `image/tiff` is simply missing, predating anyone serving TIFF through it. Adding it restores the invariant without variant-specific validators, which would need their own HEAD metadata and `Vary` story.

Variant ETags were considered and rejected for this PR on that basis. The simple exclusion is also free CPU, since a COG is internally compressed and DEFLATE over a multi-GB one buys almost nothing.

`test_gzip_middleware_strips_content_length_from_the_full_cog_get` is deleted, as its own docstring instructed, and replaced by `test_one_etag_names_one_byte_stream_whatever_the_client_accepts`: the same gzip-offering request now returns raw bytes with a real Content-Length, and a 206 under the same ETag is a slice of exactly those bytes.

### P2: `If-Match` was unreachable cross-origin, and the coupling was a memory

Two rounds after the CORS allow-list learned about ranges, the endpoint grew `If-Match` and the allow-list did not learn about that either. Same two components, same failure, second time — and invisible from the server, because the endpoint works perfectly and the browser simply never sends the request.

Adding the header fixes the instance. The coupling is what kept breaking, so it is enforced now rather than remembered. `test_cors_range_headers_1540.py` parses the route's own source:

- every `request.headers.get("if-…")` or `("range")` the module evaluates must appear in `Access-Control-Allow-Headers`;
- every `headers=` name the COG helpers set, minus Fetch's safelisted response headers, must appear in `Access-Control-Expose-Headers`.

Adding `If-Unmodified-Since` handling now fails a test that names it. Both halves carry a vacuity guard, because a source scan that silently matched nothing would pass while proving nothing. Scoping is deliberate on each side: request headers module-wide (any conditional read here is one a browser must be allowed to send), response headers only inside the `cog` helpers (the DCAT handlers in the same file set headers of their own, and the audit call passes a `details=` dict whose keys include `range`).

With the allow-list reverted the test reports exactly `the route evaluates ['if-match'] but a cross-origin client may not send them`, and dropping `Content-Disposition` from the exposed list reports that one by name too.

### P2: a 304 for an object that no longer exists

A catalog row can outlive its stored bytes — the unconditional GET has answered 404 for that since #1528 — but the precondition block ran before storage was ever consulted. So the same URL disagreed with itself about whether the resource existed, depending on whether the client held a validator, and the conditional answer was the more damaging one: a 304 tells a cache its stale copy is a current representation of something that is gone, and the cache keeps serving it.

RFC 9110 §13.2.1 puts preconditions after the normal request checks for exactly this reason. The stat happens first now, so a missing object is 404 for `If-None-Match` and `If-Match` alike, and HEAD/GET parity holds with a validator as it does without one.

**That stat is carried into the response rather than repeated.** A conditional request that goes on to transfer bytes still touches object metadata exactly once — the property the double-stat round established, which a second measurement here would have quietly undone for every well-behaved resumable downloader, since after this PR they all send validators. `test_a_conditional_request_that_transfers_still_stats_once` fails with `['HeadObject', 'HeadObject']` if the measurement stops being handed down.

## Verification

Every behaviour was observed red before green. Beyond the initial 23-failure baseline, the assertions that carry the weight were confirmed to bite by mutation:

| mutation | result |
|---|---|
| drop HEAD's explicit `Content-Length` | starlette supplies `content-length: 0` — the exact wrong-answer class #1522 had to strip — caught |
| `end - start` instead of `+ 1` | 7 range tests fail |
| chunk loop does not advance the offset | multi-chunk range test fails (proves the chunk-size monkeypatch is live) |
| unparsable Range rejected instead of ignored | 6 of 7 ignore-cases fail |
| reversed pair served instead of ignored | the 7th fails |

Failure classes covered rather than sites: reject (403/404/416), abort (unusable Range), succeed-with-garbage (every 206 body compared against the real stored slice), and a zero-byte object, where every range is unsatisfiable.

`test_cog_vsicurl_1528.py` is the end-to-end guard: it boots the real app on a real socket (the `uvicorn_url` pattern from `test_cli_round_trip.py`), writes a genuine tiled COG, and opens it with rasterio through `/vsicurl/`. It then reads the audit log back to assert GDAL issued **zero** full-object GETs — the efficiency claim checked server-side rather than asserted. It fails on `main` with `CPLE_OpenFailedError` and `HEAD ... returned 405`.

```
tests/test_cog_head_ranges_1528.py  75 passed
tests/test_cog_vsicurl_1528.py       2 passed
tests/test_cog_s3_head_wire_1540.py  4 passed  (real MinIO; skipped without one)
tests/test_cors_range_headers_1540.py  6 passed  (2 are source-derived coupling checks)
tests/test_storage_get_stream.py     9 passed  (5 new, S3 via moto)
tests/test_storage_azure.py         17 passed  (3 new, against Azurite 3.35.0)
tests/test_layering.py              47 passed
tests/test_rule1_structural.py + test_rule2_structural.py   104 passed
full sweep incl. every storage suite (19 files)  535 passed
gzip-sensitive suites (middleware, tiles, tile-cache, mvt, data-serving)  143 passed
ruff check . && ruff format --check .                      clean
```

The wire module is where the s3 splice is shown rather than argued. Through `httpx.ASGITransport` a redirect goes back into the same app and dies at the router; over a socket against a real bucket it reaches MinIO, and without the round-4 branch the resumed leg comes back **206 after one redirect** — 100 bytes of the replacement, on their way to being appended to 100 bytes of the COG the client started with.

The raster-replace suite is in that sweep deliberately: the ETag reads a field its swap path owns, so a change there is a change here.

**API surface:** `make openapi-check`, `make sdks-check`, `make cli-test` all pass with **zero drift** — `backend/openapi.json` is unmodified and no generated SDK file changed, because the HEAD route is `include_in_schema=False` and the GET's docstring (which becomes the OpenAPI description) was left alone. No regen artifacts are committed.

**Layering:** `router_export.py` crossed `_RATCHET_INCLUSION_LOC` (997 → 1224, then 1317, 1324, 1414, 1525, 1532, 1536, 1589 and 1656 across the review rounds), exactly as the inclusion rule's own comment predicted for this file. `_MODULE_LOC_CAPS` is an exact ratchet in both directions, so each round resets it to the file's current size with a note on what the lines bought. The DCAT feed handlers remain the natural split if it grows again.

**Rule 1:** HEAD shares the GET's handler, so it runs the same `check_dataset_access` / `check_dataset_access_or_anonymous` path; `test_rule1_structural.py` and the pre-commit hook both pass, and `test_head_cog_denial_matches_get` pins that HEAD cannot become an unauthenticated existence oracle.

## Out of scope

`/admin/users/export.csv`, `/admin/audit-logs/export/{format}` and `/config-ops/export/` still answer 405 on HEAD. Per the issue, they are admin-only downloads with no `/vsicurl/` story; leaving them is the decision, not an oversight.







